### PR TITLE
Support multipart upload for AWS Databricks

### DIFF
--- a/mlflow/java/client/src/main/java/com/databricks/api/proto/mlflow/DatabricksArtifacts.java
+++ b/mlflow/java/client/src/main/java/com/databricks/api/proto/mlflow/DatabricksArtifacts.java
@@ -7508,6 +7508,7088 @@ public final class DatabricksArtifacts {
 
   }
 
+  public interface CreateMultipartUploadOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mlflow.CreateMultipartUpload)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the runId field is set.
+     */
+    boolean hasRunId();
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The runId.
+     */
+    java.lang.String getRunId();
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for runId.
+     */
+    com.google.protobuf.ByteString
+        getRunIdBytes();
+
+    /**
+     * <pre>
+     * Artifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return Whether the path field is set.
+     */
+    boolean hasPath();
+    /**
+     * <pre>
+     * Artifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return The path.
+     */
+    java.lang.String getPath();
+    /**
+     * <pre>
+     * Artifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return The bytes for path.
+     */
+    com.google.protobuf.ByteString
+        getPathBytes();
+
+    /**
+     * <pre>
+     * Number of parts to upload in the initiated multipart upload
+     * </pre>
+     *
+     * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the numParts field is set.
+     */
+    boolean hasNumParts();
+    /**
+     * <pre>
+     * Number of parts to upload in the initiated multipart upload
+     * </pre>
+     *
+     * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
+     * @return The numParts.
+     */
+    long getNumParts();
+  }
+  /**
+   * Protobuf type {@code mlflow.CreateMultipartUpload}
+   */
+  public static final class CreateMultipartUpload extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:mlflow.CreateMultipartUpload)
+      CreateMultipartUploadOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use CreateMultipartUpload.newBuilder() to construct.
+    private CreateMultipartUpload(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private CreateMultipartUpload() {
+      runId_ = "";
+      path_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new CreateMultipartUpload();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private CreateMultipartUpload(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              runId_ = bs;
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              path_ = bs;
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000004;
+              numParts_ = input.readInt64();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CreateMultipartUpload_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CreateMultipartUpload_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.class, com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Builder.class);
+    }
+
+    public interface ResponseOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mlflow.CreateMultipartUpload.Response)
+        com.google.protobuf.MessageOrBuilder {
+
+      /**
+       * <pre>
+       * ID identifying the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional string upload_id = 1;</code>
+       * @return Whether the uploadId field is set.
+       */
+      boolean hasUploadId();
+      /**
+       * <pre>
+       * ID identifying the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional string upload_id = 1;</code>
+       * @return The uploadId.
+       */
+      java.lang.String getUploadId();
+      /**
+       * <pre>
+       * ID identifying the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional string upload_id = 1;</code>
+       * @return The bytes for uploadId.
+       */
+      com.google.protobuf.ByteString
+          getUploadIdBytes();
+
+      /**
+       * <pre>
+       * Credentials for uploading parts in the initiated multipart upload
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+       */
+      java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> 
+          getUploadCredentialInfosList();
+      /**
+       * <pre>
+       * Credentials for uploading parts in the initiated multipart upload
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+       */
+      com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getUploadCredentialInfos(int index);
+      /**
+       * <pre>
+       * Credentials for uploading parts in the initiated multipart upload
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+       */
+      int getUploadCredentialInfosCount();
+      /**
+       * <pre>
+       * Credentials for uploading parts in the initiated multipart upload
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+       */
+      java.util.List<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> 
+          getUploadCredentialInfosOrBuilderList();
+      /**
+       * <pre>
+       * Credentials for uploading parts in the initiated multipart upload
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+       */
+      com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getUploadCredentialInfosOrBuilder(
+          int index);
+
+      /**
+       * <pre>
+       * Credential for aborting the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional .mlflow.ArtifactCredentialInfo abort_credential_info = 3;</code>
+       * @return Whether the abortCredentialInfo field is set.
+       */
+      boolean hasAbortCredentialInfo();
+      /**
+       * <pre>
+       * Credential for aborting the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional .mlflow.ArtifactCredentialInfo abort_credential_info = 3;</code>
+       * @return The abortCredentialInfo.
+       */
+      com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getAbortCredentialInfo();
+      /**
+       * <pre>
+       * Credential for aborting the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional .mlflow.ArtifactCredentialInfo abort_credential_info = 3;</code>
+       */
+      com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getAbortCredentialInfoOrBuilder();
+    }
+    /**
+     * Protobuf type {@code mlflow.CreateMultipartUpload.Response}
+     */
+    public static final class Response extends
+        com.google.protobuf.GeneratedMessageV3 implements
+        // @@protoc_insertion_point(message_implements:mlflow.CreateMultipartUpload.Response)
+        ResponseOrBuilder {
+    private static final long serialVersionUID = 0L;
+      // Use Response.newBuilder() to construct.
+      private Response(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+        super(builder);
+      }
+      private Response() {
+        uploadId_ = "";
+        uploadCredentialInfos_ = java.util.Collections.emptyList();
+      }
+
+      @java.lang.Override
+      @SuppressWarnings({"unused"})
+      protected java.lang.Object newInstance(
+          UnusedPrivateParameter unused) {
+        return new Response();
+      }
+
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+      getUnknownFields() {
+        return this.unknownFields;
+      }
+      private Response(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        int mutable_bitField0_ = 0;
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                com.google.protobuf.ByteString bs = input.readBytes();
+                bitField0_ |= 0x00000001;
+                uploadId_ = bs;
+                break;
+              }
+              case 18: {
+                if (!((mutable_bitField0_ & 0x00000002) != 0)) {
+                  uploadCredentialInfos_ = new java.util.ArrayList<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo>();
+                  mutable_bitField0_ |= 0x00000002;
+                }
+                uploadCredentialInfos_.add(
+                    input.readMessage(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.PARSER, extensionRegistry));
+                break;
+              }
+              case 26: {
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder subBuilder = null;
+                if (((bitField0_ & 0x00000002) != 0)) {
+                  subBuilder = abortCredentialInfo_.toBuilder();
+                }
+                abortCredentialInfo_ = input.readMessage(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.PARSER, extensionRegistry);
+                if (subBuilder != null) {
+                  subBuilder.mergeFrom(abortCredentialInfo_);
+                  abortCredentialInfo_ = subBuilder.buildPartial();
+                }
+                bitField0_ |= 0x00000002;
+                break;
+              }
+              default: {
+                if (!parseUnknownField(
+                    input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
+        } finally {
+          if (((mutable_bitField0_ & 0x00000002) != 0)) {
+            uploadCredentialInfos_ = java.util.Collections.unmodifiableList(uploadCredentialInfos_);
+          }
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CreateMultipartUpload_Response_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CreateMultipartUpload_Response_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response.class, com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response.Builder.class);
+      }
+
+      private int bitField0_;
+      public static final int UPLOAD_ID_FIELD_NUMBER = 1;
+      private volatile java.lang.Object uploadId_;
+      /**
+       * <pre>
+       * ID identifying the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional string upload_id = 1;</code>
+       * @return Whether the uploadId field is set.
+       */
+      @java.lang.Override
+      public boolean hasUploadId() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <pre>
+       * ID identifying the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional string upload_id = 1;</code>
+       * @return The uploadId.
+       */
+      @java.lang.Override
+      public java.lang.String getUploadId() {
+        java.lang.Object ref = uploadId_;
+        if (ref instanceof java.lang.String) {
+          return (java.lang.String) ref;
+        } else {
+          com.google.protobuf.ByteString bs = 
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            uploadId_ = s;
+          }
+          return s;
+        }
+      }
+      /**
+       * <pre>
+       * ID identifying the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional string upload_id = 1;</code>
+       * @return The bytes for uploadId.
+       */
+      @java.lang.Override
+      public com.google.protobuf.ByteString
+          getUploadIdBytes() {
+        java.lang.Object ref = uploadId_;
+        if (ref instanceof java.lang.String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          uploadId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+
+      public static final int UPLOAD_CREDENTIAL_INFOS_FIELD_NUMBER = 2;
+      private java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> uploadCredentialInfos_;
+      /**
+       * <pre>
+       * Credentials for uploading parts in the initiated multipart upload
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+       */
+      @java.lang.Override
+      public java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> getUploadCredentialInfosList() {
+        return uploadCredentialInfos_;
+      }
+      /**
+       * <pre>
+       * Credentials for uploading parts in the initiated multipart upload
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+       */
+      @java.lang.Override
+      public java.util.List<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> 
+          getUploadCredentialInfosOrBuilderList() {
+        return uploadCredentialInfos_;
+      }
+      /**
+       * <pre>
+       * Credentials for uploading parts in the initiated multipart upload
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+       */
+      @java.lang.Override
+      public int getUploadCredentialInfosCount() {
+        return uploadCredentialInfos_.size();
+      }
+      /**
+       * <pre>
+       * Credentials for uploading parts in the initiated multipart upload
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+       */
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getUploadCredentialInfos(int index) {
+        return uploadCredentialInfos_.get(index);
+      }
+      /**
+       * <pre>
+       * Credentials for uploading parts in the initiated multipart upload
+       * </pre>
+       *
+       * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+       */
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getUploadCredentialInfosOrBuilder(
+          int index) {
+        return uploadCredentialInfos_.get(index);
+      }
+
+      public static final int ABORT_CREDENTIAL_INFO_FIELD_NUMBER = 3;
+      private com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo abortCredentialInfo_;
+      /**
+       * <pre>
+       * Credential for aborting the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional .mlflow.ArtifactCredentialInfo abort_credential_info = 3;</code>
+       * @return Whether the abortCredentialInfo field is set.
+       */
+      @java.lang.Override
+      public boolean hasAbortCredentialInfo() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <pre>
+       * Credential for aborting the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional .mlflow.ArtifactCredentialInfo abort_credential_info = 3;</code>
+       * @return The abortCredentialInfo.
+       */
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getAbortCredentialInfo() {
+        return abortCredentialInfo_ == null ? com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : abortCredentialInfo_;
+      }
+      /**
+       * <pre>
+       * Credential for aborting the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional .mlflow.ArtifactCredentialInfo abort_credential_info = 3;</code>
+       */
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getAbortCredentialInfoOrBuilder() {
+        return abortCredentialInfo_ == null ? com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : abortCredentialInfo_;
+      }
+
+      private byte memoizedIsInitialized = -1;
+      @java.lang.Override
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      @java.lang.Override
+      public void writeTo(com.google.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        if (((bitField0_ & 0x00000001) != 0)) {
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 1, uploadId_);
+        }
+        for (int i = 0; i < uploadCredentialInfos_.size(); i++) {
+          output.writeMessage(2, uploadCredentialInfos_.get(i));
+        }
+        if (((bitField0_ & 0x00000002) != 0)) {
+          output.writeMessage(3, getAbortCredentialInfo());
+        }
+        unknownFields.writeTo(output);
+      }
+
+      @java.lang.Override
+      public int getSerializedSize() {
+        int size = memoizedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        if (((bitField0_ & 0x00000001) != 0)) {
+          size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, uploadId_);
+        }
+        for (int i = 0; i < uploadCredentialInfos_.size(); i++) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeMessageSize(2, uploadCredentialInfos_.get(i));
+        }
+        if (((bitField0_ & 0x00000002) != 0)) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeMessageSize(3, getAbortCredentialInfo());
+        }
+        size += unknownFields.getSerializedSize();
+        memoizedSize = size;
+        return size;
+      }
+
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+         return true;
+        }
+        if (!(obj instanceof com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response)) {
+          return super.equals(obj);
+        }
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response other = (com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response) obj;
+
+        if (hasUploadId() != other.hasUploadId()) return false;
+        if (hasUploadId()) {
+          if (!getUploadId()
+              .equals(other.getUploadId())) return false;
+        }
+        if (!getUploadCredentialInfosList()
+            .equals(other.getUploadCredentialInfosList())) return false;
+        if (hasAbortCredentialInfo() != other.hasAbortCredentialInfo()) return false;
+        if (hasAbortCredentialInfo()) {
+          if (!getAbortCredentialInfo()
+              .equals(other.getAbortCredentialInfo())) return false;
+        }
+        if (!unknownFields.equals(other.unknownFields)) return false;
+        return true;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptor().hashCode();
+        if (hasUploadId()) {
+          hash = (37 * hash) + UPLOAD_ID_FIELD_NUMBER;
+          hash = (53 * hash) + getUploadId().hashCode();
+        }
+        if (getUploadCredentialInfosCount() > 0) {
+          hash = (37 * hash) + UPLOAD_CREDENTIAL_INFOS_FIELD_NUMBER;
+          hash = (53 * hash) + getUploadCredentialInfosList().hashCode();
+        }
+        if (hasAbortCredentialInfo()) {
+          hash = (37 * hash) + ABORT_CREDENTIAL_INFO_FIELD_NUMBER;
+          hash = (53 * hash) + getAbortCredentialInfo().hashCode();
+        }
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response parseFrom(
+          java.nio.ByteBuffer data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response parseFrom(
+          java.nio.ByteBuffer data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response parseFrom(byte[] data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response parseFrom(
+          byte[] data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response parseFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response parseDelimitedFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response parseFrom(
+          com.google.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+
+      @java.lang.Override
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder() {
+        return DEFAULT_INSTANCE.toBuilder();
+      }
+      public static Builder newBuilder(com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response prototype) {
+        return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+      }
+      @java.lang.Override
+      public Builder toBuilder() {
+        return this == DEFAULT_INSTANCE
+            ? new Builder() : new Builder().mergeFrom(this);
+      }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * Protobuf type {@code mlflow.CreateMultipartUpload.Response}
+       */
+      public static final class Builder extends
+          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mlflow.CreateMultipartUpload.Response)
+          com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.ResponseOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CreateMultipartUpload_Response_descriptor;
+        }
+
+        @java.lang.Override
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CreateMultipartUpload_Response_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response.class, com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response.Builder.class);
+        }
+
+        // Construct using com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
+            getUploadCredentialInfosFieldBuilder();
+            getAbortCredentialInfoFieldBuilder();
+          }
+        }
+        @java.lang.Override
+        public Builder clear() {
+          super.clear();
+          uploadId_ = "";
+          bitField0_ = (bitField0_ & ~0x00000001);
+          if (uploadCredentialInfosBuilder_ == null) {
+            uploadCredentialInfos_ = java.util.Collections.emptyList();
+            bitField0_ = (bitField0_ & ~0x00000002);
+          } else {
+            uploadCredentialInfosBuilder_.clear();
+          }
+          if (abortCredentialInfoBuilder_ == null) {
+            abortCredentialInfo_ = null;
+          } else {
+            abortCredentialInfoBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000004);
+          return this;
+        }
+
+        @java.lang.Override
+        public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CreateMultipartUpload_Response_descriptor;
+        }
+
+        @java.lang.Override
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response getDefaultInstanceForType() {
+          return com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response.getDefaultInstance();
+        }
+
+        @java.lang.Override
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response build() {
+          com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        @java.lang.Override
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response buildPartial() {
+          com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response result = new com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response(this);
+          int from_bitField0_ = bitField0_;
+          int to_bitField0_ = 0;
+          if (((from_bitField0_ & 0x00000001) != 0)) {
+            to_bitField0_ |= 0x00000001;
+          }
+          result.uploadId_ = uploadId_;
+          if (uploadCredentialInfosBuilder_ == null) {
+            if (((bitField0_ & 0x00000002) != 0)) {
+              uploadCredentialInfos_ = java.util.Collections.unmodifiableList(uploadCredentialInfos_);
+              bitField0_ = (bitField0_ & ~0x00000002);
+            }
+            result.uploadCredentialInfos_ = uploadCredentialInfos_;
+          } else {
+            result.uploadCredentialInfos_ = uploadCredentialInfosBuilder_.build();
+          }
+          if (((from_bitField0_ & 0x00000004) != 0)) {
+            if (abortCredentialInfoBuilder_ == null) {
+              result.abortCredentialInfo_ = abortCredentialInfo_;
+            } else {
+              result.abortCredentialInfo_ = abortCredentialInfoBuilder_.build();
+            }
+            to_bitField0_ |= 0x00000002;
+          }
+          result.bitField0_ = to_bitField0_;
+          onBuilt();
+          return result;
+        }
+
+        @java.lang.Override
+        public Builder clone() {
+          return super.clone();
+        }
+        @java.lang.Override
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return super.setField(field, value);
+        }
+        @java.lang.Override
+        public Builder clearField(
+            com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return super.clearField(field);
+        }
+        @java.lang.Override
+        public Builder clearOneof(
+            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return super.clearOneof(oneof);
+        }
+        @java.lang.Override
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index, java.lang.Object value) {
+          return super.setRepeatedField(field, index, value);
+        }
+        @java.lang.Override
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return super.addRepeatedField(field, value);
+        }
+        @java.lang.Override
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response) {
+            return mergeFrom((com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response other) {
+          if (other == com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response.getDefaultInstance()) return this;
+          if (other.hasUploadId()) {
+            bitField0_ |= 0x00000001;
+            uploadId_ = other.uploadId_;
+            onChanged();
+          }
+          if (uploadCredentialInfosBuilder_ == null) {
+            if (!other.uploadCredentialInfos_.isEmpty()) {
+              if (uploadCredentialInfos_.isEmpty()) {
+                uploadCredentialInfos_ = other.uploadCredentialInfos_;
+                bitField0_ = (bitField0_ & ~0x00000002);
+              } else {
+                ensureUploadCredentialInfosIsMutable();
+                uploadCredentialInfos_.addAll(other.uploadCredentialInfos_);
+              }
+              onChanged();
+            }
+          } else {
+            if (!other.uploadCredentialInfos_.isEmpty()) {
+              if (uploadCredentialInfosBuilder_.isEmpty()) {
+                uploadCredentialInfosBuilder_.dispose();
+                uploadCredentialInfosBuilder_ = null;
+                uploadCredentialInfos_ = other.uploadCredentialInfos_;
+                bitField0_ = (bitField0_ & ~0x00000002);
+                uploadCredentialInfosBuilder_ = 
+                  com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                     getUploadCredentialInfosFieldBuilder() : null;
+              } else {
+                uploadCredentialInfosBuilder_.addAllMessages(other.uploadCredentialInfos_);
+              }
+            }
+          }
+          if (other.hasAbortCredentialInfo()) {
+            mergeAbortCredentialInfo(other.getAbortCredentialInfo());
+          }
+          this.mergeUnknownFields(other.unknownFields);
+          onChanged();
+          return this;
+        }
+
+        @java.lang.Override
+        public final boolean isInitialized() {
+          return true;
+        }
+
+        @java.lang.Override
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response) e.getUnfinishedMessage();
+            throw e.unwrapIOException();
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        private int bitField0_;
+
+        private java.lang.Object uploadId_ = "";
+        /**
+         * <pre>
+         * ID identifying the initiated multipart upload
+         * </pre>
+         *
+         * <code>optional string upload_id = 1;</code>
+         * @return Whether the uploadId field is set.
+         */
+        public boolean hasUploadId() {
+          return ((bitField0_ & 0x00000001) != 0);
+        }
+        /**
+         * <pre>
+         * ID identifying the initiated multipart upload
+         * </pre>
+         *
+         * <code>optional string upload_id = 1;</code>
+         * @return The uploadId.
+         */
+        public java.lang.String getUploadId() {
+          java.lang.Object ref = uploadId_;
+          if (!(ref instanceof java.lang.String)) {
+            com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            if (bs.isValidUtf8()) {
+              uploadId_ = s;
+            }
+            return s;
+          } else {
+            return (java.lang.String) ref;
+          }
+        }
+        /**
+         * <pre>
+         * ID identifying the initiated multipart upload
+         * </pre>
+         *
+         * <code>optional string upload_id = 1;</code>
+         * @return The bytes for uploadId.
+         */
+        public com.google.protobuf.ByteString
+            getUploadIdBytes() {
+          java.lang.Object ref = uploadId_;
+          if (ref instanceof String) {
+            com.google.protobuf.ByteString b = 
+                com.google.protobuf.ByteString.copyFromUtf8(
+                    (java.lang.String) ref);
+            uploadId_ = b;
+            return b;
+          } else {
+            return (com.google.protobuf.ByteString) ref;
+          }
+        }
+        /**
+         * <pre>
+         * ID identifying the initiated multipart upload
+         * </pre>
+         *
+         * <code>optional string upload_id = 1;</code>
+         * @param value The uploadId to set.
+         * @return This builder for chaining.
+         */
+        public Builder setUploadId(
+            java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+          uploadId_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <pre>
+         * ID identifying the initiated multipart upload
+         * </pre>
+         *
+         * <code>optional string upload_id = 1;</code>
+         * @return This builder for chaining.
+         */
+        public Builder clearUploadId() {
+          bitField0_ = (bitField0_ & ~0x00000001);
+          uploadId_ = getDefaultInstance().getUploadId();
+          onChanged();
+          return this;
+        }
+        /**
+         * <pre>
+         * ID identifying the initiated multipart upload
+         * </pre>
+         *
+         * <code>optional string upload_id = 1;</code>
+         * @param value The bytes for uploadId to set.
+         * @return This builder for chaining.
+         */
+        public Builder setUploadIdBytes(
+            com.google.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+          uploadId_ = value;
+          onChanged();
+          return this;
+        }
+
+        private java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> uploadCredentialInfos_ =
+          java.util.Collections.emptyList();
+        private void ensureUploadCredentialInfosIsMutable() {
+          if (!((bitField0_ & 0x00000002) != 0)) {
+            uploadCredentialInfos_ = new java.util.ArrayList<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo>(uploadCredentialInfos_);
+            bitField0_ |= 0x00000002;
+           }
+        }
+
+        private com.google.protobuf.RepeatedFieldBuilderV3<
+            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> uploadCredentialInfosBuilder_;
+
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> getUploadCredentialInfosList() {
+          if (uploadCredentialInfosBuilder_ == null) {
+            return java.util.Collections.unmodifiableList(uploadCredentialInfos_);
+          } else {
+            return uploadCredentialInfosBuilder_.getMessageList();
+          }
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public int getUploadCredentialInfosCount() {
+          if (uploadCredentialInfosBuilder_ == null) {
+            return uploadCredentialInfos_.size();
+          } else {
+            return uploadCredentialInfosBuilder_.getCount();
+          }
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getUploadCredentialInfos(int index) {
+          if (uploadCredentialInfosBuilder_ == null) {
+            return uploadCredentialInfos_.get(index);
+          } else {
+            return uploadCredentialInfosBuilder_.getMessage(index);
+          }
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public Builder setUploadCredentialInfos(
+            int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
+          if (uploadCredentialInfosBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            ensureUploadCredentialInfosIsMutable();
+            uploadCredentialInfos_.set(index, value);
+            onChanged();
+          } else {
+            uploadCredentialInfosBuilder_.setMessage(index, value);
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public Builder setUploadCredentialInfos(
+            int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder builderForValue) {
+          if (uploadCredentialInfosBuilder_ == null) {
+            ensureUploadCredentialInfosIsMutable();
+            uploadCredentialInfos_.set(index, builderForValue.build());
+            onChanged();
+          } else {
+            uploadCredentialInfosBuilder_.setMessage(index, builderForValue.build());
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public Builder addUploadCredentialInfos(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
+          if (uploadCredentialInfosBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            ensureUploadCredentialInfosIsMutable();
+            uploadCredentialInfos_.add(value);
+            onChanged();
+          } else {
+            uploadCredentialInfosBuilder_.addMessage(value);
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public Builder addUploadCredentialInfos(
+            int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
+          if (uploadCredentialInfosBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            ensureUploadCredentialInfosIsMutable();
+            uploadCredentialInfos_.add(index, value);
+            onChanged();
+          } else {
+            uploadCredentialInfosBuilder_.addMessage(index, value);
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public Builder addUploadCredentialInfos(
+            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder builderForValue) {
+          if (uploadCredentialInfosBuilder_ == null) {
+            ensureUploadCredentialInfosIsMutable();
+            uploadCredentialInfos_.add(builderForValue.build());
+            onChanged();
+          } else {
+            uploadCredentialInfosBuilder_.addMessage(builderForValue.build());
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public Builder addUploadCredentialInfos(
+            int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder builderForValue) {
+          if (uploadCredentialInfosBuilder_ == null) {
+            ensureUploadCredentialInfosIsMutable();
+            uploadCredentialInfos_.add(index, builderForValue.build());
+            onChanged();
+          } else {
+            uploadCredentialInfosBuilder_.addMessage(index, builderForValue.build());
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public Builder addAllUploadCredentialInfos(
+            java.lang.Iterable<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> values) {
+          if (uploadCredentialInfosBuilder_ == null) {
+            ensureUploadCredentialInfosIsMutable();
+            com.google.protobuf.AbstractMessageLite.Builder.addAll(
+                values, uploadCredentialInfos_);
+            onChanged();
+          } else {
+            uploadCredentialInfosBuilder_.addAllMessages(values);
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public Builder clearUploadCredentialInfos() {
+          if (uploadCredentialInfosBuilder_ == null) {
+            uploadCredentialInfos_ = java.util.Collections.emptyList();
+            bitField0_ = (bitField0_ & ~0x00000002);
+            onChanged();
+          } else {
+            uploadCredentialInfosBuilder_.clear();
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public Builder removeUploadCredentialInfos(int index) {
+          if (uploadCredentialInfosBuilder_ == null) {
+            ensureUploadCredentialInfosIsMutable();
+            uploadCredentialInfos_.remove(index);
+            onChanged();
+          } else {
+            uploadCredentialInfosBuilder_.remove(index);
+          }
+          return this;
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder getUploadCredentialInfosBuilder(
+            int index) {
+          return getUploadCredentialInfosFieldBuilder().getBuilder(index);
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getUploadCredentialInfosOrBuilder(
+            int index) {
+          if (uploadCredentialInfosBuilder_ == null) {
+            return uploadCredentialInfos_.get(index);  } else {
+            return uploadCredentialInfosBuilder_.getMessageOrBuilder(index);
+          }
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public java.util.List<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> 
+             getUploadCredentialInfosOrBuilderList() {
+          if (uploadCredentialInfosBuilder_ != null) {
+            return uploadCredentialInfosBuilder_.getMessageOrBuilderList();
+          } else {
+            return java.util.Collections.unmodifiableList(uploadCredentialInfos_);
+          }
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder addUploadCredentialInfosBuilder() {
+          return getUploadCredentialInfosFieldBuilder().addBuilder(
+              com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance());
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder addUploadCredentialInfosBuilder(
+            int index) {
+          return getUploadCredentialInfosFieldBuilder().addBuilder(
+              index, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance());
+        }
+        /**
+         * <pre>
+         * Credentials for uploading parts in the initiated multipart upload
+         * </pre>
+         *
+         * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
+         */
+        public java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder> 
+             getUploadCredentialInfosBuilderList() {
+          return getUploadCredentialInfosFieldBuilder().getBuilderList();
+        }
+        private com.google.protobuf.RepeatedFieldBuilderV3<
+            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> 
+            getUploadCredentialInfosFieldBuilder() {
+          if (uploadCredentialInfosBuilder_ == null) {
+            uploadCredentialInfosBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder>(
+                    uploadCredentialInfos_,
+                    ((bitField0_ & 0x00000002) != 0),
+                    getParentForChildren(),
+                    isClean());
+            uploadCredentialInfos_ = null;
+          }
+          return uploadCredentialInfosBuilder_;
+        }
+
+        private com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo abortCredentialInfo_;
+        private com.google.protobuf.SingleFieldBuilderV3<
+            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> abortCredentialInfoBuilder_;
+        /**
+         * <pre>
+         * Credential for aborting the initiated multipart upload
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo abort_credential_info = 3;</code>
+         * @return Whether the abortCredentialInfo field is set.
+         */
+        public boolean hasAbortCredentialInfo() {
+          return ((bitField0_ & 0x00000004) != 0);
+        }
+        /**
+         * <pre>
+         * Credential for aborting the initiated multipart upload
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo abort_credential_info = 3;</code>
+         * @return The abortCredentialInfo.
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getAbortCredentialInfo() {
+          if (abortCredentialInfoBuilder_ == null) {
+            return abortCredentialInfo_ == null ? com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : abortCredentialInfo_;
+          } else {
+            return abortCredentialInfoBuilder_.getMessage();
+          }
+        }
+        /**
+         * <pre>
+         * Credential for aborting the initiated multipart upload
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo abort_credential_info = 3;</code>
+         */
+        public Builder setAbortCredentialInfo(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
+          if (abortCredentialInfoBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            abortCredentialInfo_ = value;
+            onChanged();
+          } else {
+            abortCredentialInfoBuilder_.setMessage(value);
+          }
+          bitField0_ |= 0x00000004;
+          return this;
+        }
+        /**
+         * <pre>
+         * Credential for aborting the initiated multipart upload
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo abort_credential_info = 3;</code>
+         */
+        public Builder setAbortCredentialInfo(
+            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder builderForValue) {
+          if (abortCredentialInfoBuilder_ == null) {
+            abortCredentialInfo_ = builderForValue.build();
+            onChanged();
+          } else {
+            abortCredentialInfoBuilder_.setMessage(builderForValue.build());
+          }
+          bitField0_ |= 0x00000004;
+          return this;
+        }
+        /**
+         * <pre>
+         * Credential for aborting the initiated multipart upload
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo abort_credential_info = 3;</code>
+         */
+        public Builder mergeAbortCredentialInfo(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
+          if (abortCredentialInfoBuilder_ == null) {
+            if (((bitField0_ & 0x00000004) != 0) &&
+                abortCredentialInfo_ != null &&
+                abortCredentialInfo_ != com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance()) {
+              abortCredentialInfo_ =
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.newBuilder(abortCredentialInfo_).mergeFrom(value).buildPartial();
+            } else {
+              abortCredentialInfo_ = value;
+            }
+            onChanged();
+          } else {
+            abortCredentialInfoBuilder_.mergeFrom(value);
+          }
+          bitField0_ |= 0x00000004;
+          return this;
+        }
+        /**
+         * <pre>
+         * Credential for aborting the initiated multipart upload
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo abort_credential_info = 3;</code>
+         */
+        public Builder clearAbortCredentialInfo() {
+          if (abortCredentialInfoBuilder_ == null) {
+            abortCredentialInfo_ = null;
+            onChanged();
+          } else {
+            abortCredentialInfoBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000004);
+          return this;
+        }
+        /**
+         * <pre>
+         * Credential for aborting the initiated multipart upload
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo abort_credential_info = 3;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder getAbortCredentialInfoBuilder() {
+          bitField0_ |= 0x00000004;
+          onChanged();
+          return getAbortCredentialInfoFieldBuilder().getBuilder();
+        }
+        /**
+         * <pre>
+         * Credential for aborting the initiated multipart upload
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo abort_credential_info = 3;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getAbortCredentialInfoOrBuilder() {
+          if (abortCredentialInfoBuilder_ != null) {
+            return abortCredentialInfoBuilder_.getMessageOrBuilder();
+          } else {
+            return abortCredentialInfo_ == null ?
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : abortCredentialInfo_;
+          }
+        }
+        /**
+         * <pre>
+         * Credential for aborting the initiated multipart upload
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo abort_credential_info = 3;</code>
+         */
+        private com.google.protobuf.SingleFieldBuilderV3<
+            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> 
+            getAbortCredentialInfoFieldBuilder() {
+          if (abortCredentialInfoBuilder_ == null) {
+            abortCredentialInfoBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder>(
+                    getAbortCredentialInfo(),
+                    getParentForChildren(),
+                    isClean());
+            abortCredentialInfo_ = null;
+          }
+          return abortCredentialInfoBuilder_;
+        }
+        @java.lang.Override
+        public final Builder setUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.setUnknownFields(unknownFields);
+        }
+
+        @java.lang.Override
+        public final Builder mergeUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.mergeUnknownFields(unknownFields);
+        }
+
+
+        // @@protoc_insertion_point(builder_scope:mlflow.CreateMultipartUpload.Response)
+      }
+
+      // @@protoc_insertion_point(class_scope:mlflow.CreateMultipartUpload.Response)
+      private static final com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response DEFAULT_INSTANCE;
+      static {
+        DEFAULT_INSTANCE = new com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response();
+      }
+
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+      }
+
+      @java.lang.Deprecated public static final com.google.protobuf.Parser<Response>
+          PARSER = new com.google.protobuf.AbstractParser<Response>() {
+        @java.lang.Override
+        public Response parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new Response(input, extensionRegistry);
+        }
+      };
+
+      public static com.google.protobuf.Parser<Response> parser() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<Response> getParserForType() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Response getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+      }
+
+    }
+
+    private int bitField0_;
+    public static final int RUN_ID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object runId_;
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the runId field is set.
+     */
+    @java.lang.Override
+    public boolean hasRunId() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The runId.
+     */
+    @java.lang.Override
+    public java.lang.String getRunId() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          runId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for runId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getRunIdBytes() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        runId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int PATH_FIELD_NUMBER = 2;
+    private volatile java.lang.Object path_;
+    /**
+     * <pre>
+     * Artifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return Whether the path field is set.
+     */
+    @java.lang.Override
+    public boolean hasPath() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <pre>
+     * Artifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return The path.
+     */
+    @java.lang.Override
+    public java.lang.String getPath() {
+      java.lang.Object ref = path_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          path_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Artifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return The bytes for path.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getPathBytes() {
+      java.lang.Object ref = path_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        path_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int NUM_PARTS_FIELD_NUMBER = 3;
+    private long numParts_;
+    /**
+     * <pre>
+     * Number of parts to upload in the initiated multipart upload
+     * </pre>
+     *
+     * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the numParts field is set.
+     */
+    @java.lang.Override
+    public boolean hasNumParts() {
+      return ((bitField0_ & 0x00000004) != 0);
+    }
+    /**
+     * <pre>
+     * Number of parts to upload in the initiated multipart upload
+     * </pre>
+     *
+     * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
+     * @return The numParts.
+     */
+    @java.lang.Override
+    public long getNumParts() {
+      return numParts_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runId_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, path_);
+      }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        output.writeInt64(3, numParts_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, runId_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, path_);
+      }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(3, numParts_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload)) {
+        return super.equals(obj);
+      }
+      com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload other = (com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload) obj;
+
+      if (hasRunId() != other.hasRunId()) return false;
+      if (hasRunId()) {
+        if (!getRunId()
+            .equals(other.getRunId())) return false;
+      }
+      if (hasPath() != other.hasPath()) return false;
+      if (hasPath()) {
+        if (!getPath()
+            .equals(other.getPath())) return false;
+      }
+      if (hasNumParts() != other.hasNumParts()) return false;
+      if (hasNumParts()) {
+        if (getNumParts()
+            != other.getNumParts()) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasRunId()) {
+        hash = (37 * hash) + RUN_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getRunId().hashCode();
+      }
+      if (hasPath()) {
+        hash = (37 * hash) + PATH_FIELD_NUMBER;
+        hash = (53 * hash) + getPath().hashCode();
+      }
+      if (hasNumParts()) {
+        hash = (37 * hash) + NUM_PARTS_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getNumParts());
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mlflow.CreateMultipartUpload}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mlflow.CreateMultipartUpload)
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUploadOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CreateMultipartUpload_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CreateMultipartUpload_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.class, com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.Builder.class);
+      }
+
+      // Construct using com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        runId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        path_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        numParts_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CreateMultipartUpload_descriptor;
+      }
+
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload getDefaultInstanceForType() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload build() {
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload buildPartial() {
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload result = new com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.runId_ = runId_;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.path_ = path_;
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.numParts_ = numParts_;
+          to_bitField0_ |= 0x00000004;
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload) {
+          return mergeFrom((com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload other) {
+        if (other == com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload.getDefaultInstance()) return this;
+        if (other.hasRunId()) {
+          bitField0_ |= 0x00000001;
+          runId_ = other.runId_;
+          onChanged();
+        }
+        if (other.hasPath()) {
+          bitField0_ |= 0x00000002;
+          path_ = other.path_;
+          onChanged();
+        }
+        if (other.hasNumParts()) {
+          setNumParts(other.getNumParts());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object runId_ = "";
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @return Whether the runId field is set.
+       */
+      public boolean hasRunId() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @return The runId.
+       */
+      public java.lang.String getRunId() {
+        java.lang.Object ref = runId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            runId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @return The bytes for runId.
+       */
+      public com.google.protobuf.ByteString
+          getRunIdBytes() {
+        java.lang.Object ref = runId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          runId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @param value The runId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRunId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearRunId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        runId_ = getDefaultInstance().getRunId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @param value The bytes for runId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRunIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object path_ = "";
+      /**
+       * <pre>
+       * Artifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @return Whether the path field is set.
+       */
+      public boolean hasPath() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <pre>
+       * Artifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @return The path.
+       */
+      public java.lang.String getPath() {
+        java.lang.Object ref = path_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            path_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Artifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @return The bytes for path.
+       */
+      public com.google.protobuf.ByteString
+          getPathBytes() {
+        java.lang.Object ref = path_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          path_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Artifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @param value The path to set.
+       * @return This builder for chaining.
+       */
+      public Builder setPath(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        path_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Artifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearPath() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        path_ = getDefaultInstance().getPath();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Artifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @param value The bytes for path to set.
+       * @return This builder for chaining.
+       */
+      public Builder setPathBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        path_ = value;
+        onChanged();
+        return this;
+      }
+
+      private long numParts_ ;
+      /**
+       * <pre>
+       * Number of parts to upload in the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
+       * @return Whether the numParts field is set.
+       */
+      @java.lang.Override
+      public boolean hasNumParts() {
+        return ((bitField0_ & 0x00000004) != 0);
+      }
+      /**
+       * <pre>
+       * Number of parts to upload in the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
+       * @return The numParts.
+       */
+      @java.lang.Override
+      public long getNumParts() {
+        return numParts_;
+      }
+      /**
+       * <pre>
+       * Number of parts to upload in the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
+       * @param value The numParts to set.
+       * @return This builder for chaining.
+       */
+      public Builder setNumParts(long value) {
+        bitField0_ |= 0x00000004;
+        numParts_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Number of parts to upload in the initiated multipart upload
+       * </pre>
+       *
+       * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearNumParts() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        numParts_ = 0L;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:mlflow.CreateMultipartUpload)
+    }
+
+    // @@protoc_insertion_point(class_scope:mlflow.CreateMultipartUpload)
+    private static final com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload();
+    }
+
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<CreateMultipartUpload>
+        PARSER = new com.google.protobuf.AbstractParser<CreateMultipartUpload>() {
+      @java.lang.Override
+      public CreateMultipartUpload parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new CreateMultipartUpload(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<CreateMultipartUpload> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<CreateMultipartUpload> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.databricks.api.proto.mlflow.DatabricksArtifacts.CreateMultipartUpload getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface PartEtagOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mlflow.PartEtag)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional int64 part_number = 1;</code>
+     * @return Whether the partNumber field is set.
+     */
+    boolean hasPartNumber();
+    /**
+     * <code>optional int64 part_number = 1;</code>
+     * @return The partNumber.
+     */
+    long getPartNumber();
+
+    /**
+     * <code>optional string etag = 2;</code>
+     * @return Whether the etag field is set.
+     */
+    boolean hasEtag();
+    /**
+     * <code>optional string etag = 2;</code>
+     * @return The etag.
+     */
+    java.lang.String getEtag();
+    /**
+     * <code>optional string etag = 2;</code>
+     * @return The bytes for etag.
+     */
+    com.google.protobuf.ByteString
+        getEtagBytes();
+  }
+  /**
+   * Protobuf type {@code mlflow.PartEtag}
+   */
+  public static final class PartEtag extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:mlflow.PartEtag)
+      PartEtagOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use PartEtag.newBuilder() to construct.
+    private PartEtag(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private PartEtag() {
+      etag_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new PartEtag();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private PartEtag(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 8: {
+              bitField0_ |= 0x00000001;
+              partNumber_ = input.readInt64();
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              etag_ = bs;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_PartEtag_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_PartEtag_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.class, com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int PART_NUMBER_FIELD_NUMBER = 1;
+    private long partNumber_;
+    /**
+     * <code>optional int64 part_number = 1;</code>
+     * @return Whether the partNumber field is set.
+     */
+    @java.lang.Override
+    public boolean hasPartNumber() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>optional int64 part_number = 1;</code>
+     * @return The partNumber.
+     */
+    @java.lang.Override
+    public long getPartNumber() {
+      return partNumber_;
+    }
+
+    public static final int ETAG_FIELD_NUMBER = 2;
+    private volatile java.lang.Object etag_;
+    /**
+     * <code>optional string etag = 2;</code>
+     * @return Whether the etag field is set.
+     */
+    @java.lang.Override
+    public boolean hasEtag() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <code>optional string etag = 2;</code>
+     * @return The etag.
+     */
+    @java.lang.Override
+    public java.lang.String getEtag() {
+      java.lang.Object ref = etag_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          etag_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string etag = 2;</code>
+     * @return The bytes for etag.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getEtagBytes() {
+      java.lang.Object ref = etag_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        etag_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeInt64(1, partNumber_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, etag_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(1, partNumber_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, etag_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag)) {
+        return super.equals(obj);
+      }
+      com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag other = (com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag) obj;
+
+      if (hasPartNumber() != other.hasPartNumber()) return false;
+      if (hasPartNumber()) {
+        if (getPartNumber()
+            != other.getPartNumber()) return false;
+      }
+      if (hasEtag() != other.hasEtag()) return false;
+      if (hasEtag()) {
+        if (!getEtag()
+            .equals(other.getEtag())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasPartNumber()) {
+        hash = (37 * hash) + PART_NUMBER_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getPartNumber());
+      }
+      if (hasEtag()) {
+        hash = (37 * hash) + ETAG_FIELD_NUMBER;
+        hash = (53 * hash) + getEtag().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mlflow.PartEtag}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mlflow.PartEtag)
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtagOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_PartEtag_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_PartEtag_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.class, com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.Builder.class);
+      }
+
+      // Construct using com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        partNumber_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        etag_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_PartEtag_descriptor;
+      }
+
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag getDefaultInstanceForType() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag build() {
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag buildPartial() {
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag result = new com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.partNumber_ = partNumber_;
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.etag_ = etag_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag) {
+          return mergeFrom((com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag other) {
+        if (other == com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.getDefaultInstance()) return this;
+        if (other.hasPartNumber()) {
+          setPartNumber(other.getPartNumber());
+        }
+        if (other.hasEtag()) {
+          bitField0_ |= 0x00000002;
+          etag_ = other.etag_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private long partNumber_ ;
+      /**
+       * <code>optional int64 part_number = 1;</code>
+       * @return Whether the partNumber field is set.
+       */
+      @java.lang.Override
+      public boolean hasPartNumber() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>optional int64 part_number = 1;</code>
+       * @return The partNumber.
+       */
+      @java.lang.Override
+      public long getPartNumber() {
+        return partNumber_;
+      }
+      /**
+       * <code>optional int64 part_number = 1;</code>
+       * @param value The partNumber to set.
+       * @return This builder for chaining.
+       */
+      public Builder setPartNumber(long value) {
+        bitField0_ |= 0x00000001;
+        partNumber_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 part_number = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearPartNumber() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        partNumber_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object etag_ = "";
+      /**
+       * <code>optional string etag = 2;</code>
+       * @return Whether the etag field is set.
+       */
+      public boolean hasEtag() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <code>optional string etag = 2;</code>
+       * @return The etag.
+       */
+      public java.lang.String getEtag() {
+        java.lang.Object ref = etag_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            etag_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string etag = 2;</code>
+       * @return The bytes for etag.
+       */
+      public com.google.protobuf.ByteString
+          getEtagBytes() {
+        java.lang.Object ref = etag_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          etag_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string etag = 2;</code>
+       * @param value The etag to set.
+       * @return This builder for chaining.
+       */
+      public Builder setEtag(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        etag_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string etag = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearEtag() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        etag_ = getDefaultInstance().getEtag();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string etag = 2;</code>
+       * @param value The bytes for etag to set.
+       * @return This builder for chaining.
+       */
+      public Builder setEtagBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        etag_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:mlflow.PartEtag)
+    }
+
+    // @@protoc_insertion_point(class_scope:mlflow.PartEtag)
+    private static final com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag();
+    }
+
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<PartEtag>
+        PARSER = new com.google.protobuf.AbstractParser<PartEtag>() {
+      @java.lang.Override
+      public PartEtag parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new PartEtag(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<PartEtag> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<PartEtag> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface CompleteMultipartUploadOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mlflow.CompleteMultipartUpload)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the runId field is set.
+     */
+    boolean hasRunId();
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The runId.
+     */
+    java.lang.String getRunId();
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for runId.
+     */
+    com.google.protobuf.ByteString
+        getRunIdBytes();
+
+    /**
+     * <pre>
+     * Artifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return Whether the path field is set.
+     */
+    boolean hasPath();
+    /**
+     * <pre>
+     * Artifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return The path.
+     */
+    java.lang.String getPath();
+    /**
+     * <pre>
+     * Artifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return The bytes for path.
+     */
+    com.google.protobuf.ByteString
+        getPathBytes();
+
+    /**
+     * <pre>
+     * ID identifying the multipart upload to complete
+     * </pre>
+     *
+     * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the uploadId field is set.
+     */
+    boolean hasUploadId();
+    /**
+     * <pre>
+     * ID identifying the multipart upload to complete
+     * </pre>
+     *
+     * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+     * @return The uploadId.
+     */
+    java.lang.String getUploadId();
+    /**
+     * <pre>
+     * ID identifying the multipart upload to complete
+     * </pre>
+     *
+     * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for uploadId.
+     */
+    com.google.protobuf.ByteString
+        getUploadIdBytes();
+
+    /**
+     * <pre>
+     * A list of parts uploaded in the multipart upload to complete
+     * </pre>
+     *
+     * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+     */
+    java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag> 
+        getPartEtagsList();
+    /**
+     * <pre>
+     * A list of parts uploaded in the multipart upload to complete
+     * </pre>
+     *
+     * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+     */
+    com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag getPartEtags(int index);
+    /**
+     * <pre>
+     * A list of parts uploaded in the multipart upload to complete
+     * </pre>
+     *
+     * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+     */
+    int getPartEtagsCount();
+    /**
+     * <pre>
+     * A list of parts uploaded in the multipart upload to complete
+     * </pre>
+     *
+     * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+     */
+    java.util.List<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtagOrBuilder> 
+        getPartEtagsOrBuilderList();
+    /**
+     * <pre>
+     * A list of parts uploaded in the multipart upload to complete
+     * </pre>
+     *
+     * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+     */
+    com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtagOrBuilder getPartEtagsOrBuilder(
+        int index);
+  }
+  /**
+   * Protobuf type {@code mlflow.CompleteMultipartUpload}
+   */
+  public static final class CompleteMultipartUpload extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:mlflow.CompleteMultipartUpload)
+      CompleteMultipartUploadOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use CompleteMultipartUpload.newBuilder() to construct.
+    private CompleteMultipartUpload(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private CompleteMultipartUpload() {
+      runId_ = "";
+      path_ = "";
+      uploadId_ = "";
+      partEtags_ = java.util.Collections.emptyList();
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new CompleteMultipartUpload();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private CompleteMultipartUpload(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              runId_ = bs;
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              path_ = bs;
+              break;
+            }
+            case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000004;
+              uploadId_ = bs;
+              break;
+            }
+            case 34: {
+              if (!((mutable_bitField0_ & 0x00000008) != 0)) {
+                partEtags_ = new java.util.ArrayList<com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag>();
+                mutable_bitField0_ |= 0x00000008;
+              }
+              partEtags_.add(
+                  input.readMessage(com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.PARSER, extensionRegistry));
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000008) != 0)) {
+          partEtags_ = java.util.Collections.unmodifiableList(partEtags_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CompleteMultipartUpload_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CompleteMultipartUpload_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.class, com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Builder.class);
+    }
+
+    public interface ResponseOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mlflow.CompleteMultipartUpload.Response)
+        com.google.protobuf.MessageOrBuilder {
+    }
+    /**
+     * Protobuf type {@code mlflow.CompleteMultipartUpload.Response}
+     */
+    public static final class Response extends
+        com.google.protobuf.GeneratedMessageV3 implements
+        // @@protoc_insertion_point(message_implements:mlflow.CompleteMultipartUpload.Response)
+        ResponseOrBuilder {
+    private static final long serialVersionUID = 0L;
+      // Use Response.newBuilder() to construct.
+      private Response(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+        super(builder);
+      }
+      private Response() {
+      }
+
+      @java.lang.Override
+      @SuppressWarnings({"unused"})
+      protected java.lang.Object newInstance(
+          UnusedPrivateParameter unused) {
+        return new Response();
+      }
+
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+      getUnknownFields() {
+        return this.unknownFields;
+      }
+      private Response(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!parseUnknownField(
+                    input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
+        } finally {
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CompleteMultipartUpload_Response_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CompleteMultipartUpload_Response_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response.class, com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response.Builder.class);
+      }
+
+      private byte memoizedIsInitialized = -1;
+      @java.lang.Override
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      @java.lang.Override
+      public void writeTo(com.google.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        unknownFields.writeTo(output);
+      }
+
+      @java.lang.Override
+      public int getSerializedSize() {
+        int size = memoizedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        size += unknownFields.getSerializedSize();
+        memoizedSize = size;
+        return size;
+      }
+
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+         return true;
+        }
+        if (!(obj instanceof com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response)) {
+          return super.equals(obj);
+        }
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response other = (com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response) obj;
+
+        if (!unknownFields.equals(other.unknownFields)) return false;
+        return true;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptor().hashCode();
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response parseFrom(
+          java.nio.ByteBuffer data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response parseFrom(
+          java.nio.ByteBuffer data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response parseFrom(byte[] data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response parseFrom(
+          byte[] data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response parseFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response parseDelimitedFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response parseFrom(
+          com.google.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+
+      @java.lang.Override
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder() {
+        return DEFAULT_INSTANCE.toBuilder();
+      }
+      public static Builder newBuilder(com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response prototype) {
+        return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+      }
+      @java.lang.Override
+      public Builder toBuilder() {
+        return this == DEFAULT_INSTANCE
+            ? new Builder() : new Builder().mergeFrom(this);
+      }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * Protobuf type {@code mlflow.CompleteMultipartUpload.Response}
+       */
+      public static final class Builder extends
+          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mlflow.CompleteMultipartUpload.Response)
+          com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.ResponseOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CompleteMultipartUpload_Response_descriptor;
+        }
+
+        @java.lang.Override
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CompleteMultipartUpload_Response_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response.class, com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response.Builder.class);
+        }
+
+        // Construct using com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
+          }
+        }
+        @java.lang.Override
+        public Builder clear() {
+          super.clear();
+          return this;
+        }
+
+        @java.lang.Override
+        public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CompleteMultipartUpload_Response_descriptor;
+        }
+
+        @java.lang.Override
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response getDefaultInstanceForType() {
+          return com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response.getDefaultInstance();
+        }
+
+        @java.lang.Override
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response build() {
+          com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        @java.lang.Override
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response buildPartial() {
+          com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response result = new com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response(this);
+          onBuilt();
+          return result;
+        }
+
+        @java.lang.Override
+        public Builder clone() {
+          return super.clone();
+        }
+        @java.lang.Override
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return super.setField(field, value);
+        }
+        @java.lang.Override
+        public Builder clearField(
+            com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return super.clearField(field);
+        }
+        @java.lang.Override
+        public Builder clearOneof(
+            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return super.clearOneof(oneof);
+        }
+        @java.lang.Override
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index, java.lang.Object value) {
+          return super.setRepeatedField(field, index, value);
+        }
+        @java.lang.Override
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return super.addRepeatedField(field, value);
+        }
+        @java.lang.Override
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response) {
+            return mergeFrom((com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response other) {
+          if (other == com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response.getDefaultInstance()) return this;
+          this.mergeUnknownFields(other.unknownFields);
+          onChanged();
+          return this;
+        }
+
+        @java.lang.Override
+        public final boolean isInitialized() {
+          return true;
+        }
+
+        @java.lang.Override
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response) e.getUnfinishedMessage();
+            throw e.unwrapIOException();
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        @java.lang.Override
+        public final Builder setUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.setUnknownFields(unknownFields);
+        }
+
+        @java.lang.Override
+        public final Builder mergeUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.mergeUnknownFields(unknownFields);
+        }
+
+
+        // @@protoc_insertion_point(builder_scope:mlflow.CompleteMultipartUpload.Response)
+      }
+
+      // @@protoc_insertion_point(class_scope:mlflow.CompleteMultipartUpload.Response)
+      private static final com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response DEFAULT_INSTANCE;
+      static {
+        DEFAULT_INSTANCE = new com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response();
+      }
+
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+      }
+
+      @java.lang.Deprecated public static final com.google.protobuf.Parser<Response>
+          PARSER = new com.google.protobuf.AbstractParser<Response>() {
+        @java.lang.Override
+        public Response parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new Response(input, extensionRegistry);
+        }
+      };
+
+      public static com.google.protobuf.Parser<Response> parser() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<Response> getParserForType() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Response getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+      }
+
+    }
+
+    private int bitField0_;
+    public static final int RUN_ID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object runId_;
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the runId field is set.
+     */
+    @java.lang.Override
+    public boolean hasRunId() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The runId.
+     */
+    @java.lang.Override
+    public java.lang.String getRunId() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          runId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for runId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getRunIdBytes() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        runId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int PATH_FIELD_NUMBER = 2;
+    private volatile java.lang.Object path_;
+    /**
+     * <pre>
+     * Artifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return Whether the path field is set.
+     */
+    @java.lang.Override
+    public boolean hasPath() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <pre>
+     * Artifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return The path.
+     */
+    @java.lang.Override
+    public java.lang.String getPath() {
+      java.lang.Object ref = path_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          path_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Artifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return The bytes for path.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getPathBytes() {
+      java.lang.Object ref = path_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        path_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int UPLOAD_ID_FIELD_NUMBER = 3;
+    private volatile java.lang.Object uploadId_;
+    /**
+     * <pre>
+     * ID identifying the multipart upload to complete
+     * </pre>
+     *
+     * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the uploadId field is set.
+     */
+    @java.lang.Override
+    public boolean hasUploadId() {
+      return ((bitField0_ & 0x00000004) != 0);
+    }
+    /**
+     * <pre>
+     * ID identifying the multipart upload to complete
+     * </pre>
+     *
+     * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+     * @return The uploadId.
+     */
+    @java.lang.Override
+    public java.lang.String getUploadId() {
+      java.lang.Object ref = uploadId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          uploadId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * ID identifying the multipart upload to complete
+     * </pre>
+     *
+     * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for uploadId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getUploadIdBytes() {
+      java.lang.Object ref = uploadId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        uploadId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int PART_ETAGS_FIELD_NUMBER = 4;
+    private java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag> partEtags_;
+    /**
+     * <pre>
+     * A list of parts uploaded in the multipart upload to complete
+     * </pre>
+     *
+     * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+     */
+    @java.lang.Override
+    public java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag> getPartEtagsList() {
+      return partEtags_;
+    }
+    /**
+     * <pre>
+     * A list of parts uploaded in the multipart upload to complete
+     * </pre>
+     *
+     * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+     */
+    @java.lang.Override
+    public java.util.List<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtagOrBuilder> 
+        getPartEtagsOrBuilderList() {
+      return partEtags_;
+    }
+    /**
+     * <pre>
+     * A list of parts uploaded in the multipart upload to complete
+     * </pre>
+     *
+     * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+     */
+    @java.lang.Override
+    public int getPartEtagsCount() {
+      return partEtags_.size();
+    }
+    /**
+     * <pre>
+     * A list of parts uploaded in the multipart upload to complete
+     * </pre>
+     *
+     * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+     */
+    @java.lang.Override
+    public com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag getPartEtags(int index) {
+      return partEtags_.get(index);
+    }
+    /**
+     * <pre>
+     * A list of parts uploaded in the multipart upload to complete
+     * </pre>
+     *
+     * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+     */
+    @java.lang.Override
+    public com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtagOrBuilder getPartEtagsOrBuilder(
+        int index) {
+      return partEtags_.get(index);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runId_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, path_);
+      }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, uploadId_);
+      }
+      for (int i = 0; i < partEtags_.size(); i++) {
+        output.writeMessage(4, partEtags_.get(i));
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, runId_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, path_);
+      }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, uploadId_);
+      }
+      for (int i = 0; i < partEtags_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(4, partEtags_.get(i));
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload)) {
+        return super.equals(obj);
+      }
+      com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload other = (com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload) obj;
+
+      if (hasRunId() != other.hasRunId()) return false;
+      if (hasRunId()) {
+        if (!getRunId()
+            .equals(other.getRunId())) return false;
+      }
+      if (hasPath() != other.hasPath()) return false;
+      if (hasPath()) {
+        if (!getPath()
+            .equals(other.getPath())) return false;
+      }
+      if (hasUploadId() != other.hasUploadId()) return false;
+      if (hasUploadId()) {
+        if (!getUploadId()
+            .equals(other.getUploadId())) return false;
+      }
+      if (!getPartEtagsList()
+          .equals(other.getPartEtagsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasRunId()) {
+        hash = (37 * hash) + RUN_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getRunId().hashCode();
+      }
+      if (hasPath()) {
+        hash = (37 * hash) + PATH_FIELD_NUMBER;
+        hash = (53 * hash) + getPath().hashCode();
+      }
+      if (hasUploadId()) {
+        hash = (37 * hash) + UPLOAD_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getUploadId().hashCode();
+      }
+      if (getPartEtagsCount() > 0) {
+        hash = (37 * hash) + PART_ETAGS_FIELD_NUMBER;
+        hash = (53 * hash) + getPartEtagsList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mlflow.CompleteMultipartUpload}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mlflow.CompleteMultipartUpload)
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUploadOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CompleteMultipartUpload_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CompleteMultipartUpload_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.class, com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.Builder.class);
+      }
+
+      // Construct using com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+          getPartEtagsFieldBuilder();
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        runId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        path_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        uploadId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000004);
+        if (partEtagsBuilder_ == null) {
+          partEtags_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000008);
+        } else {
+          partEtagsBuilder_.clear();
+        }
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_CompleteMultipartUpload_descriptor;
+      }
+
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload getDefaultInstanceForType() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload build() {
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload buildPartial() {
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload result = new com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.runId_ = runId_;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.path_ = path_;
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.uploadId_ = uploadId_;
+        if (partEtagsBuilder_ == null) {
+          if (((bitField0_ & 0x00000008) != 0)) {
+            partEtags_ = java.util.Collections.unmodifiableList(partEtags_);
+            bitField0_ = (bitField0_ & ~0x00000008);
+          }
+          result.partEtags_ = partEtags_;
+        } else {
+          result.partEtags_ = partEtagsBuilder_.build();
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload) {
+          return mergeFrom((com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload other) {
+        if (other == com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload.getDefaultInstance()) return this;
+        if (other.hasRunId()) {
+          bitField0_ |= 0x00000001;
+          runId_ = other.runId_;
+          onChanged();
+        }
+        if (other.hasPath()) {
+          bitField0_ |= 0x00000002;
+          path_ = other.path_;
+          onChanged();
+        }
+        if (other.hasUploadId()) {
+          bitField0_ |= 0x00000004;
+          uploadId_ = other.uploadId_;
+          onChanged();
+        }
+        if (partEtagsBuilder_ == null) {
+          if (!other.partEtags_.isEmpty()) {
+            if (partEtags_.isEmpty()) {
+              partEtags_ = other.partEtags_;
+              bitField0_ = (bitField0_ & ~0x00000008);
+            } else {
+              ensurePartEtagsIsMutable();
+              partEtags_.addAll(other.partEtags_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.partEtags_.isEmpty()) {
+            if (partEtagsBuilder_.isEmpty()) {
+              partEtagsBuilder_.dispose();
+              partEtagsBuilder_ = null;
+              partEtags_ = other.partEtags_;
+              bitField0_ = (bitField0_ & ~0x00000008);
+              partEtagsBuilder_ = 
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                   getPartEtagsFieldBuilder() : null;
+            } else {
+              partEtagsBuilder_.addAllMessages(other.partEtags_);
+            }
+          }
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object runId_ = "";
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @return Whether the runId field is set.
+       */
+      public boolean hasRunId() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @return The runId.
+       */
+      public java.lang.String getRunId() {
+        java.lang.Object ref = runId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            runId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @return The bytes for runId.
+       */
+      public com.google.protobuf.ByteString
+          getRunIdBytes() {
+        java.lang.Object ref = runId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          runId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @param value The runId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRunId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearRunId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        runId_ = getDefaultInstance().getRunId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @param value The bytes for runId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRunIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object path_ = "";
+      /**
+       * <pre>
+       * Artifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @return Whether the path field is set.
+       */
+      public boolean hasPath() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <pre>
+       * Artifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @return The path.
+       */
+      public java.lang.String getPath() {
+        java.lang.Object ref = path_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            path_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Artifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @return The bytes for path.
+       */
+      public com.google.protobuf.ByteString
+          getPathBytes() {
+        java.lang.Object ref = path_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          path_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Artifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @param value The path to set.
+       * @return This builder for chaining.
+       */
+      public Builder setPath(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        path_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Artifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearPath() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        path_ = getDefaultInstance().getPath();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Artifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @param value The bytes for path to set.
+       * @return This builder for chaining.
+       */
+      public Builder setPathBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        path_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object uploadId_ = "";
+      /**
+       * <pre>
+       * ID identifying the multipart upload to complete
+       * </pre>
+       *
+       * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+       * @return Whether the uploadId field is set.
+       */
+      public boolean hasUploadId() {
+        return ((bitField0_ & 0x00000004) != 0);
+      }
+      /**
+       * <pre>
+       * ID identifying the multipart upload to complete
+       * </pre>
+       *
+       * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+       * @return The uploadId.
+       */
+      public java.lang.String getUploadId() {
+        java.lang.Object ref = uploadId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            uploadId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID identifying the multipart upload to complete
+       * </pre>
+       *
+       * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+       * @return The bytes for uploadId.
+       */
+      public com.google.protobuf.ByteString
+          getUploadIdBytes() {
+        java.lang.Object ref = uploadId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          uploadId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID identifying the multipart upload to complete
+       * </pre>
+       *
+       * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+       * @param value The uploadId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setUploadId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        uploadId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID identifying the multipart upload to complete
+       * </pre>
+       *
+       * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearUploadId() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        uploadId_ = getDefaultInstance().getUploadId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID identifying the multipart upload to complete
+       * </pre>
+       *
+       * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+       * @param value The bytes for uploadId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setUploadIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        uploadId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag> partEtags_ =
+        java.util.Collections.emptyList();
+      private void ensurePartEtagsIsMutable() {
+        if (!((bitField0_ & 0x00000008) != 0)) {
+          partEtags_ = new java.util.ArrayList<com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag>(partEtags_);
+          bitField0_ |= 0x00000008;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag, com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtagOrBuilder> partEtagsBuilder_;
+
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag> getPartEtagsList() {
+        if (partEtagsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(partEtags_);
+        } else {
+          return partEtagsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public int getPartEtagsCount() {
+        if (partEtagsBuilder_ == null) {
+          return partEtags_.size();
+        } else {
+          return partEtagsBuilder_.getCount();
+        }
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag getPartEtags(int index) {
+        if (partEtagsBuilder_ == null) {
+          return partEtags_.get(index);
+        } else {
+          return partEtagsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public Builder setPartEtags(
+          int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag value) {
+        if (partEtagsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePartEtagsIsMutable();
+          partEtags_.set(index, value);
+          onChanged();
+        } else {
+          partEtagsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public Builder setPartEtags(
+          int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.Builder builderForValue) {
+        if (partEtagsBuilder_ == null) {
+          ensurePartEtagsIsMutable();
+          partEtags_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          partEtagsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public Builder addPartEtags(com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag value) {
+        if (partEtagsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePartEtagsIsMutable();
+          partEtags_.add(value);
+          onChanged();
+        } else {
+          partEtagsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public Builder addPartEtags(
+          int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag value) {
+        if (partEtagsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePartEtagsIsMutable();
+          partEtags_.add(index, value);
+          onChanged();
+        } else {
+          partEtagsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public Builder addPartEtags(
+          com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.Builder builderForValue) {
+        if (partEtagsBuilder_ == null) {
+          ensurePartEtagsIsMutable();
+          partEtags_.add(builderForValue.build());
+          onChanged();
+        } else {
+          partEtagsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public Builder addPartEtags(
+          int index, com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.Builder builderForValue) {
+        if (partEtagsBuilder_ == null) {
+          ensurePartEtagsIsMutable();
+          partEtags_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          partEtagsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public Builder addAllPartEtags(
+          java.lang.Iterable<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag> values) {
+        if (partEtagsBuilder_ == null) {
+          ensurePartEtagsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, partEtags_);
+          onChanged();
+        } else {
+          partEtagsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public Builder clearPartEtags() {
+        if (partEtagsBuilder_ == null) {
+          partEtags_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000008);
+          onChanged();
+        } else {
+          partEtagsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public Builder removePartEtags(int index) {
+        if (partEtagsBuilder_ == null) {
+          ensurePartEtagsIsMutable();
+          partEtags_.remove(index);
+          onChanged();
+        } else {
+          partEtagsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.Builder getPartEtagsBuilder(
+          int index) {
+        return getPartEtagsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtagOrBuilder getPartEtagsOrBuilder(
+          int index) {
+        if (partEtagsBuilder_ == null) {
+          return partEtags_.get(index);  } else {
+          return partEtagsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public java.util.List<? extends com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtagOrBuilder> 
+           getPartEtagsOrBuilderList() {
+        if (partEtagsBuilder_ != null) {
+          return partEtagsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(partEtags_);
+        }
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.Builder addPartEtagsBuilder() {
+        return getPartEtagsFieldBuilder().addBuilder(
+            com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.getDefaultInstance());
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.Builder addPartEtagsBuilder(
+          int index) {
+        return getPartEtagsFieldBuilder().addBuilder(
+            index, com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.getDefaultInstance());
+      }
+      /**
+       * <pre>
+       * A list of parts uploaded in the multipart upload to complete
+       * </pre>
+       *
+       * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
+       */
+      public java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.Builder> 
+           getPartEtagsBuilderList() {
+        return getPartEtagsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag, com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtagOrBuilder> 
+          getPartEtagsFieldBuilder() {
+        if (partEtagsBuilder_ == null) {
+          partEtagsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+              com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag, com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtagOrBuilder>(
+                  partEtags_,
+                  ((bitField0_ & 0x00000008) != 0),
+                  getParentForChildren(),
+                  isClean());
+          partEtags_ = null;
+        }
+        return partEtagsBuilder_;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:mlflow.CompleteMultipartUpload)
+    }
+
+    // @@protoc_insertion_point(class_scope:mlflow.CompleteMultipartUpload)
+    private static final com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload();
+    }
+
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<CompleteMultipartUpload>
+        PARSER = new com.google.protobuf.AbstractParser<CompleteMultipartUpload>() {
+      @java.lang.Override
+      public CompleteMultipartUpload parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new CompleteMultipartUpload(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<CompleteMultipartUpload> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<CompleteMultipartUpload> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.databricks.api.proto.mlflow.DatabricksArtifacts.CompleteMultipartUpload getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface GetPresignedUploadPartUrlOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mlflow.GetPresignedUploadPartUrl)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the runId field is set.
+     */
+    boolean hasRunId();
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The runId.
+     */
+    java.lang.String getRunId();
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for runId.
+     */
+    com.google.protobuf.ByteString
+        getRunIdBytes();
+
+    /**
+     * <pre>
+     * Atifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return Whether the path field is set.
+     */
+    boolean hasPath();
+    /**
+     * <pre>
+     * Atifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return The path.
+     */
+    java.lang.String getPath();
+    /**
+     * <pre>
+     * Atifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return The bytes for path.
+     */
+    com.google.protobuf.ByteString
+        getPathBytes();
+
+    /**
+     * <pre>
+     * ID identifying the multipart upload in which the part is uploaded
+     * </pre>
+     *
+     * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the uploadId field is set.
+     */
+    boolean hasUploadId();
+    /**
+     * <pre>
+     * ID identifying the multipart upload in which the part is uploaded
+     * </pre>
+     *
+     * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+     * @return The uploadId.
+     */
+    java.lang.String getUploadId();
+    /**
+     * <pre>
+     * ID identifying the multipart upload in which the part is uploaded
+     * </pre>
+     *
+     * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for uploadId.
+     */
+    com.google.protobuf.ByteString
+        getUploadIdBytes();
+
+    /**
+     * <pre>
+     * Part number
+     * </pre>
+     *
+     * <code>optional int64 part_number = 4 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the partNumber field is set.
+     */
+    boolean hasPartNumber();
+    /**
+     * <pre>
+     * Part number
+     * </pre>
+     *
+     * <code>optional int64 part_number = 4 [(.mlflow.validate_required) = true];</code>
+     * @return The partNumber.
+     */
+    long getPartNumber();
+  }
+  /**
+   * Protobuf type {@code mlflow.GetPresignedUploadPartUrl}
+   */
+  public static final class GetPresignedUploadPartUrl extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:mlflow.GetPresignedUploadPartUrl)
+      GetPresignedUploadPartUrlOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use GetPresignedUploadPartUrl.newBuilder() to construct.
+    private GetPresignedUploadPartUrl(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private GetPresignedUploadPartUrl() {
+      runId_ = "";
+      path_ = "";
+      uploadId_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new GetPresignedUploadPartUrl();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private GetPresignedUploadPartUrl(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              runId_ = bs;
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              path_ = bs;
+              break;
+            }
+            case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000004;
+              uploadId_ = bs;
+              break;
+            }
+            case 32: {
+              bitField0_ |= 0x00000008;
+              partNumber_ = input.readInt64();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_GetPresignedUploadPartUrl_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_GetPresignedUploadPartUrl_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.class, com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Builder.class);
+    }
+
+    public interface ResponseOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mlflow.GetPresignedUploadPartUrl.Response)
+        com.google.protobuf.MessageOrBuilder {
+
+      /**
+       * <pre>
+       * Credential for uploading the part
+       * </pre>
+       *
+       * <code>optional .mlflow.ArtifactCredentialInfo upload_credential_info = 1;</code>
+       * @return Whether the uploadCredentialInfo field is set.
+       */
+      boolean hasUploadCredentialInfo();
+      /**
+       * <pre>
+       * Credential for uploading the part
+       * </pre>
+       *
+       * <code>optional .mlflow.ArtifactCredentialInfo upload_credential_info = 1;</code>
+       * @return The uploadCredentialInfo.
+       */
+      com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getUploadCredentialInfo();
+      /**
+       * <pre>
+       * Credential for uploading the part
+       * </pre>
+       *
+       * <code>optional .mlflow.ArtifactCredentialInfo upload_credential_info = 1;</code>
+       */
+      com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getUploadCredentialInfoOrBuilder();
+    }
+    /**
+     * Protobuf type {@code mlflow.GetPresignedUploadPartUrl.Response}
+     */
+    public static final class Response extends
+        com.google.protobuf.GeneratedMessageV3 implements
+        // @@protoc_insertion_point(message_implements:mlflow.GetPresignedUploadPartUrl.Response)
+        ResponseOrBuilder {
+    private static final long serialVersionUID = 0L;
+      // Use Response.newBuilder() to construct.
+      private Response(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+        super(builder);
+      }
+      private Response() {
+      }
+
+      @java.lang.Override
+      @SuppressWarnings({"unused"})
+      protected java.lang.Object newInstance(
+          UnusedPrivateParameter unused) {
+        return new Response();
+      }
+
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+      getUnknownFields() {
+        return this.unknownFields;
+      }
+      private Response(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        int mutable_bitField0_ = 0;
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder subBuilder = null;
+                if (((bitField0_ & 0x00000001) != 0)) {
+                  subBuilder = uploadCredentialInfo_.toBuilder();
+                }
+                uploadCredentialInfo_ = input.readMessage(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.PARSER, extensionRegistry);
+                if (subBuilder != null) {
+                  subBuilder.mergeFrom(uploadCredentialInfo_);
+                  uploadCredentialInfo_ = subBuilder.buildPartial();
+                }
+                bitField0_ |= 0x00000001;
+                break;
+              }
+              default: {
+                if (!parseUnknownField(
+                    input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
+        } finally {
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_GetPresignedUploadPartUrl_Response_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_GetPresignedUploadPartUrl_Response_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response.class, com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response.Builder.class);
+      }
+
+      private int bitField0_;
+      public static final int UPLOAD_CREDENTIAL_INFO_FIELD_NUMBER = 1;
+      private com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo uploadCredentialInfo_;
+      /**
+       * <pre>
+       * Credential for uploading the part
+       * </pre>
+       *
+       * <code>optional .mlflow.ArtifactCredentialInfo upload_credential_info = 1;</code>
+       * @return Whether the uploadCredentialInfo field is set.
+       */
+      @java.lang.Override
+      public boolean hasUploadCredentialInfo() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <pre>
+       * Credential for uploading the part
+       * </pre>
+       *
+       * <code>optional .mlflow.ArtifactCredentialInfo upload_credential_info = 1;</code>
+       * @return The uploadCredentialInfo.
+       */
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getUploadCredentialInfo() {
+        return uploadCredentialInfo_ == null ? com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : uploadCredentialInfo_;
+      }
+      /**
+       * <pre>
+       * Credential for uploading the part
+       * </pre>
+       *
+       * <code>optional .mlflow.ArtifactCredentialInfo upload_credential_info = 1;</code>
+       */
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getUploadCredentialInfoOrBuilder() {
+        return uploadCredentialInfo_ == null ? com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : uploadCredentialInfo_;
+      }
+
+      private byte memoizedIsInitialized = -1;
+      @java.lang.Override
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      @java.lang.Override
+      public void writeTo(com.google.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        if (((bitField0_ & 0x00000001) != 0)) {
+          output.writeMessage(1, getUploadCredentialInfo());
+        }
+        unknownFields.writeTo(output);
+      }
+
+      @java.lang.Override
+      public int getSerializedSize() {
+        int size = memoizedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        if (((bitField0_ & 0x00000001) != 0)) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeMessageSize(1, getUploadCredentialInfo());
+        }
+        size += unknownFields.getSerializedSize();
+        memoizedSize = size;
+        return size;
+      }
+
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+         return true;
+        }
+        if (!(obj instanceof com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response)) {
+          return super.equals(obj);
+        }
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response other = (com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response) obj;
+
+        if (hasUploadCredentialInfo() != other.hasUploadCredentialInfo()) return false;
+        if (hasUploadCredentialInfo()) {
+          if (!getUploadCredentialInfo()
+              .equals(other.getUploadCredentialInfo())) return false;
+        }
+        if (!unknownFields.equals(other.unknownFields)) return false;
+        return true;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptor().hashCode();
+        if (hasUploadCredentialInfo()) {
+          hash = (37 * hash) + UPLOAD_CREDENTIAL_INFO_FIELD_NUMBER;
+          hash = (53 * hash) + getUploadCredentialInfo().hashCode();
+        }
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response parseFrom(
+          java.nio.ByteBuffer data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response parseFrom(
+          java.nio.ByteBuffer data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response parseFrom(byte[] data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response parseFrom(
+          byte[] data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response parseFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response parseDelimitedFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response parseFrom(
+          com.google.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+
+      @java.lang.Override
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder() {
+        return DEFAULT_INSTANCE.toBuilder();
+      }
+      public static Builder newBuilder(com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response prototype) {
+        return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+      }
+      @java.lang.Override
+      public Builder toBuilder() {
+        return this == DEFAULT_INSTANCE
+            ? new Builder() : new Builder().mergeFrom(this);
+      }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * Protobuf type {@code mlflow.GetPresignedUploadPartUrl.Response}
+       */
+      public static final class Builder extends
+          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mlflow.GetPresignedUploadPartUrl.Response)
+          com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.ResponseOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_GetPresignedUploadPartUrl_Response_descriptor;
+        }
+
+        @java.lang.Override
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_GetPresignedUploadPartUrl_Response_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response.class, com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response.Builder.class);
+        }
+
+        // Construct using com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
+            getUploadCredentialInfoFieldBuilder();
+          }
+        }
+        @java.lang.Override
+        public Builder clear() {
+          super.clear();
+          if (uploadCredentialInfoBuilder_ == null) {
+            uploadCredentialInfo_ = null;
+          } else {
+            uploadCredentialInfoBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000001);
+          return this;
+        }
+
+        @java.lang.Override
+        public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_GetPresignedUploadPartUrl_Response_descriptor;
+        }
+
+        @java.lang.Override
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response getDefaultInstanceForType() {
+          return com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response.getDefaultInstance();
+        }
+
+        @java.lang.Override
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response build() {
+          com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        @java.lang.Override
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response buildPartial() {
+          com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response result = new com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response(this);
+          int from_bitField0_ = bitField0_;
+          int to_bitField0_ = 0;
+          if (((from_bitField0_ & 0x00000001) != 0)) {
+            if (uploadCredentialInfoBuilder_ == null) {
+              result.uploadCredentialInfo_ = uploadCredentialInfo_;
+            } else {
+              result.uploadCredentialInfo_ = uploadCredentialInfoBuilder_.build();
+            }
+            to_bitField0_ |= 0x00000001;
+          }
+          result.bitField0_ = to_bitField0_;
+          onBuilt();
+          return result;
+        }
+
+        @java.lang.Override
+        public Builder clone() {
+          return super.clone();
+        }
+        @java.lang.Override
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return super.setField(field, value);
+        }
+        @java.lang.Override
+        public Builder clearField(
+            com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return super.clearField(field);
+        }
+        @java.lang.Override
+        public Builder clearOneof(
+            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return super.clearOneof(oneof);
+        }
+        @java.lang.Override
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index, java.lang.Object value) {
+          return super.setRepeatedField(field, index, value);
+        }
+        @java.lang.Override
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return super.addRepeatedField(field, value);
+        }
+        @java.lang.Override
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response) {
+            return mergeFrom((com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response other) {
+          if (other == com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response.getDefaultInstance()) return this;
+          if (other.hasUploadCredentialInfo()) {
+            mergeUploadCredentialInfo(other.getUploadCredentialInfo());
+          }
+          this.mergeUnknownFields(other.unknownFields);
+          onChanged();
+          return this;
+        }
+
+        @java.lang.Override
+        public final boolean isInitialized() {
+          return true;
+        }
+
+        @java.lang.Override
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response) e.getUnfinishedMessage();
+            throw e.unwrapIOException();
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        private int bitField0_;
+
+        private com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo uploadCredentialInfo_;
+        private com.google.protobuf.SingleFieldBuilderV3<
+            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> uploadCredentialInfoBuilder_;
+        /**
+         * <pre>
+         * Credential for uploading the part
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo upload_credential_info = 1;</code>
+         * @return Whether the uploadCredentialInfo field is set.
+         */
+        public boolean hasUploadCredentialInfo() {
+          return ((bitField0_ & 0x00000001) != 0);
+        }
+        /**
+         * <pre>
+         * Credential for uploading the part
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo upload_credential_info = 1;</code>
+         * @return The uploadCredentialInfo.
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getUploadCredentialInfo() {
+          if (uploadCredentialInfoBuilder_ == null) {
+            return uploadCredentialInfo_ == null ? com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : uploadCredentialInfo_;
+          } else {
+            return uploadCredentialInfoBuilder_.getMessage();
+          }
+        }
+        /**
+         * <pre>
+         * Credential for uploading the part
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo upload_credential_info = 1;</code>
+         */
+        public Builder setUploadCredentialInfo(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
+          if (uploadCredentialInfoBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            uploadCredentialInfo_ = value;
+            onChanged();
+          } else {
+            uploadCredentialInfoBuilder_.setMessage(value);
+          }
+          bitField0_ |= 0x00000001;
+          return this;
+        }
+        /**
+         * <pre>
+         * Credential for uploading the part
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo upload_credential_info = 1;</code>
+         */
+        public Builder setUploadCredentialInfo(
+            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder builderForValue) {
+          if (uploadCredentialInfoBuilder_ == null) {
+            uploadCredentialInfo_ = builderForValue.build();
+            onChanged();
+          } else {
+            uploadCredentialInfoBuilder_.setMessage(builderForValue.build());
+          }
+          bitField0_ |= 0x00000001;
+          return this;
+        }
+        /**
+         * <pre>
+         * Credential for uploading the part
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo upload_credential_info = 1;</code>
+         */
+        public Builder mergeUploadCredentialInfo(com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo value) {
+          if (uploadCredentialInfoBuilder_ == null) {
+            if (((bitField0_ & 0x00000001) != 0) &&
+                uploadCredentialInfo_ != null &&
+                uploadCredentialInfo_ != com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance()) {
+              uploadCredentialInfo_ =
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.newBuilder(uploadCredentialInfo_).mergeFrom(value).buildPartial();
+            } else {
+              uploadCredentialInfo_ = value;
+            }
+            onChanged();
+          } else {
+            uploadCredentialInfoBuilder_.mergeFrom(value);
+          }
+          bitField0_ |= 0x00000001;
+          return this;
+        }
+        /**
+         * <pre>
+         * Credential for uploading the part
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo upload_credential_info = 1;</code>
+         */
+        public Builder clearUploadCredentialInfo() {
+          if (uploadCredentialInfoBuilder_ == null) {
+            uploadCredentialInfo_ = null;
+            onChanged();
+          } else {
+            uploadCredentialInfoBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000001);
+          return this;
+        }
+        /**
+         * <pre>
+         * Credential for uploading the part
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo upload_credential_info = 1;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder getUploadCredentialInfoBuilder() {
+          bitField0_ |= 0x00000001;
+          onChanged();
+          return getUploadCredentialInfoFieldBuilder().getBuilder();
+        }
+        /**
+         * <pre>
+         * Credential for uploading the part
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo upload_credential_info = 1;</code>
+         */
+        public com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder getUploadCredentialInfoOrBuilder() {
+          if (uploadCredentialInfoBuilder_ != null) {
+            return uploadCredentialInfoBuilder_.getMessageOrBuilder();
+          } else {
+            return uploadCredentialInfo_ == null ?
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.getDefaultInstance() : uploadCredentialInfo_;
+          }
+        }
+        /**
+         * <pre>
+         * Credential for uploading the part
+         * </pre>
+         *
+         * <code>optional .mlflow.ArtifactCredentialInfo upload_credential_info = 1;</code>
+         */
+        private com.google.protobuf.SingleFieldBuilderV3<
+            com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder> 
+            getUploadCredentialInfoFieldBuilder() {
+          if (uploadCredentialInfoBuilder_ == null) {
+            uploadCredentialInfoBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo.Builder, com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfoOrBuilder>(
+                    getUploadCredentialInfo(),
+                    getParentForChildren(),
+                    isClean());
+            uploadCredentialInfo_ = null;
+          }
+          return uploadCredentialInfoBuilder_;
+        }
+        @java.lang.Override
+        public final Builder setUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.setUnknownFields(unknownFields);
+        }
+
+        @java.lang.Override
+        public final Builder mergeUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.mergeUnknownFields(unknownFields);
+        }
+
+
+        // @@protoc_insertion_point(builder_scope:mlflow.GetPresignedUploadPartUrl.Response)
+      }
+
+      // @@protoc_insertion_point(class_scope:mlflow.GetPresignedUploadPartUrl.Response)
+      private static final com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response DEFAULT_INSTANCE;
+      static {
+        DEFAULT_INSTANCE = new com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response();
+      }
+
+      public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+      }
+
+      @java.lang.Deprecated public static final com.google.protobuf.Parser<Response>
+          PARSER = new com.google.protobuf.AbstractParser<Response>() {
+        @java.lang.Override
+        public Response parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new Response(input, extensionRegistry);
+        }
+      };
+
+      public static com.google.protobuf.Parser<Response> parser() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<Response> getParserForType() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Response getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+      }
+
+    }
+
+    private int bitField0_;
+    public static final int RUN_ID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object runId_;
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the runId field is set.
+     */
+    @java.lang.Override
+    public boolean hasRunId() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The runId.
+     */
+    @java.lang.Override
+    public java.lang.String getRunId() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          runId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Run ID
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for runId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getRunIdBytes() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        runId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int PATH_FIELD_NUMBER = 2;
+    private volatile java.lang.Object path_;
+    /**
+     * <pre>
+     * Atifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return Whether the path field is set.
+     */
+    @java.lang.Override
+    public boolean hasPath() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <pre>
+     * Atifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return The path.
+     */
+    @java.lang.Override
+    public java.lang.String getPath() {
+      java.lang.Object ref = path_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          path_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Atifact path, relative to the Run's artifact root location
+     * </pre>
+     *
+     * <code>optional string path = 2;</code>
+     * @return The bytes for path.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getPathBytes() {
+      java.lang.Object ref = path_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        path_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int UPLOAD_ID_FIELD_NUMBER = 3;
+    private volatile java.lang.Object uploadId_;
+    /**
+     * <pre>
+     * ID identifying the multipart upload in which the part is uploaded
+     * </pre>
+     *
+     * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the uploadId field is set.
+     */
+    @java.lang.Override
+    public boolean hasUploadId() {
+      return ((bitField0_ & 0x00000004) != 0);
+    }
+    /**
+     * <pre>
+     * ID identifying the multipart upload in which the part is uploaded
+     * </pre>
+     *
+     * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+     * @return The uploadId.
+     */
+    @java.lang.Override
+    public java.lang.String getUploadId() {
+      java.lang.Object ref = uploadId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          uploadId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * ID identifying the multipart upload in which the part is uploaded
+     * </pre>
+     *
+     * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for uploadId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getUploadIdBytes() {
+      java.lang.Object ref = uploadId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        uploadId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int PART_NUMBER_FIELD_NUMBER = 4;
+    private long partNumber_;
+    /**
+     * <pre>
+     * Part number
+     * </pre>
+     *
+     * <code>optional int64 part_number = 4 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the partNumber field is set.
+     */
+    @java.lang.Override
+    public boolean hasPartNumber() {
+      return ((bitField0_ & 0x00000008) != 0);
+    }
+    /**
+     * <pre>
+     * Part number
+     * </pre>
+     *
+     * <code>optional int64 part_number = 4 [(.mlflow.validate_required) = true];</code>
+     * @return The partNumber.
+     */
+    @java.lang.Override
+    public long getPartNumber() {
+      return partNumber_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runId_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, path_);
+      }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, uploadId_);
+      }
+      if (((bitField0_ & 0x00000008) != 0)) {
+        output.writeInt64(4, partNumber_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, runId_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, path_);
+      }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, uploadId_);
+      }
+      if (((bitField0_ & 0x00000008) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(4, partNumber_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl)) {
+        return super.equals(obj);
+      }
+      com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl other = (com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl) obj;
+
+      if (hasRunId() != other.hasRunId()) return false;
+      if (hasRunId()) {
+        if (!getRunId()
+            .equals(other.getRunId())) return false;
+      }
+      if (hasPath() != other.hasPath()) return false;
+      if (hasPath()) {
+        if (!getPath()
+            .equals(other.getPath())) return false;
+      }
+      if (hasUploadId() != other.hasUploadId()) return false;
+      if (hasUploadId()) {
+        if (!getUploadId()
+            .equals(other.getUploadId())) return false;
+      }
+      if (hasPartNumber() != other.hasPartNumber()) return false;
+      if (hasPartNumber()) {
+        if (getPartNumber()
+            != other.getPartNumber()) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasRunId()) {
+        hash = (37 * hash) + RUN_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getRunId().hashCode();
+      }
+      if (hasPath()) {
+        hash = (37 * hash) + PATH_FIELD_NUMBER;
+        hash = (53 * hash) + getPath().hashCode();
+      }
+      if (hasUploadId()) {
+        hash = (37 * hash) + UPLOAD_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getUploadId().hashCode();
+      }
+      if (hasPartNumber()) {
+        hash = (37 * hash) + PART_NUMBER_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getPartNumber());
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mlflow.GetPresignedUploadPartUrl}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mlflow.GetPresignedUploadPartUrl)
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrlOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_GetPresignedUploadPartUrl_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_GetPresignedUploadPartUrl_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.class, com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.Builder.class);
+      }
+
+      // Construct using com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        runId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        path_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        uploadId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000004);
+        partNumber_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000008);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.internal_static_mlflow_GetPresignedUploadPartUrl_descriptor;
+      }
+
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl getDefaultInstanceForType() {
+        return com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl build() {
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl buildPartial() {
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl result = new com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.runId_ = runId_;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.path_ = path_;
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.uploadId_ = uploadId_;
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          result.partNumber_ = partNumber_;
+          to_bitField0_ |= 0x00000008;
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl) {
+          return mergeFrom((com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl other) {
+        if (other == com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl.getDefaultInstance()) return this;
+        if (other.hasRunId()) {
+          bitField0_ |= 0x00000001;
+          runId_ = other.runId_;
+          onChanged();
+        }
+        if (other.hasPath()) {
+          bitField0_ |= 0x00000002;
+          path_ = other.path_;
+          onChanged();
+        }
+        if (other.hasUploadId()) {
+          bitField0_ |= 0x00000004;
+          uploadId_ = other.uploadId_;
+          onChanged();
+        }
+        if (other.hasPartNumber()) {
+          setPartNumber(other.getPartNumber());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object runId_ = "";
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @return Whether the runId field is set.
+       */
+      public boolean hasRunId() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @return The runId.
+       */
+      public java.lang.String getRunId() {
+        java.lang.Object ref = runId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            runId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @return The bytes for runId.
+       */
+      public com.google.protobuf.ByteString
+          getRunIdBytes() {
+        java.lang.Object ref = runId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          runId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @param value The runId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRunId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearRunId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        runId_ = getDefaultInstance().getRunId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Run ID
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       * @param value The bytes for runId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRunIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object path_ = "";
+      /**
+       * <pre>
+       * Atifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @return Whether the path field is set.
+       */
+      public boolean hasPath() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <pre>
+       * Atifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @return The path.
+       */
+      public java.lang.String getPath() {
+        java.lang.Object ref = path_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            path_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Atifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @return The bytes for path.
+       */
+      public com.google.protobuf.ByteString
+          getPathBytes() {
+        java.lang.Object ref = path_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          path_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Atifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @param value The path to set.
+       * @return This builder for chaining.
+       */
+      public Builder setPath(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        path_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Atifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearPath() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        path_ = getDefaultInstance().getPath();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Atifact path, relative to the Run's artifact root location
+       * </pre>
+       *
+       * <code>optional string path = 2;</code>
+       * @param value The bytes for path to set.
+       * @return This builder for chaining.
+       */
+      public Builder setPathBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        path_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object uploadId_ = "";
+      /**
+       * <pre>
+       * ID identifying the multipart upload in which the part is uploaded
+       * </pre>
+       *
+       * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+       * @return Whether the uploadId field is set.
+       */
+      public boolean hasUploadId() {
+        return ((bitField0_ & 0x00000004) != 0);
+      }
+      /**
+       * <pre>
+       * ID identifying the multipart upload in which the part is uploaded
+       * </pre>
+       *
+       * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+       * @return The uploadId.
+       */
+      public java.lang.String getUploadId() {
+        java.lang.Object ref = uploadId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            uploadId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID identifying the multipart upload in which the part is uploaded
+       * </pre>
+       *
+       * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+       * @return The bytes for uploadId.
+       */
+      public com.google.protobuf.ByteString
+          getUploadIdBytes() {
+        java.lang.Object ref = uploadId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          uploadId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID identifying the multipart upload in which the part is uploaded
+       * </pre>
+       *
+       * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+       * @param value The uploadId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setUploadId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        uploadId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID identifying the multipart upload in which the part is uploaded
+       * </pre>
+       *
+       * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearUploadId() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        uploadId_ = getDefaultInstance().getUploadId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID identifying the multipart upload in which the part is uploaded
+       * </pre>
+       *
+       * <code>optional string upload_id = 3 [(.mlflow.validate_required) = true];</code>
+       * @param value The bytes for uploadId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setUploadIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        uploadId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private long partNumber_ ;
+      /**
+       * <pre>
+       * Part number
+       * </pre>
+       *
+       * <code>optional int64 part_number = 4 [(.mlflow.validate_required) = true];</code>
+       * @return Whether the partNumber field is set.
+       */
+      @java.lang.Override
+      public boolean hasPartNumber() {
+        return ((bitField0_ & 0x00000008) != 0);
+      }
+      /**
+       * <pre>
+       * Part number
+       * </pre>
+       *
+       * <code>optional int64 part_number = 4 [(.mlflow.validate_required) = true];</code>
+       * @return The partNumber.
+       */
+      @java.lang.Override
+      public long getPartNumber() {
+        return partNumber_;
+      }
+      /**
+       * <pre>
+       * Part number
+       * </pre>
+       *
+       * <code>optional int64 part_number = 4 [(.mlflow.validate_required) = true];</code>
+       * @param value The partNumber to set.
+       * @return This builder for chaining.
+       */
+      public Builder setPartNumber(long value) {
+        bitField0_ |= 0x00000008;
+        partNumber_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Part number
+       * </pre>
+       *
+       * <code>optional int64 part_number = 4 [(.mlflow.validate_required) = true];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearPartNumber() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        partNumber_ = 0L;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:mlflow.GetPresignedUploadPartUrl)
+    }
+
+    // @@protoc_insertion_point(class_scope:mlflow.GetPresignedUploadPartUrl)
+    private static final com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl();
+    }
+
+    public static com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<GetPresignedUploadPartUrl>
+        PARSER = new com.google.protobuf.AbstractParser<GetPresignedUploadPartUrl>() {
+      @java.lang.Override
+      public GetPresignedUploadPartUrl parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new GetPresignedUploadPartUrl(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<GetPresignedUploadPartUrl> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<GetPresignedUploadPartUrl> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.databricks.api.proto.mlflow.DatabricksArtifacts.GetPresignedUploadPartUrl getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mlflow_ArtifactCredentialInfo_descriptor;
   private static final 
@@ -7538,6 +14620,41 @@ public final class DatabricksArtifacts {
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_mlflow_GetCredentialsForWrite_Response_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_CreateMultipartUpload_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_CreateMultipartUpload_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_CreateMultipartUpload_Response_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_CreateMultipartUpload_Response_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_PartEtag_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_PartEtag_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_CompleteMultipartUpload_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_CompleteMultipartUpload_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_CompleteMultipartUpload_Response_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_CompleteMultipartUpload_Response_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_GetPresignedUploadPartUrl_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_GetPresignedUploadPartUrl_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_GetPresignedUploadPartUrl_Response_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_GetPresignedUploadPartUrl_Response_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -7568,20 +14685,56 @@ public final class DatabricksArtifacts {
       "ctCredentialInfo\022\027\n\017next_page_token\030\003 \001(" +
       "\tJ\004\010\001\020\002:_\342?(\n&com.databricks.rpc.RPC[$th" +
       "is.Response]\342?1\n/com.databricks.mlflow.a" +
-      "pi.MlflowTrackingMessage*s\n\026ArtifactCred" +
-      "entialType\022\021\n\rAZURE_SAS_URI\020\001\022\025\n\021AWS_PRE" +
-      "SIGNED_URL\020\002\022\022\n\016GCP_SIGNED_URL\020\003\022\033\n\027AZUR" +
-      "E_ADLS_GEN2_SAS_URI\020\0042\344\002\n DatabricksMlfl" +
-      "owArtifactsService\022\234\001\n\025getCredentialsFor" +
-      "Read\022\035.mlflow.GetCredentialsForRead\032&.ml" +
-      "flow.GetCredentialsForRead.Response\"<\362\206\031" +
-      "8\n4\n\004POST\022&/mlflow/artifacts/credentials" +
-      "-for-read\032\004\010\002\020\000\020\003\022\240\001\n\026getCredentialsForW" +
-      "rite\022\036.mlflow.GetCredentialsForWrite\032\'.m" +
-      "lflow.GetCredentialsForWrite.Response\"=\362" +
-      "\206\0319\n5\n\004POST\022\'/mlflow/artifacts/credentia" +
-      "ls-for-write\032\004\010\002\020\000\020\003B,\n\037com.databricks.a" +
-      "pi.proto.mlflow\220\001\001\240\001\001\342?\002\020\001"
+      "pi.MlflowTrackingMessage\"\325\002\n\025CreateMulti" +
+      "partUpload\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\022\014\n\004path" +
+      "\030\002 \001(\t\022\027\n\tnum_parts\030\003 \001(\003B\004\370\206\031\001\032\235\001\n\010Resp" +
+      "onse\022\021\n\tupload_id\030\001 \001(\t\022?\n\027upload_creden" +
+      "tial_infos\030\002 \003(\0132\036.mlflow.ArtifactCreden" +
+      "tialInfo\022=\n\025abort_credential_info\030\003 \001(\0132" +
+      "\036.mlflow.ArtifactCredentialInfo:_\342?(\n&co" +
+      "m.databricks.rpc.RPC[$this.Response]\342?1\n" +
+      "/com.databricks.mlflow.api.MlflowTrackin" +
+      "gMessage\"-\n\010PartEtag\022\023\n\013part_number\030\001 \001(" +
+      "\003\022\014\n\004etag\030\002 \001(\t\"\351\001\n\027CompleteMultipartUpl" +
+      "oad\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\022\014\n\004path\030\002 \001(\t\022" +
+      "\027\n\tupload_id\030\003 \001(\tB\004\370\206\031\001\022$\n\npart_etags\030\004" +
+      " \003(\0132\020.mlflow.PartEtag\032\n\n\010Response:_\342?(\n" +
+      "&com.databricks.rpc.RPC[$this.Response]\342" +
+      "?1\n/com.databricks.mlflow.api.MlflowTrac" +
+      "kingMessage\"\240\002\n\031GetPresignedUploadPartUr" +
+      "l\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\022\014\n\004path\030\002 \001(\t\022\027\n" +
+      "\tupload_id\030\003 \001(\tB\004\370\206\031\001\022\031\n\013part_number\030\004 " +
+      "\001(\003B\004\370\206\031\001\032J\n\010Response\022>\n\026upload_credenti" +
+      "al_info\030\001 \001(\0132\036.mlflow.ArtifactCredentia" +
+      "lInfo:_\342?(\n&com.databricks.rpc.RPC[$this" +
+      ".Response]\342?1\n/com.databricks.mlflow.api" +
+      ".MlflowTrackingMessage*s\n\026ArtifactCreden" +
+      "tialType\022\021\n\rAZURE_SAS_URI\020\001\022\025\n\021AWS_PRESI" +
+      "GNED_URL\020\002\022\022\n\016GCP_SIGNED_URL\020\003\022\033\n\027AZURE_" +
+      "ADLS_GEN2_SAS_URI\020\0042\343\006\n DatabricksMlflow" +
+      "ArtifactsService\022\234\001\n\025getCredentialsForRe" +
+      "ad\022\035.mlflow.GetCredentialsForRead\032&.mlfl" +
+      "ow.GetCredentialsForRead.Response\"<\362\206\0318\n" +
+      "4\n\004POST\022&/mlflow/artifacts/credentials-f" +
+      "or-read\032\004\010\002\020\000\020\003\022\240\001\n\026getCredentialsForWri" +
+      "te\022\036.mlflow.GetCredentialsForWrite\032\'.mlf" +
+      "low.GetCredentialsForWrite.Response\"=\362\206\031" +
+      "9\n5\n\004POST\022\'/mlflow/artifacts/credentials" +
+      "-for-write\032\004\010\002\020\000\020\003\022\237\001\n\025createMultipartUp" +
+      "load\022\035.mlflow.CreateMultipartUpload\032&.ml" +
+      "flow.CreateMultipartUpload.Response\"?\362\206\031" +
+      ";\n7\n\004POST\022)/mlflow/artifacts/create-mult" +
+      "ipart-upload\032\004\010\002\020\000\020\003\022\247\001\n\027completeMultipa" +
+      "rtUpload\022\037.mlflow.CompleteMultipartUploa" +
+      "d\032(.mlflow.CompleteMultipartUpload.Respo" +
+      "nse\"A\362\206\031=\n9\n\004POST\022+/mlflow/artifacts/com" +
+      "plete-multipart-upload\032\004\010\002\020\000\020\003\022\260\001\n\031getPr" +
+      "esignedUploadPartUrl\022!.mlflow.GetPresign" +
+      "edUploadPartUrl\032*.mlflow.GetPresignedUpl" +
+      "oadPartUrl.Response\"D\362\206\031@\n<\n\003GET\022//mlflo" +
+      "w/artifacts/get-presigned-upload-part-ur" +
+      "l\032\004\010\002\020\000\020\003B,\n\037com.databricks.api.proto.ml" +
+      "flow\220\001\001\240\001\001\342?\002\020\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -7625,6 +14778,48 @@ public final class DatabricksArtifacts {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetCredentialsForWrite_Response_descriptor,
         new java.lang.String[] { "CredentialInfos", "NextPageToken", });
+    internal_static_mlflow_CreateMultipartUpload_descriptor =
+      getDescriptor().getMessageTypes().get(3);
+    internal_static_mlflow_CreateMultipartUpload_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_CreateMultipartUpload_descriptor,
+        new java.lang.String[] { "RunId", "Path", "NumParts", });
+    internal_static_mlflow_CreateMultipartUpload_Response_descriptor =
+      internal_static_mlflow_CreateMultipartUpload_descriptor.getNestedTypes().get(0);
+    internal_static_mlflow_CreateMultipartUpload_Response_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_CreateMultipartUpload_Response_descriptor,
+        new java.lang.String[] { "UploadId", "UploadCredentialInfos", "AbortCredentialInfo", });
+    internal_static_mlflow_PartEtag_descriptor =
+      getDescriptor().getMessageTypes().get(4);
+    internal_static_mlflow_PartEtag_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_PartEtag_descriptor,
+        new java.lang.String[] { "PartNumber", "Etag", });
+    internal_static_mlflow_CompleteMultipartUpload_descriptor =
+      getDescriptor().getMessageTypes().get(5);
+    internal_static_mlflow_CompleteMultipartUpload_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_CompleteMultipartUpload_descriptor,
+        new java.lang.String[] { "RunId", "Path", "UploadId", "PartEtags", });
+    internal_static_mlflow_CompleteMultipartUpload_Response_descriptor =
+      internal_static_mlflow_CompleteMultipartUpload_descriptor.getNestedTypes().get(0);
+    internal_static_mlflow_CompleteMultipartUpload_Response_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_CompleteMultipartUpload_Response_descriptor,
+        new java.lang.String[] { });
+    internal_static_mlflow_GetPresignedUploadPartUrl_descriptor =
+      getDescriptor().getMessageTypes().get(6);
+    internal_static_mlflow_GetPresignedUploadPartUrl_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_GetPresignedUploadPartUrl_descriptor,
+        new java.lang.String[] { "RunId", "Path", "UploadId", "PartNumber", });
+    internal_static_mlflow_GetPresignedUploadPartUrl_Response_descriptor =
+      internal_static_mlflow_GetPresignedUploadPartUrl_descriptor.getNestedTypes().get(0);
+    internal_static_mlflow_GetPresignedUploadPartUrl_Response_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_GetPresignedUploadPartUrl_Response_descriptor,
+        new java.lang.String[] { "UploadCredentialInfo", });
     com.google.protobuf.ExtensionRegistry registry =
         com.google.protobuf.ExtensionRegistry.newInstance();
     registry.add(com.databricks.api.proto.databricks.Databricks.rpc);

--- a/mlflow/java/client/src/main/java/com/databricks/api/proto/mlflow/DatabricksArtifacts.java
+++ b/mlflow/java/client/src/main/java/com/databricks/api/proto/mlflow/DatabricksArtifacts.java
@@ -7543,7 +7543,7 @@ public final class DatabricksArtifacts {
 
     /**
      * <pre>
-     * Artifact path, relative to the Run's artifact root location
+     * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -7552,7 +7552,7 @@ public final class DatabricksArtifacts {
     boolean hasPath();
     /**
      * <pre>
-     * Artifact path, relative to the Run's artifact root location
+     * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -7561,7 +7561,7 @@ public final class DatabricksArtifacts {
     java.lang.String getPath();
     /**
      * <pre>
-     * Artifact path, relative to the Run's artifact root location
+     * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -7572,7 +7572,7 @@ public final class DatabricksArtifacts {
 
     /**
      * <pre>
-     * Number of parts to upload in the initiated multipart upload
+     * Number of file parts (chunks of data) to upload in the initiated multipart upload
      * </pre>
      *
      * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
@@ -7581,7 +7581,7 @@ public final class DatabricksArtifacts {
     boolean hasNumParts();
     /**
      * <pre>
-     * Number of parts to upload in the initiated multipart upload
+     * Number of file parts (chunks of data) to upload in the initiated multipart upload
      * </pre>
      *
      * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
@@ -7721,7 +7721,7 @@ public final class DatabricksArtifacts {
 
       /**
        * <pre>
-       * Credentials for uploading parts in the initiated multipart upload
+       * Credentials for uploading file parts in the initiated multipart upload
        * </pre>
        *
        * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -7730,7 +7730,7 @@ public final class DatabricksArtifacts {
           getUploadCredentialInfosList();
       /**
        * <pre>
-       * Credentials for uploading parts in the initiated multipart upload
+       * Credentials for uploading file parts in the initiated multipart upload
        * </pre>
        *
        * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -7738,7 +7738,7 @@ public final class DatabricksArtifacts {
       com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo getUploadCredentialInfos(int index);
       /**
        * <pre>
-       * Credentials for uploading parts in the initiated multipart upload
+       * Credentials for uploading file parts in the initiated multipart upload
        * </pre>
        *
        * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -7746,7 +7746,7 @@ public final class DatabricksArtifacts {
       int getUploadCredentialInfosCount();
       /**
        * <pre>
-       * Credentials for uploading parts in the initiated multipart upload
+       * Credentials for uploading file parts in the initiated multipart upload
        * </pre>
        *
        * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -7755,7 +7755,7 @@ public final class DatabricksArtifacts {
           getUploadCredentialInfosOrBuilderList();
       /**
        * <pre>
-       * Credentials for uploading parts in the initiated multipart upload
+       * Credentials for uploading file parts in the initiated multipart upload
        * </pre>
        *
        * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -7966,7 +7966,7 @@ public final class DatabricksArtifacts {
       private java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.ArtifactCredentialInfo> uploadCredentialInfos_;
       /**
        * <pre>
-       * Credentials for uploading parts in the initiated multipart upload
+       * Credentials for uploading file parts in the initiated multipart upload
        * </pre>
        *
        * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -7977,7 +7977,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Credentials for uploading parts in the initiated multipart upload
+       * Credentials for uploading file parts in the initiated multipart upload
        * </pre>
        *
        * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -7989,7 +7989,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Credentials for uploading parts in the initiated multipart upload
+       * Credentials for uploading file parts in the initiated multipart upload
        * </pre>
        *
        * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8000,7 +8000,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Credentials for uploading parts in the initiated multipart upload
+       * Credentials for uploading file parts in the initiated multipart upload
        * </pre>
        *
        * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8011,7 +8011,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Credentials for uploading parts in the initiated multipart upload
+       * Credentials for uploading file parts in the initiated multipart upload
        * </pre>
        *
        * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8586,7 +8586,7 @@ public final class DatabricksArtifacts {
 
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8600,7 +8600,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8614,7 +8614,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8628,7 +8628,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8649,7 +8649,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8667,7 +8667,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8687,7 +8687,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8708,7 +8708,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8726,7 +8726,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8744,7 +8744,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8763,7 +8763,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8780,7 +8780,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8797,7 +8797,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8808,7 +8808,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8822,7 +8822,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8837,7 +8837,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8848,7 +8848,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -8860,7 +8860,7 @@ public final class DatabricksArtifacts {
         }
         /**
          * <pre>
-         * Credentials for uploading parts in the initiated multipart upload
+         * Credentials for uploading file parts in the initiated multipart upload
          * </pre>
          *
          * <code>repeated .mlflow.ArtifactCredentialInfo upload_credential_infos = 2;</code>
@@ -9157,7 +9157,7 @@ public final class DatabricksArtifacts {
     private volatile java.lang.Object path_;
     /**
      * <pre>
-     * Artifact path, relative to the Run's artifact root location
+     * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -9169,7 +9169,7 @@ public final class DatabricksArtifacts {
     }
     /**
      * <pre>
-     * Artifact path, relative to the Run's artifact root location
+     * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -9192,7 +9192,7 @@ public final class DatabricksArtifacts {
     }
     /**
      * <pre>
-     * Artifact path, relative to the Run's artifact root location
+     * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -9217,7 +9217,7 @@ public final class DatabricksArtifacts {
     private long numParts_;
     /**
      * <pre>
-     * Number of parts to upload in the initiated multipart upload
+     * Number of file parts (chunks of data) to upload in the initiated multipart upload
      * </pre>
      *
      * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
@@ -9229,7 +9229,7 @@ public final class DatabricksArtifacts {
     }
     /**
      * <pre>
-     * Number of parts to upload in the initiated multipart upload
+     * Number of file parts (chunks of data) to upload in the initiated multipart upload
      * </pre>
      *
      * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
@@ -9718,7 +9718,7 @@ public final class DatabricksArtifacts {
       private java.lang.Object path_ = "";
       /**
        * <pre>
-       * Artifact path, relative to the Run's artifact root location
+       * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -9729,7 +9729,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Artifact path, relative to the Run's artifact root location
+       * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -9751,7 +9751,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Artifact path, relative to the Run's artifact root location
+       * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -9772,7 +9772,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Artifact path, relative to the Run's artifact root location
+       * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -9791,7 +9791,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Artifact path, relative to the Run's artifact root location
+       * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -9805,7 +9805,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Artifact path, relative to the Run's artifact root location
+       * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -9826,7 +9826,7 @@ public final class DatabricksArtifacts {
       private long numParts_ ;
       /**
        * <pre>
-       * Number of parts to upload in the initiated multipart upload
+       * Number of file parts (chunks of data) to upload in the initiated multipart upload
        * </pre>
        *
        * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
@@ -9838,7 +9838,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Number of parts to upload in the initiated multipart upload
+       * Number of file parts (chunks of data) to upload in the initiated multipart upload
        * </pre>
        *
        * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
@@ -9850,7 +9850,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Number of parts to upload in the initiated multipart upload
+       * Number of file parts (chunks of data) to upload in the initiated multipart upload
        * </pre>
        *
        * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
@@ -9865,7 +9865,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Number of parts to upload in the initiated multipart upload
+       * Number of file parts (chunks of data) to upload in the initiated multipart upload
        * </pre>
        *
        * <code>optional int64 num_parts = 3 [(.mlflow.validate_required) = true];</code>
@@ -10671,7 +10671,7 @@ public final class DatabricksArtifacts {
 
     /**
      * <pre>
-     * Artifact path, relative to the Run's artifact root location
+     * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -10680,7 +10680,7 @@ public final class DatabricksArtifacts {
     boolean hasPath();
     /**
      * <pre>
-     * Artifact path, relative to the Run's artifact root location
+     * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -10689,7 +10689,7 @@ public final class DatabricksArtifacts {
     java.lang.String getPath();
     /**
      * <pre>
-     * Artifact path, relative to the Run's artifact root location
+     * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -10729,7 +10729,7 @@ public final class DatabricksArtifacts {
 
     /**
      * <pre>
-     * A list of parts uploaded in the multipart upload to complete
+     * A list of file parts uploaded in the multipart upload to complete
      * </pre>
      *
      * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -10738,7 +10738,7 @@ public final class DatabricksArtifacts {
         getPartEtagsList();
     /**
      * <pre>
-     * A list of parts uploaded in the multipart upload to complete
+     * A list of file parts uploaded in the multipart upload to complete
      * </pre>
      *
      * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -10746,7 +10746,7 @@ public final class DatabricksArtifacts {
     com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag getPartEtags(int index);
     /**
      * <pre>
-     * A list of parts uploaded in the multipart upload to complete
+     * A list of file parts uploaded in the multipart upload to complete
      * </pre>
      *
      * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -10754,7 +10754,7 @@ public final class DatabricksArtifacts {
     int getPartEtagsCount();
     /**
      * <pre>
-     * A list of parts uploaded in the multipart upload to complete
+     * A list of file parts uploaded in the multipart upload to complete
      * </pre>
      *
      * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -10763,7 +10763,7 @@ public final class DatabricksArtifacts {
         getPartEtagsOrBuilderList();
     /**
      * <pre>
-     * A list of parts uploaded in the multipart upload to complete
+     * A list of file parts uploaded in the multipart upload to complete
      * </pre>
      *
      * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -11366,7 +11366,7 @@ public final class DatabricksArtifacts {
     private volatile java.lang.Object path_;
     /**
      * <pre>
-     * Artifact path, relative to the Run's artifact root location
+     * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -11378,7 +11378,7 @@ public final class DatabricksArtifacts {
     }
     /**
      * <pre>
-     * Artifact path, relative to the Run's artifact root location
+     * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -11401,7 +11401,7 @@ public final class DatabricksArtifacts {
     }
     /**
      * <pre>
-     * Artifact path, relative to the Run's artifact root location
+     * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -11486,7 +11486,7 @@ public final class DatabricksArtifacts {
     private java.util.List<com.databricks.api.proto.mlflow.DatabricksArtifacts.PartEtag> partEtags_;
     /**
      * <pre>
-     * A list of parts uploaded in the multipart upload to complete
+     * A list of file parts uploaded in the multipart upload to complete
      * </pre>
      *
      * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -11497,7 +11497,7 @@ public final class DatabricksArtifacts {
     }
     /**
      * <pre>
-     * A list of parts uploaded in the multipart upload to complete
+     * A list of file parts uploaded in the multipart upload to complete
      * </pre>
      *
      * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -11509,7 +11509,7 @@ public final class DatabricksArtifacts {
     }
     /**
      * <pre>
-     * A list of parts uploaded in the multipart upload to complete
+     * A list of file parts uploaded in the multipart upload to complete
      * </pre>
      *
      * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -11520,7 +11520,7 @@ public final class DatabricksArtifacts {
     }
     /**
      * <pre>
-     * A list of parts uploaded in the multipart upload to complete
+     * A list of file parts uploaded in the multipart upload to complete
      * </pre>
      *
      * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -11531,7 +11531,7 @@ public final class DatabricksArtifacts {
     }
     /**
      * <pre>
-     * A list of parts uploaded in the multipart upload to complete
+     * A list of file parts uploaded in the multipart upload to complete
      * </pre>
      *
      * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12075,7 +12075,7 @@ public final class DatabricksArtifacts {
       private java.lang.Object path_ = "";
       /**
        * <pre>
-       * Artifact path, relative to the Run's artifact root location
+       * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -12086,7 +12086,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Artifact path, relative to the Run's artifact root location
+       * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -12108,7 +12108,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Artifact path, relative to the Run's artifact root location
+       * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -12129,7 +12129,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Artifact path, relative to the Run's artifact root location
+       * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -12148,7 +12148,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Artifact path, relative to the Run's artifact root location
+       * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -12162,7 +12162,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Artifact path, relative to the Run's artifact root location
+       * Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -12302,7 +12302,7 @@ public final class DatabricksArtifacts {
 
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12316,7 +12316,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12330,7 +12330,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12344,7 +12344,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12365,7 +12365,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12383,7 +12383,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12403,7 +12403,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12424,7 +12424,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12442,7 +12442,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12460,7 +12460,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12479,7 +12479,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12496,7 +12496,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12513,7 +12513,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12524,7 +12524,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12538,7 +12538,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12553,7 +12553,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12564,7 +12564,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12576,7 +12576,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * A list of parts uploaded in the multipart upload to complete
+       * A list of file parts uploaded in the multipart upload to complete
        * </pre>
        *
        * <code>repeated .mlflow.PartEtag part_etags = 4;</code>
@@ -12687,7 +12687,7 @@ public final class DatabricksArtifacts {
 
     /**
      * <pre>
-     * Atifact path, relative to the Run's artifact root location
+     * Atifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -12696,7 +12696,7 @@ public final class DatabricksArtifacts {
     boolean hasPath();
     /**
      * <pre>
-     * Atifact path, relative to the Run's artifact root location
+     * Atifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -12705,7 +12705,7 @@ public final class DatabricksArtifacts {
     java.lang.String getPath();
     /**
      * <pre>
-     * Atifact path, relative to the Run's artifact root location
+     * Atifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -13623,7 +13623,7 @@ public final class DatabricksArtifacts {
     private volatile java.lang.Object path_;
     /**
      * <pre>
-     * Atifact path, relative to the Run's artifact root location
+     * Atifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -13635,7 +13635,7 @@ public final class DatabricksArtifacts {
     }
     /**
      * <pre>
-     * Atifact path, relative to the Run's artifact root location
+     * Atifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -13658,7 +13658,7 @@ public final class DatabricksArtifacts {
     }
     /**
      * <pre>
-     * Atifact path, relative to the Run's artifact root location
+     * Atifact path, relative to the Run's artifact root location (e.g. "path/to/file")
      * </pre>
      *
      * <code>optional string path = 2;</code>
@@ -14270,7 +14270,7 @@ public final class DatabricksArtifacts {
       private java.lang.Object path_ = "";
       /**
        * <pre>
-       * Atifact path, relative to the Run's artifact root location
+       * Atifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -14281,7 +14281,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Atifact path, relative to the Run's artifact root location
+       * Atifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -14303,7 +14303,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Atifact path, relative to the Run's artifact root location
+       * Atifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -14324,7 +14324,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Atifact path, relative to the Run's artifact root location
+       * Atifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -14343,7 +14343,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Atifact path, relative to the Run's artifact root location
+       * Atifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>
@@ -14357,7 +14357,7 @@ public final class DatabricksArtifacts {
       }
       /**
        * <pre>
-       * Atifact path, relative to the Run's artifact root location
+       * Atifact path, relative to the Run's artifact root location (e.g. "path/to/file")
        * </pre>
        *
        * <code>optional string path = 2;</code>

--- a/mlflow/protos/databricks_artifacts.proto
+++ b/mlflow/protos/databricks_artifacts.proto
@@ -42,6 +42,43 @@ service DatabricksMlflowArtifactsService {
       visibility: PUBLIC_UNDOCUMENTED,
     };
   }
+
+  // Initiate a multipart upload and return presinged URLs for uploading parts and aborting the
+  // initiated multipart upload.
+  rpc createMultipartUpload (CreateMultipartUpload) returns (CreateMultipartUpload.Response) {
+    option (rpc) = {
+      endpoints: [{
+        method: "POST",
+        path: "/mlflow/artifacts/create-multipart-upload"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+    };
+  }
+
+  // Complete a multipart upload
+  rpc completeMultipartUpload (CompleteMultipartUpload) returns (CompleteMultipartUpload.Response) {
+    option (rpc) = {
+      endpoints: [{
+        method: "POST",
+        path: "/mlflow/artifacts/complete-multipart-upload"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+    };
+  }
+
+  // Get a presigned URL to upload a part. Used when we need to retry failed part uploads.
+  rpc getPresignedUploadPartUrl (GetPresignedUploadPartUrl) returns (GetPresignedUploadPartUrl.Response) {
+    option (rpc) = {
+      endpoints: [{
+        method: "GET",
+        path: "/mlflow/artifacts/get-presigned-upload-part-url"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+    };
+  }
 }
 
 // The type of a given artifact access credential
@@ -153,5 +190,81 @@ message GetCredentialsForWrite {
     // Older versions of the MLflow client use this field to retrieve credentials via point fetches.
     reserved 1;
 
+  }
+}
+
+message CreateMultipartUpload {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+  option (scalapb.message).extends = "com.databricks.mlflow.api.MlflowTrackingMessage";
+
+  // Run ID
+  optional string run_id = 1 [(validate_required) = true];
+
+  // Artifact path, relative to the Run's artifact root location
+  optional string path = 2;
+
+  // Number of parts to upload in the initiated multipart upload
+  optional int64 num_parts = 3  [(validate_required) = true];
+
+  message Response {
+    // ID identifying the initiated multipart upload
+    optional string upload_id = 1;
+
+    // Credentials for uploading parts in the initiated multipart upload
+    repeated ArtifactCredentialInfo upload_credential_infos = 2;
+
+    // Why doesn't the response contain a presigned URL for completing the multipart upload?
+    // As reported in https://github.com/aws/aws-sdk-java/issues/1537, AWS Java SDK v1
+    // doesn't support generating a presigned URL for completing a multipart upload.
+
+    // Credential for aborting the initiated multipart upload
+    optional ArtifactCredentialInfo abort_credential_info = 3;
+  }
+}
+
+message PartEtag {
+  optional int64 part_number = 1;
+
+  optional string etag = 2;
+}
+
+message CompleteMultipartUpload {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+  option (scalapb.message).extends = "com.databricks.mlflow.api.MlflowTrackingMessage";
+
+  // Run ID
+  optional string run_id = 1 [(validate_required) = true];
+
+  // Artifact path, relative to the Run's artifact root location
+  optional string path = 2;
+
+  // ID identifying the multipart upload to complete
+  optional string upload_id = 3 [(validate_required) = true];
+
+  // A list of parts uploaded in the multipart upload to complete
+  repeated PartEtag part_etags = 4;
+
+  message Response {}
+}
+
+message GetPresignedUploadPartUrl {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+  option (scalapb.message).extends = "com.databricks.mlflow.api.MlflowTrackingMessage";
+
+  // Run ID
+  optional string run_id = 1 [(validate_required) = true];
+
+  // Atifact path, relative to the Run's artifact root location
+  optional string path = 2;
+
+  // ID identifying the multipart upload in which the part is uploaded
+  optional string upload_id = 3 [(validate_required) = true];
+
+  // Part number
+  optional int64 part_number = 4 [(validate_required) = true];
+
+  message Response {
+    // Credential for uploading the part
+    optional ArtifactCredentialInfo upload_credential_info = 1;
   }
 }

--- a/mlflow/protos/databricks_artifacts.proto
+++ b/mlflow/protos/databricks_artifacts.proto
@@ -200,17 +200,17 @@ message CreateMultipartUpload {
   // Run ID
   optional string run_id = 1 [(validate_required) = true];
 
-  // Artifact path, relative to the Run's artifact root location
+  // Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
   optional string path = 2;
 
-  // Number of parts to upload in the initiated multipart upload
+  // Number of file parts (chunks of data) to upload in the initiated multipart upload
   optional int64 num_parts = 3  [(validate_required) = true];
 
   message Response {
     // ID identifying the initiated multipart upload
     optional string upload_id = 1;
 
-    // Credentials for uploading parts in the initiated multipart upload
+    // Credentials for uploading file parts in the initiated multipart upload
     repeated ArtifactCredentialInfo upload_credential_infos = 2;
 
     // Why doesn't the response contain a presigned URL for completing the multipart upload?
@@ -235,13 +235,13 @@ message CompleteMultipartUpload {
   // Run ID
   optional string run_id = 1 [(validate_required) = true];
 
-  // Artifact path, relative to the Run's artifact root location
+  // Artifact path, relative to the Run's artifact root location (e.g. "path/to/file")
   optional string path = 2;
 
   // ID identifying the multipart upload to complete
   optional string upload_id = 3 [(validate_required) = true];
 
-  // A list of parts uploaded in the multipart upload to complete
+  // A list of file parts uploaded in the multipart upload to complete
   repeated PartEtag part_etags = 4;
 
   message Response {}
@@ -254,7 +254,7 @@ message GetPresignedUploadPartUrl {
   // Run ID
   optional string run_id = 1 [(validate_required) = true];
 
-  // Atifact path, relative to the Run's artifact root location
+  // Atifact path, relative to the Run's artifact root location (e.g. "path/to/file")
   optional string path = 2;
 
   // ID identifying the multipart upload in which the part is uploaded

--- a/mlflow/protos/databricks_artifacts_pb2.py
+++ b/mlflow/protos/databricks_artifacts_pb2.py
@@ -19,7 +19,7 @@ from .scalapb import scalapb_pb2 as scalapb_dot_scalapb__pb2
 from . import databricks_pb2 as databricks__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1a\x64\x61tabricks_artifacts.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xdf\x01\n\x16\x41rtifactCredentialInfo\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\nsigned_uri\x18\x03 \x01(\t\x12:\n\x07headers\x18\x04 \x03(\x0b\x32).mlflow.ArtifactCredentialInfo.HttpHeader\x12,\n\x04type\x18\x05 \x01(\x0e\x32\x1e.mlflow.ArtifactCredentialType\x1a)\n\nHttpHeader\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x95\x02\n\x15GetCredentialsForRead\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a\x63\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\tJ\x04\x08\x01\x10\x02:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage\"\x96\x02\n\x16GetCredentialsForWrite\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a\x63\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\tJ\x04\x08\x01\x10\x02:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage*s\n\x16\x41rtifactCredentialType\x12\x11\n\rAZURE_SAS_URI\x10\x01\x12\x15\n\x11\x41WS_PRESIGNED_URL\x10\x02\x12\x12\n\x0eGCP_SIGNED_URL\x10\x03\x12\x1b\n\x17\x41ZURE_ADLS_GEN2_SAS_URI\x10\x04\x32\xe4\x02\n DatabricksMlflowArtifactsService\x12\x9c\x01\n\x15getCredentialsForRead\x12\x1d.mlflow.GetCredentialsForRead\x1a&.mlflow.GetCredentialsForRead.Response\"<\xf2\x86\x19\x38\n4\n\x04POST\x12&/mlflow/artifacts/credentials-for-read\x1a\x04\x08\x02\x10\x00\x10\x03\x12\xa0\x01\n\x16getCredentialsForWrite\x12\x1e.mlflow.GetCredentialsForWrite\x1a\'.mlflow.GetCredentialsForWrite.Response\"=\xf2\x86\x19\x39\n5\n\x04POST\x12\'/mlflow/artifacts/credentials-for-write\x1a\x04\x08\x02\x10\x00\x10\x03\x42,\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1a\x64\x61tabricks_artifacts.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xdf\x01\n\x16\x41rtifactCredentialInfo\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\nsigned_uri\x18\x03 \x01(\t\x12:\n\x07headers\x18\x04 \x03(\x0b\x32).mlflow.ArtifactCredentialInfo.HttpHeader\x12,\n\x04type\x18\x05 \x01(\x0e\x32\x1e.mlflow.ArtifactCredentialType\x1a)\n\nHttpHeader\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x95\x02\n\x15GetCredentialsForRead\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a\x63\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\tJ\x04\x08\x01\x10\x02:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage\"\x96\x02\n\x16GetCredentialsForWrite\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x12\n\npage_token\x18\x03 \x01(\t\x1a\x63\n\x08Response\x12\x38\n\x10\x63redential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\tJ\x04\x08\x01\x10\x02:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage\"\xd5\x02\n\x15\x43reateMultipartUpload\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x17\n\tnum_parts\x18\x03 \x01(\x03\x42\x04\xf8\x86\x19\x01\x1a\x9d\x01\n\x08Response\x12\x11\n\tupload_id\x18\x01 \x01(\t\x12?\n\x17upload_credential_infos\x18\x02 \x03(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo\x12=\n\x15\x61\x62ort_credential_info\x18\x03 \x01(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage\"-\n\x08PartEtag\x12\x13\n\x0bpart_number\x18\x01 \x01(\x03\x12\x0c\n\x04\x65tag\x18\x02 \x01(\t\"\xe9\x01\n\x17\x43ompleteMultipartUpload\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x17\n\tupload_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12$\n\npart_etags\x18\x04 \x03(\x0b\x32\x10.mlflow.PartEtag\x1a\n\n\x08Response:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage\"\xa0\x02\n\x19GetPresignedUploadPartUrl\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x17\n\tupload_id\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x0bpart_number\x18\x04 \x01(\x03\x42\x04\xf8\x86\x19\x01\x1aJ\n\x08Response\x12>\n\x16upload_credential_info\x18\x01 \x01(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage*s\n\x16\x41rtifactCredentialType\x12\x11\n\rAZURE_SAS_URI\x10\x01\x12\x15\n\x11\x41WS_PRESIGNED_URL\x10\x02\x12\x12\n\x0eGCP_SIGNED_URL\x10\x03\x12\x1b\n\x17\x41ZURE_ADLS_GEN2_SAS_URI\x10\x04\x32\xe3\x06\n DatabricksMlflowArtifactsService\x12\x9c\x01\n\x15getCredentialsForRead\x12\x1d.mlflow.GetCredentialsForRead\x1a&.mlflow.GetCredentialsForRead.Response\"<\xf2\x86\x19\x38\n4\n\x04POST\x12&/mlflow/artifacts/credentials-for-read\x1a\x04\x08\x02\x10\x00\x10\x03\x12\xa0\x01\n\x16getCredentialsForWrite\x12\x1e.mlflow.GetCredentialsForWrite\x1a\'.mlflow.GetCredentialsForWrite.Response\"=\xf2\x86\x19\x39\n5\n\x04POST\x12\'/mlflow/artifacts/credentials-for-write\x1a\x04\x08\x02\x10\x00\x10\x03\x12\x9f\x01\n\x15\x63reateMultipartUpload\x12\x1d.mlflow.CreateMultipartUpload\x1a&.mlflow.CreateMultipartUpload.Response\"?\xf2\x86\x19;\n7\n\x04POST\x12)/mlflow/artifacts/create-multipart-upload\x1a\x04\x08\x02\x10\x00\x10\x03\x12\xa7\x01\n\x17\x63ompleteMultipartUpload\x12\x1f.mlflow.CompleteMultipartUpload\x1a(.mlflow.CompleteMultipartUpload.Response\"A\xf2\x86\x19=\n9\n\x04POST\x12+/mlflow/artifacts/complete-multipart-upload\x1a\x04\x08\x02\x10\x00\x10\x03\x12\xb0\x01\n\x19getPresignedUploadPartUrl\x12!.mlflow.GetPresignedUploadPartUrl\x1a*.mlflow.GetPresignedUploadPartUrl.Response\"D\xf2\x86\x19@\n<\n\x03GET\x12//mlflow/artifacts/get-presigned-upload-part-url\x1a\x04\x08\x02\x10\x00\x10\x03\x42,\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
 
 _ARTIFACTCREDENTIALTYPE = DESCRIPTOR.enum_types_by_name['ArtifactCredentialType']
 ArtifactCredentialType = enum_type_wrapper.EnumTypeWrapper(_ARTIFACTCREDENTIALTYPE)
@@ -35,6 +35,13 @@ _GETCREDENTIALSFORREAD = DESCRIPTOR.message_types_by_name['GetCredentialsForRead
 _GETCREDENTIALSFORREAD_RESPONSE = _GETCREDENTIALSFORREAD.nested_types_by_name['Response']
 _GETCREDENTIALSFORWRITE = DESCRIPTOR.message_types_by_name['GetCredentialsForWrite']
 _GETCREDENTIALSFORWRITE_RESPONSE = _GETCREDENTIALSFORWRITE.nested_types_by_name['Response']
+_CREATEMULTIPARTUPLOAD = DESCRIPTOR.message_types_by_name['CreateMultipartUpload']
+_CREATEMULTIPARTUPLOAD_RESPONSE = _CREATEMULTIPARTUPLOAD.nested_types_by_name['Response']
+_PARTETAG = DESCRIPTOR.message_types_by_name['PartEtag']
+_COMPLETEMULTIPARTUPLOAD = DESCRIPTOR.message_types_by_name['CompleteMultipartUpload']
+_COMPLETEMULTIPARTUPLOAD_RESPONSE = _COMPLETEMULTIPARTUPLOAD.nested_types_by_name['Response']
+_GETPRESIGNEDUPLOADPARTURL = DESCRIPTOR.message_types_by_name['GetPresignedUploadPartUrl']
+_GETPRESIGNEDUPLOADPARTURL_RESPONSE = _GETPRESIGNEDUPLOADPARTURL.nested_types_by_name['Response']
 ArtifactCredentialInfo = _reflection.GeneratedProtocolMessageType('ArtifactCredentialInfo', (_message.Message,), {
 
   'HttpHeader' : _reflection.GeneratedProtocolMessageType('HttpHeader', (_message.Message,), {
@@ -80,6 +87,58 @@ GetCredentialsForWrite = _reflection.GeneratedProtocolMessageType('GetCredential
 _sym_db.RegisterMessage(GetCredentialsForWrite)
 _sym_db.RegisterMessage(GetCredentialsForWrite.Response)
 
+CreateMultipartUpload = _reflection.GeneratedProtocolMessageType('CreateMultipartUpload', (_message.Message,), {
+
+  'Response' : _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), {
+    'DESCRIPTOR' : _CREATEMULTIPARTUPLOAD_RESPONSE,
+    '__module__' : 'databricks_artifacts_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.CreateMultipartUpload.Response)
+    })
+  ,
+  'DESCRIPTOR' : _CREATEMULTIPARTUPLOAD,
+  '__module__' : 'databricks_artifacts_pb2'
+  # @@protoc_insertion_point(class_scope:mlflow.CreateMultipartUpload)
+  })
+_sym_db.RegisterMessage(CreateMultipartUpload)
+_sym_db.RegisterMessage(CreateMultipartUpload.Response)
+
+PartEtag = _reflection.GeneratedProtocolMessageType('PartEtag', (_message.Message,), {
+  'DESCRIPTOR' : _PARTETAG,
+  '__module__' : 'databricks_artifacts_pb2'
+  # @@protoc_insertion_point(class_scope:mlflow.PartEtag)
+  })
+_sym_db.RegisterMessage(PartEtag)
+
+CompleteMultipartUpload = _reflection.GeneratedProtocolMessageType('CompleteMultipartUpload', (_message.Message,), {
+
+  'Response' : _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), {
+    'DESCRIPTOR' : _COMPLETEMULTIPARTUPLOAD_RESPONSE,
+    '__module__' : 'databricks_artifacts_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.CompleteMultipartUpload.Response)
+    })
+  ,
+  'DESCRIPTOR' : _COMPLETEMULTIPARTUPLOAD,
+  '__module__' : 'databricks_artifacts_pb2'
+  # @@protoc_insertion_point(class_scope:mlflow.CompleteMultipartUpload)
+  })
+_sym_db.RegisterMessage(CompleteMultipartUpload)
+_sym_db.RegisterMessage(CompleteMultipartUpload.Response)
+
+GetPresignedUploadPartUrl = _reflection.GeneratedProtocolMessageType('GetPresignedUploadPartUrl', (_message.Message,), {
+
+  'Response' : _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), {
+    'DESCRIPTOR' : _GETPRESIGNEDUPLOADPARTURL_RESPONSE,
+    '__module__' : 'databricks_artifacts_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.GetPresignedUploadPartUrl.Response)
+    })
+  ,
+  'DESCRIPTOR' : _GETPRESIGNEDUPLOADPARTURL,
+  '__module__' : 'databricks_artifacts_pb2'
+  # @@protoc_insertion_point(class_scope:mlflow.GetPresignedUploadPartUrl)
+  })
+_sym_db.RegisterMessage(GetPresignedUploadPartUrl)
+_sym_db.RegisterMessage(GetPresignedUploadPartUrl.Response)
+
 _DATABRICKSMLFLOWARTIFACTSSERVICE = DESCRIPTOR.services_by_name['DatabricksMlflowArtifactsService']
 if _descriptor._USE_C_DESCRIPTORS == False:
 
@@ -93,12 +152,38 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _GETCREDENTIALSFORWRITE.fields_by_name['run_id']._serialized_options = b'\370\206\031\001'
   _GETCREDENTIALSFORWRITE._options = None
   _GETCREDENTIALSFORWRITE._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]\342?1\n/com.databricks.mlflow.api.MlflowTrackingMessage'
+  _CREATEMULTIPARTUPLOAD.fields_by_name['run_id']._options = None
+  _CREATEMULTIPARTUPLOAD.fields_by_name['run_id']._serialized_options = b'\370\206\031\001'
+  _CREATEMULTIPARTUPLOAD.fields_by_name['num_parts']._options = None
+  _CREATEMULTIPARTUPLOAD.fields_by_name['num_parts']._serialized_options = b'\370\206\031\001'
+  _CREATEMULTIPARTUPLOAD._options = None
+  _CREATEMULTIPARTUPLOAD._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]\342?1\n/com.databricks.mlflow.api.MlflowTrackingMessage'
+  _COMPLETEMULTIPARTUPLOAD.fields_by_name['run_id']._options = None
+  _COMPLETEMULTIPARTUPLOAD.fields_by_name['run_id']._serialized_options = b'\370\206\031\001'
+  _COMPLETEMULTIPARTUPLOAD.fields_by_name['upload_id']._options = None
+  _COMPLETEMULTIPARTUPLOAD.fields_by_name['upload_id']._serialized_options = b'\370\206\031\001'
+  _COMPLETEMULTIPARTUPLOAD._options = None
+  _COMPLETEMULTIPARTUPLOAD._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]\342?1\n/com.databricks.mlflow.api.MlflowTrackingMessage'
+  _GETPRESIGNEDUPLOADPARTURL.fields_by_name['run_id']._options = None
+  _GETPRESIGNEDUPLOADPARTURL.fields_by_name['run_id']._serialized_options = b'\370\206\031\001'
+  _GETPRESIGNEDUPLOADPARTURL.fields_by_name['upload_id']._options = None
+  _GETPRESIGNEDUPLOADPARTURL.fields_by_name['upload_id']._serialized_options = b'\370\206\031\001'
+  _GETPRESIGNEDUPLOADPARTURL.fields_by_name['part_number']._options = None
+  _GETPRESIGNEDUPLOADPARTURL.fields_by_name['part_number']._serialized_options = b'\370\206\031\001'
+  _GETPRESIGNEDUPLOADPARTURL._options = None
+  _GETPRESIGNEDUPLOADPARTURL._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]\342?1\n/com.databricks.mlflow.api.MlflowTrackingMessage'
   _DATABRICKSMLFLOWARTIFACTSSERVICE.methods_by_name['getCredentialsForRead']._options = None
   _DATABRICKSMLFLOWARTIFACTSSERVICE.methods_by_name['getCredentialsForRead']._serialized_options = b'\362\206\0318\n4\n\004POST\022&/mlflow/artifacts/credentials-for-read\032\004\010\002\020\000\020\003'
   _DATABRICKSMLFLOWARTIFACTSSERVICE.methods_by_name['getCredentialsForWrite']._options = None
   _DATABRICKSMLFLOWARTIFACTSSERVICE.methods_by_name['getCredentialsForWrite']._serialized_options = b'\362\206\0319\n5\n\004POST\022\'/mlflow/artifacts/credentials-for-write\032\004\010\002\020\000\020\003'
-  _ARTIFACTCREDENTIALTYPE._serialized_start=866
-  _ARTIFACTCREDENTIALTYPE._serialized_end=981
+  _DATABRICKSMLFLOWARTIFACTSSERVICE.methods_by_name['createMultipartUpload']._options = None
+  _DATABRICKSMLFLOWARTIFACTSSERVICE.methods_by_name['createMultipartUpload']._serialized_options = b'\362\206\031;\n7\n\004POST\022)/mlflow/artifacts/create-multipart-upload\032\004\010\002\020\000\020\003'
+  _DATABRICKSMLFLOWARTIFACTSSERVICE.methods_by_name['completeMultipartUpload']._options = None
+  _DATABRICKSMLFLOWARTIFACTSSERVICE.methods_by_name['completeMultipartUpload']._serialized_options = b'\362\206\031=\n9\n\004POST\022+/mlflow/artifacts/complete-multipart-upload\032\004\010\002\020\000\020\003'
+  _DATABRICKSMLFLOWARTIFACTSSERVICE.methods_by_name['getPresignedUploadPartUrl']._options = None
+  _DATABRICKSMLFLOWARTIFACTSSERVICE.methods_by_name['getPresignedUploadPartUrl']._serialized_options = b'\362\206\031@\n<\n\003GET\022//mlflow/artifacts/get-presigned-upload-part-url\032\004\010\002\020\000\020\003'
+  _ARTIFACTCREDENTIALTYPE._serialized_start=1784
+  _ARTIFACTCREDENTIALTYPE._serialized_end=1899
   _ARTIFACTCREDENTIALINFO._serialized_start=80
   _ARTIFACTCREDENTIALINFO._serialized_end=303
   _ARTIFACTCREDENTIALINFO_HTTPHEADER._serialized_start=262
@@ -111,8 +196,22 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _GETCREDENTIALSFORWRITE._serialized_end=864
   _GETCREDENTIALSFORWRITE_RESPONSE._serialized_start=387
   _GETCREDENTIALSFORWRITE_RESPONSE._serialized_end=486
-  _DATABRICKSMLFLOWARTIFACTSSERVICE._serialized_start=984
-  _DATABRICKSMLFLOWARTIFACTSSERVICE._serialized_end=1340
+  _CREATEMULTIPARTUPLOAD._serialized_start=867
+  _CREATEMULTIPARTUPLOAD._serialized_end=1208
+  _CREATEMULTIPARTUPLOAD_RESPONSE._serialized_start=954
+  _CREATEMULTIPARTUPLOAD_RESPONSE._serialized_end=1111
+  _PARTETAG._serialized_start=1210
+  _PARTETAG._serialized_end=1255
+  _COMPLETEMULTIPARTUPLOAD._serialized_start=1258
+  _COMPLETEMULTIPARTUPLOAD._serialized_end=1491
+  _COMPLETEMULTIPARTUPLOAD_RESPONSE._serialized_start=387
+  _COMPLETEMULTIPARTUPLOAD_RESPONSE._serialized_end=397
+  _GETPRESIGNEDUPLOADPARTURL._serialized_start=1494
+  _GETPRESIGNEDUPLOADPARTURL._serialized_end=1782
+  _GETPRESIGNEDUPLOADPARTURL_RESPONSE._serialized_start=1611
+  _GETPRESIGNEDUPLOADPARTURL_RESPONSE._serialized_end=1685
+  _DATABRICKSMLFLOWARTIFACTSSERVICE._serialized_start=1902
+  _DATABRICKSMLFLOWARTIFACTSSERVICE._serialized_end=2769
 DatabricksMlflowArtifactsService = service_reflection.GeneratedServiceType('DatabricksMlflowArtifactsService', (_service.Service,), dict(
   DESCRIPTOR = _DATABRICKSMLFLOWARTIFACTSSERVICE,
   __module__ = 'databricks_artifacts_pb2'

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -60,7 +60,7 @@ from mlflow.utils.uri import (
 _logger = logging.getLogger(__name__)
 _AZURE_MAX_BLOCK_CHUNK_SIZE = 100000000  # Max. size of each block allowed is 100 MB in stage_block
 _DOWNLOAD_CHUNK_SIZE = 100000000
-_MULTIPART_UPLOAD_CHUNK_SIZE = 100 * 1000 * 1000  # 100 MB
+_MULTIPART_UPLOAD_CHUNK_SIZE = 10_000_000  # 10 MB
 _MAX_CREDENTIALS_REQUEST_SIZE = 2000  # Max number of artifact paths in a single credentials request
 _SERVICE_AND_METHOD_TO_INFO = {
     service: extract_api_info_for_service(service, _REST_API_PATH_PREFIX)

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -321,7 +321,7 @@ def cloud_storage_http_request(
 
     :return requests.Response object.
     """
-    if method.lower() not in ("put", "get", "patch"):
+    if method.lower() not in ("put", "get", "patch", "delete"):
         raise ValueError("Illegal http method: " + method)
     try:
         with _get_http_response_with_retries(


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Support multipart upload for AWS Databricks to log an artifact larger than 5 GB.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

Ran the following code with the new backend implementation and made sure a large pytorch model (> 10 MB) can be uploaded and the output of the loaded model is identical to the output of the original model.

```python
import torch
import tempfile
import pathlib
import mlflow
import uuid
import logging
from unittest import mock
import requests
import re
import urllib
from PIL import Image

print("""
# *************************************************************************
# Large model upalod
# *************************************************************************
""")


# Prepare a model that's large than the MPU chunk size
# model = torch.hub.load("pytorch/vision:v0.10.0", "resnet18", pretrained=True)
model = torch.hub.load('pytorch/vision:v0.10.0', 'resnet152', pretrained=True)
model.eval()

# Prepare an image for testing
with tempfile.TemporaryDirectory() as tmpdir:
    url = "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
    filepath = f"{tmpdir}/dog.jpg"
    try:
        urllib.URLopener().retrieve(url, filepath)
    except:
        urllib.request.urlretrieve(url, filepath)


    input_image = Image.open(filepath)

from torchvision import transforms
    
preprocess = transforms.Compose(
    [
        transforms.Resize(256),
        transforms.CenterCrop(224),
        transforms.ToTensor(),
        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
    ]
)
input_tensor = preprocess(input_image)
input_batch = input_tensor.unsqueeze(0)  # create a mini-batch as expected by the model

with torch.no_grad():
    output = model(input_batch)

logging.getLogger("mlflow").setLevel(logging.DEBUG)
mlflow.set_tracking_uri("databricks")
mlflow.set_experiment("/Users/harutaka.kawamura@databricks.com/test")

# Wrap requests.Session.request to measure how long each request takes
original = requests.Session.request

regex = re.compile(r"partNumber=(\d+)")

def wrapped(*args, **kwargs):
    url = args[2]
    m = regex.search(url)
    if m:
        print("part number", m.group(1))
    result = original(*args, **kwargs)
    return result

with mock.patch("requests.Session.request", wrapped), mlflow.start_run() as run:
    print("----- logging model -----")
    info = mlflow.pytorch.log_model(model, "model", pip_requirements=["torch"])
    print("----- loading model -----")
    loaded_model = mlflow.pytorch.load_model(info.model_uri)

# Verify the output doesn't change
print("----- verifying output -----")
output_loaded = loaded_model(input_batch)
assert torch.equal(output, output_loaded)

print("----- DONE -----")


print("""
# *************************************************************************
# > 5GB file upalod
# *************************************************************************
""")

with tempfile.TemporaryDirectory() as tmpdir:
    # Create a large file
    size = 6 * 1024 * 1024 * 1024  # 6 GB
    path = pathlib.Path(tmpdir, uuid.uuid4().hex)
    with path.open("wb") as f:
        f.seek(size - 1)
        f.write(b"\0")

    with mock.patch("requests.Session.request", wrapped), mlflow.start_run() as run:
        # Upload it
        print("----- logging large file -----")
        mlflow.log_artifact(path)
        print("----- DONE -----")
```

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
