### PR TITLE
implemented feature for allowing async inference config

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -2367,8 +2367,8 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
 
                        - ``variant_name``: A string specifying the desired name when creating a
                                            production variant.  Defaults to ``None``.                                           
-                       - ``endpoint_config``: A dictionary specifying the endpoint configuration 
-                        as key-value pairs to be set for the deployed endpoint
+                       - ``async_inference_config``: A dictionary specifying the async config 
+                                                     configuration. Defaults to ``None``.
                        - ``env``: A dictionary specifying environment variables as key-value pairs
                          to be set for the deployed model. Defaults to ``None``.
 

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -174,6 +174,7 @@ def _deploy(
     timeout_seconds=1200,
     data_capture_config=None,
     variant_name=None,
+    async_inference_config=None,
     env=None,
     tags=None,
 ):
@@ -311,6 +312,20 @@ def _deploy(
                                     mfs.deploy(..., data_capture_config=data_capture_config)
 
     :param variant_name: The name to assign to the new production variant.
+    :param async_inference_config: The name to assign to the endpoint_config
+                                    on the sagemaker endpoint.
+                                    .. code-block:: python
+                                        :caption: Example
+                                            "AsyncInferenceConfig": {
+                                                "ClientConfig": {
+                                                    "MaxConcurrentInvocationsPerInstance": 4  # pylint: disable=line-too-long
+                                                },
+                                                "OutputConfig": {
+                                                    "S3OutputPath": "s3://<path-to-output-bucket>",  # pylint: disable=line-too-long
+                                                    "NotificationConfig": {},  # pylint: disable=line-too-long
+                                                },
+                                            }
+
     :param env: An optional dictionary of environment variables to set for the model.
     :param tags: An optional dictionary of tags to apply to the endpoint.
     """
@@ -369,6 +384,7 @@ def _deploy(
         )
 
     model_name = _get_sagemaker_model_name(endpoint_name=app_name)
+
     if not image_url:
         image_url = _get_default_image_url(region_name=region_name)
     if not execution_role_arn:
@@ -402,6 +418,7 @@ def _deploy(
             sage_client=sage_client,
             s3_client=s3_client,
             variant_name=variant_name,
+            async_inference_config=async_inference_config,
             data_capture_config=data_capture_config,
             env=env,
             tags=tags,
@@ -421,6 +438,7 @@ def _deploy(
             role=execution_role_arn,
             sage_client=sage_client,
             variant_name=variant_name,
+            async_inference_config=async_inference_config,
             env=env,
             tags=tags,
         )
@@ -1474,6 +1492,7 @@ def _create_sagemaker_endpoint(
     role,
     sage_client,
     variant_name=None,
+    async_inference_config=None,
     env=None,
     tags=None,
 ):
@@ -1529,9 +1548,10 @@ def _create_sagemaker_endpoint(
         "ProductionVariants": [production_variant],
         "Tags": [{"Key": "app_name", "Value": endpoint_name}],
     }
+    if async_inference_config:
+        endpoint_config_kwargs["AsyncInferenceConfig"] = async_inference_config
     if data_capture_config is not None:
         endpoint_config_kwargs["DataCaptureConfig"] = data_capture_config
-
     endpoint_config_response = sage_client.create_endpoint_config(**endpoint_config_kwargs)
     _logger.info(
         "Created endpoint configuration with arn: %s", endpoint_config_response["EndpointConfigArn"]
@@ -1589,6 +1609,7 @@ def _update_sagemaker_endpoint(
     sage_client,
     s3_client,
     variant_name=None,
+    async_inference_config=None,
     data_capture_config=None,
     env=None,
     tags=None,
@@ -1610,7 +1631,10 @@ def _update_sagemaker_endpoint(
     :param role: SageMaker execution ARN role.
     :param sage_client: A boto3 client for SageMaker.
     :param s3_client: A boto3 client for S3.
-    :variant_name: The name to assign to the new production variant if it doesn't already exist.
+    :param variant_name: The name to assign to the new production variant if it doesn't already exist. # pylint: disable=line-too-long
+    :param async_inference_config: A dictionary specifying the async inference configuration to use.
+                         For more information, see https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_AsyncInferenceConfig.html.
+                         Defaults to ``None``.
     :param: data_capture_config: A dictionary specifying the data capture configuration to use.
                                  For more information, see https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_DataCaptureConfig.html.
                                  Defaults to ``None``.
@@ -1668,11 +1692,14 @@ def _update_sagemaker_endpoint(
     # Create the new endpoint configuration and update the endpoint
     # to adopt the new configuration
     new_config_name = _get_sagemaker_config_name(endpoint_name)
+    # This is the hardcoded config for endpoint
     endpoint_config_kwargs = {
         "EndpointConfigName": new_config_name,
         "ProductionVariants": production_variants,
         "Tags": [{"Key": "app_name", "Value": endpoint_name}],
     }
+    if async_inference_config:
+        endpoint_config_kwargs["AsyncInferenceConfig"] = async_inference_config
     if data_capture_config is not None:
         endpoint_config_kwargs["DataCaptureConfig"] = data_capture_config
     endpoint_config_response = sage_client.create_endpoint_config(**endpoint_config_kwargs)
@@ -1965,6 +1992,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
             "variant_name": None,
             "env": None,
             "tags": None,
+            "async_inference_config": {},
         }
 
         if create_mode:
@@ -1979,7 +2007,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
 
         int_fields = {"instance_count", "timeout_seconds"}
         bool_fields = {"synchronous", "archive"}
-        dict_fields = {"vpc_config", "data_capture_config", "tags", "env"}
+        dict_fields = {"vpc_config", "data_capture_config", "tags", "env", "async_inference_config"}
         for key, value in custom_config.items():
             if key not in config:
                 continue
@@ -2104,6 +2132,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
 
                        - ``variant_name``: A string specifying the desired name when creating a
                                            production variant.  Defaults to ``None``.
+                       - ``async_inference_config``: A dictionary specifying the async_inference_configuration # pylint: disable=line-too-long
 
                        - ``env``: A dictionary specifying environment variables as key-value
                          pairs to be set for the deployed model. Defaults to ``None``.
@@ -2196,6 +2225,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
             synchronous=final_config["synchronous"],
             timeout_seconds=final_config["timeout_seconds"],
             variant_name=final_config["variant_name"],
+            async_inference_config=final_config["async_inference_config"],
             env=final_config["env"],
             tags=final_config["tags"],
         )
@@ -2336,8 +2366,9 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
                          Defaults to ``None``.
 
                        - ``variant_name``: A string specifying the desired name when creating a
-                                           production variant.  Defaults to ``None``.
-
+                                           production variant.  Defaults to ``None``.                                           
+                       - ``endpoint_config``: A dictionary specifying the endpoint configuration 
+                        as key-value pairs to be set for the deployed endpoint
                        - ``env``: A dictionary specifying environment variables as key-value pairs
                          to be set for the deployed model. Defaults to ``None``.
 
@@ -2454,6 +2485,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
             synchronous=final_config["synchronous"],
             timeout_seconds=final_config["timeout_seconds"],
             variant_name=final_config["variant_name"],
+            async_inference_config=final_config["async_inference_config"],
             env=final_config["env"],
             tags=final_config["tags"],
         )

--- a/tests/sagemaker/mock/test_sagemaker_service_mock.py
+++ b/tests/sagemaker/mock/test_sagemaker_service_mock.py
@@ -223,9 +223,14 @@ def test_describe_endpoint_config_response_contains_expected_attributes(sagemake
             "InitialVariantWeight": 1.0,
         },
     ]
+    async_inference_config = {
+        "ClientConfig": {"MaxConcurrentInvocationsPerInstance": 4},
+        "OutputConfig": {"S3OutputPath": "s3://bucket_name/", "NotificationConfig": {}},
+    }
     sagemaker_client.create_endpoint_config(
         EndpointConfigName=endpoint_config_name,
         ProductionVariants=production_variants,
+        AsyncInferenceConfig=async_inference_config,
     )
 
     describe_endpoint_config_response = sagemaker_client.describe_endpoint_config(
@@ -237,6 +242,8 @@ def test_describe_endpoint_config_response_contains_expected_attributes(sagemake
     assert describe_endpoint_config_response["EndpointConfigName"] == endpoint_config_name
     assert "ProductionVariants" in describe_endpoint_config_response
     assert describe_endpoint_config_response["ProductionVariants"] == production_variants
+    assert "AsyncInferenceConfig" in describe_endpoint_config_response
+    assert describe_endpoint_config_response["AsyncInferenceConfig"] == async_inference_config
 
 
 @mock_sagemaker

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -267,6 +267,103 @@ def test_create_deployment_with_assume_role_arn(
     ]
 
 
+@mock_sagemaker_aws_services
+def test_create_deployment_with_async_config(
+    pretrained_model, sagemaker_client, sagemaker_deployment_client
+):
+    app_name = "deploy_with_async_config"
+    expected_async_inference_config = {
+        "ClientConfig": {"MaxConcurrentInvocationsPerInstance": 4},
+        "OutputConfig": {"S3OutputPath": "s3://bucket_name/", "NotificationConfig": {}},
+    }
+    sagemaker_deployment_client.create_deployment(
+        name=app_name,
+        model_uri=pretrained_model.model_uri,
+        config={"async_inference_config": expected_async_inference_config},
+    )
+    configs = sagemaker_client.list_endpoint_configs()
+    target_config = None
+    for config in configs["EndpointConfigs"]:
+        if app_name in config["EndpointConfigName"]:
+            target_config = config
+    if target_config is None:
+        raise Exception("Endpoint config not found")
+    endpoint_config = sagemaker_client.describe_endpoint_config(
+        EndpointConfigName=target_config["EndpointConfigName"]
+    )
+    assert "AsyncInferenceConfig" in endpoint_config
+    assert endpoint_config["AsyncInferenceConfig"] == expected_async_inference_config
+
+
+@mock_sagemaker_aws_services
+def test_create_deployment_without_async_config(
+    pretrained_model, sagemaker_client, sagemaker_deployment_client
+):
+    app_name = "deploy_without_endpoint_config"
+    sagemaker_deployment_client.create_deployment(
+        name=app_name,
+        model_uri=pretrained_model.model_uri,
+    )
+    configs = sagemaker_client.list_endpoint_configs()
+    target_config = None
+    for config in configs["EndpointConfigs"]:
+        if app_name in config["EndpointConfigName"]:
+            target_config = config
+    if target_config is None:
+        raise Exception("Endpoint config not found")
+    assert "AsyncInferenceConfig" not in target_config
+
+
+@mock_sagemaker_aws_services
+def test_update_deployment_with_async_config_when_endpoint_exists(
+    pretrained_model, sagemaker_client, sagemaker_deployment_client
+):
+    app_name = "update_deploy_with_async_config"
+    expected_async_inference_config = {
+        "ClientConfig": {"MaxConcurrentInvocationsPerInstance": 4},
+        "OutputConfig": {"S3OutputPath": "s3://bucket_name/", "NotificationConfig": {}},
+    }
+    sagemaker_deployment_client.create_deployment(
+        name=app_name, model_uri=pretrained_model.model_uri
+    )
+    sagemaker_deployment_client.update_deployment(
+        name=app_name,
+        model_uri=pretrained_model.model_uri,
+        config={"async_inference_config": expected_async_inference_config},
+    )
+    configs = sagemaker_client.list_endpoint_configs()
+    target_config = None
+    for config in configs["EndpointConfigs"]:
+        if app_name in config["EndpointConfigName"]:
+            target_config = config
+    if target_config is None:
+        raise Exception("Endpoint config not found")
+    endpoint_config = sagemaker_client.describe_endpoint_config(
+        EndpointConfigName=target_config["EndpointConfigName"]
+    )
+    assert "AsyncInferenceConfig" in endpoint_config
+    assert endpoint_config["AsyncInferenceConfig"] == expected_async_inference_config
+
+
+@mock_sagemaker_aws_services
+def test_update_deployment_without_async_config(
+    pretrained_model, sagemaker_client, sagemaker_deployment_client
+):
+    app_name = "deploy_without_async_config"
+    sagemaker_deployment_client.update_deployment(
+        name=app_name,
+        model_uri=pretrained_model.model_uri,
+    )
+    configs = sagemaker_client.list_endpoint_configs()
+    target_config = None
+    for config in configs["EndpointConfigs"]:
+        if app_name in config["EndpointConfigName"]:
+            target_config = config
+    if target_config is None:
+        raise Exception("Endpoint config not found")
+    assert "AsyncInferenceConfig" not in target_config
+
+
 def test_create_deployment_with_unsupported_flavor_raises_exception(
     pretrained_model, sagemaker_deployment_client
 ):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
 
<!-- Resolve --> #7954

## What changes are proposed in this pull request?

In this PR we add a parameter for updating and creating deployments with async inference config

## How is this patch tested?

- [x ] Existing unit/integration tests
- [ x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [x ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations


<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ x ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
