### PR TITLE
Use `UnityCatalogModelsArtifactRepository` when UC registry URI is set

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -35,7 +35,6 @@ from mlflow.protos.databricks_uc_registry_messages_pb2 import (
 )
 import mlflow
 from mlflow.exceptions import MlflowException
-from mlflow.models.model import Model
 from mlflow.protos.databricks_uc_registry_service_pb2 import UcModelRegistryService
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.utils.proto_json_utils import message_to_json
@@ -316,6 +315,11 @@ class UcModelRegistryStore(BaseRestStore):
         return response.headers[_DATABRICKS_ORG_ID_HEADER]
 
     def _validate_model_signature(self, local_model_dir):
+        # Import Model here instead of in the top level, to avoid circular import; the
+        # mlflow.models.model module imports from MLflow tracking, which triggers an import of
+        # this file during store registry initialization
+        from mlflow.models.model import Model
+
         try:
             model = Model.load(local_model_dir)
         except Exception as e:

--- a/mlflow/store/artifact/artifact_repository_registry.py
+++ b/mlflow/store/artifact/artifact_repository_registry.py
@@ -1,6 +1,7 @@
 import entrypoints
 import warnings
 
+import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.azure_blob_artifact_repo import AzureBlobArtifactRepository
 from mlflow.store.artifact.dbfs_artifact_repo import dbfs_artifact_repo_factory

--- a/mlflow/store/artifact/artifact_repository_registry.py
+++ b/mlflow/store/artifact/artifact_repository_registry.py
@@ -1,7 +1,6 @@
 import entrypoints
 import warnings
 
-import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.azure_blob_artifact_repo import AzureBlobArtifactRepository
 from mlflow.store.artifact.dbfs_artifact_repo import dbfs_artifact_repo_factory

--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -11,6 +11,10 @@ from mlflow.store.artifact.utils.models import (
 from mlflow.utils.uri import (
     add_databricks_profile_info_to_artifact_uri,
     get_databricks_profile_uri_from_artifact_uri,
+    is_databricks_unity_catalog_uri,
+)
+from mlflow.store.artifact.unity_catalog_models_artifact_repo import (
+    UnityCatalogModelsArtifactRepository,
 )
 
 
@@ -28,7 +32,12 @@ class ModelsArtifactRepository(ArtifactRepository):
         from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 
         super().__init__(artifact_uri)
-        if is_using_databricks_registry(artifact_uri):
+        registry_uri = mlflow.get_registry_uri()
+        if is_databricks_unity_catalog_uri(uri=registry_uri):
+            self.repo = UnityCatalogModelsArtifactRepository(
+                artifact_uri=artifact_uri, registry_uri=registry_uri
+            )
+        elif is_using_databricks_registry(artifact_uri):
             # Use the DatabricksModelsArtifactRepository if a databricks profile is being used.
             self.repo = DatabricksModelsArtifactRepository(artifact_uri)
         else:

--- a/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
+++ b/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
@@ -33,11 +33,7 @@ class UnityCatalogModelsArtifactRepository(ArtifactRepository):
     Temporary scoped tokens for the appropriate cloud storage locations are fetched from the
     remote backend and used to download model artifacts.
 
-    The artifact_uri is expected to be of the form
-    - `models:/<model_name>/<model_version>`
-    - `models:/<model_name>/<stage>`  (refers to the latest model version in the given stage)
-    - `models:/<model_name>/latest`  (refers to the latest of all model versions)
-    - `models://<profile>/<model_name>/<model_version or stage or 'latest'>`
+    The artifact_uri is expected to be of the form `models:/<model_name>/<model_version>`
 
     Note : This artifact repository is meant is to be instantiated by the ModelsArtifactRepository
     when the client is pointing to a Unity Catalog model registry.

--- a/tests/store/artifact/test_models_artifact_repo.py
+++ b/tests/store/artifact/test_models_artifact_repo.py
@@ -2,13 +2,21 @@ import pytest
 from unittest import mock
 from unittest.mock import Mock
 
+import mlflow
 from mlflow.entities.model_registry import ModelVersion
 from mlflow.store.artifact.databricks_models_artifact_repo import DatabricksModelsArtifactRepository
+from mlflow.store.artifact.unity_catalog_models_artifact_repo import (
+    UnityCatalogModelsArtifactRepository,
+)
 from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow import MlflowClient
 
+
 MODELS_ARTIFACT_REPOSITORY_PACKAGE = "mlflow.store.artifact.models_artifact_repo"
 MODELS_ARTIFACT_REPOSITORY = MODELS_ARTIFACT_REPOSITORY_PACKAGE + ".ModelsArtifactRepository"
+UC_MODELS_ARTIFACT_REPOSITORY = (
+    f"{MODELS_ARTIFACT_REPOSITORY_PACKAGE}.UnityCatalogModelsArtifactRepository"
+)
 
 
 @pytest.mark.parametrize(
@@ -44,6 +52,18 @@ def test_models_artifact_repo_init_with_db_profile_inferred_from_context(uri_wit
         assert models_repo.artifact_uri == uri_without_profile
         assert isinstance(models_repo.repo, DatabricksModelsArtifactRepository)
         mock_repo.assert_called_once_with(uri_without_profile)
+
+
+def test_models_artifact_repo_init_with_uc_registry_db_profile_inferred_from_context():
+    uri_without_profile = "models:/MyModel/12"
+    uc_registry_uri = "databricks-uc://getRegistryUriDefault"
+    with mock.patch(UC_MODELS_ARTIFACT_REPOSITORY, autospec=True) as mock_repo, mock.patch(
+        "mlflow.get_registry_uri", return_value=uc_registry_uri
+    ):
+        models_repo = ModelsArtifactRepository(uri_without_profile)
+        assert models_repo.artifact_uri == uri_without_profile
+        assert isinstance(models_repo.repo, UnityCatalogModelsArtifactRepository)
+        mock_repo.assert_called_once_with(uri_without_profile, registry_uri=uc_registry_uri)
 
 
 def test_models_artifact_repo_init_with_version_uri_and_not_using_databricks_registry():

--- a/tests/store/artifact/test_models_artifact_repo.py
+++ b/tests/store/artifact/test_models_artifact_repo.py
@@ -2,7 +2,6 @@ import pytest
 from unittest import mock
 from unittest.mock import Mock
 
-import mlflow
 from mlflow.entities.model_registry import ModelVersion
 from mlflow.store.artifact.databricks_models_artifact_repo import DatabricksModelsArtifactRepository
 from mlflow.store.artifact.unity_catalog_models_artifact_repo import (


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

https://github.com/mlflow/mlflow/pull/7912

## What changes are proposed in this pull request?

This PR cherrypicks and polishes changes from https://github.com/mlflow/mlflow/pull/7912 that update the model registry artifact repository to leverage the `UnityCatalogModelsArtifactRepository` when the UC registry URI is set.

## How is this patch tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
