### PR TITLE
Use `UcModelRegistryStore` when UC registry URI is set

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -35,7 +35,6 @@ from mlflow.protos.databricks_uc_registry_messages_pb2 import (
 )
 import mlflow
 from mlflow.exceptions import MlflowException
-from mlflow.models.model import Model
 from mlflow.protos.databricks_uc_registry_service_pb2 import UcModelRegistryService
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.utils.proto_json_utils import message_to_json
@@ -316,6 +315,11 @@ class UcModelRegistryStore(BaseRestStore):
         return response.headers[_DATABRICKS_ORG_ID_HEADER]
 
     def _validate_model_signature(self, local_model_dir):
+        # Import Model here instead of in the top level, to avoid circular import; the
+        # mlflow.models.model module imports from MLflow tracking, which triggers an import of
+        # this file during store registry initialization
+        from mlflow.models.model import Model
+
         try:
             model = Model.load(local_model_dir)
         except Exception as e:

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -95,14 +95,14 @@ class UcModelRegistryStore(BaseRestStore):
     """
     Client for a remote model registry server accessed via REST API calls
 
-    :param registry_uri: URI with scheme 'databricks-uc'
+    :param store_uri: URI with scheme 'databricks-uc'
     :param tracking_uri: URI of the Databricks MLflow tracking server from which to fetch
                          run info and download run artifacts, when creating new model
                          versions from source artifacts logged to an MLflow run.
     """
 
-    def __init__(self, registry_uri, tracking_uri):
-        super().__init__(get_host_creds=functools.partial(get_databricks_host_creds, registry_uri))
+    def __init__(self, store_uri, tracking_uri):
+        super().__init__(get_host_creds=functools.partial(get_databricks_host_creds, store_uri))
         self.tracking_uri = tracking_uri
         self.get_tracking_host_creds = functools.partial(get_databricks_host_creds, tracking_uri)
 

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -10,10 +10,15 @@ class AbstractStore:
 
     __metaclass__ = ABCMeta
 
-    def __init__(self):
+    def __init__(self, store_uri=None, tracking_uri=None):
         """
         Empty constructor. This is deliberately not marked as abstract, else every derived class
         would be forced to create one.
+
+        :param store_uri: The model registry store URI
+        :param tracking_uri: URI of the current MLflow tracking server, used to perform operations like
+                             fetching source run metadata or downloading source run artifacts to support
+                             subsequently uploading them to the model registry storage location
         """
         pass
 

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -16,9 +16,10 @@ class AbstractStore:
         would be forced to create one.
 
         :param store_uri: The model registry store URI
-        :param tracking_uri: URI of the current MLflow tracking server, used to perform operations like
-                             fetching source run metadata or downloading source run artifacts to support
-                             subsequently uploading them to the model registry storage location
+        :param tracking_uri: URI of the current MLflow tracking server, used to perform operations
+                             like fetching source run metadata or downloading source run artifacts
+                             to support subsequently uploading them to the model registry storage
+                             location
         """
         pass
 

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -29,11 +29,13 @@ class ModelRegistryClient:
     models and model versions.
     """
 
-    def __init__(self, registry_uri):
+    def __init__(self, registry_uri, tracking_uri):
         """
         :param registry_uri: Address of local or remote model registry server.
+        :param tracking_uri: Address of local or remote tracking server.
         """
         self.registry_uri = registry_uri
+        self.tracking_uri = tracking_uri
         # NB: Fetch the tracking store (`self.store`) upon client initialization to ensure that
         # the tracking URI is valid and the store can be properly resolved. We define `store` as a
         # property method to ensure that the client is serializable, even if the store is not
@@ -41,7 +43,7 @@ class ModelRegistryClient:
 
     @property
     def store(self):
-        return utils._get_store(self.registry_uri)
+        return utils._get_store(self.registry_uri, self.tracking_uri)
 
     # Registered Model Methods
 

--- a/mlflow/tracking/_model_registry/registry.py
+++ b/mlflow/tracking/_model_registry/registry.py
@@ -27,9 +27,9 @@ class ModelRegistryStoreRegistry(StoreRegistry):
         :param store_uri: The store URI. If None, it will be inferred from the environment. This URI
                           is used to select which tracking store implementation to instantiate and
                           is passed to the constructor of the implementation.
-        :param tracking_uri The optional string tracking URI to use for any MLflow tracking-related operations
-                            in the registry client, e.g. downloading source run artifacts in order to re-upload
-                            them to the model registry location
+        :param tracking_uri: The optional string tracking URI to use for any MLflow tracking-related
+                             operations in the registry client, e.g. downloading source run 
+                             artifacts in order to re-upload them to the model registry location.
 
         :return: An instance of `mlflow.store.model_registry.AbstractStore` that fulfills the
                  store URI requirements.

--- a/mlflow/tracking/_model_registry/registry.py
+++ b/mlflow/tracking/_model_registry/registry.py
@@ -21,27 +21,38 @@ class ModelRegistryStoreRegistry(StoreRegistry):
     def __init__(self):
         super().__init__("mlflow.model_registry_store")
 
-    def get_store(self, store_uri=None):
+    def get_store(self, store_uri=None, tracking_uri=None):
         """Get a store from the registry based on the scheme of store_uri
 
         :param store_uri: The store URI. If None, it will be inferred from the environment. This URI
                           is used to select which tracking store implementation to instantiate and
                           is passed to the constructor of the implementation.
+        :param tracking_uri The optional string tracking URI to use for any MLflow tracking-related operations
+                            in the registry client, e.g. downloading source run artifacts in order to re-upload
+                            them to the model registry location
 
         :return: An instance of `mlflow.store.model_registry.AbstractStore` that fulfills the
                  store URI requirements.
         """
-        from mlflow.tracking._model_registry import utils
+        from mlflow.tracking._model_registry.utils import _resolve_registry_uri
+        from mlflow.tracking._tracking_service.utils import _resolve_tracking_uri
 
-        resolved_store_uri = utils._resolve_registry_uri(store_uri)
-        return self._get_store_with_resolved_uri(resolved_store_uri)
+        resolved_store_uri = _resolve_registry_uri(store_uri)
+        resolved_tracking_uri = _resolve_tracking_uri(tracking_uri)
+        return self._get_store_with_resolved_uri(resolved_store_uri, resolved_tracking_uri)
 
     @lru_cache(maxsize=100)
-    def _get_store_with_resolved_uri(self, resolved_store_uri):
+    def _get_store_with_resolved_uri(self, resolved_store_uri, resolved_tracking_uri):
         """
         Retrieve the store associated with a resolved (non-None) store URI and an artifact URI.
         Caching is done on resolved URIs because the meaning of an unresolved (None) URI may change
         depending on external configuration, such as environment variables
         """
         builder = self.get_store_builder(resolved_store_uri)
-        return builder(store_uri=resolved_store_uri)
+        try:
+            return builder(store_uri=resolved_store_uri, tracking_uri=resolved_tracking_uri)
+        except TypeError:
+            # Not all model registry stores accept a tracking_uri parameter
+            # (e.g. old plugins may not recognize it), so we fall back to
+            # passing just the registry URI
+            return builder(store_uri=resolved_store_uri)

--- a/mlflow/tracking/_model_registry/registry.py
+++ b/mlflow/tracking/_model_registry/registry.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+import inspect
 
 from mlflow.tracking.registry import StoreRegistry
 
@@ -49,9 +50,10 @@ class ModelRegistryStoreRegistry(StoreRegistry):
         depending on external configuration, such as environment variables
         """
         builder = self.get_store_builder(resolved_store_uri)
-        try:
+        builder_param_names = set(inspect.signature(builder).parameters.keys())
+        if "store_uri" in builder_param_names and "tracking_uri" in builder_param_names:
             return builder(store_uri=resolved_store_uri, tracking_uri=resolved_tracking_uri)
-        except TypeError:
+        else:
             # Not all model registry stores accept a tracking_uri parameter
             # (e.g. old plugins may not recognize it), so we fall back to
             # passing just the registry URI

--- a/mlflow/tracking/_model_registry/registry.py
+++ b/mlflow/tracking/_model_registry/registry.py
@@ -28,7 +28,7 @@ class ModelRegistryStoreRegistry(StoreRegistry):
                           is used to select which tracking store implementation to instantiate and
                           is passed to the constructor of the implementation.
         :param tracking_uri: The optional string tracking URI to use for any MLflow tracking-related
-                             operations in the registry client, e.g. downloading source run 
+                             operations in the registry client, e.g. downloading source run
                              artifacts in order to re-upload them to the model registry location.
 
         :return: An instance of `mlflow.store.model_registry.AbstractStore` that fulfills the

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -1,10 +1,12 @@
 import os
 from functools import partial
 
+import mlflow
 from mlflow.environment_variables import MLFLOW_TRACKING_AWS_SIGV4
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.model_registry.file_store import FileStore
 from mlflow.store.model_registry.rest_store import RestStore
+from mlflow.store._unity_catalog.registry.rest_store import UcModelRegistryStore
 from mlflow.tracking._model_registry.registry import ModelRegistryStoreRegistry
 from mlflow.tracking._tracking_service.utils import (
     _TRACKING_USERNAME_ENV_VAR,
@@ -151,17 +153,8 @@ def _get_databricks_rest_store(store_uri, **_):
     return RestStore(partial(get_databricks_host_creds, store_uri))
 
 
-def _get_databricks_uc_rest_store(store_uri, **_):
-    from mlflow.exceptions import MlflowException
-    from mlflow.version import VERSION
-
-    raise MlflowException(
-        f"Detected Unity Catalog model registry URI '{store_uri}'. "
-        f"However, the current version of the MLflow client ({VERSION}) does not support models "
-        f"in the Unity Catalog. Please upgrade to the latest version of the MLflow Python client "
-        f"to access models in the Unity Catalog, or specify a different registry URI via "
-        f"mlflow.set_registry_uri()"
-    )
+def _get_databricks_uc_rest_store(store_uri, tracking_uri, **_):
+    return UcModelRegistryStore(registry_uri=store_uri, tracking_uri=tracking_uri)
 
 
 # We define the global variable as `None` so that instantiating the store does not lead to circular
@@ -199,5 +192,5 @@ def _get_store_registry():
     return _model_registry_store_registry
 
 
-def _get_store(store_uri=None):
-    return _get_store_registry().get_store(store_uri)
+def _get_store(store_uri=None, tracking_uri=None):
+    return _get_store_registry().get_store(store_uri, tracking_uri)

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -1,7 +1,6 @@
 import os
 from functools import partial
 
-import mlflow
 from mlflow.environment_variables import MLFLOW_TRACKING_AWS_SIGV4
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.model_registry.file_store import FileStore

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -153,10 +153,6 @@ def _get_databricks_rest_store(store_uri, **_):
     return RestStore(partial(get_databricks_host_creds, store_uri))
 
 
-def _get_databricks_uc_rest_store(store_uri, tracking_uri, **_):
-    return UcModelRegistryStore(registry_uri=store_uri, tracking_uri=tracking_uri)
-
-
 # We define the global variable as `None` so that instantiating the store does not lead to circular
 # dependency issues.
 _model_registry_store_registry = None
@@ -176,7 +172,7 @@ def _get_store_registry():
     # Register a placeholder function that raises if users pass a registry URI with scheme
     # "databricks-uc"
     _model_registry_store_registry.register(
-        _DATABRICKS_UNITY_CATALOG_SCHEME, _get_databricks_uc_rest_store
+        _DATABRICKS_UNITY_CATALOG_SCHEME, UcModelRegistryStore
     )
 
     for scheme in ["http", "https"]:

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -171,9 +171,7 @@ def _get_store_registry():
     _model_registry_store_registry.register("databricks", _get_databricks_rest_store)
     # Register a placeholder function that raises if users pass a registry URI with scheme
     # "databricks-uc"
-    _model_registry_store_registry.register(
-        _DATABRICKS_UNITY_CATALOG_SCHEME, UcModelRegistryStore
-    )
+    _model_registry_store_registry.register(_DATABRICKS_UNITY_CATALOG_SCHEME, UcModelRegistryStore)
 
     for scheme in ["http", "https"]:
         _model_registry_store_registry.register(scheme, _get_rest_store)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -95,7 +95,7 @@ class MlflowClient:
         registry_client = getattr(self, registry_client_attr, None)
         if registry_client is None:
             try:
-                registry_client = ModelRegistryClient(self._registry_uri)
+                registry_client = ModelRegistryClient(self._registry_uri, self.tracking_uri)
                 # Define an instance variable on this `MlflowClient` instance to reference the
                 # `ModelRegistryClient` that was just constructed. `setattr()` is used to ensure
                 # that the variable name is consistent with the variable name specified in the

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -74,7 +74,7 @@ def mock_databricks_host_creds():
 @pytest.fixture
 def store(mock_databricks_host_creds):
     with mock.patch("databricks_cli.configure.provider.get_config"):
-        yield UcModelRegistryStore(registry_uri="databricks-uc", tracking_uri="databricks")
+        yield UcModelRegistryStore(store_uri="databricks-uc", tracking_uri="databricks")
 
 
 def _args(endpoint, method, json_body, host_creds):

--- a/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
+++ b/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
@@ -32,7 +32,7 @@ def mock_get_databricks_unity_catalog_store():
         return UcModelRegistryStore(None, None)
 
     with mock.patch(
-        "mlflow.tracking._model_registry.utils._get_databricks_uc_rest_store",
+        "mlflow.tracking._model_registry.utils._get_databricks_rest_store",
         side_effect=get_uc_rest_store,
     ) as _get_databricks_uc_rest_store_mock:
         yield _get_databricks_uc_rest_store_mock

--- a/tests/tracking/_model_registry/test_model_registry_client.py
+++ b/tests/tracking/_model_registry/test_model_registry_client.py
@@ -29,7 +29,7 @@ def mock_store():
 
 
 def newModelRegistryClient():
-    return ModelRegistryClient("uri:/fake")
+    return ModelRegistryClient("uri:/fake", "uri:/fake")
 
 
 def _model_version(name, version, stage, source="some:/source", run_id="run13579", tags=None):

--- a/tests/tracking/_model_registry/test_utils.py
+++ b/tests/tracking/_model_registry/test_utils.py
@@ -9,6 +9,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.model_registry.sqlalchemy_store import SqlAlchemyStore
 from mlflow.store.model_registry.rest_store import RestStore
+from mlflow.store._unity_catalog.registry.rest_store import UcModelRegistryStore
 from mlflow.tracking._model_registry.utils import _get_store, get_registry_uri, set_registry_uri
 from mlflow.tracking._tracking_service.utils import _TRACKING_URI_ENV_VAR
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
@@ -132,11 +133,8 @@ def test_get_store_caches_on_store_uri(tmpdir):
 
 
 @pytest.mark.parametrize("store_uri", ["databricks-uc", "databricks-uc://profile"])
-def test_get_store_raises_on_uc_registry_uri(store_uri, reset_registry_uri):
-    set_registry_uri(store_uri)
-    client = mlflow.tracking.MlflowClient()
-    with pytest.raises(MlflowException, match="does not support models in the Unity Catalog"):
-        client.search_registered_models()
+def test_get_store_uc_registry_uri(store_uri, reset_registry_uri):
+    assert isinstance(_get_store(store_uri), UcModelRegistryStore)
 
 
 def test_store_object_can_be_serialized_by_pickle():

--- a/tests/tracking/_model_registry/test_utils.py
+++ b/tests/tracking/_model_registry/test_utils.py
@@ -4,8 +4,6 @@ import os
 import pytest
 from unittest import mock
 
-import mlflow.tracking
-from mlflow.exceptions import MlflowException
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.model_registry.sqlalchemy_store import SqlAlchemyStore
 from mlflow.store.model_registry.rest_store import RestStore


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

https://github.com/mlflow/mlflow/pull/7912

## What changes are proposed in this pull request?

This PR cherrypicks changes from https://github.com/mlflow/mlflow/pull/7912 that makes the MLflow client to use the `UcModelRegistryStore` REST store when the UC registry URI is set.

## How is this patch tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
