### PR TITLE
adjust logic for dry release logic to prevent unfound branches

### DIFF
--- a/dev/create_release_tag.py
+++ b/dev/create_release_tag.py
@@ -42,15 +42,15 @@ def main(new_version: str, remote: str, dry_run: bool = False):
     version = Version(new_version)
     release_branch = f"branch-{version.major}.{version.minor}"
     if dry_run:
-        subprocess.run(["git", "checkout", "-b", release_branch])
+        subprocess.run(["git", "checkout", "-b", release_branch], check=True)
     release_tag = f"v{new_version}"
     subprocess.run(["git", "tag", release_tag, release_branch], check=True)
     subprocess.run(
         ["git", "push", remote, release_tag, *(["--dry-run"] if dry_run else [])], check=True
     )
     if dry_run:
-        subprocess.run(["git", "checkout", "master"])
-        subprocess.run(["git", "branch", "-D", release_branch])
+        subprocess.run(["git", "checkout", "master"], check=True)
+        subprocess.run(["git", "branch", "-D", release_branch], check=True)
 
 
 if __name__ == "__main__":

--- a/dev/create_release_tag.py
+++ b/dev/create_release_tag.py
@@ -29,7 +29,6 @@ git branch -D branch-9.0
 import subprocess
 
 import click
-from packaging.version import Version
 
 
 @click.command(help="Create a release tag")
@@ -39,18 +38,12 @@ from packaging.version import Version
     "--dry-run/--no-dry-run", is_flag=True, default=True, show_default=True, envvar="DRY_RUN"
 )
 def main(new_version: str, remote: str, dry_run: bool = False):
-    version = Version(new_version)
-    release_branch = f"branch-{version.major}.{version.minor}"
-    if dry_run:
-        subprocess.run(["git", "checkout", "-b", release_branch], check=True)
+
     release_tag = f"v{new_version}"
-    subprocess.run(["git", "tag", release_tag, release_branch], check=True)
+    subprocess.run(["git", "tag", release_tag], check=True)
     subprocess.run(
         ["git", "push", remote, release_tag, *(["--dry-run"] if dry_run else [])], check=True
     )
-    if dry_run:
-        subprocess.run(["git", "checkout", "master"], check=True)
-        subprocess.run(["git", "branch", "-D", release_branch], check=True)
 
 
 if __name__ == "__main__":

--- a/dev/create_release_tag.py
+++ b/dev/create_release_tag.py
@@ -41,9 +41,16 @@ from packaging.version import Version
 def main(new_version: str, remote: str, dry_run: bool = False):
     version = Version(new_version)
     release_branch = f"branch-{version.major}.{version.minor}"
+    if dry_run:
+        subprocess.run(["git", "checkout", "-b", release_branch])
     release_tag = f"v{new_version}"
-    subprocess.check_call(["git", "tag", release_tag, release_branch])
-    subprocess.check_call(["git", "push", remote, release_tag, *(["--dry-run"] if dry_run else [])])
+    subprocess.run(["git", "tag", release_tag, release_branch], check=True)
+    subprocess.run(
+        ["git", "push", remote, release_tag, *(["--dry-run"] if dry_run else [])], check=True
+    )
+    if dry_run:
+        subprocess.run(["git", "checkout", "master"])
+        subprocess.run(["git", "branch", "-D", release_branch])
 
 
 if __name__ == "__main__":

--- a/dev/create_release_tag.py
+++ b/dev/create_release_tag.py
@@ -38,7 +38,6 @@ import click
     "--dry-run/--no-dry-run", is_flag=True, default=True, show_default=True, envvar="DRY_RUN"
 )
 def main(new_version: str, remote: str, dry_run: bool = False):
-
     release_tag = f"v{new_version}"
     subprocess.run(["git", "tag", release_tag], check=True)
     subprocess.run(


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Adjust tag logic for dry run tag application for CI

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
