### PR TITLE
Add Content-Type headers to HTTP artifact upload calls

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -5,7 +5,6 @@ import re
 import tempfile
 import posixpath
 import urllib
-from mimetypes import guess_type
 import pathlib
 
 import logging
@@ -19,8 +18,6 @@ from mlflow.entities import Metric, Param, RunTag, ViewType, ExperimentTag, File
 from mlflow.entities.model_registry import RegisteredModelTag, ModelVersionTag
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
-from mlflow.models.model import MLMODEL_FILE_NAME
-from mlflow.projects._project_spec import MLPROJECT_FILE_NAME
 from mlflow.protos import databricks_pb2
 from mlflow.protos.service_pb2 import (
     CreateExperiment,
@@ -83,6 +80,7 @@ from mlflow.store.artifact.artifact_repository_registry import get_artifact_repo
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.tracking._model_registry.registry import ModelRegistryStoreRegistry
 from mlflow.tracking._tracking_service.registry import TrackingStoreRegistry
+from mlflow.utils.mime_type_utils import _guess_mime_type
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.validation import _validate_batch_log_api_req
 from mlflow.utils.string_utils import is_string_type
@@ -481,50 +479,6 @@ def catch_mlflow_exception(func):
             return response
 
     return wrapper
-
-
-_TEXT_EXTENSIONS = [
-    "txt",
-    "log",
-    "err",
-    "cfg",
-    "conf",
-    "cnf",
-    "cf",
-    "ini",
-    "properties",
-    "prop",
-    "hocon",
-    "toml",
-    "yaml",
-    "yml",
-    "xml",
-    "json",
-    "js",
-    "py",
-    "py3",
-    "csv",
-    "tsv",
-    "md",
-    "rst",
-    MLMODEL_FILE_NAME,
-    MLPROJECT_FILE_NAME,
-]
-
-
-def _guess_mime_type(file_path):
-    filename = pathlib.Path(file_path).name
-    extension = os.path.splitext(filename)[-1].replace(".", "")
-    # for MLmodel/mlproject with no extensions
-    if extension == "":
-        extension = filename
-    if extension in _TEXT_EXTENSIONS:
-        return "text/plain"
-    mime_type, _ = guess_type(filename)
-    if not mime_type:
-        # As a fallback, if mime type is not detected, treat it as a binary file
-        return "application/octet-stream"
-    return mime_type
 
 
 def _disable_unless_serve_artifacts(func):

--- a/mlflow/utils/mime_type_utils.py
+++ b/mlflow/utils/mime_type_utils.py
@@ -1,0 +1,54 @@
+import os
+import pathlib
+
+from mimetypes import guess_type
+
+
+# TODO: Create a module to define constants to avoid circular imports
+#  and move MLMODEL_FILE_NAME and MLPROJECT_FILE_NAME in the module.
+def get_text_extensions():
+    from mlflow.models.model import MLMODEL_FILE_NAME
+    from mlflow.projects._project_spec import MLPROJECT_FILE_NAME
+
+    return [
+        "txt",
+        "log",
+        "err",
+        "cfg",
+        "conf",
+        "cnf",
+        "cf",
+        "ini",
+        "properties",
+        "prop",
+        "hocon",
+        "toml",
+        "yaml",
+        "yml",
+        "xml",
+        "json",
+        "js",
+        "py",
+        "py3",
+        "csv",
+        "tsv",
+        "md",
+        "rst",
+        MLMODEL_FILE_NAME,
+        MLPROJECT_FILE_NAME,
+    ]
+
+
+def _guess_mime_type(file_path):
+    filename = pathlib.Path(file_path).name
+    extension = os.path.splitext(filename)[-1].replace(".", "")
+    # for MLmodel/mlproject with no extensions
+    if extension == "":
+        extension = filename
+    if extension in get_text_extensions():
+        return "text/plain"
+    mime_type, _ = guess_type(filename)
+    if not mime_type:
+        # As a fallback, if mime type is not detected, treat it as a binary file
+        return "application/octet-stream"
+    return mime_type

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -104,6 +104,7 @@ def http_request(
     method,
     max_retries=None,
     backoff_factor=None,
+    extra_headers=None,
     retry_codes=_TRANSIENT_FAILURE_RESPONSE_CODES,
     timeout=None,
     **kwargs,
@@ -122,6 +123,7 @@ def http_request(
     :param backoff_factor: a time factor for exponential backoff. e.g. value 5 means the HTTP
       request will be retried with interval 5, 10, 20... seconds. A value of 0 turns off the
       exponential backoff.
+    :param extra_headers: a dict of HTTP header name-value pairs to be included in the request.
     :param retry_codes: a list of HTTP response error codes that qualifies for retry.
     :param timeout: wait for timeout seconds for response from remote server for connect and
       read request.
@@ -143,6 +145,9 @@ def http_request(
     from mlflow.tracking.request_header.registry import resolve_request_headers
 
     headers = dict(**resolve_request_headers())
+
+    if extra_headers:
+        headers = dict(**headers, **extra_headers)
 
     if auth_str:
         headers["Authorization"] = auth_str

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -40,7 +40,6 @@ from mlflow.server.handlers import (
     _delete_registered_model_tag,
     _set_model_version_tag,
     _delete_model_version_tag,
-    _guess_mime_type,
     _set_registered_model_alias,
     _delete_registered_model_alias,
     _get_model_version_by_alias,
@@ -77,7 +76,6 @@ from mlflow.protos.model_registry_pb2 import (
 )
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.validation import MAX_BATCH_LOG_REQUEST_SIZE
-from mlflow.utils.os import is_windows
 
 
 @pytest.fixture()
@@ -753,39 +751,3 @@ def test_get_model_version_by_alias(mock_get_request_message, mock_model_registr
     _, args = mock_model_registry_store.get_model_version_by_alias.call_args
     assert args == {"name": name, "alias": alias}
     assert json.loads(resp.get_data()) == {"model_version": jsonify(mvd)}
-
-
-@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
-@pytest.mark.parametrize(
-    ("file_path", "expected_mime_type"),
-    [
-        ("/a/b/c.txt", "text/plain"),
-        ("c.txt", "text/plain"),
-        ("c.pkl", "application/octet-stream"),
-        ("/a/b/c.pkl", "application/octet-stream"),
-        ("/a/b/c.png", "image/png"),
-        ("/a/b/c.pdf", "application/pdf"),
-        ("/a/b/MLmodel", "text/plain"),
-        ("/a/b/mlproject", "text/plain"),
-    ],
-)
-def test_guess_mime_type(file_path, expected_mime_type):
-    assert _guess_mime_type(file_path) == expected_mime_type
-
-
-@pytest.mark.skipif(not is_windows(), reason="This test only passes on Windows")
-@pytest.mark.parametrize(
-    ("file_path", "expected_mime_type"),
-    [
-        ("C:\\a\\b\\c.txt", "text/plain"),
-        ("c.txt", "text/plain"),
-        ("c.pkl", "application/octet-stream"),
-        ("C:\\a\\b\\c.pkl", "application/octet-stream"),
-        ("C:\\a\\b\\c.png", "image/png"),
-        ("C:\\a\\b\\c.pdf", "application/pdf"),
-        ("C:\\a\\b\\MLmodel", "text/plain"),
-        ("C:\\a\\b\\mlproject", "text/plain"),
-    ],
-)
-def test_guess_mime_type_on_windows(file_path, expected_mime_type):
-    assert _guess_mime_type(file_path) == expected_mime_type

--- a/tests/store/artifact/test_http_artifact_repo.py
+++ b/tests/store/artifact/test_http_artifact_repo.py
@@ -63,9 +63,17 @@ def http_artifact_repo():
     return HttpArtifactRepository(artifact_uri)
 
 
+@pytest.mark.parametrize(
+    ("filename", "expected_mime_type"),
+    [
+        ("c.txt", "text/plain"),
+        ("c.pkl", "application/octet-stream"),
+        ("MLmodel", "text/plain"),
+    ],
+)
 @pytest.mark.parametrize("artifact_path", [None, "dir"])
-def test_log_artifact(http_artifact_repo, tmpdir, artifact_path):
-    tmp_path = tmpdir.join("a.txt")
+def test_log_artifact(http_artifact_repo, tmpdir, artifact_path, filename, expected_mime_type):
+    tmp_path = tmpdir.join(filename)
     tmp_path.write("0")
     with mock.patch(
         "mlflow.store.artifact.http_artifact_repo.http_request",
@@ -78,6 +86,7 @@ def test_log_artifact(http_artifact_repo, tmpdir, artifact_path):
             posixpath.join("/", *paths),
             "PUT",
             data=FileObjectMatcher(tmp_path, "rb"),
+            extra_headers={"Content-Type": expected_mime_type},
         )
 
     with mock.patch(

--- a/tests/store/artifact/test_mlflow_artifact_repo.py
+++ b/tests/store/artifact/test_mlflow_artifact_repo.py
@@ -123,6 +123,7 @@ def test_log_artifact(mlflow_artifact_repo, tmpdir, artifact_path):
             mlflow_artifact_repo._host_creds,
             posixpath.join("/", *paths),
             "PUT",
+            extra_headers={"Content-Type": "text/plain"},
             data=FileObjectMatcher(tmp_path, "rb"),
         )
 
@@ -148,6 +149,7 @@ def test_log_artifact_with_host_and_port(mlflow_artifact_repo_with_host, tmpdir,
             mlflow_artifact_repo_with_host._host_creds,
             posixpath.join("/", *paths),
             "PUT",
+            extra_headers={"Content-Type": "text/plain"},
             data=FileObjectMatcher(tmp_path, "rb"),
         )
 

--- a/tests/utils/test_mime_type_utils.py
+++ b/tests/utils/test_mime_type_utils.py
@@ -1,0 +1,39 @@
+import pytest
+
+from mlflow.utils.mime_type_utils import _guess_mime_type
+from mlflow.utils.os import is_windows
+
+
+@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
+@pytest.mark.parametrize(
+    ("file_path", "expected_mime_type"),
+    [
+        ("c.txt", "text/plain"),
+        ("c.pkl", "application/octet-stream"),
+        ("/a/b/c.pkl", "application/octet-stream"),
+        ("/a/b/c.png", "image/png"),
+        ("/a/b/c.pdf", "application/pdf"),
+        ("/a/b/MLmodel", "text/plain"),
+        ("/a/b/mlproject", "text/plain"),
+    ],
+)
+def test_guess_mime_type(file_path, expected_mime_type):
+    assert _guess_mime_type(file_path) == expected_mime_type
+
+
+@pytest.mark.skipif(not is_windows(), reason="This test only passes on Windows")
+@pytest.mark.parametrize(
+    ("file_path", "expected_mime_type"),
+    [
+        ("C:\\a\\b\\c.txt", "text/plain"),
+        ("c.txt", "text/plain"),
+        ("c.pkl", "application/octet-stream"),
+        ("C:\\a\\b\\c.pkl", "application/octet-stream"),
+        ("C:\\a\\b\\c.png", "image/png"),
+        ("C:\\a\\b\\c.pdf", "application/pdf"),
+        ("C:\\a\\b\\MLmodel", "text/plain"),
+        ("C:\\a\\b\\mlproject", "text/plain"),
+    ],
+)
+def test_guess_mime_type_on_windows(file_path, expected_mime_type):
+    assert _guess_mime_type(file_path) == expected_mime_type

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -263,6 +263,26 @@ def test_http_request_server_cert_path(request):
 
 
 @mock.patch("requests.Session.request")
+def test_http_request_with_content_type_header(request):
+    host_only = MlflowHostCreds("http://my-host", token="my-token")
+    response = mock.MagicMock()
+    response.status_code = 200
+    request.return_value = response
+    extra_headers = {"Content-Type": "text/plain"}
+    http_request(host_only, "/my/endpoint", "GET", extra_headers=extra_headers)
+    headers = DefaultRequestHeaderProvider().request_headers()
+    headers["Authorization"] = "Bearer my-token"
+    headers["Content-Type"] = "text/plain"
+    request.assert_called_with(
+        "GET",
+        "http://my-host/my/endpoint",
+        verify=True,
+        headers=headers,
+        timeout=120,
+    )
+
+
+@mock.patch("requests.Session.request")
 def test_http_request_request_headers(request):
     """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
 


### PR DESCRIPTION
## Related Issues/PRs

Resolves https://github.com/mlflow/mlflow/issues/8026

## What changes are proposed in this pull request?

When the MLFlow client uploads artifacts via the HttpArtifactRepository, it will now send the proper HTTP Content-Type header. It pulls logic from https://github.com/mlflow/mlflow/pull/7827 that maps file extensions to Content-Types into a util module. Then it uses that util inside of `HTTPArtifactRepository` to add the right Content-Type header to artifact upload POST requests.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds Content-Type headers for outbound artifact upload calls from the HTTPArtifactRepo.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
