### PR TITLE
fix "git submodule update" command in mlflow projects

### DIFF
--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -234,7 +234,7 @@ def _fetch_git_repo(uri, version, dst_dir):
         _logger.info("Fetched '%s' branch", head_branch)
         repo.create_head(head_branch, ref)
         repo.heads[head_branch].checkout()
-    repo.submodule_update(init=True, recursive=True)
+    repo.git.execute(command=["git", "submodule", "update", "--init", "--recursive"])
 
 
 def _fetch_zip_repo(uri):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

https://github.com/mlflow/mlflow/issues/7241 https://github.com/mlflow/mlflow/pull/7251

## What changes are proposed in this pull request?

Resolved an problem where gitpython crashes when repositories have submodules imported with relative paths.

## How is this patch tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

I experimented on github codespace in https://github.com/kota-iizuka/mlflow-example/tree/add-submodule repository.

```sh
@kota-iizuka ➜ /workspaces/mlflow-example (add-submodule) $ cd mlflow
@kota-iizuka ➜ /workspaces/mlflow-example/mlflow (fix-relative-submodule) $ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
@kota-iizuka ➜ /workspaces/mlflow-example/mlflow (master) $ pip install -e .
Successfully installed mlflow-2.2.3.dev0
@kota-iizuka ➜ /workspaces/mlflow-example (add-submodule) $ mlflow run -e main -v add-submodule -P alpha=0.5 -P l1_ratio=0.1 https://github.com/kota-iizuka/mlflow-example.git
2023/03/17 02:08:12 INFO mlflow.projects.utils: === Fetching project from https://github.com/kota-iizuka/mlflow-example.git into /tmp/tmprpcqsjd7 ===
Traceback (most recent call last):
...
  File "/workspaces/mlflow-example/mlflow/mlflow/projects/utils.py", line 237, in _fetch_git_repo
    repo.submodule_update(init=True, recursive=True)
...
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v -n --separate-git-dir=/tmp/tmprpcqsjd7/.git/modules/mlflow -- ../mlflow.git /tmp/tmprpcqsjd7/mlflow
  stderr: 'fatal: repository '../mlflow.git' does not exist
@kota-iizuka ➜ /workspaces/mlflow-example/mlflow (fix-relative-submodule) $ pip install -e .
@kota-iizuka ➜ /workspaces/mlflow-example (add-submodule) $ mlflow run -e main -v add-submodule -P alpha=0.5 -P l1_ratio=0.1 https://github.com/kota-iizuka/mlflow-example.git
2023/03/17 02:09:50 INFO mlflow.projects.utils: === Fetching project from https://github.com/kota-iizuka/mlflow-example.git into /tmp/tmp1xffohks ===
...
2023/03/17 02:10:09 INFO mlflow.projects: === Run (ID 'b498c0685f15457ab3fba206fa5d9998') succeeded ===
```

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
