### PR TITLE
Add Registered Model Alias Endpoints and Update RegisteredModel/ModelVersion Payloads

### DIFF
--- a/mlflow/entities/model_registry/__init__.py
+++ b/mlflow/entities/model_registry/__init__.py
@@ -1,5 +1,6 @@
 from mlflow.entities.model_registry.registered_model import RegisteredModel
 from mlflow.entities.model_registry.model_version import ModelVersion
+from mlflow.entities.model_registry.registered_model_alias import RegisteredModelAlias
 from mlflow.entities.model_registry.registered_model_tag import RegisteredModelTag
 from mlflow.entities.model_registry.model_version_tag import ModelVersionTag
 
@@ -7,6 +8,7 @@ from mlflow.entities.model_registry.model_version_tag import ModelVersionTag
 __all__ = [
     "RegisteredModel",
     "ModelVersion",
+    "RegisteredModelAlias",
     "RegisteredModelTag",
     "ModelVersionTag",
 ]

--- a/mlflow/entities/model_registry/model_version.py
+++ b/mlflow/entities/model_registry/model_version.py
@@ -132,6 +132,10 @@ class ModelVersion(_ModelRegistryEntity):
         """List of aliases (string) for the current model version."""
         return self._aliases
 
+    @aliases.setter
+    def aliases(self, aliases):
+        self._aliases = aliases
+
     @classmethod
     def _properties(cls):
         # aggregate with base class properties since cls.__dict__ does not do it automatically

--- a/mlflow/entities/model_registry/model_version.py
+++ b/mlflow/entities/model_registry/model_version.py
@@ -27,6 +27,7 @@ class ModelVersion(_ModelRegistryEntity):
         status_message=None,
         tags=None,
         run_link=None,
+        aliases=None,
     ):
         super().__init__()
         self._name = name
@@ -42,6 +43,7 @@ class ModelVersion(_ModelRegistryEntity):
         self._status = status
         self._status_message = status_message
         self._tags = {tag.key: tag.value for tag in (tags or [])}
+        self._aliases = aliases
 
     @property
     def name(self):
@@ -125,6 +127,11 @@ class ModelVersion(_ModelRegistryEntity):
         """Dictionary of tag key (string) -> tag value for the current model version."""
         return self._tags
 
+    @property
+    def aliases(self):
+        """List of aliases (string) for the current registered model."""
+        return self._aliases
+
     @classmethod
     def _properties(cls):
         # aggregate with base class properties since cls.__dict__ does not do it automatically
@@ -151,6 +158,7 @@ class ModelVersion(_ModelRegistryEntity):
             ModelVersionStatus.to_string(proto.status),
             proto.status_message,
             run_link=proto.run_link,
+            aliases=proto.aliases,
         )
         for tag in proto.tags:
             model_version._add_tag(ModelVersionTag.from_proto(tag))
@@ -181,6 +189,8 @@ class ModelVersion(_ModelRegistryEntity):
             model_version.status = ModelVersionStatus.from_string(self.status)
         if self.status_message:
             model_version.status_message = self.status_message
+        if self.aliases:
+            model_version.aliases = self.aliases
         model_version.tags.extend(
             [ProtoModelVersionTag(key=key, value=value) for key, value in self._tags.items()]
         )

--- a/mlflow/entities/model_registry/model_version.py
+++ b/mlflow/entities/model_registry/model_version.py
@@ -193,9 +193,8 @@ class ModelVersion(_ModelRegistryEntity):
             model_version.status = ModelVersionStatus.from_string(self.status)
         if self.status_message:
             model_version.status_message = self.status_message
-        if self.aliases:
-            model_version.aliases = self.aliases
         model_version.tags.extend(
             [ProtoModelVersionTag(key=key, value=value) for key, value in self._tags.items()]
         )
+        model_version.aliases.extend(self.aliases)
         return model_version

--- a/mlflow/entities/model_registry/model_version.py
+++ b/mlflow/entities/model_registry/model_version.py
@@ -129,7 +129,7 @@ class ModelVersion(_ModelRegistryEntity):
 
     @property
     def aliases(self):
-        """List of aliases (string) for the current registered model."""
+        """List of aliases (string) for the current model version."""
         return self._aliases
 
     @classmethod

--- a/mlflow/entities/model_registry/registered_model.py
+++ b/mlflow/entities/model_registry/registered_model.py
@@ -1,8 +1,10 @@
+from mlflow.entities.model_registry.registered_model_alias import RegisteredModelAlias
 from mlflow.entities.model_registry.model_version import ModelVersion
 from mlflow.entities.model_registry.registered_model_tag import RegisteredModelTag
 from mlflow.entities.model_registry._model_registry_entity import _ModelRegistryEntity
 from mlflow.protos.model_registry_pb2 import (
     RegisteredModel as ProtoRegisteredModel,
+    RegisteredModelAlias as ProtoRegisteredModelAlias,
     RegisteredModelTag as ProtoRegisteredModelTag,
 )
 
@@ -20,6 +22,7 @@ class RegisteredModel(_ModelRegistryEntity):
         description=None,
         latest_versions=None,
         tags=None,
+        aliases=None,
     ):
         # Constructor is called only from within the system by various backend stores.
         super().__init__()
@@ -29,6 +32,7 @@ class RegisteredModel(_ModelRegistryEntity):
         self._description = description
         self._latest_version = latest_versions
         self._tags = {tag.key: tag.value for tag in (tags or [])}
+        self._aliases = {alias.alias: alias.version for alias in (aliases or [])}
 
     @property
     def name(self):
@@ -78,6 +82,11 @@ class RegisteredModel(_ModelRegistryEntity):
         """Dictionary of tag key (string) -> tag value for the current registered model."""
         return self._tags
 
+    @property
+    def aliases(self):
+        """Dictionary of aliases (string) -> version for the current registered model."""
+        return self._aliases
+
     @classmethod
     def _properties(cls):
         # aggregate with base class properties since cls.__dict__ does not do it automatically
@@ -85,6 +94,9 @@ class RegisteredModel(_ModelRegistryEntity):
 
     def _add_tag(self, tag):
         self._tags[tag.key] = tag.value
+
+    def _add_alias(self, alias):
+        self._aliases[alias.alias] = alias.version
 
     # proto mappers
     @classmethod
@@ -100,6 +112,8 @@ class RegisteredModel(_ModelRegistryEntity):
         )
         for tag in proto.tags:
             registered_model._add_tag(RegisteredModelTag.from_proto(tag))
+        for alias in proto.aliases:
+            registered_model._add_alias(RegisteredModelAlias.from_proto(alias))
         return registered_model
 
     def to_proto(self):
@@ -118,5 +132,11 @@ class RegisteredModel(_ModelRegistryEntity):
             )
         rmd.tags.extend(
             [ProtoRegisteredModelTag(key=key, value=value) for key, value in self._tags.items()]
+        )
+        rmd.aliases.extend(
+            [
+                ProtoRegisteredModelAlias(alias=alias, version=version)
+                for alias, version in self._aliases.items()
+            ]
         )
         return rmd

--- a/mlflow/entities/model_registry/registered_model_alias.py
+++ b/mlflow/entities/model_registry/registered_model_alias.py
@@ -5,8 +5,7 @@ from mlflow.protos.model_registry_pb2 import RegisteredModelAlias as ProtoRegist
 class RegisteredModelAlias(_ModelRegistryEntity):
     """Alias object associated with a registered model."""
 
-    def __init__(self, name, alias, version):
-        self._name = name
+    def __init__(self, alias, version):
         self._alias = alias
         self._version = version
 
@@ -14,11 +13,6 @@ class RegisteredModelAlias(_ModelRegistryEntity):
         if type(other) is type(self):
             return self.__dict__ == other.__dict__
         return False
-
-    @property
-    def name(self):
-        """String name of the registered model associated with the alias."""
-        return self._name
 
     @property
     def alias(self):
@@ -32,11 +26,10 @@ class RegisteredModelAlias(_ModelRegistryEntity):
 
     @classmethod
     def from_proto(cls, proto):
-        return cls(proto.name, proto.alias, proto.version)
+        return cls(proto.alias, proto.version)
 
     def to_proto(self):
-        alias = ProtoRegisteredModelAlias()
-        alias.name = self.name
-        alias.alias = self.alias
-        alias.version = self.version
-        return alias
+        alias_proto = ProtoRegisteredModelAlias()
+        alias_proto.alias = self.alias
+        alias_proto.version = self.version
+        return alias_proto

--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/ModelRegistry.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/ModelRegistry.java
@@ -367,6 +367,50 @@ public final class ModelRegistry {
      */
     org.mlflow.api.proto.ModelRegistry.RegisteredModelTagOrBuilder getTagsOrBuilder(
         int index);
+
+    /**
+     * <pre>
+     * Aliases pointing to model versions associated with this ``registered_model``.
+     * </pre>
+     *
+     * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+     */
+    java.util.List<org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias> 
+        getAliasesList();
+    /**
+     * <pre>
+     * Aliases pointing to model versions associated with this ``registered_model``.
+     * </pre>
+     *
+     * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+     */
+    org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias getAliases(int index);
+    /**
+     * <pre>
+     * Aliases pointing to model versions associated with this ``registered_model``.
+     * </pre>
+     *
+     * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+     */
+    int getAliasesCount();
+    /**
+     * <pre>
+     * Aliases pointing to model versions associated with this ``registered_model``.
+     * </pre>
+     *
+     * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+     */
+    java.util.List<? extends org.mlflow.api.proto.ModelRegistry.RegisteredModelAliasOrBuilder> 
+        getAliasesOrBuilderList();
+    /**
+     * <pre>
+     * Aliases pointing to model versions associated with this ``registered_model``.
+     * </pre>
+     *
+     * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+     */
+    org.mlflow.api.proto.ModelRegistry.RegisteredModelAliasOrBuilder getAliasesOrBuilder(
+        int index);
   }
   /**
    * Protobuf type {@code mlflow.RegisteredModel}
@@ -386,6 +430,7 @@ public final class ModelRegistry {
       description_ = "";
       latestVersions_ = java.util.Collections.emptyList();
       tags_ = java.util.Collections.emptyList();
+      aliases_ = java.util.Collections.emptyList();
     }
 
     @java.lang.Override
@@ -465,6 +510,15 @@ public final class ModelRegistry {
                   input.readMessage(org.mlflow.api.proto.ModelRegistry.RegisteredModelTag.PARSER, extensionRegistry));
               break;
             }
+            case 66: {
+              if (!((mutable_bitField0_ & 0x00000080) != 0)) {
+                aliases_ = new java.util.ArrayList<org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias>();
+                mutable_bitField0_ |= 0x00000080;
+              }
+              aliases_.add(
+                  input.readMessage(org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias.PARSER, extensionRegistry));
+              break;
+            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -485,6 +539,9 @@ public final class ModelRegistry {
         }
         if (((mutable_bitField0_ & 0x00000040) != 0)) {
           tags_ = java.util.Collections.unmodifiableList(tags_);
+        }
+        if (((mutable_bitField0_ & 0x00000080) != 0)) {
+          aliases_ = java.util.Collections.unmodifiableList(aliases_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -866,6 +923,66 @@ public final class ModelRegistry {
       return tags_.get(index);
     }
 
+    public static final int ALIASES_FIELD_NUMBER = 8;
+    private java.util.List<org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias> aliases_;
+    /**
+     * <pre>
+     * Aliases pointing to model versions associated with this ``registered_model``.
+     * </pre>
+     *
+     * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+     */
+    @java.lang.Override
+    public java.util.List<org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias> getAliasesList() {
+      return aliases_;
+    }
+    /**
+     * <pre>
+     * Aliases pointing to model versions associated with this ``registered_model``.
+     * </pre>
+     *
+     * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+     */
+    @java.lang.Override
+    public java.util.List<? extends org.mlflow.api.proto.ModelRegistry.RegisteredModelAliasOrBuilder> 
+        getAliasesOrBuilderList() {
+      return aliases_;
+    }
+    /**
+     * <pre>
+     * Aliases pointing to model versions associated with this ``registered_model``.
+     * </pre>
+     *
+     * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+     */
+    @java.lang.Override
+    public int getAliasesCount() {
+      return aliases_.size();
+    }
+    /**
+     * <pre>
+     * Aliases pointing to model versions associated with this ``registered_model``.
+     * </pre>
+     *
+     * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+     */
+    @java.lang.Override
+    public org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias getAliases(int index) {
+      return aliases_.get(index);
+    }
+    /**
+     * <pre>
+     * Aliases pointing to model versions associated with this ``registered_model``.
+     * </pre>
+     *
+     * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+     */
+    @java.lang.Override
+    public org.mlflow.api.proto.ModelRegistry.RegisteredModelAliasOrBuilder getAliasesOrBuilder(
+        int index) {
+      return aliases_.get(index);
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -901,6 +1018,9 @@ public final class ModelRegistry {
       for (int i = 0; i < tags_.size(); i++) {
         output.writeMessage(7, tags_.get(i));
       }
+      for (int i = 0; i < aliases_.size(); i++) {
+        output.writeMessage(8, aliases_.get(i));
+      }
       unknownFields.writeTo(output);
     }
 
@@ -934,6 +1054,10 @@ public final class ModelRegistry {
       for (int i = 0; i < tags_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(7, tags_.get(i));
+      }
+      for (int i = 0; i < aliases_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(8, aliases_.get(i));
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -979,6 +1103,8 @@ public final class ModelRegistry {
           .equals(other.getLatestVersionsList())) return false;
       if (!getTagsList()
           .equals(other.getTagsList())) return false;
+      if (!getAliasesList()
+          .equals(other.getAliasesList())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -1019,6 +1145,10 @@ public final class ModelRegistry {
       if (getTagsCount() > 0) {
         hash = (37 * hash) + TAGS_FIELD_NUMBER;
         hash = (53 * hash) + getTagsList().hashCode();
+      }
+      if (getAliasesCount() > 0) {
+        hash = (37 * hash) + ALIASES_FIELD_NUMBER;
+        hash = (53 * hash) + getAliasesList().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -1150,6 +1280,7 @@ public final class ModelRegistry {
                 .alwaysUseFieldBuilders) {
           getLatestVersionsFieldBuilder();
           getTagsFieldBuilder();
+          getAliasesFieldBuilder();
         }
       }
       @java.lang.Override
@@ -1176,6 +1307,12 @@ public final class ModelRegistry {
           bitField0_ = (bitField0_ & ~0x00000040);
         } else {
           tagsBuilder_.clear();
+        }
+        if (aliasesBuilder_ == null) {
+          aliases_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000080);
+        } else {
+          aliasesBuilder_.clear();
         }
         return this;
       }
@@ -1242,6 +1379,15 @@ public final class ModelRegistry {
           result.tags_ = tags_;
         } else {
           result.tags_ = tagsBuilder_.build();
+        }
+        if (aliasesBuilder_ == null) {
+          if (((bitField0_ & 0x00000080) != 0)) {
+            aliases_ = java.util.Collections.unmodifiableList(aliases_);
+            bitField0_ = (bitField0_ & ~0x00000080);
+          }
+          result.aliases_ = aliases_;
+        } else {
+          result.aliases_ = aliasesBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -1362,6 +1508,32 @@ public final class ModelRegistry {
                    getTagsFieldBuilder() : null;
             } else {
               tagsBuilder_.addAllMessages(other.tags_);
+            }
+          }
+        }
+        if (aliasesBuilder_ == null) {
+          if (!other.aliases_.isEmpty()) {
+            if (aliases_.isEmpty()) {
+              aliases_ = other.aliases_;
+              bitField0_ = (bitField0_ & ~0x00000080);
+            } else {
+              ensureAliasesIsMutable();
+              aliases_.addAll(other.aliases_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.aliases_.isEmpty()) {
+            if (aliasesBuilder_.isEmpty()) {
+              aliasesBuilder_.dispose();
+              aliasesBuilder_ = null;
+              aliases_ = other.aliases_;
+              bitField0_ = (bitField0_ & ~0x00000080);
+              aliasesBuilder_ = 
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                   getAliasesFieldBuilder() : null;
+            } else {
+              aliasesBuilder_.addAllMessages(other.aliases_);
             }
           }
         }
@@ -2476,6 +2648,318 @@ public final class ModelRegistry {
         }
         return tagsBuilder_;
       }
+
+      private java.util.List<org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias> aliases_ =
+        java.util.Collections.emptyList();
+      private void ensureAliasesIsMutable() {
+        if (!((bitField0_ & 0x00000080) != 0)) {
+          aliases_ = new java.util.ArrayList<org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias>(aliases_);
+          bitField0_ |= 0x00000080;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias, org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias.Builder, org.mlflow.api.proto.ModelRegistry.RegisteredModelAliasOrBuilder> aliasesBuilder_;
+
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public java.util.List<org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias> getAliasesList() {
+        if (aliasesBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(aliases_);
+        } else {
+          return aliasesBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public int getAliasesCount() {
+        if (aliasesBuilder_ == null) {
+          return aliases_.size();
+        } else {
+          return aliasesBuilder_.getCount();
+        }
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias getAliases(int index) {
+        if (aliasesBuilder_ == null) {
+          return aliases_.get(index);
+        } else {
+          return aliasesBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public Builder setAliases(
+          int index, org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias value) {
+        if (aliasesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureAliasesIsMutable();
+          aliases_.set(index, value);
+          onChanged();
+        } else {
+          aliasesBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public Builder setAliases(
+          int index, org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias.Builder builderForValue) {
+        if (aliasesBuilder_ == null) {
+          ensureAliasesIsMutable();
+          aliases_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          aliasesBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public Builder addAliases(org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias value) {
+        if (aliasesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureAliasesIsMutable();
+          aliases_.add(value);
+          onChanged();
+        } else {
+          aliasesBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public Builder addAliases(
+          int index, org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias value) {
+        if (aliasesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureAliasesIsMutable();
+          aliases_.add(index, value);
+          onChanged();
+        } else {
+          aliasesBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public Builder addAliases(
+          org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias.Builder builderForValue) {
+        if (aliasesBuilder_ == null) {
+          ensureAliasesIsMutable();
+          aliases_.add(builderForValue.build());
+          onChanged();
+        } else {
+          aliasesBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public Builder addAliases(
+          int index, org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias.Builder builderForValue) {
+        if (aliasesBuilder_ == null) {
+          ensureAliasesIsMutable();
+          aliases_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          aliasesBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public Builder addAllAliases(
+          java.lang.Iterable<? extends org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias> values) {
+        if (aliasesBuilder_ == null) {
+          ensureAliasesIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, aliases_);
+          onChanged();
+        } else {
+          aliasesBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public Builder clearAliases() {
+        if (aliasesBuilder_ == null) {
+          aliases_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000080);
+          onChanged();
+        } else {
+          aliasesBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public Builder removeAliases(int index) {
+        if (aliasesBuilder_ == null) {
+          ensureAliasesIsMutable();
+          aliases_.remove(index);
+          onChanged();
+        } else {
+          aliasesBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias.Builder getAliasesBuilder(
+          int index) {
+        return getAliasesFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public org.mlflow.api.proto.ModelRegistry.RegisteredModelAliasOrBuilder getAliasesOrBuilder(
+          int index) {
+        if (aliasesBuilder_ == null) {
+          return aliases_.get(index);  } else {
+          return aliasesBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public java.util.List<? extends org.mlflow.api.proto.ModelRegistry.RegisteredModelAliasOrBuilder> 
+           getAliasesOrBuilderList() {
+        if (aliasesBuilder_ != null) {
+          return aliasesBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(aliases_);
+        }
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias.Builder addAliasesBuilder() {
+        return getAliasesFieldBuilder().addBuilder(
+            org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias.getDefaultInstance());
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias.Builder addAliasesBuilder(
+          int index) {
+        return getAliasesFieldBuilder().addBuilder(
+            index, org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias.getDefaultInstance());
+      }
+      /**
+       * <pre>
+       * Aliases pointing to model versions associated with this ``registered_model``.
+       * </pre>
+       *
+       * <code>repeated .mlflow.RegisteredModelAlias aliases = 8;</code>
+       */
+      public java.util.List<org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias.Builder> 
+           getAliasesBuilderList() {
+        return getAliasesFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias, org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias.Builder, org.mlflow.api.proto.ModelRegistry.RegisteredModelAliasOrBuilder> 
+          getAliasesFieldBuilder() {
+        if (aliasesBuilder_ == null) {
+          aliasesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+              org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias, org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias.Builder, org.mlflow.api.proto.ModelRegistry.RegisteredModelAliasOrBuilder>(
+                  aliases_,
+                  ((bitField0_ & 0x00000080) != 0),
+                  getParentForChildren(),
+                  isClean());
+          aliases_ = null;
+        }
+        return aliasesBuilder_;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -2900,6 +3384,47 @@ public final class ModelRegistry {
      */
     com.google.protobuf.ByteString
         getRunLinkBytes();
+
+    /**
+     * <pre>
+     * Aliases pointing to this ``model_version``.
+     * </pre>
+     *
+     * <code>repeated string aliases = 14;</code>
+     * @return A list containing the aliases.
+     */
+    java.util.List<java.lang.String>
+        getAliasesList();
+    /**
+     * <pre>
+     * Aliases pointing to this ``model_version``.
+     * </pre>
+     *
+     * <code>repeated string aliases = 14;</code>
+     * @return The count of aliases.
+     */
+    int getAliasesCount();
+    /**
+     * <pre>
+     * Aliases pointing to this ``model_version``.
+     * </pre>
+     *
+     * <code>repeated string aliases = 14;</code>
+     * @param index The index of the element to return.
+     * @return The aliases at the given index.
+     */
+    java.lang.String getAliases(int index);
+    /**
+     * <pre>
+     * Aliases pointing to this ``model_version``.
+     * </pre>
+     *
+     * <code>repeated string aliases = 14;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the aliases at the given index.
+     */
+    com.google.protobuf.ByteString
+        getAliasesBytes(int index);
   }
   /**
    * Protobuf type {@code mlflow.ModelVersion}
@@ -2925,6 +3450,7 @@ public final class ModelRegistry {
       statusMessage_ = "";
       tags_ = java.util.Collections.emptyList();
       runLink_ = "";
+      aliases_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
 
     @java.lang.Override
@@ -3043,6 +3569,15 @@ public final class ModelRegistry {
               runLink_ = bs;
               break;
             }
+            case 114: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              if (!((mutable_bitField0_ & 0x00002000) != 0)) {
+                aliases_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00002000;
+              }
+              aliases_.add(bs);
+              break;
+            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -3060,6 +3595,9 @@ public final class ModelRegistry {
       } finally {
         if (((mutable_bitField0_ & 0x00000800) != 0)) {
           tags_ = java.util.Collections.unmodifiableList(tags_);
+        }
+        if (((mutable_bitField0_ & 0x00002000) != 0)) {
+          aliases_ = aliases_.getUnmodifiableView();
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -3766,6 +4304,57 @@ public final class ModelRegistry {
       }
     }
 
+    public static final int ALIASES_FIELD_NUMBER = 14;
+    private com.google.protobuf.LazyStringList aliases_;
+    /**
+     * <pre>
+     * Aliases pointing to this ``model_version``.
+     * </pre>
+     *
+     * <code>repeated string aliases = 14;</code>
+     * @return A list containing the aliases.
+     */
+    public com.google.protobuf.ProtocolStringList
+        getAliasesList() {
+      return aliases_;
+    }
+    /**
+     * <pre>
+     * Aliases pointing to this ``model_version``.
+     * </pre>
+     *
+     * <code>repeated string aliases = 14;</code>
+     * @return The count of aliases.
+     */
+    public int getAliasesCount() {
+      return aliases_.size();
+    }
+    /**
+     * <pre>
+     * Aliases pointing to this ``model_version``.
+     * </pre>
+     *
+     * <code>repeated string aliases = 14;</code>
+     * @param index The index of the element to return.
+     * @return The aliases at the given index.
+     */
+    public java.lang.String getAliases(int index) {
+      return aliases_.get(index);
+    }
+    /**
+     * <pre>
+     * Aliases pointing to this ``model_version``.
+     * </pre>
+     *
+     * <code>repeated string aliases = 14;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the aliases at the given index.
+     */
+    public com.google.protobuf.ByteString
+        getAliasesBytes(int index) {
+      return aliases_.getByteString(index);
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -3819,6 +4408,9 @@ public final class ModelRegistry {
       if (((bitField0_ & 0x00000800) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 13, runLink_);
       }
+      for (int i = 0; i < aliases_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 14, aliases_.getRaw(i));
+      }
       unknownFields.writeTo(output);
     }
 
@@ -3870,6 +4462,14 @@ public final class ModelRegistry {
       }
       if (((bitField0_ & 0x00000800) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(13, runLink_);
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < aliases_.size(); i++) {
+          dataSize += computeStringSizeNoTag(aliases_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getAliasesList().size();
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -3947,6 +4547,8 @@ public final class ModelRegistry {
         if (!getRunLink()
             .equals(other.getRunLink())) return false;
       }
+      if (!getAliasesList()
+          .equals(other.getAliasesList())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -4011,6 +4613,10 @@ public final class ModelRegistry {
       if (hasRunLink()) {
         hash = (37 * hash) + RUN_LINK_FIELD_NUMBER;
         hash = (53 * hash) + getRunLink().hashCode();
+      }
+      if (getAliasesCount() > 0) {
+        hash = (37 * hash) + ALIASES_FIELD_NUMBER;
+        hash = (53 * hash) + getAliasesList().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -4176,6 +4782,8 @@ public final class ModelRegistry {
         }
         runLink_ = "";
         bitField0_ = (bitField0_ & ~0x00001000);
+        aliases_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00002000);
         return this;
       }
 
@@ -4261,6 +4869,11 @@ public final class ModelRegistry {
           to_bitField0_ |= 0x00000800;
         }
         result.runLink_ = runLink_;
+        if (((bitField0_ & 0x00002000) != 0)) {
+          aliases_ = aliases_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00002000);
+        }
+        result.aliases_ = aliases_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -4388,6 +5001,16 @@ public final class ModelRegistry {
         if (other.hasRunLink()) {
           bitField0_ |= 0x00001000;
           runLink_ = other.runLink_;
+          onChanged();
+        }
+        if (!other.aliases_.isEmpty()) {
+          if (aliases_.isEmpty()) {
+            aliases_ = other.aliases_;
+            bitField0_ = (bitField0_ & ~0x00002000);
+          } else {
+            ensureAliasesIsMutable();
+            aliases_.addAll(other.aliases_);
+          }
           onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
@@ -5881,6 +6504,151 @@ public final class ModelRegistry {
   }
   bitField0_ |= 0x00001000;
         runLink_ = value;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList aliases_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureAliasesIsMutable() {
+        if (!((bitField0_ & 0x00002000) != 0)) {
+          aliases_ = new com.google.protobuf.LazyStringArrayList(aliases_);
+          bitField0_ |= 0x00002000;
+         }
+      }
+      /**
+       * <pre>
+       * Aliases pointing to this ``model_version``.
+       * </pre>
+       *
+       * <code>repeated string aliases = 14;</code>
+       * @return A list containing the aliases.
+       */
+      public com.google.protobuf.ProtocolStringList
+          getAliasesList() {
+        return aliases_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       * Aliases pointing to this ``model_version``.
+       * </pre>
+       *
+       * <code>repeated string aliases = 14;</code>
+       * @return The count of aliases.
+       */
+      public int getAliasesCount() {
+        return aliases_.size();
+      }
+      /**
+       * <pre>
+       * Aliases pointing to this ``model_version``.
+       * </pre>
+       *
+       * <code>repeated string aliases = 14;</code>
+       * @param index The index of the element to return.
+       * @return The aliases at the given index.
+       */
+      public java.lang.String getAliases(int index) {
+        return aliases_.get(index);
+      }
+      /**
+       * <pre>
+       * Aliases pointing to this ``model_version``.
+       * </pre>
+       *
+       * <code>repeated string aliases = 14;</code>
+       * @param index The index of the value to return.
+       * @return The bytes of the aliases at the given index.
+       */
+      public com.google.protobuf.ByteString
+          getAliasesBytes(int index) {
+        return aliases_.getByteString(index);
+      }
+      /**
+       * <pre>
+       * Aliases pointing to this ``model_version``.
+       * </pre>
+       *
+       * <code>repeated string aliases = 14;</code>
+       * @param index The index to set the value at.
+       * @param value The aliases to set.
+       * @return This builder for chaining.
+       */
+      public Builder setAliases(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureAliasesIsMutable();
+        aliases_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Aliases pointing to this ``model_version``.
+       * </pre>
+       *
+       * <code>repeated string aliases = 14;</code>
+       * @param value The aliases to add.
+       * @return This builder for chaining.
+       */
+      public Builder addAliases(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureAliasesIsMutable();
+        aliases_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Aliases pointing to this ``model_version``.
+       * </pre>
+       *
+       * <code>repeated string aliases = 14;</code>
+       * @param values The aliases to add.
+       * @return This builder for chaining.
+       */
+      public Builder addAllAliases(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureAliasesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, aliases_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Aliases pointing to this ``model_version``.
+       * </pre>
+       *
+       * <code>repeated string aliases = 14;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearAliases() {
+        aliases_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00002000);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Aliases pointing to this ``model_version``.
+       * </pre>
+       *
+       * <code>repeated string aliases = 14;</code>
+       * @param value The bytes of the aliases to add.
+       * @return This builder for chaining.
+       */
+      public Builder addAliasesBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureAliasesIsMutable();
+        aliases_.add(value);
         onChanged();
         return this;
       }
@@ -39093,39 +39861,10 @@ public final class ModelRegistry {
 
     /**
      * <pre>
-     * The name of the registered model associated with the alias.
-     * </pre>
-     *
-     * <code>optional string name = 1;</code>
-     * @return Whether the name field is set.
-     */
-    boolean hasName();
-    /**
-     * <pre>
-     * The name of the registered model associated with the alias.
-     * </pre>
-     *
-     * <code>optional string name = 1;</code>
-     * @return The name.
-     */
-    java.lang.String getName();
-    /**
-     * <pre>
-     * The name of the registered model associated with the alias.
-     * </pre>
-     *
-     * <code>optional string name = 1;</code>
-     * @return The bytes for name.
-     */
-    com.google.protobuf.ByteString
-        getNameBytes();
-
-    /**
-     * <pre>
      * The name of the alias.
      * </pre>
      *
-     * <code>optional string alias = 2;</code>
+     * <code>optional string alias = 1;</code>
      * @return Whether the alias field is set.
      */
     boolean hasAlias();
@@ -39134,7 +39873,7 @@ public final class ModelRegistry {
      * The name of the alias.
      * </pre>
      *
-     * <code>optional string alias = 2;</code>
+     * <code>optional string alias = 1;</code>
      * @return The alias.
      */
     java.lang.String getAlias();
@@ -39143,7 +39882,7 @@ public final class ModelRegistry {
      * The name of the alias.
      * </pre>
      *
-     * <code>optional string alias = 2;</code>
+     * <code>optional string alias = 1;</code>
      * @return The bytes for alias.
      */
     com.google.protobuf.ByteString
@@ -39154,7 +39893,7 @@ public final class ModelRegistry {
      * The model version number that the alias points to.
      * </pre>
      *
-     * <code>optional string version = 3;</code>
+     * <code>optional string version = 2;</code>
      * @return Whether the version field is set.
      */
     boolean hasVersion();
@@ -39163,7 +39902,7 @@ public final class ModelRegistry {
      * The model version number that the alias points to.
      * </pre>
      *
-     * <code>optional string version = 3;</code>
+     * <code>optional string version = 2;</code>
      * @return The version.
      */
     java.lang.String getVersion();
@@ -39172,7 +39911,7 @@ public final class ModelRegistry {
      * The model version number that the alias points to.
      * </pre>
      *
-     * <code>optional string version = 3;</code>
+     * <code>optional string version = 2;</code>
      * @return The bytes for version.
      */
     com.google.protobuf.ByteString
@@ -39195,7 +39934,6 @@ public final class ModelRegistry {
       super(builder);
     }
     private RegisteredModelAlias() {
-      name_ = "";
       alias_ = "";
       version_ = "";
     }
@@ -39234,18 +39972,12 @@ public final class ModelRegistry {
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              name_ = bs;
+              alias_ = bs;
               break;
             }
             case 18: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              alias_ = bs;
-              break;
-            }
-            case 26: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000004;
               version_ = bs;
               break;
             }
@@ -39282,86 +40014,26 @@ public final class ModelRegistry {
     }
 
     private int bitField0_;
-    public static final int NAME_FIELD_NUMBER = 1;
-    private volatile java.lang.Object name_;
-    /**
-     * <pre>
-     * The name of the registered model associated with the alias.
-     * </pre>
-     *
-     * <code>optional string name = 1;</code>
-     * @return Whether the name field is set.
-     */
-    @java.lang.Override
-    public boolean hasName() {
-      return ((bitField0_ & 0x00000001) != 0);
-    }
-    /**
-     * <pre>
-     * The name of the registered model associated with the alias.
-     * </pre>
-     *
-     * <code>optional string name = 1;</code>
-     * @return The name.
-     */
-    @java.lang.Override
-    public java.lang.String getName() {
-      java.lang.Object ref = name_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          name_ = s;
-        }
-        return s;
-      }
-    }
-    /**
-     * <pre>
-     * The name of the registered model associated with the alias.
-     * </pre>
-     *
-     * <code>optional string name = 1;</code>
-     * @return The bytes for name.
-     */
-    @java.lang.Override
-    public com.google.protobuf.ByteString
-        getNameBytes() {
-      java.lang.Object ref = name_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        name_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
-    }
-
-    public static final int ALIAS_FIELD_NUMBER = 2;
+    public static final int ALIAS_FIELD_NUMBER = 1;
     private volatile java.lang.Object alias_;
     /**
      * <pre>
      * The name of the alias.
      * </pre>
      *
-     * <code>optional string alias = 2;</code>
+     * <code>optional string alias = 1;</code>
      * @return Whether the alias field is set.
      */
     @java.lang.Override
     public boolean hasAlias() {
-      return ((bitField0_ & 0x00000002) != 0);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
      * The name of the alias.
      * </pre>
      *
-     * <code>optional string alias = 2;</code>
+     * <code>optional string alias = 1;</code>
      * @return The alias.
      */
     @java.lang.Override
@@ -39384,7 +40056,7 @@ public final class ModelRegistry {
      * The name of the alias.
      * </pre>
      *
-     * <code>optional string alias = 2;</code>
+     * <code>optional string alias = 1;</code>
      * @return The bytes for alias.
      */
     @java.lang.Override
@@ -39402,26 +40074,26 @@ public final class ModelRegistry {
       }
     }
 
-    public static final int VERSION_FIELD_NUMBER = 3;
+    public static final int VERSION_FIELD_NUMBER = 2;
     private volatile java.lang.Object version_;
     /**
      * <pre>
      * The model version number that the alias points to.
      * </pre>
      *
-     * <code>optional string version = 3;</code>
+     * <code>optional string version = 2;</code>
      * @return Whether the version field is set.
      */
     @java.lang.Override
     public boolean hasVersion() {
-      return ((bitField0_ & 0x00000004) != 0);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
      * The model version number that the alias points to.
      * </pre>
      *
-     * <code>optional string version = 3;</code>
+     * <code>optional string version = 2;</code>
      * @return The version.
      */
     @java.lang.Override
@@ -39444,7 +40116,7 @@ public final class ModelRegistry {
      * The model version number that the alias points to.
      * </pre>
      *
-     * <code>optional string version = 3;</code>
+     * <code>optional string version = 2;</code>
      * @return The bytes for version.
      */
     @java.lang.Override
@@ -39477,13 +40149,10 @@ public final class ModelRegistry {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) != 0)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, alias_);
       }
       if (((bitField0_ & 0x00000002) != 0)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, alias_);
-      }
-      if (((bitField0_ & 0x00000004) != 0)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, version_);
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, version_);
       }
       unknownFields.writeTo(output);
     }
@@ -39495,13 +40164,10 @@ public final class ModelRegistry {
 
       size = 0;
       if (((bitField0_ & 0x00000001) != 0)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, alias_);
       }
       if (((bitField0_ & 0x00000002) != 0)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, alias_);
-      }
-      if (((bitField0_ & 0x00000004) != 0)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, version_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, version_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -39518,11 +40184,6 @@ public final class ModelRegistry {
       }
       org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias other = (org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias) obj;
 
-      if (hasName() != other.hasName()) return false;
-      if (hasName()) {
-        if (!getName()
-            .equals(other.getName())) return false;
-      }
       if (hasAlias() != other.hasAlias()) return false;
       if (hasAlias()) {
         if (!getAlias()
@@ -39544,10 +40205,6 @@ public final class ModelRegistry {
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      if (hasName()) {
-        hash = (37 * hash) + NAME_FIELD_NUMBER;
-        hash = (53 * hash) + getName().hashCode();
-      }
       if (hasAlias()) {
         hash = (37 * hash) + ALIAS_FIELD_NUMBER;
         hash = (53 * hash) + getAlias().hashCode();
@@ -39693,12 +40350,10 @@ public final class ModelRegistry {
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        name_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
         alias_ = "";
-        bitField0_ = (bitField0_ & ~0x00000002);
+        bitField0_ = (bitField0_ & ~0x00000001);
         version_ = "";
-        bitField0_ = (bitField0_ & ~0x00000004);
+        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
 
@@ -39725,6 +40380,1433 @@ public final class ModelRegistry {
       @java.lang.Override
       public org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias buildPartial() {
         org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias result = new org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.alias_ = alias_;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.version_ = version_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias) {
+          return mergeFrom((org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias other) {
+        if (other == org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias.getDefaultInstance()) return this;
+        if (other.hasAlias()) {
+          bitField0_ |= 0x00000001;
+          alias_ = other.alias_;
+          onChanged();
+        }
+        if (other.hasVersion()) {
+          bitField0_ |= 0x00000002;
+          version_ = other.version_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object alias_ = "";
+      /**
+       * <pre>
+       * The name of the alias.
+       * </pre>
+       *
+       * <code>optional string alias = 1;</code>
+       * @return Whether the alias field is set.
+       */
+      public boolean hasAlias() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <pre>
+       * The name of the alias.
+       * </pre>
+       *
+       * <code>optional string alias = 1;</code>
+       * @return The alias.
+       */
+      public java.lang.String getAlias() {
+        java.lang.Object ref = alias_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            alias_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The name of the alias.
+       * </pre>
+       *
+       * <code>optional string alias = 1;</code>
+       * @return The bytes for alias.
+       */
+      public com.google.protobuf.ByteString
+          getAliasBytes() {
+        java.lang.Object ref = alias_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          alias_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The name of the alias.
+       * </pre>
+       *
+       * <code>optional string alias = 1;</code>
+       * @param value The alias to set.
+       * @return This builder for chaining.
+       */
+      public Builder setAlias(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        alias_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The name of the alias.
+       * </pre>
+       *
+       * <code>optional string alias = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearAlias() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        alias_ = getDefaultInstance().getAlias();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The name of the alias.
+       * </pre>
+       *
+       * <code>optional string alias = 1;</code>
+       * @param value The bytes for alias to set.
+       * @return This builder for chaining.
+       */
+      public Builder setAliasBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        alias_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object version_ = "";
+      /**
+       * <pre>
+       * The model version number that the alias points to.
+       * </pre>
+       *
+       * <code>optional string version = 2;</code>
+       * @return Whether the version field is set.
+       */
+      public boolean hasVersion() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <pre>
+       * The model version number that the alias points to.
+       * </pre>
+       *
+       * <code>optional string version = 2;</code>
+       * @return The version.
+       */
+      public java.lang.String getVersion() {
+        java.lang.Object ref = version_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            version_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The model version number that the alias points to.
+       * </pre>
+       *
+       * <code>optional string version = 2;</code>
+       * @return The bytes for version.
+       */
+      public com.google.protobuf.ByteString
+          getVersionBytes() {
+        java.lang.Object ref = version_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          version_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The model version number that the alias points to.
+       * </pre>
+       *
+       * <code>optional string version = 2;</code>
+       * @param value The version to set.
+       * @return This builder for chaining.
+       */
+      public Builder setVersion(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        version_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The model version number that the alias points to.
+       * </pre>
+       *
+       * <code>optional string version = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearVersion() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        version_ = getDefaultInstance().getVersion();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The model version number that the alias points to.
+       * </pre>
+       *
+       * <code>optional string version = 2;</code>
+       * @param value The bytes for version to set.
+       * @return This builder for chaining.
+       */
+      public Builder setVersionBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        version_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:mlflow.RegisteredModelAlias)
+    }
+
+    // @@protoc_insertion_point(class_scope:mlflow.RegisteredModelAlias)
+    private static final org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias();
+    }
+
+    public static org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<RegisteredModelAlias>
+        PARSER = new com.google.protobuf.AbstractParser<RegisteredModelAlias>() {
+      @java.lang.Override
+      public RegisteredModelAlias parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new RegisteredModelAlias(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<RegisteredModelAlias> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<RegisteredModelAlias> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface SetRegisteredModelAliasOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mlflow.SetRegisteredModelAlias)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the name field is set.
+     */
+    boolean hasName();
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The name.
+     */
+    java.lang.String getName();
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for name.
+     */
+    com.google.protobuf.ByteString
+        getNameBytes();
+
+    /**
+     * <pre>
+     * Name of the alias. Maximum size depends on storage backend.
+     * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
+     * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the alias field is set.
+     */
+    boolean hasAlias();
+    /**
+     * <pre>
+     * Name of the alias. Maximum size depends on storage backend.
+     * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
+     * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The alias.
+     */
+    java.lang.String getAlias();
+    /**
+     * <pre>
+     * Name of the alias. Maximum size depends on storage backend.
+     * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
+     * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for alias.
+     */
+    com.google.protobuf.ByteString
+        getAliasBytes();
+
+    /**
+     * <pre>
+     * Model version number.
+     * </pre>
+     *
+     * <code>optional string version = 3 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the version field is set.
+     */
+    boolean hasVersion();
+    /**
+     * <pre>
+     * Model version number.
+     * </pre>
+     *
+     * <code>optional string version = 3 [(.mlflow.validate_required) = true];</code>
+     * @return The version.
+     */
+    java.lang.String getVersion();
+    /**
+     * <pre>
+     * Model version number.
+     * </pre>
+     *
+     * <code>optional string version = 3 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for version.
+     */
+    com.google.protobuf.ByteString
+        getVersionBytes();
+  }
+  /**
+   * Protobuf type {@code mlflow.SetRegisteredModelAlias}
+   */
+  public static final class SetRegisteredModelAlias extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:mlflow.SetRegisteredModelAlias)
+      SetRegisteredModelAliasOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use SetRegisteredModelAlias.newBuilder() to construct.
+    private SetRegisteredModelAlias(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private SetRegisteredModelAlias() {
+      name_ = "";
+      alias_ = "";
+      version_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new SetRegisteredModelAlias();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private SetRegisteredModelAlias(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              name_ = bs;
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              alias_ = bs;
+              break;
+            }
+            case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000004;
+              version_ = bs;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_SetRegisteredModelAlias_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_SetRegisteredModelAlias_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.class, org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Builder.class);
+    }
+
+    public interface ResponseOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mlflow.SetRegisteredModelAlias.Response)
+        com.google.protobuf.MessageOrBuilder {
+    }
+    /**
+     * Protobuf type {@code mlflow.SetRegisteredModelAlias.Response}
+     */
+    public static final class Response extends
+        com.google.protobuf.GeneratedMessageV3 implements
+        // @@protoc_insertion_point(message_implements:mlflow.SetRegisteredModelAlias.Response)
+        ResponseOrBuilder {
+    private static final long serialVersionUID = 0L;
+      // Use Response.newBuilder() to construct.
+      private Response(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+        super(builder);
+      }
+      private Response() {
+      }
+
+      @java.lang.Override
+      @SuppressWarnings({"unused"})
+      protected java.lang.Object newInstance(
+          UnusedPrivateParameter unused) {
+        return new Response();
+      }
+
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+      getUnknownFields() {
+        return this.unknownFields;
+      }
+      private Response(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!parseUnknownField(
+                    input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
+        } finally {
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_SetRegisteredModelAlias_Response_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_SetRegisteredModelAlias_Response_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response.class, org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response.Builder.class);
+      }
+
+      private byte memoizedIsInitialized = -1;
+      @java.lang.Override
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      @java.lang.Override
+      public void writeTo(com.google.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        unknownFields.writeTo(output);
+      }
+
+      @java.lang.Override
+      public int getSerializedSize() {
+        int size = memoizedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        size += unknownFields.getSerializedSize();
+        memoizedSize = size;
+        return size;
+      }
+
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+         return true;
+        }
+        if (!(obj instanceof org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response)) {
+          return super.equals(obj);
+        }
+        org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response other = (org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response) obj;
+
+        if (!unknownFields.equals(other.unknownFields)) return false;
+        return true;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptor().hashCode();
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
+      public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response parseFrom(
+          java.nio.ByteBuffer data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response parseFrom(
+          java.nio.ByteBuffer data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response parseFrom(byte[] data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response parseFrom(
+          byte[] data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response parseFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response parseDelimitedFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response parseFrom(
+          com.google.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+
+      @java.lang.Override
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder() {
+        return DEFAULT_INSTANCE.toBuilder();
+      }
+      public static Builder newBuilder(org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response prototype) {
+        return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+      }
+      @java.lang.Override
+      public Builder toBuilder() {
+        return this == DEFAULT_INSTANCE
+            ? new Builder() : new Builder().mergeFrom(this);
+      }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * Protobuf type {@code mlflow.SetRegisteredModelAlias.Response}
+       */
+      public static final class Builder extends
+          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mlflow.SetRegisteredModelAlias.Response)
+          org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.ResponseOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_SetRegisteredModelAlias_Response_descriptor;
+        }
+
+        @java.lang.Override
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_SetRegisteredModelAlias_Response_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response.class, org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response.Builder.class);
+        }
+
+        // Construct using org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
+          }
+        }
+        @java.lang.Override
+        public Builder clear() {
+          super.clear();
+          return this;
+        }
+
+        @java.lang.Override
+        public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_SetRegisteredModelAlias_Response_descriptor;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response getDefaultInstanceForType() {
+          return org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response.getDefaultInstance();
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response build() {
+          org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response buildPartial() {
+          org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response result = new org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response(this);
+          onBuilt();
+          return result;
+        }
+
+        @java.lang.Override
+        public Builder clone() {
+          return super.clone();
+        }
+        @java.lang.Override
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return super.setField(field, value);
+        }
+        @java.lang.Override
+        public Builder clearField(
+            com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return super.clearField(field);
+        }
+        @java.lang.Override
+        public Builder clearOneof(
+            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return super.clearOneof(oneof);
+        }
+        @java.lang.Override
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index, java.lang.Object value) {
+          return super.setRepeatedField(field, index, value);
+        }
+        @java.lang.Override
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return super.addRepeatedField(field, value);
+        }
+        @java.lang.Override
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response) {
+            return mergeFrom((org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response other) {
+          if (other == org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response.getDefaultInstance()) return this;
+          this.mergeUnknownFields(other.unknownFields);
+          onChanged();
+          return this;
+        }
+
+        @java.lang.Override
+        public final boolean isInitialized() {
+          return true;
+        }
+
+        @java.lang.Override
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response) e.getUnfinishedMessage();
+            throw e.unwrapIOException();
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        @java.lang.Override
+        public final Builder setUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.setUnknownFields(unknownFields);
+        }
+
+        @java.lang.Override
+        public final Builder mergeUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.mergeUnknownFields(unknownFields);
+        }
+
+
+        // @@protoc_insertion_point(builder_scope:mlflow.SetRegisteredModelAlias.Response)
+      }
+
+      // @@protoc_insertion_point(class_scope:mlflow.SetRegisteredModelAlias.Response)
+      private static final org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response DEFAULT_INSTANCE;
+      static {
+        DEFAULT_INSTANCE = new org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response();
+      }
+
+      public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+      }
+
+      @java.lang.Deprecated public static final com.google.protobuf.Parser<Response>
+          PARSER = new com.google.protobuf.AbstractParser<Response>() {
+        @java.lang.Override
+        public Response parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new Response(input, extensionRegistry);
+        }
+      };
+
+      public static com.google.protobuf.Parser<Response> parser() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<Response> getParserForType() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Response getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+      }
+
+    }
+
+    private int bitField0_;
+    public static final int NAME_FIELD_NUMBER = 1;
+    private volatile java.lang.Object name_;
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the name field is set.
+     */
+    @java.lang.Override
+    public boolean hasName() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The name.
+     */
+    @java.lang.Override
+    public java.lang.String getName() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          name_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for name.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getNameBytes() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        name_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int ALIAS_FIELD_NUMBER = 2;
+    private volatile java.lang.Object alias_;
+    /**
+     * <pre>
+     * Name of the alias. Maximum size depends on storage backend.
+     * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
+     * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the alias field is set.
+     */
+    @java.lang.Override
+    public boolean hasAlias() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <pre>
+     * Name of the alias. Maximum size depends on storage backend.
+     * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
+     * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The alias.
+     */
+    @java.lang.Override
+    public java.lang.String getAlias() {
+      java.lang.Object ref = alias_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          alias_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Name of the alias. Maximum size depends on storage backend.
+     * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
+     * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for alias.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getAliasBytes() {
+      java.lang.Object ref = alias_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        alias_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int VERSION_FIELD_NUMBER = 3;
+    private volatile java.lang.Object version_;
+    /**
+     * <pre>
+     * Model version number.
+     * </pre>
+     *
+     * <code>optional string version = 3 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the version field is set.
+     */
+    @java.lang.Override
+    public boolean hasVersion() {
+      return ((bitField0_ & 0x00000004) != 0);
+    }
+    /**
+     * <pre>
+     * Model version number.
+     * </pre>
+     *
+     * <code>optional string version = 3 [(.mlflow.validate_required) = true];</code>
+     * @return The version.
+     */
+    @java.lang.Override
+    public java.lang.String getVersion() {
+      java.lang.Object ref = version_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          version_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Model version number.
+     * </pre>
+     *
+     * <code>optional string version = 3 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for version.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getVersionBytes() {
+      java.lang.Object ref = version_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        version_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, alias_);
+      }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, version_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, alias_);
+      }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, version_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias)) {
+        return super.equals(obj);
+      }
+      org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias other = (org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias) obj;
+
+      if (hasName() != other.hasName()) return false;
+      if (hasName()) {
+        if (!getName()
+            .equals(other.getName())) return false;
+      }
+      if (hasAlias() != other.hasAlias()) return false;
+      if (hasAlias()) {
+        if (!getAlias()
+            .equals(other.getAlias())) return false;
+      }
+      if (hasVersion() != other.hasVersion()) return false;
+      if (hasVersion()) {
+        if (!getVersion()
+            .equals(other.getVersion())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasName()) {
+        hash = (37 * hash) + NAME_FIELD_NUMBER;
+        hash = (53 * hash) + getName().hashCode();
+      }
+      if (hasAlias()) {
+        hash = (37 * hash) + ALIAS_FIELD_NUMBER;
+        hash = (53 * hash) + getAlias().hashCode();
+      }
+      if (hasVersion()) {
+        hash = (37 * hash) + VERSION_FIELD_NUMBER;
+        hash = (53 * hash) + getVersion().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mlflow.SetRegisteredModelAlias}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mlflow.SetRegisteredModelAlias)
+        org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAliasOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_SetRegisteredModelAlias_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_SetRegisteredModelAlias_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.class, org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.Builder.class);
+      }
+
+      // Construct using org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        name_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        alias_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        version_ = "";
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_SetRegisteredModelAlias_descriptor;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias getDefaultInstanceForType() {
+        return org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias build() {
+        org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias buildPartial() {
+        org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias result = new org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
@@ -39778,16 +41860,16 @@ public final class ModelRegistry {
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias) {
-          return mergeFrom((org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias)other);
+        if (other instanceof org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias) {
+          return mergeFrom((org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias other) {
-        if (other == org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias.getDefaultInstance()) return this;
+      public Builder mergeFrom(org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias other) {
+        if (other == org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias.getDefaultInstance()) return this;
         if (other.hasName()) {
           bitField0_ |= 0x00000001;
           name_ = other.name_;
@@ -39818,11 +41900,11 @@ public final class ModelRegistry {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias parsedMessage = null;
+        org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias) e.getUnfinishedMessage();
+          parsedMessage = (org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -39836,10 +41918,10 @@ public final class ModelRegistry {
       private java.lang.Object name_ = "";
       /**
        * <pre>
-       * The name of the registered model associated with the alias.
+       * Name of the registered model.
        * </pre>
        *
-       * <code>optional string name = 1;</code>
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
        * @return Whether the name field is set.
        */
       public boolean hasName() {
@@ -39847,10 +41929,10 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * The name of the registered model associated with the alias.
+       * Name of the registered model.
        * </pre>
        *
-       * <code>optional string name = 1;</code>
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
        * @return The name.
        */
       public java.lang.String getName() {
@@ -39869,10 +41951,10 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * The name of the registered model associated with the alias.
+       * Name of the registered model.
        * </pre>
        *
-       * <code>optional string name = 1;</code>
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
        * @return The bytes for name.
        */
       public com.google.protobuf.ByteString
@@ -39890,10 +41972,10 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * The name of the registered model associated with the alias.
+       * Name of the registered model.
        * </pre>
        *
-       * <code>optional string name = 1;</code>
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
        * @param value The name to set.
        * @return This builder for chaining.
        */
@@ -39909,10 +41991,10 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * The name of the registered model associated with the alias.
+       * Name of the registered model.
        * </pre>
        *
-       * <code>optional string name = 1;</code>
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
        * @return This builder for chaining.
        */
       public Builder clearName() {
@@ -39923,10 +42005,10 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * The name of the registered model associated with the alias.
+       * Name of the registered model.
        * </pre>
        *
-       * <code>optional string name = 1;</code>
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
        * @param value The bytes for name to set.
        * @return This builder for chaining.
        */
@@ -39944,10 +42026,12 @@ public final class ModelRegistry {
       private java.lang.Object alias_ = "";
       /**
        * <pre>
-       * The name of the alias.
+       * Name of the alias. Maximum size depends on storage backend.
+       * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
+       * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
        * </pre>
        *
-       * <code>optional string alias = 2;</code>
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
        * @return Whether the alias field is set.
        */
       public boolean hasAlias() {
@@ -39955,10 +42039,12 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * The name of the alias.
+       * Name of the alias. Maximum size depends on storage backend.
+       * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
+       * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
        * </pre>
        *
-       * <code>optional string alias = 2;</code>
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
        * @return The alias.
        */
       public java.lang.String getAlias() {
@@ -39977,10 +42063,12 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * The name of the alias.
+       * Name of the alias. Maximum size depends on storage backend.
+       * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
+       * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
        * </pre>
        *
-       * <code>optional string alias = 2;</code>
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
        * @return The bytes for alias.
        */
       public com.google.protobuf.ByteString
@@ -39998,10 +42086,12 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * The name of the alias.
+       * Name of the alias. Maximum size depends on storage backend.
+       * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
+       * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
        * </pre>
        *
-       * <code>optional string alias = 2;</code>
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
        * @param value The alias to set.
        * @return This builder for chaining.
        */
@@ -40017,10 +42107,12 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * The name of the alias.
+       * Name of the alias. Maximum size depends on storage backend.
+       * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
+       * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
        * </pre>
        *
-       * <code>optional string alias = 2;</code>
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
        * @return This builder for chaining.
        */
       public Builder clearAlias() {
@@ -40031,10 +42123,12 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * The name of the alias.
+       * Name of the alias. Maximum size depends on storage backend.
+       * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
+       * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
        * </pre>
        *
-       * <code>optional string alias = 2;</code>
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
        * @param value The bytes for alias to set.
        * @return This builder for chaining.
        */
@@ -40052,10 +42146,10 @@ public final class ModelRegistry {
       private java.lang.Object version_ = "";
       /**
        * <pre>
-       * The model version number that the alias points to.
+       * Model version number.
        * </pre>
        *
-       * <code>optional string version = 3;</code>
+       * <code>optional string version = 3 [(.mlflow.validate_required) = true];</code>
        * @return Whether the version field is set.
        */
       public boolean hasVersion() {
@@ -40063,10 +42157,10 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * The model version number that the alias points to.
+       * Model version number.
        * </pre>
        *
-       * <code>optional string version = 3;</code>
+       * <code>optional string version = 3 [(.mlflow.validate_required) = true];</code>
        * @return The version.
        */
       public java.lang.String getVersion() {
@@ -40085,10 +42179,10 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * The model version number that the alias points to.
+       * Model version number.
        * </pre>
        *
-       * <code>optional string version = 3;</code>
+       * <code>optional string version = 3 [(.mlflow.validate_required) = true];</code>
        * @return The bytes for version.
        */
       public com.google.protobuf.ByteString
@@ -40106,10 +42200,10 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * The model version number that the alias points to.
+       * Model version number.
        * </pre>
        *
-       * <code>optional string version = 3;</code>
+       * <code>optional string version = 3 [(.mlflow.validate_required) = true];</code>
        * @param value The version to set.
        * @return This builder for chaining.
        */
@@ -40125,10 +42219,10 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * The model version number that the alias points to.
+       * Model version number.
        * </pre>
        *
-       * <code>optional string version = 3;</code>
+       * <code>optional string version = 3 [(.mlflow.validate_required) = true];</code>
        * @return This builder for chaining.
        */
       public Builder clearVersion() {
@@ -40139,10 +42233,10 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * The model version number that the alias points to.
+       * Model version number.
        * </pre>
        *
-       * <code>optional string version = 3;</code>
+       * <code>optional string version = 3 [(.mlflow.validate_required) = true];</code>
        * @param value The bytes for version to set.
        * @return This builder for chaining.
        */
@@ -40169,41 +42263,2859 @@ public final class ModelRegistry {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:mlflow.RegisteredModelAlias)
+      // @@protoc_insertion_point(builder_scope:mlflow.SetRegisteredModelAlias)
     }
 
-    // @@protoc_insertion_point(class_scope:mlflow.RegisteredModelAlias)
-    private static final org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:mlflow.SetRegisteredModelAlias)
+    private static final org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias();
+      DEFAULT_INSTANCE = new org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias();
     }
 
-    public static org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias getDefaultInstance() {
+    public static org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    @java.lang.Deprecated public static final com.google.protobuf.Parser<RegisteredModelAlias>
-        PARSER = new com.google.protobuf.AbstractParser<RegisteredModelAlias>() {
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<SetRegisteredModelAlias>
+        PARSER = new com.google.protobuf.AbstractParser<SetRegisteredModelAlias>() {
       @java.lang.Override
-      public RegisteredModelAlias parsePartialFrom(
+      public SetRegisteredModelAlias parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new RegisteredModelAlias(input, extensionRegistry);
+        return new SetRegisteredModelAlias(input, extensionRegistry);
       }
     };
 
-    public static com.google.protobuf.Parser<RegisteredModelAlias> parser() {
+    public static com.google.protobuf.Parser<SetRegisteredModelAlias> parser() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Parser<RegisteredModelAlias> getParserForType() {
+    public com.google.protobuf.Parser<SetRegisteredModelAlias> getParserForType() {
       return PARSER;
     }
 
     @java.lang.Override
-    public org.mlflow.api.proto.ModelRegistry.RegisteredModelAlias getDefaultInstanceForType() {
+    public org.mlflow.api.proto.ModelRegistry.SetRegisteredModelAlias getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface DeleteRegisteredModelAliasOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mlflow.DeleteRegisteredModelAlias)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the name field is set.
+     */
+    boolean hasName();
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The name.
+     */
+    java.lang.String getName();
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for name.
+     */
+    com.google.protobuf.ByteString
+        getNameBytes();
+
+    /**
+     * <pre>
+     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the alias field is set.
+     */
+    boolean hasAlias();
+    /**
+     * <pre>
+     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The alias.
+     */
+    java.lang.String getAlias();
+    /**
+     * <pre>
+     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for alias.
+     */
+    com.google.protobuf.ByteString
+        getAliasBytes();
+  }
+  /**
+   * Protobuf type {@code mlflow.DeleteRegisteredModelAlias}
+   */
+  public static final class DeleteRegisteredModelAlias extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:mlflow.DeleteRegisteredModelAlias)
+      DeleteRegisteredModelAliasOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use DeleteRegisteredModelAlias.newBuilder() to construct.
+    private DeleteRegisteredModelAlias(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private DeleteRegisteredModelAlias() {
+      name_ = "";
+      alias_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new DeleteRegisteredModelAlias();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private DeleteRegisteredModelAlias(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              name_ = bs;
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              alias_ = bs;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_DeleteRegisteredModelAlias_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_DeleteRegisteredModelAlias_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.class, org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Builder.class);
+    }
+
+    public interface ResponseOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mlflow.DeleteRegisteredModelAlias.Response)
+        com.google.protobuf.MessageOrBuilder {
+    }
+    /**
+     * Protobuf type {@code mlflow.DeleteRegisteredModelAlias.Response}
+     */
+    public static final class Response extends
+        com.google.protobuf.GeneratedMessageV3 implements
+        // @@protoc_insertion_point(message_implements:mlflow.DeleteRegisteredModelAlias.Response)
+        ResponseOrBuilder {
+    private static final long serialVersionUID = 0L;
+      // Use Response.newBuilder() to construct.
+      private Response(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+        super(builder);
+      }
+      private Response() {
+      }
+
+      @java.lang.Override
+      @SuppressWarnings({"unused"})
+      protected java.lang.Object newInstance(
+          UnusedPrivateParameter unused) {
+        return new Response();
+      }
+
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+      getUnknownFields() {
+        return this.unknownFields;
+      }
+      private Response(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!parseUnknownField(
+                    input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
+        } finally {
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_DeleteRegisteredModelAlias_Response_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_DeleteRegisteredModelAlias_Response_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response.class, org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response.Builder.class);
+      }
+
+      private byte memoizedIsInitialized = -1;
+      @java.lang.Override
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      @java.lang.Override
+      public void writeTo(com.google.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        unknownFields.writeTo(output);
+      }
+
+      @java.lang.Override
+      public int getSerializedSize() {
+        int size = memoizedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        size += unknownFields.getSerializedSize();
+        memoizedSize = size;
+        return size;
+      }
+
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+         return true;
+        }
+        if (!(obj instanceof org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response)) {
+          return super.equals(obj);
+        }
+        org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response other = (org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response) obj;
+
+        if (!unknownFields.equals(other.unknownFields)) return false;
+        return true;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptor().hashCode();
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
+      public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response parseFrom(
+          java.nio.ByteBuffer data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response parseFrom(
+          java.nio.ByteBuffer data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response parseFrom(byte[] data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response parseFrom(
+          byte[] data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response parseFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response parseDelimitedFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response parseFrom(
+          com.google.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+
+      @java.lang.Override
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder() {
+        return DEFAULT_INSTANCE.toBuilder();
+      }
+      public static Builder newBuilder(org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response prototype) {
+        return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+      }
+      @java.lang.Override
+      public Builder toBuilder() {
+        return this == DEFAULT_INSTANCE
+            ? new Builder() : new Builder().mergeFrom(this);
+      }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * Protobuf type {@code mlflow.DeleteRegisteredModelAlias.Response}
+       */
+      public static final class Builder extends
+          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mlflow.DeleteRegisteredModelAlias.Response)
+          org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.ResponseOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_DeleteRegisteredModelAlias_Response_descriptor;
+        }
+
+        @java.lang.Override
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_DeleteRegisteredModelAlias_Response_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response.class, org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response.Builder.class);
+        }
+
+        // Construct using org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
+          }
+        }
+        @java.lang.Override
+        public Builder clear() {
+          super.clear();
+          return this;
+        }
+
+        @java.lang.Override
+        public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_DeleteRegisteredModelAlias_Response_descriptor;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response getDefaultInstanceForType() {
+          return org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response.getDefaultInstance();
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response build() {
+          org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response buildPartial() {
+          org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response result = new org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response(this);
+          onBuilt();
+          return result;
+        }
+
+        @java.lang.Override
+        public Builder clone() {
+          return super.clone();
+        }
+        @java.lang.Override
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return super.setField(field, value);
+        }
+        @java.lang.Override
+        public Builder clearField(
+            com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return super.clearField(field);
+        }
+        @java.lang.Override
+        public Builder clearOneof(
+            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return super.clearOneof(oneof);
+        }
+        @java.lang.Override
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index, java.lang.Object value) {
+          return super.setRepeatedField(field, index, value);
+        }
+        @java.lang.Override
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return super.addRepeatedField(field, value);
+        }
+        @java.lang.Override
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response) {
+            return mergeFrom((org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response other) {
+          if (other == org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response.getDefaultInstance()) return this;
+          this.mergeUnknownFields(other.unknownFields);
+          onChanged();
+          return this;
+        }
+
+        @java.lang.Override
+        public final boolean isInitialized() {
+          return true;
+        }
+
+        @java.lang.Override
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response) e.getUnfinishedMessage();
+            throw e.unwrapIOException();
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        @java.lang.Override
+        public final Builder setUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.setUnknownFields(unknownFields);
+        }
+
+        @java.lang.Override
+        public final Builder mergeUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.mergeUnknownFields(unknownFields);
+        }
+
+
+        // @@protoc_insertion_point(builder_scope:mlflow.DeleteRegisteredModelAlias.Response)
+      }
+
+      // @@protoc_insertion_point(class_scope:mlflow.DeleteRegisteredModelAlias.Response)
+      private static final org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response DEFAULT_INSTANCE;
+      static {
+        DEFAULT_INSTANCE = new org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response();
+      }
+
+      public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+      }
+
+      @java.lang.Deprecated public static final com.google.protobuf.Parser<Response>
+          PARSER = new com.google.protobuf.AbstractParser<Response>() {
+        @java.lang.Override
+        public Response parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new Response(input, extensionRegistry);
+        }
+      };
+
+      public static com.google.protobuf.Parser<Response> parser() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<Response> getParserForType() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Response getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+      }
+
+    }
+
+    private int bitField0_;
+    public static final int NAME_FIELD_NUMBER = 1;
+    private volatile java.lang.Object name_;
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the name field is set.
+     */
+    @java.lang.Override
+    public boolean hasName() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The name.
+     */
+    @java.lang.Override
+    public java.lang.String getName() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          name_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for name.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getNameBytes() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        name_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int ALIAS_FIELD_NUMBER = 2;
+    private volatile java.lang.Object alias_;
+    /**
+     * <pre>
+     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the alias field is set.
+     */
+    @java.lang.Override
+    public boolean hasAlias() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <pre>
+     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The alias.
+     */
+    @java.lang.Override
+    public java.lang.String getAlias() {
+      java.lang.Object ref = alias_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          alias_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for alias.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getAliasBytes() {
+      java.lang.Object ref = alias_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        alias_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, alias_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, alias_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias)) {
+        return super.equals(obj);
+      }
+      org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias other = (org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias) obj;
+
+      if (hasName() != other.hasName()) return false;
+      if (hasName()) {
+        if (!getName()
+            .equals(other.getName())) return false;
+      }
+      if (hasAlias() != other.hasAlias()) return false;
+      if (hasAlias()) {
+        if (!getAlias()
+            .equals(other.getAlias())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasName()) {
+        hash = (37 * hash) + NAME_FIELD_NUMBER;
+        hash = (53 * hash) + getName().hashCode();
+      }
+      if (hasAlias()) {
+        hash = (37 * hash) + ALIAS_FIELD_NUMBER;
+        hash = (53 * hash) + getAlias().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mlflow.DeleteRegisteredModelAlias}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mlflow.DeleteRegisteredModelAlias)
+        org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAliasOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_DeleteRegisteredModelAlias_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_DeleteRegisteredModelAlias_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.class, org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.Builder.class);
+      }
+
+      // Construct using org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        name_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        alias_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_DeleteRegisteredModelAlias_descriptor;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias getDefaultInstanceForType() {
+        return org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias build() {
+        org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias buildPartial() {
+        org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias result = new org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.name_ = name_;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.alias_ = alias_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias) {
+          return mergeFrom((org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias other) {
+        if (other == org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias.getDefaultInstance()) return this;
+        if (other.hasName()) {
+          bitField0_ |= 0x00000001;
+          name_ = other.name_;
+          onChanged();
+        }
+        if (other.hasAlias()) {
+          bitField0_ |= 0x00000002;
+          alias_ = other.alias_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object name_ = "";
+      /**
+       * <pre>
+       * Name of the registered model.
+       * </pre>
+       *
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+       * @return Whether the name field is set.
+       */
+      public boolean hasName() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <pre>
+       * Name of the registered model.
+       * </pre>
+       *
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+       * @return The name.
+       */
+      public java.lang.String getName() {
+        java.lang.Object ref = name_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            name_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Name of the registered model.
+       * </pre>
+       *
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+       * @return The bytes for name.
+       */
+      public com.google.protobuf.ByteString
+          getNameBytes() {
+        java.lang.Object ref = name_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          name_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Name of the registered model.
+       * </pre>
+       *
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+       * @param value The name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        name_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Name of the registered model.
+       * </pre>
+       *
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearName() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        name_ = getDefaultInstance().getName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Name of the registered model.
+       * </pre>
+       *
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+       * @param value The bytes for name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        name_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object alias_ = "";
+      /**
+       * <pre>
+       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+       * </pre>
+       *
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+       * @return Whether the alias field is set.
+       */
+      public boolean hasAlias() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <pre>
+       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+       * </pre>
+       *
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+       * @return The alias.
+       */
+      public java.lang.String getAlias() {
+        java.lang.Object ref = alias_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            alias_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+       * </pre>
+       *
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+       * @return The bytes for alias.
+       */
+      public com.google.protobuf.ByteString
+          getAliasBytes() {
+        java.lang.Object ref = alias_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          alias_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+       * </pre>
+       *
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+       * @param value The alias to set.
+       * @return This builder for chaining.
+       */
+      public Builder setAlias(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        alias_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+       * </pre>
+       *
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearAlias() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        alias_ = getDefaultInstance().getAlias();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+       * </pre>
+       *
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+       * @param value The bytes for alias to set.
+       * @return This builder for chaining.
+       */
+      public Builder setAliasBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        alias_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:mlflow.DeleteRegisteredModelAlias)
+    }
+
+    // @@protoc_insertion_point(class_scope:mlflow.DeleteRegisteredModelAlias)
+    private static final org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias();
+    }
+
+    public static org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<DeleteRegisteredModelAlias>
+        PARSER = new com.google.protobuf.AbstractParser<DeleteRegisteredModelAlias>() {
+      @java.lang.Override
+      public DeleteRegisteredModelAlias parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new DeleteRegisteredModelAlias(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<DeleteRegisteredModelAlias> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<DeleteRegisteredModelAlias> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public org.mlflow.api.proto.ModelRegistry.DeleteRegisteredModelAlias getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface GetModelVersionByAliasOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mlflow.GetModelVersionByAlias)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the name field is set.
+     */
+    boolean hasName();
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The name.
+     */
+    java.lang.String getName();
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for name.
+     */
+    com.google.protobuf.ByteString
+        getNameBytes();
+
+    /**
+     * <pre>
+     * Name of the alias. Maximum size is 250 bytes.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the alias field is set.
+     */
+    boolean hasAlias();
+    /**
+     * <pre>
+     * Name of the alias. Maximum size is 250 bytes.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The alias.
+     */
+    java.lang.String getAlias();
+    /**
+     * <pre>
+     * Name of the alias. Maximum size is 250 bytes.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for alias.
+     */
+    com.google.protobuf.ByteString
+        getAliasBytes();
+  }
+  /**
+   * Protobuf type {@code mlflow.GetModelVersionByAlias}
+   */
+  public static final class GetModelVersionByAlias extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:mlflow.GetModelVersionByAlias)
+      GetModelVersionByAliasOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use GetModelVersionByAlias.newBuilder() to construct.
+    private GetModelVersionByAlias(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private GetModelVersionByAlias() {
+      name_ = "";
+      alias_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new GetModelVersionByAlias();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private GetModelVersionByAlias(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              name_ = bs;
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              alias_ = bs;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetModelVersionByAlias_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetModelVersionByAlias_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.class, org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Builder.class);
+    }
+
+    public interface ResponseOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mlflow.GetModelVersionByAlias.Response)
+        com.google.protobuf.MessageOrBuilder {
+
+      /**
+       * <code>optional .mlflow.ModelVersion model_version = 1;</code>
+       * @return Whether the modelVersion field is set.
+       */
+      boolean hasModelVersion();
+      /**
+       * <code>optional .mlflow.ModelVersion model_version = 1;</code>
+       * @return The modelVersion.
+       */
+      org.mlflow.api.proto.ModelRegistry.ModelVersion getModelVersion();
+      /**
+       * <code>optional .mlflow.ModelVersion model_version = 1;</code>
+       */
+      org.mlflow.api.proto.ModelRegistry.ModelVersionOrBuilder getModelVersionOrBuilder();
+    }
+    /**
+     * Protobuf type {@code mlflow.GetModelVersionByAlias.Response}
+     */
+    public static final class Response extends
+        com.google.protobuf.GeneratedMessageV3 implements
+        // @@protoc_insertion_point(message_implements:mlflow.GetModelVersionByAlias.Response)
+        ResponseOrBuilder {
+    private static final long serialVersionUID = 0L;
+      // Use Response.newBuilder() to construct.
+      private Response(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+        super(builder);
+      }
+      private Response() {
+      }
+
+      @java.lang.Override
+      @SuppressWarnings({"unused"})
+      protected java.lang.Object newInstance(
+          UnusedPrivateParameter unused) {
+        return new Response();
+      }
+
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+      getUnknownFields() {
+        return this.unknownFields;
+      }
+      private Response(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        int mutable_bitField0_ = 0;
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                org.mlflow.api.proto.ModelRegistry.ModelVersion.Builder subBuilder = null;
+                if (((bitField0_ & 0x00000001) != 0)) {
+                  subBuilder = modelVersion_.toBuilder();
+                }
+                modelVersion_ = input.readMessage(org.mlflow.api.proto.ModelRegistry.ModelVersion.PARSER, extensionRegistry);
+                if (subBuilder != null) {
+                  subBuilder.mergeFrom(modelVersion_);
+                  modelVersion_ = subBuilder.buildPartial();
+                }
+                bitField0_ |= 0x00000001;
+                break;
+              }
+              default: {
+                if (!parseUnknownField(
+                    input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
+        } finally {
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetModelVersionByAlias_Response_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetModelVersionByAlias_Response_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response.class, org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response.Builder.class);
+      }
+
+      private int bitField0_;
+      public static final int MODEL_VERSION_FIELD_NUMBER = 1;
+      private org.mlflow.api.proto.ModelRegistry.ModelVersion modelVersion_;
+      /**
+       * <code>optional .mlflow.ModelVersion model_version = 1;</code>
+       * @return Whether the modelVersion field is set.
+       */
+      @java.lang.Override
+      public boolean hasModelVersion() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>optional .mlflow.ModelVersion model_version = 1;</code>
+       * @return The modelVersion.
+       */
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.ModelVersion getModelVersion() {
+        return modelVersion_ == null ? org.mlflow.api.proto.ModelRegistry.ModelVersion.getDefaultInstance() : modelVersion_;
+      }
+      /**
+       * <code>optional .mlflow.ModelVersion model_version = 1;</code>
+       */
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.ModelVersionOrBuilder getModelVersionOrBuilder() {
+        return modelVersion_ == null ? org.mlflow.api.proto.ModelRegistry.ModelVersion.getDefaultInstance() : modelVersion_;
+      }
+
+      private byte memoizedIsInitialized = -1;
+      @java.lang.Override
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      @java.lang.Override
+      public void writeTo(com.google.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        if (((bitField0_ & 0x00000001) != 0)) {
+          output.writeMessage(1, getModelVersion());
+        }
+        unknownFields.writeTo(output);
+      }
+
+      @java.lang.Override
+      public int getSerializedSize() {
+        int size = memoizedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        if (((bitField0_ & 0x00000001) != 0)) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeMessageSize(1, getModelVersion());
+        }
+        size += unknownFields.getSerializedSize();
+        memoizedSize = size;
+        return size;
+      }
+
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+         return true;
+        }
+        if (!(obj instanceof org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response)) {
+          return super.equals(obj);
+        }
+        org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response other = (org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response) obj;
+
+        if (hasModelVersion() != other.hasModelVersion()) return false;
+        if (hasModelVersion()) {
+          if (!getModelVersion()
+              .equals(other.getModelVersion())) return false;
+        }
+        if (!unknownFields.equals(other.unknownFields)) return false;
+        return true;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptor().hashCode();
+        if (hasModelVersion()) {
+          hash = (37 * hash) + MODEL_VERSION_FIELD_NUMBER;
+          hash = (53 * hash) + getModelVersion().hashCode();
+        }
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
+      public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response parseFrom(
+          java.nio.ByteBuffer data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response parseFrom(
+          java.nio.ByteBuffer data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response parseFrom(byte[] data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response parseFrom(
+          byte[] data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response parseFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response parseDelimitedFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response parseFrom(
+          com.google.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+
+      @java.lang.Override
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder() {
+        return DEFAULT_INSTANCE.toBuilder();
+      }
+      public static Builder newBuilder(org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response prototype) {
+        return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+      }
+      @java.lang.Override
+      public Builder toBuilder() {
+        return this == DEFAULT_INSTANCE
+            ? new Builder() : new Builder().mergeFrom(this);
+      }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * Protobuf type {@code mlflow.GetModelVersionByAlias.Response}
+       */
+      public static final class Builder extends
+          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mlflow.GetModelVersionByAlias.Response)
+          org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.ResponseOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetModelVersionByAlias_Response_descriptor;
+        }
+
+        @java.lang.Override
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetModelVersionByAlias_Response_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response.class, org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response.Builder.class);
+        }
+
+        // Construct using org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
+            getModelVersionFieldBuilder();
+          }
+        }
+        @java.lang.Override
+        public Builder clear() {
+          super.clear();
+          if (modelVersionBuilder_ == null) {
+            modelVersion_ = null;
+          } else {
+            modelVersionBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000001);
+          return this;
+        }
+
+        @java.lang.Override
+        public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetModelVersionByAlias_Response_descriptor;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response getDefaultInstanceForType() {
+          return org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response.getDefaultInstance();
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response build() {
+          org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response buildPartial() {
+          org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response result = new org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response(this);
+          int from_bitField0_ = bitField0_;
+          int to_bitField0_ = 0;
+          if (((from_bitField0_ & 0x00000001) != 0)) {
+            if (modelVersionBuilder_ == null) {
+              result.modelVersion_ = modelVersion_;
+            } else {
+              result.modelVersion_ = modelVersionBuilder_.build();
+            }
+            to_bitField0_ |= 0x00000001;
+          }
+          result.bitField0_ = to_bitField0_;
+          onBuilt();
+          return result;
+        }
+
+        @java.lang.Override
+        public Builder clone() {
+          return super.clone();
+        }
+        @java.lang.Override
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return super.setField(field, value);
+        }
+        @java.lang.Override
+        public Builder clearField(
+            com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return super.clearField(field);
+        }
+        @java.lang.Override
+        public Builder clearOneof(
+            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return super.clearOneof(oneof);
+        }
+        @java.lang.Override
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index, java.lang.Object value) {
+          return super.setRepeatedField(field, index, value);
+        }
+        @java.lang.Override
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return super.addRepeatedField(field, value);
+        }
+        @java.lang.Override
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response) {
+            return mergeFrom((org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response other) {
+          if (other == org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response.getDefaultInstance()) return this;
+          if (other.hasModelVersion()) {
+            mergeModelVersion(other.getModelVersion());
+          }
+          this.mergeUnknownFields(other.unknownFields);
+          onChanged();
+          return this;
+        }
+
+        @java.lang.Override
+        public final boolean isInitialized() {
+          return true;
+        }
+
+        @java.lang.Override
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response) e.getUnfinishedMessage();
+            throw e.unwrapIOException();
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        private int bitField0_;
+
+        private org.mlflow.api.proto.ModelRegistry.ModelVersion modelVersion_;
+        private com.google.protobuf.SingleFieldBuilderV3<
+            org.mlflow.api.proto.ModelRegistry.ModelVersion, org.mlflow.api.proto.ModelRegistry.ModelVersion.Builder, org.mlflow.api.proto.ModelRegistry.ModelVersionOrBuilder> modelVersionBuilder_;
+        /**
+         * <code>optional .mlflow.ModelVersion model_version = 1;</code>
+         * @return Whether the modelVersion field is set.
+         */
+        public boolean hasModelVersion() {
+          return ((bitField0_ & 0x00000001) != 0);
+        }
+        /**
+         * <code>optional .mlflow.ModelVersion model_version = 1;</code>
+         * @return The modelVersion.
+         */
+        public org.mlflow.api.proto.ModelRegistry.ModelVersion getModelVersion() {
+          if (modelVersionBuilder_ == null) {
+            return modelVersion_ == null ? org.mlflow.api.proto.ModelRegistry.ModelVersion.getDefaultInstance() : modelVersion_;
+          } else {
+            return modelVersionBuilder_.getMessage();
+          }
+        }
+        /**
+         * <code>optional .mlflow.ModelVersion model_version = 1;</code>
+         */
+        public Builder setModelVersion(org.mlflow.api.proto.ModelRegistry.ModelVersion value) {
+          if (modelVersionBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            modelVersion_ = value;
+            onChanged();
+          } else {
+            modelVersionBuilder_.setMessage(value);
+          }
+          bitField0_ |= 0x00000001;
+          return this;
+        }
+        /**
+         * <code>optional .mlflow.ModelVersion model_version = 1;</code>
+         */
+        public Builder setModelVersion(
+            org.mlflow.api.proto.ModelRegistry.ModelVersion.Builder builderForValue) {
+          if (modelVersionBuilder_ == null) {
+            modelVersion_ = builderForValue.build();
+            onChanged();
+          } else {
+            modelVersionBuilder_.setMessage(builderForValue.build());
+          }
+          bitField0_ |= 0x00000001;
+          return this;
+        }
+        /**
+         * <code>optional .mlflow.ModelVersion model_version = 1;</code>
+         */
+        public Builder mergeModelVersion(org.mlflow.api.proto.ModelRegistry.ModelVersion value) {
+          if (modelVersionBuilder_ == null) {
+            if (((bitField0_ & 0x00000001) != 0) &&
+                modelVersion_ != null &&
+                modelVersion_ != org.mlflow.api.proto.ModelRegistry.ModelVersion.getDefaultInstance()) {
+              modelVersion_ =
+                org.mlflow.api.proto.ModelRegistry.ModelVersion.newBuilder(modelVersion_).mergeFrom(value).buildPartial();
+            } else {
+              modelVersion_ = value;
+            }
+            onChanged();
+          } else {
+            modelVersionBuilder_.mergeFrom(value);
+          }
+          bitField0_ |= 0x00000001;
+          return this;
+        }
+        /**
+         * <code>optional .mlflow.ModelVersion model_version = 1;</code>
+         */
+        public Builder clearModelVersion() {
+          if (modelVersionBuilder_ == null) {
+            modelVersion_ = null;
+            onChanged();
+          } else {
+            modelVersionBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000001);
+          return this;
+        }
+        /**
+         * <code>optional .mlflow.ModelVersion model_version = 1;</code>
+         */
+        public org.mlflow.api.proto.ModelRegistry.ModelVersion.Builder getModelVersionBuilder() {
+          bitField0_ |= 0x00000001;
+          onChanged();
+          return getModelVersionFieldBuilder().getBuilder();
+        }
+        /**
+         * <code>optional .mlflow.ModelVersion model_version = 1;</code>
+         */
+        public org.mlflow.api.proto.ModelRegistry.ModelVersionOrBuilder getModelVersionOrBuilder() {
+          if (modelVersionBuilder_ != null) {
+            return modelVersionBuilder_.getMessageOrBuilder();
+          } else {
+            return modelVersion_ == null ?
+                org.mlflow.api.proto.ModelRegistry.ModelVersion.getDefaultInstance() : modelVersion_;
+          }
+        }
+        /**
+         * <code>optional .mlflow.ModelVersion model_version = 1;</code>
+         */
+        private com.google.protobuf.SingleFieldBuilderV3<
+            org.mlflow.api.proto.ModelRegistry.ModelVersion, org.mlflow.api.proto.ModelRegistry.ModelVersion.Builder, org.mlflow.api.proto.ModelRegistry.ModelVersionOrBuilder> 
+            getModelVersionFieldBuilder() {
+          if (modelVersionBuilder_ == null) {
+            modelVersionBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+                org.mlflow.api.proto.ModelRegistry.ModelVersion, org.mlflow.api.proto.ModelRegistry.ModelVersion.Builder, org.mlflow.api.proto.ModelRegistry.ModelVersionOrBuilder>(
+                    getModelVersion(),
+                    getParentForChildren(),
+                    isClean());
+            modelVersion_ = null;
+          }
+          return modelVersionBuilder_;
+        }
+        @java.lang.Override
+        public final Builder setUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.setUnknownFields(unknownFields);
+        }
+
+        @java.lang.Override
+        public final Builder mergeUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.mergeUnknownFields(unknownFields);
+        }
+
+
+        // @@protoc_insertion_point(builder_scope:mlflow.GetModelVersionByAlias.Response)
+      }
+
+      // @@protoc_insertion_point(class_scope:mlflow.GetModelVersionByAlias.Response)
+      private static final org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response DEFAULT_INSTANCE;
+      static {
+        DEFAULT_INSTANCE = new org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response();
+      }
+
+      public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+      }
+
+      @java.lang.Deprecated public static final com.google.protobuf.Parser<Response>
+          PARSER = new com.google.protobuf.AbstractParser<Response>() {
+        @java.lang.Override
+        public Response parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new Response(input, extensionRegistry);
+        }
+      };
+
+      public static com.google.protobuf.Parser<Response> parser() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<Response> getParserForType() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Response getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+      }
+
+    }
+
+    private int bitField0_;
+    public static final int NAME_FIELD_NUMBER = 1;
+    private volatile java.lang.Object name_;
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the name field is set.
+     */
+    @java.lang.Override
+    public boolean hasName() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The name.
+     */
+    @java.lang.Override
+    public java.lang.String getName() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          name_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Name of the registered model.
+     * </pre>
+     *
+     * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for name.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getNameBytes() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        name_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int ALIAS_FIELD_NUMBER = 2;
+    private volatile java.lang.Object alias_;
+    /**
+     * <pre>
+     * Name of the alias. Maximum size is 250 bytes.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return Whether the alias field is set.
+     */
+    @java.lang.Override
+    public boolean hasAlias() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <pre>
+     * Name of the alias. Maximum size is 250 bytes.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The alias.
+     */
+    @java.lang.Override
+    public java.lang.String getAlias() {
+      java.lang.Object ref = alias_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          alias_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Name of the alias. Maximum size is 250 bytes.
+     * </pre>
+     *
+     * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+     * @return The bytes for alias.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getAliasBytes() {
+      java.lang.Object ref = alias_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        alias_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, alias_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, alias_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias)) {
+        return super.equals(obj);
+      }
+      org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias other = (org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias) obj;
+
+      if (hasName() != other.hasName()) return false;
+      if (hasName()) {
+        if (!getName()
+            .equals(other.getName())) return false;
+      }
+      if (hasAlias() != other.hasAlias()) return false;
+      if (hasAlias()) {
+        if (!getAlias()
+            .equals(other.getAlias())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasName()) {
+        hash = (37 * hash) + NAME_FIELD_NUMBER;
+        hash = (53 * hash) + getName().hashCode();
+      }
+      if (hasAlias()) {
+        hash = (37 * hash) + ALIAS_FIELD_NUMBER;
+        hash = (53 * hash) + getAlias().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mlflow.GetModelVersionByAlias}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mlflow.GetModelVersionByAlias)
+        org.mlflow.api.proto.ModelRegistry.GetModelVersionByAliasOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetModelVersionByAlias_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetModelVersionByAlias_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.class, org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.Builder.class);
+      }
+
+      // Construct using org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        name_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        alias_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetModelVersionByAlias_descriptor;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias getDefaultInstanceForType() {
+        return org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias build() {
+        org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias buildPartial() {
+        org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias result = new org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.name_ = name_;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.alias_ = alias_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias) {
+          return mergeFrom((org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias other) {
+        if (other == org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias.getDefaultInstance()) return this;
+        if (other.hasName()) {
+          bitField0_ |= 0x00000001;
+          name_ = other.name_;
+          onChanged();
+        }
+        if (other.hasAlias()) {
+          bitField0_ |= 0x00000002;
+          alias_ = other.alias_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object name_ = "";
+      /**
+       * <pre>
+       * Name of the registered model.
+       * </pre>
+       *
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+       * @return Whether the name field is set.
+       */
+      public boolean hasName() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <pre>
+       * Name of the registered model.
+       * </pre>
+       *
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+       * @return The name.
+       */
+      public java.lang.String getName() {
+        java.lang.Object ref = name_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            name_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Name of the registered model.
+       * </pre>
+       *
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+       * @return The bytes for name.
+       */
+      public com.google.protobuf.ByteString
+          getNameBytes() {
+        java.lang.Object ref = name_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          name_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Name of the registered model.
+       * </pre>
+       *
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+       * @param value The name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        name_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Name of the registered model.
+       * </pre>
+       *
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearName() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        name_ = getDefaultInstance().getName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Name of the registered model.
+       * </pre>
+       *
+       * <code>optional string name = 1 [(.mlflow.validate_required) = true];</code>
+       * @param value The bytes for name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        name_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object alias_ = "";
+      /**
+       * <pre>
+       * Name of the alias. Maximum size is 250 bytes.
+       * </pre>
+       *
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+       * @return Whether the alias field is set.
+       */
+      public boolean hasAlias() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <pre>
+       * Name of the alias. Maximum size is 250 bytes.
+       * </pre>
+       *
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+       * @return The alias.
+       */
+      public java.lang.String getAlias() {
+        java.lang.Object ref = alias_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            alias_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Name of the alias. Maximum size is 250 bytes.
+       * </pre>
+       *
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+       * @return The bytes for alias.
+       */
+      public com.google.protobuf.ByteString
+          getAliasBytes() {
+        java.lang.Object ref = alias_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          alias_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Name of the alias. Maximum size is 250 bytes.
+       * </pre>
+       *
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+       * @param value The alias to set.
+       * @return This builder for chaining.
+       */
+      public Builder setAlias(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        alias_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Name of the alias. Maximum size is 250 bytes.
+       * </pre>
+       *
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearAlias() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        alias_ = getDefaultInstance().getAlias();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Name of the alias. Maximum size is 250 bytes.
+       * </pre>
+       *
+       * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
+       * @param value The bytes for alias to set.
+       * @return This builder for chaining.
+       */
+      public Builder setAliasBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        alias_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:mlflow.GetModelVersionByAlias)
+    }
+
+    // @@protoc_insertion_point(class_scope:mlflow.GetModelVersionByAlias)
+    private static final org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias();
+    }
+
+    public static org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<GetModelVersionByAlias>
+        PARSER = new com.google.protobuf.AbstractParser<GetModelVersionByAlias>() {
+      @java.lang.Override
+      public GetModelVersionByAlias parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new GetModelVersionByAlias(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<GetModelVersionByAlias> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<GetModelVersionByAlias> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public org.mlflow.api.proto.ModelRegistry.GetModelVersionByAlias getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -40414,6 +45326,36 @@ public final class ModelRegistry {
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_mlflow_RegisteredModelAlias_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_SetRegisteredModelAlias_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_SetRegisteredModelAlias_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_SetRegisteredModelAlias_Response_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_SetRegisteredModelAlias_Response_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_DeleteRegisteredModelAlias_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_DeleteRegisteredModelAlias_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_DeleteRegisteredModelAlias_Response_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_DeleteRegisteredModelAlias_Response_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_GetModelVersionByAlias_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_GetModelVersionByAlias_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_GetModelVersionByAlias_Response_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_GetModelVersionByAlias_Response_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -40424,189 +45366,215 @@ public final class ModelRegistry {
   static {
     java.lang.String[] descriptorData = {
       "\n\024model_registry.proto\022\006mlflow\032\025scalapb/" +
-      "scalapb.proto\032\020databricks.proto\"\332\001\n\017Regi" +
+      "scalapb.proto\032\020databricks.proto\"\211\002\n\017Regi" +
       "steredModel\022\014\n\004name\030\001 \001(\t\022\032\n\022creation_ti" +
       "mestamp\030\002 \001(\003\022\036\n\026last_updated_timestamp\030" +
       "\003 \001(\003\022\017\n\007user_id\030\004 \001(\t\022\023\n\013description\030\005 " +
       "\001(\t\022-\n\017latest_versions\030\006 \003(\0132\024.mlflow.Mo" +
       "delVersion\022(\n\004tags\030\007 \003(\0132\032.mlflow.Regist" +
-      "eredModelTag\"\303\002\n\014ModelVersion\022\014\n\004name\030\001 " +
-      "\001(\t\022\017\n\007version\030\002 \001(\t\022\032\n\022creation_timesta" +
-      "mp\030\003 \001(\003\022\036\n\026last_updated_timestamp\030\004 \001(\003" +
-      "\022\017\n\007user_id\030\005 \001(\t\022\025\n\rcurrent_stage\030\006 \001(\t" +
-      "\022\023\n\013description\030\007 \001(\t\022\016\n\006source\030\010 \001(\t\022\016\n" +
-      "\006run_id\030\t \001(\t\022*\n\006status\030\n \001(\0162\032.mlflow.M" +
-      "odelVersionStatus\022\026\n\016status_message\030\013 \001(" +
-      "\t\022%\n\004tags\030\014 \003(\0132\027.mlflow.ModelVersionTag" +
-      "\022\020\n\010run_link\030\r \001(\t\"\326\001\n\025CreateRegisteredM" +
-      "odel\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022(\n\004tags\030\002 \003(\0132\032" +
-      ".mlflow.RegisteredModelTag\022\023\n\013descriptio" +
-      "n\030\003 \001(\t\032=\n\010Response\0221\n\020registered_model\030" +
-      "\001 \001(\0132\027.mlflow.RegisteredModel:+\342?(\n&com" +
-      ".databricks.rpc.RPC[$this.Response]\"\251\001\n\025" +
-      "RenameRegisteredModel\022\022\n\004name\030\001 \001(\tB\004\370\206\031" +
-      "\001\022\020\n\010new_name\030\002 \001(\t\032=\n\010Response\0221\n\020regis" +
-      "tered_model\030\001 \001(\0132\027.mlflow.RegisteredMod" +
-      "el:+\342?(\n&com.databricks.rpc.RPC[$this.Re" +
-      "sponse]\"\254\001\n\025UpdateRegisteredModel\022\022\n\004nam" +
-      "e\030\001 \001(\tB\004\370\206\031\001\022\023\n\013description\030\002 \001(\t\032=\n\010Re" +
-      "sponse\0221\n\020registered_model\030\001 \001(\0132\027.mlflo" +
-      "w.RegisteredModel:+\342?(\n&com.databricks.r" +
-      "pc.RPC[$this.Response]\"d\n\025DeleteRegister" +
-      "edModel\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\032\n\n\010Response:" +
-      "+\342?(\n&com.databricks.rpc.RPC[$this.Respo" +
-      "nse]\"\224\001\n\022GetRegisteredModel\022\022\n\004name\030\001 \001(" +
-      "\tB\004\370\206\031\001\032=\n\010Response\0221\n\020registered_model\030" +
-      "\001 \001(\0132\027.mlflow.RegisteredModel:+\342?(\n&com" +
-      ".databricks.rpc.RPC[$this.Response]\"\356\001\n\026" +
-      "SearchRegisteredModels\022\016\n\006filter\030\001 \001(\t\022\030" +
-      "\n\013max_results\030\002 \001(\003:\003100\022\020\n\010order_by\030\003 \003" +
-      "(\t\022\022\n\npage_token\030\004 \001(\t\032W\n\010Response\0222\n\021re" +
-      "gistered_models\030\001 \003(\0132\027.mlflow.Registere" +
-      "dModel\022\027\n\017next_page_token\030\002 \001(\t:+\342?(\n&co" +
-      "m.databricks.rpc.RPC[$this.Response]\"\236\001\n" +
-      "\021GetLatestVersions\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\016" +
-      "\n\006stages\030\002 \003(\t\0328\n\010Response\022,\n\016model_vers" +
-      "ions\030\001 \003(\0132\024.mlflow.ModelVersion:+\342?(\n&c" +
-      "om.databricks.rpc.RPC[$this.Response]\"\202\002" +
-      "\n\022CreateModelVersion\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001" +
-      "\022\024\n\006source\030\002 \001(\tB\004\370\206\031\001\022\016\n\006run_id\030\003 \001(\t\022%" +
-      "\n\004tags\030\004 \003(\0132\027.mlflow.ModelVersionTag\022\020\n" +
-      "\010run_link\030\005 \001(\t\022\023\n\013description\030\006 \001(\t\0327\n\010" +
-      "Response\022+\n\rmodel_version\030\001 \001(\0132\024.mlflow" +
-      ".ModelVersion:+\342?(\n&com.databricks.rpc.R" +
-      "PC[$this.Response]\"\272\001\n\022UpdateModelVersio" +
-      "n\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004" +
-      "\370\206\031\001\022\023\n\013description\030\003 \001(\t\0327\n\010Response\022+\n" +
-      "\rmodel_version\030\001 \001(\0132\024.mlflow.ModelVersi" +
-      "on:+\342?(\n&com.databricks.rpc.RPC[$this.Re" +
-      "sponse]\"\354\001\n\033TransitionModelVersionStage\022" +
-      "\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206" +
-      "\031\001\022\023\n\005stage\030\003 \001(\tB\004\370\206\031\001\022\'\n\031archive_exist" +
-      "ing_versions\030\004 \001(\010B\004\370\206\031\001\0327\n\010Response\022+\n\r" +
-      "model_version\030\001 \001(\0132\024.mlflow.ModelVersio" +
-      "n:+\342?(\n&com.databricks.rpc.RPC[$this.Res" +
-      "ponse]\"x\n\022DeleteModelVersion\022\022\n\004name\030\001 \001" +
-      "(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\032\n\n\010Respo" +
-      "nse:+\342?(\n&com.databricks.rpc.RPC[$this.R" +
-      "esponse]\"\242\001\n\017GetModelVersion\022\022\n\004name\030\001 \001" +
-      "(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\0327\n\010Respo" +
-      "nse\022+\n\rmodel_version\030\001 \001(\0132\024.mlflow.Mode" +
-      "lVersion:+\342?(\n&com.databricks.rpc.RPC[$t" +
-      "his.Response]\"\350\001\n\023SearchModelVersions\022\016\n" +
-      "\006filter\030\001 \001(\t\022\033\n\013max_results\030\002 \001(\003:\0062000" +
-      "00\022\020\n\010order_by\030\003 \003(\t\022\022\n\npage_token\030\004 \001(\t" +
-      "\032Q\n\010Response\022,\n\016model_versions\030\001 \003(\0132\024.m" +
-      "lflow.ModelVersion\022\027\n\017next_page_token\030\002 " +
-      "\001(\t:+\342?(\n&com.databricks.rpc.RPC[$this.R" +
-      "esponse]\"\226\001\n\032GetModelVersionDownloadUri\022" +
-      "\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206" +
-      "\031\001\032 \n\010Response\022\024\n\014artifact_uri\030\001 \001(\t:+\342?" +
-      "(\n&com.databricks.rpc.RPC[$this.Response" +
-      "]\"-\n\017ModelVersionTag\022\013\n\003key\030\001 \001(\t\022\r\n\005val" +
-      "ue\030\002 \001(\t\"0\n\022RegisteredModelTag\022\013\n\003key\030\001 " +
-      "\001(\t\022\r\n\005value\030\002 \001(\t\"\214\001\n\025SetRegisteredMode" +
-      "lTag\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001(\tB\004\370" +
-      "\206\031\001\022\023\n\005value\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?" +
-      "(\n&com.databricks.rpc.RPC[$this.Response" +
-      "]\"\240\001\n\022SetModelVersionTag\022\022\n\004name\030\001 \001(\tB\004" +
-      "\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\022\021\n\003key\030\003 \001(\t" +
-      "B\004\370\206\031\001\022\023\n\005value\030\004 \001(\tB\004\370\206\031\001\032\n\n\010Response:" +
-      "+\342?(\n&com.databricks.rpc.RPC[$this.Respo" +
-      "nse]\"z\n\030DeleteRegisteredModelTag\022\022\n\004name" +
-      "\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\032\n\n\010Respo" +
-      "nse:+\342?(\n&com.databricks.rpc.RPC[$this.R" +
-      "esponse]\"\216\001\n\025DeleteModelVersionTag\022\022\n\004na" +
-      "me\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\022\021\n" +
-      "\003key\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.d" +
-      "atabricks.rpc.RPC[$this.Response]\"D\n\024Reg" +
-      "isteredModelAlias\022\014\n\004name\030\001 \001(\t\022\r\n\005alias" +
-      "\030\002 \001(\t\022\017\n\007version\030\003 \001(\t*R\n\022ModelVersionS" +
-      "tatus\022\030\n\024PENDING_REGISTRATION\020\001\022\027\n\023FAILE" +
-      "D_REGISTRATION\020\002\022\t\n\005READY\020\0032\304\031\n\024ModelReg" +
-      "istryService\022\256\001\n\025createRegisteredModel\022\035" +
-      ".mlflow.CreateRegisteredModel\032&.mlflow.C" +
-      "reateRegisteredModel.Response\"N\362\206\031J\n.\n\004P" +
-      "OST\022 /mlflow/registered-models/create\032\004\010" +
-      "\002\020\000\020\001*\026Create RegisteredModel\022\256\001\n\025rename" +
-      "RegisteredModel\022\035.mlflow.RenameRegistere" +
-      "dModel\032&.mlflow.RenameRegisteredModel.Re" +
+      "eredModelTag\022-\n\007aliases\030\010 \003(\0132\034.mlflow.R" +
+      "egisteredModelAlias\"\324\002\n\014ModelVersion\022\014\n\004" +
+      "name\030\001 \001(\t\022\017\n\007version\030\002 \001(\t\022\032\n\022creation_" +
+      "timestamp\030\003 \001(\003\022\036\n\026last_updated_timestam" +
+      "p\030\004 \001(\003\022\017\n\007user_id\030\005 \001(\t\022\025\n\rcurrent_stag" +
+      "e\030\006 \001(\t\022\023\n\013description\030\007 \001(\t\022\016\n\006source\030\010" +
+      " \001(\t\022\016\n\006run_id\030\t \001(\t\022*\n\006status\030\n \001(\0162\032.m" +
+      "lflow.ModelVersionStatus\022\026\n\016status_messa" +
+      "ge\030\013 \001(\t\022%\n\004tags\030\014 \003(\0132\027.mlflow.ModelVer" +
+      "sionTag\022\020\n\010run_link\030\r \001(\t\022\017\n\007aliases\030\016 \003" +
+      "(\t\"\326\001\n\025CreateRegisteredModel\022\022\n\004name\030\001 \001" +
+      "(\tB\004\370\206\031\001\022(\n\004tags\030\002 \003(\0132\032.mlflow.Register" +
+      "edModelTag\022\023\n\013description\030\003 \001(\t\032=\n\010Respo" +
+      "nse\0221\n\020registered_model\030\001 \001(\0132\027.mlflow.R" +
+      "egisteredModel:+\342?(\n&com.databricks.rpc." +
+      "RPC[$this.Response]\"\251\001\n\025RenameRegistered" +
+      "Model\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\020\n\010new_name\030\002 " +
+      "\001(\t\032=\n\010Response\0221\n\020registered_model\030\001 \001(" +
+      "\0132\027.mlflow.RegisteredModel:+\342?(\n&com.dat" +
+      "abricks.rpc.RPC[$this.Response]\"\254\001\n\025Upda" +
+      "teRegisteredModel\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\023\n" +
+      "\013description\030\002 \001(\t\032=\n\010Response\0221\n\020regist" +
+      "ered_model\030\001 \001(\0132\027.mlflow.RegisteredMode" +
+      "l:+\342?(\n&com.databricks.rpc.RPC[$this.Res" +
+      "ponse]\"d\n\025DeleteRegisteredModel\022\022\n\004name\030" +
+      "\001 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.databr" +
+      "icks.rpc.RPC[$this.Response]\"\224\001\n\022GetRegi" +
+      "steredModel\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\032=\n\010Respo" +
+      "nse\0221\n\020registered_model\030\001 \001(\0132\027.mlflow.R" +
+      "egisteredModel:+\342?(\n&com.databricks.rpc." +
+      "RPC[$this.Response]\"\356\001\n\026SearchRegistered" +
+      "Models\022\016\n\006filter\030\001 \001(\t\022\030\n\013max_results\030\002 " +
+      "\001(\003:\003100\022\020\n\010order_by\030\003 \003(\t\022\022\n\npage_token" +
+      "\030\004 \001(\t\032W\n\010Response\0222\n\021registered_models\030" +
+      "\001 \003(\0132\027.mlflow.RegisteredModel\022\027\n\017next_p" +
+      "age_token\030\002 \001(\t:+\342?(\n&com.databricks.rpc" +
+      ".RPC[$this.Response]\"\236\001\n\021GetLatestVersio" +
+      "ns\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\016\n\006stages\030\002 \003(\t\0328" +
+      "\n\010Response\022,\n\016model_versions\030\001 \003(\0132\024.mlf" +
+      "low.ModelVersion:+\342?(\n&com.databricks.rp" +
+      "c.RPC[$this.Response]\"\202\002\n\022CreateModelVer" +
+      "sion\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\024\n\006source\030\002 \001(\t" +
+      "B\004\370\206\031\001\022\016\n\006run_id\030\003 \001(\t\022%\n\004tags\030\004 \003(\0132\027.m" +
+      "lflow.ModelVersionTag\022\020\n\010run_link\030\005 \001(\t\022" +
+      "\023\n\013description\030\006 \001(\t\0327\n\010Response\022+\n\rmode" +
+      "l_version\030\001 \001(\0132\024.mlflow.ModelVersion:+\342" +
+      "?(\n&com.databricks.rpc.RPC[$this.Respons" +
+      "e]\"\272\001\n\022UpdateModelVersion\022\022\n\004name\030\001 \001(\tB" +
+      "\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\022\023\n\013descript" +
+      "ion\030\003 \001(\t\0327\n\010Response\022+\n\rmodel_version\030\001" +
+      " \001(\0132\024.mlflow.ModelVersion:+\342?(\n&com.dat" +
+      "abricks.rpc.RPC[$this.Response]\"\354\001\n\033Tran" +
+      "sitionModelVersionStage\022\022\n\004name\030\001 \001(\tB\004\370" +
+      "\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\022\023\n\005stage\030\003 \001(" +
+      "\tB\004\370\206\031\001\022\'\n\031archive_existing_versions\030\004 \001" +
+      "(\010B\004\370\206\031\001\0327\n\010Response\022+\n\rmodel_version\030\001 " +
+      "\001(\0132\024.mlflow.ModelVersion:+\342?(\n&com.data" +
+      "bricks.rpc.RPC[$this.Response]\"x\n\022Delete" +
+      "ModelVersion\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007vers" +
+      "ion\030\002 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.da" +
+      "tabricks.rpc.RPC[$this.Response]\"\242\001\n\017Get" +
+      "ModelVersion\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007vers" +
+      "ion\030\002 \001(\tB\004\370\206\031\001\0327\n\010Response\022+\n\rmodel_ver" +
+      "sion\030\001 \001(\0132\024.mlflow.ModelVersion:+\342?(\n&c" +
+      "om.databricks.rpc.RPC[$this.Response]\"\350\001" +
+      "\n\023SearchModelVersions\022\016\n\006filter\030\001 \001(\t\022\033\n" +
+      "\013max_results\030\002 \001(\003:\006200000\022\020\n\010order_by\030\003" +
+      " \003(\t\022\022\n\npage_token\030\004 \001(\t\032Q\n\010Response\022,\n\016" +
+      "model_versions\030\001 \003(\0132\024.mlflow.ModelVersi" +
+      "on\022\027\n\017next_page_token\030\002 \001(\t:+\342?(\n&com.da" +
+      "tabricks.rpc.RPC[$this.Response]\"\226\001\n\032Get" +
+      "ModelVersionDownloadUri\022\022\n\004name\030\001 \001(\tB\004\370" +
+      "\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\032 \n\010Response\022\024" +
+      "\n\014artifact_uri\030\001 \001(\t:+\342?(\n&com.databrick" +
+      "s.rpc.RPC[$this.Response]\"-\n\017ModelVersio" +
+      "nTag\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\"0\n\022Regi" +
+      "steredModelTag\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001" +
+      "(\t\"\214\001\n\025SetRegisteredModelTag\022\022\n\004name\030\001 \001" +
+      "(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\022\023\n\005value\030\003 \001" +
+      "(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.databrick" +
+      "s.rpc.RPC[$this.Response]\"\240\001\n\022SetModelVe" +
+      "rsionTag\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030" +
+      "\002 \001(\tB\004\370\206\031\001\022\021\n\003key\030\003 \001(\tB\004\370\206\031\001\022\023\n\005value\030" +
+      "\004 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.databr" +
+      "icks.rpc.RPC[$this.Response]\"z\n\030DeleteRe" +
+      "gisteredModelTag\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\021\n\003" +
+      "key\030\002 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.da" +
+      "tabricks.rpc.RPC[$this.Response]\"\216\001\n\025Del" +
+      "eteModelVersionTag\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025" +
+      "\n\007version\030\002 \001(\tB\004\370\206\031\001\022\021\n\003key\030\003 \001(\tB\004\370\206\031\001" +
+      "\032\n\n\010Response:+\342?(\n&com.databricks.rpc.RP" +
+      "C[$this.Response]\"6\n\024RegisteredModelAlia" +
+      "s\022\r\n\005alias\030\001 \001(\t\022\017\n\007version\030\002 \001(\t\"\222\001\n\027Se" +
+      "tRegisteredModelAlias\022\022\n\004name\030\001 \001(\tB\004\370\206\031" +
+      "\001\022\023\n\005alias\030\002 \001(\tB\004\370\206\031\001\022\025\n\007version\030\003 \001(\tB" +
+      "\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.databricks.r" +
+      "pc.RPC[$this.Response]\"~\n\032DeleteRegister" +
+      "edModelAlias\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\023\n\005alia" +
+      "s\030\002 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.data" +
+      "bricks.rpc.RPC[$this.Response]\"\247\001\n\026GetMo" +
+      "delVersionByAlias\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\023\n" +
+      "\005alias\030\002 \001(\tB\004\370\206\031\001\0327\n\010Response\022+\n\rmodel_" +
+      "version\030\001 \001(\0132\024.mlflow.ModelVersion:+\342?(" +
+      "\n&com.databricks.rpc.RPC[$this.Response]" +
+      "*R\n\022ModelVersionStatus\022\030\n\024PENDING_REGIST" +
+      "RATION\020\001\022\027\n\023FAILED_REGISTRATION\020\002\022\t\n\005REA" +
+      "DY\020\0032\374\035\n\024ModelRegistryService\022\256\001\n\025create" +
+      "RegisteredModel\022\035.mlflow.CreateRegistere" +
+      "dModel\032&.mlflow.CreateRegisteredModel.Re" +
       "sponse\"N\362\206\031J\n.\n\004POST\022 /mlflow/registered" +
-      "-models/rename\032\004\010\002\020\000\020\001*\026Rename Registere" +
-      "dModel\022\257\001\n\025updateRegisteredModel\022\035.mlflo" +
-      "w.UpdateRegisteredModel\032&.mlflow.UpdateR" +
-      "egisteredModel.Response\"O\362\206\031K\n/\n\005PATCH\022 " +
-      "/mlflow/registered-models/update\032\004\010\002\020\000\020\001" +
-      "*\026Update RegisteredModel\022\260\001\n\025deleteRegis" +
-      "teredModel\022\035.mlflow.DeleteRegisteredMode" +
-      "l\032&.mlflow.DeleteRegisteredModel.Respons" +
-      "e\"P\362\206\031L\n0\n\006DELETE\022 /mlflow/registered-mo" +
-      "dels/delete\032\004\010\002\020\000\020\001*\026Delete RegisteredMo" +
-      "del\022\236\001\n\022getRegisteredModel\022\032.mlflow.GetR" +
-      "egisteredModel\032#.mlflow.GetRegisteredMod" +
-      "el.Response\"G\362\206\031C\n*\n\003GET\022\035/mlflow/regist" +
-      "ered-models/get\032\004\010\002\020\000\020\001*\023Get RegisteredM" +
-      "odel\022\261\001\n\026searchRegisteredModels\022\036.mlflow" +
-      ".SearchRegisteredModels\032\'.mlflow.SearchR" +
-      "egisteredModels.Response\"N\362\206\031J\n-\n\003GET\022 /" +
-      "mlflow/registered-models/search\032\004\010\002\020\000\020\001*" +
-      "\027Search RegisteredModels\022\357\001\n\021getLatestVe" +
-      "rsions\022\031.mlflow.GetLatestVersions\032\".mlfl" +
-      "ow.GetLatestVersions.Response\"\232\001\362\206\031\225\001\n;\n" +
-      "\004POST\022-/mlflow/registered-models/get-lat" +
-      "est-versions\032\004\010\002\020\000\n:\n\003GET\022-/mlflow/regis" +
-      "tered-models/get-latest-versions\032\004\010\002\020\000\020\001" +
-      "*\030Get Latest ModelVersions\022\237\001\n\022createMod" +
-      "elVersion\022\032.mlflow.CreateModelVersion\032#." +
-      "mlflow.CreateModelVersion.Response\"H\362\206\031D" +
-      "\n+\n\004POST\022\035/mlflow/model-versions/create\032" +
-      "\004\010\002\020\000\020\001*\023Create ModelVersion\022\240\001\n\022updateM" +
-      "odelVersion\022\032.mlflow.UpdateModelVersion\032" +
-      "#.mlflow.UpdateModelVersion.Response\"I\362\206" +
-      "\031E\n,\n\005PATCH\022\035/mlflow/model-versions/upda" +
-      "te\032\004\010\002\020\000\020\001*\023Update ModelVersion\022\316\001\n\033tran" +
-      "sitionModelVersionStage\022#.mlflow.Transit" +
-      "ionModelVersionStage\032,.mlflow.Transition" +
-      "ModelVersionStage.Response\"\\\362\206\031X\n5\n\004POST" +
-      "\022\'/mlflow/model-versions/transition-stag" +
-      "e\032\004\010\002\020\000\020\001*\035Transition ModelVersion Stage" +
-      "\022\241\001\n\022deleteModelVersion\022\032.mlflow.DeleteM" +
-      "odelVersion\032#.mlflow.DeleteModelVersion." +
-      "Response\"J\362\206\031F\n-\n\006DELETE\022\035/mlflow/model-" +
-      "versions/delete\032\004\010\002\020\000\020\001*\023Delete ModelVer" +
-      "sion\022\217\001\n\017getModelVersion\022\027.mlflow.GetMod" +
-      "elVersion\032 .mlflow.GetModelVersion.Respo" +
-      "nse\"A\362\206\031=\n\'\n\003GET\022\032/mlflow/model-versions" +
-      "/get\032\004\010\002\020\000\020\001*\020Get ModelVersion\022\242\001\n\023searc" +
-      "hModelVersions\022\033.mlflow.SearchModelVersi" +
-      "ons\032$.mlflow.SearchModelVersions.Respons" +
-      "e\"H\362\206\031D\n*\n\003GET\022\035/mlflow/model-versions/s" +
-      "earch\032\004\010\002\020\000\020\001*\024Search ModelVersions\022\330\001\n\032" +
-      "getModelVersionDownloadUri\022\".mlflow.GetM" +
-      "odelVersionDownloadUri\032+.mlflow.GetModel" +
-      "VersionDownloadUri.Response\"i\362\206\031e\n4\n\003GET" +
-      "\022\'/mlflow/model-versions/get-download-ur" +
-      "i\032\004\010\002\020\000\020\001*+Get Download URI For ModelVer" +
-      "sion Artifacts\022\261\001\n\025setRegisteredModelTag" +
-      "\022\035.mlflow.SetRegisteredModelTag\032&.mlflow" +
-      ".SetRegisteredModelTag.Response\"Q\362\206\031M\n/\n" +
-      "\004POST\022!/mlflow/registered-models/set-tag" +
-      "\032\004\010\002\020\000\020\001*\030Set Registered Model Tag\022\242\001\n\022s" +
-      "etModelVersionTag\022\032.mlflow.SetModelVersi" +
-      "onTag\032#.mlflow.SetModelVersionTag.Respon" +
-      "se\"K\362\206\031G\n,\n\004POST\022\036/mlflow/model-versions" +
-      "/set-tag\032\004\010\002\020\000\020\001*\025Set Model Version Tag\022" +
-      "\302\001\n\030deleteRegisteredModelTag\022 .mlflow.De" +
-      "leteRegisteredModelTag\032).mlflow.DeleteRe" +
-      "gisteredModelTag.Response\"Y\362\206\031U\n4\n\006DELET" +
-      "E\022$/mlflow/registered-models/delete-tag\032" +
-      "\004\010\002\020\000\020\001*\033Delete Registered Model Tag\022\263\001\n" +
-      "\025deleteModelVersionTag\022\035.mlflow.DeleteMo" +
-      "delVersionTag\032&.mlflow.DeleteModelVersio" +
-      "nTag.Response\"S\362\206\031O\n1\n\006DELETE\022!/mlflow/m" +
-      "odel-versions/delete-tag\032\004\010\002\020\000\020\001*\030Delete" +
-      " Model Version TagB!\n\024org.mlflow.api.pro" +
-      "to\220\001\001\240\001\001\342?\002\020\001"
+      "-models/create\032\004\010\002\020\000\020\001*\026Create Registere" +
+      "dModel\022\256\001\n\025renameRegisteredModel\022\035.mlflo" +
+      "w.RenameRegisteredModel\032&.mlflow.RenameR" +
+      "egisteredModel.Response\"N\362\206\031J\n.\n\004POST\022 /" +
+      "mlflow/registered-models/rename\032\004\010\002\020\000\020\001*" +
+      "\026Rename RegisteredModel\022\257\001\n\025updateRegist" +
+      "eredModel\022\035.mlflow.UpdateRegisteredModel" +
+      "\032&.mlflow.UpdateRegisteredModel.Response" +
+      "\"O\362\206\031K\n/\n\005PATCH\022 /mlflow/registered-mode" +
+      "ls/update\032\004\010\002\020\000\020\001*\026Update RegisteredMode" +
+      "l\022\260\001\n\025deleteRegisteredModel\022\035.mlflow.Del" +
+      "eteRegisteredModel\032&.mlflow.DeleteRegist" +
+      "eredModel.Response\"P\362\206\031L\n0\n\006DELETE\022 /mlf" +
+      "low/registered-models/delete\032\004\010\002\020\000\020\001*\026De" +
+      "lete RegisteredModel\022\236\001\n\022getRegisteredMo" +
+      "del\022\032.mlflow.GetRegisteredModel\032#.mlflow" +
+      ".GetRegisteredModel.Response\"G\362\206\031C\n*\n\003GE" +
+      "T\022\035/mlflow/registered-models/get\032\004\010\002\020\000\020\001" +
+      "*\023Get RegisteredModel\022\261\001\n\026searchRegister" +
+      "edModels\022\036.mlflow.SearchRegisteredModels" +
+      "\032\'.mlflow.SearchRegisteredModels.Respons" +
+      "e\"N\362\206\031J\n-\n\003GET\022 /mlflow/registered-model" +
+      "s/search\032\004\010\002\020\000\020\001*\027Search RegisteredModel" +
+      "s\022\357\001\n\021getLatestVersions\022\031.mlflow.GetLate" +
+      "stVersions\032\".mlflow.GetLatestVersions.Re" +
+      "sponse\"\232\001\362\206\031\225\001\n;\n\004POST\022-/mlflow/register" +
+      "ed-models/get-latest-versions\032\004\010\002\020\000\n:\n\003G" +
+      "ET\022-/mlflow/registered-models/get-latest" +
+      "-versions\032\004\010\002\020\000\020\001*\030Get Latest ModelVersi" +
+      "ons\022\237\001\n\022createModelVersion\022\032.mlflow.Crea" +
+      "teModelVersion\032#.mlflow.CreateModelVersi" +
+      "on.Response\"H\362\206\031D\n+\n\004POST\022\035/mlflow/model" +
+      "-versions/create\032\004\010\002\020\000\020\001*\023Create ModelVe" +
+      "rsion\022\240\001\n\022updateModelVersion\022\032.mlflow.Up" +
+      "dateModelVersion\032#.mlflow.UpdateModelVer" +
+      "sion.Response\"I\362\206\031E\n,\n\005PATCH\022\035/mlflow/mo" +
+      "del-versions/update\032\004\010\002\020\000\020\001*\023Update Mode" +
+      "lVersion\022\316\001\n\033transitionModelVersionStage" +
+      "\022#.mlflow.TransitionModelVersionStage\032,." +
+      "mlflow.TransitionModelVersionStage.Respo" +
+      "nse\"\\\362\206\031X\n5\n\004POST\022\'/mlflow/model-version" +
+      "s/transition-stage\032\004\010\002\020\000\020\001*\035Transition M" +
+      "odelVersion Stage\022\241\001\n\022deleteModelVersion" +
+      "\022\032.mlflow.DeleteModelVersion\032#.mlflow.De" +
+      "leteModelVersion.Response\"J\362\206\031F\n-\n\006DELET" +
+      "E\022\035/mlflow/model-versions/delete\032\004\010\002\020\000\020\001" +
+      "*\023Delete ModelVersion\022\217\001\n\017getModelVersio" +
+      "n\022\027.mlflow.GetModelVersion\032 .mlflow.GetM" +
+      "odelVersion.Response\"A\362\206\031=\n\'\n\003GET\022\032/mlfl" +
+      "ow/model-versions/get\032\004\010\002\020\000\020\001*\020Get Model" +
+      "Version\022\242\001\n\023searchModelVersions\022\033.mlflow" +
+      ".SearchModelVersions\032$.mlflow.SearchMode" +
+      "lVersions.Response\"H\362\206\031D\n*\n\003GET\022\035/mlflow" +
+      "/model-versions/search\032\004\010\002\020\000\020\001*\024Search M" +
+      "odelVersions\022\330\001\n\032getModelVersionDownload" +
+      "Uri\022\".mlflow.GetModelVersionDownloadUri\032" +
+      "+.mlflow.GetModelVersionDownloadUri.Resp" +
+      "onse\"i\362\206\031e\n4\n\003GET\022\'/mlflow/model-version" +
+      "s/get-download-uri\032\004\010\002\020\000\020\001*+Get Download" +
+      " URI For ModelVersion Artifacts\022\261\001\n\025setR" +
+      "egisteredModelTag\022\035.mlflow.SetRegistered" +
+      "ModelTag\032&.mlflow.SetRegisteredModelTag." +
+      "Response\"Q\362\206\031M\n/\n\004POST\022!/mlflow/register" +
+      "ed-models/set-tag\032\004\010\002\020\000\020\001*\030Set Registere" +
+      "d Model Tag\022\242\001\n\022setModelVersionTag\022\032.mlf" +
+      "low.SetModelVersionTag\032#.mlflow.SetModel" +
+      "VersionTag.Response\"K\362\206\031G\n,\n\004POST\022\036/mlfl" +
+      "ow/model-versions/set-tag\032\004\010\002\020\000\020\001*\025Set M" +
+      "odel Version Tag\022\302\001\n\030deleteRegisteredMod" +
+      "elTag\022 .mlflow.DeleteRegisteredModelTag\032" +
+      ").mlflow.DeleteRegisteredModelTag.Respon" +
+      "se\"Y\362\206\031U\n4\n\006DELETE\022$/mlflow/registered-m" +
+      "odels/delete-tag\032\004\010\002\020\000\020\001*\033Delete Registe" +
+      "red Model Tag\022\263\001\n\025deleteModelVersionTag\022" +
+      "\035.mlflow.DeleteModelVersionTag\032&.mlflow." +
+      "DeleteModelVersionTag.Response\"S\362\206\031O\n1\n\006" +
+      "DELETE\022!/mlflow/model-versions/delete-ta" +
+      "g\032\004\010\002\020\000\020\001*\030Delete Model Version Tag\022\267\001\n\027" +
+      "setRegisteredModelAlias\022\037.mlflow.SetRegi" +
+      "steredModelAlias\032(.mlflow.SetRegisteredM" +
+      "odelAlias.Response\"Q\362\206\031M\n-\n\004POST\022\037/mlflo" +
+      "w/registered-models/alias\032\004\010\002\020\000\020\001*\032Set R" +
+      "egistered Model Alias\022\305\001\n\032deleteRegister" +
+      "edModelAlias\022\".mlflow.DeleteRegisteredMo" +
+      "delAlias\032+.mlflow.DeleteRegisteredModelA" +
+      "lias.Response\"V\362\206\031R\n/\n\006DELETE\022\037/mlflow/r" +
+      "egistered-models/alias\032\004\010\002\020\000\020\001*\035Delete R" +
+      "egistered Model Alias\022\263\001\n\026getModelVersio" +
+      "nByAlias\022\036.mlflow.GetModelVersionByAlias" +
+      "\032\'.mlflow.GetModelVersionByAlias.Respons" +
+      "e\"P\362\206\031L\n,\n\003GET\022\037/mlflow/registered-model" +
+      "s/alias\032\004\010\002\020\000\020\001*\032Get Model Version by Al" +
+      "iasB!\n\024org.mlflow.api.proto\220\001\001\240\001\001\342?\002\020\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -40619,13 +45587,13 @@ public final class ModelRegistry {
     internal_static_mlflow_RegisteredModel_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_RegisteredModel_descriptor,
-        new java.lang.String[] { "Name", "CreationTimestamp", "LastUpdatedTimestamp", "UserId", "Description", "LatestVersions", "Tags", });
+        new java.lang.String[] { "Name", "CreationTimestamp", "LastUpdatedTimestamp", "UserId", "Description", "LatestVersions", "Tags", "Aliases", });
     internal_static_mlflow_ModelVersion_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_mlflow_ModelVersion_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_ModelVersion_descriptor,
-        new java.lang.String[] { "Name", "Version", "CreationTimestamp", "LastUpdatedTimestamp", "UserId", "CurrentStage", "Description", "Source", "RunId", "Status", "StatusMessage", "Tags", "RunLink", });
+        new java.lang.String[] { "Name", "Version", "CreationTimestamp", "LastUpdatedTimestamp", "UserId", "CurrentStage", "Description", "Source", "RunId", "Status", "StatusMessage", "Tags", "RunLink", "Aliases", });
     internal_static_mlflow_CreateRegisteredModel_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_mlflow_CreateRegisteredModel_fieldAccessorTable = new
@@ -40859,7 +45827,43 @@ public final class ModelRegistry {
     internal_static_mlflow_RegisteredModelAlias_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_RegisteredModelAlias_descriptor,
+        new java.lang.String[] { "Alias", "Version", });
+    internal_static_mlflow_SetRegisteredModelAlias_descriptor =
+      getDescriptor().getMessageTypes().get(23);
+    internal_static_mlflow_SetRegisteredModelAlias_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_SetRegisteredModelAlias_descriptor,
         new java.lang.String[] { "Name", "Alias", "Version", });
+    internal_static_mlflow_SetRegisteredModelAlias_Response_descriptor =
+      internal_static_mlflow_SetRegisteredModelAlias_descriptor.getNestedTypes().get(0);
+    internal_static_mlflow_SetRegisteredModelAlias_Response_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_SetRegisteredModelAlias_Response_descriptor,
+        new java.lang.String[] { });
+    internal_static_mlflow_DeleteRegisteredModelAlias_descriptor =
+      getDescriptor().getMessageTypes().get(24);
+    internal_static_mlflow_DeleteRegisteredModelAlias_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_DeleteRegisteredModelAlias_descriptor,
+        new java.lang.String[] { "Name", "Alias", });
+    internal_static_mlflow_DeleteRegisteredModelAlias_Response_descriptor =
+      internal_static_mlflow_DeleteRegisteredModelAlias_descriptor.getNestedTypes().get(0);
+    internal_static_mlflow_DeleteRegisteredModelAlias_Response_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_DeleteRegisteredModelAlias_Response_descriptor,
+        new java.lang.String[] { });
+    internal_static_mlflow_GetModelVersionByAlias_descriptor =
+      getDescriptor().getMessageTypes().get(25);
+    internal_static_mlflow_GetModelVersionByAlias_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_GetModelVersionByAlias_descriptor,
+        new java.lang.String[] { "Name", "Alias", });
+    internal_static_mlflow_GetModelVersionByAlias_Response_descriptor =
+      internal_static_mlflow_GetModelVersionByAlias_descriptor.getNestedTypes().get(0);
+    internal_static_mlflow_GetModelVersionByAlias_Response_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_GetModelVersionByAlias_Response_descriptor,
+        new java.lang.String[] { "ModelVersion", });
     com.google.protobuf.ExtensionRegistry registry =
         com.google.protobuf.ExtensionRegistry.newInstance();
     registry.add(com.databricks.api.proto.databricks.Databricks.rpc);

--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/ModelRegistry.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/ModelRegistry.java
@@ -40784,7 +40784,7 @@ public final class ModelRegistry {
      * <pre>
      * Name of the alias. Maximum size depends on storage backend.
      * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
-     * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+     * All storage backends are guaranteed to support alias name values up to 256 bytes in size.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -40795,7 +40795,7 @@ public final class ModelRegistry {
      * <pre>
      * Name of the alias. Maximum size depends on storage backend.
      * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
-     * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+     * All storage backends are guaranteed to support alias name values up to 256 bytes in size.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -40806,7 +40806,7 @@ public final class ModelRegistry {
      * <pre>
      * Name of the alias. Maximum size depends on storage backend.
      * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
-     * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+     * All storage backends are guaranteed to support alias name values up to 256 bytes in size.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -41428,7 +41428,7 @@ public final class ModelRegistry {
      * <pre>
      * Name of the alias. Maximum size depends on storage backend.
      * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
-     * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+     * All storage backends are guaranteed to support alias name values up to 256 bytes in size.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -41442,7 +41442,7 @@ public final class ModelRegistry {
      * <pre>
      * Name of the alias. Maximum size depends on storage backend.
      * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
-     * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+     * All storage backends are guaranteed to support alias name values up to 256 bytes in size.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -41467,7 +41467,7 @@ public final class ModelRegistry {
      * <pre>
      * Name of the alias. Maximum size depends on storage backend.
      * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
-     * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+     * All storage backends are guaranteed to support alias name values up to 256 bytes in size.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -42028,7 +42028,7 @@ public final class ModelRegistry {
        * <pre>
        * Name of the alias. Maximum size depends on storage backend.
        * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
-       * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+       * All storage backends are guaranteed to support alias name values up to 256 bytes in size.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -42041,7 +42041,7 @@ public final class ModelRegistry {
        * <pre>
        * Name of the alias. Maximum size depends on storage backend.
        * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
-       * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+       * All storage backends are guaranteed to support alias name values up to 256 bytes in size.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -42065,7 +42065,7 @@ public final class ModelRegistry {
        * <pre>
        * Name of the alias. Maximum size depends on storage backend.
        * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
-       * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+       * All storage backends are guaranteed to support alias name values up to 256 bytes in size.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -42088,7 +42088,7 @@ public final class ModelRegistry {
        * <pre>
        * Name of the alias. Maximum size depends on storage backend.
        * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
-       * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+       * All storage backends are guaranteed to support alias name values up to 256 bytes in size.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -42109,7 +42109,7 @@ public final class ModelRegistry {
        * <pre>
        * Name of the alias. Maximum size depends on storage backend.
        * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
-       * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+       * All storage backends are guaranteed to support alias name values up to 256 bytes in size.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -42125,7 +42125,7 @@ public final class ModelRegistry {
        * <pre>
        * Name of the alias. Maximum size depends on storage backend.
        * If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
-       * All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+       * All storage backends are guaranteed to support alias name values up to 256 bytes in size.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -42338,7 +42338,7 @@ public final class ModelRegistry {
 
     /**
      * <pre>
-     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 256 bytes.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -42347,7 +42347,7 @@ public final class ModelRegistry {
     boolean hasAlias();
     /**
      * <pre>
-     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 256 bytes.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -42356,7 +42356,7 @@ public final class ModelRegistry {
     java.lang.String getAlias();
     /**
      * <pre>
-     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 256 bytes.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -42940,7 +42940,7 @@ public final class ModelRegistry {
     private volatile java.lang.Object alias_;
     /**
      * <pre>
-     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 256 bytes.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -42952,7 +42952,7 @@ public final class ModelRegistry {
     }
     /**
      * <pre>
-     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 256 bytes.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -42975,7 +42975,7 @@ public final class ModelRegistry {
     }
     /**
      * <pre>
-     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+     * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 256 bytes.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -43448,7 +43448,7 @@ public final class ModelRegistry {
       private java.lang.Object alias_ = "";
       /**
        * <pre>
-       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 256 bytes.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -43459,7 +43459,7 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 256 bytes.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -43481,7 +43481,7 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 256 bytes.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -43502,7 +43502,7 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 256 bytes.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -43521,7 +43521,7 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 256 bytes.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -43535,7 +43535,7 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+       * Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 256 bytes.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -43640,7 +43640,7 @@ public final class ModelRegistry {
 
     /**
      * <pre>
-     * Name of the alias. Maximum size is 250 bytes.
+     * Name of the alias. Maximum size is 256 bytes.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -43649,7 +43649,7 @@ public final class ModelRegistry {
     boolean hasAlias();
     /**
      * <pre>
-     * Name of the alias. Maximum size is 250 bytes.
+     * Name of the alias. Maximum size is 256 bytes.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -43658,7 +43658,7 @@ public final class ModelRegistry {
     java.lang.String getAlias();
     /**
      * <pre>
-     * Name of the alias. Maximum size is 250 bytes.
+     * Name of the alias. Maximum size is 256 bytes.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -44456,7 +44456,7 @@ public final class ModelRegistry {
     private volatile java.lang.Object alias_;
     /**
      * <pre>
-     * Name of the alias. Maximum size is 250 bytes.
+     * Name of the alias. Maximum size is 256 bytes.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -44468,7 +44468,7 @@ public final class ModelRegistry {
     }
     /**
      * <pre>
-     * Name of the alias. Maximum size is 250 bytes.
+     * Name of the alias. Maximum size is 256 bytes.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -44491,7 +44491,7 @@ public final class ModelRegistry {
     }
     /**
      * <pre>
-     * Name of the alias. Maximum size is 250 bytes.
+     * Name of the alias. Maximum size is 256 bytes.
      * </pre>
      *
      * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -44964,7 +44964,7 @@ public final class ModelRegistry {
       private java.lang.Object alias_ = "";
       /**
        * <pre>
-       * Name of the alias. Maximum size is 250 bytes.
+       * Name of the alias. Maximum size is 256 bytes.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -44975,7 +44975,7 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Name of the alias. Maximum size is 250 bytes.
+       * Name of the alias. Maximum size is 256 bytes.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -44997,7 +44997,7 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Name of the alias. Maximum size is 250 bytes.
+       * Name of the alias. Maximum size is 256 bytes.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -45018,7 +45018,7 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Name of the alias. Maximum size is 250 bytes.
+       * Name of the alias. Maximum size is 256 bytes.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -45037,7 +45037,7 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Name of the alias. Maximum size is 250 bytes.
+       * Name of the alias. Maximum size is 256 bytes.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>
@@ -45051,7 +45051,7 @@ public final class ModelRegistry {
       }
       /**
        * <pre>
-       * Name of the alias. Maximum size is 250 bytes.
+       * Name of the alias. Maximum size is 256 bytes.
        * </pre>
        *
        * <code>optional string alias = 2 [(.mlflow.validate_required) = true];</code>

--- a/mlflow/protos/model_registry.proto
+++ b/mlflow/protos/model_registry.proto
@@ -233,6 +233,42 @@ service ModelRegistryService {
       rpc_doc_title: "Delete Model Version Tag",
     };
   }
+
+  rpc setRegisteredModelAlias (SetRegisteredModelAlias) returns (SetRegisteredModelAlias.Response) {
+    option (rpc) = {
+      endpoints: [{
+        method: "POST",
+        path: "/mlflow/registered-models/alias"
+        since { major: 2, minor: 0},
+      }],
+      visibility: PUBLIC,
+      rpc_doc_title: "Set Registered Model Alias",
+    };
+  }
+
+  rpc deleteRegisteredModelAlias (DeleteRegisteredModelAlias) returns (DeleteRegisteredModelAlias.Response) {
+    option (rpc) = {
+      endpoints: [{
+        method: "DELETE",
+        path: "/mlflow/registered-models/alias"
+        since { major: 2, minor: 0},
+      }],
+      visibility: PUBLIC,
+      rpc_doc_title: "Delete Registered Model Alias",
+    };
+  }
+
+  rpc getModelVersionByAlias (GetModelVersionByAlias) returns (GetModelVersionByAlias.Response) {
+    option (rpc) = {
+      endpoints: [{
+        method: "GET",
+        path: "/mlflow/registered-models/alias"
+        since { major: 2, minor: 0},
+      }],
+      visibility: PUBLIC,
+      rpc_doc_title: "Get Model Version by Alias",
+    };
+  }
 }
 
 message RegisteredModel {
@@ -258,6 +294,9 @@ message RegisteredModel {
 
   // Tags: Additional metadata key-value pairs for this ``registered_model``.
   repeated RegisteredModelTag tags = 7;
+
+  // Aliases pointing to model versions associated with this ``registered_model``.
+  repeated RegisteredModelAlias aliases = 8;
 }
 
 enum ModelVersionStatus {
@@ -312,6 +351,9 @@ message ModelVersion {
   // Run Link: Direct link to the run that generated this version. This field is set at model version creation time
   // only for model versions whose source run is from a tracking server that is different from the registry server.
   optional string run_link = 13;
+
+  // Aliases pointing to this ``model_version``.
+  repeated string aliases = 14;
 }
 
 message CreateRegisteredModel {
@@ -654,10 +696,53 @@ message DeleteModelVersionTag {
 
 // Alias for a registered model
 message RegisteredModelAlias {
-  // The name of the registered model associated with the alias.
-  optional string name = 1;
   // The name of the alias.
-  optional string alias = 2;
+  optional string alias = 1;
   // The model version number that the alias points to.
-  optional string version = 3;
+  optional string version = 2;
+}
+
+message SetRegisteredModelAlias {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // Name of the registered model.
+  optional string name = 1 [(validate_required) = true];
+
+  // Name of the alias. Maximum size depends on storage backend.
+  // If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
+  // All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+  optional string alias = 2 [(validate_required) = true];
+
+  // Model version number.
+  optional string version = 3 [(validate_required) = true];
+
+  message Response {
+  }
+}
+
+message DeleteRegisteredModelAlias {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // Name of the registered model.
+  optional string name = 1 [(validate_required) = true];
+
+  // Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+  optional string alias = 2 [(validate_required) = true];
+
+  message Response {
+  }
+}
+
+message GetModelVersionByAlias {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // Name of the registered model.
+  optional string name = 1 [(validate_required) = true];
+
+  // Name of the alias. Maximum size is 250 bytes.
+  optional string alias = 2 [(validate_required) = true];
+
+  message Response {
+    optional ModelVersion model_version = 1;
+  }
 }

--- a/mlflow/protos/model_registry.proto
+++ b/mlflow/protos/model_registry.proto
@@ -710,7 +710,7 @@ message SetRegisteredModelAlias {
 
   // Name of the alias. Maximum size depends on storage backend.
   // If an alias with this name already exists, its preexisting value will be replaced by the specified `version`.
-  // All storage backends are guaranteed to support alias name values up to 250 bytes in size.
+  // All storage backends are guaranteed to support alias name values up to 256 bytes in size.
   optional string alias = 2 [(validate_required) = true];
 
   // Model version number.
@@ -726,7 +726,7 @@ message DeleteRegisteredModelAlias {
   // Name of the registered model.
   optional string name = 1 [(validate_required) = true];
 
-  // Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes.
+  // Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 256 bytes.
   optional string alias = 2 [(validate_required) = true];
 
   message Response {
@@ -739,7 +739,7 @@ message GetModelVersionByAlias {
   // Name of the registered model.
   optional string name = 1 [(validate_required) = true];
 
-  // Name of the alias. Maximum size is 250 bytes.
+  // Name of the alias. Maximum size is 256 bytes.
   optional string alias = 2 [(validate_required) = true];
 
   message Response {

--- a/mlflow/protos/model_registry_pb2.py
+++ b/mlflow/protos/model_registry_pb2.py
@@ -19,7 +19,7 @@ from .scalapb import scalapb_pb2 as scalapb_dot_scalapb__pb2
 from . import databricks_pb2 as databricks__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14model_registry.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xda\x01\n\x0fRegisteredModel\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x02 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x03 \x01(\x03\x12\x0f\n\x07user_id\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x01(\t\x12-\n\x0flatest_versions\x18\x06 \x03(\x0b\x32\x14.mlflow.ModelVersion\x12(\n\x04tags\x18\x07 \x03(\x0b\x32\x1a.mlflow.RegisteredModelTag\"\xc3\x02\n\x0cModelVersion\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x03 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x04 \x01(\x03\x12\x0f\n\x07user_id\x18\x05 \x01(\t\x12\x15\n\rcurrent_stage\x18\x06 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x07 \x01(\t\x12\x0e\n\x06source\x18\x08 \x01(\t\x12\x0e\n\x06run_id\x18\t \x01(\t\x12*\n\x06status\x18\n \x01(\x0e\x32\x1a.mlflow.ModelVersionStatus\x12\x16\n\x0estatus_message\x18\x0b \x01(\t\x12%\n\x04tags\x18\x0c \x03(\x0b\x32\x17.mlflow.ModelVersionTag\x12\x10\n\x08run_link\x18\r \x01(\t\"\xd6\x01\n\x15\x43reateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12(\n\x04tags\x18\x02 \x03(\x0b\x32\x1a.mlflow.RegisteredModelTag\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa9\x01\n\x15RenameRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\x15UpdateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"d\n\x15\x44\x65leteRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x94\x01\n\x12GetRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xee\x01\n\x16SearchRegisteredModels\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x18\n\x0bmax_results\x18\x02 \x01(\x03:\x03\x31\x30\x30\x12\x10\n\x08order_by\x18\x03 \x03(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aW\n\x08Response\x12\x32\n\x11registered_models\x18\x01 \x03(\x0b\x32\x17.mlflow.RegisteredModel\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9e\x01\n\x11GetLatestVersions\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06stages\x18\x02 \x03(\t\x1a\x38\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x82\x02\n\x12\x43reateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x14\n\x06source\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12%\n\x04tags\x18\x04 \x03(\x0b\x32\x17.mlflow.ModelVersionTag\x12\x10\n\x08run_link\x18\x05 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x06 \x01(\t\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x01\n\x12UpdateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xec\x01\n\x1bTransitionModelVersionStage\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05stage\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\'\n\x19\x61rchive_existing_versions\x18\x04 \x01(\x08\x42\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"x\n\x12\x44\x65leteModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa2\x01\n\x0fGetModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe8\x01\n\x13SearchModelVersions\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x1b\n\x0bmax_results\x18\x02 \x01(\x03:\x06\x32\x30\x30\x30\x30\x30\x12\x10\n\x08order_by\x18\x03 \x03(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aQ\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\x1aGetModelVersionDownloadUri\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a \n\x08Response\x12\x14\n\x0c\x61rtifact_uri\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"-\n\x0fModelVersionTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"0\n\x12RegisteredModelTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x8c\x01\n\x15SetRegisteredModelTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa0\x01\n\x12SetModelVersionTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x04 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x18\x44\x65leteRegisteredModelTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8e\x01\n\x15\x44\x65leteModelVersionTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"D\n\x14RegisteredModelAlias\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05\x61lias\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t*R\n\x12ModelVersionStatus\x12\x18\n\x14PENDING_REGISTRATION\x10\x01\x12\x17\n\x13\x46\x41ILED_REGISTRATION\x10\x02\x12\t\n\x05READY\x10\x03\x32\xc4\x19\n\x14ModelRegistryService\x12\xae\x01\n\x15\x63reateRegisteredModel\x12\x1d.mlflow.CreateRegisteredModel\x1a&.mlflow.CreateRegisteredModel.Response\"N\xf2\x86\x19J\n.\n\x04POST\x12 /mlflow/registered-models/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x43reate RegisteredModel\x12\xae\x01\n\x15renameRegisteredModel\x12\x1d.mlflow.RenameRegisteredModel\x1a&.mlflow.RenameRegisteredModel.Response\"N\xf2\x86\x19J\n.\n\x04POST\x12 /mlflow/registered-models/rename\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Rename RegisteredModel\x12\xaf\x01\n\x15updateRegisteredModel\x12\x1d.mlflow.UpdateRegisteredModel\x1a&.mlflow.UpdateRegisteredModel.Response\"O\xf2\x86\x19K\n/\n\x05PATCH\x12 /mlflow/registered-models/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Update RegisteredModel\x12\xb0\x01\n\x15\x64\x65leteRegisteredModel\x12\x1d.mlflow.DeleteRegisteredModel\x1a&.mlflow.DeleteRegisteredModel.Response\"P\xf2\x86\x19L\n0\n\x06\x44\x45LETE\x12 /mlflow/registered-models/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x44\x65lete RegisteredModel\x12\x9e\x01\n\x12getRegisteredModel\x12\x1a.mlflow.GetRegisteredModel\x1a#.mlflow.GetRegisteredModel.Response\"G\xf2\x86\x19\x43\n*\n\x03GET\x12\x1d/mlflow/registered-models/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Get RegisteredModel\x12\xb1\x01\n\x16searchRegisteredModels\x12\x1e.mlflow.SearchRegisteredModels\x1a\'.mlflow.SearchRegisteredModels.Response\"N\xf2\x86\x19J\n-\n\x03GET\x12 /mlflow/registered-models/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x17Search RegisteredModels\x12\xef\x01\n\x11getLatestVersions\x12\x19.mlflow.GetLatestVersions\x1a\".mlflow.GetLatestVersions.Response\"\x9a\x01\xf2\x86\x19\x95\x01\n;\n\x04POST\x12-/mlflow/registered-models/get-latest-versions\x1a\x04\x08\x02\x10\x00\n:\n\x03GET\x12-/mlflow/registered-models/get-latest-versions\x1a\x04\x08\x02\x10\x00\x10\x01*\x18Get Latest ModelVersions\x12\x9f\x01\n\x12\x63reateModelVersion\x12\x1a.mlflow.CreateModelVersion\x1a#.mlflow.CreateModelVersion.Response\"H\xf2\x86\x19\x44\n+\n\x04POST\x12\x1d/mlflow/model-versions/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x43reate ModelVersion\x12\xa0\x01\n\x12updateModelVersion\x12\x1a.mlflow.UpdateModelVersion\x1a#.mlflow.UpdateModelVersion.Response\"I\xf2\x86\x19\x45\n,\n\x05PATCH\x12\x1d/mlflow/model-versions/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Update ModelVersion\x12\xce\x01\n\x1btransitionModelVersionStage\x12#.mlflow.TransitionModelVersionStage\x1a,.mlflow.TransitionModelVersionStage.Response\"\\\xf2\x86\x19X\n5\n\x04POST\x12\'/mlflow/model-versions/transition-stage\x1a\x04\x08\x02\x10\x00\x10\x01*\x1dTransition ModelVersion Stage\x12\xa1\x01\n\x12\x64\x65leteModelVersion\x12\x1a.mlflow.DeleteModelVersion\x1a#.mlflow.DeleteModelVersion.Response\"J\xf2\x86\x19\x46\n-\n\x06\x44\x45LETE\x12\x1d/mlflow/model-versions/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x44\x65lete ModelVersion\x12\x8f\x01\n\x0fgetModelVersion\x12\x17.mlflow.GetModelVersion\x1a .mlflow.GetModelVersion.Response\"A\xf2\x86\x19=\n\'\n\x03GET\x12\x1a/mlflow/model-versions/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x10Get ModelVersion\x12\xa2\x01\n\x13searchModelVersions\x12\x1b.mlflow.SearchModelVersions\x1a$.mlflow.SearchModelVersions.Response\"H\xf2\x86\x19\x44\n*\n\x03GET\x12\x1d/mlflow/model-versions/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x14Search ModelVersions\x12\xd8\x01\n\x1agetModelVersionDownloadUri\x12\".mlflow.GetModelVersionDownloadUri\x1a+.mlflow.GetModelVersionDownloadUri.Response\"i\xf2\x86\x19\x65\n4\n\x03GET\x12\'/mlflow/model-versions/get-download-uri\x1a\x04\x08\x02\x10\x00\x10\x01*+Get Download URI For ModelVersion Artifacts\x12\xb1\x01\n\x15setRegisteredModelTag\x12\x1d.mlflow.SetRegisteredModelTag\x1a&.mlflow.SetRegisteredModelTag.Response\"Q\xf2\x86\x19M\n/\n\x04POST\x12!/mlflow/registered-models/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x18Set Registered Model Tag\x12\xa2\x01\n\x12setModelVersionTag\x12\x1a.mlflow.SetModelVersionTag\x1a#.mlflow.SetModelVersionTag.Response\"K\xf2\x86\x19G\n,\n\x04POST\x12\x1e/mlflow/model-versions/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x15Set Model Version Tag\x12\xc2\x01\n\x18\x64\x65leteRegisteredModelTag\x12 .mlflow.DeleteRegisteredModelTag\x1a).mlflow.DeleteRegisteredModelTag.Response\"Y\xf2\x86\x19U\n4\n\x06\x44\x45LETE\x12$/mlflow/registered-models/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x1b\x44\x65lete Registered Model Tag\x12\xb3\x01\n\x15\x64\x65leteModelVersionTag\x12\x1d.mlflow.DeleteModelVersionTag\x1a&.mlflow.DeleteModelVersionTag.Response\"S\xf2\x86\x19O\n1\n\x06\x44\x45LETE\x12!/mlflow/model-versions/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x18\x44\x65lete Model Version TagB!\n\x14org.mlflow.api.proto\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14model_registry.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\x89\x02\n\x0fRegisteredModel\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x02 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x03 \x01(\x03\x12\x0f\n\x07user_id\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x01(\t\x12-\n\x0flatest_versions\x18\x06 \x03(\x0b\x32\x14.mlflow.ModelVersion\x12(\n\x04tags\x18\x07 \x03(\x0b\x32\x1a.mlflow.RegisteredModelTag\x12-\n\x07\x61liases\x18\x08 \x03(\x0b\x32\x1c.mlflow.RegisteredModelAlias\"\xd4\x02\n\x0cModelVersion\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x03 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x04 \x01(\x03\x12\x0f\n\x07user_id\x18\x05 \x01(\t\x12\x15\n\rcurrent_stage\x18\x06 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x07 \x01(\t\x12\x0e\n\x06source\x18\x08 \x01(\t\x12\x0e\n\x06run_id\x18\t \x01(\t\x12*\n\x06status\x18\n \x01(\x0e\x32\x1a.mlflow.ModelVersionStatus\x12\x16\n\x0estatus_message\x18\x0b \x01(\t\x12%\n\x04tags\x18\x0c \x03(\x0b\x32\x17.mlflow.ModelVersionTag\x12\x10\n\x08run_link\x18\r \x01(\t\x12\x0f\n\x07\x61liases\x18\x0e \x03(\t\"\xd6\x01\n\x15\x43reateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12(\n\x04tags\x18\x02 \x03(\x0b\x32\x1a.mlflow.RegisteredModelTag\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa9\x01\n\x15RenameRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\x15UpdateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"d\n\x15\x44\x65leteRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x94\x01\n\x12GetRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xee\x01\n\x16SearchRegisteredModels\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x18\n\x0bmax_results\x18\x02 \x01(\x03:\x03\x31\x30\x30\x12\x10\n\x08order_by\x18\x03 \x03(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aW\n\x08Response\x12\x32\n\x11registered_models\x18\x01 \x03(\x0b\x32\x17.mlflow.RegisteredModel\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9e\x01\n\x11GetLatestVersions\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06stages\x18\x02 \x03(\t\x1a\x38\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x82\x02\n\x12\x43reateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x14\n\x06source\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12%\n\x04tags\x18\x04 \x03(\x0b\x32\x17.mlflow.ModelVersionTag\x12\x10\n\x08run_link\x18\x05 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x06 \x01(\t\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x01\n\x12UpdateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xec\x01\n\x1bTransitionModelVersionStage\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05stage\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\'\n\x19\x61rchive_existing_versions\x18\x04 \x01(\x08\x42\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"x\n\x12\x44\x65leteModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa2\x01\n\x0fGetModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe8\x01\n\x13SearchModelVersions\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x1b\n\x0bmax_results\x18\x02 \x01(\x03:\x06\x32\x30\x30\x30\x30\x30\x12\x10\n\x08order_by\x18\x03 \x03(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aQ\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\x1aGetModelVersionDownloadUri\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a \n\x08Response\x12\x14\n\x0c\x61rtifact_uri\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"-\n\x0fModelVersionTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"0\n\x12RegisteredModelTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x8c\x01\n\x15SetRegisteredModelTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa0\x01\n\x12SetModelVersionTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x04 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x18\x44\x65leteRegisteredModelTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8e\x01\n\x15\x44\x65leteModelVersionTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"6\n\x14RegisteredModelAlias\x12\r\n\x05\x61lias\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\"\x92\x01\n\x17SetRegisteredModelAlias\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05\x61lias\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"~\n\x1a\x44\x65leteRegisteredModelAlias\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05\x61lias\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa7\x01\n\x16GetModelVersionByAlias\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05\x61lias\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*R\n\x12ModelVersionStatus\x12\x18\n\x14PENDING_REGISTRATION\x10\x01\x12\x17\n\x13\x46\x41ILED_REGISTRATION\x10\x02\x12\t\n\x05READY\x10\x03\x32\xfc\x1d\n\x14ModelRegistryService\x12\xae\x01\n\x15\x63reateRegisteredModel\x12\x1d.mlflow.CreateRegisteredModel\x1a&.mlflow.CreateRegisteredModel.Response\"N\xf2\x86\x19J\n.\n\x04POST\x12 /mlflow/registered-models/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x43reate RegisteredModel\x12\xae\x01\n\x15renameRegisteredModel\x12\x1d.mlflow.RenameRegisteredModel\x1a&.mlflow.RenameRegisteredModel.Response\"N\xf2\x86\x19J\n.\n\x04POST\x12 /mlflow/registered-models/rename\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Rename RegisteredModel\x12\xaf\x01\n\x15updateRegisteredModel\x12\x1d.mlflow.UpdateRegisteredModel\x1a&.mlflow.UpdateRegisteredModel.Response\"O\xf2\x86\x19K\n/\n\x05PATCH\x12 /mlflow/registered-models/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Update RegisteredModel\x12\xb0\x01\n\x15\x64\x65leteRegisteredModel\x12\x1d.mlflow.DeleteRegisteredModel\x1a&.mlflow.DeleteRegisteredModel.Response\"P\xf2\x86\x19L\n0\n\x06\x44\x45LETE\x12 /mlflow/registered-models/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x44\x65lete RegisteredModel\x12\x9e\x01\n\x12getRegisteredModel\x12\x1a.mlflow.GetRegisteredModel\x1a#.mlflow.GetRegisteredModel.Response\"G\xf2\x86\x19\x43\n*\n\x03GET\x12\x1d/mlflow/registered-models/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Get RegisteredModel\x12\xb1\x01\n\x16searchRegisteredModels\x12\x1e.mlflow.SearchRegisteredModels\x1a\'.mlflow.SearchRegisteredModels.Response\"N\xf2\x86\x19J\n-\n\x03GET\x12 /mlflow/registered-models/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x17Search RegisteredModels\x12\xef\x01\n\x11getLatestVersions\x12\x19.mlflow.GetLatestVersions\x1a\".mlflow.GetLatestVersions.Response\"\x9a\x01\xf2\x86\x19\x95\x01\n;\n\x04POST\x12-/mlflow/registered-models/get-latest-versions\x1a\x04\x08\x02\x10\x00\n:\n\x03GET\x12-/mlflow/registered-models/get-latest-versions\x1a\x04\x08\x02\x10\x00\x10\x01*\x18Get Latest ModelVersions\x12\x9f\x01\n\x12\x63reateModelVersion\x12\x1a.mlflow.CreateModelVersion\x1a#.mlflow.CreateModelVersion.Response\"H\xf2\x86\x19\x44\n+\n\x04POST\x12\x1d/mlflow/model-versions/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x43reate ModelVersion\x12\xa0\x01\n\x12updateModelVersion\x12\x1a.mlflow.UpdateModelVersion\x1a#.mlflow.UpdateModelVersion.Response\"I\xf2\x86\x19\x45\n,\n\x05PATCH\x12\x1d/mlflow/model-versions/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Update ModelVersion\x12\xce\x01\n\x1btransitionModelVersionStage\x12#.mlflow.TransitionModelVersionStage\x1a,.mlflow.TransitionModelVersionStage.Response\"\\\xf2\x86\x19X\n5\n\x04POST\x12\'/mlflow/model-versions/transition-stage\x1a\x04\x08\x02\x10\x00\x10\x01*\x1dTransition ModelVersion Stage\x12\xa1\x01\n\x12\x64\x65leteModelVersion\x12\x1a.mlflow.DeleteModelVersion\x1a#.mlflow.DeleteModelVersion.Response\"J\xf2\x86\x19\x46\n-\n\x06\x44\x45LETE\x12\x1d/mlflow/model-versions/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x44\x65lete ModelVersion\x12\x8f\x01\n\x0fgetModelVersion\x12\x17.mlflow.GetModelVersion\x1a .mlflow.GetModelVersion.Response\"A\xf2\x86\x19=\n\'\n\x03GET\x12\x1a/mlflow/model-versions/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x10Get ModelVersion\x12\xa2\x01\n\x13searchModelVersions\x12\x1b.mlflow.SearchModelVersions\x1a$.mlflow.SearchModelVersions.Response\"H\xf2\x86\x19\x44\n*\n\x03GET\x12\x1d/mlflow/model-versions/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x14Search ModelVersions\x12\xd8\x01\n\x1agetModelVersionDownloadUri\x12\".mlflow.GetModelVersionDownloadUri\x1a+.mlflow.GetModelVersionDownloadUri.Response\"i\xf2\x86\x19\x65\n4\n\x03GET\x12\'/mlflow/model-versions/get-download-uri\x1a\x04\x08\x02\x10\x00\x10\x01*+Get Download URI For ModelVersion Artifacts\x12\xb1\x01\n\x15setRegisteredModelTag\x12\x1d.mlflow.SetRegisteredModelTag\x1a&.mlflow.SetRegisteredModelTag.Response\"Q\xf2\x86\x19M\n/\n\x04POST\x12!/mlflow/registered-models/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x18Set Registered Model Tag\x12\xa2\x01\n\x12setModelVersionTag\x12\x1a.mlflow.SetModelVersionTag\x1a#.mlflow.SetModelVersionTag.Response\"K\xf2\x86\x19G\n,\n\x04POST\x12\x1e/mlflow/model-versions/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x15Set Model Version Tag\x12\xc2\x01\n\x18\x64\x65leteRegisteredModelTag\x12 .mlflow.DeleteRegisteredModelTag\x1a).mlflow.DeleteRegisteredModelTag.Response\"Y\xf2\x86\x19U\n4\n\x06\x44\x45LETE\x12$/mlflow/registered-models/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x1b\x44\x65lete Registered Model Tag\x12\xb3\x01\n\x15\x64\x65leteModelVersionTag\x12\x1d.mlflow.DeleteModelVersionTag\x1a&.mlflow.DeleteModelVersionTag.Response\"S\xf2\x86\x19O\n1\n\x06\x44\x45LETE\x12!/mlflow/model-versions/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x18\x44\x65lete Model Version Tag\x12\xb7\x01\n\x17setRegisteredModelAlias\x12\x1f.mlflow.SetRegisteredModelAlias\x1a(.mlflow.SetRegisteredModelAlias.Response\"Q\xf2\x86\x19M\n-\n\x04POST\x12\x1f/mlflow/registered-models/alias\x1a\x04\x08\x02\x10\x00\x10\x01*\x1aSet Registered Model Alias\x12\xc5\x01\n\x1a\x64\x65leteRegisteredModelAlias\x12\".mlflow.DeleteRegisteredModelAlias\x1a+.mlflow.DeleteRegisteredModelAlias.Response\"V\xf2\x86\x19R\n/\n\x06\x44\x45LETE\x12\x1f/mlflow/registered-models/alias\x1a\x04\x08\x02\x10\x00\x10\x01*\x1d\x44\x65lete Registered Model Alias\x12\xb3\x01\n\x16getModelVersionByAlias\x12\x1e.mlflow.GetModelVersionByAlias\x1a\'.mlflow.GetModelVersionByAlias.Response\"P\xf2\x86\x19L\n,\n\x03GET\x12\x1f/mlflow/registered-models/alias\x1a\x04\x08\x02\x10\x00\x10\x01*\x1aGet Model Version by AliasB!\n\x14org.mlflow.api.proto\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
 
 _MODELVERSIONSTATUS = DESCRIPTOR.enum_types_by_name['ModelVersionStatus']
 ModelVersionStatus = enum_type_wrapper.EnumTypeWrapper(_MODELVERSIONSTATUS)
@@ -69,6 +69,12 @@ _DELETEREGISTEREDMODELTAG_RESPONSE = _DELETEREGISTEREDMODELTAG.nested_types_by_n
 _DELETEMODELVERSIONTAG = DESCRIPTOR.message_types_by_name['DeleteModelVersionTag']
 _DELETEMODELVERSIONTAG_RESPONSE = _DELETEMODELVERSIONTAG.nested_types_by_name['Response']
 _REGISTEREDMODELALIAS = DESCRIPTOR.message_types_by_name['RegisteredModelAlias']
+_SETREGISTEREDMODELALIAS = DESCRIPTOR.message_types_by_name['SetRegisteredModelAlias']
+_SETREGISTEREDMODELALIAS_RESPONSE = _SETREGISTEREDMODELALIAS.nested_types_by_name['Response']
+_DELETEREGISTEREDMODELALIAS = DESCRIPTOR.message_types_by_name['DeleteRegisteredModelAlias']
+_DELETEREGISTEREDMODELALIAS_RESPONSE = _DELETEREGISTEREDMODELALIAS.nested_types_by_name['Response']
+_GETMODELVERSIONBYALIAS = DESCRIPTOR.message_types_by_name['GetModelVersionByAlias']
+_GETMODELVERSIONBYALIAS_RESPONSE = _GETMODELVERSIONBYALIAS.nested_types_by_name['Response']
 RegisteredModel = _reflection.GeneratedProtocolMessageType('RegisteredModel', (_message.Message,), {
   'DESCRIPTOR' : _REGISTEREDMODEL,
   '__module__' : 'model_registry_pb2'
@@ -374,6 +380,51 @@ RegisteredModelAlias = _reflection.GeneratedProtocolMessageType('RegisteredModel
   })
 _sym_db.RegisterMessage(RegisteredModelAlias)
 
+SetRegisteredModelAlias = _reflection.GeneratedProtocolMessageType('SetRegisteredModelAlias', (_message.Message,), {
+
+  'Response' : _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), {
+    'DESCRIPTOR' : _SETREGISTEREDMODELALIAS_RESPONSE,
+    '__module__' : 'model_registry_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.SetRegisteredModelAlias.Response)
+    })
+  ,
+  'DESCRIPTOR' : _SETREGISTEREDMODELALIAS,
+  '__module__' : 'model_registry_pb2'
+  # @@protoc_insertion_point(class_scope:mlflow.SetRegisteredModelAlias)
+  })
+_sym_db.RegisterMessage(SetRegisteredModelAlias)
+_sym_db.RegisterMessage(SetRegisteredModelAlias.Response)
+
+DeleteRegisteredModelAlias = _reflection.GeneratedProtocolMessageType('DeleteRegisteredModelAlias', (_message.Message,), {
+
+  'Response' : _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), {
+    'DESCRIPTOR' : _DELETEREGISTEREDMODELALIAS_RESPONSE,
+    '__module__' : 'model_registry_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.DeleteRegisteredModelAlias.Response)
+    })
+  ,
+  'DESCRIPTOR' : _DELETEREGISTEREDMODELALIAS,
+  '__module__' : 'model_registry_pb2'
+  # @@protoc_insertion_point(class_scope:mlflow.DeleteRegisteredModelAlias)
+  })
+_sym_db.RegisterMessage(DeleteRegisteredModelAlias)
+_sym_db.RegisterMessage(DeleteRegisteredModelAlias.Response)
+
+GetModelVersionByAlias = _reflection.GeneratedProtocolMessageType('GetModelVersionByAlias', (_message.Message,), {
+
+  'Response' : _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), {
+    'DESCRIPTOR' : _GETMODELVERSIONBYALIAS_RESPONSE,
+    '__module__' : 'model_registry_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.GetModelVersionByAlias.Response)
+    })
+  ,
+  'DESCRIPTOR' : _GETMODELVERSIONBYALIAS,
+  '__module__' : 'model_registry_pb2'
+  # @@protoc_insertion_point(class_scope:mlflow.GetModelVersionByAlias)
+  })
+_sym_db.RegisterMessage(GetModelVersionByAlias)
+_sym_db.RegisterMessage(GetModelVersionByAlias.Response)
+
 _MODELREGISTRYSERVICE = DESCRIPTOR.services_by_name['ModelRegistryService']
 if _descriptor._USE_C_DESCRIPTORS == False:
 
@@ -479,6 +530,26 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _DELETEMODELVERSIONTAG.fields_by_name['key']._serialized_options = b'\370\206\031\001'
   _DELETEMODELVERSIONTAG._options = None
   _DELETEMODELVERSIONTAG._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
+  _SETREGISTEREDMODELALIAS.fields_by_name['name']._options = None
+  _SETREGISTEREDMODELALIAS.fields_by_name['name']._serialized_options = b'\370\206\031\001'
+  _SETREGISTEREDMODELALIAS.fields_by_name['alias']._options = None
+  _SETREGISTEREDMODELALIAS.fields_by_name['alias']._serialized_options = b'\370\206\031\001'
+  _SETREGISTEREDMODELALIAS.fields_by_name['version']._options = None
+  _SETREGISTEREDMODELALIAS.fields_by_name['version']._serialized_options = b'\370\206\031\001'
+  _SETREGISTEREDMODELALIAS._options = None
+  _SETREGISTEREDMODELALIAS._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
+  _DELETEREGISTEREDMODELALIAS.fields_by_name['name']._options = None
+  _DELETEREGISTEREDMODELALIAS.fields_by_name['name']._serialized_options = b'\370\206\031\001'
+  _DELETEREGISTEREDMODELALIAS.fields_by_name['alias']._options = None
+  _DELETEREGISTEREDMODELALIAS.fields_by_name['alias']._serialized_options = b'\370\206\031\001'
+  _DELETEREGISTEREDMODELALIAS._options = None
+  _DELETEREGISTEREDMODELALIAS._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
+  _GETMODELVERSIONBYALIAS.fields_by_name['name']._options = None
+  _GETMODELVERSIONBYALIAS.fields_by_name['name']._serialized_options = b'\370\206\031\001'
+  _GETMODELVERSIONBYALIAS.fields_by_name['alias']._options = None
+  _GETMODELVERSIONBYALIAS.fields_by_name['alias']._serialized_options = b'\370\206\031\001'
+  _GETMODELVERSIONBYALIAS._options = None
+  _GETMODELVERSIONBYALIAS._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
   _MODELREGISTRYSERVICE.methods_by_name['createRegisteredModel']._options = None
   _MODELREGISTRYSERVICE.methods_by_name['createRegisteredModel']._serialized_options = b'\362\206\031J\n.\n\004POST\022 /mlflow/registered-models/create\032\004\010\002\020\000\020\001*\026Create RegisteredModel'
   _MODELREGISTRYSERVICE.methods_by_name['renameRegisteredModel']._options = None
@@ -515,92 +586,110 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _MODELREGISTRYSERVICE.methods_by_name['deleteRegisteredModelTag']._serialized_options = b'\362\206\031U\n4\n\006DELETE\022$/mlflow/registered-models/delete-tag\032\004\010\002\020\000\020\001*\033Delete Registered Model Tag'
   _MODELREGISTRYSERVICE.methods_by_name['deleteModelVersionTag']._options = None
   _MODELREGISTRYSERVICE.methods_by_name['deleteModelVersionTag']._serialized_options = b'\362\206\031O\n1\n\006DELETE\022!/mlflow/model-versions/delete-tag\032\004\010\002\020\000\020\001*\030Delete Model Version Tag'
-  _MODELVERSIONSTATUS._serialized_start=3945
-  _MODELVERSIONSTATUS._serialized_end=4027
+  _MODELREGISTRYSERVICE.methods_by_name['setRegisteredModelAlias']._options = None
+  _MODELREGISTRYSERVICE.methods_by_name['setRegisteredModelAlias']._serialized_options = b'\362\206\031M\n-\n\004POST\022\037/mlflow/registered-models/alias\032\004\010\002\020\000\020\001*\032Set Registered Model Alias'
+  _MODELREGISTRYSERVICE.methods_by_name['deleteRegisteredModelAlias']._options = None
+  _MODELREGISTRYSERVICE.methods_by_name['deleteRegisteredModelAlias']._serialized_options = b'\362\206\031R\n/\n\006DELETE\022\037/mlflow/registered-models/alias\032\004\010\002\020\000\020\001*\035Delete Registered Model Alias'
+  _MODELREGISTRYSERVICE.methods_by_name['getModelVersionByAlias']._options = None
+  _MODELREGISTRYSERVICE.methods_by_name['getModelVersionByAlias']._serialized_options = b'\362\206\031L\n,\n\003GET\022\037/mlflow/registered-models/alias\032\004\010\002\020\000\020\001*\032Get Model Version by Alias'
+  _MODELVERSIONSTATUS._serialized_start=4442
+  _MODELVERSIONSTATUS._serialized_end=4524
   _REGISTEREDMODEL._serialized_start=74
-  _REGISTEREDMODEL._serialized_end=292
-  _MODELVERSION._serialized_start=295
-  _MODELVERSION._serialized_end=618
-  _CREATEREGISTEREDMODEL._serialized_start=621
-  _CREATEREGISTEREDMODEL._serialized_end=835
-  _CREATEREGISTEREDMODEL_RESPONSE._serialized_start=729
-  _CREATEREGISTEREDMODEL_RESPONSE._serialized_end=790
-  _RENAMEREGISTEREDMODEL._serialized_start=838
-  _RENAMEREGISTEREDMODEL._serialized_end=1007
-  _RENAMEREGISTEREDMODEL_RESPONSE._serialized_start=729
-  _RENAMEREGISTEREDMODEL_RESPONSE._serialized_end=790
-  _UPDATEREGISTEREDMODEL._serialized_start=1010
-  _UPDATEREGISTEREDMODEL._serialized_end=1182
-  _UPDATEREGISTEREDMODEL_RESPONSE._serialized_start=729
-  _UPDATEREGISTEREDMODEL_RESPONSE._serialized_end=790
-  _DELETEREGISTEREDMODEL._serialized_start=1184
-  _DELETEREGISTEREDMODEL._serialized_end=1284
-  _DELETEREGISTEREDMODEL_RESPONSE._serialized_start=729
-  _DELETEREGISTEREDMODEL_RESPONSE._serialized_end=739
-  _GETREGISTEREDMODEL._serialized_start=1287
-  _GETREGISTEREDMODEL._serialized_end=1435
-  _GETREGISTEREDMODEL_RESPONSE._serialized_start=729
-  _GETREGISTEREDMODEL_RESPONSE._serialized_end=790
-  _SEARCHREGISTEREDMODELS._serialized_start=1438
-  _SEARCHREGISTEREDMODELS._serialized_end=1676
-  _SEARCHREGISTEREDMODELS_RESPONSE._serialized_start=1544
-  _SEARCHREGISTEREDMODELS_RESPONSE._serialized_end=1631
-  _GETLATESTVERSIONS._serialized_start=1679
-  _GETLATESTVERSIONS._serialized_end=1837
-  _GETLATESTVERSIONS_RESPONSE._serialized_start=1736
-  _GETLATESTVERSIONS_RESPONSE._serialized_end=1792
-  _CREATEMODELVERSION._serialized_start=1840
-  _CREATEMODELVERSION._serialized_end=2098
-  _CREATEMODELVERSION_RESPONSE._serialized_start=1998
-  _CREATEMODELVERSION_RESPONSE._serialized_end=2053
-  _UPDATEMODELVERSION._serialized_start=2101
-  _UPDATEMODELVERSION._serialized_end=2287
-  _UPDATEMODELVERSION_RESPONSE._serialized_start=1998
-  _UPDATEMODELVERSION_RESPONSE._serialized_end=2053
-  _TRANSITIONMODELVERSIONSTAGE._serialized_start=2290
-  _TRANSITIONMODELVERSIONSTAGE._serialized_end=2526
-  _TRANSITIONMODELVERSIONSTAGE_RESPONSE._serialized_start=1998
-  _TRANSITIONMODELVERSIONSTAGE_RESPONSE._serialized_end=2053
-  _DELETEMODELVERSION._serialized_start=2528
-  _DELETEMODELVERSION._serialized_end=2648
-  _DELETEMODELVERSION_RESPONSE._serialized_start=729
-  _DELETEMODELVERSION_RESPONSE._serialized_end=739
-  _GETMODELVERSION._serialized_start=2651
-  _GETMODELVERSION._serialized_end=2813
-  _GETMODELVERSION_RESPONSE._serialized_start=1998
-  _GETMODELVERSION_RESPONSE._serialized_end=2053
-  _SEARCHMODELVERSIONS._serialized_start=2816
-  _SEARCHMODELVERSIONS._serialized_end=3048
-  _SEARCHMODELVERSIONS_RESPONSE._serialized_start=2922
-  _SEARCHMODELVERSIONS_RESPONSE._serialized_end=3003
-  _GETMODELVERSIONDOWNLOADURI._serialized_start=3051
-  _GETMODELVERSIONDOWNLOADURI._serialized_end=3201
-  _GETMODELVERSIONDOWNLOADURI_RESPONSE._serialized_start=3124
-  _GETMODELVERSIONDOWNLOADURI_RESPONSE._serialized_end=3156
-  _MODELVERSIONTAG._serialized_start=3203
-  _MODELVERSIONTAG._serialized_end=3248
-  _REGISTEREDMODELTAG._serialized_start=3250
-  _REGISTEREDMODELTAG._serialized_end=3298
-  _SETREGISTEREDMODELTAG._serialized_start=3301
-  _SETREGISTEREDMODELTAG._serialized_end=3441
-  _SETREGISTEREDMODELTAG_RESPONSE._serialized_start=729
-  _SETREGISTEREDMODELTAG_RESPONSE._serialized_end=739
-  _SETMODELVERSIONTAG._serialized_start=3444
-  _SETMODELVERSIONTAG._serialized_end=3604
-  _SETMODELVERSIONTAG_RESPONSE._serialized_start=729
-  _SETMODELVERSIONTAG_RESPONSE._serialized_end=739
-  _DELETEREGISTEREDMODELTAG._serialized_start=3606
-  _DELETEREGISTEREDMODELTAG._serialized_end=3728
-  _DELETEREGISTEREDMODELTAG_RESPONSE._serialized_start=729
-  _DELETEREGISTEREDMODELTAG_RESPONSE._serialized_end=739
-  _DELETEMODELVERSIONTAG._serialized_start=3731
-  _DELETEMODELVERSIONTAG._serialized_end=3873
-  _DELETEMODELVERSIONTAG_RESPONSE._serialized_start=729
-  _DELETEMODELVERSIONTAG_RESPONSE._serialized_end=739
-  _REGISTEREDMODELALIAS._serialized_start=3875
-  _REGISTEREDMODELALIAS._serialized_end=3943
-  _MODELREGISTRYSERVICE._serialized_start=4030
-  _MODELREGISTRYSERVICE._serialized_end=7298
+  _REGISTEREDMODEL._serialized_end=339
+  _MODELVERSION._serialized_start=342
+  _MODELVERSION._serialized_end=682
+  _CREATEREGISTEREDMODEL._serialized_start=685
+  _CREATEREGISTEREDMODEL._serialized_end=899
+  _CREATEREGISTEREDMODEL_RESPONSE._serialized_start=793
+  _CREATEREGISTEREDMODEL_RESPONSE._serialized_end=854
+  _RENAMEREGISTEREDMODEL._serialized_start=902
+  _RENAMEREGISTEREDMODEL._serialized_end=1071
+  _RENAMEREGISTEREDMODEL_RESPONSE._serialized_start=793
+  _RENAMEREGISTEREDMODEL_RESPONSE._serialized_end=854
+  _UPDATEREGISTEREDMODEL._serialized_start=1074
+  _UPDATEREGISTEREDMODEL._serialized_end=1246
+  _UPDATEREGISTEREDMODEL_RESPONSE._serialized_start=793
+  _UPDATEREGISTEREDMODEL_RESPONSE._serialized_end=854
+  _DELETEREGISTEREDMODEL._serialized_start=1248
+  _DELETEREGISTEREDMODEL._serialized_end=1348
+  _DELETEREGISTEREDMODEL_RESPONSE._serialized_start=793
+  _DELETEREGISTEREDMODEL_RESPONSE._serialized_end=803
+  _GETREGISTEREDMODEL._serialized_start=1351
+  _GETREGISTEREDMODEL._serialized_end=1499
+  _GETREGISTEREDMODEL_RESPONSE._serialized_start=793
+  _GETREGISTEREDMODEL_RESPONSE._serialized_end=854
+  _SEARCHREGISTEREDMODELS._serialized_start=1502
+  _SEARCHREGISTEREDMODELS._serialized_end=1740
+  _SEARCHREGISTEREDMODELS_RESPONSE._serialized_start=1608
+  _SEARCHREGISTEREDMODELS_RESPONSE._serialized_end=1695
+  _GETLATESTVERSIONS._serialized_start=1743
+  _GETLATESTVERSIONS._serialized_end=1901
+  _GETLATESTVERSIONS_RESPONSE._serialized_start=1800
+  _GETLATESTVERSIONS_RESPONSE._serialized_end=1856
+  _CREATEMODELVERSION._serialized_start=1904
+  _CREATEMODELVERSION._serialized_end=2162
+  _CREATEMODELVERSION_RESPONSE._serialized_start=2062
+  _CREATEMODELVERSION_RESPONSE._serialized_end=2117
+  _UPDATEMODELVERSION._serialized_start=2165
+  _UPDATEMODELVERSION._serialized_end=2351
+  _UPDATEMODELVERSION_RESPONSE._serialized_start=2062
+  _UPDATEMODELVERSION_RESPONSE._serialized_end=2117
+  _TRANSITIONMODELVERSIONSTAGE._serialized_start=2354
+  _TRANSITIONMODELVERSIONSTAGE._serialized_end=2590
+  _TRANSITIONMODELVERSIONSTAGE_RESPONSE._serialized_start=2062
+  _TRANSITIONMODELVERSIONSTAGE_RESPONSE._serialized_end=2117
+  _DELETEMODELVERSION._serialized_start=2592
+  _DELETEMODELVERSION._serialized_end=2712
+  _DELETEMODELVERSION_RESPONSE._serialized_start=793
+  _DELETEMODELVERSION_RESPONSE._serialized_end=803
+  _GETMODELVERSION._serialized_start=2715
+  _GETMODELVERSION._serialized_end=2877
+  _GETMODELVERSION_RESPONSE._serialized_start=2062
+  _GETMODELVERSION_RESPONSE._serialized_end=2117
+  _SEARCHMODELVERSIONS._serialized_start=2880
+  _SEARCHMODELVERSIONS._serialized_end=3112
+  _SEARCHMODELVERSIONS_RESPONSE._serialized_start=2986
+  _SEARCHMODELVERSIONS_RESPONSE._serialized_end=3067
+  _GETMODELVERSIONDOWNLOADURI._serialized_start=3115
+  _GETMODELVERSIONDOWNLOADURI._serialized_end=3265
+  _GETMODELVERSIONDOWNLOADURI_RESPONSE._serialized_start=3188
+  _GETMODELVERSIONDOWNLOADURI_RESPONSE._serialized_end=3220
+  _MODELVERSIONTAG._serialized_start=3267
+  _MODELVERSIONTAG._serialized_end=3312
+  _REGISTEREDMODELTAG._serialized_start=3314
+  _REGISTEREDMODELTAG._serialized_end=3362
+  _SETREGISTEREDMODELTAG._serialized_start=3365
+  _SETREGISTEREDMODELTAG._serialized_end=3505
+  _SETREGISTEREDMODELTAG_RESPONSE._serialized_start=793
+  _SETREGISTEREDMODELTAG_RESPONSE._serialized_end=803
+  _SETMODELVERSIONTAG._serialized_start=3508
+  _SETMODELVERSIONTAG._serialized_end=3668
+  _SETMODELVERSIONTAG_RESPONSE._serialized_start=793
+  _SETMODELVERSIONTAG_RESPONSE._serialized_end=803
+  _DELETEREGISTEREDMODELTAG._serialized_start=3670
+  _DELETEREGISTEREDMODELTAG._serialized_end=3792
+  _DELETEREGISTEREDMODELTAG_RESPONSE._serialized_start=793
+  _DELETEREGISTEREDMODELTAG_RESPONSE._serialized_end=803
+  _DELETEMODELVERSIONTAG._serialized_start=3795
+  _DELETEMODELVERSIONTAG._serialized_end=3937
+  _DELETEMODELVERSIONTAG_RESPONSE._serialized_start=793
+  _DELETEMODELVERSIONTAG_RESPONSE._serialized_end=803
+  _REGISTEREDMODELALIAS._serialized_start=3939
+  _REGISTEREDMODELALIAS._serialized_end=3993
+  _SETREGISTEREDMODELALIAS._serialized_start=3996
+  _SETREGISTEREDMODELALIAS._serialized_end=4142
+  _SETREGISTEREDMODELALIAS_RESPONSE._serialized_start=793
+  _SETREGISTEREDMODELALIAS_RESPONSE._serialized_end=803
+  _DELETEREGISTEREDMODELALIAS._serialized_start=4144
+  _DELETEREGISTEREDMODELALIAS._serialized_end=4270
+  _DELETEREGISTEREDMODELALIAS_RESPONSE._serialized_start=793
+  _DELETEREGISTEREDMODELALIAS_RESPONSE._serialized_end=803
+  _GETMODELVERSIONBYALIAS._serialized_start=4273
+  _GETMODELVERSIONBYALIAS._serialized_end=4440
+  _GETMODELVERSIONBYALIAS_RESPONSE._serialized_start=2062
+  _GETMODELVERSIONBYALIAS_RESPONSE._serialized_end=2117
+  _MODELREGISTRYSERVICE._serialized_start=4527
+  _MODELREGISTRYSERVICE._serialized_end=8363
 ModelRegistryService = service_reflection.GeneratedServiceType('ModelRegistryService', (_service.Service,), dict(
   DESCRIPTOR = _MODELREGISTRYSERVICE,
   __module__ = 'model_registry_pb2'

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -67,6 +67,9 @@ from mlflow.protos.model_registry_pb2 import (
     DeleteRegisteredModelTag,
     SetModelVersionTag,
     DeleteModelVersionTag,
+    SetRegisteredModelAlias,
+    DeleteRegisteredModelAlias,
+    GetModelVersionByAlias,
 )
 from mlflow.protos.mlflow_artifacts_pb2 import (
     MlflowArtifactsService,
@@ -1588,6 +1591,57 @@ def _delete_model_version_tag():
     return _wrap_response(DeleteModelVersionTag.Response())
 
 
+@catch_mlflow_exception
+@_disable_if_artifacts_only
+def _set_registered_model_alias():
+    request_message = _get_request_message(
+        SetRegisteredModelAlias(),
+        schema={
+            "name": [_assert_string, _assert_required],
+            "alias": [_assert_string, _assert_required],
+            "version": [_assert_string, _assert_required],
+        },
+    )
+    _get_model_registry_store().set_registered_model_alias(
+        name=request_message.name, alias=request_message.alias, version=request_message.version
+    )
+    return _wrap_response(SetRegisteredModelAlias.Response())
+
+
+@catch_mlflow_exception
+@_disable_if_artifacts_only
+def _delete_registered_model_alias():
+    request_message = _get_request_message(
+        DeleteRegisteredModelAlias(),
+        schema={
+            "name": [_assert_string, _assert_required],
+            "alias": [_assert_string, _assert_required],
+        },
+    )
+    _get_model_registry_store().set_registered_model_alias(
+        name=request_message.name, alias=request_message.alias
+    )
+    return _wrap_response(DeleteRegisteredModelAlias.Response())
+
+
+@catch_mlflow_exception
+@_disable_if_artifacts_only
+def _get_model_version_by_alias():
+    request_message = _get_request_message(
+        GetModelVersionByAlias(),
+        schema={
+            "name": [_assert_string, _assert_required],
+            "alias": [_assert_string, _assert_required],
+        },
+    )
+    model_version = _get_model_registry_store().get_model_version_by_alias(
+        name=request_message.name, alias=request_message.alias
+    )
+    response_proto = model_version.to_proto()
+    response_message = GetModelVersionByAlias.Response(model_version=response_proto)
+    return _wrap_response(response_message)
+
+
 # MLflow Artifacts APIs
 
 
@@ -1773,6 +1827,9 @@ HANDLERS = {
     DeleteRegisteredModelTag: _delete_registered_model_tag,
     SetModelVersionTag: _set_model_version_tag,
     DeleteModelVersionTag: _delete_model_version_tag,
+    SetRegisteredModelAlias: _set_registered_model_alias,
+    DeleteRegisteredModelAlias: _delete_registered_model_alias,
+    GetModelVersionByAlias: _get_model_version_by_alias,
     # MLflow Artifacts APIs
     DownloadArtifact: _download_artifact,
     UploadArtifact: _upload_artifact,

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1618,7 +1618,7 @@ def _delete_registered_model_alias():
             "alias": [_assert_string, _assert_required],
         },
     )
-    _get_model_registry_store().set_registered_model_alias(
+    _get_model_registry_store().delete_registered_model_alias(
         name=request_message.name, alias=request_message.alias
     )
     return _wrap_response(DeleteRegisteredModelAlias.Response())

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -499,3 +499,34 @@ class UcModelRegistryStore(BaseRestStore):
         :param key: Tag key.
         """
         _raise_unsupported_method(method="delete_model_version_tag")
+
+    def set_registered_model_alias(self, name, alias, version):
+        """
+        Set a registered model alias pointing to a model version.
+
+        :param name: Registered model name.
+        :param alias: Name of the alias.
+        :param version: Registered model version number.
+        :return: None
+        """
+        _raise_unsupported_method(method="set_registered_model_alias")
+
+    def delete_registered_model_alias(self, name, alias):
+        """
+        Delete an alias associated with a registered model.
+
+        :param name: Registered model name.
+        :param alias: Name of the alias.
+        :return: None
+        """
+        _raise_unsupported_method(method="delete_registered_model_alias")
+
+    def get_model_version_by_alias(self, name, alias):
+        """
+        Get the model version instance by name and alias.
+
+        :param name: Registered model name.
+        :param alias: Name of the alias.
+        :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
+        """
+        _raise_unsupported_method(method="get_model_version_by_alias")

--- a/mlflow/store/db_migrations/versions/3500859a5d39_add_model_aliases_table.py
+++ b/mlflow/store/db_migrations/versions/3500859a5d39_add_model_aliases_table.py
@@ -35,6 +35,7 @@ def upgrade():
                 sa.ForeignKey(
                     "registered_models.name",
                     onupdate="cascade",
+                    ondelete="cascade",
                     name="registered_model_alias_name_fkey",
                 ),
                 primary_key=True,

--- a/mlflow/store/db_migrations/versions/3500859a5d39_add_model_aliases_table.py
+++ b/mlflow/store/db_migrations/versions/3500859a5d39_add_model_aliases_table.py
@@ -27,16 +27,20 @@ def upgrade():
     if SqlRegisteredModelAlias.__tablename__ not in get_existing_tables():
         op.create_table(
             SqlRegisteredModelAlias.__tablename__,
-            sa.Column("name", sa.String(length=256), primary_key=True, nullable=False),
+            sa.Column(
+                "name",
+                sa.String(length=256),
+                sa.ForeignKey(
+                    "registered_models.name",
+                    onupdate="cascade",
+                    name="registered_model_alias_name_fkey",
+                ),
+                primary_key=True,
+                nullable=False,
+            ),
             sa.Column("alias", sa.String(length=256), primary_key=True, nullable=False),
             sa.Column("version", sa.Integer(), nullable=False),
             sa.PrimaryKeyConstraint("name", "alias", name="registered_model_alias_pk"),
-            sa.ForeignKeyConstraint(
-                ("name", "version"),
-                ("model_versions.name", "model_versions.version"),
-                onupdate="cascade",
-                name="registered_model_alias_name_version_fkey",
-            ),
         )
 
 

--- a/mlflow/store/db_migrations/versions/3500859a5d39_add_model_aliases_table.py
+++ b/mlflow/store/db_migrations/versions/3500859a5d39_add_model_aliases_table.py
@@ -27,6 +27,8 @@ def upgrade():
     if SqlRegisteredModelAlias.__tablename__ not in get_existing_tables():
         op.create_table(
             SqlRegisteredModelAlias.__tablename__,
+            sa.Column("alias", sa.String(length=256), primary_key=True, nullable=False),
+            sa.Column("version", sa.Integer(), nullable=False),
             sa.Column(
                 "name",
                 sa.String(length=256),
@@ -38,8 +40,6 @@ def upgrade():
                 primary_key=True,
                 nullable=False,
             ),
-            sa.Column("alias", sa.String(length=256), primary_key=True, nullable=False),
-            sa.Column("version", sa.Integer(), nullable=False),
             sa.PrimaryKeyConstraint("name", "alias", name="registered_model_alias_pk"),
         )
 

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -258,3 +258,37 @@ class AbstractStore:
         :return: None
         """
         pass
+
+    @abstractmethod
+    def set_registered_model_alias(self, name, alias, version):
+        """
+        Set a registered model alias pointing to a model version.
+
+        :param name: Registered model name.
+        :param alias: Name of the alias.
+        :param version: Registered model version number.
+        :return: None
+        """
+        pass
+
+    @abstractmethod
+    def delete_registered_model_alias(self, name, alias):
+        """
+        Delete an alias associated with a registered model.
+
+        :param name: Registered model name.
+        :param alias: Name of the alias.
+        :return: None
+        """
+        pass
+
+    @abstractmethod
+    def get_model_version_by_alias(self, name, alias):
+        """
+        Get the model version instance by name and alias.
+
+        :param name: Registered model name.
+        :param alias: Name of the alias.
+        :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
+        """
+        pass

--- a/mlflow/store/model_registry/dbmodels/models.py
+++ b/mlflow/store/model_registry/dbmodels/models.py
@@ -110,6 +110,7 @@ class SqlModelVersion(Base):
             self.status_message,
             [tag.to_mlflow_entity() for tag in self.model_version_tags],
             self.run_link,
+            [],
         )
 
 

--- a/mlflow/store/model_registry/dbmodels/models.py
+++ b/mlflow/store/model_registry/dbmodels/models.py
@@ -179,7 +179,10 @@ class SqlRegisteredModelAlias(Base):
     name = Column(
         String(256),
         ForeignKey(
-            "registered_models.name", onupdate="cascade", name="registered_model_alias_name_fkey"
+            "registered_models.name",
+            onupdate="cascade",
+            ondelete="cascade",
+            name="registered_model_alias_name_fkey",
         ),
     )
     alias = Column(String(256), nullable=False)

--- a/mlflow/store/model_registry/dbmodels/models.py
+++ b/mlflow/store/model_registry/dbmodels/models.py
@@ -55,6 +55,7 @@ class SqlRegisteredModel(Base):
             self.description,
             [mvd.to_mlflow_entity() for mvd in latest_versions.values()],
             [tag.to_mlflow_entity() for tag in self.registered_model_tags],
+            [alias.to_mlflow_entity() for alias in self.registered_model_aliases],
         )
 
 
@@ -108,6 +109,7 @@ class SqlModelVersion(Base):
             self.status_message,
             [tag.to_mlflow_entity() for tag in self.model_version_tags],
             self.run_link,
+            [alias.to_mlflow_entity() for alias in self.registered_model_aliases],
         )
 
 

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -573,6 +573,7 @@ class FileStore(AbstractStore):
                     run_id=run_id,
                     run_link=run_link,
                     tags=tags,
+                    aliases=[],
                 )
                 model_version_dir = self._get_model_version_dir(name, version)
                 mkdir(model_version_dir)

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -872,6 +872,10 @@ class FileStore(AbstractStore):
         if exists(alias_path):
             version = read_file(os.path.dirname(alias_path), os.path.basename(alias_path))
             return self.get_model_version(name, version)
+        else:
+            raise MlflowException(
+                f"Registered model alias {alias} not found.", INVALID_PARAMETER_VALUE
+            )
 
     @staticmethod
     def _read_yaml(root, file_name, retries=2):

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -8,6 +8,7 @@ import time
 from mlflow.entities.model_registry import (
     RegisteredModel,
     ModelVersion,
+    RegisteredModelAlias,
     RegisteredModelTag,
     ModelVersionTag,
 )
@@ -40,6 +41,7 @@ from mlflow.utils.validation import (
     _validate_model_name as _original_validate_model_name,
     _validate_model_version,
     _validate_tag_name,
+    _validate_model_alias_name,
 )
 from mlflow.utils.env import get_env
 from mlflow.utils.file_utils import (
@@ -83,6 +85,7 @@ class FileStore(AbstractStore):
     TAGS_FOLDER_NAME = "tags"
     MODEL_VERSION_TAGS_FOLDER_NAME = "tags"
     CREATE_MODEL_VERSION_RETRIES = 3
+    REGISTERED_MODELS_ALIASES_FOLDER_NAME = "aliases"
 
     def __init__(self, root_directory=None):
         """
@@ -185,6 +188,7 @@ class FileStore(AbstractStore):
     def _get_registered_model_from_path(self, model_path):
         meta = FileStore._read_yaml(model_path, FileStore.META_DATA_FILE_NAME)
         meta["tags"] = self.get_all_registered_model_tags_from_path(model_path)
+        meta["aliases"] = self.get_all_registered_model_aliases_from_path(model_path)
         registered_model = RegisteredModel.from_dictionary(meta)
         registered_model.latest_versions = self.get_latest_versions(os.path.basename(model_path))
         return registered_model
@@ -392,6 +396,10 @@ class FileStore(AbstractStore):
         tag_data = read_file(parent_path, tag_name)
         return RegisteredModelTag(tag_name, tag_data)
 
+    def _get_registered_model_alias_from_file(self, parent_path, alias_name):
+        alias_data = read_file(parent_path, alias_name)
+        return RegisteredModelAlias(alias_name, alias_data)
+
     def _get_resource_files(self, root_dir, subfolder_name):
         source_dirs = find(root_dir, subfolder_name, full_path=True)
         if len(source_dirs) == 0:
@@ -418,6 +426,15 @@ class FileStore(AbstractStore):
         for tag_file in tag_files:
             tags.append(self._get_registered_model_tag_from_file(parent_path, tag_file))
         return tags
+
+    def get_all_registered_model_aliases_from_path(self, model_path):
+        parent_path, alias_files = self._get_resource_files(
+            model_path, FileStore.REGISTERED_MODELS_ALIASES_FOLDER_NAME
+        )
+        aliases = []
+        for alias_file in alias_files:
+            aliases.append(self._get_registered_model_alias_from_file(parent_path, alias_file))
+        return aliases
 
     def _writeable_value(self, tag_value):
         if tag_value is None:
@@ -479,9 +496,15 @@ class FileStore(AbstractStore):
             )
         return join(registered_model_path, f"version-{version}")
 
+    def _get_model_version_aliases(self, directory):
+        aliases = self.get_all_registered_model_aliases_from_path(os.path.dirname(directory))
+        version = os.path.basename(directory).replace("version-", "")
+        return [alias.alias for alias in aliases if alias.version == version]
+
     def _get_model_version_from_dir(self, directory):
         meta = FileStore._read_yaml(directory, FileStore.META_DATA_FILE_NAME)
         meta["tags"] = self._get_model_version_tags_from_dir(directory)
+        meta["aliases"] = self._get_model_version_aliases(directory)
         model_version = ModelVersion.from_dictionary(meta)
         return model_version
 
@@ -800,6 +823,61 @@ class FileStore(AbstractStore):
             os.remove(tag_path)
             updated_time = get_current_time_millis()
             self._update_registered_model_last_updated_time(name, updated_time)
+
+    def _get_registered_model_alias_path(self, name, alias):
+        _validate_model_name(name)
+        _validate_model_alias_name(alias)
+        registered_model_path = self._get_registered_model_path(name)
+        if not exists(registered_model_path):
+            raise MlflowException(
+                f"Registered Model with name={name} not found",
+                RESOURCE_DOES_NOT_EXIST,
+            )
+        return os.path.join(
+            registered_model_path, FileStore.REGISTERED_MODELS_ALIASES_FOLDER_NAME, alias
+        )
+
+    def set_registered_model_alias(self, name, alias, version):
+        """
+        Set a registered model alias pointing to a model version.
+
+        :param name: Registered model name.
+        :param alias: Name of the alias.
+        :param version: Registered model version number.
+        :return: None
+        """
+        alias_path = self._get_registered_model_alias_path(name, alias)
+        make_containing_dirs(alias_path)
+        write_to(alias_path, self._writeable_value(version))
+        updated_time = get_current_time_millis()
+        self._update_registered_model_last_updated_time(name, updated_time)
+
+    def delete_registered_model_alias(self, name, alias):
+        """
+        Delete an alias associated with a registered model.
+
+        :param name: Registered model name.
+        :param alias: Name of the alias.
+        :return: None
+        """
+        alias_path = self._get_registered_model_alias_path(name, alias)
+        if exists(alias_path):
+            os.remove(alias_path)
+            updated_time = get_current_time_millis()
+            self._update_registered_model_last_updated_time(name, updated_time)
+
+    def get_model_version_by_alias(self, name, alias):
+        """
+        Get the model version instance by name and alias.
+
+        :param name: Registered model name.
+        :param alias: Name of the alias.
+        :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
+        """
+        alias_path = self._get_registered_model_alias_path(name, alias)
+        if exists(alias_path):
+            version = read_file(os.path.dirname(alias_path), os.path.basename(alias_path))
+            return self.get_model_version(name, version)
 
     @staticmethod
     def _read_yaml(root, file_name, retries=2):

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -21,6 +21,9 @@ from mlflow.protos.model_registry_pb2 import (
     SetModelVersionTag,
     DeleteRegisteredModelTag,
     DeleteModelVersionTag,
+    SetRegisteredModelAlias,
+    DeleteRegisteredModelAlias,
+    GetModelVersionByAlias,
 )
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry.base_rest_store import BaseRestStore
@@ -354,3 +357,38 @@ class RestStore(BaseRestStore):
         """
         req_body = message_to_json(DeleteModelVersionTag(name=name, version=version, key=key))
         self._call_endpoint(DeleteModelVersionTag, req_body)
+
+    def set_registered_model_alias(self, name, alias, version):
+        """
+        Set a registered model alias pointing to a model version.
+
+        :param name: Registered model name.
+        :param alias: Name of the alias.
+        :param version: Registered model version number.
+        :return: None
+        """
+        req_body = message_to_json(SetRegisteredModelAlias(name=name, alias=alias, version=version))
+        self._call_endpoint(SetRegisteredModelAlias, req_body)
+
+    def delete_registered_model_alias(self, name, alias):
+        """
+        Delete an alias associated with a registered model.
+
+        :param name: Registered model name.
+        :param alias: Name of the alias.
+        :return: None
+        """
+        req_body = message_to_json(DeleteRegisteredModelAlias(name=name, alias=alias))
+        self._call_endpoint(DeleteRegisteredModelAlias, req_body)
+
+    def get_model_version_by_alias(self, name, alias):
+        """
+        Get the model version instance by name and alias.
+
+        :param name: Registered model name.
+        :param alias: Name of the alias.
+        :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
+        """
+        req_body = message_to_json(GetModelVersionByAlias(name=name, alias=alias))
+        response_proto = self._call_endpoint(GetModelVersionByAlias, req_body)
+        return ModelVersion.from_proto(response_proto.model_version)

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -1042,7 +1042,7 @@ class SqlAlchemyStore(AbstractStore):
 
     @classmethod
     def _get_registered_model_alias(cls, session, name, alias):
-        aliases = (
+        alias = (
             session.query(SqlRegisteredModelAlias)
             .filter(
                 SqlRegisteredModelAlias.name == name,
@@ -1050,15 +1050,7 @@ class SqlAlchemyStore(AbstractStore):
             )
             .first()
         )
-        if len(aliases) == 0:
-            return None
-        if len(aliases) > 1:
-            raise MlflowException(
-                "Expected only 1 registered model alias with name={}, alias={}. "
-                "Found {}.".format(name, alias, len(aliases)),
-                INVALID_STATE,
-            )
-        return aliases[0]
+        return alias
 
     def set_registered_model_alias(self, name, alias, version):
         """

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -684,8 +684,10 @@ class SqlAlchemyStore(AbstractStore):
 
     @classmethod
     def _populate_model_version_aliases(cls, session, name, version):
-        model_aliases = cls._get_registered_model(session, name).aliases
-        version.aliases = [alias.alias for alias in model_aliases if alias.version == version]
+        model_aliases = cls._get_registered_model(session, name).registered_model_aliases
+        version.aliases = [
+            alias.alias for alias in model_aliases if alias.version == version.version
+        ]
         return version
 
     @classmethod

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -1112,3 +1112,7 @@ class SqlAlchemyStore(AbstractStore):
                     session, name, sql_model_version.to_mlflow_entity()
                 )
                 return model_version_entity
+            else:
+                raise MlflowException(
+                    f"Registered model alias {alias} not found.", INVALID_PARAMETER_VALUE
+                )

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -21,6 +21,10 @@ _RUN_ID_REGEX = re.compile(r"^[a-zA-Z0-9][\w\-]{0,255}$")
 # including alphanumerics, underscores, or dashes.
 _EXPERIMENT_ID_REGEX = re.compile(r"^[a-zA-Z0-9][\w\-]{0,63}$")
 
+# Regex for valid registered model alias names: may only contain alphanumerics,
+# underscores, and dashes.
+_REGISTERED_MODEL_ALIAS_REGEX = re.compile(r"^[\w\-]*$")
+
 _BAD_CHARACTERS_MESSAGE = (
     "Names may only contain alphanumerics, underscores (_), dashes (-), periods (.),"
     " spaces ( ), and slashes (/)."
@@ -361,6 +365,11 @@ def _validate_model_alias_name(model_alias_name):
     if model_alias_name is None or model_alias_name == "":
         raise MlflowException(
             "Registered model alias name cannot be empty.", INVALID_PARAMETER_VALUE
+        )
+    if not _REGISTERED_MODEL_ALIAS_REGEX.match(model_alias_name):
+        raise MlflowException(
+            f"Invalid alias name: '{model_alias_name}'. {_BAD_CHARACTERS_MESSAGE}",
+            INVALID_PARAMETER_VALUE,
         )
     _validate_length_limit(
         "Registered model alias name", MAX_REGISTERED_MODEL_ALIAS_LENGTH, model_alias_name

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -40,6 +40,7 @@ MAX_ENTITY_KEY_LENGTH = 250
 MAX_MODEL_REGISTRY_TAG_KEY_LENGTH = 250
 MAX_MODEL_REGISTRY_TAG_VALUE_LENGTH = 5000
 MAX_EXPERIMENTS_LISTED_PER_PAGE = 50000
+MAX_REGISTERED_MODEL_ALIAS_LENGTH = 250
 
 _UNSUPPORTED_DB_TYPE_MSG = "Supported database engines are {%s}" % ", ".join(DATABASE_ENGINES)
 
@@ -354,6 +355,16 @@ def _validate_model_version(model_version):
             f"Model version must be an integer, got '{model_version}'",
             error_code=INVALID_PARAMETER_VALUE,
         )
+
+
+def _validate_model_alias_name(model_alias_name):
+    if model_alias_name is None or model_alias_name == "":
+        raise MlflowException(
+            "Registered model alias name cannot be empty.", INVALID_PARAMETER_VALUE
+        )
+    _validate_length_limit(
+        "Registered model alias name", MAX_REGISTERED_MODEL_ALIAS_LENGTH, model_alias_name
+    )
 
 
 def _validate_experiment_artifact_location(artifact_location):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -30,6 +30,10 @@ _BAD_CHARACTERS_MESSAGE = (
     " spaces ( ), and slashes (/)."
 )
 
+_BAD_ALIAS_CHARACTERS_MESSAGE = (
+    "Names may only contain alphanumerics, underscores (_), and dashes (-)."
+)
+
 _MISSING_KEY_NAME_MESSAGE = "A key name must be provided."
 
 MAX_PARAMS_TAGS_PER_BATCH = 100
@@ -44,7 +48,7 @@ MAX_ENTITY_KEY_LENGTH = 250
 MAX_MODEL_REGISTRY_TAG_KEY_LENGTH = 250
 MAX_MODEL_REGISTRY_TAG_VALUE_LENGTH = 5000
 MAX_EXPERIMENTS_LISTED_PER_PAGE = 50000
-MAX_REGISTERED_MODEL_ALIAS_LENGTH = 250
+MAX_REGISTERED_MODEL_ALIAS_LENGTH = 256
 
 _UNSUPPORTED_DB_TYPE_MSG = "Supported database engines are {%s}" % ", ".join(DATABASE_ENGINES)
 
@@ -368,7 +372,7 @@ def _validate_model_alias_name(model_alias_name):
         )
     if not _REGISTERED_MODEL_ALIAS_REGEX.match(model_alias_name):
         raise MlflowException(
-            f"Invalid alias name: '{model_alias_name}'. {_BAD_CHARACTERS_MESSAGE}",
+            f"Invalid alias name: '{model_alias_name}'. {_BAD_ALIAS_CHARACTERS_MESSAGE}",
             INVALID_PARAMETER_VALUE,
         )
     _validate_length_limit(

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -137,5 +137,5 @@ CREATE TABLE registered_model_aliases (
 	alias VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	version INTEGER NOT NULL,
 	CONSTRAINT registered_model_alias_pk PRIMARY KEY (name, alias),
-	CONSTRAINT registered_model_alias_name_version_fkey FOREIGN KEY(version) REFERENCES model_versions (name, version) ON UPDATE CASCADE
+	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
 )

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -137,5 +137,5 @@ CREATE TABLE registered_model_aliases (
 	alias VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	version INTEGER NOT NULL,
 	CONSTRAINT registered_model_alias_pk PRIMARY KEY (name, alias),
-	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
+	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE ON DELETE CASCADE
 )

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -145,5 +145,5 @@ CREATE TABLE registered_model_aliases (
 	alias VARCHAR(256) NOT NULL,
 	version INTEGER NOT NULL,
 	CONSTRAINT registered_model_alias_pk PRIMARY KEY (name, alias),
-	CONSTRAINT registered_model_alias_name_version_fkey FOREIGN KEY(name, version) REFERENCES model_versions (name, version) ON UPDATE CASCADE
+	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
 )

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -145,5 +145,5 @@ CREATE TABLE registered_model_aliases (
 	alias VARCHAR(256) NOT NULL,
 	version INTEGER NOT NULL,
 	CONSTRAINT registered_model_alias_pk PRIMARY KEY (name, alias),
-	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
+	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE ON DELETE CASCADE
 )

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -143,5 +143,5 @@ CREATE TABLE registered_model_aliases (
 	alias VARCHAR(256) NOT NULL,
 	version INTEGER NOT NULL,
 	CONSTRAINT registered_model_alias_pk PRIMARY KEY (name, alias),
-	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
+	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE ON DELETE CASCADE
 )

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -143,5 +143,5 @@ CREATE TABLE registered_model_aliases (
 	alias VARCHAR(256) NOT NULL,
 	version INTEGER NOT NULL,
 	CONSTRAINT registered_model_alias_pk PRIMARY KEY (name, alias),
-	CONSTRAINT registered_model_alias_name_version_fkey FOREIGN KEY(name, version) REFERENCES model_versions (name, version) ON UPDATE CASCADE
+	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
 )

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -146,5 +146,5 @@ CREATE TABLE registered_model_aliases (
 	alias VARCHAR(256) NOT NULL,
 	version INTEGER NOT NULL,
 	CONSTRAINT registered_model_alias_pk PRIMARY KEY (name, alias),
-	CONSTRAINT registered_model_alias_name_version_fkey FOREIGN KEY(name, version) REFERENCES model_versions (name, version) ON UPDATE CASCADE
+	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
 )

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -146,5 +146,5 @@ CREATE TABLE registered_model_aliases (
 	alias VARCHAR(256) NOT NULL,
 	version INTEGER NOT NULL,
 	CONSTRAINT registered_model_alias_pk PRIMARY KEY (name, alias),
-	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
+	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE ON DELETE CASCADE
 )

--- a/tests/entities/model_registry/test_model_version.py
+++ b/tests/entities/model_registry/test_model_version.py
@@ -21,6 +21,7 @@ def _check(
     status,
     status_message,
     tags,
+    aliases,
 ):
     assert isinstance(model_version, ModelVersion)
     assert model_version.name == name
@@ -35,6 +36,7 @@ def _check(
     assert model_version.status == status
     assert model_version.status_message == status_message
     assert model_version.tags == tags
+    assert model_version.aliases == aliases
 
 
 def test_creation_and_hydration():
@@ -44,6 +46,7 @@ def test_creation_and_hydration():
     run_id = uuid.uuid4().hex
     run_link = "http://localhost:5000/path/to/run"
     tags = [ModelVersionTag("key", "value"), ModelVersionTag("randomKey", "not a random value")]
+    aliases = ["test_alias"]
     mvd = ModelVersion(
         name,
         "5",
@@ -58,6 +61,7 @@ def test_creation_and_hydration():
         "Model version #5 is ready to use.",
         tags,
         run_link,
+        aliases,
     )
     _check(
         mvd,
@@ -73,6 +77,7 @@ def test_creation_and_hydration():
         "READY",
         "Model version #5 is ready to use.",
         {tag.key: tag.value for tag in (tags or [])},
+        ["test_alias"],
     )
 
     expected_dict = {
@@ -89,6 +94,7 @@ def test_creation_and_hydration():
         "status": "READY",
         "status_message": "Model version #5 is ready to use.",
         "tags": {tag.key: tag.value for tag in (tags or [])},
+        "aliases": ["test_alias"],
     }
     model_version_as_dict = dict(mvd)
     assert model_version_as_dict == expected_dict
@@ -100,6 +106,7 @@ def test_creation_and_hydration():
     assert proto.status_message == "Model version #5 is ready to use."
     assert {tag.key for tag in proto.tags} == {"key", "randomKey"}
     assert {tag.value for tag in proto.tags} == {"value", "not a random value"}
+    assert proto.aliases == ["test_alias"]
     mvd_2 = ModelVersion.from_proto(proto)
     _check(
         mvd_2,
@@ -115,6 +122,7 @@ def test_creation_and_hydration():
         "READY",
         "Model version #5 is ready to use.",
         {tag.key: tag.value for tag in (tags or [])},
+        ["test_alias"],
     )
 
     expected_dict.update({"registered_model": RegisteredModel(name)})
@@ -134,6 +142,7 @@ def test_creation_and_hydration():
         "READY",
         "Model version #5 is ready to use.",
         {tag.key: tag.value for tag in (tags or [])},
+        ["test_alias"],
     )
 
 
@@ -152,10 +161,11 @@ def test_string_repr():
         status="PENDING_REGISTRATION",
         status_message="Copying!",
         tags=[],
+        aliases=[],
     )
 
     assert (
-        str(model_version) == "<ModelVersion: creation_timestamp=12, "
+        str(model_version) == "<ModelVersion: aliases=[], creation_timestamp=12, "
         "current_stage='Archived', description='This is a test "
         "model.', last_updated_timestamp=100, "
         "name='myname', "

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -55,6 +55,15 @@ CREATE TABLE model_versions (
 )
 
 
+CREATE TABLE registered_model_aliases (
+	name VARCHAR(256) NOT NULL,
+	alias VARCHAR(256) NOT NULL,
+	version INTEGER NOT NULL,
+	CONSTRAINT registered_model_alias_pk PRIMARY KEY (name, alias),
+	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
 CREATE TABLE registered_model_tags (
 	key VARCHAR(250) NOT NULL,
 	value VARCHAR(5000),
@@ -129,15 +138,6 @@ CREATE TABLE params (
 	run_uuid VARCHAR(32) NOT NULL,
 	CONSTRAINT param_pk PRIMARY KEY (key, run_uuid),
 	FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
-)
-
-
-CREATE TABLE registered_model_aliases (
-	name VARCHAR(256) NOT NULL,
-	alias VARCHAR(256) NOT NULL,
-	version INTEGER NOT NULL,
-	CONSTRAINT registered_model_alias_pk PRIMARY KEY (name, alias),
-	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE ON DELETE CASCADE
 )
 
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -137,7 +137,7 @@ CREATE TABLE registered_model_aliases (
 	alias VARCHAR(256) NOT NULL,
 	version INTEGER NOT NULL,
 	CONSTRAINT registered_model_alias_pk PRIMARY KEY (name, alias),
-	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
+	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE ON DELETE CASCADE
 )
 
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -137,7 +137,7 @@ CREATE TABLE registered_model_aliases (
 	alias VARCHAR(256) NOT NULL,
 	version INTEGER NOT NULL,
 	CONSTRAINT registered_model_alias_pk PRIMARY KEY (name, alias),
-	CONSTRAINT registered_model_alias_name_version_fkey FOREIGN KEY(name, version) REFERENCES model_versions (name, version) ON UPDATE CASCADE
+	CONSTRAINT registered_model_alias_name_fkey FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
 )
 
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -717,7 +717,7 @@ def test_set_registered_model_alias(mock_get_request_message, mock_model_registr
         name=name, alias=alias, version=version
     )
     _set_registered_model_alias()
-    _, args = mock_model_registry_store._set_registered_model_alias.call_args
+    _, args = mock_model_registry_store.set_registered_model_alias.call_args
     assert args == {"name": name, "alias": alias, "version": version}
 
 
@@ -726,7 +726,7 @@ def test_delete_registered_model_alias(mock_get_request_message, mock_model_regi
     alias = "test_alias"
     mock_get_request_message.return_value = DeleteRegisteredModelAlias(name=name, alias=alias)
     _delete_registered_model_alias()
-    _, args = mock_model_registry_store._delete_registered_model_alias.call_args
+    _, args = mock_model_registry_store.delete_registered_model_alias.call_args
     assert args == {"name": name, "alias": alias}
 
 
@@ -735,7 +735,7 @@ def test_get_model_version_by_alias(mock_get_request_message, mock_model_registr
     alias = "test_alias"
     mock_get_request_message.return_value = GetModelVersionByAlias(name=name, alias=alias)
     _get_model_version_by_alias()
-    _, args = mock_model_registry_store._get_model_version_by_alias.call_args
+    _, args = mock_model_registry_store.get_model_version_by_alias.call_args
     assert args == {"name": name, "alias": alias}
 
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -41,6 +41,9 @@ from mlflow.server.handlers import (
     _set_model_version_tag,
     _delete_model_version_tag,
     _guess_mime_type,
+    _set_registered_model_alias,
+    _delete_registered_model_alias,
+    _get_model_version_by_alias,
 )
 from mlflow.server import BACKEND_STORE_URI_ENV_VAR, app
 from mlflow.store.entities.paged_list import PagedList
@@ -68,6 +71,9 @@ from mlflow.protos.model_registry_pb2 import (
     DeleteRegisteredModelTag,
     SetModelVersionTag,
     DeleteModelVersionTag,
+    SetRegisteredModelAlias,
+    DeleteRegisteredModelAlias,
+    GetModelVersionByAlias,
 )
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.validation import MAX_BATCH_LOG_REQUEST_SIZE
@@ -701,6 +707,38 @@ def test_delete_model_version_tag(mock_get_request_message, mock_model_registry_
     _delete_model_version_tag()
     _, args = mock_model_registry_store.delete_model_version_tag.call_args
     assert args == {"name": name, "version": version, "key": key}
+
+
+def test_set_registered_model_alias(mock_get_request_message, mock_model_registry_store):
+    name = "model1"
+    alias = "test_alias"
+    version = "1"
+    mock_get_request_message.return_value = SetRegisteredModelAlias(
+        name=name, alias=alias, version=version
+    )
+    _set_registered_model_alias()
+    _, args = mock_model_registry_store._set_registered_model_alias.call_args
+    assert args == {"name": name, "alias": alias, "version": version}
+
+
+def test_delete_registered_model_alias(mock_get_request_message, mock_model_registry_store):
+    name = "model1"
+    alias = "test_alias"
+    version = "1"
+    mock_get_request_message.return_value = DeleteRegisteredModelAlias(name=name, alias=alias)
+    _delete_registered_model_alias()
+    _, args = mock_model_registry_store._delete_registered_model_alias.call_args
+    assert args == {"name": name, "alias": alias}
+
+
+def test_get_model_version_by_alias(mock_get_request_message, mock_model_registry_store):
+    name = "model1"
+    alias = "test_alias"
+    version = "1"
+    mock_get_request_message.return_value = GetModelVersionByAlias(name=name, alias=alias)
+    _get_model_version_by_alias()
+    _, args = mock_model_registry_store._get_model_version_by_alias.call_args
+    assert args == {"name": name, "alias": alias}
 
 
 @pytest.mark.skipif(is_windows(), reason="This test fails on Windows")

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -748,7 +748,7 @@ def test_get_model_version_by_alias(mock_get_request_message, mock_model_registr
         status_message=None,
         aliases=["test_alias"],
     )
-    mock_model_registry_store.get_model_version.return_value = mvd
+    mock_model_registry_store.get_model_version_by_alias.return_value = mvd
     resp = _get_model_version_by_alias()
     _, args = mock_model_registry_store.get_model_version_by_alias.call_args
     assert args == {"name": name, "alias": alias}

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -734,9 +734,25 @@ def test_get_model_version_by_alias(mock_get_request_message, mock_model_registr
     name = "model1"
     alias = "test_alias"
     mock_get_request_message.return_value = GetModelVersionByAlias(name=name, alias=alias)
-    _get_model_version_by_alias()
+    mvd = ModelVersion(
+        name="model1",
+        version="5",
+        creation_timestamp=1,
+        last_updated_timestamp=12,
+        description="v 5",
+        user_id="u1",
+        current_stage="Production",
+        source="A/B",
+        run_id=uuid.uuid4().hex,
+        status="READY",
+        status_message=None,
+        aliases=["test_alias"],
+    )
+    mock_model_registry_store.get_model_version.return_value = mvd
+    resp = _get_model_version_by_alias()
     _, args = mock_model_registry_store.get_model_version_by_alias.call_args
     assert args == {"name": name, "alias": alias}
+    assert json.loads(resp.get_data()) == {"model_version": jsonify(mvd)}
 
 
 @pytest.mark.skipif(is_windows(), reason="This test fails on Windows")

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -724,7 +724,6 @@ def test_set_registered_model_alias(mock_get_request_message, mock_model_registr
 def test_delete_registered_model_alias(mock_get_request_message, mock_model_registry_store):
     name = "model1"
     alias = "test_alias"
-    version = "1"
     mock_get_request_message.return_value = DeleteRegisteredModelAlias(name=name, alias=alias)
     _delete_registered_model_alias()
     _, args = mock_model_registry_store._delete_registered_model_alias.call_args
@@ -734,7 +733,6 @@ def test_delete_registered_model_alias(mock_get_request_message, mock_model_regi
 def test_get_model_version_by_alias(mock_get_request_message, mock_model_registry_store):
     name = "model1"
     alias = "test_alias"
-    version = "1"
     mock_get_request_message.return_value = GetModelVersionByAlias(name=name, alias=alias)
     _get_model_version_by_alias()
     _, args = mock_model_registry_store._get_model_version_by_alias.call_args

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -23,6 +23,9 @@ from mlflow.protos.model_registry_pb2 import (
     SetModelVersionTag,
     DeleteRegisteredModelTag,
     DeleteModelVersionTag,
+    SetRegisteredModelAlias,
+    DeleteRegisteredModelAlias,
+    GetModelVersionByAlias,
 )
 from mlflow.store.model_registry.rest_store import RestStore
 from mlflow.utils.proto_json_utils import message_to_json
@@ -377,4 +380,43 @@ def test_delete_model_version_tag(store, creds):
         "model-versions/delete-tag",
         "DELETE",
         DeleteModelVersionTag(name=name, version="1", key="key"),
+    )
+
+
+def test_set_registered_model_alias(store, creds):
+    name = "model_1"
+    with mock_http_request_200() as mock_http:
+        store.set_registered_model_alias(name=name, alias="test_alias", version="1")
+    _verify_requests(
+        mock_http,
+        creds,
+        "registered-models/alias",
+        "POST",
+        SetRegisteredModelAlias(name=name, alias="test_alias", version="1"),
+    )
+
+
+def test_delete_registered_model_alias(store, creds):
+    name = "model_1"
+    with mock_http_request_200() as mock_http:
+        store.delete_registered_model_alias(name=name, alias="test_alias")
+    _verify_requests(
+        mock_http,
+        creds,
+        "registered-models/alias",
+        "DELETE",
+        DeleteRegisteredModelAlias(name=name, alias="test_alias"),
+    )
+
+
+def test_get_model_version_by_alias(store, creds):
+    name = "model_1"
+    with mock_http_request_200() as mock_http:
+        store.get_model_version_by_alias(name=name, alias="test_alias")
+    _verify_requests(
+        mock_http,
+        creds,
+        "registered-models/alias",
+        "GET",
+        GetModelVersionByAlias(name=name, alias="test_alias"),
     )

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1576,3 +1576,39 @@ def test_delete_model_version_tag(store):
     ) as exception_context:
         store.delete_model_version_tag(name1, "I am not a version", "key")
     assert exception_context.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def _setup_and_test_aliases(store, model_name):
+    store.create_registered_model(model_name)
+    run_id_1 = uuid.uuid4().hex
+    run_id_2 = uuid.uuid4().hex
+    store.create_model_version(model_name, "v1", run_id_1)
+    store.create_model_version(model_name, "v2", run_id_2)
+    store.set_registered_model_alias(model_name, "test_alias", "2")
+    model = store.get_registered_model(model_name)
+    assert model.aliases == {"test_alias": "2"}
+    mv1 = store.get_model_version(model_name, 1)
+    mv2 = store.get_model_version(model_name, 2)
+    assert mv1.aliases == []
+    assert mv2.aliases == ["test_alias"]
+
+
+def test_set_registered_model_alias(store):
+    _setup_and_test_aliases(store, "SetRegisteredModelAlias_TestMod")
+
+
+def test_delete_registered_model_alias(store):
+    model_name = "DeleteRegisteredModelAlias_TestMod"
+    _setup_and_test_aliases(store, model_name)
+    store.delete_registered_model_alias(model_name, "test_alias")
+    model = store.get_registered_model(model_name)
+    assert model.aliases == {}
+    mv2 = store.get_model_version(model_name, 2)
+    assert mv2.aliases == []
+
+
+def test_get_model_version_by_alias(store):
+    model_name = "GetModelVersionByAlias_TestMod"
+    _setup_and_test_aliases(store, model_name)
+    mv = store.get_model_version_by_alias(model_name, "test_alias")
+    assert mv.aliases == ["test_alias"]

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1586,7 +1586,7 @@ def _setup_and_test_aliases(store, model_name):
     store.create_model_version(model_name, "v2", run_id_2)
     store.set_registered_model_alias(model_name, "test_alias", "2")
     model = store.get_registered_model(model_name)
-    assert model.aliases == {"test_alias": "2"}
+    assert model.aliases == {"test_alias": 2}
     mv1 = store.get_model_version(model_name, 1)
     mv2 = store.get_model_version(model_name, 2)
     assert mv1.aliases == []

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -15,6 +15,7 @@ from mlflow.utils.validation import (
     _validate_experiment_artifact_location,
     _validate_db_type_string,
     _validate_experiment_name,
+    _validate_model_alias_name,
 )
 
 GOOD_METRIC_OR_PARAM_NAMES = [
@@ -41,6 +42,33 @@ BAD_METRIC_OR_PARAM_NAMES = [
     "\\",
     "./",
     "/./",
+]
+
+GOOD_ALIAS_NAMES = [
+    "a",
+    "Ab-5_",
+    "test-alias",
+    "1a2b5cDeFgH",
+    "a" * 256,
+]
+
+BAD_ALIAS_NAMES = [
+    "",
+    ".",
+    "/",
+    "..",
+    "//",
+    "a b",
+    "a/./b",
+    "/a",
+    "a/",
+    ":",
+    "\\",
+    "./",
+    "/./",
+    "a" * 257,
+    None,
+    "$dgs",
 ]
 
 
@@ -112,6 +140,18 @@ def test_validate_tag_name_good(tag_name):
 def test_validate_tag_name_bad(tag_name):
     with pytest.raises(MlflowException, match="Invalid tag name") as e:
         _validate_tag_name(tag_name)
+    assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+@pytest.mark.parametrize("alias_name", GOOD_ALIAS_NAMES)
+def test_validate_model_alias_name_good(alias_name):
+    _validate_model_alias_name(alias_name)
+
+
+@pytest.mark.parametrize("alias_name", BAD_ALIAS_NAMES)
+def test_validate_model_alias_name_bad(alias_name):
+    with pytest.raises(MlflowException, match="alias name") as e:
+        _validate_model_alias_name(alias_name)
     assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

https://github.com/mlflow/mlflow/pull/8001

## What changes are proposed in this pull request?

Add SetRegisteredModelAlias, DeleteRegisteredModelAlias, and GetModelVersionByAlias methods to `file_store`, `rest_store`, and `sqlalchemy_store`. Also update `RegisteredModel` payload to have an `aliases` field that returns a map of aliases to version numbers, and `ModelVersion` payload to have an `aliases` field that returns a list of aliases associated with the version.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add SetRegisteredModelAlias, DeleteRegisteredModelAlias, and GetModelVersionByAlias methods to `file_store`, `rest_store`, and `sqlalchemy_store`. Also update `RegisteredModel` payload to have an `aliases` field that returns a map of aliases to version numbers, and `ModelVersion` payload to have an `aliases` field that returns a list of aliases associated with the version.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [X] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
