### PR TITLE
[Feature branch] Rename datasets download() to load(), add dst_path for downloads

### DIFF
--- a/mlflow/data/artifact_dataset_sources.py
+++ b/mlflow/data/artifact_dataset_sources.py
@@ -107,7 +107,7 @@ def _create_dataset_source_for_artifact_repo(
         def _get_source_type() -> str:
             return source_type
 
-        def load(self, /, dst_path=None) -> str:
+        def load(self, dst_path=None) -> str:
             """
             Downloads the dataset source to the local filesystem.
 

--- a/mlflow/data/artifact_dataset_sources.py
+++ b/mlflow/data/artifact_dataset_sources.py
@@ -107,13 +107,19 @@ def _create_dataset_source_for_artifact_repo(
         def _get_source_type() -> str:
             return source_type
 
-        def download(self) -> str:
+        def load(self, /, dst_path=None) -> str:
             """
-            Downloads the dataset to the local filesystem.
+            Downloads the dataset source to the local filesystem.
 
-            :return: The path to the downloaded dataset on the local filesystem.
+            :param dst_path: Path of the local filesystem destination directory to which to download
+                             the dataset source. If the directory does not exist, it is created. If
+                             unspecified, the dataset source is downloaded to a new uniquely-named
+                             directory on the local filesystem, unless the dataset source already
+                             exists on the local filesystem, in which case its local path is
+                             returned directly.
+            :return: The path to the downloaded dataset source on the local filesystem.
             """
-            return download_artifacts(self.uri)
+            return download_artifacts(artifact_uri=self.uri, dst_path=dst_path)
 
         @staticmethod
         def _can_resolve(raw_source: Any):

--- a/mlflow/data/dataset_source.py
+++ b/mlflow/data/dataset_source.py
@@ -23,9 +23,10 @@ class DatasetSource:
         """
 
     @abstractmethod
-    def download(self) -> Any:
+    def load(self) -> Any:
         """
-        Downloads the files / objects referred to be this DatasetSource.
+        Loads files / objects referred to by this DatasetSource, e.g. downloads source CSV files
+        from S3 to the local filesystem or loads a Delta Table as a Spark DataFrame.
 
         :return: The downloaded source, e.g. a local filesystem path, a Spark DataFrame, etc.
         """

--- a/mlflow/data/filesystem_dataset_source.py
+++ b/mlflow/data/filesystem_dataset_source.py
@@ -33,7 +33,7 @@ class FileSystemDatasetSource(DatasetSource):
         """
 
     @abstractmethod
-    def load(self, /, dst_path=None) -> str:
+    def load(self, dst_path=None) -> str:
         """
         Downloads the dataset source to the local filesystem.
 

--- a/mlflow/data/filesystem_dataset_source.py
+++ b/mlflow/data/filesystem_dataset_source.py
@@ -33,10 +33,16 @@ class FileSystemDatasetSource(DatasetSource):
         """
 
     @abstractmethod
-    def download(self) -> str:
+    def load(self, /, dst_path=None) -> str:
         """
         Downloads the dataset source to the local filesystem.
 
+        :param dst_path: Path of the local filesystem destination directory to which to download the
+                         dataset source. If the directory does not exist, it is created. If
+                         unspecified, the dataset source is downloaded to a new uniquely-named
+                         directory on the local filesystem, unless the dataset source already
+                         exists on the local filesystem, in which case its local path is returned
+                         directly.
         :return: The path to the downloaded dataset source on the local filesystem.
         """
 

--- a/tests/data/test_dataset_source.py
+++ b/tests/data/test_dataset_source.py
@@ -3,8 +3,8 @@ import json
 from tests.resources.data.dataset_source import TestDatasetSource
 
 
-def test_download(tmp_path):
-    assert TestDatasetSource("test:" + str(tmp_path)).download() == str(tmp_path)
+def test_load(tmp_path):
+    assert TestDatasetSource("test:" + str(tmp_path)).load() == str(tmp_path)
 
 
 def test_conversion_to_json_and_back():

--- a/tests/data/test_dataset_source_registry.py
+++ b/tests/data/test_dataset_source_registry.py
@@ -1,61 +1,12 @@
-from typing import Any, Dict
-from urllib.parse import urlparse
+from typing import Any
 
 import pytest
 from unittest import mock
 
-from mlflow.artifacts import download_artifacts
-from mlflow.data.dataset_source import DatasetSource
 from mlflow.data.dataset_source_registry import DatasetSourceRegistry
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
-
-class TestDatasetSource(DatasetSource):
-    def __init__(self, uri):
-        self._uri = uri
-
-    @property
-    def uri(self):
-        return self._uri
-
-    @staticmethod
-    def _get_source_type() -> str:
-        return "test"
-
-    def download(self) -> str:
-        # Ignore the "test" URI scheme and download the local path
-        parsed_uri = urlparse(self._uri)
-        return download_artifacts(parsed_uri.path)
-
-    @staticmethod
-    def _can_resolve(raw_source: Any) -> bool:
-        if not isinstance(raw_source, str):
-            return False
-
-        try:
-            parsed_source = urlparse(raw_source)
-            return parsed_source.scheme == "test"
-        except Exception:
-            return False
-
-    @classmethod
-    def _resolve(cls, raw_source: Any) -> DatasetSource:
-        return cls(raw_source)
-
-    def _to_dict(self) -> Dict[str, str]:
-        return {"uri": self.uri}
-
-    @classmethod
-    def _from_dict(cls, source_dict: Dict[str, str]) -> DatasetSource:
-        uri = source_dict.get("uri")
-        if uri is None:
-            raise MlflowException(
-                'Failed to parse dummy dataset source. Missing expected key: "uri"',
-                INVALID_PARAMETER_VALUE,
-            )
-
-        return cls(uri=uri)
+from tests.resources.data.dataset_source import TestDatasetSource
 
 
 def test_register_entrypoints_and_resolve(tmp_path):

--- a/tests/resources/data/dataset_source.py
+++ b/tests/resources/data/dataset_source.py
@@ -19,7 +19,7 @@ class TestDatasetSource(DatasetSource):
     def _get_source_type() -> str:
         return "test"
 
-    def download(self) -> str:
+    def load(self) -> str:
         # Ignore the "test" URI scheme and download the local path
         parsed_uri = urlparse(self._uri)
         return download_artifacts(parsed_uri.path)

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_dataset_source.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_dataset_source.py
@@ -19,7 +19,7 @@ class DummyDatasetSource(DatasetSource):
     def _get_source_type() -> str:
         return "dummy"
 
-    def download(self) -> str:
+    def load(self) -> str:
         # Ignore the "dummy" URI scheme and download the local path
         parsed_uri = urlparse(self._uri)
         return download_artifacts(parsed_uri.path)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Rename datasets download() to load(), add dst_path for downloads

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
