### PR TITLE
Pytorch and Lightning 2.0 fixes

### DIFF
--- a/examples/pytorch/AxHyperOptimizationPTL/ax_hpo_iris.py
+++ b/examples/pytorch/AxHyperOptimizationPTL/ax_hpo_iris.py
@@ -6,7 +6,7 @@ from iris_data_module import IrisDataModule
 import pytorch_lightning as pl
 
 
-def train_evaluate(params, max_epochs=100):
+def train_evaluate(params, max_epochs):
     model = IrisClassification(**params)
     dm = IrisDataModule()
     dm.setup(stage="fit")
@@ -71,13 +71,8 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    if "max_epochs" in args:
-        max_epochs = args.max_epochs
-    else:
-        max_epochs = 100
-
     params = {"lr": 0.1, "momentum": 0.9, "weight_decay": 0}
 
     model_training_hyperparameter_tuning(
-        max_epochs=int(max_epochs), total_trials=int(args.total_trials), params=params
+        max_epochs=int(args.max_epochs), total_trials=int(args.total_trials), params=params
     )

--- a/examples/pytorch/AxHyperOptimizationPTL/ax_hpo_iris.py
+++ b/examples/pytorch/AxHyperOptimizationPTL/ax_hpo_iris.py
@@ -56,7 +56,12 @@ def model_training_hyperparameter_tuning(max_epochs, total_trials, params):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser = pl.Trainer.add_argparse_args(parent_parser=parser)
+
+    parser.add_argument(
+        "--max_epochs",
+        default=50,
+        help="number of epochs",
+    )
 
     parser.add_argument(
         "--total_trials",

--- a/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
+++ b/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
@@ -5,14 +5,15 @@ dependencies:
   - pip
   - pip:
       - mlflow
-      - pytorch-lightning==1.7.6
+      - lightning==2.0.0
+      - jsonargparse[signatures]>=4.17.0
       # typeguard is used for type validation in the ax-platform code base. 3.0.0 release has
       # breaking changes that need to be resolved in ax. Remove this pin when
       # https://github.com/facebook/Ax/issues/1509 is addressed
       - typeguard<3.0.0
       - ax-platform
-      - torchvision>=0.9.1
-      - torch>=1.9.0
+      - torchvision>=0.15.1
+      - torch>=2.0
       # gyptorch 1.9.x is incompatible with the versions of botorch
       # required by many versions of pytorch
       - gpytorch<1.9.0

--- a/examples/pytorch/AxHyperOptimizationPTL/python_env.yaml
+++ b/examples/pytorch/AxHyperOptimizationPTL/python_env.yaml
@@ -3,14 +3,15 @@ build_dependencies:
   - pip
 dependencies:
   - mlflow
-  - pytorch-lightning==1.7.6
+  - lightning==2.0.0
+  - jsonargparse[signatures]>=4.17.0
   # typeguard is used for type validation in the ax-platform code base. 3.0.0 release has
   # breaking changes that need to be resolved in ax. Remove this pin when
   # https://github.com/facebook/Ax/issues/1509 is addressed
   - typeguard<3.0.0
   - ax-platform
-  - torchvision>=0.9.1
-  - torch>=1.9.0
+  - torchvision>=0.15.1
+  - torch>=2.0
   # gyptorch 1.9.x is incompatible with the versions of botorch
   # required by many versions of pytorch
   - gpytorch<1.9.0

--- a/examples/pytorch/BertNewsClassification/MLproject
+++ b/examples/pytorch/BertNewsClassification/MLproject
@@ -1,28 +1,29 @@
 name: bert-classification
 
-python_env: python_env.yaml
+# python_env: python_env.yaml
+conda_env: conda.yaml
 
 entry_points:
   main:
     parameters:
-      max_epochs: {type: int, default: 5}
-      devices: {type: int, default: "None"}
-      strategy: {type str, default: "None"}
-      accelerator: {type str, default: "cpu"}
+      max_epochs: {type: int, default: 1}
+      devices: {type: int, default: "auto"}
+      strategy: {type str, default: "auto"}
+      accelerator: {type str, default: "auto"}
       batch_size: {type: int, default: 64}
       num_workers: {type: int, default: 3}
       learning_rate: {type: float, default: 0.001}
-      num_samples: {type: int, default: 2000}
+      num_samples: {type: int, default: 100}
       dataset: {type: str, default: "20newsgroups"}
 
     command: |
           python bert_classification.py \
-            --max_epochs {max_epochs} \
-            --devices {devices} \
-            --strategy {strategy} \
-            --accelerator {accelerator} \
-            --batch_size {batch_size} \
-            --num_workers {num_workers} \
-            --num_samples {num_samples} \
-            --lr {learning_rate} \
-            --dataset {dataset}
+            --trainer.max_epochs {max_epochs} \
+            --trainer.devices {devices} \
+            --trainer.strategy {strategy} \
+            --trainer.accelerator {accelerator} \
+            --data.batch_size {batch_size} \
+            --data.num_workers {num_workers} \
+            --data.num_samples {num_samples} \
+            --model.lr {learning_rate} \
+            --data.dataset {dataset}

--- a/examples/pytorch/BertNewsClassification/MLproject
+++ b/examples/pytorch/BertNewsClassification/MLproject
@@ -1,7 +1,6 @@
 name: bert-classification
 
-# python_env: python_env.yaml
-conda_env: conda.yaml
+python_env: python_env.yaml
 
 entry_points:
   main:

--- a/examples/pytorch/BertNewsClassification/MLproject
+++ b/examples/pytorch/BertNewsClassification/MLproject
@@ -5,14 +5,14 @@ python_env: python_env.yaml
 entry_points:
   main:
     parameters:
-      max_epochs: {type: int, default: 1}
+      max_epochs: {type: int, default: 5}
       devices: {type: int, default: "auto"}
       strategy: {type str, default: "auto"}
       accelerator: {type str, default: "auto"}
       batch_size: {type: int, default: 64}
       num_workers: {type: int, default: 3}
       learning_rate: {type: float, default: 0.001}
-      num_samples: {type: int, default: 100}
+      num_samples: {type: int, default: 2000}
       dataset: {type: str, default: "20newsgroups"}
 
     command: |

--- a/examples/pytorch/BertNewsClassification/README.md
+++ b/examples/pytorch/BertNewsClassification/README.md
@@ -6,7 +6,7 @@ In this example, we train a Pytorch Lightning model to classify news articles in
 
 To run the example via MLflow, navigate to the `mlflow/examples/pytorch/BertNewsClassification` directory and run the command
 
-```
+```bash
 mlflow run .
 ```
 
@@ -14,7 +14,7 @@ This will run `bert_classification.py` with the default set of parameters such a
 
 In order to run the file with custom parameters, run the command
 
-```
+```bash
 mlflow run . -P max_epochs=X
 ```
 
@@ -22,7 +22,7 @@ where `X` is your desired value for `max_epochs`.
 
 If you have the required modules for the file and would like to skip the creation of a conda environment, add the argument `--env-manager=local`.
 
-```
+```bash
 mlflow run . --env-manager=local
 ```
 
@@ -30,7 +30,7 @@ mlflow run . --env-manager=local
 
 Once the code is finished executing, you can view the run's metrics, parameters, and details by running the command
 
-```
+```bash
 mlflow ui
 ```
 
@@ -43,29 +43,32 @@ For more details on MLflow tracking, see [the docs](https://www.mlflow.org/docs/
 The parameters can be overridden via the command line:
 
 1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
-2. devices - Number of GPUs
+2. devices - Number of GPUs.
 3. strategy - [strategy](https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#trainer-class-api) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no strategy is used.
-4. accelerator - [accelerator](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.accelerators.Accelerator.html#pytorch_lightning.accelerators.Accelerator) (e.g. "gpu" - for running in GPU environment. Set to "cpu" by default)
+4. accelerator - [accelerator](https://lightning.ai/docs/pytorch/stable/extensions/accelerator.html) (e.g. "gpu" - for running in GPU environment. Set to "cpu" by default)
 5. batch_size - Input batch size for training
 6. num_workers - Number of worker threads to load training data
 7. lr - Learning rate
 
 For example:
 
-```
-mlflow run . -P max_epochs=5 -P devices=1 -P batch_size=32 -P num_workers=2 -P learning_rate=0.01 -P strategy=ddp -P accelerator=gpu
+```bash
+mlflow run . -P max_epochs=5 -P devices=1 -P batch_size=32 -P num_workers=2 -P learning_rate=0.01 -P strategy="ddp" -P accelerator=gpu
 ```
 
 Or to run the training script directly with custom parameters:
 
-```
+```bash
 python bert_classification.py \
-    --max_epochs 5 \
-    --devices 1 \
-    --strategy "ddp" \
-    --batch_size 64 \
-    --num_workers 2 \
-    --lr 0.001
+    --trainer.max_epochs 5 \
+    --trainer.devices 1 \
+    --trainer.strategy "ddp" \
+    --trainer.accelerator "gpu" \
+    --data.batch_size 64 \
+    --data.num_workers 3 \
+    --data.num_samples 2000 \
+    --model.lr 0.001 \
+    --data.dataset "20newsgroups"
 ```
 
 ## Logging to a custom tracking server

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -126,13 +126,13 @@ class BertDataModule(L.LightningDataModule):
         self.RANDOM_SEED = 42
         self.news_group_df = None
 
-    def prepare_data(self):
+    def setup(self, stage=None):
         """
-        Downloads the ag_news or 20newsgroup dataset and initializes bert tokenizer
-        """
-        np.random.seed(self.RANDOM_SEED)
-        torch.manual_seed(self.RANDOM_SEED)
+        Split the data into train, test, validation data
 
+        :param stage: Stage - training or testing
+        """
+        self.tokenizer = BertTokenizer.from_pretrained(self.PRE_TRAINED_MODEL_NAME)
         if self.dataset == "20newsgroups":
             num_samples = self.num_samples
             self.news_group_df = (
@@ -145,14 +145,6 @@ class BertDataModule(L.LightningDataModule):
             self.train_dataset = to_map_style_dataset(train_iter)
             self.test_dataset = to_map_style_dataset(test_iter)
 
-        self.tokenizer = BertTokenizer.from_pretrained(self.PRE_TRAINED_MODEL_NAME)
-
-    def setup(self, stage=None):
-        """
-        Split the data into train, test, validation data
-
-        :param stage: Stage - training or testing
-        """
         if stage == "fit":
             if self.dataset == "20newsgroups":
                 self.train_dataset, self.test_dataset = train_test_split(

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -4,25 +4,24 @@
 
 import math
 import os
-from argparse import ArgumentParser
 
-import logging
 import numpy as np
 import pandas as pd
-import pytorch_lightning as pl
+import lightning as L
 import torch
 import torch.nn.functional as F
 import torchtext.datasets as td
-from pytorch_lightning.callbacks import (
+from lightning.pytorch.callbacks import (
     EarlyStopping,
     ModelCheckpoint,
     LearningRateMonitor,
 )
+from lightning.pytorch.cli import LightningCLI
 from sklearn.datasets import fetch_20newsgroups
 from sklearn.metrics import accuracy_score
 from sklearn.model_selection import train_test_split
 from torch import nn
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import DataLoader
 from torch.utils.data.dataset import random_split
 from torchdata.datapipes.iter import IterDataPipe
 from torchtext.data.functional import to_map_style_dataset
@@ -104,8 +103,8 @@ class NewsDataset(IterDataPipe):
             }
 
 
-class BertDataModule(pl.LightningDataModule):
-    def __init__(self, **kwargs):
+class BertDataModule(L.LightningDataModule):
+    def __init__(self, dataset, batch_size, num_workers, num_samples):
         """
         Initialization of inherited lightning data module
         """
@@ -117,8 +116,10 @@ class BertDataModule(pl.LightningDataModule):
         self.MAX_LEN = 100
         self.encoding = None
         self.tokenizer = None
-        self.args = kwargs
-        self.dataset = self.args["dataset"]
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+        self.dataset = dataset
+        self.num_samples = num_samples
         self.train_count = None
         self.val_count = None
         self.test_count = None
@@ -133,10 +134,10 @@ class BertDataModule(pl.LightningDataModule):
         torch.manual_seed(self.RANDOM_SEED)
 
         if self.dataset == "20newsgroups":
-            num_samples = self.args["num_samples"]
+            num_samples = self.num_samples
             self.news_group_df = (
                 get_20newsgroups(num_samples)
-                if self.args["dataset"] == "20newsgroups"
+                if self.dataset == "20newsgroups"
                 else get_ag_news(num_samples)
             )
         else:
@@ -176,7 +177,7 @@ class BertDataModule(pl.LightningDataModule):
                     self.train_dataset, [num_train, len(self.train_dataset) - num_train]
                 )
 
-                self.train_count = self.args.get("num_samples")
+                self.train_count = self.num_samples
                 self.val_count = int(self.train_count / 10)
                 self.test_count = int(self.train_count / 10)
                 self.train_count = self.train_count - (self.val_count + self.test_count)
@@ -184,32 +185,6 @@ class BertDataModule(pl.LightningDataModule):
             print("Number of samples used for training: {}".format(self.train_count))
             print("Number of samples used for validation: {}".format(self.val_count))
             print("Number of samples used for test: {}".format(self.test_count))
-
-    @staticmethod
-    def add_model_specific_args(parent_parser):
-        """
-        Returns the review text and the targets of the specified item
-
-        :param parent_parser: Application specific parser
-
-        :return: Returns the augmented argument parser
-        """
-        parser = ArgumentParser(parents=[parent_parser], add_help=False)
-        parser.add_argument(
-            "--batch_size",
-            type=int,
-            default=16,
-            metavar="N",
-            help="input batch size for training (default: 16)",
-        )
-        parser.add_argument(
-            "--num_workers",
-            type=int,
-            default=3,
-            metavar="N",
-            help="number of workers (default: 3)",
-        )
-        return parser
 
     def create_data_loader(self, source, count):
         """
@@ -229,9 +204,7 @@ class BertDataModule(pl.LightningDataModule):
             dataset=self.dataset,
         )
 
-        return DataLoader(
-            ds, batch_size=self.args["batch_size"], num_workers=self.args["num_workers"]
-        )
+        return DataLoader(ds, batch_size=self.batch_size, num_workers=self.num_workers)
 
     def train_dataloader(self):
         """
@@ -252,12 +225,14 @@ class BertDataModule(pl.LightningDataModule):
         return self.create_data_loader(source=self.test_dataset, count=self.test_count)
 
 
-class BertNewsClassifier(pl.LightningModule):
-    def __init__(self, **kwargs):
+class BertNewsClassifier(L.LightningModule):
+    def __init__(self, dataset, lr):
         """
         Initializes the network, optimizer and scheduler
         """
         super().__init__()
+        self.dataset = dataset
+        self.lr = lr
         self.PRE_TRAINED_MODEL_NAME = "bert-base-uncased"
         self.bert_model = BertModel.from_pretrained(self.PRE_TRAINED_MODEL_NAME)
         for param in self.bert_model.parameters():
@@ -266,7 +241,7 @@ class BertNewsClassifier(pl.LightningModule):
         # assigning labels
         self.class_names = (
             ["alt.atheism", "talk.religion.misc", "comp.graphics", "sci.space"]
-            if kwargs["dataset"] == "20newsgroups"
+            if self.dataset == "20newsgroups"
             else ["world", "Sports", "Business", "Sci/Tech"]
         )
         n_classes = len(self.class_names)
@@ -276,7 +251,8 @@ class BertNewsClassifier(pl.LightningModule):
 
         self.scheduler = None
         self.optimizer = None
-        self.args = kwargs
+        self.val_outputs = []
+        self.test_outputs = []
 
     def forward(self, input_ids, attention_mask):
         """
@@ -290,25 +266,6 @@ class BertNewsClassifier(pl.LightningModule):
         output = self.drop(output)
         output = self.out(output)
         return output
-
-    @staticmethod
-    def add_model_specific_args(parent_parser):
-        """
-        Returns the review text and the targets of the specified item
-
-        :param parent_parser: Application specific parser
-
-        :return: Returns the augmented argument parser
-        """
-        parser = ArgumentParser(parents=[parent_parser], add_help=False)
-        parser.add_argument(
-            "--lr",
-            type=float,
-            default=0.001,
-            metavar="LR",
-            help="learning rate (default: 0.001)",
-        )
-        return parser
 
     def training_step(self, train_batch, batch_idx):
         """
@@ -341,8 +298,9 @@ class BertNewsClassifier(pl.LightningModule):
         targets = test_batch["targets"].to(self.device)
         output = self.forward(input_ids, attention_mask)
         _, y_hat = torch.max(output, dim=1)
-        test_acc = accuracy_score(y_hat.cpu(), targets.cpu())
-        return {"test_acc": torch.tensor(test_acc)}
+        test_acc = torch.tensor(accuracy_score(y_hat.cpu(), targets.cpu()))
+        self.test_outputs.append(test_acc)
+        return {"test_acc": test_acc}
 
     def validation_step(self, val_batch, batch_idx):
         """
@@ -359,29 +317,25 @@ class BertNewsClassifier(pl.LightningModule):
         targets = val_batch["targets"].to(self.device)
         output = self.forward(input_ids, attention_mask)
         loss = F.cross_entropy(output, targets)
+        self.val_outputs.append(loss)
         return {"val_step_loss": loss}
 
-    def validation_epoch_end(self, outputs):
+    def on_validation_epoch_end(self):
         """
         Computes average validation accuracy
-
-        :param outputs: outputs after every epoch end
-
-        :return: output - average valid loss
         """
-        avg_loss = torch.stack([x["val_step_loss"] for x in outputs]).mean()
+        avg_loss = torch.stack(self.val_outputs).mean()
         self.log("val_loss", avg_loss, sync_dist=True)
+        self.val_outputs.clear()
 
-    def test_epoch_end(self, outputs):
+    def on_test_epoch_end(self):
         """
         Computes average test accuracy score
-
-        :param outputs: outputs after every epoch end
-
-        :return: output - average test loss
         """
-        avg_test_acc = torch.stack([x["test_acc"] for x in outputs]).mean()
+        print(self.test_outputs)
+        avg_test_acc = torch.stack(self.test_outputs).mean()
         self.log("avg_test_acc", avg_test_acc)
+        self.test_outputs.clear()
 
     def configure_optimizers(self):
         """
@@ -389,7 +343,7 @@ class BertNewsClassifier(pl.LightningModule):
 
         :return: output - Initialized optimizer and scheduler
         """
-        self.optimizer = AdamW(self.parameters(), lr=self.args["lr"])
+        self.optimizer = AdamW(self.parameters(), lr=self.lr)
         self.scheduler = {
             "scheduler": torch.optim.lr_scheduler.ReduceLROnPlateau(
                 self.optimizer,
@@ -404,77 +358,32 @@ class BertNewsClassifier(pl.LightningModule):
         return [self.optimizer], [self.scheduler]
 
 
-if __name__ == "__main__":
-    parser = ArgumentParser(description="Bert-News Classifier Example")
+class MNISTLightningCLI(LightningCLI):
+    def add_arguments_to_parser(self, parser):
+        parser.link_arguments("data.dataset", "model.dataset")
 
-    parser.add_argument(
-        "--num_samples",
-        type=int,
-        default=2000,
-        metavar="N",
-        help="Number of samples to be used for training and evaluation steps (default: 15000) Maximum:100000",
+
+def cli_main():
+    mlflow.pytorch.autolog()
+    early_stopping = EarlyStopping(
+        monitor="val_loss",
     )
-    parser.add_argument(
-        "--dataset",
-        default="20newsgroups",
-        metavar="DATASET",
-        help="Dataset to use",
-        choices=["20newsgroups", "ag_news"],
-    )
-    parser = pl.Trainer.add_argparse_args(parent_parser=parser)
-    parser = BertNewsClassifier.add_model_specific_args(parent_parser=parser)
-    parser = BertDataModule.add_model_specific_args(parent_parser=parser)
-
-    args = parser.parse_args()
-    dict_args = vars(args)
-
-    if "devices" in dict_args:
-        if dict_args["devices"] == "None":
-            dict_args["devices"] = None
-
-    if "strategy" in dict_args:
-        if dict_args["strategy"] == "None":
-            dict_args["strategy"] = None
-
-    dm = BertDataModule(**dict_args)
-    dm.prepare_data()
-
-    model = BertNewsClassifier(**dict_args)
-    early_stopping = EarlyStopping(monitor="val_loss", mode="min", verbose=True)
 
     checkpoint_callback = ModelCheckpoint(
-        dirpath=os.getcwd(),
-        save_top_k=1,
-        verbose=True,
-        monitor="val_loss",
-        mode="min",
+        dirpath=os.getcwd(), save_top_k=1, verbose=True, monitor="val_loss", mode="min"
     )
-
     lr_logger = LearningRateMonitor()
-
-    trainer = pl.Trainer.from_argparse_args(
-        args,
-        callbacks=[lr_logger, early_stopping, checkpoint_callback],
-        enable_checkpointing=True,
+    cli = MNISTLightningCLI(
+        BertNewsClassifier,
+        BertDataModule,
+        run=False,
+        save_config_callback=None,
+        trainer_defaults={"callbacks": [early_stopping, checkpoint_callback, lr_logger]},
     )
+    # cli.model=torch.compile(cli.model)
+    cli.trainer.fit(cli.model, datamodule=cli.datamodule)
+    cli.trainer.test(ckpt_path="best", datamodule=cli.datamodule)
 
-    # It is safe to use `mlflow.pytorch.autolog` in DDP training, as below condition invokes
-    # autolog with only rank 0 gpu.
 
-    # For CPU Training
-    if dict_args["devices"] is None or int(dict_args["devices"]) == 0:
-        mlflow.pytorch.autolog()
-    elif int(dict_args["devices"]) >= 1 and trainer.global_rank == 0:
-        # In case of multi gpu training, the training script is invoked multiple times,
-        # The following condition is needed to avoid multiple copies of mlflow runs.
-        # When one or more gpus are used for training, it is enough to save
-        # the model and its parameters using rank 0 gpu.
-        mlflow.pytorch.autolog()
-    else:
-        # This condition is met only for multi-gpu training when the global rank is non zero.
-        # Since the parameters are already logged using global rank 0 gpu, it is safe to ignore
-        # this condition.
-        logging.info("Active run exists.. ")
-
-    trainer.fit(model, dm)
-    trainer.test(model, datamodule=dm)
+if __name__ == "__main__":
+    cli_main()

--- a/examples/pytorch/BertNewsClassification/conda.yaml
+++ b/examples/pytorch/BertNewsClassification/conda.yaml
@@ -13,6 +13,6 @@ dependencies:
       - torch>=2.0.0
       - torchdata>=0.6.0
       - torchtext==0.15.1
-      - lightning>=2.0.0
+      - lightning==2.0.0
       - jsonargparse[signatures]>=4.17.0
       - protobuf<4.0.0

--- a/examples/pytorch/BertNewsClassification/conda.yaml
+++ b/examples/pytorch/BertNewsClassification/conda.yaml
@@ -10,8 +10,9 @@ dependencies:
       - boto3
       - transformers>=4.0.0
       - pandas
-      - torch>=1.11.0
-      - torchdata
-      - torchtext==0.12.0
-      - pytorch-lightning==1.7.6
+      - torch>=2.0.0
+      - torchdata>=0.6.0
+      - torchtext==0.15.1
+      - lightning>=2.0.0
+      - jsonargparse[signatures]>=4.17.0
       - protobuf<4.0.0

--- a/examples/pytorch/BertNewsClassification/python_env.yaml
+++ b/examples/pytorch/BertNewsClassification/python_env.yaml
@@ -8,8 +8,9 @@ dependencies:
   - boto3
   - transformers>=4.0.0
   - pandas
-  - torch>=1.11.0
+  - torch>=2.0
   - torchdata
-  - torchtext==0.12.0
-  - pytorch-lightning==1.7.6
+  - torchtext==0.15.1
+  - lightning==2.0.0
+  - jsonargparse[signatures]>=4.17.0
   - protobuf<4.0.0

--- a/examples/pytorch/IterativePruning/conda.yaml
+++ b/examples/pytorch/IterativePruning/conda.yaml
@@ -5,16 +5,17 @@ dependencies:
   - pip
   - pip:
       - mlflow
-      - torchvision>=0.9.1
+      - torchvision>=0.15.1
       - cloudpickle==1.6.0
-      - pytorch_lightning==1.7.6
+      - lightning==2.0.0
+      - jsonargparse[signatures]>=4.17.0
       # typeguard is used for type validation in the ax-platform code base. 3.0.0 release has
       # breaking changes that need to be resolved in ax. Remove this pin when
       # https://github.com/facebook/Ax/issues/1509 is addressed
       - typeguard<3.0.0
       - ax-platform
       - prettytable
-      - torch>=1.9.0
+      - torch>=2.0
       - protobuf<4.0.0
       # gyptorch 1.9.x is incompatible with the versions of botorch
       # required by many versions of pytorch

--- a/examples/pytorch/IterativePruning/iterative_prune_mnist.py
+++ b/examples/pytorch/IterativePruning/iterative_prune_mnist.py
@@ -5,7 +5,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
-import pytorch_lightning as pl
+import lightning as L
 import torch
 from ax.service.ax_client import AxClient
 from prettytable import PrettyTable
@@ -31,11 +31,11 @@ class IterativePrune:
         if base:
             mlflow.start_run(run_name="BaseModel")
         mlflow.pytorch.autolog()
-        dm = MNISTDataModule(**parser_dict)
+        dm = MNISTDataModule()
         dm.setup(stage="fit")
 
-        model = LightningMNISTClassifier(**parser_dict)
-        trainer = pl.Trainer.from_argparse_args(self.parser_args)
+        model = LightningMNISTClassifier()
+        trainer = L.Trainer(max_epochs=self.parser_args.max_epochs)
         trainer.fit(model, dm)
         trainer.test(datamodule=dm)
         if os.path.exists(self.base_model_path):
@@ -137,12 +137,17 @@ class IterativePrune:
 
     def get_parser_args(self):
         parser = argparse.ArgumentParser()
-        parser = pl.Trainer.add_argparse_args(parent_parser=parser)
-        parser = LightningMNISTClassifier.add_model_specific_args(parent_parser=parser)
+        parser.add_argument(
+            "--max_epochs",
+            default=3,
+            type=int,
+            help="Number of AX trials to be run for the optimization experiment",
+        )
 
         parser.add_argument(
             "--total_trials",
             default=3,
+            type=int,
             help="Number of AX trials to be run for the optimization experiment",
         )
 

--- a/examples/pytorch/IterativePruning/iterative_prune_mnist.py
+++ b/examples/pytorch/IterativePruning/iterative_prune_mnist.py
@@ -27,7 +27,6 @@ class IterativePrune:
         self.pruning_amount = None
 
     def run_mnist_model(self, base=False):
-        parser_dict = vars(self.parser_args)
         if base:
             mlflow.start_run(run_name="BaseModel")
         mlflow.pytorch.autolog()

--- a/examples/pytorch/IterativePruning/python_env.yaml
+++ b/examples/pytorch/IterativePruning/python_env.yaml
@@ -3,16 +3,17 @@ build_dependencies:
   - pip
 dependencies:
   - mlflow
-  - torchvision>=0.9.1
+  - torchvision>=0.15.1
   - cloudpickle==1.6.0
-  - pytorch_lightning==1.7.6
+  - lightning==2.0.0
+  - jsonargparse[signatures]>=4.17.0
   # typeguard is used for type validation in the ax-platform code base. 3.0.0 release has
   # breaking changes that need to be resolved in ax. Remove this pin when
   # https://github.com/facebook/Ax/issues/1509 is addressed
   - typeguard<3.0.0
   - ax-platform
   - prettytable
-  - torch>=1.9.0
+  - torch>=2.0
   # gyptorch 1.9.x is incompatible with the versions of botorch
   # required by many versions of pytorch
   - gpytorch<1.9.0

--- a/examples/pytorch/MNIST/MLproject
+++ b/examples/pytorch/MNIST/MLproject
@@ -6,27 +6,19 @@ entry_points:
   main:
     parameters:
       max_epochs: {type: int, default: 5}
-      devices : {type: str, default: "None"}
-      strategy: {type str, default: "None"}
-      accelerator: {type str, default: "cpu"}
+      devices : {type: str, default: "auto"}
+      strategy: {type str, default: "auto"}
+      accelerator: {type str, default: "auto"}
       batch_size: {type: int, default: 64}
       num_workers: {type: int, default: 3}
       learning_rate: {type: float, default: 0.001}
-      patience: {type int, default: 3}
-      mode: {type str, default: 'min'}
-      verbose: {type bool, default: True}
-      monitor: {type str, default: 'val_loss'}
 
     command: |
           python mnist_autolog_example.py \
-            --max_epochs {max_epochs} \
-            --devices {devices} \
-            --strategy {strategy} \
-            --accelerator {accelerator} \
-            --batch_size {batch_size} \
-            --num_workers {num_workers} \
-            --lr {learning_rate} \
-            --es_patience {patience} \
-            --es_mode {mode} \
-            --es_verbose {verbose} \
-            --es_monitor {monitor}
+            --trainer.max_epochs={max_epochs} \
+            --trainer.devices={devices} \
+            --trainer.strategy={strategy} \
+            --trainer.accelerator={accelerator} \
+            --data.batch_size={batch_size} \
+            --data.num_workers={num_workers} \
+            --model.learning_rate={learning_rate}

--- a/examples/pytorch/MNIST/README.md
+++ b/examples/pytorch/MNIST/README.md
@@ -12,7 +12,7 @@ To run the example via MLflow, navigate to the `mlflow/examples/pytorch/MNIST` d
 mlflow run .
 ```
 
-This will run `mnist_autolog_example.py` with the default set of parameters such as `--max_epochs=5`. You can see the default value in the `MLproject` file.
+This will run `mnist_autolog_example.py` with the default set of parameters such as `max_epochs=5`. You can see the default value in the `MLproject` file.
 
 In order to run the file with custom parameters, run the command
 
@@ -47,36 +47,28 @@ The parameters can be overridden via the command line:
 1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
 2. devices - Number of GPUs.
 3. strategy - [strategy](https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#trainer-class-api) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no strategy is used.
-4. accelerator - [accelerator](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.accelerators.Accelerator.html#pytorch_lightning.accelerators.Accelerator) (e.g. "gpu" - for running in GPU environment. Set to "cpu" by default)
+4. accelerator - [accelerator](https://lightning.ai/docs/pytorch/stable/extensions/accelerator.html) (e.g. "gpu" - for running in GPU environment. Set to "cpu" by default)
 5. batch_size - Input batch size for training
 6. num_workers - Number of worker threads to load training data
-7. lr - Learning rate
-8. patience -parameter of early stopping
-9. mode - parameter of early stopping
-10. monitor - parameter of early stopping
-    11.verbose - parameter of early stopping
+7. learning_rate - Learning rate
 
 For example:
 
 ```
-mlflow run . -P max_epochs=5 -P gpus=1 -P batch_size=32 -P num_workers=2 -P learning_rate=0.01 -P strategy="ddp" -P patience=5 -P mode="min" -P monitor="val_loss" -P verbose=True
+mlflow run . -P max_epochs=5 -P devices=1 -P batch_size=32 -P num_workers=2 -P learning_rate=0.01 -P strategy="ddp"
 ```
 
 Or to run the training script directly with custom parameters:
 
 ```
 python mnist_autolog_example.py \
-    --max_epochs 5 \
-    --devices 1 \
-    --strategy "ddp" \
-    --accelerator "gpu" \
-    --batch_size 64 \
-    --num_workers 3 \
-    --lr 0.001 \
-    --es_patience 5 \
-    --es_mode "min" \
-    --es_monitor "val_loss" \
-    --es_verbose True
+    --trainer.max_epochs 5 \
+    --trainer.devices 1 \
+    --trainer.strategy "ddp" \
+    --trainer.accelerator "gpu" \
+    --data.batch_size 64 \
+    --data.num_workers 3 \
+    --model.learning_rate 0.001
 ```
 
 ## Logging to a custom tracking server

--- a/examples/pytorch/MNIST/conda.yaml
+++ b/examples/pytorch/MNIST/conda.yaml
@@ -5,7 +5,7 @@ dependencies:
   - pip
   - pip:
       - mlflow
-      - torchvision>=0.9.1
-      - torch>=1.9.0
-      - pytorch-lightning==1.7.6
+      - torchvision>=0.15.1
+      - torch>=2.0
+      - lightning==2.0.0
       - protobuf<4.0.0

--- a/examples/pytorch/MNIST/conda.yaml
+++ b/examples/pytorch/MNIST/conda.yaml
@@ -8,4 +8,5 @@ dependencies:
       - torchvision>=0.15.1
       - torch>=2.0
       - lightning==2.0.0
+      - jsonargparse[signatures]>=4.17.0
       - protobuf<4.0.0

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -221,7 +221,6 @@ class LightningMNISTClassifier(L.LightningModule):
 
 
 def cli_main():
-    mlflow.pytorch.autolog()
     early_stopping = EarlyStopping(
         monitor="val_loss",
     )
@@ -237,6 +236,8 @@ def cli_main():
         save_config_callback=None,
         trainer_defaults={"callbacks": [early_stopping, checkpoint_callback, lr_logger]},
     )
+    if cli.trainer.global_rank == 0:
+        mlflow.pytorch.autolog()
     cli.trainer.fit(cli.model, datamodule=cli.datamodule)
     cli.trainer.test(ckpt_path="best", datamodule=cli.datamodule)
 

--- a/examples/pytorch/MNIST/python_env.yaml
+++ b/examples/pytorch/MNIST/python_env.yaml
@@ -3,7 +3,7 @@ build_dependencies:
   - pip
 dependencies:
   - mlflow
-  - torchvision>=0.9.1
-  - torch>=1.9.0
-  - pytorch-lightning==1.7.6
+  - torchvision>=0.15.1
+  - torch>=2.0
+  - lightning==2.0.0
   - protobuf<4.0.0

--- a/examples/pytorch/MNIST/python_env.yaml
+++ b/examples/pytorch/MNIST/python_env.yaml
@@ -6,4 +6,5 @@ dependencies:
   - torchvision>=0.15.1
   - torch>=2.0
   - lightning==2.0.0
+  - jsonargparse[signatures]>=4.17.0
   - protobuf<4.0.0

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -928,7 +928,6 @@ def autolog(
     silent=False,
     registered_model_name=None,
 ):  # pylint: disable=unused-argument
-
     """
     Enables (or disables) and configures autologging from `PyTorch Lightning
     <https://pytorch-lightning.readthedocs.io/en/latest>`_ to MLflow.
@@ -1087,9 +1086,13 @@ def autolog(
     try:
         import lightning as L
     except ImportError:
-        pass
+        import pytorch_lightning as pl
+        from mlflow.pytorch._lightning_autolog import patched_fit
+
+        safe_patch(FLAVOR_NAME, pl.Trainer, "fit", patched_fit, manage_run=True)
     else:
         from mlflow.pytorch._lightning_autolog import patched_fit
+
         safe_patch(FLAVOR_NAME, L.Trainer, "fit", patched_fit, manage_run=True)
 
     try:

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -1083,13 +1083,20 @@ def autolog(
     """
     import atexit
 
+    # For lightning>=2.0.0 flavor
     try:
         import lightning as L
     except ImportError:
-        import pytorch_lightning as pl
-        from mlflow.pytorch._lightning_autolog import patched_fit
+        # for pytorch-lightning <= 1.9.4 flavor
+        try:
+            import pytorch_lightning as pl
+        except ImportError:
+            # For PyTorch flavor
+            pass
+        else:
+            from mlflow.pytorch._lightning_autolog import patched_fit
 
-        safe_patch(FLAVOR_NAME, pl.Trainer, "fit", patched_fit, manage_run=True)
+            safe_patch(FLAVOR_NAME, pl.Trainer, "fit", patched_fit, manage_run=True)
     else:
         from mlflow.pytorch._lightning_autolog import patched_fit
 

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -928,6 +928,7 @@ def autolog(
     silent=False,
     registered_model_name=None,
 ):  # pylint: disable=unused-argument
+
     """
     Enables (or disables) and configures autologging from `PyTorch Lightning
     <https://pytorch-lightning.readthedocs.io/en/latest>`_ to MLflow.
@@ -1084,13 +1085,12 @@ def autolog(
     import atexit
 
     try:
-        import pytorch_lightning as pl
+        import lightning as L
     except ImportError:
         pass
     else:
         from mlflow.pytorch._lightning_autolog import patched_fit
-
-        safe_patch(FLAVOR_NAME, pl.Trainer, "fit", patched_fit, manage_run=True)
+        safe_patch(FLAVOR_NAME, L.Trainer, "fit", patched_fit, manage_run=True)
 
     try:
         import torch.utils.tensorboard.writer

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -1083,20 +1083,19 @@ def autolog(
     """
     import atexit
 
-    # For lightning>=2.0.0 flavor
+    try:
+        import pytorch_lightning as pl
+    except ImportError:
+        pass
+    else:
+        from mlflow.pytorch._lightning_autolog import patched_fit
+
+        safe_patch(FLAVOR_NAME, pl.Trainer, "fit", patched_fit, manage_run=True)
+
     try:
         import lightning as L
     except ImportError:
-        # for pytorch-lightning <= 1.9.4 flavor
-        try:
-            import pytorch_lightning as pl
-        except ImportError:
-            # For PyTorch flavor
-            pass
-        else:
-            from mlflow.pytorch._lightning_autolog import patched_fit
-
-            safe_patch(FLAVOR_NAME, pl.Trainer, "fit", patched_fit, manage_run=True)
+        pass
     else:
         from mlflow.pytorch._lightning_autolog import patched_fit
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Pytorch 2.0 and Lightning 2.0 has been released recently.

Lightning 2.0 changes are published [here](https://lightning.ai/pages/releases/2.0.0/)

Following are the impacts on mlflow pytorch library

1. The package name has been changed from `pytorch_lightning` to `lightning`
2. `validation_epoch_end` and `test_epoch_end` has been removed
3. `pl.Trainer.add_argparse_args(parent_parser=parser)` has been removed. This line of code combines all the pytorch lightning command line arguments with the user's ArgumentParser. Instead we have to use LightningCLI as mentioned in the release link
4. The training arguments have changed. Previously, we use `--max_epochs` . Now, its `--trainer.max_epochs`
5. When installing `lightning` package, `pytorch_lightning` gets installed as well. Hence, we dont have to change everything in `mllfow.pytorch.autolog` library. But, we may need to remove older version checks.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- MNIST
[mnist_cpu_conda.txt](https://github.com/mlflow/mlflow/files/11032318/mnist_cpu_conda.txt)
[mnist_cpu_virtualenv.txt](https://github.com/mlflow/mlflow/files/11032319/mnist_cpu_virtualenv.txt)
[mnist_gpu_conda.txt](https://github.com/mlflow/mlflow/files/11043544/mnist_gpu_conda.txt)

- BERT
[bert_cpu_conda .txt](https://github.com/mlflow/mlflow/files/11032316/bert_cpu_conda.txt)
[bert_gpu_conda.txt](https://github.com/mlflow/mlflow/files/11043843/bert_gpu_conda.txt)


- Captum
[captum_cpu_virtual_env.txt](https://github.com/mlflow/mlflow/files/11032317/captum_cpu_virtual_env.txt)

- AX
[ax_hyper_param_tuning_cpu_conda.txt](https://github.com/mlflow/mlflow/files/11039550/ax_hyper_param_tuning_cpu_conda.txt)

- Iterative Pruning
[iterative_pruning_cpu_conda.txt](https://github.com/mlflow/mlflow/files/11043805/iterative_pruning_cpu_conda.txt)


Observation:
In multi gpu tests, the lightning throws `_thread.lock` object error while pickling the model and the model is not getting logged into mlflow. However, the issue has been fixed in lightning master branch. Attaching screenshot for reference

[screenshots.zip](https://github.com/mlflow/mlflow/files/11043814/screenshots.zip)





- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
