### PR TITLE
Fix uc model registry default argument values

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -65,7 +65,8 @@ _METHOD_TO_ALL_INFO = extract_all_api_info_for_service(
 _logger = logging.getLogger(__name__)
 
 
-def _require_arg_unspecified(arg_name, arg_value, default_values=[None], message=None):
+def _require_arg_unspecified(arg_name, arg_value, default_values=None, message=None):
+    default_values=[None] if default_values is None else default_values
     if arg_value not in default_values:
         _raise_unsupported_arg(arg_name, message)
 

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -66,7 +66,7 @@ _logger = logging.getLogger(__name__)
 
 
 def _require_arg_unspecified(arg_name, arg_value, default_values=None, message=None):
-    default_values=[None] if default_values is None else default_values
+    default_values = [None] if default_values is None else default_values
     if arg_value not in default_values:
         _raise_unsupported_arg(arg_name, message)
 

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -65,8 +65,8 @@ _METHOD_TO_ALL_INFO = extract_all_api_info_for_service(
 _logger = logging.getLogger(__name__)
 
 
-def _require_arg_unspecified(arg_name, arg_value, default_value=None, message=None):
-    if arg_value != default_value:
+def _require_arg_unspecified(arg_name, arg_value, default_values=[None], message=None):
+    if arg_value not in default_values:
         _raise_unsupported_arg(arg_name, message)
 
 
@@ -145,7 +145,7 @@ class UcModelRegistryStore(BaseRestStore):
         :return: A single object of :py:class:`mlflow.entities.model_registry.RegisteredModel`
                  created in the backend.
         """
-        _require_arg_unspecified("tags", tags)
+        _require_arg_unspecified(arg_name="tags", arg_value=tags, default_values=[[], None])
         req_body = message_to_json(CreateRegisteredModelRequest(name=name, description=description))
         response_proto = self._call_endpoint(CreateRegisteredModelRequest, req_body)
         return registered_model_from_uc_proto(response_proto.registered_model)
@@ -365,7 +365,7 @@ class UcModelRegistryStore(BaseRestStore):
                  created in the backend.
         """
         _require_arg_unspecified(arg_name="run_link", arg_value=run_link)
-        _require_arg_unspecified(arg_name="tags", arg_value=tags)
+        _require_arg_unspecified(arg_name="tags", arg_value=tags, default_values=[[], None])
         source_workspace_id = self._get_workspace_id(run_id)
         req_body = message_to_json(
             CreateModelVersionRequest(

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -34,7 +34,7 @@ from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.utils.annotations import deprecated
 from mlflow.utils.databricks_utils import get_databricks_run_url
 from mlflow.utils.logging_utils import eprint
-from mlflow.utils.uri import is_databricks_uri
+from mlflow.utils.uri import is_databricks_uri, is_databricks_unity_catalog_uri
 from mlflow.utils.validation import _validate_model_version_or_stage_exists
 
 if TYPE_CHECKING:
@@ -2273,7 +2273,12 @@ class MlflowClient:
             Stage: None
         """
         tracking_uri = self._tracking_client.tracking_uri
-        if not run_link and is_databricks_uri(tracking_uri) and tracking_uri != self._registry_uri:
+        if (
+            not run_link
+            and is_databricks_uri(tracking_uri)
+            and tracking_uri != self._registry_uri
+            and not is_databricks_unity_catalog_uri(self._registry_uri)
+        ):
             if not run_id:
                 eprint(
                     "Warning: no run_link will be recorded with the model version "

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -629,3 +629,11 @@ def test_delete_model_version_tag_unsupported(store):
         match=_expected_unsupported_method_error_message("delete_model_version_tag"),
     ):
         store.delete_model_version_tag(name=name, version="1", key="key")
+
+
+@mock_http_200
+@pytest.mark.parametrize("tags", [None, []])
+def test_default_values_for_tags(store, tags):
+    # No unsupported arg exceptions should be thrown
+    store.create_registered_model(name="model_1", description="description", tags=tags)
+    store.create_model_version(name="mymodel", source="source")

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -461,6 +461,26 @@ def test_create_model_version_run_link_in_notebook_with_default_profile(
         )
 
 
+def test_creation_default_values_in_unity_catalog(mock_registry_store):
+    client = MlflowClient(tracking_uri="databricks", registry_uri="databricks-uc")
+    mock_registry_store.create_model_version.return_value = ModelVersion(
+        "name",
+        1,
+        0,
+        1,
+        source="source",
+        run_id="runid",
+    )
+    client.create_model_version("name", "source", "runid")
+    # verify that registry store was called with tags=[] and run_link=None
+    mock_registry_store.create_model_version.assert_called_once_with(
+        "name", "source", "runid", [], None, None
+    )
+    client.create_registered_model(name="name", description="description")
+    # verify that registry store was called with tags=[]
+    mock_registry_store.create_registered_model.assert_called_once_with("name", [], "description")
+
+
 def test_create_model_version_non_ready_model(mock_registry_store):
     run_id = "runid"
     client = MlflowClient(tracking_uri="http://10.123.1231.11")


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

N/A

## What changes are proposed in this pull request?

During the bug bash, we discovered some errors with default argument values with the `create_registered_model` and `create_model_version` endpoints. While both endpoints expect tags and run_link to be set to `None`, the model registry client supplies the UC model registry rest store with non-`None` values. This PR sets `run_link` to none when the UC model registry is being used and changes the model registry store to play well with the `tags` default value `[]`

## How is this patch tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

I added unit tests to test the default behavior.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
