### PR TITLE
fix TF autolog for multi input models

### DIFF
--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -1174,7 +1174,7 @@ def autolog(
 
             batch_size = None
             try:
-                single_input_model = isinstance(inst.input_shape, tuple)
+                is_single_input_model = isinstance(inst.input_shape, tuple)
                 training_data = kwargs["x"] if "x" in kwargs else args[0]
                 if isinstance(training_data, tensorflow.data.Dataset) and hasattr(
                     training_data, "_batch_size"
@@ -1182,13 +1182,13 @@ def autolog(
                     batch_size = training_data._batch_size.numpy()
                 elif isinstance(training_data, tensorflow.keras.utils.Sequence):
                     first_batch_inputs, _ = training_data[0]
-                    if single_input_model:
+                    if is_single_input_model:
                         batch_size = len(first_batch_inputs)
                     else:
                         batch_size = len(first_batch_inputs[0])
                 elif is_iterator(training_data):
                     peek = next(training_data)
-                    if single_input_model:
+                    if is_single_input_model:
                         batch_size = len(peek[0])
                     else:
                         batch_size = len(peek[0][0])

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -1174,6 +1174,7 @@ def autolog(
 
             batch_size = None
             try:
+                single_input_model = isinstance(inst.input_shape, tuple)
                 training_data = kwargs["x"] if "x" in kwargs else args[0]
                 if isinstance(training_data, tensorflow.data.Dataset) and hasattr(
                     training_data, "_batch_size"
@@ -1181,10 +1182,16 @@ def autolog(
                     batch_size = training_data._batch_size.numpy()
                 elif isinstance(training_data, tensorflow.keras.utils.Sequence):
                     first_batch_inputs, _ = training_data[0]
-                    batch_size = len(first_batch_inputs)
+                    if single_input_model:
+                        batch_size = len(first_batch_inputs)
+                    else:
+                        batch_size = len(first_batch_inputs[0])
                 elif is_iterator(training_data):
                     peek = next(training_data)
-                    batch_size = len(peek[0])
+                    if single_input_model:
+                        batch_size = len(peek[0])
+                    else:
+                        batch_size = len(peek[0][0])
 
                     def __restore_generator(prev_generator):
                         yield peek

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -324,6 +324,89 @@ def test_tf_keras_autolog_implicit_batch_size_works(generate_data, batch_size):
     assert mlflow.last_active_run().data.params["batch_size"] == str(batch_size)
 
 
+def __example_tf_dataset_multi_input(batch_size):
+    a = tf.data.Dataset.range(1)
+    b = tf.data.Dataset.range(1)
+    c = tf.data.Dataset.range(1)
+    ds = tf.data.Dataset.zip(((a, b), c))
+    return ds.batch(batch_size)
+
+
+class __ExampleSequenceMultiInput(tf.keras.utils.Sequence):
+    def __init__(self, batch_size):
+        self.batch_size = batch_size
+
+    def __len__(self):
+        return 10
+
+    def __getitem__(self, idx):
+        return (np.array([idx] * self.batch_size), np.array([idx + 1] * self.batch_size)), np.array(
+            [-idx] * self.batch_size
+        )
+
+
+def __generator_multi_input(data, target, batch_size):
+    data_batches = np.split(data, data.shape[1] // batch_size, axis=1)
+    target_batches = np.split(target, target.shape[0] // batch_size)
+    for inputs, output in zip(data_batches, target_batches):
+        yield tuple(inputs), output
+
+
+class __GeneratorClassMultiInput:
+    def __init__(self, data, target, batch_size):
+        self.data = data
+        self.target = target
+        self.batch_size = batch_size
+        self.ptr = 0
+
+    def __next__(self):
+        if self.ptr >= len(self.data):
+            raise StopIteration
+        idx = self.ptr % len(self.data)
+        self.ptr += 1
+        return (
+            self.data[idx : idx + self.batch_size, 0],
+            self.data[idx : idx + self.batch_size, 1],
+        ), self.target[idx : idx + self.batch_size]
+
+    def __iter__(self):
+        return self
+
+
+@pytest.mark.parametrize(
+    "generate_data",
+    [
+        __example_tf_dataset_multi_input,
+        __ExampleSequenceMultiInput,
+        functools.partial(
+            __generator_multi_input, np.array([[1] * 10, [2] * 10]), np.array([[1]] * 10)
+        ),
+        functools.partial(
+            __GeneratorClassMultiInput, np.array([[1, 2]] * 10), np.array([[1]] * 10)
+        ),
+    ],
+)
+@pytest.mark.parametrize("batch_size", [5, 10])
+def test_tf_keras_autolog_implicit_batch_size_works_multi_input(generate_data, batch_size):
+    mlflow.autolog()
+
+    input1 = tf.keras.Input(shape=(1,))
+    input2 = tf.keras.Input(shape=(1,))
+    concat = tf.keras.layers.Concatenate()([input1, input2])
+    output = tf.keras.layers.Dense(1, activation="sigmoid")(concat)
+
+    model = tf.keras.models.Model(inputs=[input1, input2], outputs=output)
+    model.compile(loss="mse")
+
+    # 'x' passed as arg
+    model.fit(generate_data(batch_size), verbose=0)
+    assert mlflow.last_active_run().data.params["batch_size"] == str(batch_size)
+
+    # 'x' passed as kwarg
+    model.fit(x=generate_data(batch_size), verbose=0)
+    assert mlflow.last_active_run().data.params["batch_size"] == str(batch_size)
+
+
 @pytest.mark.skipif(
     Version(tf.__version__) < Version("2.1.4"),
     reason="Does not support passing of generator classes as `x` in `fit`",

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -340,8 +340,8 @@ class __SequenceMultiInput(tf.keras.utils.Sequence):
         return 10
 
     def __getitem__(self, idx):
-        return (np.array([idx] * self.batch_size), np.array([idx + 1] * self.batch_size)), np.array(
-            [-idx] * self.batch_size
+        return (np.random.rand(self.batch_size), np.random.rand(self.batch_size)), np.random.rand(
+            self.batch_size
         )
 
 
@@ -378,12 +378,8 @@ class __GeneratorClassMultiInput:
     [
         __tf_dataset_multi_input,
         __SequenceMultiInput,
-        functools.partial(
-            __generator_multi_input, np.random.rand(2, 10), np.random.rand(1, 10)
-        ),
-        functools.partial(
-            __GeneratorClassMultiInput, np.random.rand(10, 2), np.random.rand(10, 1)
-        ),
+        functools.partial(__generator_multi_input, np.random.rand(2, 10), np.random.rand(10)),
+        functools.partial(__GeneratorClassMultiInput, np.random.rand(10, 2), np.random.rand(10, 1)),
     ],
 )
 @pytest.mark.parametrize("batch_size", [5, 10])

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -379,7 +379,7 @@ class __GeneratorClassMultiInput:
         __tf_dataset_multi_input,
         __SequenceMultiInput,
         functools.partial(
-            __generator_multi_input, np.array([[1] * 10, [2] * 10]), np.array([[1]] * 10)
+            __generator_multi_input, np.random.rand(2, 10), np.random.rand(1, 10)
         ),
         functools.partial(
             __GeneratorClassMultiInput, np.array([[1, 2]] * 10), np.array([[1]] * 10)

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -388,7 +388,7 @@ class __GeneratorClassMultiInput:
 )
 @pytest.mark.parametrize("batch_size", [5, 10])
 def test_tf_keras_autolog_implicit_batch_size_works_multi_input(generate_data, batch_size):
-    mlflow.autolog()
+    mlflow.tensorflow.autolog()
 
     input1 = tf.keras.Input(shape=(1,))
     input2 = tf.keras.Input(shape=(1,))

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -382,7 +382,7 @@ class __GeneratorClassMultiInput:
             __generator_multi_input, np.random.rand(2, 10), np.random.rand(1, 10)
         ),
         functools.partial(
-            __GeneratorClassMultiInput, np.array([[1, 2]] * 10), np.array([[1]] * 10)
+            __GeneratorClassMultiInput, np.random.rand(10, 2), np.random.rand(10, 1)
         ),
     ],
 )

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -324,7 +324,7 @@ def test_tf_keras_autolog_implicit_batch_size_works(generate_data, batch_size):
     assert mlflow.last_active_run().data.params["batch_size"] == str(batch_size)
 
 
-def __example_tf_dataset_multi_input(batch_size):
+def __tf_dataset_multi_input(batch_size):
     a = tf.data.Dataset.range(1)
     b = tf.data.Dataset.range(1)
     c = tf.data.Dataset.range(1)
@@ -332,7 +332,7 @@ def __example_tf_dataset_multi_input(batch_size):
     return ds.batch(batch_size)
 
 
-class __ExampleSequenceMultiInput(tf.keras.utils.Sequence):
+class __SequenceMultiInput(tf.keras.utils.Sequence):
     def __init__(self, batch_size):
         self.batch_size = batch_size
 
@@ -376,8 +376,8 @@ class __GeneratorClassMultiInput:
 @pytest.mark.parametrize(
     "generate_data",
     [
-        __example_tf_dataset_multi_input,
-        __ExampleSequenceMultiInput,
+        __tf_dataset_multi_input,
+        __SequenceMultiInput,
         functools.partial(
             __generator_multi_input, np.array([[1] * 10, [2] * 10]), np.array([[1]] * 10)
         ),


### PR DESCRIPTION
## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Resolve #8082

## What changes are proposed in this pull request?

This PR fixes [#8082](https://github.com/mlflow/mlflow/issues/8082) by checking wether the trained model has more than one input and picking the right dimension. Also fixes that batch_size logged when using a generator.

The logic is as follow: if the model has multiple inputs `inst.input_shape` is a list with the shapes of each of the inputs, otherwise it is directly the shape of the only input of the model. Shapes stored as tuples.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
Bug fix: Log the correct `batch_size` value when using `mlflow.tensorflow.autolog` and training a multiple input model. Previous value logged was the number of inputs of the model instead of the `batch_size`.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
