### PR TITLE
Fix: [BUG] log_artifact fails when tracking uri scheme is 'file' (#7819)

### DIFF
--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -22,7 +22,7 @@ from mlflow.store.artifact.artifact_repository_registry import get_artifact_repo
 from mlflow.utils import chunk_list
 from mlflow.utils.mlflow_tags import MLFLOW_USER
 from mlflow.utils.string_utils import is_string_type
-from mlflow.utils.uri import add_databricks_profile_info_to_artifact_uri
+from mlflow.utils.uri import add_databricks_profile_info_to_artifact_uri, is_local_uri
 from mlflow.utils.validation import (
     MAX_METRICS_PER_BATCH,
     MAX_PARAMS_TAGS_PER_BATCH,
@@ -410,9 +410,12 @@ class TrackingServiceClient:
             return cached_repo
         else:
             run = self.get_run(run_id)
-            artifact_uri = add_databricks_profile_info_to_artifact_uri(
-                run.info.artifact_uri, self.tracking_uri
-            )
+            if is_local_uri(self.tracking_uri) and not is_local_uri(run.info.artifact_uri):
+                artifact_uri = self.tracking_uri
+            else:
+                artifact_uri = add_databricks_profile_info_to_artifact_uri(
+                    run.info.artifact_uri, self.tracking_uri
+                )
             artifact_repo = get_artifact_repository(artifact_uri)
             # Cache the artifact repo to avoid a future network call, removing the oldest
             # entry in the cache if there are too many elements

--- a/tests/tracking/_tracking_service/test_tracking_service_client.py
+++ b/tests/tracking/_tracking_service/test_tracking_service_client.py
@@ -35,6 +35,8 @@ def newTrackingServiceClient():
         ),
         ("s3:/path", "databricks://profile", "s3:/path"),
         ("ftp://user:pass@host/path", "databricks://profile", "ftp://user:pass@host/path"),
+        ("mlflow-artifacts:/run-id", "file:///tmp/", "file:///tmp/"),
+        ("file:///tmp/artifact", "file:///tmp/", "file:///tmp/artifact"),
     ],
 )
 def test_get_artifact_repo(artifact_uri, databricks_uri, uri_for_repo):


### PR DESCRIPTION
- Added a check to see if the tracking uri scheme is 'file' and if so, use the local artifact repository to log the artifact

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Close #7819

## What changes are proposed in this pull request?

I noticed that the function `add_databricks_profile_info_to_artifact_uri` switches the `artifact_location` assigned in _meta.yaml_ with the tracking uri given in the code that a user runs (https://github.com/mlflow/mlflow/blob/master/mlflow/utils/uri.py#L149-L150), so I think that's what's causing this problem. Thus check if the provided tracing uri is a local artifact location, if so assign the `artifact_uri` with the local `tracking_uri` and skip the `add_databricks_profile_info_to_artifact_uri` function.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

I tested this manually by using one the example provided in the bug report issue.

```python
import mlflow
mlflow_exp_name = 'object_detection'
mlflow.set_tracking_uri('file:///efs/mlflow/mlruns')
os.environ['MLFLOW_EXPERIMENT_NAME'] = mlflow_exp_name

path_html = 'example.html'
with open(path_html, "w") as f:
    f.write('')
with mlflow.start_run():
    mlflow.log_artifact(path_html)
```

Steps to reproduce this issue:

1. Make a experiment from the UI with the name `object_detection` without providing the artifact location.
2. Run the code given above.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
