### PR TITLE
Fix keras version in tensorflow model saving

### DIFF
--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -265,6 +265,15 @@ _NO_MODEL_SIGNATURE_WARNING = (
 )
 
 
+def _get_keras_version():
+    import tensorflow
+    if Version(tensorflow.__version__) >= Version("2.6.0"):
+        import keras
+        return keras.__version__
+    else:
+        return tensorflow.__version__
+
+
 def save_model(
     model,
     path,
@@ -439,15 +448,11 @@ def save_model(
         pyfunc_options = {
             "data": data_subpath,
         }
-        if Version(tensorflow.__version__) >= Version("2.6.0"):
-            import keras
-            keras_version = keras.__version__
-        else:
-            keras_version = keras_module.__version__
+
         flavor_options = {
             **pyfunc_options,
             "model_type": _MODEL_TYPE_KERAS,
-            "keras_version": keras_version,
+            "keras_version": _get_keras_version(),
             "save_format": save_format,
         }
     elif isinstance(model, tensorflow.Module):
@@ -535,7 +540,7 @@ def _load_keras_model(model_path, keras_module, save_format, **kwargs):
 
     # keras in tensorflow used to have a '-tf' suffix in the version:
     # https://github.com/tensorflow/tensorflow/blob/v2.2.1/tensorflow/python/keras/__init__.py#L36
-    unsuffixed_version = re.sub(r"-tf$", "", keras_module.__version__)
+    unsuffixed_version = re.sub(r"-tf$", "", _get_keras_version())
     if save_format == "h5" and Version(unsuffixed_version) >= Version("2.2.3"):
         # NOTE: Keras 2.2.3 does not work with unicode paths in python2. Pass in h5py.File instead
         # of string to avoid issues.

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -267,8 +267,10 @@ _NO_MODEL_SIGNATURE_WARNING = (
 
 def _get_keras_version(keras_module):
     import tensorflow
+
     if Version(tensorflow.__version__) >= Version("2.6.0"):
         import keras
+
         return keras.__version__
     else:
         return keras_module.__version__

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -439,10 +439,15 @@ def save_model(
         pyfunc_options = {
             "data": data_subpath,
         }
+        if Version(tensorflow.__version__) >= Version("2.6.0"):
+            import keras
+            keras_version = keras.__version__
+        else:
+            keras_version = keras_module.__version__
         flavor_options = {
             **pyfunc_options,
             "model_type": _MODEL_TYPE_KERAS,
-            "keras_version": keras_module.__version__,
+            "keras_version": keras_version,
             "save_format": save_format,
         }
     elif isinstance(model, tensorflow.Module):

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -265,13 +265,13 @@ _NO_MODEL_SIGNATURE_WARNING = (
 )
 
 
-def _get_keras_version():
+def _get_keras_version(keras_module):
     import tensorflow
     if Version(tensorflow.__version__) >= Version("2.6.0"):
         import keras
         return keras.__version__
     else:
-        return tensorflow.__version__
+        return keras_module.__version__
 
 
 def save_model(
@@ -452,7 +452,7 @@ def save_model(
         flavor_options = {
             **pyfunc_options,
             "model_type": _MODEL_TYPE_KERAS,
-            "keras_version": _get_keras_version(),
+            "keras_version": _get_keras_version(keras_module),
             "save_format": save_format,
         }
     elif isinstance(model, tensorflow.Module):
@@ -540,7 +540,7 @@ def _load_keras_model(model_path, keras_module, save_format, **kwargs):
 
     # keras in tensorflow used to have a '-tf' suffix in the version:
     # https://github.com/tensorflow/tensorflow/blob/v2.2.1/tensorflow/python/keras/__init__.py#L36
-    unsuffixed_version = re.sub(r"-tf$", "", _get_keras_version())
+    unsuffixed_version = re.sub(r"-tf$", "", _get_keras_version(keras_module))
     if save_format == "h5" and Version(unsuffixed_version) >= Version("2.2.3"):
         # NOTE: Keras 2.2.3 does not work with unicode paths in python2. Pass in h5py.File instead
         # of string to avoid issues.

--- a/tests/tensorflow/test_keras_model_export.py
+++ b/tests/tensorflow/test_keras_model_export.py
@@ -622,11 +622,14 @@ def test_load_without_save_format(tf_keras_model, model_path):
 # TODO: Remove skipif condition `not Version(tf.__version__).is_devrelease` once
 #  https://github.com/huggingface/transformers/issues/22421 is resolved.
 @pytest.mark.skipif(
-    not (_is_importable("transformers") and Version(tf.__version__) >= Version("2.6.0")
-         and not Version(tf.__version__).is_devrelease),
+    not (
+        _is_importable("transformers")
+        and Version(tf.__version__) >= Version("2.6.0")
+        and not Version(tf.__version__).is_devrelease
+    ),
     reason="This test requires transformers, which is no longer compatible with Keras < 2.6.0, "
-           "and transformers is not compatible with Tensorflow dev version, see "
-           "https://github.com/huggingface/transformers/issues/22421",
+    "and transformers is not compatible with Tensorflow dev version, see "
+    "https://github.com/huggingface/transformers/issues/22421",
 )
 def test_pyfunc_serve_and_score_transformers():
     from transformers import BertConfig, TFBertModel  # pylint: disable=import-error

--- a/tests/tensorflow/test_keras_model_export.py
+++ b/tests/tensorflow/test_keras_model_export.py
@@ -619,9 +619,14 @@ def test_load_without_save_format(tf_keras_model, model_path):
     assert tf_keras_model.to_json() == model_loaded.to_json()
 
 
+# TODO: Remove skipif condition `not Version(tf.__version__).is_devrelease` once
+#  https://github.com/huggingface/transformers/issues/22421 is resolved.
 @pytest.mark.skipif(
-    not (_is_importable("transformers") and Version(tf.__version__) >= Version("2.6.0")),
-    reason="This test requires transformers, which is no longer compatible with Keras < 2.6.0",
+    not (_is_importable("transformers") and Version(tf.__version__) >= Version("2.6.0")
+         and not Version(tf.__version__).is_devrelease),
+    reason="This test requires transformers, which is no longer compatible with Keras < 2.6.0, "
+           "and transformers is not compatible with Tensorflow dev version, see "
+           "https://github.com/huggingface/transformers/issues/22421",
 )
 def test_pyfunc_serve_and_score_transformers():
     from transformers import BertConfig, TFBertModel  # pylint: disable=import-error


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fixes https://github.com/mlflow/mlflow/actions/runs/4524745992/jobs/7968792442#step:13:104075

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
