### PR TITLE
Enable `load_model` for UC models

### DIFF
--- a/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
+++ b/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
@@ -99,12 +99,19 @@ class UnityCatalogModelsArtifactRepository(ArtifactRepository):
         raise MlflowException("This repository does not support listing artifacts.")
 
     def download_artifacts(self, artifact_path, dst_path=None):
+        print("========= UC REPO =========")
+        print("artifact_path: " + artifact_path)
+        print("dst_path: " + dst_path)
         scoped_token = self._get_scoped_token()
+        print("Scoped token: " + scoped_token)
         blob_storage_path = self._get_blob_storage_path()
+        print("Blob storage path: " + blob_storage_path)
         repo = get_artifact_repo_from_storage_info(
             storage_location=blob_storage_path, scoped_token=scoped_token
         )
-        repo.download_artifacts(artifact_path, dst_path)
+        print("UC repo: " + repo)
+        local_path = repo.download_artifacts(artifact_path, dst_path)
+        return local_path
 
     def log_artifact(self, local_file, artifact_path=None):
         raise MlflowException("This repository does not support logging artifacts.")

--- a/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
+++ b/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
@@ -104,7 +104,7 @@ class UnityCatalogModelsArtifactRepository(ArtifactRepository):
         repo = get_artifact_repo_from_storage_info(
             storage_location=blob_storage_path, scoped_token=scoped_token
         )
-        repo.download_artifacts(artifact_path, dst_path)
+        repo.download_artifacts('', dst_path)
 
     def log_artifact(self, local_file, artifact_path=None):
         raise MlflowException("This repository does not support logging artifacts.")

--- a/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
+++ b/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
@@ -99,19 +99,12 @@ class UnityCatalogModelsArtifactRepository(ArtifactRepository):
         raise MlflowException("This repository does not support listing artifacts.")
 
     def download_artifacts(self, artifact_path, dst_path=None):
-        print("========= UC REPO =========")
-        print("artifact_path: " + artifact_path)
-        print("dst_path: " + dst_path)
         scoped_token = self._get_scoped_token()
-        print("Scoped token: " + scoped_token)
         blob_storage_path = self._get_blob_storage_path()
-        print("Blob storage path: " + blob_storage_path)
         repo = get_artifact_repo_from_storage_info(
             storage_location=blob_storage_path, scoped_token=scoped_token
         )
-        print("UC repo: " + repo)
-        local_path = repo.download_artifacts(artifact_path, dst_path)
-        return local_path
+        return repo.download_artifacts(artifact_path, dst_path)
 
     def log_artifact(self, local_file, artifact_path=None):
         raise MlflowException("This repository does not support logging artifacts.")

--- a/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
+++ b/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
@@ -104,7 +104,7 @@ class UnityCatalogModelsArtifactRepository(ArtifactRepository):
         repo = get_artifact_repo_from_storage_info(
             storage_location=blob_storage_path, scoped_token=scoped_token
         )
-        repo.download_artifacts('', dst_path)
+        repo.download_artifacts(artifact_path, dst_path)
 
     def log_artifact(self, local_file, artifact_path=None):
         raise MlflowException("This repository does not support logging artifacts.")

--- a/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
+++ b/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
@@ -122,18 +122,20 @@ def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_aws(
             "session_token": fake_session_token,
         }
     }
+    fake_local_path = "/tmp/fake_path"
     with mock.patch.object(
         MlflowClient, "get_model_version_download_uri", return_value=artifact_location
     ), mock.patch("mlflow.utils.rest_utils.http_request") as request_mock, mock.patch(
         "mlflow.store.artifact.s3_artifact_repo.S3ArtifactRepository"
     ) as s3_artifact_repo_class_mock:
         mock_s3_repo = mock.MagicMock(autospec=S3ArtifactRepository)
+        mock_s3_repo.download_artifacts.return_value = fake_local_path
         s3_artifact_repo_class_mock.return_value = mock_s3_repo
         request_mock.return_value = _mock_temporary_creds_response(temporary_creds)
         models_repo = UnityCatalogModelsArtifactRepository(
             artifact_uri="models:/MyModel/12", registry_uri=_DATABRICKS_UNITY_CATALOG_SCHEME
         )
-        models_repo.download_artifacts("artifact_path", "dst_path")
+        assert models_repo.download_artifacts("artifact_path", "dst_path") == fake_local_path
         s3_artifact_repo_class_mock.assert_called_once_with(
             artifact_uri=artifact_location,
             access_key_id=fake_key_id,
@@ -160,18 +162,20 @@ def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_azure(
             "sas_token": fake_sas_token,
         },
     }
+    fake_local_path = "/tmp/fake_path"
     with mock.patch.object(
         MlflowClient, "get_model_version_download_uri", return_value=artifact_location
     ), mock.patch("mlflow.utils.rest_utils.http_request") as request_mock, mock.patch(
         "mlflow.store.artifact.azure_data_lake_artifact_repo.AzureDataLakeArtifactRepository"
     ) as adls_artifact_repo_class_mock:
         mock_adls_repo = mock.MagicMock(autospec=AzureDataLakeArtifactRepository)
+        mock_adls_repo.download_artifacts.return_value = fake_local_path
         adls_artifact_repo_class_mock.return_value = mock_adls_repo
         request_mock.return_value = _mock_temporary_creds_response(temporary_creds)
         models_repo = UnityCatalogModelsArtifactRepository(
             artifact_uri="models:/MyModel/12", registry_uri=_DATABRICKS_UNITY_CATALOG_SCHEME
         )
-        models_repo.download_artifacts("artifact_path", "dst_path")
+        assert models_repo.download_artifacts("artifact_path", "dst_path") == fake_local_path
         adls_artifact_repo_class_mock.assert_called_once_with(
             artifact_uri=artifact_location, credential=ANY
         )
@@ -198,6 +202,7 @@ def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_gcp(
             "oauth_token": fake_oauth_token,
         },
     }
+    fake_local_path = "/tmp/fake_path"
     with mock.patch.object(
         MlflowClient, "get_model_version_download_uri", return_value=artifact_location
     ), mock.patch("mlflow.utils.rest_utils.http_request") as request_mock, mock.patch(
@@ -208,12 +213,13 @@ def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_gcp(
         mock_gcs_client = mock.MagicMock(autospec=Client)
         gcs_client_class_mock.return_value = mock_gcs_client
         mock_gcs_repo = mock.MagicMock(autospec=GCSArtifactRepository)
+        mock_gcs_repo.download_artifacts.return_value = fake_local_path
         gcs_artifact_repo_class_mock.return_value = mock_gcs_repo
         request_mock.return_value = _mock_temporary_creds_response(temporary_creds)
         models_repo = UnityCatalogModelsArtifactRepository(
             artifact_uri="models:/MyModel/12", registry_uri=_DATABRICKS_UNITY_CATALOG_SCHEME
         )
-        models_repo.download_artifacts("artifact_path", "dst_path")
+        assert models_repo.download_artifacts("artifact_path", "dst_path") == fake_local_path
         gcs_artifact_repo_class_mock.assert_called_once_with(
             artifact_uri=artifact_location, client=ANY
         )


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

This PR fixes a small bug to enable loading models from UC in Databricks.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

I successfully loaded a model. See screenshot below:
<img width="1768" alt="Screen Shot 2023-03-27 at 2 50 54 PM" src="https://user-images.githubusercontent.com/66143562/228075134-5c9fbc14-1860-4f14-9b00-c5bc764bd014.png">


## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
