### PR TITLE
Parallelize chunk uploads in a multipart upload

### DIFF
--- a/mlflow/azure/client.py
+++ b/mlflow/azure/client.py
@@ -7,6 +7,7 @@ import urllib
 import logging
 
 from mlflow.utils import rest_utils
+from mlflow.utils.file_utils import read_chunk
 
 _logger = logging.getLogger(__name__)
 _PUT_BLOCK_HEADERS = {
@@ -38,16 +39,19 @@ def put_adls_file_creation(sas_url, headers):
         rest_utils.augmented_raise_for_status(response)
 
 
-def patch_adls_file_upload(sas_url, data, position, headers, is_single):
+def patch_adls_file_upload(sas_url, local_file, start_byte, size, position, headers, is_single):
     """
     Performs an ADLS Azure file create `Patch` operation
     (https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update)
 
     :param sas_url: A shared access signature URL referring to the Azure ADLS server
                     to which the file update command should be issued.
-    :param data: Data to include in the Patch request body.
+    :param local_file: The local file to upload
+    :param start_byte: The starting byte of the local file to upload
+    :param size: The number of bytes to upload
     :param position: Positional offset of the data in the Patch request
     :param headers: Additional headers to include in the Patch request body
+    :param is_single: Whether this is the only patch operation for this file
     """
     new_params = {"action": "append", "position": str(position)}
     if is_single:
@@ -61,6 +65,7 @@ def patch_adls_file_upload(sas_url, data, position, headers, is_single):
         else:
             _logger.debug("Removed unsupported '%s' header for ADLS Gen2 Patch operation", name)
 
+    data = read_chunk(local_file, size, start_byte)
     with rest_utils.cloud_storage_http_request(
         "patch", request_url, data=data, headers=request_headers
     ) as response:

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -13,7 +13,7 @@ from mlflow.utils.validation import path_not_unique, bad_path_message
 
 # Constants used to determine max level of parallelism to use while uploading/downloading artifacts.
 # Max threads to use for parallelism.
-_NUM_MAX_THREADS = 8
+_NUM_MAX_THREADS = 20
 # Max threads per CPU
 _NUM_MAX_THREADS_PER_CPU = 2
 assert _NUM_MAX_THREADS >= _NUM_MAX_THREADS_PER_CPU

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -6,6 +6,7 @@ import requests
 import uuid
 import math
 from collections import namedtuple
+from concurrent.futures import as_completed
 
 from mlflow.azure.client import (
     put_adls_file_creation,
@@ -39,10 +40,10 @@ from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.file_utils import (
     download_file_using_http_uri,
     relative_path_to_artifact_path,
-    yield_file_in_chunks,
 )
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils import rest_utils
+from mlflow.utils.file_utils import read_chunk
 from mlflow.utils.rest_utils import (
     call_endpoint,
     extract_api_info_for_service,
@@ -58,7 +59,6 @@ from mlflow.utils.uri import (
 )
 
 _logger = logging.getLogger(__name__)
-_AZURE_MAX_BLOCK_CHUNK_SIZE = 100000000  # Max. size of each block allowed is 100 MB in stage_block
 _DOWNLOAD_CHUNK_SIZE = 100000000
 _MULTIPART_UPLOAD_CHUNK_SIZE = 10_000_000  # 10 MB
 _MAX_CREDENTIALS_REQUEST_SIZE = 2000  # Max number of artifact paths in a single credentials request
@@ -66,6 +66,13 @@ _SERVICE_AND_METHOD_TO_INFO = {
     service: extract_api_info_for_service(service, _REST_API_PATH_PREFIX)
     for service in [MlflowService, DatabricksMlflowArtifactsService]
 }
+
+
+def _compute_num_chunks(local_file: os.PathLike, chunk_size: int) -> int:
+    """
+    Computes the number of chunks to use for a multipart upload of the specified file.
+    """
+    return math.ceil(os.path.getsize(local_file) / chunk_size)
 
 
 class DatabricksArtifactRepository(ArtifactRepository):
@@ -194,6 +201,47 @@ class DatabricksArtifactRepository(ArtifactRepository):
         """
         return {header.name: header.value for header in headers}
 
+    def _complete_futures(self, futures_dict):
+        """
+        Waits for the completion of all the futures in the given dictionary and returns
+        a tuple of two dictionaries. The first dictionary contains the results of the
+        futures (unordered) and the second contains the errors (unordered) that occurred
+        during the execution of the futures.
+        """
+        results = {}
+        errors = {}
+        for future in as_completed(futures_dict):
+            key = futures_dict[future]
+            try:
+                results[key] = future.result()
+            except Exception as e:
+                errors[key] = repr(e)
+
+        return results, errors
+
+    def _azure_upload_chunk(
+        self, credentials, headers, local_file, artifact_path, start_byte, size
+    ):
+        # Base64-encode a UUID, producing a UTF8-encoded bytestring. Then, decode
+        # the bytestring for compliance with Azure Blob Storage API requests
+        block_id = base64.b64encode(uuid.uuid4().hex.encode()).decode("utf-8")
+        chunk = read_chunk(local_file, size, start_byte)
+        try:
+            put_block(credentials.signed_uri, block_id, chunk, headers=headers)
+        except requests.HTTPError as e:
+            if e.response.status_code in [401, 403]:
+                _logger.info(
+                    "Failed to authorize request, possibly due to credential expiration."
+                    " Refreshing credentials and trying again..."
+                )
+                credential_info = self._get_write_credential_infos(
+                    run_id=self.run_id, paths=[artifact_path]
+                )[0]
+                put_block(credential_info.signed_uri, block_id, chunk, headers=headers)
+            else:
+                raise e
+        return block_id
+
     def _azure_upload_file(self, credentials, local_file, artifact_path):
         """
         Uploads a file to a given Azure storage location.
@@ -207,26 +255,29 @@ class DatabricksArtifactRepository(ArtifactRepository):
         """
         try:
             headers = self._extract_headers_from_credentials(credentials.headers)
-            uploading_block_list = []
-            for chunk in yield_file_in_chunks(local_file, _AZURE_MAX_BLOCK_CHUNK_SIZE):
-                # Base64-encode a UUID, producing a UTF8-encoded bytestring. Then, decode
-                # the bytestring for compliance with Azure Blob Storage API requests
-                block_id = base64.b64encode(uuid.uuid4().hex.encode()).decode("utf-8")
-                try:
-                    put_block(credentials.signed_uri, block_id, chunk, headers=headers)
-                except requests.HTTPError as e:
-                    if e.response.status_code in [401, 403]:
-                        _logger.info(
-                            "Failed to authorize request, possibly due to credential expiration."
-                            " Refreshing credentials and trying again..."
-                        )
-                        credential_info = self._get_write_credential_infos(
-                            run_id=self.run_id, paths=[artifact_path]
-                        )[0]
-                        put_block(credential_info.signed_uri, block_id, chunk, headers=headers)
-                    else:
-                        raise e
-                uploading_block_list.append(block_id)
+            futures = {}
+            num_chunks = _compute_num_chunks(local_file, _MULTIPART_UPLOAD_CHUNK_SIZE)
+            for index in range(num_chunks):
+                start_byte = index * _MULTIPART_UPLOAD_CHUNK_SIZE
+                future = self.thread_pool.submit(
+                    self._azure_upload_chunk,
+                    credentials=credentials,
+                    headers=headers,
+                    local_file=local_file,
+                    artifact_path=artifact_path,
+                    start_byte=start_byte,
+                    size=_MULTIPART_UPLOAD_CHUNK_SIZE,
+                )
+                futures[future] = index
+
+            results, errors = self._complete_futures(futures)
+            if errors:
+                raise MlflowException(
+                    f"Failed to upload at least one part of {local_file}. Errors: {errors}"
+                )
+            # Sort results by the chunk index
+            uploading_block_list = [results[index] for index in sorted(results)]
+
             try:
                 put_block_list(credentials.signed_uri, uploading_block_list, headers=headers)
             except requests.HTTPError as e:
@@ -280,24 +331,31 @@ class DatabricksArtifactRepository(ArtifactRepository):
             )
 
             # next try to append the file
-            cursor_position = 0
-            use_single_part_upload = False
-            for idx, chunk in enumerate(
-                yield_file_in_chunks(local_file, _AZURE_MAX_BLOCK_CHUNK_SIZE)
-            ):
-                cur_chunk_size = len(chunk)
-                if idx == 0 and cur_chunk_size < _AZURE_MAX_BLOCK_CHUNK_SIZE:
-                    use_single_part_upload = True
-                self._retryable_adls_function(
+            futures = {}
+            file_size = os.path.getsize(local_file)
+            num_chunks = _compute_num_chunks(local_file, _MULTIPART_UPLOAD_CHUNK_SIZE)
+            use_single_part_upload = num_chunks == 1
+            for index in range(num_chunks):
+                start_byte = index * _MULTIPART_UPLOAD_CHUNK_SIZE
+                future = self.thread_pool.submit(
+                    self._retryable_adls_function,
                     func=patch_adls_file_upload,
                     artifact_path=artifact_path,
                     sas_url=credentials.signed_uri,
-                    data=chunk,
-                    position=cursor_position,
+                    local_file=local_file,
+                    start_byte=start_byte,
+                    size=_MULTIPART_UPLOAD_CHUNK_SIZE,
+                    position=start_byte,
                     headers=headers,
                     is_single=use_single_part_upload,
                 )
-                cursor_position += cur_chunk_size
+                futures[future] = index
+
+            _, errors = self._complete_futures(futures)
+            if errors:
+                raise MlflowException(
+                    f"Failed to upload at least one part of {artifact_path}. Errors: {errors}"
+                )
 
             # finally try to flush the file
             if not use_single_part_upload:
@@ -305,7 +363,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
                     func=patch_adls_flush,
                     artifact_path=artifact_path,
                     sas_url=credentials.signed_uri,
-                    position=cursor_position,
+                    position=file_size,
                     headers=headers,
                 )
         except Exception as err:
@@ -435,7 +493,8 @@ class DatabricksArtifactRepository(ArtifactRepository):
             augmented_raise_for_status(response)
             return response.headers["ETag"]
 
-    def _upload_part_retry(self, cred_info, upload_id, part_number, data):
+    def _upload_part_retry(self, cred_info, upload_id, part_number, local_file, start_byte, size):
+        data = read_chunk(local_file, size, start_byte)
         try:
             return self._upload_part(cred_info, data)
         except requests.HTTPError as e:
@@ -451,18 +510,31 @@ class DatabricksArtifactRepository(ArtifactRepository):
             return self._upload_part(resp.upload_credential_info, data)
 
     def _upload_parts(self, local_file, create_mpu_resp):
-        part_etags = []
-        # TODO: Parallelize part uploads
-        with open(local_file, "rb") as f:
-            for idx, upload_info in enumerate(create_mpu_resp.upload_credential_infos):
-                part_number = idx + 1
-                data = f.read(_MULTIPART_UPLOAD_CHUNK_SIZE)
-                etag = self._upload_part_retry(
-                    upload_info, create_mpu_resp.upload_id, part_number, data
-                )
-                part_etags.append(PartEtag(part_number=part_number, etag=etag))
+        futures = {}
+        for index, cred_info in enumerate(create_mpu_resp.upload_credential_infos):
+            part_number = index + 1
+            start_byte = index * _MULTIPART_UPLOAD_CHUNK_SIZE
+            future = self.thread_pool.submit(
+                self._upload_part_retry,
+                cred_info=cred_info,
+                upload_id=create_mpu_resp.upload_id,
+                part_number=part_number,
+                local_file=local_file,
+                start_byte=start_byte,
+                size=_MULTIPART_UPLOAD_CHUNK_SIZE,
+            )
+            futures[future] = part_number
 
-        return part_etags
+        results, errors = self._complete_futures(futures)
+        if errors:
+            raise MlflowException(
+                f"Failed to upload at least one part of {local_file}. Errors: {errors}"
+            )
+
+        return [
+            PartEtag(part_number=part_number, etag=results[part_number])
+            for part_number in sorted(results)
+        ]
 
     def _complete_multipart_upload(self, run_id, path, upload_id, part_etags):
         return self._call_endpoint(
@@ -487,7 +559,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
             return response
 
     def _multipart_upload(self, local_file, artifact_path):
-        num_parts = math.ceil(os.path.getsize(local_file) / _MULTIPART_UPLOAD_CHUNK_SIZE)
+        num_parts = _compute_num_chunks(local_file, _MULTIPART_UPLOAD_CHUNK_SIZE)
         create_mpu_resp = self._create_multipart_upload(self.run_id, artifact_path, num_parts)
         try:
             part_etags = self._upload_parts(local_file, create_mpu_resp)

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -718,3 +718,18 @@ def contains_path_separator(path):
     Returns True if a path contains a path separator, False otherwise.
     """
     return any((sep in path) for sep in (os.path.sep, os.path.altsep) if sep is not None)
+
+
+def read_chunk(path: os.PathLike, size: int, start_byte: int = 0) -> bytes:
+    """
+    Read a chunk of bytes from a file.
+
+    :param path: Path to the file.
+    :param size: The size of the chunk.
+    :param start_byte: The start byte of the chunk.
+    :return: The chunk of bytes.
+    """
+    with open(path, "rb") as f:
+        if start_byte > 0:
+            f.seek(start_byte)
+        return f.read(size)

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -335,7 +335,7 @@ def test_log_artifact_adls_gen2_with_headers(
     ) as write_credential_infos_mock, mock.patch(
         "requests.Session.request", return_value=mock_response
     ) as request_mock, mock.patch(
-        "mlflow.store.artifact.databricks_artifact_repo._AZURE_MAX_BLOCK_CHUNK_SIZE",
+        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}._MULTIPART_UPLOAD_CHUNK_SIZE",
         5,
     ):
         databricks_artifact_repo.log_artifact(test_file.strpath, artifact_path)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Parallelize chunk uploads in a multipart upload.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)
  - [x] AWS
  - [x] Azure ADLS Gen 2
  - [x] Azure 

<details><summary>Benchmark code</summary>
<p>

```python
import math
import tempfile
import threading
import time
import urllib
import uuid
import hashlib
import random
import string
from contextlib import contextmanager
from unittest import mock
from urllib.parse import parse_qs, urlparse


import pandas
import requests
import torch
from PIL import Image
from torchvision import transforms

import mlflow


def log_and_load_large_model():
    """
    Log a large model to MLflow and load it back, and ensure that the loaded model is the same as the
    original model by comparing the output of the model on a sample input.
    """
    model = torch.hub.load("pytorch/vision:v0.10.0", "resnet152", pretrained=True)
    model.eval()

    with tempfile.TemporaryDirectory() as tmpdir:
        url = "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
        filepath = f"{tmpdir}/dog.jpg"
        try:
            urllib.URLopener().retrieve(url, filepath)
        except:
            urllib.request.urlretrieve(url, filepath)

        input_image = Image.open(filepath)

    preprocess = transforms.Compose(
        [
            transforms.Resize(256),
            transforms.CenterCrop(224),
            transforms.ToTensor(),
            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
        ]
    )
    input_tensor = preprocess(input_image)
    input_batch = input_tensor.unsqueeze(0)  # create a mini-batch as expected by the model

    with torch.no_grad():
        output = model(input_batch)

    with mlflow.start_run():
        print("Logging model")
        info = mlflow.pytorch.log_model(model, "model", pip_requirements=["torch"])
        print("Loading model")
        loaded_model = mlflow.pytorch.load_model(info.model_uri)

    output_loaded = loaded_model(input_batch)
    print("Comparing output")
    assert torch.equal(output, output_loaded)


lock = threading.Lock()


@contextmanager
def timer():
    start = time.time()
    yield lambda: time.time() - start


def extract_params_from_url(url):
    parsed = urlparse(url)
    return tuple(
        k
        for k in parse_qs(parsed.query).keys()
        if k
        in [
            "uploadId",
            "partNumber",
        ]
    )


def md5_checksum(path):
    with open(path, "rb") as f:
        file_hash = hashlib.md5()
        while chunk := f.read(8192):
            file_hash.update(chunk)
    return file_hash.hexdigest()


MB = 1_000_000


def log_and_load_random_text():
    with tempfile.TemporaryDirectory() as tmpdir:
        random_text_path = f"{tmpdir}/random.txt"
        print("Creating random text file")
        content = "".join(random.choices(string.ascii_uppercase + string.digits, k=30 * MB))
        with open(random_text_path, "w") as f:
            f.write(content)

        with mlflow.start_run():
            print("Logging random text file")
            mlflow.log_artifact(random_text_path)

            # Load the artifact back and ensure that the checksums match
            artifact_uri = mlflow.get_artifact_uri("random.txt")
            print("Downloading random text file")
            dst = mlflow.artifacts.download_artifacts(artifact_uri, dst_path=tmpdir)
            print("Comparing checksums")
            assert md5_checksum(random_text_path) == md5_checksum(dst)

            with open(dst, "r") as f:
                content_loaded = f.read()
                assert content == content_loaded


def main():
    mlflow.set_tracking_uri("databricks")
    mlflow.set_experiment("/Users/harutaka.kawamura@databricks.com/test")
    log_and_load_large_model()
    log_and_load_random_text()

    file_size = 10 * 1000**3

    with tempfile.TemporaryDirectory() as tmpdir:
        filename = str(uuid.uuid4())
        # Create a 10GB file
        path = f"{tmpdir}/{filename}"
        with open(f"{tmpdir}/{filename}", "wb") as f:
            f.seek(1 * file_size - 1)
            f.write(b"\0")

        stats_path = f"{tmpdir}/stats.csv"
        with open(stats_path, "w") as f:
            f.write("method,url,chunk_size_in_mb,num_chunks,time\n")

        # Wrap requests.Session.request to measure how long each request takes
        original = requests.Session.request

        for chunk_size_in_mb in [10, 25, 50, 100]:
            print("=" * 20, f"Chunk size: {chunk_size_in_mb}MB", "=" * 20)
            chunk_size = chunk_size_in_mb * MB
            num_chunks = math.ceil(file_size / chunk_size)

            def new_request(*args, **kwargs):
                with timer() as t:
                    result = original(*args, **kwargs)
                    elapsed = t()
                    method, url = args[1:3]
                    print(method, url, f"took {elapsed:.3} seconds")
                    with lock:
                        with open(stats_path, "a") as f:
                            f.write(
                                f"{method.lower()},{url},{chunk_size_in_mb},{num_chunks},{elapsed}\n"
                            )

                    return result

            mock_chunk_size = mock.patch(
                "mlflow.store.artifact.databricks_artifact_repo._MULTIPART_UPLOAD_CHUNK_SIZE",
                chunk_size,
            )
            mock_request = mock.patch("requests.Session.request", new_request)
            with mock_chunk_size, mock_request:
                with mlflow.start_run():
                    with timer() as t:
                        mlflow.log_artifact(path)
                        elapsed = t()
                        print(f"mlflow.log_artifact took {elapsed:.3} seconds")

        df = pandas.read_csv(stats_path)
        df = df[df["url"].str.contains("/artifacts/")]
        df["params"] = df["url"].apply(extract_params_from_url)
        df["path"] = df["url"].apply(lambda url: urlparse(url).path)
        df["path"] = df["path"].apply(lambda path: path[:60] + "..." if len(path) > 60 else path)
        # Extract the comp parameter from the URL
        df = (
            df.groupby(["method", "path", "chunk_size_in_mb", "num_chunks"])
            .agg(
                time_min_in_sec=("time", "min"),
                time_max_in_sec=("time", "max"),
                time_mean_in_sec=("time", "mean"),
                count=("time", "count"),
            )
            .reset_index()
            .sort_values(["path", "method", "chunk_size_in_mb"])
        )
        print(df.to_markdown(index=False))


if __name__ == "__main__":
    main()

```

```
mkdir -p ~/miniconda3
wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
rm -rf ~/miniconda3/miniconda.sh
~/miniconda3/bin/conda init bash
source ~/.bashrc
conda create -n mlflow python=3.8

cd /tmp
git clone --branch parallelize-azure-upload https://github.com/harupy/mlflow.git
cd mlflow
pip install -e .
git fetch origin master
git fetch origin parallelize-azure-upload
git pull origin parallelize-azure-upload
git reset --hard origin/parallelize-azure-upload
export DATABRICKS_TOKEN=...
export DATABRICKS_HOST=...
```


</p>
</details> 

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
