### PR TITLE
Implement parallelized artifact/model downloads using range headers

### DIFF
--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -43,6 +43,7 @@ from mlflow.utils.file_utils import (
     parallelized_download_file_using_http_uri,
     download_chunk,
 )
+from mlflow.utils.os import is_windows
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils import rest_utils
 from mlflow.utils.file_utils import read_chunk
@@ -745,7 +746,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
         # Read credentials for only one file were requested. So we expected only one value in
         # the response.
         assert len(read_credentials) == 1
-        if file_size is None or file_size <= _DOWNLOAD_CHUNK_SIZE:
+        if file_size is None or file_size <= _DOWNLOAD_CHUNK_SIZE or is_windows():
             self._download_from_cloud(
                 cloud_credential_info=read_credentials[0],
                 dst_local_file_path=local_path,

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -726,9 +726,10 @@ class DatabricksArtifactRepository(ArtifactRepository):
         return infos
 
     def _download_file(self, remote_file_path, local_path):
-        # list_artifacts API only returns a list of FileInfos at the specified path if it's a directory.
-        # To get file size, we need to iterate over FileInfos contained by the parent directory. A bad path
-        # could result in there being no matching FileInfos (by path), so fall back to None size to prevent
+        # list_artifacts API only returns a list of FileInfos at the specified path
+        # if it's a directory. To get file size, we need to iterate over FileInfos
+        # contained by the parent directory. A bad path could result in there being
+        # no matching FileInfos (by path), so fall back to None size to prevent
         # parallelized download.
         parent_dir, _ = posixpath.split(remote_file_path)
         file_infos = self.list_artifacts(parent_dir)

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -418,7 +418,9 @@ class DatabricksArtifactRepository(ArtifactRepository):
                 message="Cloud provider not supported.", error_code=INTERNAL_ERROR
             )
 
-    def _parallelized_download_from_cloud(self, cloud_credential_info, file_size, dst_local_file_path, dst_run_relative_artifact_path):
+    def _parallelized_download_from_cloud(
+        self, cloud_credential_info, file_size, dst_local_file_path, dst_run_relative_artifact_path
+    ):
         try:
             failed_downloads = parallelized_download_file_using_http_uri(
                 http_uri=cloud_credential_info.signed_uri,
@@ -429,13 +431,17 @@ class DatabricksArtifactRepository(ArtifactRepository):
                 headers=self._extract_headers_from_credentials(cloud_credential_info.headers),
             )
             if failed_downloads:
-                new_cloud_creds = self._get_read_credential_infos(self.run_id, dst_run_relative_artifact_path)[0]
+                new_cloud_creds = self._get_read_credential_infos(
+                    self.run_id, dst_run_relative_artifact_path
+                )[0]
                 new_signed_uri = new_cloud_creds.signed_uri
                 new_headers = self._extract_headers_from_credentials(new_cloud_creds.headers)
             for i, excep in failed_downloads.items():
                 if excep.response.status_code not in (401, 403):
                     raise excep
-                download_chunk(i, _DOWNLOAD_CHUNK_SIZE, new_headers, dst_local_file_path, new_signed_uri)
+                download_chunk(
+                    i, _DOWNLOAD_CHUNK_SIZE, new_headers, dst_local_file_path, new_signed_uri
+                )
         except Exception as err:
             raise MlflowException(err)
 

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -68,7 +68,6 @@ _SERVICE_AND_METHOD_TO_INFO = {
     service: extract_api_info_for_service(service, _REST_API_PATH_PREFIX)
     for service in [MlflowService, DatabricksMlflowArtifactsService]
 }
-METHOD = "parallel"
 
 
 def _compute_num_chunks(local_file: os.PathLike, chunk_size: int) -> int:
@@ -739,7 +738,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
         # Read credentials for only one file were requested. So we expected only one value in
         # the response.
         assert len(read_credentials) == 1
-        if file_size is None or file_size <= _DOWNLOAD_CHUNK_SIZE or METHOD == "serial":
+        if file_size is None or file_size <= _DOWNLOAD_CHUNK_SIZE:
             self._download_from_cloud(
                 cloud_credential_info=read_credentials[0],
                 dst_local_file_path=local_path,

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -40,6 +40,8 @@ from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.file_utils import (
     download_file_using_http_uri,
     relative_path_to_artifact_path,
+    parallelized_download_file_using_http_uri,
+    download_chunk,
 )
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils import rest_utils
@@ -59,13 +61,14 @@ from mlflow.utils.uri import (
 )
 
 _logger = logging.getLogger(__name__)
-_DOWNLOAD_CHUNK_SIZE = 100000000
+_DOWNLOAD_CHUNK_SIZE = 10_000_000
 _MULTIPART_UPLOAD_CHUNK_SIZE = 10_000_000  # 10 MB
 _MAX_CREDENTIALS_REQUEST_SIZE = 2000  # Max number of artifact paths in a single credentials request
 _SERVICE_AND_METHOD_TO_INFO = {
     service: extract_api_info_for_service(service, _REST_API_PATH_PREFIX)
     for service in [MlflowService, DatabricksMlflowArtifactsService]
 }
+METHOD = "parallel"
 
 
 def _compute_num_chunks(local_file: os.PathLike, chunk_size: int) -> int:
@@ -416,6 +419,27 @@ class DatabricksArtifactRepository(ArtifactRepository):
                 message="Cloud provider not supported.", error_code=INTERNAL_ERROR
             )
 
+    def _parallelized_download_from_cloud(self, cloud_credential_info, file_size, dst_local_file_path, dst_run_relative_artifact_path):
+        try:
+            failed_downloads = parallelized_download_file_using_http_uri(
+                http_uri=cloud_credential_info.signed_uri,
+                download_path=dst_local_file_path,
+                file_size=file_size,
+                uri_type=cloud_credential_info.type,
+                chunk_size=_DOWNLOAD_CHUNK_SIZE,
+                headers=self._extract_headers_from_credentials(cloud_credential_info.headers),
+            )
+            if failed_downloads:
+                new_cloud_creds = self._get_read_credential_infos(self.run_id, dst_run_relative_artifact_path)[0]
+                new_signed_uri = new_cloud_creds.signed_uri
+                new_headers = self._extract_headers_from_credentials(new_cloud_creds.headers)
+            for i, excep in failed_downloads.items():
+                if excep.response.status_code not in (401, 403):
+                    raise excep
+                download_chunk(i, _DOWNLOAD_CHUNK_SIZE, new_headers, dst_local_file_path, new_signed_uri)
+        except Exception as err:
+            raise MlflowException(err)
+
     def _download_from_cloud(self, cloud_credential_info, dst_local_file_path):
         """
         Download a file from the input `cloud_credential_info` and save it to `dst_local_file_path`.
@@ -697,6 +721,15 @@ class DatabricksArtifactRepository(ArtifactRepository):
         return infos
 
     def _download_file(self, remote_file_path, local_path):
+        # list_artifacts API only returns a list of FileInfos at the specified path if it's a directory.
+        # To get file size, we need to iterate over FileInfos contained by the parent directory. A bad path
+        # could result in there being no matching FileInfos (by path), so fall back to None size to prevent
+        # parallelized download.
+        parent_dir, _ = posixpath.split(remote_file_path)
+        file_infos = self.list_artifacts(parent_dir)
+        file_info = [info for info in file_infos if info.path == remote_file_path]
+        file_size = file_info[0].file_size if len(file_info) == 1 else None
+
         run_relative_remote_file_path = posixpath.join(
             self.run_relative_artifact_repo_root_path, remote_file_path
         )
@@ -706,9 +739,15 @@ class DatabricksArtifactRepository(ArtifactRepository):
         # Read credentials for only one file were requested. So we expected only one value in
         # the response.
         assert len(read_credentials) == 1
-        self._download_from_cloud(
-            cloud_credential_info=read_credentials[0], dst_local_file_path=local_path
-        )
+        if file_size is None or file_size <= _DOWNLOAD_CHUNK_SIZE or METHOD == "serial":
+            self._download_from_cloud(
+                cloud_credential_info=read_credentials[0],
+                dst_local_file_path=local_path,
+            )
+        else:
+            self._parallelized_download_from_cloud(
+                read_credentials[0], file_size, local_path, remote_file_path
+            )
 
     def delete_artifacts(self, artifact_path=None):
         raise MlflowException("Not implemented yet")

--- a/mlflow/store/artifact/databricks_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_models_artifact_repo.py
@@ -13,6 +13,7 @@ from mlflow.utils.file_utils import (
     parallelized_download_file_using_http_uri,
     download_chunk,
 )
+from mlflow.utils.os import is_windows
 from mlflow.utils.rest_utils import http_request
 from mlflow.utils.uri import get_databricks_profile_uri_from_artifact_uri
 from mlflow.store.artifact.utils.models import (
@@ -161,7 +162,7 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
             if raw_headers is not None:
                 # Don't send None to _extract_headers_from_signed_url
                 headers = self._extract_headers_from_signed_url(raw_headers)
-            if file_size is None or file_size <= _DOWNLOAD_CHUNK_SIZE:
+            if file_size is None or file_size <= _DOWNLOAD_CHUNK_SIZE or is_windows():
                 download_file_using_http_uri(
                     signed_uri,
                     local_path,

--- a/mlflow/store/artifact/databricks_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_models_artifact_repo.py
@@ -10,7 +10,8 @@ from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.file_utils import (
     download_file_using_http_uri,
-    parallelized_download_file_using_http_uri, download_chunk,
+    parallelized_download_file_using_http_uri,
+    download_chunk,
 )
 from mlflow.utils.rest_utils import http_request
 from mlflow.utils.uri import get_databricks_profile_uri_from_artifact_uri
@@ -123,7 +124,9 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
         filtered_headers = filter(lambda h: "name" in h and "value" in h, headers)
         return {header.get("name"): header.get("value") for header in filtered_headers}
 
-    def _parallelized_download_from_cloud(self, signed_uri, headers, file_size, dst_local_file_path, dst_run_relative_artifact_path):
+    def _parallelized_download_from_cloud(
+        self, signed_uri, headers, file_size, dst_local_file_path, dst_run_relative_artifact_path
+    ):
         try:
             failed_downloads = parallelized_download_file_using_http_uri(
                 http_uri=signed_uri,
@@ -135,11 +138,15 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
                 headers=headers,
             )
             if failed_downloads:
-                new_signed_uri, new_headers = self._get_signed_download_uri(dst_run_relative_artifact_path)
+                new_signed_uri, new_headers = self._get_signed_download_uri(
+                    dst_run_relative_artifact_path
+                )
             for i, excep in failed_downloads.items():
                 if excep.response.status_code not in (401, 403):
                     raise excep
-                download_chunk(i, _DOWNLOAD_CHUNK_SIZE, new_headers, dst_local_file_path, new_signed_uri)
+                download_chunk(
+                    i, _DOWNLOAD_CHUNK_SIZE, new_headers, dst_local_file_path, new_signed_uri
+                )
         except Exception as err:
             raise MlflowException(err)
 

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -11,7 +11,6 @@ import tarfile
 import tempfile
 import stat
 import pathlib
-import time
 
 import urllib.parse
 import urllib.request
@@ -24,15 +23,14 @@ import atexit
 import requests
 import yaml
 
-from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialType
-
 try:
     from yaml import CSafeLoader as YamlSafeLoader, CSafeDumper as YamlSafeDumper
 except ImportError:
     from yaml import SafeLoader as YamlSafeLoader, SafeDumper as YamlSafeDumper
 
+from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialType
 from mlflow.entities import FileInfo
-from mlflow.exceptions import MissingConfigException, MlflowException
+from mlflow.exceptions import MissingConfigException
 from mlflow.utils.rest_utils import cloud_storage_http_request, augmented_raise_for_status
 from mlflow.utils.process import cache_return_value_per_process
 from mlflow.utils import merge_dicts

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -626,7 +626,7 @@ def parallelized_download_file_using_http_uri(
     # Create file if it doesn't exist. We should do this here before sending to the workers
     # so they can each individually seek to their respective positions and write chunks
     # without overwriting.
-    Path().touch(download_path)
+    Path(download_path).touch()
     futures = {}
     starting_index = 0
     if uri_type == ArtifactCredentialType.GCP_SIGNED_URL or uri_type is None:

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -597,7 +597,7 @@ def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, 
 def download_chunk(request_index, chunk_size, headers, download_path, http_uri):
     range_start = chunk_size * request_index
     range_end = str(range_start + chunk_size - 1)
-    combined_headers = headers | {"Range": f"bytes={range_start}-{range_end}"}
+    combined_headers = {**headers, "Range": f"bytes={range_start}-{range_end}"}
     with cloud_storage_http_request(
         "get", http_uri, stream=False, headers=combined_headers
     ) as response:

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -600,7 +600,7 @@ def download_chunk(request_index, chunk_size, headers, download_path, http_uri):
     range_end = range_start + chunk_size - 1
     combined_headers = {**headers, "Range": f"bytes={range_start}-{range_end}"}
     with cloud_storage_http_request(
-        "get", http_uri, stream=False, headers=combined_headers
+        "get", http_uri, stream=False, headers=combined_headers, cached_session=False
     ) as response:
         # File will have been created upstream. Use r+b to ensure chunks
         # don't overwrite the entire file.

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -1,6 +1,8 @@
 import codecs
 import errno
 import gzip
+import math
+import multiprocessing
 import os
 import posixpath
 import shutil
@@ -9,15 +11,20 @@ import tarfile
 import tempfile
 import stat
 import pathlib
+import time
 
 import urllib.parse
 import urllib.request
+from concurrent.futures import ProcessPoolExecutor
 from urllib.parse import unquote
 from urllib.request import pathname2url
 
 import atexit
 
+import requests
 import yaml
+
+from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialType
 
 try:
     from yaml import CSafeLoader as YamlSafeLoader, CSafeDumper as YamlSafeDumper
@@ -25,7 +32,7 @@ except ImportError:
     from yaml import SafeLoader as YamlSafeLoader, SafeDumper as YamlSafeDumper
 
 from mlflow.entities import FileInfo
-from mlflow.exceptions import MissingConfigException
+from mlflow.exceptions import MissingConfigException, MlflowException
 from mlflow.utils.rest_utils import cloud_storage_http_request, augmented_raise_for_status
 from mlflow.utils.process import cache_return_value_per_process
 from mlflow.utils import merge_dicts
@@ -33,6 +40,7 @@ from mlflow.utils.databricks_utils import _get_dbutils
 from mlflow.utils.os import is_windows
 
 ENCODING = "utf-8"
+MAX_PARALLEL_DOWNLOAD_WORKERS = 32
 
 
 def is_directory(name):
@@ -586,6 +594,76 @@ def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, 
                 if not chunk:
                     break
                 output_file.write(chunk)
+
+
+def download_chunk(request_index, chunk_size, headers, download_path, http_uri):
+    range_start = chunk_size * request_index
+    range_end = str(range_start + chunk_size - 1)
+    combined_headers = headers | {"Range": f"bytes={range_start}-{range_end}"}
+    with cloud_storage_http_request(
+        "get", http_uri, stream=False, headers=combined_headers
+    ) as response:
+        with open(download_path, "r+b") as f:
+            f.seek(range_start)
+            f.write(response.content)
+
+
+def parallelized_download_file_using_http_uri(
+    http_uri, download_path, file_size, uri_type, chunk_size, headers=None
+):
+    """
+    Downloads a file specified using the `http_uri` to a local `download_path`. This function
+    sends multiple requests in parallel each specifying its own desired byte range as a header,
+    then reconstructs the file from the downloaded chunks. This allows for downloads of large files
+    without OOM risk.
+
+    Note : This function is meant to download files using presigned urls from various cloud
+            providers.
+    Returns a dict of chunk index : exception, if one was thrown for that index.
+    """
+    num_requests = int(math.ceil(file_size / float(chunk_size)))
+    # Create file if it doesn't exist. We should do this here before sending to the workers
+    # so they can each individually seek to their respective positions and write chunks
+    # without overwriting.
+    f = open(download_path, "wb")
+    f.close()
+    futures = {}
+    starting_index = 0
+    if uri_type == ArtifactCredentialType.GCP_SIGNED_URL or uri_type is None:
+        # GCP files could be transcoded, in which case the range header is ignored.
+        # Test if this is the case by downloading one chunk and seeing if it's larger than the
+        # requested size. If yes, let that be the file; if not, continue downloading more chunks.
+        download_chunk(0, chunk_size, headers, download_path, http_uri)
+        downloaded_size = os.path.getsize(download_path)
+        # If downloaded size was equal to the chunk size it would have been downloaded serially,
+        # so we don't need to consider this here
+        if downloaded_size > chunk_size:
+            return
+        else:
+            starting_index = 1
+
+    failed_downloads = {}
+    with ProcessPoolExecutor(
+        max_workers=MAX_PARALLEL_DOWNLOAD_WORKERS, mp_context=multiprocessing.get_context("fork")
+    ) as executor:
+        for i in range(starting_index, num_requests):
+            fut = executor.submit(
+                download_chunk,
+                request_index=i,
+                chunk_size=chunk_size,
+                headers=headers,
+                download_path=download_path,
+                http_uri=http_uri,
+            )
+            futures[i] = fut
+
+    for i, fut in futures.items():
+        try:
+            fut.result()
+        except requests.HTTPError as e:
+            failed_downloads[i] = e
+
+    return failed_downloads
 
 
 def _handle_readonly_on_windows(func, path, exc_info):

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -46,7 +46,7 @@ def _get_request_session(max_retries, backoff_factor, retry_codes):
 
 def _get_request_session_uncached(max_retries, backoff_factor, retry_codes):
     """
-    Returns a cached Requests.Session object for making HTTP request.
+    Returns a Requests.Session object for making HTTP request.
 
     :param max_retries: Maximum total number of retries.
     :param backoff_factor: a time factor for exponential backoff. e.g. value 5 means the HTTP

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -41,6 +41,10 @@ _TRANSIENT_FAILURE_RESPONSE_CODES = frozenset(
 
 @lru_cache(maxsize=64)
 def _get_request_session(max_retries, backoff_factor, retry_codes):
+    return _get_request_session_uncached(max_retries, backoff_factor, retry_codes)
+
+
+def _get_request_session_uncached(max_retries, backoff_factor, retry_codes):
     """
     Returns a cached Requests.Session object for making HTTP request.
 
@@ -93,7 +97,10 @@ def _get_http_response_with_retries(
 
     :return: requests.Response object.
     """
-    session = _get_request_session(max_retries, backoff_factor, retry_codes)
+    if kwargs.get("cached_session", True):
+        session = _get_request_session(max_retries, backoff_factor, retry_codes)
+    else:
+        session = _get_request_session_uncached(max_retries, backoff_factor, retry_codes)
     return session.request(method, url, **kwargs)
 
 

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -1435,23 +1435,30 @@ def test_multipart_upload_abort(databricks_artifact_repo, large_file, mock_chunk
         )
 
 
-def test_parallelized_download_retries_failed_chunks(databricks_artifact_repo, large_file, mock_chunk_size):
+def test_parallelized_download_retries_failed_chunks(
+    databricks_artifact_repo, large_file, mock_chunk_size
+):
     mock_credential_info = ArtifactCredentialInfo(
         signed_uri=MOCK_AWS_SIGNED_URI, type=ArtifactCredentialType.AWS_PRESIGNED_URL
     )
     response = Response()
     response.status_code = 401
-    failed_downloads = {2: requests.HTTPError(response=response), 5: requests.HTTPError(response=response)}
+    failed_downloads = {
+        2: requests.HTTPError(response=response),
+        5: requests.HTTPError(response=response),
+    }
 
     with mock.patch(
-            f"{DATABRICKS_ARTIFACT_REPOSITORY}._get_read_credential_infos",
-            return_value=[mock_credential_info],
+        f"{DATABRICKS_ARTIFACT_REPOSITORY}._get_read_credential_infos",
+        return_value=[mock_credential_info],
     ) as get_creds_mock, mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.parallelized_download_file_using_http_uri", return_value=failed_downloads
+        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.parallelized_download_file_using_http_uri",
+        return_value=failed_downloads,
     ), mock.patch(
         f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.download_chunk"
     ) as download_chunk_mock, mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY}.list_artifacts", side_effect=[[], [FileInfo(path="a.txt", is_dir=False, file_size=20_000_000)]]
+        f"{DATABRICKS_ARTIFACT_REPOSITORY}.list_artifacts",
+        side_effect=[[], [FileInfo(path="a.txt", is_dir=False, file_size=20_000_000)]],
     ):
         databricks_artifact_repo.download_artifacts("a.txt")
         assert get_creds_mock.call_count == 2  # Once for initial fetch, once for retries

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -29,6 +29,7 @@ from mlflow.store.artifact.databricks_artifact_repo import (
     DatabricksArtifactRepository,
     _MAX_CREDENTIALS_REQUEST_SIZE,
 )
+from mlflow.utils.os import is_windows
 
 DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE = "mlflow.store.artifact.databricks_artifact_repo"
 DATABRICKS_ARTIFACT_REPOSITORY = (
@@ -1433,6 +1434,7 @@ def test_multipart_upload_abort(databricks_artifact_repo, large_file, mock_chunk
         )
 
 
+@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
 def test_parallelized_download_retries_failed_chunks(
     databricks_artifact_repo, large_file, mock_chunk_size
 ):
@@ -1463,6 +1465,7 @@ def test_parallelized_download_retries_failed_chunks(
         assert {call.args[0] for call in download_chunk_mock.call_args_list} == {2, 5}
 
 
+@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
 def test_parallelized_download_throws_for_other_errors(
     databricks_artifact_repo, large_file, mock_chunk_size
 ):

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -958,7 +958,6 @@ def test_databricks_download_file(
         download_mock.assert_called_with(
             cloud_credential_info=mock_credential_info,
             dst_local_file_path=ANY,
-            file_size=ANY,
         )
 
 
@@ -988,7 +987,6 @@ def test_databricks_download_file_with_relative_path(remote_file_path, local_pat
         download_mock.assert_called_with(
             cloud_credential_info=mock_credential_info,
             dst_local_file_path=ANY,
-            file_size=ANY,
         )
 
 

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -1462,4 +1462,4 @@ def test_parallelized_download_retries_failed_chunks(
     ):
         databricks_artifact_repo.download_artifacts("a.txt")
         assert get_creds_mock.call_count == 2  # Once for initial fetch, once for retries
-        assert set([call.args[0] for call in download_chunk_mock.call_args_list]) == {2, 5}
+        assert {call.args[0] for call in download_chunk_mock.call_args_list} == {2, 5}

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -373,6 +373,7 @@ def test_shutil_copytree_without_file_permissions(tmp_path):
     assert dst_dir.joinpath("top-level-file.txt").read_text() == "hi"
 
 
+@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
 def test_parallelized_download_file_using_http_uri_requests_appropriate_chunks():
     calls_kwargs = multiprocessing.Manager().list([])
 
@@ -403,14 +404,13 @@ def test_parallelized_download_file_using_http_uri_requests_appropriate_chunks()
     assert len(requested_ranges) == 10
     expected_ranges = []
     for i in range(10):
-        byte_range = f"bytes={100*i}-"
-        if i != 9:
-            byte_range += f"{(100*(i+1))-1}"
+        byte_range = f"bytes={100*i}-{(100*(i+1))-1}"
         expected_ranges.append(byte_range)
     assert set(requested_ranges) == set(expected_ranges)
     os.unlink(f.name)
 
 
+@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
 def test_parallelized_download_file_using_http_uri_handles_gcp_transcoding():
     calls_kwargs = multiprocessing.Manager().list([])
     file_content = b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"
@@ -437,6 +437,7 @@ def test_parallelized_download_file_using_http_uri_handles_gcp_transcoding():
         )
     # Should only have called once because the whole file was returned
     assert len(calls_kwargs) == 1
+    f = open(f.name, 'rb')
     f.seek(0)
     contents = f.read()
     assert contents == file_content
@@ -444,6 +445,7 @@ def test_parallelized_download_file_using_http_uri_handles_gcp_transcoding():
     os.unlink(f.name)
 
 
+@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
 def test_parallelized_download_file_using_http_uri_returns_errors_correctly():
     calls_kwargs = multiprocessing.Manager().list([])
     file_content = b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -2,18 +2,24 @@
 import codecs
 import filecmp
 import hashlib
+import multiprocessing
 import os
 import shutil
+import tempfile
+from unittest import mock
 
 import jinja2.exceptions
 import pytest
 import tarfile
 import stat
 import pandas as pd
+import requests
 from pyspark.sql import SparkSession
+from requests import Response
 
 import mlflow
 from mlflow.exceptions import MissingConfigException
+from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialType
 from mlflow.utils import file_utils
 from mlflow.utils.file_utils import (
     get_parent_dir,
@@ -23,7 +29,7 @@ from mlflow.utils.file_utils import (
     write_spark_dataframe_to_parquet_on_local_disk,
     TempDir,
     _handle_readonly_on_windows,
-    local_file_uri_to_path,
+    local_file_uri_to_path, parallelized_download_file_using_http_uri,
 )
 from mlflow.utils.os import is_windows
 from tests.projects.utils import TEST_PROJECT_DIR
@@ -364,3 +370,99 @@ def test_shutil_copytree_without_file_permissions(tmp_path):
     assert set(os.listdir(dst_dir.joinpath("subdir"))) == {"subdir-file.txt"}
     assert dst_dir.joinpath("subdir/subdir-file.txt").read_text() == "testing 123"
     assert dst_dir.joinpath("top-level-file.txt").read_text() == "hi"
+
+
+def test_parallelized_download_file_using_http_uri_requests_appropriate_chunks():
+    calls_kwargs = multiprocessing.Manager().list([])
+
+    # Get call kwargs manually. Calls are not properly stored in a MagicMock object
+    # in a multiprocessing context.
+    def mock_request_side_effect(method, url, *args, **kwargs):
+        calls_kwargs.append(kwargs)
+        response_mock = Response()
+        response_mock.status_code = 206
+        response_mock._content = b'\x01\x01'
+        return response_mock
+
+    f = tempfile.NamedTemporaryFile()
+    with mock.patch('requests.Session.request') as request_mock:
+        request_mock.side_effect = mock_request_side_effect
+        parallelized_download_file_using_http_uri(
+            "fake_uri",
+            f.name,
+            file_size=1000,
+            uri_type=ArtifactCredentialType.AWS_PRESIGNED_URL,
+            chunk_size=100,
+            headers={}
+        )
+    f.close()
+    requested_ranges = [call_kwargs['headers']['Range'] for call_kwargs in calls_kwargs]
+    assert len(requested_ranges) == 10
+    expected_ranges = []
+    for i in range(10):
+        byte_range = f"bytes={100*i}-"
+        if i != 9:
+            byte_range += f"{(100*(i+1))-1}"
+        expected_ranges.append(byte_range)
+    assert set(requested_ranges) == set(expected_ranges)
+
+
+def test_parallelized_download_file_using_http_uri_handles_gcp_transcoding():
+    calls_kwargs = multiprocessing.Manager().list([])
+    file_content = b'\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01'
+
+    def mock_request_side_effect(method, url, *args, **kwargs):
+        calls_kwargs.append(kwargs)
+        response_mock = Response()
+        response_mock.status_code = 200
+        # 10-byte file
+        response_mock._content = file_content
+        return response_mock
+
+    f = tempfile.NamedTemporaryFile()
+    with mock.patch('requests.Session.request') as request_mock:
+        request_mock.side_effect = mock_request_side_effect
+        parallelized_download_file_using_http_uri(
+            "fake_uri",
+            f.name,
+            file_size=10,
+            uri_type=ArtifactCredentialType.GCP_SIGNED_URL,
+            chunk_size=2,
+            headers={}
+        )
+    # Should only have called once because the whole file was returned
+    assert len(calls_kwargs) == 1
+    f.seek(0)
+    contents = f.read()
+    assert contents == file_content
+    f.close()
+
+
+def test_parallelized_download_file_using_http_uri_returns_errors_correctly():
+    calls_kwargs = multiprocessing.Manager().list([])
+    file_content = b'\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01'
+
+    def mock_request_side_effect(method, url, *args, **kwargs):
+        calls_kwargs.append(kwargs)
+        response_mock = Response()
+        response_mock.status_code = 200
+        # 10-byte file
+        response_mock._content = file_content
+        # Randomly fail for the first chunk
+        if kwargs['headers']['Range'].startswith('bytes=0'):
+            raise requests.HTTPError("test exception")
+        return response_mock
+
+    f = tempfile.NamedTemporaryFile()
+    with mock.patch('requests.Session.request') as request_mock:
+        request_mock.side_effect = mock_request_side_effect
+        failed_downloads = parallelized_download_file_using_http_uri(
+            "fake_uri",
+            f.name,
+            file_size=10,
+            uri_type=ArtifactCredentialType.AWS_PRESIGNED_URL,
+            chunk_size=2,
+            headers={}
+        )
+        assert len(failed_downloads) == 1
+        assert str(failed_downloads[0]) == "test exception"

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -29,7 +29,8 @@ from mlflow.utils.file_utils import (
     write_spark_dataframe_to_parquet_on_local_disk,
     TempDir,
     _handle_readonly_on_windows,
-    local_file_uri_to_path, parallelized_download_file_using_http_uri,
+    local_file_uri_to_path,
+    parallelized_download_file_using_http_uri,
 )
 from mlflow.utils.os import is_windows
 from tests.projects.utils import TEST_PROJECT_DIR
@@ -381,11 +382,11 @@ def test_parallelized_download_file_using_http_uri_requests_appropriate_chunks()
         calls_kwargs.append(kwargs)
         response_mock = Response()
         response_mock.status_code = 206
-        response_mock._content = b'\x01\x01'
+        response_mock._content = b"\x01\x01"
         return response_mock
 
     f = tempfile.NamedTemporaryFile()
-    with mock.patch('requests.Session.request') as request_mock:
+    with mock.patch("requests.Session.request") as request_mock:
         request_mock.side_effect = mock_request_side_effect
         parallelized_download_file_using_http_uri(
             "fake_uri",
@@ -393,10 +394,10 @@ def test_parallelized_download_file_using_http_uri_requests_appropriate_chunks()
             file_size=1000,
             uri_type=ArtifactCredentialType.AWS_PRESIGNED_URL,
             chunk_size=100,
-            headers={}
+            headers={},
         )
     f.close()
-    requested_ranges = [call_kwargs['headers']['Range'] for call_kwargs in calls_kwargs]
+    requested_ranges = [call_kwargs["headers"]["Range"] for call_kwargs in calls_kwargs]
     assert len(requested_ranges) == 10
     expected_ranges = []
     for i in range(10):
@@ -409,7 +410,7 @@ def test_parallelized_download_file_using_http_uri_requests_appropriate_chunks()
 
 def test_parallelized_download_file_using_http_uri_handles_gcp_transcoding():
     calls_kwargs = multiprocessing.Manager().list([])
-    file_content = b'\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01'
+    file_content = b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"
 
     def mock_request_side_effect(method, url, *args, **kwargs):
         calls_kwargs.append(kwargs)
@@ -420,7 +421,7 @@ def test_parallelized_download_file_using_http_uri_handles_gcp_transcoding():
         return response_mock
 
     f = tempfile.NamedTemporaryFile()
-    with mock.patch('requests.Session.request') as request_mock:
+    with mock.patch("requests.Session.request") as request_mock:
         request_mock.side_effect = mock_request_side_effect
         parallelized_download_file_using_http_uri(
             "fake_uri",
@@ -428,7 +429,7 @@ def test_parallelized_download_file_using_http_uri_handles_gcp_transcoding():
             file_size=10,
             uri_type=ArtifactCredentialType.GCP_SIGNED_URL,
             chunk_size=2,
-            headers={}
+            headers={},
         )
     # Should only have called once because the whole file was returned
     assert len(calls_kwargs) == 1
@@ -440,7 +441,7 @@ def test_parallelized_download_file_using_http_uri_handles_gcp_transcoding():
 
 def test_parallelized_download_file_using_http_uri_returns_errors_correctly():
     calls_kwargs = multiprocessing.Manager().list([])
-    file_content = b'\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01'
+    file_content = b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"
 
     def mock_request_side_effect(method, url, *args, **kwargs):
         calls_kwargs.append(kwargs)
@@ -449,12 +450,12 @@ def test_parallelized_download_file_using_http_uri_returns_errors_correctly():
         # 10-byte file
         response_mock._content = file_content
         # Randomly fail for the first chunk
-        if kwargs['headers']['Range'].startswith('bytes=0'):
+        if kwargs["headers"]["Range"].startswith("bytes=0"):
             raise requests.HTTPError("test exception")
         return response_mock
 
     f = tempfile.NamedTemporaryFile()
-    with mock.patch('requests.Session.request') as request_mock:
+    with mock.patch("requests.Session.request") as request_mock:
         request_mock.side_effect = mock_request_side_effect
         failed_downloads = parallelized_download_file_using_http_uri(
             "fake_uri",
@@ -462,7 +463,7 @@ def test_parallelized_download_file_using_http_uri_returns_errors_correctly():
             file_size=10,
             uri_type=ArtifactCredentialType.AWS_PRESIGNED_URL,
             chunk_size=2,
-            headers={}
+            headers={},
         )
         assert len(failed_downloads) == 1
         assert str(failed_downloads[0]) == "test exception"


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
 
<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Parallelize artifact downloads from Databricks MLflow tracking and Databricks model registry. Works by using range headers to download 10mb chunks at a time against a single presigned URL if the file is greater than 10mb.
Tested manually on Databricks AWS, Azure and GCP and added unit tests.

Note this is skipped on windows due to the `fork` multiprocessing context being only available on unix.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Artifact downloads on Databricks and Databricks Model Registry are parallelized to improve performance on non-Windows machines.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
