### PR TITLE
Do not push Docker image when --build-image is not specified

### DIFF
--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -20,14 +20,22 @@ _logger = logging.getLogger(__name__)
 _DOCKER_API_TIMEOUT = 300
 
 
-def push_image_to_registry(image_tag):
+def push_image_to_registry(image_tag, docker_auth=None):
     client = docker.from_env(timeout=_DOCKER_API_TIMEOUT)
+    if docker_auth is not None:
+        client.login(**docker_auth)
     _logger.info("=== Pushing docker image %s ===", image_tag)
     for line in client.images.push(repository=image_tag, stream=True, decode=True):
         if "error" in line and line["error"]:
             raise ExecutionException(
                 "Error while pushing to docker registry: {error}".format(error=line["error"])
             )
+
+
+def get_image_digest(image_tag, docker_auth=None):
+    client = docker.from_env(timeout=_DOCKER_API_TIMEOUT)
+    if docker_auth is not None:
+        client.login(**docker_auth)
     return client.images.get_registry_data(image_tag).id
 
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Resolve #8118 

## What changes are proposed in this pull request?

Fix to not push an image to a Docker registry with Kubernetes backend when `--build-image` option is not specified.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

```console
# Clone repository
$ git clone https://github.com/ry3s/mlflow.git
$ cd mlflow
$ git checkout projects-k8s-no-push

# Install mlflow
$ python -m venv .venv
$ . .venv/bin/activate
$ pip install -e '.[extras]'

# Build Docker iamge
$ cd examples/docker
$ cat Dockerfile
FROM python:3.8

RUN pip install mlflow>=1.0 \
    && pip install azure-storage-blob==12.3.0 \
    && pip install numpy==1.21.2 \
    && pip install scipy \
    && pip install pandas==1.3.3 \
    && pip install scikit-learn==0.24.2 \
    && pip install cloudpickle

COPY train.py train.py
COPY wine-quality.csv wine-quality.csv
$ docker build -t <image> -f Dockerfile .
$ docker push <image>
$ cat kubernetes_config.json
{
  "kube-job-template-path": "kubernetes_job_template.yaml",
  "repository-uri": "<registry>"
}
$ cat kubernetes_job_template.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: "{replaced with MLflow Project name}"
  namespace: mlflow
spec:
  ttlSecondsAfterFinished: 100
  backoffLimit: 0
  template:
    spec:
      containers:
        - name: "{replaced with MLflow Project name}"
          image: "{replaced with URI of Docker image created during Project execution}"
          command: ["{replaced with MLflow Project entry point command}"]
          resources:
            limits:
              memory: 512Mi
            requests:
              memory: 256Mi
      restartPolicy: Never
      imagePullSecrets:
        - name: <secret-name>
```

test without `--build-image`
```console
$ mlflow run . --backend kubernetes --backend-config kubernetes_config.json -P alpha=0.5
2023/03/29 19:06:51 INFO mlflow.projects.docker: <image> already exists
2023/03/29 19:06:52 INFO mlflow.projects.utils: === Created directory /tmp/tmplcilg92w for downloading remote URIs passed to arguments of type 'path' ===
2023/03/29 19:06:52 INFO mlflow.projects.kubernetes: === Creating Job docker-example-2023-03-29-19-06-52-175505 ===
2023/03/29 19:06:52 INFO mlflow.projects.kubernetes: Job started.
2023/03/29 19:07:02 INFO mlflow.projects.kubernetes: None
2023/03/29 19:07:02 INFO mlflow.projects: === Run (ID '3fcaba482464404980356c0a8a2a62ed') succeeded ===
```

test with `--build-image`
```console
$ mlflow run . --backend kubernetes --backend-config kubernetes_config.json -P alpha=0.5 --build-image
2023/03/29 19:12:01 INFO mlflow.projects.docker: === Building docker image <image>:6fa2f72 ===
2023/03/29 19:12:02 INFO mlflow.projects.kubernetes: === Pushing docker image <image>:6fa2f72 ===
2023/03/29 19:12:02 INFO mlflow.projects.utils: === Created directory /tmp/tmp5ocmyp4i for downloading remote URIs passed to arguments of type 'path' ===
2023/03/29 19:12:02 INFO mlflow.projects.kubernetes: === Creating Job docker-example-2023-03-29-19-12-02-740129 ===
2023/03/29 19:12:02 INFO mlflow.projects.kubernetes: Job started.
2023/03/29 19:12:12 INFO mlflow.projects.kubernetes: None
2023/03/29 19:12:12 INFO mlflow.projects: === Run (ID '628f8733d42d450cbed1bd1ce5114fb5') succeeded ===
```
## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
