### PR TITLE
Disallow using a file URI as model version source

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -206,7 +206,7 @@ MLFLOW_DEFAULT_PREDICTION_DEVICE = _EnvironmentVariable(
 #: Specifies whether or not to allow using a file URI as a model version source.
 #: Please be aware that setting this environment variable to True is potentially risky
 #: because it can allow access to arbitrary files on the specified filesystem
-# (default: ``False``).
+#: (default: ``False``).
 MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE = _BooleanEnvironmentVariable(
     "MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE", False
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -203,8 +203,8 @@ MLFLOW_DEFAULT_PREDICTION_DEVICE = _EnvironmentVariable(
     "MLFLOW_DEFAULT_PREDICTION_DEVICE", str, None
 )
 
-#: Specifies whether or not to allow file:// URIs as model version source URIs.
-#: (default: ``False``)
+#: Specifies whether or not to allow using a file URI as a model version source.
+# (default: ``False``).
 MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE = _BooleanEnvironmentVariable(
     "MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE", False
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -205,7 +205,7 @@ MLFLOW_DEFAULT_PREDICTION_DEVICE = _EnvironmentVariable(
 
 #: Specifies whether or not to allow using a file URI as a model version source.
 #: Please be aware that setting this environment variable to True is potentially risky
-#: because it can allow access to arbitrary files on the specified filesystem.
+#: because it can allow access to arbitrary files on the specified filesystem
 # (default: ``False``).
 MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE = _BooleanEnvironmentVariable(
     "MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE", False

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -202,3 +202,10 @@ MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT = _EnvironmentVariable(
 MLFLOW_DEFAULT_PREDICTION_DEVICE = _EnvironmentVariable(
     "MLFLOW_DEFAULT_PREDICTION_DEVICE", str, None
 )
+
+
+#: Specifies whether or not to allow file:// URIs as model version source URIs.
+#: (default: ``False``)
+MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE = _BooleanEnvironmentVariable(
+    "MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE", False
+)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -204,6 +204,8 @@ MLFLOW_DEFAULT_PREDICTION_DEVICE = _EnvironmentVariable(
 )
 
 #: Specifies whether or not to allow using a file URI as a model version source.
+#: Please be aware that setting this environment variable to True is potentially risky
+#: because it can allow access to arbitrary files on the specified filesystem.
 # (default: ``False``).
 MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE = _BooleanEnvironmentVariable(
     "MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE", False

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -203,7 +203,6 @@ MLFLOW_DEFAULT_PREDICTION_DEVICE = _EnvironmentVariable(
     "MLFLOW_DEFAULT_PREDICTION_DEVICE", str, None
 )
 
-
 #: Specifies whether or not to allow file:// URIs as model version source URIs.
 #: (default: ``False``)
 MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE = _BooleanEnvironmentVariable(

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -84,9 +84,10 @@ from mlflow.utils.mime_type_utils import _guess_mime_type
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.validation import _validate_batch_log_api_req
 from mlflow.utils.string_utils import is_string_type
-from mlflow.utils.uri import is_local_uri
+from mlflow.utils.uri import is_local_uri, is_file_uri
 from mlflow.utils.file_utils import local_file_uri_to_path
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
+from mlflow.environment_variables import MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE
 
 _logger = logging.getLogger(__name__)
 _tracking_store = None
@@ -1322,6 +1323,13 @@ def _delete_registered_model_tag():
 
 
 def _validate_source(source: str, run_id: str) -> None:
+    if not MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE.get() and is_file_uri(source):
+        raise MlflowException(
+            f"Invalid source: '{source}'. To use a file URI as source, set the "
+            f"{MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE.name} environment variable to True.",
+            INVALID_PARAMETER_VALUE,
+        )
+
     if not is_local_uri(source):
         return
 

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -30,7 +30,9 @@ def is_local_uri(uri):
 
     parsed_uri = urllib.parse.urlparse(uri)
     if parsed_uri.hostname and not (
-        parsed_uri.hostname == "." or parsed_uri.hostname.startswith("localhost")
+        parsed_uri.hostname == "."
+        or parsed_uri.hostname.startswith("localhost")
+        or parsed_uri.hostname.startswith("127.0.0.1")
     ):
         return False
 

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -29,7 +29,9 @@ def is_local_uri(uri):
         return False
 
     parsed_uri = urllib.parse.urlparse(uri)
-    if parsed_uri.hostname:
+    if parsed_uri.hostname and not (
+        parsed_uri.hostname == "." or parsed_uri.hostname.startswith("localhost")
+    ):
         return False
 
     scheme = parsed_uri.scheme

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -42,6 +42,10 @@ def is_local_uri(uri):
     return False
 
 
+def is_file_uri(uri):
+    return urllib.parse.urlparse(uri).scheme == "file"
+
+
 def is_http_uri(uri):
     scheme = urllib.parse.urlparse(uri).scheme
     return scheme == "http" or scheme == "https"

--- a/tests/tracking/integration_test_utils.py
+++ b/tests/tracking/integration_test_utils.py
@@ -38,7 +38,7 @@ def _terminate_server(process, timeout=10):
     process.wait(timeout=timeout)
 
 
-def _init_server(backend_uri, root_artifact_uri):
+def _init_server(backend_uri, root_artifact_uri, extra_env=None):
     """
     Launch a new REST server using the tracking store specified by backend_uri and root artifact
     directory specified by root_artifact_uri.
@@ -57,6 +57,7 @@ def _init_server(backend_uri, root_artifact_uri):
             **os.environ,
             BACKEND_STORE_URI_ENV_VAR: backend_uri,
             ARTIFACT_ROOT_ENV_VAR: root_artifact_uri,
+            **(extra_env or {}),
         },
     )
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -1166,6 +1166,20 @@ def test_file_uri_can_be_used_as_model_version_source_when_env_var_is_set(tmp_pa
         },
     )
     assert response.status_code == 200
+
+    # A file URI is allowed, but one that looks like a local path that's not in the run's artifact
+    # directory is not allowed.
+    assert run.info.artifact_uri.startswith("file://")
+    response = requests.post(
+        f"{mlflow_client.tracking_uri}/api/2.0/mlflow/model-versions/create",
+        json={
+            "name": name,
+            "source": "file:///tmp",
+            "run_id": run.info.run_id,
+        },
+    )
+    assert response.status_code == 400
+
     _terminate_server(process)
 
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -1044,12 +1044,52 @@ def test_get_metric_history_bulk_calls_optimized_impl_when_expected(monkeypatch,
         )
 
 
-def test_create_model_version_with_local_source(mlflow_client):
+def test_create_model_version_with_path_source(mlflow_client):
     name = "mode"
     mlflow_client.create_registered_model(name)
     exp_id = mlflow_client.create_experiment("test")
     run = mlflow_client.create_run(experiment_id=exp_id)
 
+    response = requests.post(
+        f"{mlflow_client.tracking_uri}/api/2.0/mlflow/model-versions/create",
+        json={
+            "name": name,
+            "source": run.info.artifact_uri[len("file://") :],
+            "run_id": run.info.run_id,
+        },
+    )
+    assert response.status_code == 200
+
+    # run_id is not specified
+    response = requests.post(
+        f"{mlflow_client.tracking_uri}/api/2.0/mlflow/model-versions/create",
+        json={
+            "name": name,
+            "source": run.info.artifact_uri[len("file://") :],
+        },
+    )
+    assert response.status_code == 400
+    assert "To use a local path as a model version" in response.json()["message"]
+
+    # run_id is specified but source is not in the run's artifact directory
+    response = requests.post(
+        f"{mlflow_client.tracking_uri}/api/2.0/mlflow/model-versions/create",
+        json={
+            "name": name,
+            "source": "/tmp",
+            "run_id": run.info.run_id,
+        },
+    )
+    assert response.status_code == 400
+    assert "To use a local path as a model version" in response.json()["message"]
+
+
+def test_create_model_version_with_file_uri(mlflow_client):
+    name = "test"
+    mlflow_client.create_registered_model(name)
+    exp_id = mlflow_client.create_experiment("test")
+    run = mlflow_client.create_run(experiment_id=exp_id)
+    assert run.info.artifact_uri.startswith("file://")
     response = requests.post(
         f"{mlflow_client.tracking_uri}/api/2.0/mlflow/model-versions/create",
         json={
@@ -1090,16 +1130,7 @@ def test_create_model_version_with_local_source(mlflow_client):
     )
     assert response.status_code == 200
 
-    response = requests.post(
-        f"{mlflow_client.tracking_uri}/api/2.0/mlflow/model-versions/create",
-        json={
-            "name": name,
-            "source": run.info.artifact_uri[len("file://") :],
-            "run_id": run.info.run_id,
-        },
-    )
-    assert response.status_code == 200
-
+    # run_id is not specified
     response = requests.post(
         f"{mlflow_client.tracking_uri}/api/2.0/mlflow/model-versions/create",
         json={
@@ -1108,79 +1139,56 @@ def test_create_model_version_with_local_source(mlflow_client):
         },
     )
     assert response.status_code == 400
-    resp = response.json()
-    assert "Invalid source" in resp["message"]
+    assert "To use a local path as a model version" in response.json()["message"]
+
+    # run_id is specified but source is not in the run's artifact directory
+    response = requests.post(
+        f"{mlflow_client.tracking_uri}/api/2.0/mlflow/model-versions/create",
+        json={
+            "name": name,
+            "source": "file:///tmp",
+        },
+    )
+    assert response.status_code == 400
+    assert "To use a local path as a model version" in response.json()["message"]
 
     response = requests.post(
         f"{mlflow_client.tracking_uri}/api/2.0/mlflow/model-versions/create",
         json={
             "name": name,
-            "source": "/tmp",
+            "source": "file://123.456.789.123/path/to/source",
             "run_id": run.info.run_id,
         },
     )
     assert response.status_code == 400
-    resp = response.json()
-    assert "Invalid source" in resp["message"]
+    assert "MLflow tracking server doesn't allow" in response.json()["message"]
 
 
-def test_file_uri_cannot_be_used_as_model_version_source_by_default(mlflow_client):
-    name = "test"
-    mlflow_client.create_registered_model(name)
-    exp_id = mlflow_client.create_experiment("test")
-    run = mlflow_client.create_run(experiment_id=exp_id)
-    assert run.info.artifact_uri.startswith("file://")
-    response = requests.post(
-        f"{mlflow_client.tracking_uri}/api/2.0/mlflow/model-versions/create",
-        json={
-            "name": name,
-            "source": run.info.artifact_uri,
-            "run_id": run.info.run_id,
-        },
-    )
-    assert response.status_code == 400
-    assert "Invalid source" in response.text
-    assert "MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE" in response.text
-
-
-def test_file_uri_can_be_used_as_model_version_source_when_env_var_is_set(tmp_path):
+def test_create_model_version_with_file_uri_env_var(tmp_path):
     backend_uri = tmp_path.joinpath("file").as_uri()
     url, process = _init_server(
         backend_uri,
         root_artifact_uri=tmp_path.as_uri(),
         extra_env={"MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE": "true"},
     )
-    mlflow_client = MlflowClient(url)
+    try:
+        mlflow_client = MlflowClient(url)
 
-    name = "test"
-    mlflow_client.create_registered_model(name)
-    exp_id = mlflow_client.create_experiment("test")
-    run = mlflow_client.create_run(experiment_id=exp_id)
-    assert run.info.artifact_uri.startswith("file://")
-    response = requests.post(
-        f"{mlflow_client.tracking_uri}/api/2.0/mlflow/model-versions/create",
-        json={
-            "name": name,
-            "source": run.info.artifact_uri,
-            "run_id": run.info.run_id,
-        },
-    )
-    assert response.status_code == 200
-
-    # A file URI is allowed, but one that looks like a local path that's not in the run's artifact
-    # directory is not allowed.
-    assert run.info.artifact_uri.startswith("file://")
-    response = requests.post(
-        f"{mlflow_client.tracking_uri}/api/2.0/mlflow/model-versions/create",
-        json={
-            "name": name,
-            "source": "file:///tmp",
-            "run_id": run.info.run_id,
-        },
-    )
-    assert response.status_code == 400
-
-    _terminate_server(process)
+        name = "test"
+        mlflow_client.create_registered_model(name)
+        exp_id = mlflow_client.create_experiment("test")
+        run = mlflow_client.create_run(experiment_id=exp_id)
+        response = requests.post(
+            f"{mlflow_client.tracking_uri}/api/2.0/mlflow/model-versions/create",
+            json={
+                "name": name,
+                "source": "file://123.456.789.123/path/to/source",
+                "run_id": run.info.run_id,
+            },
+        )
+        assert response.status_code == 200
+    finally:
+        _terminate_server(process)
 
 
 def test_logging_model_with_local_artifact_uri(mlflow_client):

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -1137,6 +1137,7 @@ def test_file_uri_can_be_used_as_model_version_source_when_env_var_is_set(tmp_pa
     client.create_registered_model(name)
     exp_id = client.create_experiment("test")
     run = client.create_run(experiment_id=exp_id)
+    assert run.info.artifact_uri.startswith("file://")
     response = requests.post(
         f"{url}/api/2.0/mlflow/model-versions/create",
         json={

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -94,6 +94,8 @@ def test_is_local_uri():
     assert is_local_uri("file://./mlruns")
     assert is_local_uri("file://localhost/mlruns")
     assert is_local_uri("file://localhost:5000/mlruns")
+    assert is_local_uri("file://127.0.0.1/mlruns")
+    assert is_local_uri("file://127.0.0.1:5000/mlruns")
 
     assert not is_local_uri("file://myhostname/path/to/file")
     assert not is_local_uri("https://whatever")

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -91,6 +91,7 @@ def test_is_local_uri():
     assert is_local_uri("./mlruns")
     assert is_local_uri("file:///foo/mlruns")
     assert is_local_uri("file:foo/mlruns")
+    assert is_local_uri("file://./mlruns")
 
     assert not is_local_uri("file://myhostname/path/to/file")
     assert not is_local_uri("https://whatever")

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -93,6 +93,7 @@ def test_is_local_uri():
     assert is_local_uri("file:foo/mlruns")
     assert is_local_uri("file://./mlruns")
     assert is_local_uri("file://localhost/mlruns")
+    assert is_local_uri("file://localhost:5000/mlruns")
 
     assert not is_local_uri("file://myhostname/path/to/file")
     assert not is_local_uri("https://whatever")

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -92,6 +92,7 @@ def test_is_local_uri():
     assert is_local_uri("file:///foo/mlruns")
     assert is_local_uri("file:foo/mlruns")
     assert is_local_uri("file://./mlruns")
+    assert is_local_uri("file://localhost/mlruns")
 
     assert not is_local_uri("file://myhostname/path/to/file")
     assert not is_local_uri("https://whatever")


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fixes `is_loca_uri` and disallows file URI usage for a model version source.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
