### PR TITLE
Fix databricks config fetch in R client for DBR 13.x versions

### DIFF
--- a/mlflow/R/mlflow/R/databricks-utils.R
+++ b/mlflow/R/mlflow/R/databricks-utils.R
@@ -77,10 +77,12 @@ get_databricks_config_from_env <- function() {
 get_databricks_config <- function(profile) {
   config <- if (!is.na(profile)) {
     get_databricks_config_for_profile(profile)
-  } else if (exists("spark.databricks.token") && exists("spark.databricks.api.url")) {
+  } else if (require("SparkR") &&
+      !is.null(SparkR:::getLocalProperty("spark.databricks.token")) &&
+      !is.null(SparkR:::getLocalProperty("spark.databricks.api.url"))) {
     config_vars <- list(
-      host = get("spark.databricks.api.url", envir = .GlobalEnv),
-      token = get("spark.databricks.token", envir = .GlobalEnv),
+      host = SparkR:::getLocalProperty("spark.databricks.api.url"),
+      token = SparkR:::getLocalProperty("spark.databricks.token"),
       insecure = Sys.getenv(config_variable_map$insecure, "False")
     )
     new_databricks_config(config_source = "db_dynamic", config_vars = config_vars)

--- a/mlflow/R/mlflow/R/databricks-utils.R
+++ b/mlflow/R/mlflow/R/databricks-utils.R
@@ -78,11 +78,11 @@ get_databricks_config <- function(profile) {
   config <- if (!is.na(profile)) {
     get_databricks_config_for_profile(profile)
   } else if (require("SparkR") &&
-      !is.null(SparkR:::getLocalProperty("spark.databricks.token")) &&
-      !is.null(SparkR:::getLocalProperty("spark.databricks.api.url"))) {
+      !is.null(SparkR::getLocalProperty("spark.databricks.token")) &&
+      !is.null(SparkR::getLocalProperty("spark.databricks.api.url"))) {
     config_vars <- list(
-      host = SparkR:::getLocalProperty("spark.databricks.api.url"),
-      token = SparkR:::getLocalProperty("spark.databricks.token"),
+      host = SparkR::getLocalProperty("spark.databricks.api.url"),
+      token = SparkR::getLocalProperty("spark.databricks.token"),
       insecure = Sys.getenv(config_variable_map$insecure, "False")
     )
     new_databricks_config(config_source = "db_dynamic", config_vars = config_vars)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

User context variables are no longer passed directly into the namespace in 13.x versions. Use the spark property fetch to get variables instead.


## How is this patch tested?
Manually on a 13.x version.

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
