### PR TITLE
Disallow local model version source and `..` in path parameter

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -175,3 +175,11 @@ MLFLOW_SQLALCHEMYSTORE_POOLCLASS = _EnvironmentVariable(
 MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT", int, 120
 )
+
+#: Specifies whether or not to allow using a file URI as a model version source.
+#: Please be aware that setting this environment variable to True is potentially risky
+#: because it can allow access to arbitrary files on the specified filesystem
+#: (default: ``False``).
+MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE = _BooleanEnvironmentVariable(
+    "MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE", False
+)

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1287,7 +1287,6 @@ def _validate_source(source: str, run_id: str) -> None:
     if is_local_uri(source):
         if run_id:
             store = _get_tracking_store()
-            print("foo")
             run = store.get_run(run_id)
             source = pathlib.Path(local_file_uri_to_path(source)).resolve()
             run_artifact_dir = pathlib.Path(local_file_uri_to_path(run.info.artifact_uri)).resolve()

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -5,6 +5,7 @@ import re
 import tempfile
 import posixpath
 import urllib
+import pathlib
 
 import logging
 from functools import wraps
@@ -84,7 +85,10 @@ from mlflow.utils.name_utils import _generate_random_name
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.validation import _validate_batch_log_api_req
 from mlflow.utils.string_utils import is_string_type
+from mlflow.utils.uri import is_local_uri, is_file_uri
+from mlflow.utils.file_utils import local_file_uri_to_path
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
+from mlflow.environment_variables import MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE
 
 _logger = logging.getLogger(__name__)
 _tracking_store = None
@@ -561,7 +565,6 @@ def _not_implemented():
 @catch_mlflow_exception
 @_disable_if_artifacts_only
 def _create_experiment():
-
     request_message = _get_request_message(
         CreateExperiment(),
         schema={
@@ -856,7 +859,6 @@ def _get_run():
 @catch_mlflow_exception
 @_disable_if_artifacts_only
 def _search_runs():
-
     request_message = _get_request_message(
         SearchRuns(),
         schema={
@@ -1188,7 +1190,6 @@ def _delete_registered_model():
 @catch_mlflow_exception
 @_disable_if_artifacts_only
 def _list_registered_models():
-
     request_message = _get_request_message(
         ListRegisteredModels(),
         schema={
@@ -1209,7 +1210,6 @@ def _list_registered_models():
 @catch_mlflow_exception
 @_disable_if_artifacts_only
 def _search_registered_models():
-
     request_message = _get_request_message(
         SearchRegisteredModels(),
         schema={
@@ -1283,6 +1283,37 @@ def _delete_registered_model_tag():
     return _wrap_response(DeleteRegisteredModelTag.Response())
 
 
+def _validate_source(source: str, run_id: str) -> None:
+    if is_local_uri(source):
+        if run_id:
+            store = _get_tracking_store()
+            print("foo")
+            run = store.get_run(run_id)
+            source = pathlib.Path(local_file_uri_to_path(source)).resolve()
+            run_artifact_dir = pathlib.Path(local_file_uri_to_path(run.info.artifact_uri)).resolve()
+            if run_artifact_dir in [source, *source.parents]:
+                return
+
+        raise MlflowException(
+            f"Invalid model version source: '{source}'. To use a local path as a model version "
+            "source, the run_id request parameter has to be specified and the local path has to be "
+            "contained within the artifact directory of the run specified by the run_id.",
+            INVALID_PARAMETER_VALUE,
+        )
+
+    # There might be file URIs that are local but can bypass the above check. To prevent this, we
+    # disallow using file URIs as model version sources by default unless it's explicitly allowed
+    # by setting the MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE environment variable to True.
+    if not MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE.get() and is_file_uri(source):
+        raise MlflowException(
+            f"Invalid model version source: '{source}'. MLflow tracking server doesn't allow using "
+            "a file URI as a model version source for security reasons. To disable this check, set "
+            f"the {MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE.name} environment variable to "
+            "True.",
+            INVALID_PARAMETER_VALUE,
+        )
+
+
 @catch_mlflow_exception
 @_disable_if_artifacts_only
 def _create_model_version():
@@ -1297,6 +1328,7 @@ def _create_model_version():
             "description": [_assert_string],
         },
     )
+    _validate_source(request_message.source, request_message.run_id)
     model_version = _get_model_registry_store().create_model_version(
         name=request_message.name,
         source=request_message.source,

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -30,6 +30,7 @@ from mlflow.utils.rest_utils import cloud_storage_http_request, augmented_raise_
 from mlflow.utils.process import cache_return_value_per_process
 from mlflow.utils import merge_dicts
 from mlflow.utils.databricks_utils import _get_dbutils
+from mlflow.utils.os import is_windows
 
 ENCODING = "utf-8"
 
@@ -507,7 +508,13 @@ def local_file_uri_to_path(uri):
     Convert URI to local filesystem path.
     No-op if the uri does not have the expected scheme.
     """
-    path = urllib.parse.urlparse(uri).path if uri.startswith("file:") else uri
+    path = uri
+    if uri.startswith("file:"):
+        parsed_path = urllib.parse.urlparse(uri)
+        path = parsed_path.path
+        # Fix for retaining server name in UNC path.
+        if is_windows() and parsed_path.netloc:
+            return urllib.request.url2pathname(rf"\\{parsed_path.netloc}{path}")
     return urllib.request.url2pathname(path)
 
 

--- a/mlflow/utils/os.py
+++ b/mlflow/utils/os.py
@@ -1,0 +1,8 @@
+import os
+
+
+def is_windows():
+    """
+    :return: Returns true if the local system/OS name is Windows.
+    """
+    return os.name == "nt"

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -1,4 +1,3 @@
-import os
 import posixpath
 import urllib.parse
 import pathlib
@@ -7,6 +6,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.utils.validation import _validate_db_type_string
+from mlflow.utils.os import is_windows
 
 _INVALID_DB_URI_MSG = (
     "Please refer to https://mlflow.org/docs/latest/tracking.html#storage for "
@@ -15,10 +15,6 @@ _INVALID_DB_URI_MSG = (
 
 _DBFS_FUSE_PREFIX = "/dbfs/"
 _DBFS_HDFS_URI_PREFIX = "dbfs:/"
-
-
-def is_windows():
-    return os.name == "nt"
 
 
 def is_local_uri(uri):

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -1,5 +1,7 @@
+import os
 import posixpath
 import urllib.parse
+import pathlib
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
@@ -15,10 +17,39 @@ _DBFS_FUSE_PREFIX = "/dbfs/"
 _DBFS_HDFS_URI_PREFIX = "dbfs:/"
 
 
+def is_windows():
+    return os.name == "nt"
+
+
 def is_local_uri(uri):
     """Returns true if this is a local file path (/foo or file:/foo)."""
-    scheme = urllib.parse.urlparse(uri).scheme
-    return uri != "databricks" and (scheme == "" or scheme == "file")
+    if uri == "databricks":
+        return False
+
+    if is_windows() and uri.startswith("\\\\"):
+        # windows network drive path looks like: "\\<server name>\path\..."
+        return False
+
+    parsed_uri = urllib.parse.urlparse(uri)
+    if parsed_uri.hostname and not (
+        parsed_uri.hostname == "."
+        or parsed_uri.hostname.startswith("localhost")
+        or parsed_uri.hostname.startswith("127.0.0.1")
+    ):
+        return False
+
+    scheme = parsed_uri.scheme
+    if scheme == "" or scheme == "file":
+        return True
+
+    if is_windows() and len(scheme) == 1 and scheme.lower() == pathlib.Path(uri).drive.lower()[0]:
+        return True
+
+    return False
+
+
+def is_file_uri(uri):
+    return urllib.parse.urlparse(uri).scheme == "file"
 
 
 def is_http_uri(uri):

--- a/tests/tracking/integration_test_utils.py
+++ b/tests/tracking/integration_test_utils.py
@@ -1,17 +1,15 @@
 from subprocess import Popen
 
-from unittest import mock
+import sys
 import os
 from threading import Thread
 
 import logging
 import socket
 import time
-import tempfile
 
 import mlflow
 from mlflow.server import BACKEND_STORE_URI_ENV_VAR, ARTIFACT_ROOT_ENV_VAR
-from mlflow.utils.file_utils import path_to_local_file_uri, local_file_uri_to_path
 from tests.helper_functions import LOCALHOST, get_safe_port
 
 _logger = logging.getLogger(__name__)
@@ -53,7 +51,7 @@ def _await_server_down_or_die(process, timeout=60):
         raise Exception("Server failed to shutdown after %s seconds" % timeout)
 
 
-def _init_server(backend_uri, root_artifact_uri):
+def _init_server(backend_uri, root_artifact_uri, extra_env=None):
     """
     Launch a new REST server using the tracking store specified by backend_uri and root artifact
     directory specified by root_artifact_uri.
@@ -62,26 +60,31 @@ def _init_server(backend_uri, root_artifact_uri):
     """
     mlflow.set_tracking_uri(None)
     server_port = get_safe_port()
-    env = {
-        BACKEND_STORE_URI_ENV_VAR: backend_uri,
-        ARTIFACT_ROOT_ENV_VAR: path_to_local_file_uri(
-            tempfile.mkdtemp(dir=local_file_uri_to_path(root_artifact_uri))
-        ),
-    }
-    with mock.patch.dict(os.environ, env):
-        cmd = [
-            "python",
+    process = Popen(
+        [
+            sys.executable,
             "-c",
-            'from mlflow.server import app; app.run("{hostname}", {port})'.format(
-                hostname=LOCALHOST, port=server_port
-            ),
-        ]
-        process = Popen(cmd)
+            f'from mlflow.server import app; app.run("{LOCALHOST}", {server_port})',
+        ],
+        env={
+            **os.environ,
+            BACKEND_STORE_URI_ENV_VAR: backend_uri,
+            ARTIFACT_ROOT_ENV_VAR: root_artifact_uri,
+            **(extra_env or {}),
+        },
+    )
 
     _await_server_up_or_die(server_port)
-    url = "http://{hostname}:{port}".format(hostname=LOCALHOST, port=server_port)
+    url = f"http://{LOCALHOST}:{server_port}"
     _logger.info(f"Launching tracking server against backend URI {backend_uri}. Server URL: {url}")
     return url, process
+
+
+def _terminate_server(process, timeout=10):
+    """Waits until the local flask server process is terminated."""
+    _logger.info("Terminating server...")
+    process.terminate()
+    process.wait(timeout=timeout)
 
 
 def _send_rest_tracking_post_request(tracking_server_uri, api_path, json_payload):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Backports the changes to disallow local model version sources.

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)


```python
import requests
import uuid
import subprocess
import time

# Run the following command before running this script:
# mlflow server --backend-store-uri sqlite:///mlflow.db --default-artifact-root outputs

r = requests.post(
    "http://127.0.0.1:5000/api/2.0/mlflow/runs/create",
    json={
        "experiment_id": 0,
    },
)
r.raise_for_status()
run_id = r.json()["run"]["info"]["run_id"]
artifact_uri = r.json()["run"]["info"]["artifact_uri"]

name = uuid.uuid4().hex
r = requests.post(
    "http://127.0.0.1:5000/api/2.0/mlflow/registered-models/create",
    json={"name": name},
)
r.raise_for_status()
print(r.json())

# Should not work
r = requests.post(
    "http://127.0.0.1:5000/api/2.0/mlflow/model-versions/create",
    json={
        "name": name,
        "source": "file://./foo",
    },
)

assert "INVALID_PARAMETER_VALUE" == r.json()["error_code"]
assert "Invalid model version source" in r.json()["message"]


# Should work
r = requests.post(
    "http://127.0.0.1:5000/api/2.0/mlflow/model-versions/create",
    json={
        "name": name,
        "source": artifact_uri,
        "run_id": run_id,
    },
)
r.raise_for_status()
print(r.json())

```

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
