### PR TITLE
[FR]: Enable evaluate custom metric (_evaluate_custom_metric) to accept optional dataframes or numpy arrays + Enable MLflow evaluate to take in 2D inputs

### DIFF
--- a/dev/custom_metrics_patch.py
+++ b/dev/custom_metrics_patch.py
@@ -1,7 +1,7 @@
 from sklearn.metrics import mean_squared_error
 
 
-def weighted_mean_squared_error(eval_df, _builtin_metrics):
+def weighted_mean_squared_error(eval_df, _builtin_metrics, additional_df=None, additional_array=None):
     return mean_squared_error(
         eval_df["prediction"],
         eval_df["target"],

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -469,7 +469,7 @@ def _evaluate_custom_metric(
     :param eval_df: A Pandas dataframe object containing a prediction and a target column.
     :param builtin_metrics: A dictionary of metrics produced by the default evaluator.
     :param additional_df: A Pandas dataframe that contains additional information for the overall dataset
-    :param additional_array: A numpy array that contains additional information for the overall dataset.
+    :param additional_array: A numpy array that contains additional information for the overall dataset
     :return: A scalar metric value.
     """
     exception_header = (

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -248,11 +248,7 @@ def _get_multiclass_classifier_metrics(
 def _get_classifier_per_class_metrics_collection_df(y, y_pred, labels, sample_weights):
     per_class_metrics_list = []
     for positive_class_index, positive_class in enumerate(labels):
-        (
-            y_bin,
-            y_pred_bin,
-            _,
-        ) = _get_binary_sum_up_label_pred_prob(
+        (y_bin, y_pred_bin, _,) = _get_binary_sum_up_label_pred_prob(
             positive_class_index, positive_class, y, y_pred, None
         )
         per_class_metrics = {"positive_class": positive_class}
@@ -456,7 +452,13 @@ def _is_numeric(value):
     return isinstance(value, (int, float, np.number))
 
 
-def _evaluate_custom_metric(custom_metric_tuple, eval_df, builtin_metrics):
+def _evaluate_custom_metric(
+    custom_metric_tuple,
+    eval_df,
+    builtin_metrics,
+    additional_df: pd.DataFrame = None,
+    additional_array: np.array = None,
+):
     """
     This function calls the `custom_metric` function and performs validations on the returned
     result to ensure that they are in the expected format. It will raise a MlflowException if
@@ -466,6 +468,8 @@ def _evaluate_custom_metric(custom_metric_tuple, eval_df, builtin_metrics):
                                 ``custom_metrics`` parameter of ``mlflow.evaluate``
     :param eval_df: A Pandas dataframe object containing a prediction and a target column.
     :param builtin_metrics: A dictionary of metrics produced by the default evaluator.
+    :param additional_df: A Pandas dataframe that contains additional information for the overall dataset
+    :param additional_array: A numpy array that contains additional information for the overall dataset.
     :return: A scalar metric value.
     """
     exception_header = (
@@ -473,7 +477,7 @@ def _evaluate_custom_metric(custom_metric_tuple, eval_df, builtin_metrics):
         " in the `custom_metrics` parameter"
     )
 
-    metric = custom_metric_tuple.function(eval_df, builtin_metrics)
+    metric = custom_metric_tuple.function(eval_df, builtin_metrics, additional_df, additional_array)
 
     if metric is None:
         raise MlflowException(f"{exception_header} returned None.")
@@ -1007,7 +1011,8 @@ class DefaultEvaluator(ModelEvaluator):
         if not self.custom_metrics and not self.custom_artifacts:
             return
         builtin_metrics = copy.deepcopy(self.metrics)
-        eval_df = pd.DataFrame({"prediction": copy.deepcopy(self.y_pred), "target": self.y})
+        # this is to accept 2d inputs of `y_pred`
+        eval_df = pd.DataFrame({"prediction": list(copy.deepcopy(self.y_pred)), "target": list(self.y)})
         for index, custom_metric in enumerate(self.custom_metrics or []):
             # deepcopying eval_df and builtin_metrics for each custom metric function call,
             # in case the user modifies them inside their function(s).

--- a/tests/models/test_default_evaluator.py
+++ b/tests/models/test_default_evaluator.py
@@ -1349,11 +1349,11 @@ def test_evaluate_custom_metric_incorrect_return_formats():
     ("fn", "expectation"),
     [
         (
-            lambda eval_df, _: sum(eval_df["prediction"]),
+            lambda eval_df, _, __, ___: sum(eval_df["prediction"]),
             does_not_raise(),
         ),
         (
-            lambda _, __: None,
+            lambda _, __, ___, ____: None,
             pytest.raises(MlflowException, match="returned None"),
         ),
     ],
@@ -1369,7 +1369,7 @@ def test_evaluate_custom_metric_success():
     eval_df = pd.DataFrame({"prediction": [1.2, 1.9, 3.2], "target": [1, 2, 3]})
     metrics = _get_regressor_metrics(eval_df["target"], eval_df["prediction"], sample_weights=None)
 
-    def example_count_times_1_point_5(_, given_metrics):
+    def example_count_times_1_point_5(_, given_metrics, __, ___):
         return given_metrics["example_count"] * 1.5
 
     res_metric = _evaluate_custom_metric(
@@ -1443,10 +1443,10 @@ def test_custom_metric_produced_multiple_artifacts_with_same_name_throw_exceptio
 
 
 def test_custom_metric_mixed(binary_logistic_regressor_model_uri, breast_cancer_dataset):
-    def true_count(_eval_df, given_metrics):
+    def true_count(_eval_df, given_metrics, additional_df, additional_array):
         return given_metrics["true_negatives"] + given_metrics["true_positives"]
 
-    def positive_count(eval_df, _given_metrics):
+    def positive_count(eval_df, _given_metrics, additional_df, additional_array):
         return np.sum(eval_df["prediction"])
 
     def example_custom_artifact(_eval_df, _given_metrics, tmp_path):
@@ -1921,7 +1921,7 @@ def test_custom_metrics():
             evaluators="default",
             custom_metrics=[
                 make_metric(
-                    eval_fn=lambda _eval_df, _builtin_metrics: 1.0,
+                    eval_fn=lambda _eval_df, _builtin_metrics, _, __: 1.0,
                     name="cm",
                     greater_is_better=True,
                     long_name="custom_metric",

--- a/tests/recipes/test_evaluate_step.py
+++ b/tests/recipes/test_evaluate_step.py
@@ -89,7 +89,7 @@ custom_metrics:
     recipe_steps_dir.mkdir(parents=True)
     recipe_steps_dir.joinpath("custom_metrics.py").write_text(
         """
-def weighted_mean_squared_error_func(eval_df, builtin_metrics):
+def weighted_mean_squared_error_func(eval_df, builtin_metrics, additional_df=None, additional_array=None):
     from sklearn.metrics import mean_squared_error
 
     return mean_squared_error(

--- a/tests/recipes/test_register_step.py
+++ b/tests/recipes/test_register_step.py
@@ -75,7 +75,7 @@ custom_metrics:
     recipe_steps_dir.mkdir(parents=True)
     recipe_steps_dir.joinpath("custom_metrics.py").write_text(
         """
-def weighted_mean_squared_error(eval_df, builtin_metrics):
+def weighted_mean_squared_error(eval_df, builtin_metrics, additional_df=None, additional_array=None):
     from sklearn.metrics import mean_squared_error
 
     return mean_squared_error(
@@ -186,7 +186,7 @@ custom_metrics:
     recipe_steps_dir.mkdir(parents=True)
     recipe_steps_dir.joinpath("custom_metrics.py").write_text(
         """
-def weighted_mean_squared_error(eval_df, builtin_metrics):
+def weighted_mean_squared_error(eval_df, builtin_metrics, additional_df=None, additional_array=None):
     from sklearn.metrics import mean_squared_error
 
     return mean_squared_error(
@@ -248,7 +248,7 @@ custom_metrics:
     recipe_steps_dir.mkdir(parents=True)
     recipe_steps_dir.joinpath("custom_metrics.py").write_text(
         """
-def weighted_mean_squared_error(eval_df, builtin_metrics):
+def weighted_mean_squared_error(eval_df, builtin_metrics, additional_df=None, additional_array=None):
     from sklearn.metrics import mean_squared_error
 
     return mean_squared_error(

--- a/tests/recipes/test_train_step.py
+++ b/tests/recipes/test_train_step.py
@@ -628,7 +628,7 @@ def test_automl(
             recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
             recipe_steps_dir.joinpath("custom_metrics.py").write_text(
                 """
-def weighted_mean_squared_error(eval_df, builtin_metrics):
+def weighted_mean_squared_error(eval_df, builtin_metrics, additional_df=None, additional_array=None):
     from sklearn.metrics import mean_squared_error
 
     return mean_squared_error(


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #8060, #8059 

## What changes are proposed in this pull request?

- issue 8060: we are adding 2 more optional parameters to `_evaluate_custom_metric`
- issue 8059: we are allowing for 2d inputs from `y_pred`
- both issues do not need to make any changes to the current code, and would be backwards compatible

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

both issues do not need to make any changes to the current code, and would be backwards compatible

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
