### PR TITLE
Add alias support to model URI parsing and disallow reserved aliases

### DIFF
--- a/mlflow/models/wheeled_model.py
+++ b/mlflow/models/wheeled_model.py
@@ -72,7 +72,7 @@ class WheeledModel:
             with mlflow.start_run():
                 WheeledModel.log_model(model_uri)
         """
-        model_name, _, _ = _parse_model_uri(model_uri)
+        model_name, _, _, _ = _parse_model_uri(model_uri)
         return Model.log(
             artifact_path=None,
             flavor=WheeledModel(model_uri),

--- a/mlflow/models/wheeled_model.py
+++ b/mlflow/models/wheeled_model.py
@@ -72,11 +72,11 @@ class WheeledModel:
             with mlflow.start_run():
                 WheeledModel.log_model(model_uri)
         """
-        model_name, _, _, _ = _parse_model_uri(model_uri)
+        parsed_uri = _parse_model_uri(model_uri)
         return Model.log(
             artifact_path=None,
             flavor=WheeledModel(model_uri),
-            registered_model_name=registered_model_name or model_name,
+            registered_model_name=registered_model_name or parsed_uri.name,
         )
 
     def save_model(self, path, mlflow_model=None):

--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -46,7 +46,7 @@ class ParsedModelUri(NamedTuple):
 
 def _parse_model_uri(uri):
     """
-    Returns (name, version, stage, alias). Since a models:/ URI can only have one of
+    Returns a ParsedModelUri tuple. Since a models:/ URI can only have one of
     {version, stage, 'latest', alias}, it will return
         - (name, version, None, None) to look for a specific version,
         - (name, None, stage, None) to look for the latest version of a stage,

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -26,7 +26,7 @@ _EXPERIMENT_ID_REGEX = re.compile(r"^[a-zA-Z0-9][\w\-]{0,63}$")
 _REGISTERED_MODEL_ALIAS_REGEX = re.compile(r"^[\w\-]*$")
 
 # Regex for valid registered model alias to prevent conflict with version aliases.
-_REGISTERED_MODEL_ALIAS_VERSION_REGEX = re.compile(r"^v\d+$")
+_REGISTERED_MODEL_ALIAS_VERSION_REGEX = re.compile(r"^[vV]\d+$")
 
 _BAD_CHARACTERS_MESSAGE = (
     "Names may only contain alphanumerics, underscores (_), dashes (-), periods (.),"
@@ -382,7 +382,9 @@ def _validate_model_alias_name(model_alias_name):
         "Registered model alias name", MAX_REGISTERED_MODEL_ALIAS_LENGTH, model_alias_name
     )
     if model_alias_name.lower() == "latest":
-        raise MlflowException("'latest' alias name is reserved.", INVALID_PARAMETER_VALUE)
+        raise MlflowException(
+            "'latest' alias name (case insensitive) is reserved.", INVALID_PARAMETER_VALUE
+        )
     if _REGISTERED_MODEL_ALIAS_VERSION_REGEX.match(model_alias_name):
         raise MlflowException(
             f"Version alias name '{model_alias_name}' is reserved.", INVALID_PARAMETER_VALUE

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -25,6 +25,9 @@ _EXPERIMENT_ID_REGEX = re.compile(r"^[a-zA-Z0-9][\w\-]{0,63}$")
 # underscores, and dashes.
 _REGISTERED_MODEL_ALIAS_REGEX = re.compile(r"^[\w\-]*$")
 
+# Regex for valid registered model alias to prevent conflict with version aliases.
+_REGISTERED_MODEL_ALIAS_VERSION_REGEX = re.compile(r"^v\d+$")
+
 _BAD_CHARACTERS_MESSAGE = (
     "Names may only contain alphanumerics, underscores (_), dashes (-), periods (.),"
     " spaces ( ), and slashes (/)."
@@ -378,6 +381,12 @@ def _validate_model_alias_name(model_alias_name):
     _validate_length_limit(
         "Registered model alias name", MAX_REGISTERED_MODEL_ALIAS_LENGTH, model_alias_name
     )
+    if model_alias_name.lower() == "latest":
+        raise MlflowException("'latest' alias name is reserved.", INVALID_PARAMETER_VALUE)
+    if _REGISTERED_MODEL_ALIAS_VERSION_REGEX.match(model_alias_name):
+        raise MlflowException(
+            f"Version alias name '{model_alias_name}' is reserved.", INVALID_PARAMETER_VALUE
+        )
 
 
 def _validate_experiment_artifact_location(artifact_location):

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -10,10 +10,10 @@ from mlflow.entities.model_registry import ModelVersion
 @pytest.mark.parametrize(
     ("uri", "expected_name", "expected_version"),
     [
-        ("models:/AdsModel1/0", "AdsModel1", 0),
-        ("models:/Ads Model 1/12345", "Ads Model 1", 12345),
-        ("models:/12345/67890", "12345", 67890),
-        ("models://profile@databricks/12345/67890", "12345", 67890),
+        ("models:/AdsModel1/0", "AdsModel1", "0"),
+        ("models:/Ads Model 1/12345", "Ads Model 1", "12345"),
+        ("models:/12345/67890", "12345", "67890"),
+        ("models://profile@databricks/12345/67890", "12345", "67890"),
     ],
 )
 def test_parse_models_uri_with_version(uri, expected_name, expected_version):
@@ -85,6 +85,9 @@ def test_parse_models_uri_with_alias(uri, expected_name, expected_alias):
         "notmodels:/NameOfModel/StageName",  # wrong scheme with stage
         "notmodels:/NameOfModel@alias",  # wrong scheme with alias
         "models:/",  # no model name
+        "models:/Name",  # no specifiers
+        "models:/Name/",  # empty suffix
+        "models:/Name@",  # empty alias
         "models:/Name/Stage/0",  # too many specifiers
         "models:/Name/Stage@Alias",  # stage and alias both specified
         "models:/Name@alias/Stage",  # Stage and alias both specified

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -85,6 +85,7 @@ def test_parse_models_uri_with_alias(uri, expected_name, expected_alias):
         "notmodels:/NameOfModel/StageName",  # wrong scheme with stage
         "notmodels:/NameOfModel@alias",  # wrong scheme with alias
         "models:/",  # no model name
+        "models:/ /Stage",  # empty name
         "models:/Name",  # no specifiers
         "models:/Name/",  # empty suffix
         "models:/Name@",  # empty alias

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -95,6 +95,7 @@ def test_parse_models_uri_with_alias(uri, expected_name, expected_alias):
         "models:/Name@Alias@other",  # too many aliases
         "models:Name/Stage",  # missing slash
         "models://Name/Stage",  # hostnames are ignored, path too short
+        "models://Name@te#ty;",  # invalid characters
     ],
 )
 def test_parse_models_uri_invalid_input(uri):

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -75,6 +75,7 @@ BAD_ALIAS_NAMES = [
     None,
     "$dgs",
     "latest",
+    "Latest",
     "v123",
     "V1",
 ]

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -50,6 +50,11 @@ GOOD_ALIAS_NAMES = [
     "test-alias",
     "1a2b5cDeFgH",
     "a" * 256,
+    "lates",
+    "v123_temp",
+    "123",
+    "123v",
+    "temp_v123",
 ]
 
 BAD_ALIAS_NAMES = [
@@ -69,6 +74,9 @@ BAD_ALIAS_NAMES = [
     "a" * 257,
     None,
     "$dgs",
+    "latest",
+    "v123",
+    "v1",
 ]
 
 

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -54,7 +54,7 @@ GOOD_ALIAS_NAMES = [
     "v123_temp",
     "123",
     "123v",
-    "temp_v123",
+    "temp_V123",
 ]
 
 BAD_ALIAS_NAMES = [
@@ -76,7 +76,7 @@ BAD_ALIAS_NAMES = [
     "$dgs",
     "latest",
     "v123",
-    "v1",
+    "V1",
 ]
 
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

https://github.com/mlflow/mlflow/pull/8001
https://github.com/mlflow/mlflow/pull/8055
https://github.com/mlflow/mlflow/pull/8094

## What changes are proposed in this pull request?

This PR adds alias support to model URI parsing and disallows reserved aliases for `latest` and version numbers (`v###`).

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

This PR adds alias support to model URI parsing and disallows reserved aliases for `latest` and version numbers (`v###`).

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
