### PR TITLE
Fix `delete_experiment` and `restore_experiment` in FileStore implementation

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1,14 +1,14 @@
 import json
 import logging
-import os
-import shutil
-import sys
 import time
+import os
+import sys
+import shutil
+
 import uuid
 
 from mlflow.entities import (
     Experiment,
-    ExperimentTag,
     Metric,
     Param,
     Run,
@@ -16,19 +16,19 @@ from mlflow.entities import (
     RunInfo,
     RunStatus,
     RunTag,
-    SourceType,
     ViewType,
+    SourceType,
+    ExperimentTag,
 )
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.entities.run_info import check_run_is_active
-from mlflow.exceptions import MissingConfigException, MlflowException
+from mlflow.exceptions import MlflowException, MissingConfigException
 from mlflow.protos import databricks_pb2
 from mlflow.protos.databricks_pb2 import (
     INTERNAL_ERROR,
-    INVALID_PARAMETER_VALUE,
     RESOURCE_DOES_NOT_EXIST,
+    INVALID_PARAMETER_VALUE,
 )
-from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry.file_store import FileStore as ModelRegistryFileStore
 from mlflow.store.tracking import (
     DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
@@ -36,51 +36,51 @@ from mlflow.store.tracking import (
     SEARCH_MAX_RESULTS_THRESHOLD,
 )
 from mlflow.store.tracking.abstract_store import AbstractStore
+from mlflow.store.entities.paged_list import PagedList
 from mlflow.utils import get_results_from_paginated_fn
-from mlflow.utils.env import get_env
-from mlflow.utils.file_utils import (
-    append_to,
-    exists,
-    find,
-    get_parent_dir,
-    is_directory,
-    list_all,
-    list_subdirs,
-    local_file_uri_to_path,
-    make_containing_dirs,
-    mkdir,
-    mv,
-    overwrite_yaml,
-    path_to_local_file_uri,
-    read_file,
-    read_file_lines,
-    read_yaml,
-    write_to,
-    write_yaml,
-)
-from mlflow.utils.mlflow_tags import (
-    MLFLOW_LOGGED_MODELS,
-    MLFLOW_RUN_NAME,
-    _get_run_name_from_tags,
-)
 from mlflow.utils.name_utils import _generate_random_name, _generate_unique_integer_id
-from mlflow.utils.search_utils import SearchExperimentsUtils, SearchUtils
-from mlflow.utils.string_utils import is_string_type
-from mlflow.utils.time_utils import get_current_time_millis
-from mlflow.utils.uri import append_to_uri_path, resolve_uri_if_local
 from mlflow.utils.validation import (
-    _validate_batch_log_data,
-    _validate_batch_log_limits,
-    _validate_experiment_id,
-    _validate_experiment_name,
     _validate_metric,
     _validate_metric_name,
-    _validate_param,
-    _validate_param_keys_unique,
     _validate_param_name,
+    _validate_param,
     _validate_run_id,
     _validate_tag_name,
+    _validate_experiment_id,
+    _validate_batch_log_limits,
+    _validate_batch_log_data,
+    _validate_param_keys_unique,
+    _validate_experiment_name,
 )
+from mlflow.utils.env import get_env
+from mlflow.utils.file_utils import (
+    is_directory,
+    list_subdirs,
+    mkdir,
+    exists,
+    write_yaml,
+    overwrite_yaml,
+    read_yaml,
+    find,
+    read_file_lines,
+    read_file,
+    write_to,
+    append_to,
+    make_containing_dirs,
+    mv,
+    get_parent_dir,
+    list_all,
+    local_file_uri_to_path,
+    path_to_local_file_uri,
+)
+from mlflow.utils.search_utils import SearchUtils, SearchExperimentsUtils
+from mlflow.utils.string_utils import is_string_type
+from mlflow.utils.time_utils import get_current_time_millis
+from mlflow.utils.uri import (
+    append_to_uri_path,
+    resolve_uri_if_local,
+)
+from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_MODELS, MLFLOW_RUN_NAME, _get_run_name_from_tags
 
 _TRACKING_DIR_ENV_VAR = "MLFLOW_TRACKING_DIR"
 

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -437,9 +437,7 @@ class FileStore(AbstractStore):
             run_id = run.info.run_id
             run_info = self._get_run_info(run_id)
             if run_info is None:
-                raise MlflowException(
-                    "Run '%s' metadata is in invalid state." % run_id, databricks_pb2.INVALID_STATE
-                )
+                logging.warning(f"Run {run_id} metadata is in invalid state.")
             new_info = run_info._copy_with_overrides(lifecycle_stage=LifecycleStage.DELETED)
             self._overwrite_run_info(new_info, deleted_time=deletion_time)
         meta_dir = os.path.join(self.root_directory, experiment_id)
@@ -482,9 +480,7 @@ class FileStore(AbstractStore):
             run_id = run.info.run_id
             run_info = self._get_run_info(run_id)
             if run_info is None:
-                raise MlflowException(
-                    "Run '%s' metadata is in invalid state." % run_id, databricks_pb2.INVALID_STATE
-                )
+                logging.warning(f"Run {run_id} metadata is in invalid state.")
             new_info = run_info._copy_with_overrides(lifecycle_stage=LifecycleStage.ACTIVE)
             self._overwrite_run_info(new_info, deleted_time=None)
         overwrite_yaml(

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1,14 +1,14 @@
 import json
 import logging
-import time
 import os
-import sys
 import shutil
-
+import sys
+import time
 import uuid
 
 from mlflow.entities import (
     Experiment,
+    ExperimentTag,
     Metric,
     Param,
     Run,
@@ -16,19 +16,19 @@ from mlflow.entities import (
     RunInfo,
     RunStatus,
     RunTag,
-    ViewType,
     SourceType,
-    ExperimentTag,
+    ViewType,
 )
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.entities.run_info import check_run_is_active
-from mlflow.exceptions import MlflowException, MissingConfigException
+from mlflow.exceptions import MissingConfigException, MlflowException
 from mlflow.protos import databricks_pb2
 from mlflow.protos.databricks_pb2 import (
     INTERNAL_ERROR,
-    RESOURCE_DOES_NOT_EXIST,
     INVALID_PARAMETER_VALUE,
+    RESOURCE_DOES_NOT_EXIST,
 )
+from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry.file_store import FileStore as ModelRegistryFileStore
 from mlflow.store.tracking import (
     DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
@@ -36,51 +36,51 @@ from mlflow.store.tracking import (
     SEARCH_MAX_RESULTS_THRESHOLD,
 )
 from mlflow.store.tracking.abstract_store import AbstractStore
-from mlflow.store.entities.paged_list import PagedList
 from mlflow.utils import get_results_from_paginated_fn
-from mlflow.utils.name_utils import _generate_random_name, _generate_unique_integer_id
-from mlflow.utils.validation import (
-    _validate_metric,
-    _validate_metric_name,
-    _validate_param_name,
-    _validate_param,
-    _validate_run_id,
-    _validate_tag_name,
-    _validate_experiment_id,
-    _validate_batch_log_limits,
-    _validate_batch_log_data,
-    _validate_param_keys_unique,
-    _validate_experiment_name,
-)
 from mlflow.utils.env import get_env
 from mlflow.utils.file_utils import (
-    is_directory,
-    list_subdirs,
-    mkdir,
-    exists,
-    write_yaml,
-    overwrite_yaml,
-    read_yaml,
-    find,
-    read_file_lines,
-    read_file,
-    write_to,
     append_to,
-    make_containing_dirs,
-    mv,
+    exists,
+    find,
     get_parent_dir,
+    is_directory,
     list_all,
+    list_subdirs,
     local_file_uri_to_path,
+    make_containing_dirs,
+    mkdir,
+    mv,
+    overwrite_yaml,
     path_to_local_file_uri,
+    read_file,
+    read_file_lines,
+    read_yaml,
+    write_to,
+    write_yaml,
 )
-from mlflow.utils.search_utils import SearchUtils, SearchExperimentsUtils
+from mlflow.utils.mlflow_tags import (
+    MLFLOW_LOGGED_MODELS,
+    MLFLOW_RUN_NAME,
+    _get_run_name_from_tags,
+)
+from mlflow.utils.name_utils import _generate_random_name, _generate_unique_integer_id
+from mlflow.utils.search_utils import SearchExperimentsUtils, SearchUtils
 from mlflow.utils.string_utils import is_string_type
 from mlflow.utils.time_utils import get_current_time_millis
-from mlflow.utils.uri import (
-    append_to_uri_path,
-    resolve_uri_if_local,
+from mlflow.utils.uri import append_to_uri_path, resolve_uri_if_local
+from mlflow.utils.validation import (
+    _validate_batch_log_data,
+    _validate_batch_log_limits,
+    _validate_experiment_id,
+    _validate_experiment_name,
+    _validate_metric,
+    _validate_metric_name,
+    _validate_param,
+    _validate_param_keys_unique,
+    _validate_param_name,
+    _validate_run_id,
+    _validate_tag_name,
 )
-from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_MODELS, MLFLOW_RUN_NAME, _get_run_name_from_tags
 
 _TRACKING_DIR_ENV_VAR = "MLFLOW_TRACKING_DIR"
 

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -381,10 +381,6 @@ class FileStore(AbstractStore):
                 databricks_pb2.RESOURCE_DOES_NOT_EXIST,
             )
         meta = FileStore._read_yaml(experiment_dir, FileStore.META_DATA_FILE_NAME)
-        if experiment_dir.startswith(self.trash_folder):
-            meta["lifecycle_stage"] = LifecycleStage.DELETED
-        else:
-            meta["lifecycle_stage"] = LifecycleStage.ACTIVE
         meta["tags"] = self.get_all_experiment_tags(experiment_id)
         experiment = _read_persisted_experiment_dict(meta)
         if experiment_id != experiment.experiment_id:
@@ -439,7 +435,7 @@ class FileStore(AbstractStore):
                 self._overwrite_run_info(new_info, deleted_time=deletion_time)
             else:
                 logging.warning("Run metadata is in invalid state.")
-        meta_dir = os.path.join(self.root_directory, str(experiment_id))
+        meta_dir = os.path.join(self.root_directory, experiment_id)
         overwrite_yaml(
             root=meta_dir,
             file_name=FileStore.META_DATA_FILE_NAME,
@@ -474,7 +470,7 @@ class FileStore(AbstractStore):
         meta_dir = os.path.join(self.root_directory, experiment_id)
         experiment._lifecycle_stage = LifecycleStage.ACTIVE
         experiment._set_last_update_time(get_current_time_millis())
-        runs = self._list_run_infos(experiment_id, view_type=ViewType.ACTIVE_ONLY)
+        runs = self._list_run_infos(experiment_id, view_type=ViewType.DELETED_ONLY)
         for run_info in runs:
             if run_info is not None:
                 new_info = run_info._copy_with_overrides(lifecycle_stage=LifecycleStage.ACTIVE)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -2,44 +2,47 @@ import json
 import os
 import posixpath
 import random
+import re
 import shutil
 import time
 import uuid
 from pathlib import Path
-import re
-
-import pytest
 from unittest import mock
 
+import pytest
+
 from mlflow.entities import (
+    ExperimentTag,
+    LifecycleStage,
     Metric,
     Param,
+    RunData,
+    RunStatus,
     RunTag,
     ViewType,
-    LifecycleStage,
-    RunStatus,
-    RunData,
-    ExperimentTag,
 )
-from mlflow.store.entities.paged_list import PagedList
-from mlflow.exceptions import MlflowException, MissingConfigException
+from mlflow.exceptions import MissingConfigException, MlflowException
 from mlflow.models import Model
-from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
-from mlflow.store.tracking.file_store import FileStore
-from mlflow.utils.file_utils import write_yaml, read_yaml, path_to_local_file_uri, TempDir
-from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_MODELS
-from mlflow.utils.os import is_windows
-from mlflow.utils.uri import append_to_uri_path
-from mlflow.utils.name_utils import _GENERATOR_PREDICATES, _EXPERIMENT_ID_FIXED_WIDTH
-from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME
-from mlflow.utils.time_utils import get_current_time_millis
 from mlflow.protos.databricks_pb2 import (
-    ErrorCode,
-    RESOURCE_DOES_NOT_EXIST,
     INTERNAL_ERROR,
     INVALID_PARAMETER_VALUE,
+    RESOURCE_DOES_NOT_EXIST,
+    ErrorCode,
 )
-
+from mlflow.store.entities.paged_list import PagedList
+from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
+from mlflow.store.tracking.file_store import FileStore
+from mlflow.utils.file_utils import (
+    TempDir,
+    path_to_local_file_uri,
+    read_yaml,
+    write_yaml,
+)
+from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_MODELS, MLFLOW_RUN_NAME
+from mlflow.utils.name_utils import _EXPERIMENT_ID_FIXED_WIDTH, _GENERATOR_PREDICATES
+from mlflow.utils.os import is_windows
+from mlflow.utils.time_utils import get_current_time_millis
+from mlflow.utils.uri import append_to_uri_path
 from tests.helper_functions import random_int, random_str, safe_edit_yaml
 
 FILESTORE_PACKAGE = "mlflow.store.tracking.file_store"

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -357,6 +357,7 @@ def _create_root(store):
             "experiment_id": exp,
             "name": random_str(),
             "artifact_location": exp_folder,
+            "lifecycle_stage": LifecycleStage.ACTIVE,
             "creation_time": current_time,
             "last_update_time": current_time,
         }
@@ -381,6 +382,7 @@ def _create_root(store):
                 "deleted_time": random_int(20, 30),
                 "tags": [],
                 "artifact_uri": os.path.join(run_folder, FileStore.ARTIFACTS_FOLDER_NAME),
+                "lifecycle_stage": LifecycleStage.ACTIVE,
             }
             write_yaml(run_folder, FileStore.META_DATA_FILE_NAME, run_info)
             run_data[run_id] = run_info
@@ -593,39 +595,58 @@ def _extract_ids(experiments):
 
 
 def test_delete_restore_experiment(store):
-    exp_id = store.create_experiment("test_delete")
-    exp_name = store.get_experiment(exp_id).name
+    experiments, _, _ = _create_root(store)
+    exp1_id = experiments[random_int(0, len(experiments) - 2)]  # never select default experiment
+    exp1 = store.get_experiment(exp1_id)
 
-    exp1 = store.get_experiment(exp_id)
-    time.sleep(0.001)
-
-    # delete it
-    store.delete_experiment(exp_id)
-    assert exp_id not in _extract_ids(store.search_experiments(view_type=ViewType.ACTIVE_ONLY))
-    assert exp_id in _extract_ids(store.search_experiments(view_type=ViewType.DELETED_ONLY))
-    assert exp_id in _extract_ids(store.search_experiments(view_type=ViewType.ALL))
-    assert store.get_experiment(exp_id).lifecycle_stage == LifecycleStage.DELETED
-
-    deleted_exp1 = store.get_experiment(exp_id)
+    # test deleting experiment
+    store.delete_experiment(exp1_id)
+    assert exp1_id not in _extract_ids(store.search_experiments(view_type=ViewType.ACTIVE_ONLY))
+    assert exp1_id in _extract_ids(store.search_experiments(view_type=ViewType.DELETED_ONLY))
+    assert exp1_id in _extract_ids(store.search_experiments(view_type=ViewType.ALL))
+    deleted_exp1 = store.get_experiment(exp1_id)
     assert deleted_exp1.last_update_time > exp1.last_update_time
     assert deleted_exp1.lifecycle_stage == LifecycleStage.DELETED
 
-    # restore it
-    exp1 = store.get_experiment(exp_id)
-    time.sleep(0.01)
-    store.restore_experiment(exp_id)
-    restored_1 = store.get_experiment(exp_id)
-    assert restored_1.experiment_id == exp_id
-    assert restored_1.name == exp_name
-    assert restored_1.last_update_time > exp1.last_update_time
+    # test if setting lifecycle_stage is persisted correctly
+    deleted_exp1_dir = store._get_experiment_path(
+        experiment_id=exp1_id, view_type=ViewType.DELETED_ONLY
+    )
+    deleted_exp1_meta = FileStore._read_yaml(
+        root=deleted_exp1_dir, file_name=FileStore.META_DATA_FILE_NAME
+    )
+    assert deleted_exp1_meta["lifecycle_stage"] == LifecycleStage.DELETED
+    for run in store.search_runs(
+        experiment_ids=[exp1_id], filter_string="", run_view_type=ViewType.ALL
+    ):
+        assert run.info.lifecycle_stage == LifecycleStage.DELETED
 
-    restored_2 = store.get_experiment_by_name(exp_name)
-    assert restored_2.experiment_id == exp_id
-    assert restored_2.name == exp_name
-    assert exp_id in _extract_ids(store.search_experiments(view_type=ViewType.ACTIVE_ONLY))
-    assert exp_id not in _extract_ids(store.search_experiments(view_type=ViewType.DELETED_ONLY))
-    assert exp_id in _extract_ids(store.search_experiments(view_type=ViewType.ALL))
-    assert store.get_experiment(exp_id).lifecycle_stage == LifecycleStage.ACTIVE
+    # test restoring experiment
+    store.restore_experiment(exp1_id)
+    assert exp1_id in _extract_ids(store.search_experiments(view_type=ViewType.ACTIVE_ONLY))
+    assert exp1_id not in _extract_ids(store.search_experiments(view_type=ViewType.DELETED_ONLY))
+    assert exp1_id in _extract_ids(store.search_experiments(view_type=ViewType.ALL))
+    restored1_exp1 = store.get_experiment(exp1_id)
+    assert restored1_exp1.experiment_id == exp1_id
+    assert restored1_exp1.name == exp1.name
+    assert restored1_exp1.last_update_time > exp1.last_update_time
+    assert restored1_exp1.lifecycle_stage == LifecycleStage.ACTIVE
+    restored2_exp1 = store.get_experiment_by_name(exp1.name)
+    assert restored2_exp1.experiment_id == exp1_id
+    assert restored2_exp1.name == exp1.name
+
+    # test if setting lifecycle_stage is persisted correctly
+    restored_exp1_dir = store._get_experiment_path(
+        experiment_id=exp1_id, view_type=ViewType.ACTIVE_ONLY
+    )
+    restored_exp1_meta = FileStore._read_yaml(
+        root=restored_exp1_dir, file_name=FileStore.META_DATA_FILE_NAME
+    )
+    assert restored_exp1_meta["lifecycle_stage"] == LifecycleStage.ACTIVE
+    for run in store.search_runs(
+        experiment_ids=[exp1_id], filter_string="", run_view_type=ViewType.ALL
+    ):
+        assert run.info.lifecycle_stage == LifecycleStage.ACTIVE
 
 
 def test_rename_experiment(store):

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -2,47 +2,44 @@ import json
 import os
 import posixpath
 import random
-import re
 import shutil
 import time
 import uuid
 from pathlib import Path
-from unittest import mock
+import re
 
 import pytest
+from unittest import mock
 
 from mlflow.entities import (
-    ExperimentTag,
-    LifecycleStage,
     Metric,
     Param,
-    RunData,
-    RunStatus,
     RunTag,
     ViewType,
-)
-from mlflow.exceptions import MissingConfigException, MlflowException
-from mlflow.models import Model
-from mlflow.protos.databricks_pb2 import (
-    INTERNAL_ERROR,
-    INVALID_PARAMETER_VALUE,
-    RESOURCE_DOES_NOT_EXIST,
-    ErrorCode,
+    LifecycleStage,
+    RunStatus,
+    RunData,
+    ExperimentTag,
 )
 from mlflow.store.entities.paged_list import PagedList
+from mlflow.exceptions import MlflowException, MissingConfigException
+from mlflow.models import Model
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.tracking.file_store import FileStore
-from mlflow.utils.file_utils import (
-    TempDir,
-    path_to_local_file_uri,
-    read_yaml,
-    write_yaml,
-)
-from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_MODELS, MLFLOW_RUN_NAME
-from mlflow.utils.name_utils import _EXPERIMENT_ID_FIXED_WIDTH, _GENERATOR_PREDICATES
+from mlflow.utils.file_utils import write_yaml, read_yaml, path_to_local_file_uri, TempDir
+from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_MODELS
 from mlflow.utils.os import is_windows
-from mlflow.utils.time_utils import get_current_time_millis
 from mlflow.utils.uri import append_to_uri_path
+from mlflow.utils.name_utils import _GENERATOR_PREDICATES, _EXPERIMENT_ID_FIXED_WIDTH
+from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME
+from mlflow.utils.time_utils import get_current_time_millis
+from mlflow.protos.databricks_pb2 import (
+    ErrorCode,
+    RESOURCE_DOES_NOT_EXIST,
+    INTERNAL_ERROR,
+    INVALID_PARAMETER_VALUE,
+)
+
 from tests.helper_functions import random_int, random_str, safe_edit_yaml
 
 FILESTORE_PACKAGE = "mlflow.store.tracking.file_store"


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #8177

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

Fix persistent updating of `lifecycle_stage` of experiments and related runs when deleting/restoring experiments with FileStore backend (#8178, @mariusschlegel).

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
