### PR TITLE
Document experiment provider plugin

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -105,6 +105,9 @@ The example package contains a ``setup.py`` that declares a number of
             # Define a RunContextProvider plugin. The entry point name for run context providers
             # is not used, and so is set to the string "unused" here
             "mlflow.run_context_provider": "unused=mlflow_test_plugin.run_context_provider:PluginRunContextProvider",
+            # Define a DefaultExperimentProvider plugin. The entry point name for
+            # default experiment providers is not used, and so is set to the string "unused" here
+            "mlflow.default_experiment_provider": "unused=mlflow_test_plugin.default_experiment_provider:PluginDefaultExperimentProvider",
             # Define a RequestHeaderProvider plugin. The entry point name for request header providers
             # is not used, and so is set to the string "unused" here
             "mlflow.request_header_provider": "unused=mlflow_test_plugin.request_header_provider:PluginRequestHeaderProvider",
@@ -116,6 +119,8 @@ The example package contains a ``setup.py`` that declares a number of
             "mlflow.deployments": "faketarget=mlflow_test_plugin.fake_deployment_plugin",
             # Define a Mlflow model evaluator with name "dummy_evaluator"
             "mlflow.model_evaluator": "dummy_evaluator=mlflow_test_plugin.dummy_evaluator:DummyEvaluator",
+            # Define a custom Mlflow application with name custom_app
+            "mlflow.app": "custom_app=mlflow_test_plugin.app:custom_app",
         },
     )
 
@@ -168,6 +173,14 @@ plugin:
        within the ``mlflow_test_plugin`` module) to register.
      - `GitRunContext <https://github.com/mlflow/mlflow/blob/branch-1.13/mlflow/tracking/context/git_context.py#L38>`_,
        `DefaultRunContext <https://github.com/mlflow/mlflow/blob/branch-1.13/mlflow/tracking/context/default_context.py#L41>`_
+   * - Plugins for specifying custom experiment id lookup/creation at runtime. The plugin must have a way to create or look up the experiment id.
+     - mlflow.default_experiment_provider
+     - The entry point name is unused. The entry point value (e.g. ``mlflow_test_plugin.default_experiment_provider:PluginDefaultExperimentProvider``) specifies a custom subclass of
+       `mlflow.tracking.default_experiment.abstract_context.DefaultExperimentProvider <https://github.com/mlflow/mlflow/blob/branch-2.2/mlflow/tracking/default_experiment/abstract_context.py#L6>`_
+       (e.g., the `PluginDefaultExperimentProvider class <https://github.com/mlflow/mlflow/blob/branch-2.2/tests/resources/mlflow-test-plugin/mlflow_test_plugin/default_experiment_provider.py#L4>`_
+       within the ``mlflow_test_plugin`` module) to register.
+     - `DatabricksJobExperimentProvider <https://github.com/mlflow/mlflow/blob/branch-2.2/mlflow/tracking/default_experiment/databricks_job_experiment_provider.py#L15>`_,
+       `DatabricksNotebookExperimentProvider <https://github.com/mlflow/mlflow/blob/branch-2.2/mlflow/tracking/default_experiment/databricks_notebook_experiment_provider.py#L12>`_
    * - Plugins for specifying custom context request headers to attach to outgoing requests, e.g. headers identifying the client's environment.
      - mlflow.request_header_provider
      - The entry point name is unused. The entry point value (e.g. ``mlflow_test_plugin.request_header_provider:PluginRequestHeaderProvider``) specifies a custom subclass of


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Closes #7639 

## What changes are proposed in this pull request?
Document the experiments provider plugin. 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->
N/A docs only
- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Document default experiment provider plugin.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
