### PR TITLE
remove Protocol from dataset registry

### DIFF
--- a/mlflow/data/dataset_registry.py
+++ b/mlflow/data/dataset_registry.py
@@ -2,7 +2,6 @@ import inspect
 import entrypoints
 import warnings
 from typing import Any, Dict
-from typing_extensions import Protocol
 
 import mlflow.data
 from mlflow.exceptions import MlflowException
@@ -10,7 +9,7 @@ from mlflow.data.dataset import Dataset
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
 
-class ConstructorFunction(Protocol):
+class ConstructorFunction():
     def __call__(self, *args: Any) -> Dataset:
         pass
 

--- a/mlflow/data/dataset_registry.py
+++ b/mlflow/data/dataset_registry.py
@@ -9,7 +9,7 @@ from mlflow.data.dataset import Dataset
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
 
-class ConstructorFunction():
+class ConstructorFunction:
     def __call__(self, *args: Any) -> Dataset:
         pass
 

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_dataset.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_dataset.py
@@ -1,9 +1,6 @@
 import json
 from typing import Any, Dict, List, Optional
 
-import numpy as np
-import pandas as pd
-
 from mlflow.data.dataset import Dataset
 from mlflow.types import Schema
 from mlflow.types.utils import _infer_schema
@@ -27,6 +24,9 @@ class DummyDataset(Dataset):
         Computes a digest for the dataset. Called if the user doesn't supply
         a digest when constructing the dataset.
         """
+        import numpy as np
+        import pandas as pd
+
         return pd.util.hash_array(np.ndarray(self._data_list))
 
     def _to_dict(self, base_dict: Dict[str, str]) -> Dict[str, str]:


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Remove `Protocol` from dataset registry which requires `typing_extensions`, which causes python-skinny test to fail. 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
