### PR TITLE
Remove protobuf dependency in `tests/tensorflow/test_keras_model_export.py::test_pyfunc_serve_and_score`

### DIFF
--- a/tests/tensorflow/test_keras_model_export.py
+++ b/tests/tensorflow/test_keras_model_export.py
@@ -214,11 +214,7 @@ def test_pyfunc_serve_and_score(data):
     x, _ = data
     model = get_model(data)
     with mlflow.start_run():
-        model_info = mlflow.tensorflow.log_model(
-            model,
-            artifact_path="model",
-            extra_pip_requirements=[PROTOBUF_REQUIREMENT],
-        )
+        model_info = mlflow.tensorflow.log_model(model, artifact_path="model")
     expected = model.predict(x.values)
     scoring_response = pyfunc_serve_and_score_model(
         model_uri=model_info.model_uri,


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Remove the proto requirement in `tests/tensorflow/test_keras_model_export.py::test_pyfunc_serve_and_score` to fix the following error:

https://github.com/mlflow/mlflow/actions/runs/4650697909/jobs/8229868216#step:13:843

```
Installed Python-3.8.12 to /home/runner/.pyenv/versions/3.8.12
2023/04/09 14:39:39 INFO mlflow.utils.virtualenv: Creating a new environment in /home/runner/.mlflow/envs/mlflow-c8bdd7c0b3bbed3265edacf9081464aa908aec0e with /home/runner/.pyenv/versions/3.8.12/bin/python
created virtual environment CPython3.8.12.final.0-64 in 607ms
  creator CPython3Posix(dest=/home/runner/.mlflow/envs/mlflow-c8bdd7c0b3bbed3265edacf9081464aa908aec0e, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/home/runner/.local/share/virtualenv)
    added seed packages: pip==23.0.1, setuptools==67.4.0, wheel==0.38.4
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
2023/04/09 14:39:40 INFO mlflow.utils.virtualenv: Installing dependencies
ERROR: Cannot install protobuf<4.0.0 and protobuf==4.22.1 because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
2023/04/09 14:39:58 WARNING mlflow.utils.virtualenv: Encountered unexpected error while creating /home/runner/.mlflow/envs/mlflow-c8bdd7c0b3bbed3265edacf9081464aa908aec0e
2023/04/09 14:39:58 WARNING mlflow.utils.virtualenv: Attempting to remove /home/runner/.mlflow/envs/mlflow-c8bdd7c0b3bbed3265edacf9081464aa908aec0e
2023/04/09 14:39:58 WARNING mlflow.utils.virtualenv: Successfully removed /home/runner/.mlflow/envs/mlflow-c8bdd7c0b3bbed3265edacf9081464aa908aec0e
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
