### PR TITLE
Implement searchRegisteredModels() API in Java client

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -1000,6 +1000,76 @@ public class MlflowClient implements Serializable, Closeable {
   }
 
   /**
+   * Return up to 1000 registered models.
+   *
+   * @return A page of registered models with up to 1000 items.
+   */
+  public Page<RegisteredModel> searchRegisteredModels() {
+    return searchRegisteredModels(null, 1000, new ArrayList<>(), null);
+  }
+
+  /**
+   * Return up to 1000 registered models that satisfy the search query.
+   *
+   * @param searchFilter SQL compatible search query string.
+   *                     Examples:
+   *                         - "name = 'model_name'"
+   *                         - "name LIKE '%my_model_name%'"
+   *                     If null, the result will be equivalent to having an empty search filter.
+   *
+   * @return A page of registered models with up to 1000 items.
+   */
+  public Page<RegisteredModel> searchRegisteredModels(String searchFilter) {
+    return searchRegisteredModels(searchFilter, 1000, new ArrayList<>(), null);
+  }
+
+  /**
+   * Return registered models that satisfy the search query.
+   *
+   * @param searchFilter SQL compatible search query string.
+   *                     Examples:
+   *                         - "name = 'model_name'"
+   *                         - "name LIKE '%my_model_name%'"
+   *                     If null, the result will be equivalent to having an empty search filter.
+   * @param maxResults Maximum number of model versions desired in one page.
+   * @param orderBy List of properties to order by. Example: "name DESC".
+   *
+   * @return A page of registered models that satisfy the search filter.
+   */
+  public Page<RegisteredModel> searchRegisteredModels(String searchFilter, int maxResults, List<String> orderBy) {
+    return searchRegisteredModels(searchFilter, maxResults, orderBy, null);
+  }
+
+  /**
+   * Return registered models that satisfy the search query.
+   *
+   * @param searchFilter SQL compatible search query string.
+   *                     Examples:
+   *                         - "name = 'model_name'"
+   *                         - "name LIKE '%my_model_name%'"
+   *                     If null, the result will be equivalent to having an empty search filter.
+   * @param maxResults Maximum number of registered models desired in one page.
+   * @param orderBy List of properties to order by. Example: "name DESC".
+   * @param pageToken String token specifying the next page of results. It should be obtained from
+   *             a call to {@link #searchRegisteredModels(String)}.
+   *
+   * @return A page of registered models that satisfy the search filter.
+   */
+  public Page<RegisteredModel> searchRegisteredModels(String searchFilter, int maxResults, List<String> orderBy, String pageToken) {
+    String json = sendGet(mapper.makeSearchRegisteredModels(
+        searchFilter, maxResults, orderBy, pageToken
+    ));
+    SearchRegisteredModels.Response response = mapper.toSearchRegisteredModelsResponse(json);
+    return new RegisteredModelsPage(
+        response.getRegisteredModelsList(),
+        response.getNextPageToken(),
+        searchFilter,
+        maxResults,
+        orderBy,
+        this);
+  }
+
+  /**
    * Closes the MlflowClient and releases any associated resources.
    */
   public void close() {

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -1036,7 +1036,9 @@ public class MlflowClient implements Serializable, Closeable {
    *
    * @return A page of registered models that satisfy the search filter.
    */
-  public Page<RegisteredModel> searchRegisteredModels(String searchFilter, int maxResults, List<String> orderBy) {
+  public Page<RegisteredModel> searchRegisteredModels(String searchFilter,
+                                                      int maxResults,
+                                                      List<String> orderBy) {
     return searchRegisteredModels(searchFilter, maxResults, orderBy, null);
   }
 
@@ -1055,7 +1057,10 @@ public class MlflowClient implements Serializable, Closeable {
    *
    * @return A page of registered models that satisfy the search filter.
    */
-  public Page<RegisteredModel> searchRegisteredModels(String searchFilter, int maxResults, List<String> orderBy, String pageToken) {
+  public Page<RegisteredModel> searchRegisteredModels(String searchFilter,
+                                                      int maxResults,
+                                                      List<String> orderBy,
+                                                      String pageToken) {
     String json = sendGet(mapper.makeSearchRegisteredModels(
         searchFilter, maxResults, orderBy, pageToken
     ));

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
@@ -220,6 +220,25 @@ class MlflowProtobufMapper {
     }
   }
 
+  String makeSearchRegisteredModels(String searchFilter, int maxResults, List<String> orderBy, String pageToken) {
+    try {
+      URIBuilder builder = new URIBuilder("registered-models/search")
+              .addParameter("max_results", Integer.toString(maxResults));
+      if (searchFilter != null && searchFilter != "") {
+        builder.addParameter("filter", searchFilter);
+      }
+      if (pageToken != null && pageToken != "") {
+        builder.addParameter("page_token", pageToken);
+      }
+      for( String order: orderBy) {
+        builder.addParameter("order_by", order);
+      }
+      return builder.build().toString();
+    } catch (URISyntaxException e) {
+      throw new MlflowClientException("Failed to construct request URI for search registered models.", e);
+    }
+  }
+
   String toJson(MessageOrBuilder mb) {
     return print(mb);
   }
@@ -299,6 +318,12 @@ class MlflowProtobufMapper {
 
   SearchModelVersions.Response toSearchModelVersionsResponse(String json) {
     SearchModelVersions.Response.Builder builder = SearchModelVersions.Response.newBuilder();
+    merge(json, builder);
+    return builder.build();
+  }
+
+  SearchRegisteredModels.Response toSearchRegisteredModelsResponse(String json) {
+    SearchRegisteredModels.Response.Builder builder = SearchRegisteredModels.Response.newBuilder();
     merge(json, builder);
     return builder.build();
   }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
@@ -220,7 +220,9 @@ class MlflowProtobufMapper {
     }
   }
 
-  String makeSearchRegisteredModels(String searchFilter, int maxResults, List<String> orderBy, String pageToken) {
+  String makeSearchRegisteredModels(String searchFilter,
+                                    int maxResults,
+                                    List<String> orderBy, String pageToken) {
     try {
       URIBuilder builder = new URIBuilder("registered-models/search")
               .addParameter("max_results", Integer.toString(maxResults));
@@ -235,7 +237,9 @@ class MlflowProtobufMapper {
       }
       return builder.build().toString();
     } catch (URISyntaxException e) {
-      throw new MlflowClientException("Failed to construct request URI for search registered models.", e);
+      throw new MlflowClientException(
+          "Failed to construct request URI for search registered models.",
+          e);
     }
   }
 

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/RegisteredModelsPage.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/RegisteredModelsPage.java
@@ -1,0 +1,81 @@
+package org.mlflow.tracking;
+
+import org.mlflow.api.proto.ModelRegistry.RegisteredModel;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+class RegisteredModelsPage implements Page<RegisteredModel> {
+
+  private final String token;
+  private final List<RegisteredModel> items;
+
+  private final MlflowClient client;
+  private final String searchFilter;
+  private final List<String> orderBy;
+  private final int maxResults;
+
+  /**
+   * Creates a fixed size page of RegisteredModels.
+   */
+  RegisteredModelsPage(List<RegisteredModel> models,
+                       String token,
+                       String searchFilter,
+                       int maxResults,
+                       List<String> orderBy,
+                       MlflowClient client) {
+    this.items = Collections.unmodifiableList(models);
+    this.token = token;
+    this.searchFilter = searchFilter;
+    this.orderBy = orderBy;
+    this.maxResults = maxResults;
+    this.client = client;
+  }
+
+  /**
+   * @return The number of registered models in the page.
+   */
+  public int getPageSize() {
+    return this.items.size();
+  }
+
+  /**
+   * @return True if a token for the next page exists and isn't empty. Otherwise returns false.
+   */
+  public boolean hasNextPage() {
+    return this.token != null && this.token != "";
+  }
+
+  /**
+   * @return An optional with the token for the next page.
+   * Empty if the token doesn't exist or is empty.
+   */
+  public Optional<String> getNextPageToken() {
+    if (this.hasNextPage()) {
+      return Optional.of(this.token);
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * @return The next page of registered models matching the search criteria.
+   * If there are no more pages, an {@link EmptyPage} will be returned.
+   */
+  public Page<RegisteredModel> getNextPage() {
+    if (this.hasNextPage()) {
+      return this.client.searchRegisteredModels(this.searchFilter, this.maxResults, this.orderBy, this.token);
+    } else {
+      return new EmptyPage<>();
+    }
+  }
+
+  /**
+   * @return An iterable over the registered models in this page.
+   */
+  public List<RegisteredModel> getItems() {
+    return items;
+  }
+
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/RegisteredModelsPage.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/RegisteredModelsPage.java
@@ -65,7 +65,10 @@ class RegisteredModelsPage implements Page<RegisteredModel> {
    */
   public Page<RegisteredModel> getNextPage() {
     if (this.hasNextPage()) {
-      return this.client.searchRegisteredModels(this.searchFilter, this.maxResults, this.orderBy, this.token);
+      return this.client.searchRegisteredModels(this.searchFilter,
+                                                this.maxResults,
+                                                this.orderBy,
+                                                this.token);
     } else {
       return new EmptyPage<>();
     }


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Resolves #8169

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

## What changes are proposed in this pull request?

Implements searchRegisteredModels() method in the Java client.
This calls the equivalent method [in the web API](https://mlflow.org/docs/latest/rest-api.html#search-registeredmodels)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Implement `searchRegisteredModels()` API in Java client

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [x] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
