### PR TITLE
Adding the ability to log LLM predictions to MLflow artifacts

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -72,6 +72,7 @@ try:
     from mlflow import pmdarima
     from mlflow import diviner
     from mlflow import transformers
+    from mlflow import llm
 
     _model_flavors_supported = [
         "catboost",

--- a/mlflow/llm.py
+++ b/mlflow/llm.py
@@ -1,0 +1,9 @@
+"""
+The ``mlflow.llm`` module provides a utility for Large Language Models (LLMs).
+"""
+
+from mlflow.tracking.llm_utils import log_predictions
+
+__all__ = [
+    "log_predictions",
+]

--- a/mlflow/tracking/llm_utils.py
+++ b/mlflow/tracking/llm_utils.py
@@ -1,0 +1,95 @@
+import csv
+import logging
+import mlflow
+import os
+import tempfile
+
+from mlflow.tracking.client import MlflowClient
+from mlflow.utils.annotations import experimental
+from typing import Dict, List, Union
+
+_logger = logging.getLogger(__name__)
+
+
+@experimental
+def log_predictions(
+    inputs: List[Union[str, Dict[str, str]]],
+    outputs: List[str],
+    prompts: List[Union[str, Dict[str, str]]],
+) -> None:
+    """
+    Log a batch of inputs, outputs and prompts for the current evaluation run.
+    If no run is active, this method will create a new active run.
+
+    :param inputs: Union of either List of input strings or List of input dictionary
+    :param outputs: List of output strings
+    :param prompts: Union of either List of prompt strings or List of prompt dictionary
+    :returns: None
+
+    .. test-code-block:: python
+        :caption: Example
+
+        import mlflow
+
+        inputs = [
+            {
+                "question": "How do I create a Databricks cluster with UC access?",
+                "context": "Databricks clusters are ...",
+            },
+        ]
+
+        outputs = [
+            "<Instructions for cluster creation with UC enabled>",
+        ]
+
+        prompts = [
+            "Get Databricks documentation to answer all the questions: {input}",
+        ]
+
+
+        # Log llm predictions
+        with mlflow.start_run():
+            mlflow.llm.log_predictions(inputs, outputs, prompts)
+    """
+    if len(inputs) <= 0 or len(inputs) != len(outputs) or len(inputs) != len(prompts):
+        raise ValueError(
+            "The length of inputs, outputs and prompts must be the same and not empty."
+        )
+
+    artifact_path = None
+    predictions = []
+    run_id = mlflow.tracking.fluent._get_or_start_run().info.run_id
+    LLM_ARTIFACT_NAME = "llm_predictions.csv"
+
+    for row in zip(inputs, outputs, prompts):
+        predictions.append(row)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        artifacts = [f.path for f in MlflowClient().list_artifacts(run_id)]
+        if LLM_ARTIFACT_NAME in artifacts:
+            artifact_path = mlflow.artifacts.download_artifacts(
+                run_id=run_id, artifact_path=LLM_ARTIFACT_NAME, dst_path=tmpdir
+            )
+            _logger.info(
+                "Appending new inputs to already existing artifact "
+                f"{LLM_ARTIFACT_NAME} for run {run_id}."
+            )
+        else:
+            # If the artifact doesn't exist, we need to write the header.
+            predictions.insert(0, ["inputs", "outputs", "prompts"])
+            artifact_path = os.path.join(tmpdir, LLM_ARTIFACT_NAME)
+            _logger.info(f"Creating a new {LLM_ARTIFACT_NAME} for run {run_id}.")
+
+        if os.path.exists(artifact_path):
+            with open(artifact_path, newline="") as llm_prediction:
+                num_existing_predictions = sum(1 for _ in csv.reader(llm_prediction))
+                if num_existing_predictions + len(predictions) > 1000:
+                    _logger.warning(
+                        f"Trying to log a {LLM_ARTIFACT_NAME} with length "
+                        "more than 1000 records. It might slow down performance."
+                    )
+
+        with open(artifact_path, "a", encoding="UTF8", newline="") as llm_prediction:
+            writer = csv.writer(llm_prediction)
+            writer.writerows(predictions)
+        mlflow.tracking.fluent.log_artifact(artifact_path)

--- a/tests/tracking/test_llm_utils.py
+++ b/tests/tracking/test_llm_utils.py
@@ -1,0 +1,58 @@
+import mlflow
+import pytest
+
+from mlflow.utils.file_utils import local_file_uri_to_path
+
+
+def test_llm_predictions_logging():
+    import csv
+
+    inputs = [
+        {
+            "question": "How do I create a Databricks cluster with UC enabled?",
+            "context": "Databricks clusters are amazing",
+        }
+    ]
+
+    outputs = [
+        "<Instructions for cluster creation with UC enabled>",
+    ]
+
+    prompts = [
+        "Get Databricks documentation to answer all the questions: {input}",
+    ]
+
+    artifact_file_name = "llm_predictions.csv"
+    with mlflow.start_run():
+        with pytest.raises(
+            ValueError,
+            match="The length of inputs, outputs and prompts must be the same and not empty.",
+        ):
+            mlflow.llm.log_predictions([], [], [])
+
+        with pytest.raises(
+            ValueError,
+            match="The length of inputs, outputs and prompts must be the same and not empty.",
+        ):
+            mlflow.llm.log_predictions(
+                [], ["<Instructions for cluster creation with UC enabled>"], []
+            )
+
+        mlflow.llm.log_predictions(inputs, outputs, prompts)
+        artifact_path = local_file_uri_to_path(mlflow.get_artifact_uri(artifact_file_name))
+
+        with open(artifact_path, newline="") as csvfile:
+            predictions = list(csv.reader(csvfile))
+
+        # length of header + length of inputs
+        assert len(predictions) == 2
+        assert predictions[1][0] == str(inputs[0])
+        assert predictions[1][1] == outputs[0]
+        assert predictions[1][2] == prompts[0]
+
+        mlflow.llm.log_predictions(inputs, outputs, prompts)
+
+        with open(artifact_path, newline="") as csvfile:
+            predictions = list(csv.reader(csvfile))
+
+        assert len(predictions) == 3


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adding the ability to log LLM predictions to MLflow artifacts

## How is this patch tested?
- [x] Test added
- [x] Verified in a notebook
```
import lorem
import mlflow

mlflow.set_experiment(experiment_id=experiment_id)

inputs=[]
for _ in range(num_inputs):
  inputs.append(lorem.sentence())

for _ in range(num_runs):
  ouputs=[]
  prompts=[]
  for j in range(num_inputs):
    ouputs.append(lorem.paragraph())
    prompts.append(lorem.text())

  mlflow.start_run(run_id=run_id)
  mlflow.llm.log_predictions(inputs, ouputs, prompts)
  mlflow.end_run()
  ```

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adding the ability to log LLM predictions to MLflow artifacts

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
