### PR TITLE
Add `search_model_versions` to high-level fluent API

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -159,7 +159,11 @@ from mlflow.tracking.fluent import (
     autolog,
     last_active_run,
 )
-from mlflow.tracking._model_registry.fluent import register_model, search_registered_models
+from mlflow.tracking._model_registry.fluent import (
+    register_model,
+    search_registered_models,
+    search_model_versions,
+)
 from mlflow.tracking import (
     get_tracking_uri,
     set_tracking_uri,
@@ -202,6 +206,7 @@ __all__ = [
     "get_experiment_by_name",
     "search_experiments",
     "search_registered_models",
+    "search_model_versions",
     "create_experiment",
     "set_experiment",
     "delete_experiment",

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -7,7 +7,10 @@ from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils import get_results_from_paginated_fn
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
-from mlflow.store.model_registry import SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT
+from mlflow.store.model_registry import (
+    SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
+    SEARCH_MODEL_VERSION_MAX_RESULTS_DEFAULT,
+)
 from typing import Any, Dict, Optional, List
 
 
@@ -199,4 +202,24 @@ def search_registered_models(
         pagination_wrapper_func,
         SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
         max_results,
+    )
+
+
+def search_model_versions(
+    max_results: Optional[int] = None,
+    filter_string: Optional[str] = None,
+    order_by: Optional[List[str]] = None,
+) -> List[ModelVersion]:
+    def pagination_wrapper_func(number_to_get, next_page_token):
+        return MlflowClient().search_model_versions(
+            max_results=number_to_get,
+            filter_string=filter_string,
+            order_by=order_by,
+            page_token=next_page_token,
+        )
+
+    return get_results_from_paginated_fn(
+        paginated_fn=pagination_wrapper_func,
+        max_results_per_page=SEARCH_MODEL_VERSION_MAX_RESULTS_DEFAULT,
+        max_results=max_results,
     )

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -2,7 +2,10 @@ from collections import defaultdict
 from importlib import reload
 from itertools import zip_longest
 
-from mlflow.store.model_registry import SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT
+from mlflow.store.model_registry import (
+    SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
+    SEARCH_MODEL_VERSION_MAX_RESULTS_DEFAULT,
+)
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 
 import os
@@ -468,6 +471,59 @@ def test_search_registered_models(tmp_path):
     # Order by name
     models = mlflow.search_registered_models(order_by=["name DESC"], max_results=3)
     assert [m.name for m in models] == sorted(model_names, reverse=True)[:3]
+
+
+def test_search_model_versions(tmp_path):
+    sqlite_uri = "sqlite:///{}".format(tmp_path.joinpath("test.db"))
+    mlflow.set_tracking_uri(sqlite_uri)
+
+    num_all_model_versions = SEARCH_MODEL_VERSION_MAX_RESULTS_DEFAULT + 1
+    num_a_model_versions = num_all_model_versions // 4
+    num_b_model_versions = num_all_model_versions - num_a_model_versions
+
+    a_model_version_names = ["AModel" for i in range(num_a_model_versions)]
+    b_model_version_names = ["BModel" for i in range(num_b_model_versions)]
+    model_version_names = b_model_version_names + a_model_version_names
+
+    MlflowClient().create_registered_model(name="AModel")
+    MlflowClient().create_registered_model(name="BModel")
+
+    tag_values = ["x", "x", "y"]
+    for tag, model_name in zip_longest(tag_values, model_version_names):
+        MlflowClient().create_model_version(
+            name=model_name, source="foo/bar", tags={"tag": tag} if tag else None
+        )
+
+    # max_results is unspecified
+    model_versions = mlflow.search_model_versions()
+    assert len(model_versions) == num_all_model_versions
+
+    # max_results is larger than the number of model versions in the database
+    model_versions = mlflow.search_model_versions(max_results=num_all_model_versions + 1)
+    assert len(model_versions) == num_all_model_versions
+
+    # max_results is equal to the number of model versions in the database
+    model_versions = mlflow.search_model_versions(max_results=num_all_model_versions)
+    assert len(model_versions) == num_all_model_versions
+    # max_results is smaller than the number of models in the database
+    model_versions = mlflow.search_model_versions(max_results=num_all_model_versions - 1)
+    assert len(model_versions) == num_all_model_versions - 1
+
+    # Filter by name
+    model_versions = mlflow.search_model_versions(filter_string="name = 'AModel'")
+    assert [m.name for m in model_versions] == a_model_version_names
+    model_versions = mlflow.search_model_versions(filter_string="name ILIKE 'bmodel'")
+    assert len(model_versions) == num_b_model_versions
+
+    # Filter by tags
+    model_versions = mlflow.search_model_versions(filter_string="tags.tag = 'x'")
+    assert [m.name for m in model_versions] == model_version_names[:2]
+    model_versions = mlflow.search_model_versions(filter_string="tags.tag = 'y'")
+    assert [m.name for m in model_versions] == [model_version_names[2]]
+
+    # Order by version_number
+    model_versions = mlflow.search_model_versions(order_by=["version_number ASC"], max_results=5)
+    assert [m.version for m in model_versions] == [1, 1, 2, 2, 3]
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Resolve #8222

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

While the MLflow high-level fluent API provides a convenient function to search registered models according to filter criteria (`mlflow.search_registered_models`), an equivalent convenient function to search model versions of registered models is missing. My proposal is to add a corresponding function (`mlflow.search_model_versions`).

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

Add `search_model_versions` to high-level fluent API (#8223, @mariusschlegel).

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
