### PR TITLE
Handling Invalid URL exception during mlflow gc process with invalid …

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -30,7 +30,7 @@ from mlflow.utils.server_cli_utils import (
     artifacts_only_config_validation,
 )
 from mlflow.entities.lifecycle_stage import LifecycleStage
-from mlflow.exceptions import MlflowException
+from mlflow.exceptions import MlflowException, InvalidUrlException
 
 _logger = logging.getLogger(__name__)
 
@@ -584,7 +584,15 @@ def gc(older_than, backend_store_uri, run_ids, experiment_ids):
                 error_code=INVALID_PARAMETER_VALUE,
             )
         artifact_repo = get_artifact_repository(run.info.artifact_uri)
-        artifact_repo.delete_artifacts()
+        try:
+            artifact_repo.delete_artifacts()
+        except InvalidUrlException as iue:
+            click.echo(f"Warning: {iue}")
+            click.echo(
+                "Do not delete artifact target. Keep the gc process going. "
+                "Please check whether the artifact exists or not "
+                "and delete unused artifacts manually."
+            )
         backend_store._hard_delete_run(run_id)
         click.echo("Run with ID %s has been permanently deleted." % str(run_id))
 

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -123,6 +123,12 @@ class RestException(MlflowException):
         self.json = json
 
 
+class InvalidUrlException(MlflowException):
+    """Exception thrown when http request fails to send due to an invalid URL."""
+
+    pass
+
+
 class ExecutionException(MlflowException):
     """Exception thrown when executing a project fails"""
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -14,7 +14,7 @@ from mlflow.protos import databricks_pb2
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, ENDPOINT_NOT_FOUND, ErrorCode
 from mlflow.utils.proto_json_utils import parse_dict
 from mlflow.utils.string_utils import strip_suffix
-from mlflow.exceptions import get_error_code, MlflowException, RestException
+from mlflow.exceptions import get_error_code, MlflowException, RestException, InvalidUrlException
 
 from mlflow.environment_variables import (
     MLFLOW_HTTP_REQUEST_TIMEOUT,
@@ -188,6 +188,8 @@ def http_request(
             f" To increase the timeout, set the environment variable {MLFLOW_HTTP_REQUEST_TIMEOUT}"
             " to a larger value."
         )
+    except requests.exceptions.InvalidURL as iu:
+        raise InvalidUrlException(f"Invalid artifact url: {url}\n{iu}")
     except Exception as e:
         raise MlflowException(f"API request to {url} failed with exception {e}")
 


### PR DESCRIPTION
…artifact url

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #8211

## What changes are proposed in this pull request?

Create a new Exception class that inherits from MlflowException to handle the InvalidURL exception that may occur during an HTTP request.
That should be used to handle InvalidURL exceptions that occur when attempting to delete an artifact from http artifact server.
If the artifact URI stored in the RDB is invalid, it should be set to an empty URI and the Invalid artifact URI deletion exception should be passed and let `mlflow gc` process complete properly.


## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

run the mlflow tracking server with an invalid arifact server hostname
![截圖 2023-04-13 下午6 39 09](https://user-images.githubusercontent.com/13614761/231734312-a37ae720-76d0-40aa-b402-f490788618ad.png)

Run any MLflow example code to insert experiments with invalid URIs, and then delete them from the UI to label them as `deleted`.

![截圖 2023-04-13 下午6 41 19](https://user-images.githubusercontent.com/13614761/231734763-3ae6cbd7-ce3b-4827-a563-f3ba80b0ba07.png)

Before the fixed, the gc process would be interrupted due to the`requests.exceptions.InvalidURL` exception

After the fixed, the gc process will handle the invalid artifact uri and display a warning message to inform the user that invalid artifact URIs were found. The user should check the artifact server to determine if there are any unused objects..

<img width="1163" alt="截圖 2023-04-13 下午6 46 24" src="https://user-images.githubusercontent.com/13614761/231735824-15feeed6-84cf-44fa-b107-d2345cc8a6b1.png">

![截圖 2023-04-13 下午6 59 07](https://user-images.githubusercontent.com/13614761/231739079-381361d4-9da2-4977-abb7-178f0406c20c.png)


<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
