### PR TITLE
Removing the experimental tag for MLflow Recipes and stabalizing the API

### DIFF
--- a/docs/source/python_api/mlflow.recipes.rst
+++ b/docs/source/python_api/mlflow.recipes.rst
@@ -10,20 +10,6 @@ mlflow.recipes
     :undoc-members:
     :special-members: __new__
 
-Regression Recipe
-~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: mlflow.recipes.regression.v1.recipe
-
-.. autoclass:: mlflow.recipes.regression.v1.recipe.RegressionRecipe()
-    :members:
-    :undoc-members:
-
-Classification Recipe
-~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: mlflow.recipes.classification.v1.recipe
-
-.. autoclass:: mlflow.recipes.classification.v1.recipe.ClassificationRecipe()
+.. autoclass:: mlflow.recipes.recipe.BaseRecipe()
     :members:
     :undoc-members:

--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -1,7 +1,7 @@
 .. _recipes:
 
 ===============================
-MLflow Recipes (experimental)
+MLflow Recipes
 ===============================
 
 MLflow Recipes (previously known as MLflow Pipelines) is a framework that enables data scientists
@@ -175,7 +175,7 @@ The general model development workflow for using MLflow Recipes is as follows:
     .. code-section::
 
         .. code-block:: python
-            :caption: Example API and CLI workflows for running the :ref:`Regression Recipe <mlflow-regression-recipe>` and inspecting results. Note that recipes must be run from within their corresponding git repositories.
+            :caption: Example API and CLI workflows for running the |MLflow Recipes Regression Template| and inspecting results. Note that recipes must be run from within their corresponding git repositories.
 
             import os
             from mlflow.recipes import Recipe
@@ -206,7 +206,7 @@ The general model development workflow for using MLflow Recipes is as follows:
       :width: 60%
 
       An example step card produced by running the **evaluate** step of the
-      :ref:`MLflow Regression Recipe <mlflow-regression-recipe>`. The step card results
+      |MLflow Recipes Regression Template|. The step card results
       indicate that the trained model passed all performance validations and is ready for
       registration with the :ref:`MLflow Model Registry <registry>`.
 
@@ -316,15 +316,11 @@ to develop and deploy high-quality, production-ready models for your use cases:
 
 .. _regression-template:
 
-- **MLflow Recipes Regression Template**: The `MLflow Recipes Regression Template
-  <https://github.com/mlflow/recipes-regression-template>`_ is designed for developing and scoring
-  regression models. For more information, see the |Regression Template reference guide| and
-  the :ref:`Regression Recipe API documentation <mlflow-regression-recipe>`.
+- **MLflow Recipes Regression Template**: The MLflow Recipes Regression Template is designed for developing and scoring
+  regression models. For more information, see the |Regression Template reference guide|.
 
-- **MLflow Recipes Classification Template**: The `MLflow Recipes Classification Template
-  <https://github.com/mlflow/recipes-classification-template>`_ is designed for developing and scoring
-  classification models. For more information, see the |Classification Template reference guide| and
-  the :ref:`Classification Recipe API documentation <mlflow-classification-recipe>`.
+- **MLflow Recipes Classification Template**: The MLflow Recipes Classification Template is designed for developing and scoring
+  classification models. For more information, see the |Classification Template reference guide|.
 
 Additional recipes for a variety of ML problems and MLOps tasks are under active development.
 
@@ -501,15 +497,14 @@ The following profile customizations are supported:
             :caption: Example ``recipe.yaml`` configuration file defining a ``DATASET_INFO``
                       variable whose value must be specified by the selected recipe profile
 
-            data:
-              # Specifies the dataset to use for model training
-              {{DATASET_INFO}}
+            # Specifies the dataset to use for model training
+            ingest: {{INGEST_CONFIG}}
 
           .. code-block:: yaml
             :caption: Example ``dev.yaml`` profile that provides a value for ``DATASET_INFO``
                       corresponding to a small dataset for development purposes
 
-            DATASET_INFO:
+            INGEST_CONFIG:
                 location: ./data/taxi-small.parquet
                 format: parquet
 
@@ -540,8 +535,8 @@ The following profile customizations are supported:
 .. |Regression Template reference guide| replace:: `Regression Template reference guide <https://github.com/mlflow/recipes-regression-template/blob/main/README.md>`__
 .. |Classification Template reference guide| replace:: `Classification Template reference guide <https://github.com/mlflow/recipes-classification-template/blob/main/README.md>`__
 .. |recipe.yaml| replace:: `recipe.yaml <https://github.com/mlflow/recipes-regression-template/blob/main/recipe.yaml>`__
-.. |train step| replace:: :ref:`train step <mlflow-regression-recipe-train-step>`
-.. |split step| replace:: :ref:`split step <mlflow-regression-recipe-split-step>`
+.. |train step| replace:: `train step <https://github.com/mlflow/recipes-regression-template#train-step>`__
+.. |split step| replace:: `split step <https://github.com/mlflow/recipes-regression-template#split-step>`__
 .. |Jinja2| replace:: `Jinja2 <https://jinja.palletsprojects.com>`__
 .. |local profile| replace:: `profiles/local.yaml profile <https://github.com/mlflow/recipes-regression-template/blob/main/profiles/local.yaml>`__
 .. |databricks profile| replace:: `profiles/databricks.yaml profile <https://github.com/mlflow/recipes-regression-template/blob/main/profiles/databricks.yaml>`__

--- a/mlflow/recipes/classification/v1/recipe.py
+++ b/mlflow/recipes/classification/v1/recipe.py
@@ -5,8 +5,8 @@ The MLflow Classification Recipe is an MLflow Recipe for developing binary class
 models. Multiclass classifiers are currently not supported.
 The classification recipe is designed for developing models using scikit-learn and
 frameworks that integrate with scikit-learn, such as the ``XGBClassifier`` API from XGBoost.
-The :py:class:`ClassificationRecipe API Documentation <ClassificationRecipe>` provides
-instructions for executing the recipe and inspecting its results.
+The `ClassificationRecipe API Documentation <https://github.com/mlflow/recipes-classification-template/blob/main/README.md>`
+provides instructions for executing the recipe and inspecting its results.
 
 The training recipe contains the following sequential steps:
 
@@ -122,7 +122,7 @@ The recipe steps are defined as follows:
 import logging
 from typing import Any, Optional
 
-from mlflow.recipes.recipe import _BaseRecipe
+from mlflow.recipes.recipe import BaseRecipe
 from mlflow.recipes.steps.ingest import IngestStep, IngestScoringStep
 from mlflow.recipes.steps.split import SplitStep
 from mlflow.recipes.steps.transform import TransformStep
@@ -131,13 +131,11 @@ from mlflow.recipes.steps.evaluate import EvaluateStep
 from mlflow.recipes.steps.predict import PredictStep
 from mlflow.recipes.steps.register import RegisterStep
 from mlflow.recipes.step import BaseStep
-from mlflow.utils.annotations import experimental
 
 _logger = logging.getLogger(__name__)
 
 
-@experimental
-class ClassificationRecipe(_BaseRecipe):
+class ClassificationRecipe(BaseRecipe):
     """
     A recipe for developing high-quality classification models. The recipe is designed for
     developing models using scikit-learn and frameworks that integrate with scikit-learn,
@@ -266,7 +264,6 @@ class ClassificationRecipe(_BaseRecipe):
         """
         return super().run(step=step)
 
-    @experimental
     def get_artifact(self, artifact_name: str) -> Optional[Any]:
         """
         Reads an artifact from the recipe's outputs. Supported artifact names can be obtained by

--- a/mlflow/recipes/cli.py
+++ b/mlflow/recipes/cli.py
@@ -2,7 +2,6 @@ import click
 
 from mlflow.recipes.utils import _RECIPE_PROFILE_ENV_VAR
 from mlflow.recipes import Recipe
-from mlflow.utils.annotations import experimental
 
 _CLI_ARG_RECIPE_PROFILE = click.option(
     "--profile",
@@ -37,7 +36,6 @@ def commands():
     help="The name of the recipe step to run.",
 )
 @_CLI_ARG_RECIPE_PROFILE
-@experimental("command")
 def run(step, profile):
     """
     Run the full recipe, or run a particular recipe step if specified, producing
@@ -61,7 +59,6 @@ def run(step, profile):
     help="The name of the recipe step for which to remove cached outputs.",
 )
 @_CLI_ARG_RECIPE_PROFILE
-@experimental("command")
 def clean(step, profile):
     """
     Remove all recipe outputs from the cache, or remove the cached outputs of a particular
@@ -85,7 +82,6 @@ def clean(step, profile):
     help="The name of the recipe step to inspect.",
 )
 @_CLI_ARG_RECIPE_PROFILE
-@experimental("command")
 def inspect(step, profile):
     """
     Display a visual overview of the recipe graph, or display a summary of results from a
@@ -105,7 +101,6 @@ def inspect(step, profile):
     help="The name of the artifact to retrieve.",
 )
 @_CLI_ARG_RECIPE_PROFILE
-@experimental("command")
 def get_artifact(profile, artifact):
     """
     Get the location of an artifact output from the recipe.

--- a/mlflow/recipes/recipe.py
+++ b/mlflow/recipes/recipe.py
@@ -19,20 +19,17 @@ from mlflow.recipes.utils.execution import (
 )
 from mlflow.recipes.utils.step import display_html
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, INTERNAL_ERROR, BAD_REQUEST
-from mlflow.utils.annotations import experimental
 from mlflow.utils.class_utils import _get_class_from_string
-from typing import List, Union
+from typing import List
 
 _logger = logging.getLogger(__name__)
 
 
-@experimental
-class _BaseRecipe:
+class BaseRecipe:
     """
     Base Recipe
     """
 
-    @experimental
     def __init__(self, recipe_root_path: str, profile: str) -> None:
         """
         Recipe base class.
@@ -55,13 +52,11 @@ class _BaseRecipe:
         self._steps = self._resolve_recipe_steps()
         self._recipe = get_recipe_config(self._recipe_root_path, self._profile).get("recipe")
 
-    @experimental
     @property
     def name(self) -> str:
         """Returns the name of the recipe."""
         return self._name
 
-    @experimental
     @property
     def profile(self) -> str:
         """
@@ -69,7 +64,6 @@ class _BaseRecipe:
         """
         return self._profile
 
-    @experimental
     def run(self, step: str = None) -> None:
         """
         Runs a step in the recipe, or the entire recipe if a step is not specified.
@@ -115,7 +109,6 @@ class _BaseRecipe:
                     error_code=BAD_REQUEST,
                 )
 
-    @experimental
     def inspect(self, step: str = None) -> None:
         """
         Displays main output from a step, or a recipe DAG if no step is specified.
@@ -131,13 +124,12 @@ class _BaseRecipe:
             output_directory = get_step_output_path(self._recipe_root_path, step, "")
             self._get_step(step).inspect(output_directory)
 
-    @experimental
     def clean(self, step: str = None) -> None:
         """
         Removes the outputs of the specified step from the cache, or removes the cached outputs
         of all steps if no particular step is specified. After cached outputs are cleaned
         for a particular step, the step will be re-executed in its entirety the next time it is
-        invoked via ``_BaseRecipe.run()``.
+        invoked via ``BaseRecipe.run()``.
 
         :param step: String name of the step to clean within the recipe. If not specified,
                      cached outputs are removed for all recipe steps.
@@ -155,7 +147,6 @@ class _BaseRecipe:
             )
         return self._steps[step_names.index(step_name)]
 
-    @experimental
     def _get_subgraph_for_target_step(self, target_step: BaseStep) -> List[BaseStep]:
         """
         Return a list of step objects representing a connected DAG containing the target_step.
@@ -169,7 +160,6 @@ class _BaseRecipe:
                 subgraph.append(step)
         return subgraph
 
-    @experimental
     @abc.abstractmethod
     def _get_default_step(self) -> BaseStep:
         """
@@ -179,7 +169,6 @@ class _BaseRecipe:
         """
         pass
 
-    @experimental
     @abc.abstractmethod
     def _get_step_classes(self):
         """
@@ -189,7 +178,6 @@ class _BaseRecipe:
         """
         pass
 
-    @experimental
     def _get_recipe_dag_file(self) -> str:
         """
         Returns absolute path to the recipe DAG representation HTML file.
@@ -329,7 +317,6 @@ class _BaseRecipe:
             for s in self._get_step_classes()
         ]
 
-    @experimental
     def get_artifact(self, artifact_name: str):
         """
         Read an artifact from recipe output. artifact names can be obtained from
@@ -340,7 +327,6 @@ class _BaseRecipe:
         """
         return self._get_artifact(artifact_name).load()
 
-    @experimental
     def _get_artifact(self, artifact_name: str) -> Artifact:
         """
         Read an Artifact object from recipe output. artifact names can be obtained
@@ -359,11 +345,6 @@ class _BaseRecipe:
         )
 
 
-from mlflow.recipes.classification.v1.recipe import ClassificationRecipe
-from mlflow.recipes.regression.v1.recipe import RegressionRecipe
-
-
-@experimental
 class Recipe:
     """
     A factory class that creates an instance of a recipe for a particular ML problem
@@ -381,8 +362,7 @@ class Recipe:
         regression_recipe.run(step="train")
     """
 
-    @experimental
-    def __new__(cls, profile: str) -> Union[RegressionRecipe, ClassificationRecipe]:
+    def __new__(cls, profile: str):
         """
         Creates an instance of an MLflow Recipe for a particular ML problem or MLOps task based
         on the current working directory and supplied configuration. The current working directory
@@ -394,8 +374,7 @@ class Recipe:
                         one or more recipe steps, and recipe executions with different profiles
                         often produce different results.
         :return: A recipe for a particular ML problem or MLOps task. For example, an instance of
-                 :py:class:`RegressionRecipe
-                 <mlflow.recipes.regression.v1.recipe.RegressionRecipe>`
+                 `RegressionRecipe <https://github.com/mlflow/recipes-regression-template>`_
                  for regression problems.
 
         .. code-block:: python

--- a/mlflow/recipes/regression/v1/recipe.py
+++ b/mlflow/recipes/regression/v1/recipe.py
@@ -5,8 +5,8 @@ The MLflow Regression Recipe is an MLflow Recipe for developing high-quality reg
 It is designed for developing models using scikit-learn and frameworks that integrate with
 scikit-learn, such as the ``XGBRegressor`` API from XGBoost. The corresponding recipe
 template repository is available at https://github.com/mlflow/recipes-regression-template, and the
-:py:class:`RegressionRecipe API Documentation <RegressionRecipe>` provides instructions for
-executing the recipe and inspecting its results.
+`RegressionRecipe API Documentation <https://github.com/mlflow/recipes-regression-template/blob/main/README.md>_`
+provides instructions for executing the recipe and inspecting its results.
 
 The training recipe contains the following sequential steps:
 
@@ -131,7 +131,7 @@ The recipe steps are defined as follows:
 
 import logging
 
-from mlflow.recipes.recipe import _BaseRecipe
+from mlflow.recipes.recipe import BaseRecipe
 from mlflow.recipes.steps.ingest import IngestStep, IngestScoringStep
 from mlflow.recipes.steps.split import SplitStep
 from mlflow.recipes.steps.transform import TransformStep
@@ -141,13 +141,11 @@ from mlflow.recipes.steps.predict import PredictStep
 from mlflow.recipes.steps.register import RegisterStep
 from mlflow.recipes.step import BaseStep
 from typing import Any, Optional
-from mlflow.utils.annotations import experimental
 
 _logger = logging.getLogger(__name__)
 
 
-@experimental
-class RegressionRecipe(_BaseRecipe):
+class RegressionRecipe(BaseRecipe):
     """
     A recipe for developing high-quality regression models. The recipe is designed for
     developing models using scikit-learn and frameworks that integrate with scikit-learn,
@@ -277,7 +275,6 @@ class RegressionRecipe(_BaseRecipe):
         """
         return super().run(step=step)
 
-    @experimental
     def get_artifact(self, artifact_name: str) -> Optional[Any]:
         """
         Reads an artifact from the recipe's outputs. Supported artifact names can be obtained by

--- a/mlflow/recipes/step.py
+++ b/mlflow/recipes/step.py
@@ -13,7 +13,6 @@ from mlflow.recipes.cards import BaseCard, CARD_PICKLE_NAME, FailureCard, CARD_H
 from mlflow.recipes.utils import get_recipe_name
 from mlflow.recipes.utils.step import display_html
 from mlflow.tracking import MlflowClient
-from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 
 _logger = logging.getLogger(__name__)
@@ -98,7 +97,6 @@ class StepExecutionState:
 StepType = TypeVar("StepType", bound="BaseStep")
 
 
-@experimental
 class BaseStep(metaclass=abc.ABCMeta):
     """
     Base class representing a step in an MLflow Recipe
@@ -106,7 +104,6 @@ class BaseStep(metaclass=abc.ABCMeta):
 
     _EXECUTION_STATE_FILE_NAME = "execution_state.json"
 
-    @experimental
     def __init__(self, step_config: Dict[str, Any], recipe_root: str):
         """
         :param step_config: dictionary of the config needed to
@@ -120,7 +117,6 @@ class BaseStep(metaclass=abc.ABCMeta):
         self.task = self.step_config.get("recipe", "regression/v1").rsplit("/", 1)[0]
         self.step_card = None
 
-    @experimental
     def run(self, output_directory: str):
         """
         Executes the step by running common setup operations and invoking
@@ -153,7 +149,6 @@ class BaseStep(metaclass=abc.ABCMeta):
         finally:
             self._serialize_card(start_timestamp, output_directory)
 
-    @experimental
     def inspect(self, output_directory: str):
         """
         Inspect the step output state by running the generic inspect information here and
@@ -175,7 +170,6 @@ class BaseStep(metaclass=abc.ABCMeta):
         card_html_path = os.path.join(output_directory, CARD_HTML_NAME)
         display_html(html_data=card.to_html(), html_file_path=card_html_path)
 
-    @experimental
     @abc.abstractmethod
     def _run(self, output_directory: str) -> BaseCard:
         """
@@ -189,7 +183,6 @@ class BaseStep(metaclass=abc.ABCMeta):
         """
         pass
 
-    @experimental
     @abc.abstractmethod
     def _validate_and_apply_step_config(self) -> None:
         """
@@ -198,7 +191,6 @@ class BaseStep(metaclass=abc.ABCMeta):
         """
         pass
 
-    @experimental
     @classmethod
     @abc.abstractmethod
     def from_recipe_config(cls, recipe_config: Dict[str, Any], recipe_root: str) -> StepType:
@@ -214,7 +206,6 @@ class BaseStep(metaclass=abc.ABCMeta):
         """
         pass
 
-    @experimental
     @classmethod
     def from_step_config_path(cls, step_config_path: str, recipe_root: str) -> StepType:
         """
@@ -231,7 +222,6 @@ class BaseStep(metaclass=abc.ABCMeta):
             step_config = yaml.safe_load(f)
         return cls(step_config, recipe_root)
 
-    @experimental
     @property
     @abc.abstractmethod
     def name(self) -> str:
@@ -241,7 +231,6 @@ class BaseStep(metaclass=abc.ABCMeta):
         """
         pass
 
-    @experimental
     @property
     def environment(self) -> Dict[str, str]:
         """
@@ -250,14 +239,12 @@ class BaseStep(metaclass=abc.ABCMeta):
         """
         return {}
 
-    @experimental
     def get_artifacts(self) -> List[Any]:
         """
         Returns the named artifacts produced by the step for the current class instance.
         """
         return {}
 
-    @experimental
     @abc.abstractmethod
     def step_class(self) -> StepClass:
         """
@@ -265,7 +252,6 @@ class BaseStep(metaclass=abc.ABCMeta):
         """
         pass
 
-    @experimental
     def get_execution_state(self, output_directory: str) -> StepExecutionState:
         """
         Returns the execution state of the step, which provides information about its

--- a/mlflow/recipes/steps/automl/flaml.py
+++ b/mlflow/recipes/steps/automl/flaml.py
@@ -17,7 +17,7 @@ from mlflow.recipes.utils.metrics import RecipeMetric, _load_custom_metrics
 
 _logger = logging.getLogger(__name__)
 
-_AUTOML_DEFAULT_TIME_BUDGET = 30
+_AUTOML_DEFAULT_TIME_BUDGET = 600
 _MLFLOW_TO_FLAML_METRICS = {
     "mean_absolute_error": "mae",
     "mean_squared_error": "mse",

--- a/mlflow/recipes/steps/predict.py
+++ b/mlflow/recipes/steps/predict.py
@@ -70,7 +70,7 @@ class PredictStep(BaseStep):
                 self.step_config["model_uri"] = f"models:/{model_name}/latest"
         self.registry_uri = self.step_config.get("registry_uri", None)
         self.skip_data_profiling = self.step_config.get("skip_data_profiling", False)
-        self.save_mode = self.step_config.get("save_mode", "default")
+        self.save_mode = self.step_config.get("save_mode", "overwrite")
         self.run_end_time = None
         self.execution_duration = None
 

--- a/mlflow/recipes/steps/split.py
+++ b/mlflow/recipes/steps/split.py
@@ -435,8 +435,6 @@ class SplitStep(BaseStep):
                 f"Running {post_split_filter_config} on train, validation and test datasets."
             )
             train_df = train_df[post_split_filter(train_df)]
-            validation_df = validation_df[post_split_filter(validation_df)]
-            test_df = test_df[post_split_filter(test_df)]
 
         if min(len(train_df), len(validation_df), len(test_df)) < 4:
             raise MlflowException(


### PR DESCRIPTION
## What changes are proposed in this pull request?
Removing the experimental tag for MLflow Recipes and stabalizing the API

## How is this patch tested?
- [x] Test passes

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Removing the experimental tag for MLflow Recipes

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
