### PR TITLE
Unpin mlserver

### DIFF
--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -126,7 +126,7 @@ def _install_pyfunc_deps(
     # dependency of mlflow on pip and we expect mlflow to be part of the environment.
     server_deps = ["gunicorn[gevent]"]
     if enable_mlserver:
-        server_deps = ["'mlserver>=1.2.0'", "'mlserver-mlflow>=1.2.0'"]
+        server_deps = ["'mlserver>=1.2.0,!=1.3.1'", "'mlserver-mlflow>=1.2.0,!=1.3.1'"]
 
     install_server_deps = [f"pip install {' '.join(server_deps)}"]
     if Popen(["bash", "-c", " && ".join(activate_cmd + install_server_deps)]).wait() != 0:

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -126,7 +126,7 @@ def _install_pyfunc_deps(
     # dependency of mlflow on pip and we expect mlflow to be part of the environment.
     server_deps = ["gunicorn[gevent]"]
     if enable_mlserver:
-        server_deps = ["'mlserver>=1.2.0, <1.3'", "'mlserver-mlflow>=1.2.0, <1.3'"]
+        server_deps = ["'mlserver>=1.2.0'", "'mlserver-mlflow>=1.2.0'"]
 
     install_server_deps = [f"pip install {' '.join(server_deps)}"]
     if Popen(["bash", "-c", " && ".join(activate_cmd + install_server_deps)]).wait() != 0:

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -27,7 +27,7 @@ sktime>=0.16.0
 # they are not installed here due to their size and stability implications for other test suites
 huggingface_hub
 # Pinned due to protobuf requirement pinning in 1.3.0 of ml-server that is incompatible
-mlserver>=1.2.0, <1.3
-mlserver-mlflow>=1.2.0, <1.3
-# Required by evaluator tests 
+mlserver>=1.2.0
+mlserver-mlflow>=1.2.0
+# Required by evaluator tests
 shap

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -27,7 +27,7 @@ sktime>=0.16.0
 # they are not installed here due to their size and stability implications for other test suites
 huggingface_hub
 # Pinned due to protobuf requirement pinning in 1.3.0 of ml-server that is incompatible
-mlserver>=1.2.0
-mlserver-mlflow>=1.2.0
+mlserver>=1.2.0,!=1.3.1
+mlserver-mlflow>=1.2.0,!=1.3.1
 # Required by evaluator tests
 shap

--- a/setup.py
+++ b/setup.py
@@ -142,8 +142,8 @@ setup(
             # Required to serve models through MLServer
             # NOTE: remove the upper version pin once protobuf is no longer pinned in mlserver
             # Reference issue: https://github.com/SeldonIO/MLServer/issues/1089
-            "mlserver>=1.2.0",
-            "mlserver-mlflow>=1.2.0",
+            "mlserver>=1.2.0,!=1.3.1",
+            "mlserver-mlflow>=1.2.0,!=1.3.1",
             "virtualenv",
             # Required for exporting metrics from the MLflow server to Prometheus
             # as part of the MLflow server monitoring add-on

--- a/setup.py
+++ b/setup.py
@@ -142,8 +142,8 @@ setup(
             # Required to serve models through MLServer
             # NOTE: remove the upper version pin once protobuf is no longer pinned in mlserver
             # Reference issue: https://github.com/SeldonIO/MLServer/issues/1089
-            "mlserver>=1.2.0, <1.3",
-            "mlserver-mlflow>=1.2.0, <1.3",
+            "mlserver>=1.2.0",
+            "mlserver-mlflow>=1.2.0",
             "virtualenv",
             # Required for exporting metrics from the MLflow server to Prometheus
             # as part of the MLflow server monitoring add-on

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -406,8 +406,8 @@ def test_mlflow_models_serve(enable_mlserver):
                 artifact_path="model",
                 python_model=model,
                 extra_pip_requirements=[
-                    "mlserver>=1.2.0",
-                    "mlserver-mlflow>=1.2.0",
+                    "mlserver>=1.2.0,!=1.3.1",
+                    "mlserver-mlflow>=1.2.0,!=1.3.1",
                     PROTOBUF_REQUIREMENT,
                 ],
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -406,8 +406,8 @@ def test_mlflow_models_serve(enable_mlserver):
                 artifact_path="model",
                 python_model=model,
                 extra_pip_requirements=[
-                    "mlserver>=1.2.0, <1.3",
-                    "mlserver-mlflow>=1.2.0, <1.3",
+                    "mlserver>=1.2.0",
+                    "mlserver-mlflow>=1.2.0",
                     PROTOBUF_REQUIREMENT,
                 ],
             )


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Unpin `mlserver`. The latest version doesn't pin protobuf.

https://pypi.org/project/mlserver/1.3.1/

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
