### PR TITLE
Fix captum example

### DIFF
--- a/examples/pytorch/CaptumExample/Titanic_Captum_Interpret.py
+++ b/examples/pytorch/CaptumExample/Titanic_Captum_Interpret.py
@@ -43,9 +43,9 @@ def get_titanic():
     titanic_data = pd.concat(
         [
             titanic_data,
-            pd.get_dummies(titanic_data["sex"]),
-            pd.get_dummies(titanic_data["embarked"], prefix="embark"),
-            pd.get_dummies(titanic_data["pclass"], prefix="class"),
+            pd.get_dummies(titanic_data["sex"], dtype=np.uint8),
+            pd.get_dummies(titanic_data["embarked"], prefix="embark", dtype=np.uint8),
+            pd.get_dummies(titanic_data["pclass"], prefix="class", dtype=np.uint8),
         ],
         axis=1,
     )
@@ -156,6 +156,7 @@ def train(USE_PRETRAINED_MODEL=False):
         mlflow.log_param("lr", dict_args["lr"])
 
         optimizer = torch.optim.Adam(net.parameters(), lr=dict_args["lr"])
+        print(train_features.dtype)
         input_tensor = torch.from_numpy(train_features).type(torch.FloatTensor)
         label_tensor = torch.from_numpy(train_labels)
         for epoch in range(num_epochs):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix the following issue:

https://github.com/mlflow/mlflow/actions/runs/4713454472/jobs/8359161888#step:7:195

```
Notice:  A new release of pip is available: 23.0.1 -> 23.1
Notice:  To update, run: pip install --upgrade pip

Notice:  A new release of pip is available: 23.0.1 -> 23.1
Notice:  To update, run: pip install --upgrade pip
Traceback (most recent call last):
  File "Titanic_Captum_Interpret.py", line 338, in <module>
    net, train_features, train_labels, test_features, test_labels, feature_names = train()
  File "Titanic_Captum_Interpret.py", line 159, in train
    input_tensor = torch.from_numpy(train_features).type(torch.FloatTensor)
TypeError: can't convert np.ndarray of type numpy.object_. The only supported types are: float64, float32, float16, complex64, complex128, int64, int32, int16, int8, uint8, and bool.
```

In pandas 2.0, the default value of `dtype` for `get_dummies` was changed to `bool` from `uint8`: https://github.com/pandas-dev/pandas/issues/45848

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
