### PR TITLE
Add InstructionalPipeline support and fix inference config bug

### DIFF
--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -1286,7 +1286,7 @@ def _load_pyfunc(path):
     """
     local_path = pathlib.Path(path)
     flavor_configuration = _get_flavor_configuration(local_path, FLAVOR_NAME)
-    inference_config = _get_inference_config(local_path)
+    inference_config = _get_inference_config(local_path.joinpath(_COMPONENTS_BINARY_KEY))
     return _TransformersWrapper(
         _load_model(str(local_path), flavor_configuration, "pipeline"), inference_config
     )
@@ -1320,28 +1320,8 @@ class _TransformersWrapper:
     def __init__(self, pipeline, inference_config=None):
         self.pipeline = pipeline
         self.inference_config = inference_config
-        if inference_config:
-            self._validate_inference_config_keys(pipeline, inference_config)
         self._conversation = None
-
-    @staticmethod
-    def _validate_inference_config_keys(pipeline, inference_config):
-        """
-        Raise an Exception if invalid inference_config keys for the given Pipeline and
-        Model were provided during save.
-        """
-        invalid_keys = []
-        for key in inference_config:
-            if not hasattr(pipeline, key) and not hasattr(pipeline.model, key):
-                invalid_keys.append(key)
-        if invalid_keys:
-            raise MlflowException(
-                "The Inference Configuration overrides that were saved with "
-                "this model are not compatible as overrides to either the "
-                "Pipeline or the Model. Please re-save the model with valid "
-                f"inference configuration keys. Invalid keys: {invalid_keys}",
-                error_code=INVALID_PARAMETER_VALUE,
-            )
+        self._supported_custom_generator_types = {"InstructionTextGenerationPipeline"}
 
     def _convert_pandas_to_dict(self, data):
         import transformers
@@ -1449,6 +1429,9 @@ class _TransformersWrapper:
             if not self._conversation:
                 self._conversation = transformers.Conversation()
             self._conversation.add_user_input(data)
+        elif type(self.pipeline).__name__ in self._supported_custom_generator_types:
+            self._validate_str_or_list_str(data)
+            output_key = "generated_text"
         else:
             raise MlflowException(
                 f"The loaded pipeline type {type(self.pipeline).__name__} is "
@@ -1461,12 +1444,24 @@ class _TransformersWrapper:
             conversation_output = self.pipeline(self._conversation)
             return conversation_output.generated_responses[-1]
         elif isinstance(data, dict):
-            raw_output = self.pipeline(**data)
+            if self.inference_config:
+                raw_output = self.pipeline(**data, **self.inference_config)
+            else:
+                raw_output = self.pipeline(**data)
         else:
-            raw_output = self.pipeline(data)
+            if self.inference_config:
+                raw_output = self.pipeline(data, **self.inference_config)
+            else:
+                raw_output = self.pipeline(data)
 
         # Handle the pipeline outputs
-        if isinstance(self.pipeline, transformers.FillMaskPipeline):
+        if type(self.pipeline).__name__ in self._supported_custom_generator_types or isinstance(
+            self.pipeline, transformers.TextGenerationPipeline
+        ):
+            output = self._strip_input_from_response_in_instruction_pipelines(
+                data, raw_output, output_key
+            )
+        elif isinstance(self.pipeline, transformers.FillMaskPipeline):
             output = self._parse_list_of_multiple_dicts(raw_output, output_key)
         elif isinstance(self.pipeline, transformers.ZeroShotClassificationPipeline):
             interim_output = self._parse_lists_of_dict_to_list_of_str(raw_output, output_key)
@@ -1600,6 +1595,54 @@ class _TransformersWrapper:
             return parsed
         else:
             return data
+
+    @staticmethod
+    def _strip_input_from_response_in_instruction_pipelines(input_data, output, output_key):
+        """
+        Parse the output from instruction pipelines to conform with other text generator
+        pipeline types and remove line feed characters and other confusing outputs
+        """
+        replacements = {"\n\n": " ", "A:": ""}
+
+        def extract_response_data(data_out):
+            if all(isinstance(x, dict) for x in data_out):
+                return [elem[output_key] for elem in data_out][0]
+            elif all(isinstance(x, list) for x in data_out):
+                return [elem[output_key] for coll in data_out for elem in coll]
+            else:
+                raise MlflowException(
+                    "Unable to parse the pipeline output. Expected List[Dict[str,str]] or "
+                    f"List[List[Dict[str,str]]] but got {type(data_out)} instead."
+                )
+
+        output = extract_response_data(output)
+
+        def trim_input(data_in, data_out):
+            # NB: the '\n\n' pattern is exclusive to specific InstructionalTextGenerationPipeline
+            # types that have been loaded as a plain TextGenerator. The structure of these
+            # pipelines will precisely repeat the input question immediately followed by 2 carriage
+            # return statements, followed by the start of the response to the prompt. We only
+            # want to left-trim these types of pipelines output values.
+            if data_out.startswith(data_in + "\n\n"):
+                output_string = data_out[len(data_in) :].strip()
+            else:
+                output_string = data_out.strip()
+
+            for to_replace, replace in replacements.items():
+                output_string = output_string.replace(to_replace, replace)
+
+            return output_string
+
+        if isinstance(input_data, list) and isinstance(output, list):
+            zipped = list(zip(input_data, output))
+            return [trim_input(data_in, data_out) for data_in, data_out in zipped]
+        elif isinstance(input_data, str) and isinstance(output, str):
+            return trim_input(input_data, output)
+        else:
+            raise MlflowException(
+                "Unknown data structure after parsing output. Expected str or List[str]. "
+                f"Got {type(output)} instead."
+            )
 
     def _sanitize_output(self, output, input_data):
         # Some pipelines and their underlying models leave leading or trailing whitespace.

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1929,14 +1929,25 @@ def test_parse_list_output_for_multiple_candidate_pipelines(mock_pyfunc_wrapper)
     [
         (
             "What answers?",
-            [{"generated_text": "What answers?\n\nA collection of \n\nanswers"}],
+            [{"generated_text": "What answers?\n\nA collection of\n\nanswers"}],
             "A collection of answers",
         ),
         ("Hello!", [{"generated_text": "Hello!\n\nHow are you?"}], "How are you?"),
         (
             ["Hi!", "What's up?"],
-            [[{"generated_text": "Hi!\nHello there"}, {"generated_text": "Not much, and you?"}]],
+            [[{"generated_text": "Hi!\n\nHello there"}, {"generated_text": "Not much, and you?"}]],
             ["Hello there", "Not much, and you?"],
+        ),
+        # Tests a standard TextGenerationPipeline output
+        (
+            ["We like to", "Open the"],
+            [
+                [
+                    {"generated_text": "We like to party"},
+                    {"generated_text": "Open the door get on the floor everybody do the dinosaur"},
+                ]
+            ],
+            ["We like to party", "Open the door get on the floor everybody do the dinosaur"],
         ),
     ],
 )

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1160,6 +1160,10 @@ def test_qa_pipeline_pyfunc_load_and_infer(small_qa_pipeline, model_path, infere
         ("muppet keyboard type", "A muppet is typing on a keyboard."),
         (
             ["pencil draw paper", "pie apple eat"],
+            # NB: The result of this test case, without inference config overrides is:
+            # ["A man drawing on paper with pencil", "A man eating a pie with applies"]
+            # The inference config override forces additional insertion of more grammatically
+            # correct responses to validate that the inference config is being applied.
             ["A man is drawing on paper with a pencil.", "A man is eating a pie with apples."],
         ),
     ],
@@ -1171,11 +1175,6 @@ def test_text2text_generation_pipeline_with_inference_configs(
     signature = infer_signature(
         data, mlflow.transformers.generate_signature_output(text2text_generation_pipeline, data)
     )
-
-    # NB: The result of the 2nd test, without inference config overrides is:
-    # ["A man drawing on paper with pencil", "A man eating a pie with applies"]
-    # The inference config override forces additional insertion of more grammatically correct
-    # responses.
 
     inference_config = {
         "top_k": 2,
@@ -1925,18 +1924,31 @@ def test_parse_list_output_for_multiple_candidate_pipelines(mock_pyfunc_wrapper)
 
 
 @pytest.mark.parametrize(
-    "pipeline_input, pipeline_output, expected_output",
+    "pipeline_input, pipeline_output, expected_output, flavor_config",
     [
         (
             "What answers?",
             [{"generated_text": "What answers?\n\nA collection of\n\nanswers"}],
             "A collection of answers",
+            {"instance_type": "InstructionTextGenerationPipeline"},
         ),
-        ("Hello!", [{"generated_text": "Hello!\n\nHow are you?"}], "How are you?"),
+        (
+            "Hello!",
+            [{"generated_text": "Hello!\n\nHow are you?"}],
+            "How are you?",
+            {"instance_type": "InstructionTextGenerationPipeline"},
+        ),
+        (
+            "Hello!",
+            [{"generated_text": "Hello!\n\nA: How are you?"}],
+            "How are you?",
+            {"instance_type": "InstructionTextGenerationPipeline"},
+        ),
         (
             ["Hi!", "What's up?"],
             [[{"generated_text": "Hi!\n\nHello there"}, {"generated_text": "Not much, and you?"}]],
             ["Hello there", "Not much, and you?"],
+            {"instance_type": "InstructionTextGenerationPipeline"},
         ),
         # Tests a standard TextGenerationPipeline output
         (
@@ -1948,28 +1960,36 @@ def test_parse_list_output_for_multiple_candidate_pipelines(mock_pyfunc_wrapper)
                 ]
             ],
             ["We like to party", "Open the door get on the floor everybody do the dinosaur"],
+            {"instance_type": "TextGenerationPipeline"},
         ),
     ],
 )
 def test_parse_input_from_instruction_pipeline(
-    mock_pyfunc_wrapper, pipeline_input, pipeline_output, expected_output
+    mock_pyfunc_wrapper, pipeline_input, pipeline_output, expected_output, flavor_config
 ):
     assert (
         mock_pyfunc_wrapper._strip_input_from_response_in_instruction_pipelines(
-            pipeline_input, pipeline_output, "generated_text"
+            pipeline_input, pipeline_output, "generated_text", flavor_config, False
         )
         == expected_output
     )
 
 
-def test_invalid_instruction_pipeline_parsing(mock_pyfunc_wrapper):
+@pytest.mark.parametrize(
+    "flavor_config",
+    [
+        {"instance_type": "InstructionTextGenerationPipeline"},
+        {"instance_type": "TextGenerationPipeline"},
+    ],
+)
+def test_invalid_instruction_pipeline_parsing(mock_pyfunc_wrapper, flavor_config):
     prompt = "What is your favorite boba flavor?"
 
     bad_output = {"generated_text": ["Strawberry Milk Cap", "Honeydew with boba"]}
 
     with pytest.raises(MlflowException, match="Unable to parse the pipeline output. Expected"):
         mock_pyfunc_wrapper._strip_input_from_response_in_instruction_pipelines(
-            prompt, bad_output, "generated_text"
+            prompt, bad_output, "generated_text", flavor_config, True
         )
 
 
@@ -1991,4 +2011,25 @@ def test_instructional_pipeline(model_path):
     inference = pyfunc_loaded.predict("What is MLflow?")
 
     assert not inference.startswith("What is MLflow?")
+    assert "\n" not in inference
+
+
+@pytest.mark.skipif(RUNNING_IN_GITHUB_ACTIONS, reason=GITHUB_ACTIONS_SKIP_REASON)
+@pytest.mark.skipcacheclean
+def test_instructional_pipeline_with_prompt_in_output(model_path):
+    architecture = "databricks/dolly-v2-3b"
+    dolly = transformers.pipeline(model=architecture, trust_remote_code=True)
+
+    mlflow.transformers.save_model(
+        transformers_model=dolly,
+        path=model_path,
+        inference_config={"max_length": 100, "include_prompt": True},
+        input_example="Hello, Dolly!",
+    )
+
+    pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
+
+    inference = pyfunc_loaded.predict("What is MLflow?")
+
+    assert inference.startswith("What is MLflow?")
     assert "\n" not in inference

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1160,7 +1160,7 @@ def test_qa_pipeline_pyfunc_load_and_infer(small_qa_pipeline, model_path, infere
         ("muppet keyboard type", "A muppet is typing on a keyboard."),
         (
             ["pencil draw paper", "pie apple eat"],
-            ["A man is drawing on paper with a pencil.", "A man eating a pie with apples."],
+            ["A man is drawing on paper with a pencil.", "A man is eating a pie with apples."],
         ),
     ],
 )
@@ -1171,6 +1171,11 @@ def test_text2text_generation_pipeline_with_inference_configs(
     signature = infer_signature(
         data, mlflow.transformers.generate_signature_output(text2text_generation_pipeline, data)
     )
+
+    # NB: The result of the 2nd test, without inference config overrides is:
+    # ["A man drawing on paper with pencil", "A man eating a pie with applies"]
+    # The inference config override forces additional insertion of more grammatically correct
+    # responses.
 
     inference_config = {
         "top_k": 2,
@@ -1475,14 +1480,12 @@ def test_translation_pipeline(translation_pipeline, model_path, data, result):
 @pytest.mark.skipif(RUNNING_IN_GITHUB_ACTIONS, reason=GITHUB_ACTIONS_SKIP_REASON)
 def test_summarization_pipeline(summarizer_pipeline, model_path, data):
     inference_config = {
-        "prefix": "software",
         "top_k": 2,
         "num_beams": 5,
-        "max_length": 30,
+        "max_length": 90,
         "temperature": 0.62,
         "top_p": 0.85,
         "repetition_penalty": 1.15,
-        "min_length": 10,
     }
     signature = infer_signature(
         data, mlflow.transformers.generate_signature_output(summarizer_pipeline, data)
@@ -1919,3 +1922,62 @@ def test_parse_list_output_for_multiple_candidate_pipelines(mock_pyfunc_wrapper)
         mock_pyfunc_wrapper._parse_list_output_for_multiple_candidate_pipelines(output_data)
         == expected_output
     )
+
+
+@pytest.mark.parametrize(
+    "pipeline_input, pipeline_output, expected_output",
+    [
+        (
+            "What answers?",
+            [{"generated_text": "What answers?\n\nA collection of \n\nanswers"}],
+            "A collection of answers",
+        ),
+        ("Hello!", [{"generated_text": "Hello!\n\nHow are you?"}], "How are you?"),
+        (
+            ["Hi!", "What's up?"],
+            [[{"generated_text": "Hi!\nHello there"}, {"generated_text": "Not much, and you?"}]],
+            ["Hello there", "Not much, and you?"],
+        ),
+    ],
+)
+def test_parse_input_from_instruction_pipeline(
+    mock_pyfunc_wrapper, pipeline_input, pipeline_output, expected_output
+):
+    assert (
+        mock_pyfunc_wrapper._strip_input_from_response_in_instruction_pipelines(
+            pipeline_input, pipeline_output, "generated_text"
+        )
+        == expected_output
+    )
+
+
+def test_invalid_instruction_pipeline_parsing(mock_pyfunc_wrapper):
+    prompt = "What is your favorite boba flavor?"
+
+    bad_output = {"generated_text": ["Strawberry Milk Cap", "Honeydew with boba"]}
+
+    with pytest.raises(MlflowException, match="Unable to parse the pipeline output. Expected"):
+        mock_pyfunc_wrapper._strip_input_from_response_in_instruction_pipelines(
+            prompt, bad_output, "generated_text"
+        )
+
+
+@pytest.mark.skipif(RUNNING_IN_GITHUB_ACTIONS, reason=GITHUB_ACTIONS_SKIP_REASON)
+@pytest.mark.skipcacheclean
+def test_instructional_pipeline(model_path):
+    architecture = "databricks/dolly-v2-3b"
+    dolly = transformers.pipeline(model=architecture, trust_remote_code=True)
+
+    mlflow.transformers.save_model(
+        transformers_model=dolly,
+        path=model_path,
+        inference_config={"max_length": 100},
+        input_example="Hello, Dolly!",
+    )
+
+    pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
+
+    inference = pyfunc_loaded.predict("What is MLflow?")
+
+    assert not inference.startswith("What is MLflow?")
+    assert "\n" not in inference


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Adds support for Dolly and resolves a bug in inference configuration overrides

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

Manually validated multiple inference configuration settings for pyfunc predict overrides to the generate method of pipelines, validated that using Dolly as pyfunc functions correctly and removes question repetition, newline characters, and the random `A:` artifacts that appear in some types of questions' responses.

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
