### PR TITLE
[Bug-fix] fixing null columns profiling for MLflow Recipes

### DIFF
--- a/mlflow/recipes/cards/pandas_renderer.py
+++ b/mlflow/recipes/cards/pandas_renderer.py
@@ -157,7 +157,9 @@ def convert_to_dataset_feature_statistics(
             strs = current_column_value.dropna()
 
             feat_stats.avg_length = (
-                np.mean(np.vectorize(len)(strs)) if not is_current_column_boolean_type else 0
+                np.mean(np.vectorize(len)(strs))
+                if not is_current_column_boolean_type and not current_column_value.isnull().all()
+                else 0
             )
             vals, counts = np.unique(strs, return_counts=True)
             feat_stats.unique = pandas_describe_key.get("unique", len(vals))

--- a/tests/recipes/cards/test_pandas_renderer.py
+++ b/tests/recipes/cards/test_pandas_renderer.py
@@ -102,6 +102,7 @@ def test_convert_to_proto():
         "Symbol": ["MSFT", "AAPL", "MSFT", "AAPL", "NFLX"],
         "Shares": [100, 170, 150, 200, None],
         "Access": [True, True, False, True, False],
+        "All_Null": [None, None, None, None, None],
     }
     df = pd.DataFrame(data)
 
@@ -314,6 +315,25 @@ def test_convert_to_proto():
             custom_stats {
               name: "data type"
               str: "bool"
+            }
+          },
+          features {
+            name: "All_Null"
+            type: STRING
+            string_stats {
+              common_stats {
+                num_non_missing: 0
+                num_missing: 5
+                min_num_values: 1
+                max_num_values: 1
+                avg_num_values: 1.0
+              }
+              unique: 0
+              avg_length: 0.0
+            }
+            custom_stats {
+              name: "data type"
+              str: "object"
             }
           }
         }


### PR DESCRIPTION
## What changes are proposed in this pull request?
[Bug-fix] fixing null columns profiling for MLflow Recipes

## How is this patch tested?
Before:
<img width="2163" alt="image" src="https://user-images.githubusercontent.com/5621432/232884498-50d8586c-2a8e-4e22-8d8f-c08142b04d9b.png">

After: 
<img width="2162" alt="image" src="https://user-images.githubusercontent.com/5621432/232884370-8027fb79-69ad-42a5-835e-b1f2c37798c8.png">


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

[Bug-fix] fixing null columns profiling for MLflow Recipes

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
