### PR TITLE
Fix IN comparison parsing 

### DIFF
--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -58,9 +58,15 @@ def _join_in_comparison_tokens(tokens):
     iterator = enumerate(non_whitespace_tokens)
     while elem := next(iterator, None):
         index, first = elem
+        # We need at least 3 tokens to form an IN comparison or a NOT IN comparison
         if num_tokens - index < 3:
             joined_tokens.extend(non_whitespace_tokens[index:])
             break
+
+        # Wait until we encounter an identifier token
+        if not isinstance(first, Identifier):
+            joined_tokens.append(first)
+            continue
 
         (_, second) = next(iterator)
         (_, third) = next(iterator)
@@ -71,7 +77,7 @@ def _join_in_comparison_tokens(tokens):
             and second.match(ttype=TokenType.Keyword, values=["IN"])
             and isinstance(third, Parenthesis)
         ):
-            joined_tokens.append(Comparison(TokenList(tokens)))
+            joined_tokens.append(Comparison(TokenList([first, second, third])))
             continue
 
         (_, fourth) = next(iterator, (None, None))
@@ -92,6 +98,7 @@ def _join_in_comparison_tokens(tokens):
             continue
 
         joined_tokens.extend([first, second, third, fourth])
+
     return joined_tokens
 
 

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -45,36 +45,54 @@ def _ilike(string, pattern):
 
 def _join_in_comparison_tokens(tokens):
     """
-    If a given list of tokens matches the pattern of an IN comparison or a NOT IN comparison,
+    Find a sequence of tokens that matches the pattern of an IN comparison or a NOT IN comparison,
     join the tokens into a single Comparison token. Otherwise, return the original list of tokens.
     """
     if Version(sqlparse.__version__) < Version("0.4.4"):
         # In sqlparse < 0.4.4, IN is treated as a comparison, we don't need to join tokens
         return tokens
 
-    tokens = [t for t in tokens if not t.is_whitespace]
-    num_tokens = len(tokens)
-    # IN
-    if num_tokens == 3:
-        first, second, third = tokens
+    non_whitespace_tokens = [t for t in tokens if not t.is_whitespace]
+    joined_tokens = []
+    num_tokens = len(non_whitespace_tokens)
+    iterator = enumerate(non_whitespace_tokens)
+    while elem := next(iterator, None):
+        index, first = elem
+        if num_tokens - index < 3:
+            joined_tokens.extend(non_whitespace_tokens[index:])
+            break
+
+        (_, second) = next(iterator)
+        (_, third) = next(iterator)
+
+        # IN
         if (
             isinstance(first, Identifier)
             and second.match(ttype=TokenType.Keyword, values=["IN"])
             and isinstance(third, Parenthesis)
         ):
-            return [Comparison(TokenList(tokens))]
-    # NOT IN
-    elif num_tokens == 4:
-        first, second, third, fourth = tokens
+            joined_tokens.append(Comparison(TokenList(tokens)))
+            continue
+
+        (_, fourth) = next(iterator, (None, None))
+        if fourth is None:
+            joined_tokens.extend([first, second, third])
+            break
+
+        # NOT IN
         if (
             isinstance(first, Identifier)
             and second.match(ttype=TokenType.Keyword, values=["NOT"])
             and third.match(ttype=TokenType.Keyword, values=["IN"])
             and isinstance(fourth, Parenthesis)
         ):
-            return [Comparison(TokenList([first, Token(TokenType.Keyword, "NOT IN"), fourth]))]
+            joined_tokens.append(
+                Comparison(TokenList([first, Token(TokenType.Keyword, "NOT IN"), fourth]))
+            )
+            continue
 
-    return tokens
+        joined_tokens.extend([first, second, third, fourth])
+    return joined_tokens
 
 
 class SearchUtils:

--- a/tests/store/model_registry/test_file_store.py
+++ b/tests/store/model_registry/test_file_store.py
@@ -692,6 +692,11 @@ def test_search_model_versions(store):
     # search IN operator with right-hand side value containing whitespaces
     assert set(search_versions(f"run_id IN ('{run_id_1}', '{run_id_2}')")) == {1, 2, 3}
 
+    # search IN operator with other conditions
+    assert set(
+        search_versions(f"version_number=2 AND run_id IN ('{run_id_1.upper()}','{run_id_2}')")
+    ) == {2}
+
     # search using the IN operator with bad lists should return exceptions
     with pytest.raises(
         MlflowException,

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -766,6 +766,11 @@ def test_search_model_versions(store):
     # search IN operator is case sensitive
     assert set(search_versions(f"run_id IN ('{run_id_1.upper()}','{run_id_2}')")) == {2, 3}
 
+    # search IN operator with other conditions
+    assert set(
+        search_versions(f"version_number=2 AND run_id IN ('{run_id_1.upper()}','{run_id_2}')")
+    ) == {2}
+
     # search IN operator with right-hand side value containing whitespaces
     assert set(search_versions(f"run_id IN ('{run_id_1}', '{run_id_2}')")) == {1, 2, 3}
 

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1231,17 +1231,17 @@ def test_search_runs_run_id(store):
 
     result = store.search_runs(
         [exp_id],
-        filter_string=f"attributes.run_name = '1' AND attributes.run_id IN ('{run_id1}')",
-        run_view_type=ViewType.ACTIVE_ONLY,
-    )
-    assert [r.info.run_id for r in result] == [run_id1]
-
-    result = store.search_runs(
-        [exp_id],
         filter_string=f"attributes.run_id NOT IN ('{run_id1}')",
         run_view_type=ViewType.ACTIVE_ONLY,
     )
     assert [r.info.run_id for r in result] == [run_id2]
+
+    result = store.search_runs(
+        [exp_id],
+        filter_string=f"run_name = '{run1.info.run_name}' AND run_id IN ('{run_id1}')",
+        run_view_type=ViewType.ACTIVE_ONLY,
+    )
+    assert [r.info.run_id for r in result] == [run_id1]
 
     for filter_string in [
         f"attributes.run_id IN ('{run_id1}','{run_id2}')",

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1231,6 +1231,13 @@ def test_search_runs_run_id(store):
 
     result = store.search_runs(
         [exp_id],
+        filter_string=f"attributes.run_name = '1' AND attributes.run_id IN ('{run_id1}')",
+        run_view_type=ViewType.ACTIVE_ONLY,
+    )
+    assert [r.info.run_id for r in result] == [run_id1]
+
+    result = store.search_runs(
+        [exp_id],
         filter_string=f"attributes.run_id NOT IN ('{run_id1}')",
         run_view_type=ViewType.ACTIVE_ONLY,
     )

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2110,6 +2110,13 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             run_view_type=ViewType.ACTIVE_ONLY,
         )
 
+        result = self.store.search_runs(
+            [exp_id],
+            filter_string=f"run_name = '{run1.info.run_name}' AND run_id IN ('{run_id1}')",
+            run_view_type=ViewType.ACTIVE_ONLY,
+        )
+        assert [r.info.run_id for r in result] == [run_id1]
+
         for filter_string in [
             f"attributes.run_id IN ('{run_id1}','{run_id2}')",
             f"attributes.run_id IN ('{run_id1}', '{run_id2}')",


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #8258

## What changes are proposed in this pull request?

The fix made by #8258 doesn't work if an `IN` comparison is concatenated with other conditions. This PR fixes it.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
