### PR TITLE
Handle cyclic dependencies in dependency inference

### DIFF
--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -163,7 +163,7 @@ def _get_requires(pkg_name):
             yield _normalize_package_name(req.name)
 
 
-def _get_requires_recursive(pkg_name, seen_before=None) -> set:
+def _get_requires_recursive(pkg_name, seen_before=None):
     """
     Recursively yields both direct and transitive dependencies of the specified
     package.

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -156,43 +156,27 @@ def _normalize_package_name(pkg_name):
     return _NORMALIZE_REGEX.sub("-", pkg_name).lower()
 
 
-def _get_requires(pkg_name, top_pkg_name=None):
-    if top_pkg_name is None:
-        # Assume the top package
-        top_pkg_name = pkg_name
-
-    pkg_name = _normalize_package_name(pkg_name)
-    if pkg_name not in pkg_resources.working_set.by_key:
-        return
-
-    package = pkg_resources.working_set.by_key[pkg_name]
-    reqs = package.requires()
-    if len(reqs) == 0:
-        return
-
-    for req in reqs:
-        req_name = _normalize_package_name(req.name)
-        if req_name == top_pkg_name:
-            # If the top package ends up providing himself again through a
-            # recursive dependency, we don't want to consider it as a
-            # dependency
-            continue
-
-        yield req_name
+def _get_requires(pkg_name):
+    norm_pkg_name = _normalize_package_name(pkg_name)
+    if package := pkg_resources.working_set.by_key.get(norm_pkg_name):
+        for req in package.requires():
+            yield _normalize_package_name(req.name)
 
 
-def _get_requires_recursive(pkg_name, top_pkg_name=None) -> set:
+def _get_requires_recursive(pkg_name, seen_before=None) -> set:
     """
     Recursively yields both direct and transitive dependencies of the specified
     package.
-    The `top_pkg_name` argument will track what's the top-level dependency for
-    which we want to list all sub-dependencies.
-    This ensures that we don't fall into recursive loops for packages with are
-    dependant on each other.
     """
-    for req in _get_requires(pkg_name, top_pkg_name):
+    norm_pkg_name = _normalize_package_name(pkg_name)
+    seen_before = seen_before or {norm_pkg_name}
+    for req in _get_requires(pkg_name):
+        # Prevent infinite recursion due to cyclic dependencies
+        if req in seen_before:
+            continue
+        seen_before.add(req)
         yield req
-        yield from _get_requires_recursive(req, top_pkg_name)
+        yield from _get_requires_recursive(req, seen_before)
 
 
 def _prune_packages(packages):

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -867,6 +867,7 @@ def test_pyfunc_serve_and_score(data):
 @pytest.mark.skipif(not _is_importable("transformers"), reason="This test requires transformers")
 def test_pyfunc_serve_and_score_transformers():
     from transformers import BertModel, BertConfig  # pylint: disable=import-error
+    from mlflow.deployments import PredictionsResponse
 
     class MyBertModel(BertModel):
         def forward(self, *args, **kwargs):  # pylint: disable=arguments-differ
@@ -895,7 +896,6 @@ def test_pyfunc_serve_and_score_transformers():
         pyfunc_scoring_server.CONTENT_TYPE_JSON,
         extra_args=EXTRA_PYFUNC_SERVING_TEST_ARGS,
     )
-    from mlflow.deployments import PredictionsResponse
 
     scores = PredictionsResponse.from_json(resp.content.decode("utf-8")).get_predictions(
         predictions_format="ndarray"


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix the following error caused by cyclic dependency between torch and triton: 

https://github.com/mlflow/mlflow/actions/runs/4734875094/jobs/8406147396

```
  File "/home/runner/work/mlflow/mlflow/mlflow/pyfunc/scoring_server/wsgi.py", line 6, in <module>
    app = scoring_server.init(load_model(os.environ[scoring_server._SERVER_MODEL_PATH]))
  File "/home/runner/work/mlflow/mlflow/mlflow/pyfunc/__init__.py", line 596, in load_model
    model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
  File "/home/runner/work/mlflow/mlflow/mlflow/pytorch/__init__.py", line 763, in _load_pyfunc
    return _PyTorchWrapper(_load_model(path, **kwargs))
  File "/home/runner/work/mlflow/mlflow/mlflow/pytorch/__init__.py", line 669, in _load_model
    return torch.load(model_path, **kwargs)
  File "/home/runner/.mlflow/envs/mlflow-ad098d267024a6b0014bcb7252a215609256db7e/lib/python3.8/site-packages/torch/serialization.py", line 809, in load
    return _load(opened_zipfile, map_location, pickle_module, **pickle_load_args)
  File "/home/runner/.mlflow/envs/mlflow-ad098d267024a6b0014bcb7252a215609256db7e/lib/python3.8/site-packages/torch/serialization.py", line 1172, in _load
    result = unpickler.load()
  File "/home/runner/.mlflow/envs/mlflow-ad098d267024a6b0014bcb7252a215609256db7e/lib/python3.8/site-packages/torch/serialization.py", line 1165, in find_class
    return super().find_class(mod_name, name)
ModuleNotFoundError: No module named 'transformers'
```

Cyclic dependency results in infinite recursion, which results in an error during dependency inference.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
