### PR TITLE
Invert the default output parsing for TextGenerator subtypes

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2000,6 +2000,15 @@ and standardizes both the inputs and outputs of pipeline inference. This conform
 and batch inference by coercing the data structures that are required for ``transformers`` inference pipelines
 to formats that are compatible with json serialization and casting to Pandas DataFrames.
 
+.. note::
+    Certain `TextGenerationPipeline` types, particularly instructional-based ones, may return the original
+    prompt and included line-formatting carriage returns `"\n"` in their outputs. For these pipeline types,
+    if you would like to disable the prompt return, you can set the following in the `inference_config` dictionary when
+    saving or logging the model: `"include_prompt": False`. To remove the newline characters from within the body
+    of the generated text output, you can add the `"remove_newlines": True` option to the `inference_config` dictionary.
+    If the pipeline type being saved does not inherit from `TextGenerationPipeline`, these options will not perform
+    any modification to the output returned from pipeline inference.
+
 .. attention::
     Not all ``transformers`` pipeline types are supported. See the table below for the list of currently supported Pipeline
     types that can be loaded as ``pyfunc``.

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2005,7 +2005,7 @@ to formats that are compatible with json serialization and casting to Pandas Dat
     prompt and included line-formatting carriage returns `"\n"` in their outputs. For these pipeline types,
     if you would like to disable the prompt return, you can set the following in the `inference_config` dictionary when
     saving or logging the model: `"include_prompt": False`. To remove the newline characters from within the body
-    of the generated text output, you can add the `"shrink_newlines": True` option to the `inference_config` dictionary.
+    of the generated text output, you can add the `"collapse_whitespace": True` option to the `inference_config` dictionary.
     If the pipeline type being saved does not inherit from `TextGenerationPipeline`, these options will not perform
     any modification to the output returned from pipeline inference.
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2005,7 +2005,7 @@ to formats that are compatible with json serialization and casting to Pandas Dat
     prompt and included line-formatting carriage returns `"\n"` in their outputs. For these pipeline types,
     if you would like to disable the prompt return, you can set the following in the `inference_config` dictionary when
     saving or logging the model: `"include_prompt": False`. To remove the newline characters from within the body
-    of the generated text output, you can add the `"remove_newlines": True` option to the `inference_config` dictionary.
+    of the generated text output, you can add the `"shrink_newlines": True` option to the `inference_config` dictionary.
     If the pipeline type being saved does not inherit from `TextGenerationPipeline`, these options will not perform
     any modification to the output returned from pipeline inference.
 

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -1446,9 +1446,12 @@ class _TransformersWrapper:
                 error_code=BAD_REQUEST,
             )
 
-        # Optional input preservation for specific pipeline types
+        # Optional input preservation for specific pipeline types. This is True (include raw
+        # formatting output), but if `include_prompt` is set to False in the `inference_config`
+        # option during model saving, excess newline characters and the fed-in prompt will be
+        # trimmed out.
         include_prompt = (
-            self.inference_config.pop("include_prompt", False) if self.inference_config else False
+            self.inference_config.pop("include_prompt", True) if self.inference_config else True
         )
 
         # Generate inference data with the pipeline object
@@ -1609,7 +1612,7 @@ class _TransformersWrapper:
             return data
 
     def _strip_input_from_response_in_instruction_pipelines(
-        self, input_data, output, output_key, flavor_config, include_prompt
+        self, input_data, output, output_key, flavor_config, include_prompt=True
     ):
         """
         Parse the output from instruction pipelines to conform with other text generator
@@ -1647,8 +1650,8 @@ class _TransformersWrapper:
                     data_out = data_out[len(data_in) :].lstrip()
                     if data_out.startswith("A:"):
                         data_out = data_out[2:].lstrip()
-                for to_replace, replace in replacements.items():
-                    data_out = data_out.replace(to_replace, replace)
+                    for to_replace, replace in replacements.items():
+                        data_out = data_out.replace(to_replace, replace)
                 return data_out
             else:
                 return data_out

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -1449,9 +1449,13 @@ class _TransformersWrapper:
         # Optional input preservation for specific pipeline types. This is True (include raw
         # formatting output), but if `include_prompt` is set to False in the `inference_config`
         # option during model saving, excess newline characters and the fed-in prompt will be
-        # trimmed out.
+        # trimmed out from the start of the response.
         include_prompt = (
             self.inference_config.pop("include_prompt", True) if self.inference_config else True
+        )
+        # Optional stripping out of `\n` for specific generator pipelines.
+        remove_newlines = (
+            self.inference_config.pop("remove_newlines", False) if self.inference_config else False
         )
 
         # Generate inference data with the pipeline object
@@ -1474,7 +1478,7 @@ class _TransformersWrapper:
             self.pipeline, transformers.TextGenerationPipeline
         ):
             output = self._strip_input_from_response_in_instruction_pipelines(
-                data, raw_output, output_key, self.flavor_config, include_prompt
+                data, raw_output, output_key, self.flavor_config, include_prompt, remove_newlines
             )
         elif isinstance(self.pipeline, transformers.FillMaskPipeline):
             output = self._parse_list_of_multiple_dicts(raw_output, output_key)
@@ -1612,13 +1616,19 @@ class _TransformersWrapper:
             return data
 
     def _strip_input_from_response_in_instruction_pipelines(
-        self, input_data, output, output_key, flavor_config, include_prompt=True
+        self,
+        input_data,
+        output,
+        output_key,
+        flavor_config,
+        include_prompt=True,
+        remove_newlines=False,
     ):
         """
         Parse the output from instruction pipelines to conform with other text generator
         pipeline types and remove line feed characters and other confusing outputs
         """
-        replacements = {"\n\n": " "}
+        replacements = {"\n\n": " ", "\n": " "}
 
         def extract_response_data(data_out):
             if all(isinstance(x, dict) for x in data_out):
@@ -1640,6 +1650,8 @@ class _TransformersWrapper:
             # return statements, followed by the start of the response to the prompt. We only
             # want to left-trim these types of pipelines output values if the user hasn't disabled
             # the removal action of the input prompt in the returned str or List[str]
+            # Stripping out additional carriage returns (\n) is another additional optional flag
+            # that can be set for these generator pipelines. It is off by default (False).
             if (
                 data_out.startswith(data_in + "\n\n")
                 and flavor_config[_INSTANCE_TYPE_KEY] in self._supported_custom_generator_types
@@ -1650,8 +1662,9 @@ class _TransformersWrapper:
                     data_out = data_out[len(data_in) :].lstrip()
                     if data_out.startswith("A:"):
                         data_out = data_out[2:].lstrip()
+                if remove_newlines:
                     for to_replace, replace in replacements.items():
-                        data_out = data_out.replace(to_replace, replace)
+                        data_out = data_out.replace(to_replace, replace).strip()
                 return data_out
             else:
                 return data_out

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1925,7 +1925,7 @@ def test_parse_list_output_for_multiple_candidate_pipelines(mock_pyfunc_wrapper)
 
 @pytest.mark.parametrize(
     "pipeline_input, pipeline_output, expected_output, flavor_config, include_prompt, "
-    "remove_newlines",
+    "shrink_newlines",
     [
         (
             "What answers?",
@@ -2034,7 +2034,7 @@ def test_parse_input_from_instruction_pipeline(
     expected_output,
     flavor_config,
     include_prompt,
-    remove_newlines,
+    shrink_newlines,
 ):
     assert (
         mock_pyfunc_wrapper._strip_input_from_response_in_instruction_pipelines(
@@ -2043,7 +2043,7 @@ def test_parse_input_from_instruction_pipeline(
             "generated_text",
             flavor_config,
             include_prompt,
-            remove_newlines,
+            shrink_newlines,
         )
         == expected_output
     )
@@ -2099,7 +2099,7 @@ def test_instructional_pipeline_no_prompt_in_output_and_removal_of_newlines(mode
         transformers_model=dolly,
         path=model_path,
         # Validate removal of prompt but inclusion of newlines by default
-        inference_config={"max_length": 100, "include_prompt": False, "remove_newlines": True},
+        inference_config={"max_length": 100, "include_prompt": False, "shrink_newlines": True},
         input_example="Hello, Dolly!",
     )
 

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1925,7 +1925,7 @@ def test_parse_list_output_for_multiple_candidate_pipelines(mock_pyfunc_wrapper)
 
 @pytest.mark.parametrize(
     "pipeline_input, pipeline_output, expected_output, flavor_config, include_prompt, "
-    "shrink_newlines",
+    "collapse_whitespace",
     [
         (
             "What answers?",
@@ -2034,7 +2034,7 @@ def test_parse_input_from_instruction_pipeline(
     expected_output,
     flavor_config,
     include_prompt,
-    shrink_newlines,
+    collapse_whitespace,
 ):
     assert (
         mock_pyfunc_wrapper._strip_input_from_response_in_instruction_pipelines(
@@ -2043,7 +2043,7 @@ def test_parse_input_from_instruction_pipeline(
             "generated_text",
             flavor_config,
             include_prompt,
-            shrink_newlines,
+            collapse_whitespace,
         )
         == expected_output
     )
@@ -2099,7 +2099,7 @@ def test_instructional_pipeline_no_prompt_in_output_and_removal_of_newlines(mode
         transformers_model=dolly,
         path=model_path,
         # Validate removal of prompt but inclusion of newlines by default
-        inference_config={"max_length": 100, "include_prompt": False, "shrink_newlines": True},
+        inference_config={"max_length": 100, "include_prompt": False, "collapse_whitespace": True},
         input_example="Hello, Dolly!",
     )
 
@@ -2120,7 +2120,7 @@ def test_instructional_pipeline_with_prompt_in_output(model_path):
     mlflow.transformers.save_model(
         transformers_model=dolly,
         path=model_path,
-        # test default propagation of `include_prompt`=True and `remove_newlines`=False
+        # test default propagation of `include_prompt`=True and `collapse_whitespace`=False
         inference_config={"max_length": 100},
         input_example="Hello, Dolly!",
     )


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Inverts the output parsing default configuration making newline removal and prompt stripping opt-in via an inference_config setting.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
