### PR TITLE
Fixed a bug in MLflow R set_experiment

### DIFF
--- a/mlflow/R/mlflow/R/tracking-experiments.R
+++ b/mlflow/R/mlflow/R/tracking-experiments.R
@@ -229,11 +229,7 @@ mlflow_set_experiment <- function(experiment_name = NULL, experiment_id = NULL, 
     tryCatch(
       mlflow_id(mlflow_get_experiment(client = client, name = experiment_name)),
       error = function(e) {
-        if (grepl(
-              fixed = TRUE,
-              x = e$message,
-              pattern = paste(
-                "Could not find experiment with name '", experiment_name, "'", sep=""))) {
+        if (grep("RESOURCE_DOES_NOT_EXIST", e$message, fixed = TRUE)) {
           message("Experiment `", experiment_name, "` does not exist. Creating a new experiment.")
           mlflow_create_experiment(client = client, name = experiment_name, artifact_location = artifact_location)
         } else {

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -4,12 +4,14 @@ teardown({
   mlflow_clear_test_dir("mlruns")
 })
 
-test_that("mlflow_create/get_experiment() basic functionality (fluent)", {
+test_that("mlflow_create/set/get_experiment() basic functionality (fluent)", {
   mlflow_clear_test_dir("mlruns")
   artifact_relative_path <- "art_loc"
-  experiment_1_id <- mlflow_create_experiment("exp_name", artifact_relative_path)
+  experiment_1_id <- mlflow_create_experiment("exp_name_1", artifact_relative_path)
+  experiment_2_id <- mlflow_set_experiment("exp_name_2", artifact_relative_path)
   experiment_1a <- mlflow_get_experiment(experiment_id = experiment_1_id)
-  experiment_1b <- mlflow_get_experiment(name = "exp_name")
+  experiment_1b <- mlflow_get_experiment(name = "exp_name_1")
+  experiment_2a <- mlflow_get_experiment(name = "exp_name_2")
 
   expect_identical(experiment_1a, experiment_1b)
   expected_artifact_location <- sprintf("%s/%s", getwd(), artifact_relative_path)

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -16,7 +16,9 @@ test_that("mlflow_create/set/get_experiment() basic functionality (fluent)", {
   expect_identical(experiment_1a, experiment_1b)
   expected_artifact_location <- sprintf("%s/%s", getwd(), artifact_relative_path)
   expect_identical(experiment_1a$artifact_location, expected_artifact_location)
-  expect_identical(experiment_1a$name, "exp_name")
+  expect_identical(experiment_1a$name, "exp_name_1")
+  expect_identical(experiment_2a$name, "exp_name_2")
+  expect_identical(experiment_2a$artifact_location, expected_artifact_location)
 })
 
 test_that("mlflow_create/get_experiment() basic functionality (client)", {

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -8,7 +8,7 @@ test_that("mlflow_create/set/get_experiment() basic functionality (fluent)", {
   mlflow_clear_test_dir("mlruns")
   artifact_relative_path <- "art_loc"
   experiment_1_id <- mlflow_create_experiment("exp_name_1", artifact_relative_path)
-  experiment_2_id <- mlflow_set_experiment("exp_name_2", artifact_relative_path)
+  experiment_2_id <- mlflow_set_experiment(experiment_name = "exp_name_2", artifact_location = artifact_relative_path)
   experiment_1a <- mlflow_get_experiment(experiment_id = experiment_1_id)
   experiment_1b <- mlflow_get_experiment(name = "exp_name_1")
   experiment_2a <- mlflow_get_experiment(name = "exp_name_2")


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?
Fixed a bug reported by Databricks customer. See ES-667050 for more details.

Ways to reproduce:
```
install.packages("mlflow") 
library(mlflow) 
mlflow_set_tracking_uri("databricks") 
mlflow_set_experiment("/Shared/new_experiment")
faces the below error 
```
Result in
```
Error : API request to endpoint 'experiments/get-by-name' failed with error code 404. Reponse body: 'RESOURCE_DOES_NOT_EXIST; Node /Shared/new_experiment does not exist.'   
```
After change
```
Experiment `/Shared/new_experiment` does not exist. Creating a new experiment.
[1] "3576731183624291"
```
## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
