### PR TITLE
Fix SFTP connections pool deadlock

### DIFF
--- a/mlflow/store/artifact/sftp_artifact_repo.py
+++ b/mlflow/store/artifact/sftp_artifact_repo.py
@@ -32,8 +32,12 @@ class _SftpPool:
         with self._cond:
             self._cond.wait_for(lambda: bool(self._connections))
             connection = self._connections.pop(-1)
+
         yield connection
-        self._connections.append(connection)
+
+        with self._cond:
+            self._connections.append(connection)
+            self._cond.notify()
 
 
 class SFTPArtifactRepository(ArtifactRepository):

--- a/mlflow/store/artifact/sftp_artifact_repo.py
+++ b/mlflow/store/artifact/sftp_artifact_repo.py
@@ -28,7 +28,7 @@ class _SftpPool:
         self._cond = threading.Condition()
 
     @contextmanager
-    def get_sfp_connection(self):
+    def get_sftp_connection(self):
         with self._cond:
             self._cond.wait_for(lambda: bool(self._connections))
             connection = self._connections.pop(-1)
@@ -90,13 +90,13 @@ class SFTPArtifactRepository(ArtifactRepository):
 
     def log_artifact(self, local_file, artifact_path=None):
         artifact_dir = posixpath.join(self.path, artifact_path) if artifact_path else self.path
-        with self.pool.get_sfp_connection() as sftp:
+        with self.pool.get_sftp_connection() as sftp:
             sftp.makedirs(artifact_dir)
             sftp.put(local_file, posixpath.join(artifact_dir, os.path.basename(local_file)))
 
     def log_artifacts(self, local_dir, artifact_path=None):
         artifact_dir = posixpath.join(self.path, artifact_path) if artifact_path else self.path
-        with self.pool.get_sfp_connection() as sftp:
+        with self.pool.get_sftp_connection() as sftp:
             sftp.makedirs(artifact_dir)
             if sys.platform == "win32":
                 _put_r_for_windows(sftp, local_dir, artifact_dir)
@@ -106,13 +106,13 @@ class SFTPArtifactRepository(ArtifactRepository):
     def _is_directory(self, artifact_path):
         artifact_dir = self.path
         path = posixpath.join(artifact_dir, artifact_path) if artifact_path else artifact_dir
-        with self.pool.get_sfp_connection() as sftp:
+        with self.pool.get_sftp_connection() as sftp:
             return sftp.isdir(path)
 
     def list_artifacts(self, path=None):
         artifact_dir = self.path
         list_dir = posixpath.join(artifact_dir, path) if path else artifact_dir
-        with self.pool.get_sfp_connection() as sftp:
+        with self.pool.get_sftp_connection() as sftp:
             if not sftp.isdir(list_dir):
                 return []
             artifact_files = sftp.listdir(list_dir)
@@ -128,12 +128,12 @@ class SFTPArtifactRepository(ArtifactRepository):
 
     def _download_file(self, remote_file_path, local_path):
         remote_full_path = posixpath.join(self.path, remote_file_path)
-        with self.pool.get_sfp_connection() as sftp:
+        with self.pool.get_sftp_connection() as sftp:
             sftp.get(remote_full_path, local_path)
 
     def delete_artifacts(self, artifact_path=None):
         artifact_dir = posixpath.join(self.path, artifact_path) if artifact_path else self.path
-        with self.pool.get_sfp_connection() as sftp:
+        with self.pool.get_sftp_connection() as sftp:
             self._delete_inner(artifact_dir, sftp)
 
     def _delete_inner(self, artifact_path, sftp):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Resolve #7422 

## What changes are proposed in this pull request?

The SFTP connections now notify waiting threads when finished. This will prevent deadlock state when all the connections are in use. For my case, the deadlock state happened when exporting experiments with high number of artifacts associated, leading to having all threads in use at the same time. The probability of this happening was decreased when the max number of threads was increased from 8 to 20 in #8112.

Also, a typo in function name was corrected: ~~`get_sfp_connection`~~  **get_sftp_connection** 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

Prior to the fix, the connection was silently added back to pool, without holding the lock.
```python
self._connections.append(connection)
```

Now, the connection is added back into the pool and notifies the waiting threads, while holding the lock.
```python
with self._cond:
    self._connections.append(connection)
    self._cond.notify()
```

Prior to the fix, the experiment export entered deadlock state and had to be manually stopped.
After the fix, the export worked as expected.


## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
