### PR TITLE
[Feature branch] NumPy dataset fix: incorporate targets into schema and profile

### DIFF
--- a/mlflow/data/numpy_dataset.py
+++ b/mlflow/data/numpy_dataset.py
@@ -105,7 +105,12 @@ class NumpyDataset(Dataset, PyFuncConvertibleDatasetMixin):
         An MLflow TensorSpec schema representing the tensor dataset
         """
         try:
-            return _infer_schema(self._features)
+            schema_dict = {
+                "features": self._features,
+            }
+            if self._targets is not None:
+                schema_dict["targets"] = self._targets
+            return _infer_schema(schema_dict)
         except Exception as e:
             _logger.warning("Failed to infer schema for Numpy dataset. Exception: %s", e)
             return None

--- a/mlflow/data/numpy_dataset.py
+++ b/mlflow/data/numpy_dataset.py
@@ -93,11 +93,21 @@ class NumpyDataset(Dataset, PyFuncConvertibleDatasetMixin):
         """
         A profile of the dataset. May be None if no profile is available.
         """
-        return {
-            "shape": self._features.shape,
-            "size": self._features.size,
-            "nbytes": self._features.nbytes,
+        profile = {
+            "features_shape": self._features.shape,
+            "features_size": self._features.size,
+            "features_nbytes": self._features.nbytes,
         }
+        if self._targets is not None:
+            profile.update(
+                {
+                    "targets_shape": self._targets.shape,
+                    "targets_size": self._targets.size,
+                    "targets_nbytes": self._targets.nbytes,
+                }
+            )
+
+        return profile
 
     @cached_property
     def schema(self) -> Optional[Schema]:

--- a/tests/data/test_numpy_dataset.py
+++ b/tests/data/test_numpy_dataset.py
@@ -76,7 +76,7 @@ def test_to_pyfunc():
     assert isinstance(dataset.to_pyfunc(), PyFuncInputsOutputs)
 
 
-def test_from_numpy(tmp_path):
+def test_from_numpy_features_only(tmp_path):
     features = np.array([1, 2, 3])
     path = tmp_path / "temp.csv"
     pd.DataFrame(features).to_csv(path)
@@ -84,11 +84,39 @@ def test_from_numpy(tmp_path):
 
     assert isinstance(mlflow_features, NumpyDataset)
     assert np.array_equal(mlflow_features.features, features)
-    assert mlflow_features.schema == _infer_schema(features)
+    assert mlflow_features.schema == _infer_schema({"features": features})
     assert mlflow_features.profile == {
-        "shape": features.shape,
-        "size": features.size,
-        "nbytes": features.nbytes,
+        "features_shape": features.shape,
+        "features_size": features.size,
+        "features_nbytes": features.nbytes,
     }
 
     assert isinstance(mlflow_features.source, FileSystemDatasetSource)
+
+
+def test_from_numpy_features_and_targets(tmp_path):
+    features = np.array([[1, 2, 3], [3, 2, 1], [2, 3, 1]])
+    targets = np.array([4, 5, 6])
+    path = tmp_path / "temp.csv"
+    pd.DataFrame(features).to_csv(path)
+    mlflow_ds = mlflow.data.from_numpy(features, targets=targets, source=path)
+
+    assert isinstance(mlflow_ds, NumpyDataset)
+    assert np.array_equal(mlflow_ds.features, features)
+    assert np.array_equal(mlflow_ds.targets, targets)
+    assert mlflow_ds.schema == _infer_schema(
+        {
+            "features": features,
+            "targets": targets,
+        }
+    )
+    assert mlflow_ds.profile == {
+        "features_shape": features.shape,
+        "features_size": features.size,
+        "features_nbytes": features.nbytes,
+        "targets_shape": targets.shape,
+        "targets_size": targets.size,
+        "targets_nbytes": targets.nbytes,
+    }
+
+    assert isinstance(mlflow_ds.source, FileSystemDatasetSource)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

NumPy dataset fix: incorporate targets into schema and profile

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
