### PR TITLE
Fix regression in model registry alias path parsing

### DIFF
--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -11,8 +11,8 @@ _MODELS_URI_SUFFIX_LATEST = "latest"
 # This regex is used by _parse_model_uri and details for the regex match
 # can be found in _improper_model_uri_msg.
 _MODEL_URI_REGEX = re.compile(
-    r"^\/(?P<model_name>[\w \.\-_\+\#\?\;\:\!\%\|\"\<\>]+)(\/(?P<suffix>[\w]+))?(@(?P<alias>["
-    r"\w\-]+))?$"
+    r"^\/(?P<model_name>[\w \.\-_\+\#\?\;\:\!\%\|\"\<\>\(\)\*\&\=\[\]\']+)(\/(?P<suffix>[\w]+))?"
+    r"(@(?P<alias>[\w\-]+))?$"
 )
 
 

--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -10,10 +10,9 @@ _MODELS_URI_SUFFIX_LATEST = "latest"
 
 # This regex is used by _parse_model_uri and details for the regex match
 # can be found in _improper_model_uri_msg.
-_DISALLOWED_CHARACTERS = r"\\\/$@"
 
 _MODEL_URI_REGEX = re.compile(
-    rf"^\/(?P<model_name>[^{_DISALLOWED_CHARACTERS}]+)(\/(?P<suffix>[\w]+))?(@(?P<alias>[\w\-]+))?$"
+    r"^\/(?P<model_name>[^\\\/$@]+)(\/(?P<suffix>[\w]+))?(@(?P<alias>[\w\-]+))?$"
 )
 
 

--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -10,10 +10,10 @@ _MODELS_URI_SUFFIX_LATEST = "latest"
 
 # This regex is used by _parse_model_uri and details for the regex match
 # can be found in _improper_model_uri_msg.
-disallowed_characters = r"\\\/$@"
+_DISALLOWED_CHARACTERS = r"\\\/$@"
 
 _MODEL_URI_REGEX = re.compile(
-    rf"^\/(?P<model_name>[^{disallowed_characters}]+)(\/(?P<suffix>[\w]+))?(@(?P<alias>[\w\-]+))?$"
+    rf"^\/(?P<model_name>[^{_DISALLOWED_CHARACTERS}]+)(\/(?P<suffix>[\w]+))?(@(?P<alias>[\w\-]+))?$"
 )
 
 

--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -10,9 +10,10 @@ _MODELS_URI_SUFFIX_LATEST = "latest"
 
 # This regex is used by _parse_model_uri and details for the regex match
 # can be found in _improper_model_uri_msg.
+disallowed_characters = r"\\\/$@"
+
 _MODEL_URI_REGEX = re.compile(
-    r"^\/(?P<model_name>[\w \.\-_\+\#\?\;\:\!\%\|\"\<\>\(\)\*\&\=\[\]\']+)(\/(?P<suffix>[\w]+))?"
-    r"(@(?P<alias>[\w\-]+))?$"
+    rf"^\/(?P<model_name>[^{disallowed_characters}]+)(\/(?P<suffix>[\w]+))?(@(?P<alias>[\w\-]+))?$"
 )
 
 
@@ -34,8 +35,8 @@ def _improper_model_uri_msg(uri):
 
 def _get_latest_model_version(client, name, stage):
     """
-    Returns the latest version of the stage if stage is not None. Otherwise return the latest of all
-    versions.
+    Returns the latest version of the stage if stage is not None. Otherwise, return the latest of
+    all versions.
     """
     latest = client.get_latest_versions(name, None if stage is None else [stage])
     if len(latest) == 0:

--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -11,7 +11,7 @@ _MODELS_URI_SUFFIX_LATEST = "latest"
 # This regex is used by _parse_model_uri and details for the regex match
 # can be found in _improper_model_uri_msg.
 _MODEL_URI_REGEX = re.compile(
-    r"^\/(?P<model_name>[\w \.\-]+)(\/(?P<suffix>[\w]+))?(@(?P<alias>[\w\-]+))?$"
+    r"^\/(?P<model_name>[\w \.\-_\+\#]+)(\/(?P<suffix>[\w]+))?(@(?P<alias>[\w\-]+))?$"
 )
 
 
@@ -63,6 +63,8 @@ def _parse_model_uri(uri):
     if parsed.scheme != "models":
         raise MlflowException(_improper_model_uri_msg(uri))
     path = parsed.path
+    if parsed.fragment:
+        path = f"{path}#{parsed.fragment}"
     m = _MODEL_URI_REGEX.match(path)
     if m is None:
         raise MlflowException(_improper_model_uri_msg(uri))

--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -12,7 +12,7 @@ _MODELS_URI_SUFFIX_LATEST = "latest"
 # can be found in _improper_model_uri_msg.
 
 _MODEL_URI_REGEX = re.compile(
-    r"^\/(?P<model_name>[^\\\/$@]+)(\/(?P<suffix>[\w]+))?(@(?P<alias>[\w\-]+))?$"
+    r"^\/(?P<model_name>[^\/@]+)(\/(?P<suffix>[\w]+))?(@(?P<alias>[\w\-]+))?$"
 )
 
 

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -34,6 +34,10 @@ from mlflow.entities.model_registry import ModelVersion
         ("models:/a=model/3", "a=model", "3"),
         ("models:/some[cool]model/2", "some[cool]model", "2"),
         ("models:/a'model'/1", "a'model'", "1"),
+        ("models:/a#model?amodel/1", "a#model?amodel", "1"),  # fragment before query
+        ("models:/a?model#amodel/1", "a?model#amodel", "1"),  # query before fragment
+        ("models:/a?mo#del?b#?model/2", "a?mo#del?b#?model", "2"),  # multiple queries and fragments
+        ("models:/a#mo?del?b#?model/2", "a#mo?del?b#?model", "2"),  # multiple queries and fragments
     ],
 )
 def test_parse_models_uri_with_version(uri, expected_name, expected_version):
@@ -71,6 +75,8 @@ def test_parse_models_uri_with_version(uri, expected_name, expected_version):
         ("models:/a=model/stage", "a=model", "stage"),
         ("models:/some[cool]model/stage", "some[cool]model", "stage"),
         ("models:/a'model'/stage", "a'model'", "stage"),
+        ("models:/a#model?amodel/prod", "a#model?amodel", "prod"),  # fragment before query
+        ("models:/a?model#amodel/dev", "a?model#amodel", "dev"),  # query before fragment
     ],
 )
 def test_parse_models_uri_with_stage(uri, expected_name, expected_stage):
@@ -127,6 +133,12 @@ def test_parse_models_uri_with_latest(uri, expected_name):
         ("models:/a=model@3", "a=model", "3"),
         ("models:/some[cool]model@2", "some[cool]model", "2"),
         ("models:/a'model'@1", "a'model'", "1"),
+        ("models:/a#model?amodel@model", "a#model?amodel", "model"),  # fragment before query
+        (
+            "models:/a?model#amodel@coolmodel",
+            "a?model#amodel",
+            "coolmodel",
+        ),  # query before fragment
     ],
 )
 def test_parse_models_uri_with_alias(uri, expected_name, expected_alias):

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -15,6 +15,7 @@ from mlflow.entities.model_registry import ModelVersion
         ("models:/12345/67890", "12345", "67890"),
         ("models://profile@databricks/12345/67890", "12345", "67890"),
         ("models:/catalog.schema.model/0", "catalog.schema.model", "0"),  # UC Model format
+        ("models:/model#2+_1/0", "model#2+_1", "0"),
     ],
 )
 def test_parse_models_uri_with_version(uri, expected_name, expected_version):
@@ -33,6 +34,7 @@ def test_parse_models_uri_with_version(uri, expected_name, expected_version):
         ("models:/AdsModel1/pROduction", "AdsModel1", "pROduction"),  # case insensitive
         ("models:/Ads Model 1/None", "Ads Model 1", "None"),
         ("models://scope:key@databricks/Ads Model 1/None", "Ads Model 1", "None"),
+        ("models://host:port@myserver/model+_#34/prod", "model+_#34", "prod"),
     ],
 )
 def test_parse_models_uri_with_stage(uri, expected_name, expected_stage):
@@ -71,6 +73,8 @@ def test_parse_models_uri_with_latest(uri, expected_name):
         ("models:/Ads Model 1@challenger", "Ads Model 1", "challenger"),
         ("models://scope:key/Ads Model 1@None", "Ads Model 1", "None"),
         ("models:/catalog.schema.model@None", "catalog.schema.model", "None"),  # UC Model format
+        ("models:/TYS_NVS_DAY_1+_MODEL#22@my_version", "TYS_NVS_DAY_1+_MODEL#22", "my_version"),
+        ("models:/#1#2#3++ver@test", "#1#2#3++ver", "test"),
     ],
 )
 def test_parse_models_uri_with_alias(uri, expected_name, expected_alias):

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -16,6 +16,18 @@ from mlflow.entities.model_registry import ModelVersion
         ("models://profile@databricks/12345/67890", "12345", "67890"),
         ("models:/catalog.schema.model/0", "catalog.schema.model", "0"),  # UC Model format
         ("models:/model#2+_1/0", "model#2+_1", "0"),
+        ("models:/model#1/0", "model#1", "0"),
+        ("models:/Some+Model/2", "Some+Model", "2"),
+        ("models:/??A??Model/1", "??A??Model", "1"),
+        ("models:/MyModel??AA/2", "MyModel??AA", "2"),
+        ("models:/Some;Model/1", "Some;Model", "1"),
+        ("models:/some:model/0", "some:model", "0"),
+        ("models://host:port/some:model/4", "some:model", "4"),
+        ("models:/a!model/1", "a!model", "1"),
+        ("models:/a%model%/0", "a%model%", "0"),
+        ('models:/my"model"/1', 'my"model"', "1"),
+        ("models:/your<model>/2", "your<model>", "2"),
+        ("models:/our|model|/3", "our|model|", "3"),
     ],
 )
 def test_parse_models_uri_with_version(uri, expected_name, expected_version):
@@ -35,6 +47,18 @@ def test_parse_models_uri_with_version(uri, expected_name, expected_version):
         ("models:/Ads Model 1/None", "Ads Model 1", "None"),
         ("models://scope:key@databricks/Ads Model 1/None", "Ads Model 1", "None"),
         ("models://host:port@myserver/model+_#34/prod", "model+_#34", "prod"),
+        ("models:/MyModel+1/prod", "MyModel+1", "prod"),
+        ("models:/Some#Model/dev", "Some#Model", "dev"),
+        ("models:/??A??Model/stage", "??A??Model", "stage"),
+        ("models:/MyModel??AA/dev", "MyModel??AA", "dev"),
+        ("models:/Some;Model/prod", "Some;Model", "prod"),
+        ("models:/some:model/dev", "some:model", "dev"),
+        ("models://host:port/some:model/staging", "some:model", "staging"),
+        ("models:/Some!Model!/dev", "Some!Model!", "dev"),
+        ("models:/Some%Model%/dev", "Some%Model%", "dev"),
+        ('models:/Some"Model"/dev', 'Some"Model"', "dev"),
+        ("models:/Some<Model>/dev", "Some<Model>", "dev"),
+        ("models:/Some|Model|/dev", "Some|Model|", "dev"),
     ],
 )
 def test_parse_models_uri_with_stage(uri, expected_name, expected_stage):
@@ -75,6 +99,16 @@ def test_parse_models_uri_with_latest(uri, expected_name):
         ("models:/catalog.schema.model@None", "catalog.schema.model", "None"),  # UC Model format
         ("models:/TYS_NVS_DAY_1+_MODEL#22@my_version", "TYS_NVS_DAY_1+_MODEL#22", "my_version"),
         ("models:/#1#2#3++ver@test", "#1#2#3++ver", "test"),
+        ("models:/??A??Model@1", "??A??Model", "1"),
+        ("models:/MyModel??AA@2", "MyModel??AA", "2"),
+        ("models:/Some;Model@new", "Some;Model", "new"),
+        ("models:/some:model@new", "some:model", "new"),
+        ("models://host:port/some:model@new", "some:model", "new"),
+        ("models:/My!Model@7", "My!Model", "7"),
+        ("models:/Some%Model%@test", "Some%Model%", "test"),
+        ('models:/My"Model"@guess', 'My"Model"', "guess"),
+        ("models:/<A>Model@3", "<A>Model", "3"),
+        ("models:/A||Model||@9", "A||Model||", "9"),
     ],
 )
 def test_parse_models_uri_with_alias(uri, expected_name, expected_alias):

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -28,6 +28,12 @@ from mlflow.entities.model_registry import ModelVersion
         ('models:/my"model"/1', 'my"model"', "1"),
         ("models:/your<model>/2", "your<model>", "2"),
         ("models:/our|model|/3", "our|model|", "3"),
+        ("models:/our(model)/1", "our(model)", "1"),
+        ("models:/a*model/1", "a*model", "1"),
+        ("models:/some&model/2", "some&model", "2"),
+        ("models:/a=model/3", "a=model", "3"),
+        ("models:/some[cool]model/2", "some[cool]model", "2"),
+        ("models:/a'model'/1", "a'model'", "1"),
     ],
 )
 def test_parse_models_uri_with_version(uri, expected_name, expected_version):
@@ -59,6 +65,12 @@ def test_parse_models_uri_with_version(uri, expected_name, expected_version):
         ('models:/Some"Model"/dev', 'Some"Model"', "dev"),
         ("models:/Some<Model>/dev", "Some<Model>", "dev"),
         ("models:/Some|Model|/dev", "Some|Model|", "dev"),
+        ("models:/our(model)/prod", "our(model)", "prod"),
+        ("models:/a*model/prod", "a*model", "prod"),
+        ("models:/some&model/prod", "some&model", "prod"),
+        ("models:/a=model/stage", "a=model", "stage"),
+        ("models:/some[cool]model/stage", "some[cool]model", "stage"),
+        ("models:/a'model'/stage", "a'model'", "stage"),
     ],
 )
 def test_parse_models_uri_with_stage(uri, expected_name, expected_stage):
@@ -109,6 +121,12 @@ def test_parse_models_uri_with_latest(uri, expected_name):
         ('models:/My"Model"@guess', 'My"Model"', "guess"),
         ("models:/<A>Model@3", "<A>Model", "3"),
         ("models:/A||Model||@9", "A||Model||", "9"),
+        ("models:/our(model)@1", "our(model)", "1"),
+        ("models:/a*model@1", "a*model", "1"),
+        ("models:/some&model@2", "some&model", "2"),
+        ("models:/a=model@3", "a=model", "3"),
+        ("models:/some[cool]model@2", "some[cool]model", "2"),
+        ("models:/a'model'@1", "a'model'", "1"),
     ],
 )
 def test_parse_models_uri_with_alias(uri, expected_name, expected_alias):

--- a/tests/tracking/test_model_registry.py
+++ b/tests/tracking/test_model_registry.py
@@ -687,6 +687,10 @@ def test_set_delete_registered_model_alias_and_get_model_version_by_alias_flow(c
         ("a=model", "4", "EqualAlias", "==Alias"),
         ("some[cool]model", "5", "BracketAlias", "[Alias]"),
         ("a'model'", "6", "QuoteAlias", "my'alias'"),
+        ("a#model?amodel", "7", "FragQuery", "Frag#?Query"),  # fragment before query
+        ("a?model#amodel", "8", "QueryFrag", "Query?#Frag"),  # query before fragment
+        ("a?mo#del?b#?model", "9", "QueryFrag", "?#model"),  # multiple queries and fragments
+        ("a#mo?del?b#?model", "3", "FragQuery", "#?model"),  # multiple queries and fragments
     ],
 )
 def test_register_model_with_alias_and_special_characters(

--- a/tests/tracking/test_model_registry.py
+++ b/tests/tracking/test_model_registry.py
@@ -681,6 +681,12 @@ def test_set_delete_registered_model_alias_and_get_model_version_by_alias_flow(c
         ('My"Model"', "8", "QuoteAlias", 'Quote"Alias'),
         ("My<Model>", "9", "CaretAlias", "Caret<>Alias"),
         ("My||Model|", "10", "PipeAlias", "Pipe||Alias"),
+        ("our(model)", "1", "ParenAlias", "Paren()alias"),
+        ("a*model", "2", "StarAlias", "star**alias"),
+        ("some&model", "3", "AmpAlias", "amp&alias"),
+        ("a=model", "4", "EqualAlias", "==Alias"),
+        ("some[cool]model", "5", "BracketAlias", "[Alias]"),
+        ("a'model'", "6", "QuoteAlias", "my'alias'"),
     ],
 )
 def test_register_model_with_alias_and_special_characters(

--- a/tests/tracking/test_model_registry.py
+++ b/tests/tracking/test_model_registry.py
@@ -666,3 +666,19 @@ def test_set_delete_registered_model_alias_and_get_model_version_by_alias_flow(c
     assert model.aliases == {}
     mv = client.get_model_version(name, "1")
     assert mv.aliases == []
+
+
+def test_register_model_with_alias_and_special_characters(client):
+    model_name = "MyModel#4_+ver1"
+    alias = "My_3-test"
+    client.create_registered_model(model_name)
+    model_ver = client.create_model_version(model_name, "runs:/run_id/model", "run_id")
+    client.set_registered_model_alias(model_name, alias=alias, version=model_ver.version)
+    registered_details = client.get_registered_model(model_name)
+    assert registered_details.name == model_name
+    assert registered_details.aliases == {alias: "1"}
+
+    with pytest.raises(MlflowException, match="Invalid alias name: 'Invalid#3\\+version'. Names"):
+        client.set_registered_model_alias(
+            model_name, alias="Invalid#3+version", version=model_ver.version
+        )

--- a/tests/tracking/test_model_registry.py
+++ b/tests/tracking/test_model_registry.py
@@ -668,17 +668,35 @@ def test_set_delete_registered_model_alias_and_get_model_version_by_alias_flow(c
     assert mv.aliases == []
 
 
-def test_register_model_with_alias_and_special_characters(client):
-    model_name = "MyModel#4_+ver1"
-    alias = "My_3-test"
+@pytest.mark.parametrize(
+    "model_name, run_id, valid_alias, invalid_alias",
+    [
+        ("MyModel#4#6", "1", "HashAlias", "Alias#1#2"),
+        ("MyModel?42", "2", "QuestionAlias", "Alias?20"),
+        ("My+Model+2", "3", "PlusAlias", "Plus++Alias"),
+        ("My;Model;1", "4", "SemiColonAlias", "Semi;Alias;"),
+        ("My:Model:2:", "5", "ColonAlias", "Colon:Alias:"),
+        ("My!Model!", "6", "ExclamationAlias", "Exclamation!Alias"),
+        ("My%Model%", "7", "PercentAlias", "Percent%Alias"),
+        ('My"Model"', "8", "QuoteAlias", 'Quote"Alias'),
+        ("My<Model>", "9", "CaretAlias", "Caret<>Alias"),
+        ("My||Model|", "10", "PipeAlias", "Pipe||Alias"),
+    ],
+)
+def test_register_model_with_alias_and_special_characters(
+    client, model_name, run_id, valid_alias, invalid_alias
+):
+    # NB: Not testing the uri-reserved `/` path designator as that will cause completely different
+    # issues. This test validates all other reserved keys for uri's within a path that have
+    # historically been supported model names in MLflow.
     client.create_registered_model(model_name)
-    model_ver = client.create_model_version(model_name, "runs:/run_id/model", "run_id")
-    client.set_registered_model_alias(model_name, alias=alias, version=model_ver.version)
+    model_ver = client.create_model_version(model_name, "runs:/run_id/model", run_id)
+    client.set_registered_model_alias(model_name, alias=valid_alias, version=model_ver.version)
     registered_details = client.get_registered_model(model_name)
     assert registered_details.name == model_name
-    assert registered_details.aliases == {alias: "1"}
+    assert registered_details.aliases == {valid_alias: "1"}
 
-    with pytest.raises(MlflowException, match="Invalid alias name: 'Invalid#3\\+version'. Names"):
+    with pytest.raises(MlflowException, match="Invalid alias name"):
         client.set_registered_model_alias(
-            model_name, alias="Invalid#3+version", version=model_ver.version
+            model_name, alias=invalid_alias, version=model_ver.version
         )


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix a regression that was introduced with the regex parsing for the path when determining what an alias name should be. The characters `#` and `+` were previously permitted in model names. This PR reintroduces support for this.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
