### PR TITLE
Insert databricks profile in artifact URI before initializing artifact repo  in `mlflow.artifacts.download_artifacts`

### DIFF
--- a/mlflow/artifacts/__init__.py
+++ b/mlflow/artifacts/__init__.py
@@ -9,7 +9,11 @@ from typing import Optional
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, BAD_REQUEST
 from mlflow.tracking import _get_store
-from mlflow.tracking.artifact_utils import _download_artifact_from_uri, get_artifact_repository
+from mlflow.tracking.artifact_utils import (
+    _download_artifact_from_uri,
+    get_artifact_repository,
+    add_databricks_profile_info_to_artifact_uri,
+)
 
 
 def download_artifacts(
@@ -59,7 +63,9 @@ def download_artifacts(
 
     store = _get_store(store_uri=tracking_uri)
     artifact_uri = store.get_run(run_id).info.artifact_uri
-    artifact_repo = get_artifact_repository(artifact_uri)
+    artifact_repo = get_artifact_repository(
+        add_databricks_profile_info_to_artifact_uri(artifact_uri, tracking_uri)
+    )
     artifact_location = artifact_repo.download_artifacts(artifact_path, dst_path=dst_path)
     return artifact_location
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix the following error that occurs on Databricks when `mlflow.artifacts.download_artifacts` is called with a tracking URI containing a profile and the tracking URI is not equal to the active tracking URI.

```python
import mlflow
import tempfile

mlflow.set_tracking_uri("databricks://haru-scope:ML-30287")
mlflow.set_experiment("/Users/harutaka.kawamura@databricks.com/test")

open("a.txt", "w").close()

with mlflow.start_run() as run:
    print(run.info.artifact_uri)
    mlflow.log_artifact("a.txt")

mlflow.set_tracking_uri("databricks")

with tempfile.TemporaryDirectory() as tmpdir:
    mlflow.artifacts.download_artifacts(
        run_id=run.info.run_id,
        artifact_path="a.txt",
        dst_path=tmpdir,
        tracking_uri="databricks://haru-scope:ML-30287"
    )
```

```python
Traceback (most recent call last):
  File "/databricks/python/lib/python3.9/site-packages/IPython/core/interactiveshell.py", line 3378, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<command-2043997742080414>", line 16, in <module>
    mlflow.artifacts.download_artifacts(
  File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-c54dc3c0-6acb-4433-bb45-63339a33398b/lib/python3.9/site-packages/mlflow/artifacts/__init__.py", line 62, in download_artifacts
    artifact_repo = get_artifact_repository(artifact_uri)
  File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-c54dc3c0-6acb-4433-bb45-63339a33398b/lib/python3.9/site-packages/mlflow/store/artifact/artifact_repository_registry.py", line 106, in get_artifact_repository
    return _artifact_repository_registry.get_artifact_repository(artifact_uri)
  File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-c54dc3c0-6acb-4433-bb45-63339a33398b/lib/python3.9/site-packages/mlflow/store/artifact/artifact_repository_registry.py", line 72, in get_artifact_repository
    return repository(artifact_uri)
  File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-c54dc3c0-6acb-4433-bb45-63339a33398b/lib/python3.9/site-packages/mlflow/store/artifact/dbfs_artifact_repo.py", line 213, in dbfs_artifact_repo_factory
    return DatabricksArtifactRepository(cleaned_artifact_uri)
  File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-c54dc3c0-6acb-4433-bb45-63339a33398b/lib/python3.9/site-packages/mlflow/store/artifact/databricks_artifact_repo.py", line 144, in __init__
    run_artifact_root_uri = self._get_run_artifact_root(self.run_id)
  File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-c54dc3c0-6acb-4433-bb45-63339a33398b/lib/python3.9/site-packages/mlflow/store/artifact/databricks_artifact_repo.py", line 178, in _get_run_artifact_root
    run_response = self._call_endpoint(MlflowService, GetRun, json_body)
  File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-c54dc3c0-6acb-4433-bb45-63339a33398b/lib/python3.9/site-packages/mlflow/store/artifact/databricks_artifact_repo.py", line 174, in _call_endpoint
    return call_endpoint(db_creds, endpoint, method, json_body, response_proto)
  File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-c54dc3c0-6acb-4433-bb45-63339a33398b/lib/python3.9/site-packages/mlflow/utils/rest_utils.py", line 290, in call_endpoint
    response = verify_rest_response(response, endpoint)
  File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-c54dc3c0-6acb-4433-bb45-63339a33398b/lib/python3.9/site-packages/mlflow/utils/rest_utils.py", line 214, in verify_rest_response
    raise RestException(json.loads(response.text))
mlflow.exceptions.RestException: RESOURCE_DOES_NOT_EXIST: Run 'ef23eb746c3445fcb59ef6b457e55377' not found.
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
