### PR TITLE
Update parse model URI to prevent breaking old cases while supporting aliases

### DIFF
--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -61,10 +61,12 @@ def _parse_model_uri(uri):
         raise MlflowException(_improper_model_uri_msg(uri))
 
     parts = path[1:].split("/")
-    if len(parts) < 1 or len(parts) > 2 or parts[0].strip() == "":
+    if len(parts) > 2 or parts[0].strip() == "":
         raise MlflowException(_improper_model_uri_msg(uri))
 
     if len(parts) == 2:
+        if parts[1].strip() == "":
+            raise MlflowException(_improper_model_uri_msg(uri))
         # The URI is in the suffix format
         if parts[1].isdigit():
             # The suffix is a specific version, e.g. "models:/AdsModel1/123"
@@ -78,10 +80,9 @@ def _parse_model_uri(uri):
     else:
         # The URI is an alias URI, e.g. "models:/AdsModel1@Champion"
         alias_parts = parts[0].split("@")
-        if len(alias_parts) == 2:
-            return ParsedModelUri(alias_parts[0], alias=alias_parts[1])
-        else:
+        if len(alias_parts) != 2 or alias_parts[1].strip() == "":
             raise MlflowException(_improper_model_uri_msg(uri))
+        return ParsedModelUri(alias_parts[0], alias=alias_parts[1])
 
 
 def get_model_name_and_version(client, models_uri):

--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -52,7 +52,7 @@ def _parse_model_uri(uri):
         - (name, None, None, None) to look for the latest of all versions.
         - (name, None, None, alias) to look for a registered model alias.
     """
-    parsed = urllib.parse.urlparse(uri)
+    parsed = urllib.parse.urlparse(uri, allow_fragments=False)
     if parsed.scheme != "models":
         raise MlflowException(_improper_model_uri_msg(uri))
     path = parsed.path

--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -1,4 +1,3 @@
-import re
 from typing import NamedTuple, Optional
 import urllib.parse
 
@@ -60,26 +59,27 @@ def _parse_model_uri(uri):
     if not path.startswith("/") or len(path) <= 1:
         raise MlflowException(_improper_model_uri_msg(uri))
 
-    parts = path[1:].split("/")
+    parts = path.lstrip("/").split("/")
     if len(parts) > 2 or parts[0].strip() == "":
         raise MlflowException(_improper_model_uri_msg(uri))
 
     if len(parts) == 2:
-        if parts[1].strip() == "":
+        name, suffix = parts
+        if suffix.strip() == "":
             raise MlflowException(_improper_model_uri_msg(uri))
         # The URI is in the suffix format
-        if parts[1].isdigit():
+        if suffix.isdigit():
             # The suffix is a specific version, e.g. "models:/AdsModel1/123"
-            return ParsedModelUri(parts[0], version=parts[1])
-        elif parts[1].lower() == _MODELS_URI_SUFFIX_LATEST.lower():
+            return ParsedModelUri(name, version=suffix)
+        elif suffix.lower() == _MODELS_URI_SUFFIX_LATEST.lower():
             # The suffix is the 'latest' string (case insensitive), e.g. "models:/AdsModel1/latest"
-            return ParsedModelUri(parts[0])
+            return ParsedModelUri(name)
         else:
             # The suffix is a specific stage (case insensitive), e.g. "models:/AdsModel1/Production"
-            return ParsedModelUri(parts[0], stage=parts[1])
+            return ParsedModelUri(name, stage=suffix)
     else:
         # The URI is an alias URI, e.g. "models:/AdsModel1@Champion"
-        alias_parts = parts[0].split("@")
+        alias_parts = parts[0].rsplit("@", 1)
         if len(alias_parts) != 2 or alias_parts[1].strip() == "":
             raise MlflowException(_improper_model_uri_msg(uri))
         return ParsedModelUri(alias_parts[0], alias=alias_parts[1])

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -33,6 +33,12 @@ def test_parse_models_uri_with_version(uri, expected_name, expected_version):
         ("models:/AdsModel1/pROduction", "AdsModel1", "pROduction"),  # case insensitive
         ("models:/Ads Model 1/None", "Ads Model 1", "None"),
         ("models://scope:key@databricks/Ads Model 1/None", "Ads Model 1", "None"),
+        (
+            "models:/Name/Stage@Alias",
+            "Name",
+            "Stage@Alias",
+        ),  # technically allowed, but the backend would throw
+        ("models:/Name@Alias/Stage", "Name@Alias", "Stage"),
     ],
 )
 def test_parse_models_uri_with_stage(uri, expected_name, expected_stage):
@@ -90,6 +96,8 @@ def test_parse_models_uri_with_alias(uri, expected_name, expected_alias):
         "models:/",  # no model name
         "models:/ /Stage",  # empty name
         "models:/Name",  # no specifiers
+        "models:/Name/",  # empty suffix
+        "models:/Name@",  # empty alias
         "models:/Name/Stage/0",  # too many specifiers
         "models:/Name@Alias@other",  # too many aliases
         "models:Name/Stage",  # missing slash

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -90,11 +90,7 @@ def test_parse_models_uri_with_alias(uri, expected_name, expected_alias):
         "models:/",  # no model name
         "models:/ /Stage",  # empty name
         "models:/Name",  # no specifiers
-        "models:/Name/",  # empty suffix
-        "models:/Name@",  # empty alias
         "models:/Name/Stage/0",  # too many specifiers
-        "models:/Name/Stage@Alias",  # stage and alias both specified
-        "models:/Name@alias/Stage",  # Stage and alias both specified
         "models:/Name@Alias@other",  # too many aliases
         "models:Name/Stage",  # missing slash
         "models://Name/Stage",  # hostnames are ignored, path too short

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -12,6 +12,7 @@ from mlflow.entities.model_registry import ModelVersion
     [
         ("models:/AdsModel1/0", "AdsModel1", "0"),
         ("models:/Ads Model 1/12345", "Ads Model 1", "12345"),
+        ("models://////Ads Model 1/12345", "Ads Model 1", "12345"),  # many slashes
         ("models:/12345/67890", "12345", "67890"),
         ("models://profile@databricks/12345/67890", "12345", "67890"),
         ("models:/catalog.schema.model/0", "catalog.schema.model", "0"),  # UC Model format
@@ -32,6 +33,7 @@ def test_parse_models_uri_with_version(uri, expected_name, expected_version):
         ("models:/AdsModel1/production", "AdsModel1", "production"),  # case insensitive
         ("models:/AdsModel1/pROduction", "AdsModel1", "pROduction"),  # case insensitive
         ("models:/Ads Model 1/None", "Ads Model 1", "None"),
+        ("models://////Ads Model 1/Staging", "Ads Model 1", "Staging"),  # many slashes
         ("models://scope:key@databricks/Ads Model 1/None", "Ads Model 1", "None"),
         (
             "models:/Name/Stage@Alias",
@@ -56,6 +58,7 @@ def test_parse_models_uri_with_stage(uri, expected_name, expected_stage):
         ("models:/AdsModel1/Latest", "AdsModel1"),  # case insensitive
         ("models:/AdsModel1/LATEST", "AdsModel1"),  # case insensitive
         ("models:/Ads Model 1/latest", "Ads Model 1"),
+        ("models://////Ads Model 1/latest", "Ads Model 1"),  # many slashes
         ("models://scope:key@databricks/Ads Model 1/latest", "Ads Model 1"),
         ("models:/catalog.schema.model/latest", "catalog.schema.model"),  # UC Model format
     ],
@@ -76,7 +79,14 @@ def test_parse_models_uri_with_latest(uri, expected_name):
         ("models:/AdsModel1@cHAmpion", "AdsModel1", "cHAmpion"),  # case insensitive
         ("models:/Ads Model 1@challenger", "Ads Model 1", "challenger"),
         ("models://scope:key/Ads Model 1@None", "Ads Model 1", "None"),
+        ("models://////Ads Model 1@TestAlias", "Ads Model 1", "TestAlias"),  # many slashes
         ("models:/catalog.schema.model@None", "catalog.schema.model", "None"),  # UC Model format
+        ("models:/A!&$%;{}()[]CrazyName@Alias", "A!&$%;{}()[]CrazyName", "Alias"),
+        (
+            "models:/NameWith@IntheMiddle@Alias",
+            "NameWith@IntheMiddle",
+            "Alias",
+        ),  # check for model name with alias
     ],
 )
 def test_parse_models_uri_with_alias(uri, expected_name, expected_alias):
@@ -99,7 +109,6 @@ def test_parse_models_uri_with_alias(uri, expected_name, expected_alias):
         "models:/Name/",  # empty suffix
         "models:/Name@",  # empty alias
         "models:/Name/Stage/0",  # too many specifiers
-        "models:/Name@Alias@other",  # too many aliases
         "models:Name/Stage",  # missing slash
         "models://Name/Stage",  # hostnames are ignored, path too short
         "models://Name@te#ty;",  # invalid characters

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -81,7 +81,7 @@ def test_parse_models_uri_with_latest(uri, expected_name):
         ("models://scope:key/Ads Model 1@None", "Ads Model 1", "None"),
         ("models://////Ads Model 1@TestAlias", "Ads Model 1", "TestAlias"),  # many slashes
         ("models:/catalog.schema.model@None", "catalog.schema.model", "None"),  # UC Model format
-        ("models:/A!&$%;{}()[]CrazyName@Alias", "A!&$%;{}()[]CrazyName", "Alias"),
+        ("models:/A!&#$%;{}()[]CrazyName@Alias", "A!&#$%;{}()[]CrazyName", "Alias"),
         (
             "models:/NameWith@IntheMiddle@Alias",
             "NameWith@IntheMiddle",
@@ -111,7 +111,6 @@ def test_parse_models_uri_with_alias(uri, expected_name, expected_alias):
         "models:/Name/Stage/0",  # too many specifiers
         "models:Name/Stage",  # missing slash
         "models://Name/Stage",  # hostnames are ignored, path too short
-        "models://Name@te#ty;",  # invalid characters
     ],
 )
 def test_parse_models_uri_invalid_input(uri):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

https://github.com/mlflow/mlflow/pull/8164

## What changes are proposed in this pull request?

This PR fixes model naming and other URI regressions caused by https://github.com/mlflow/mlflow/pull/8164, while still maintaining the aliases logic.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
