### PR TITLE
Fix RunInputs to return entity instead of proto

### DIFF
--- a/mlflow/entities/run_inputs.py
+++ b/mlflow/entities/run_inputs.py
@@ -35,4 +35,7 @@ class RunInputs(_MLflowObject):
 
     @classmethod
     def from_proto(cls, proto):
-        return cls(proto.dataset_inputs)
+        dataset_inputs = [
+            DatasetInput.from_proto(dataset_input) for dataset_input in proto.dataset_inputs
+        ]
+        return cls(dataset_inputs)

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -1,6 +1,8 @@
 from typing import List, Optional
 
 from mlflow.entities import Experiment, Run, RunInfo, Metric, ViewType, DatasetInput
+from mlflow.entities.run_data import RunData
+from mlflow.entities.run_inputs import RunInputs
 from mlflow.exceptions import MlflowException
 from mlflow.protos import databricks_pb2
 from mlflow.protos.service_pb2 import (
@@ -135,7 +137,11 @@ class RestStore(AbstractStore):
         """
         req_body = message_to_json(GetRun(run_uuid=run_id, run_id=run_id))
         response_proto = self._call_endpoint(GetRun, req_body)
-        return Run.from_proto(response_proto.run)
+        return Run(
+            RunInfo.from_proto(response_proto.run_info),
+            RunData.from_proto(response_proto.run_data),
+            RunInputs.from_proto(response_proto.run_inputs),
+        )
 
     def update_run_info(self, run_id, run_status, end_time, run_name):
         """Updates the metadata of the specified run."""

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -138,9 +138,9 @@ class RestStore(AbstractStore):
         req_body = message_to_json(GetRun(run_uuid=run_id, run_id=run_id))
         response_proto = self._call_endpoint(GetRun, req_body)
         return Run(
-            RunInfo.from_proto(response_proto.run_info),
-            RunData.from_proto(response_proto.run_data),
-            RunInputs.from_proto(response_proto.run_inputs),
+            RunInfo.from_proto(response_proto.info),
+            RunData.from_proto(response_proto.data),
+            RunInputs.from_proto(response_proto.inputs),
         )
 
     def update_run_info(self, run_id, run_status, end_time, run_name):
@@ -292,7 +292,14 @@ class RestStore(AbstractStore):
         )
         req_body = message_to_json(sr)
         response_proto = self._call_endpoint(SearchRuns, req_body)
-        runs = [Run.from_proto(proto_run) for proto_run in response_proto.runs]
+        runs = [
+            Run(
+                RunInfo.from_proto(proto_run.info),
+                RunData.from_proto(proto_run.data),
+                RunInputs.from_proto(proto_run.inputs),
+            )
+            for proto_run in response_proto.runs
+        ]
         # If next_page_token is not set, we will see it as "". We need to convert this to None.
         next_page_token = None
         if response_proto.next_page_token:

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -1,8 +1,6 @@
 from typing import List, Optional
 
 from mlflow.entities import Experiment, Run, RunInfo, Metric, ViewType, DatasetInput
-from mlflow.entities.run_data import RunData
-from mlflow.entities.run_inputs import RunInputs
 from mlflow.exceptions import MlflowException
 from mlflow.protos import databricks_pb2
 from mlflow.protos.service_pb2 import (
@@ -137,11 +135,7 @@ class RestStore(AbstractStore):
         """
         req_body = message_to_json(GetRun(run_uuid=run_id, run_id=run_id))
         response_proto = self._call_endpoint(GetRun, req_body)
-        return Run(
-            RunInfo.from_proto(response_proto.info),
-            RunData.from_proto(response_proto.data),
-            RunInputs.from_proto(response_proto.inputs),
-        )
+        return Run.from_proto(response_proto.run)
 
     def update_run_info(self, run_id, run_status, end_time, run_name):
         """Updates the metadata of the specified run."""
@@ -292,14 +286,7 @@ class RestStore(AbstractStore):
         )
         req_body = message_to_json(sr)
         response_proto = self._call_endpoint(SearchRuns, req_body)
-        runs = [
-            Run(
-                RunInfo.from_proto(proto_run.info),
-                RunData.from_proto(proto_run.data),
-                RunInputs.from_proto(proto_run.inputs),
-            )
-            for proto_run in response_proto.runs
-        ]
+        runs = [Run.from_proto(proto_run) for proto_run in response_proto.runs]
         # If next_page_token is not set, we will see it as "". We need to convert this to None.
         next_page_token = None
         if response_proto.next_page_token:

--- a/tests/entities/test_run_inputs.py
+++ b/tests/entities/test_run_inputs.py
@@ -1,4 +1,5 @@
 from mlflow.entities import RunInputs
+from mlflow.entities.dataset_input import DatasetInput
 
 
 def _check_inputs(run_datasets, datasets):
@@ -27,3 +28,4 @@ def test_creation_and_hydration(run_inputs):
     proto = run_inputs.to_proto()
     run_inputs2 = RunInputs.from_proto(proto)
     _check(run_inputs2, datasets)
+    assert isinstance(run_inputs2.dataset_inputs[0], DatasetInput)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

`mlflow.get_run()` works 
![image](https://user-images.githubusercontent.com/46332835/235045253-60014753-a109-4b24-ac79-c8175a733234.png)

`client.get_run()` works
![image](https://user-images.githubusercontent.com/46332835/235047747-da0453f6-b172-4075-9de4-e860ed143991.png)



## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
