### PR TITLE
Use separate thread pool executors when uploading chunks to avoid deadlock

### DIFF
--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -36,7 +36,10 @@ class ArtifactRepository:
         # Limit the number of threads used for artifact uploads/downloads. Use at most
         # constants._NUM_MAX_THREADS threads or 2 * the number of CPU cores available on the
         # system (whichever is smaller)
-        self.thread_pool = ThreadPoolExecutor(max_workers=self.max_workers)
+        self.thread_pool = self._create_thread_pool()
+
+    def _create_thread_pool(self):
+        return ThreadPoolExecutor(max_workers=self.max_workers)
 
     @abstractmethod
     def log_artifact(self, local_file, artifact_path=None):

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -363,7 +363,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
                 )
                 futures[future] = index
 
-                _, errors = _complete_futures(futures)
+            _, errors = _complete_futures(futures)
             if errors:
                 raise MlflowException(
                     f"Failed to upload at least one part of {artifact_path}. Errors: {errors}"

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -278,7 +278,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
                     )
                     futures[future] = index
 
-            results, errors = _complete_futures(futures)
+                results, errors = _complete_futures(futures)
             if errors:
                 raise MlflowException(
                     f"Failed to upload at least one part of {local_file}. Errors: {errors}"

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -269,19 +269,18 @@ class DatabricksArtifactRepository(ArtifactRepository):
             headers = self._extract_headers_from_credentials(credentials.headers)
             futures = {}
             num_chunks = _compute_num_chunks(local_file, _MULTIPART_UPLOAD_CHUNK_SIZE)
-            with self.chunk_upload_thread_pool as executor:
-                for index in range(num_chunks):
-                    start_byte = index * _MULTIPART_UPLOAD_CHUNK_SIZE
-                    future = executor.submit(
-                        self._azure_upload_chunk,
-                        credentials=credentials,
-                        headers=headers,
-                        local_file=local_file,
-                        artifact_path=artifact_path,
-                        start_byte=start_byte,
-                        size=_MULTIPART_UPLOAD_CHUNK_SIZE,
-                    )
-                    futures[future] = index
+            for index in range(num_chunks):
+                start_byte = index * _MULTIPART_UPLOAD_CHUNK_SIZE
+                future = self.chunk_upload_thread_pool.submit(
+                    self._azure_upload_chunk,
+                    credentials=credentials,
+                    headers=headers,
+                    local_file=local_file,
+                    artifact_path=artifact_path,
+                    start_byte=start_byte,
+                    size=_MULTIPART_UPLOAD_CHUNK_SIZE,
+                )
+                futures[future] = index
 
                 results, errors = _complete_futures(futures)
             if errors:
@@ -348,22 +347,21 @@ class DatabricksArtifactRepository(ArtifactRepository):
             file_size = os.path.getsize(local_file)
             num_chunks = _compute_num_chunks(local_file, _MULTIPART_UPLOAD_CHUNK_SIZE)
             use_single_part_upload = num_chunks == 1
-            with self.chunk_upload_thread_pool as executor:
-                for index in range(num_chunks):
-                    start_byte = index * _MULTIPART_UPLOAD_CHUNK_SIZE
-                    future = executor.submit(
-                        self._retryable_adls_function,
-                        func=patch_adls_file_upload,
-                        artifact_path=artifact_path,
-                        sas_url=credentials.signed_uri,
-                        local_file=local_file,
-                        start_byte=start_byte,
-                        size=_MULTIPART_UPLOAD_CHUNK_SIZE,
-                        position=start_byte,
-                        headers=headers,
-                        is_single=use_single_part_upload,
-                    )
-                    futures[future] = index
+            for index in range(num_chunks):
+                start_byte = index * _MULTIPART_UPLOAD_CHUNK_SIZE
+                future = self.chunk_upload_thread_pool.submit(
+                    self._retryable_adls_function,
+                    func=patch_adls_file_upload,
+                    artifact_path=artifact_path,
+                    sas_url=credentials.signed_uri,
+                    local_file=local_file,
+                    start_byte=start_byte,
+                    size=_MULTIPART_UPLOAD_CHUNK_SIZE,
+                    position=start_byte,
+                    headers=headers,
+                    is_single=use_single_part_upload,
+                )
+                futures[future] = index
 
                 _, errors = _complete_futures(futures)
             if errors:
@@ -562,20 +560,19 @@ class DatabricksArtifactRepository(ArtifactRepository):
 
     def _upload_parts(self, local_file, create_mpu_resp):
         futures = {}
-        with self.chunk_upload_thread_pool as executor:
-            for index, cred_info in enumerate(create_mpu_resp.upload_credential_infos):
-                part_number = index + 1
-                start_byte = index * _MULTIPART_UPLOAD_CHUNK_SIZE
-                future = executor.submit(
-                    self._upload_part_retry,
-                    cred_info=cred_info,
-                    upload_id=create_mpu_resp.upload_id,
-                    part_number=part_number,
-                    local_file=local_file,
-                    start_byte=start_byte,
-                    size=_MULTIPART_UPLOAD_CHUNK_SIZE,
-                )
-                futures[future] = part_number
+        for index, cred_info in enumerate(create_mpu_resp.upload_credential_infos):
+            part_number = index + 1
+            start_byte = index * _MULTIPART_UPLOAD_CHUNK_SIZE
+            future = self.chunk_upload_thread_pool.submit(
+                self._upload_part_retry,
+                cred_info=cred_info,
+                upload_id=create_mpu_resp.upload_id,
+                part_number=part_number,
+                local_file=local_file,
+                start_byte=start_byte,
+                size=_MULTIPART_UPLOAD_CHUNK_SIZE,
+            )
+            futures[future] = part_number
 
             results, errors = _complete_futures(futures)
         if errors:

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -282,7 +282,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
                 )
                 futures[future] = index
 
-                results, errors = _complete_futures(futures)
+            results, errors = _complete_futures(futures)
             if errors:
                 raise MlflowException(
                     f"Failed to upload at least one part of {local_file}. Errors: {errors}"
@@ -574,7 +574,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
             )
             futures[future] = part_number
 
-            results, errors = _complete_futures(futures)
+        results, errors = _complete_futures(futures)
         if errors:
             raise MlflowException(
                 f"Failed to upload at least one part of {local_file}. Errors: {errors}"


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Use separate thread pool executors when uploading chunks to avoid deadlock.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
