### PR TITLE
[branch-2.3] Revert multipart download support for Databricks

### DIFF
--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -40,10 +40,7 @@ from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.file_utils import (
     download_file_using_http_uri,
     relative_path_to_artifact_path,
-    parallelized_download_file_using_http_uri,
-    download_chunk,
 )
-from mlflow.utils.os import is_windows
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils import rest_utils
 from mlflow.utils.file_utils import read_chunk
@@ -62,7 +59,7 @@ from mlflow.utils.uri import (
 )
 
 _logger = logging.getLogger(__name__)
-_DOWNLOAD_CHUNK_SIZE = 10_000_000
+_DOWNLOAD_CHUNK_SIZE = 100000000
 _MULTIPART_UPLOAD_CHUNK_SIZE = 10_000_000  # 10 MB
 _MAX_CREDENTIALS_REQUEST_SIZE = 2000  # Max number of artifact paths in a single credentials request
 _SERVICE_AND_METHOD_TO_INFO = {
@@ -422,43 +419,6 @@ class DatabricksArtifactRepository(ArtifactRepository):
                 message="Cloud provider not supported.", error_code=INTERNAL_ERROR
             )
 
-    def _parallelized_download_from_cloud(
-        self, cloud_credential_info, file_size, dst_local_file_path, dst_run_relative_artifact_path
-    ):
-        try:
-            failed_downloads = parallelized_download_file_using_http_uri(
-                http_uri=cloud_credential_info.signed_uri,
-                download_path=dst_local_file_path,
-                file_size=file_size,
-                uri_type=cloud_credential_info.type,
-                chunk_size=_DOWNLOAD_CHUNK_SIZE,
-                headers=self._extract_headers_from_credentials(cloud_credential_info.headers),
-            )
-            download_errors = [
-                e for e in failed_downloads.values() if e.response.status_code not in (401, 403)
-            ]
-            if download_errors:
-                raise MlflowException(
-                    f"Failed to download artifact {dst_run_relative_artifact_path}: "
-                    f"{download_errors}"
-                )
-
-            if failed_downloads:
-                new_cloud_creds = self._get_read_credential_infos(
-                    self.run_id, dst_run_relative_artifact_path
-                )[0]
-                new_signed_uri = new_cloud_creds.signed_uri
-                new_headers = self._extract_headers_from_credentials(new_cloud_creds.headers)
-
-            for i in failed_downloads:
-                download_chunk(
-                    i, _DOWNLOAD_CHUNK_SIZE, new_headers, dst_local_file_path, new_signed_uri
-                )
-        except Exception as err:
-            if os.path.exists(dst_local_file_path):
-                os.remove(dst_local_file_path)
-            raise MlflowException(err)
-
     def _download_from_cloud(self, cloud_credential_info, dst_local_file_path):
         """
         Download a file from the input `cloud_credential_info` and save it to `dst_local_file_path`.
@@ -748,16 +708,6 @@ class DatabricksArtifactRepository(ArtifactRepository):
         return infos
 
     def _download_file(self, remote_file_path, local_path):
-        # list_artifacts API only returns a list of FileInfos at the specified path
-        # if it's a directory. To get file size, we need to iterate over FileInfos
-        # contained by the parent directory. A bad path could result in there being
-        # no matching FileInfos (by path), so fall back to None size to prevent
-        # parallelized download.
-        parent_dir, _ = posixpath.split(remote_file_path)
-        file_infos = self.list_artifacts(parent_dir)
-        file_info = [info for info in file_infos if info.path == remote_file_path]
-        file_size = file_info[0].file_size if len(file_info) == 1 else None
-
         run_relative_remote_file_path = posixpath.join(
             self.run_relative_artifact_repo_root_path, remote_file_path
         )
@@ -767,16 +717,9 @@ class DatabricksArtifactRepository(ArtifactRepository):
         # Read credentials for only one file were requested. So we expected only one value in
         # the response.
         assert len(read_credentials) == 1
-        # Windows doesn't support the 'fork' multiprocessing context.
-        if file_size is None or file_size <= _DOWNLOAD_CHUNK_SIZE or is_windows():
-            self._download_from_cloud(
-                cloud_credential_info=read_credentials[0],
-                dst_local_file_path=local_path,
-            )
-        else:
-            self._parallelized_download_from_cloud(
-                read_credentials[0], file_size, local_path, remote_file_path
-            )
+        self._download_from_cloud(
+            cloud_credential_info=read_credentials[0], dst_local_file_path=local_path
+        )
 
     def delete_artifacts(self, artifact_path=None):
         raise MlflowException("Not implemented yet")

--- a/mlflow/store/artifact/databricks_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_models_artifact_repo.py
@@ -1,7 +1,5 @@
 import logging
 import json
-import os
-import posixpath
 
 import mlflow.tracking
 from mlflow.entities import FileInfo
@@ -9,12 +7,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.utils.databricks_utils import get_databricks_host_creds
-from mlflow.utils.file_utils import (
-    download_file_using_http_uri,
-    parallelized_download_file_using_http_uri,
-    download_chunk,
-)
-from mlflow.utils.os import is_windows
+from mlflow.utils.file_utils import download_file_using_http_uri
 from mlflow.utils.rest_utils import http_request
 from mlflow.utils.uri import get_databricks_profile_uri_from_artifact_uri
 from mlflow.store.artifact.utils.models import (
@@ -23,7 +16,7 @@ from mlflow.store.artifact.utils.models import (
 )
 
 _logger = logging.getLogger(__name__)
-_DOWNLOAD_CHUNK_SIZE = 10_000_000
+_DOWNLOAD_CHUNK_SIZE = 100000000
 # The constant REGISTRY_LIST_ARTIFACT_ENDPOINT is defined as @developer_stable
 REGISTRY_LIST_ARTIFACTS_ENDPOINT = "/api/2.0/mlflow/model-versions/list-artifacts"
 # The constant REGISTRY_ARTIFACT_PRESIGNED_URI_ENDPOINT is defined as @developer_stable
@@ -126,67 +119,14 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
         filtered_headers = filter(lambda h: "name" in h and "value" in h, headers)
         return {header.get("name"): header.get("value") for header in filtered_headers}
 
-    def _parallelized_download_from_cloud(
-        self, signed_uri, headers, file_size, dst_local_file_path, dst_run_relative_artifact_path
-    ):
-        try:
-            failed_downloads = parallelized_download_file_using_http_uri(
-                http_uri=signed_uri,
-                download_path=dst_local_file_path,
-                file_size=file_size,
-                # URI type is not known in this context
-                uri_type=None,
-                chunk_size=_DOWNLOAD_CHUNK_SIZE,
-                headers=headers,
-            )
-            download_errors = [
-                e for e in failed_downloads.values() if e.response.status_code not in (401, 403)
-            ]
-            if download_errors:
-                raise MlflowException(
-                    f"Failed to download artifact {dst_run_relative_artifact_path}: "
-                    f"{download_errors}"
-                )
-            if failed_downloads:
-                new_signed_uri, new_headers = self._get_signed_download_uri(
-                    dst_run_relative_artifact_path
-                )
-            for i in failed_downloads:
-                download_chunk(
-                    i, _DOWNLOAD_CHUNK_SIZE, new_headers, dst_local_file_path, new_signed_uri
-                )
-        except Exception as err:
-            if os.path.exists(dst_local_file_path):
-                os.remove(dst_local_file_path)
-            raise MlflowException(err)
-
     def _download_file(self, remote_file_path, local_path):
-        parent_dir, _ = posixpath.split(remote_file_path)
-        file_infos = self.list_artifacts(parent_dir)
-        file_info = [info for info in file_infos if info.path == remote_file_path]
-        file_size = file_info[0].file_size if len(file_info) == 1 else None
         try:
             signed_uri, raw_headers = self._get_signed_download_uri(remote_file_path)
             headers = {}
             if raw_headers is not None:
                 # Don't send None to _extract_headers_from_signed_url
                 headers = self._extract_headers_from_signed_url(raw_headers)
-            # Windows doesn't support the 'fork' multiprocessing context.
-            if file_size is None or file_size <= _DOWNLOAD_CHUNK_SIZE or is_windows():
-                download_file_using_http_uri(
-                    signed_uri,
-                    local_path,
-                    _DOWNLOAD_CHUNK_SIZE,
-                    headers,
-                )
-            else:
-                self._parallelized_download_from_cloud(
-                    signed_uri,
-                    headers,
-                    file_size,
-                    local_path,
-                    remote_file_path,
-                )
+            download_file_using_http_uri(signed_uri, local_path, _DOWNLOAD_CHUNK_SIZE, headers)
         except Exception as err:
             raise MlflowException(err)
 

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -1,8 +1,6 @@
 import codecs
 import errno
 import gzip
-import math
-import multiprocessing
 import os
 import posixpath
 import shutil
@@ -15,13 +13,11 @@ from contextlib import contextmanager
 
 import urllib.parse
 import urllib.request
-from concurrent.futures import ProcessPoolExecutor
 from urllib.parse import unquote
 from urllib.request import pathname2url
 
 import atexit
 
-import requests
 import yaml
 
 try:
@@ -29,7 +25,6 @@ try:
 except ImportError:
     from yaml import SafeLoader as YamlSafeLoader, SafeDumper as YamlSafeDumper
 
-from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialType
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MissingConfigException
 from mlflow.utils.rest_utils import cloud_storage_http_request, augmented_raise_for_status
@@ -39,7 +34,6 @@ from mlflow.utils.databricks_utils import _get_dbutils
 from mlflow.utils.os import is_windows
 
 ENCODING = "utf-8"
-MAX_PARALLEL_DOWNLOAD_WORKERS = 32
 
 
 def is_directory(name):
@@ -593,77 +587,6 @@ def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, 
                 if not chunk:
                     break
                 output_file.write(chunk)
-
-
-def download_chunk(request_index, chunk_size, headers, download_path, http_uri):
-    range_start = chunk_size * request_index
-    range_end = range_start + chunk_size - 1
-    combined_headers = {**headers, "Range": f"bytes={range_start}-{range_end}"}
-    with cloud_storage_http_request(
-        "get", http_uri, stream=False, headers=combined_headers
-    ) as response:
-        # File will have been created upstream. Use r+b to ensure chunks
-        # don't overwrite the entire file.
-        with open(download_path, "r+b") as f:
-            f.seek(range_start)
-            f.write(response.content)
-
-
-def parallelized_download_file_using_http_uri(
-    http_uri, download_path, file_size, uri_type, chunk_size, headers=None
-):
-    """
-    Downloads a file specified using the `http_uri` to a local `download_path`. This function
-    sends multiple requests in parallel each specifying its own desired byte range as a header,
-    then reconstructs the file from the downloaded chunks. This allows for downloads of large files
-    without OOM risk.
-
-    Note : This function is meant to download files using presigned urls from various cloud
-            providers.
-    Returns a dict of chunk index : exception, if one was thrown for that index.
-    """
-    num_requests = int(math.ceil(file_size / float(chunk_size)))
-    # Create file if it doesn't exist or erase the contents if it does. We should do this here
-    # before sending to the workers so they can each individually seek to their respective positions
-    # and write chunks without overwriting.
-    open(download_path, "w").close()
-    futures = {}
-    starting_index = 0
-    if uri_type == ArtifactCredentialType.GCP_SIGNED_URL or uri_type is None:
-        # GCP files could be transcoded, in which case the range header is ignored.
-        # Test if this is the case by downloading one chunk and seeing if it's larger than the
-        # requested size. If yes, let that be the file; if not, continue downloading more chunks.
-        download_chunk(0, chunk_size, headers, download_path, http_uri)
-        downloaded_size = os.path.getsize(download_path)
-        # If downloaded size was equal to the chunk size it would have been downloaded serially,
-        # so we don't need to consider this here
-        if downloaded_size > chunk_size:
-            return {}
-        else:
-            starting_index = 1
-
-    failed_downloads = {}
-    with ProcessPoolExecutor(
-        max_workers=MAX_PARALLEL_DOWNLOAD_WORKERS, mp_context=multiprocessing.get_context("fork")
-    ) as executor:
-        for i in range(starting_index, num_requests):
-            fut = executor.submit(
-                download_chunk,
-                request_index=i,
-                chunk_size=chunk_size,
-                headers=headers,
-                download_path=download_path,
-                http_uri=http_uri,
-            )
-            futures[i] = fut
-
-    for i, fut in futures.items():
-        try:
-            fut.result()
-        except requests.HTTPError as e:
-            failed_downloads[i] = e
-
-    return failed_downloads
 
 
 def _handle_readonly_on_windows(func, path, exc_info):

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -6,8 +6,6 @@ import re
 
 import pytest
 import posixpath
-
-import requests
 from requests.models import Response
 from unittest import mock
 from unittest.mock import ANY
@@ -29,7 +27,6 @@ from mlflow.store.artifact.databricks_artifact_repo import (
     DatabricksArtifactRepository,
     _MAX_CREDENTIALS_REQUEST_SIZE,
 )
-from mlflow.utils.os import is_windows
 
 DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE = "mlflow.store.artifact.databricks_artifact_repo"
 DATABRICKS_ARTIFACT_REPOSITORY = (
@@ -1464,64 +1461,3 @@ def test_multipart_upload_abort(databricks_artifact_repo, large_file, mock_chunk
             headers={"header": "abort"},
             timeout=None,
         )
-
-
-@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
-def test_parallelized_download_retries_failed_chunks(
-    databricks_artifact_repo, large_file, mock_chunk_size
-):
-    mock_credential_info = ArtifactCredentialInfo(
-        signed_uri=MOCK_AWS_SIGNED_URI, type=ArtifactCredentialType.AWS_PRESIGNED_URL
-    )
-    response = Response()
-    response.status_code = 401
-    failed_downloads = {
-        2: requests.HTTPError(response=response),
-        5: requests.HTTPError(response=response),
-    }
-
-    with mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY}._get_read_credential_infos",
-        return_value=[mock_credential_info],
-    ) as get_creds_mock, mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.parallelized_download_file_using_http_uri",
-        return_value=failed_downloads,
-    ), mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.download_chunk"
-    ) as download_chunk_mock, mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY}.list_artifacts",
-        side_effect=[[], [FileInfo(path="a.txt", is_dir=False, file_size=20_000_000)]],
-    ):
-        databricks_artifact_repo.download_artifacts("a.txt")
-        assert get_creds_mock.call_count == 2  # Once for initial fetch, once for retries
-        assert {call.args[0] for call in download_chunk_mock.call_args_list} == {2, 5}
-
-
-@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
-def test_parallelized_download_throws_for_other_errors(
-    databricks_artifact_repo, large_file, mock_chunk_size
-):
-    mock_credential_info = ArtifactCredentialInfo(
-        signed_uri=MOCK_AWS_SIGNED_URI, type=ArtifactCredentialType.AWS_PRESIGNED_URL
-    )
-    response = Response()
-    response.status_code = 500
-    failed_downloads = {
-        2: requests.HTTPError(response=response),
-        5: requests.HTTPError(response=response),
-    }
-
-    with mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY}._get_read_credential_infos",
-        return_value=[mock_credential_info],
-    ), mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.parallelized_download_file_using_http_uri",
-        return_value=failed_downloads,
-    ), mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.download_chunk"
-    ), mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY}.list_artifacts",
-        side_effect=[[], [FileInfo(path="a.txt", is_dir=False, file_size=20_000_000)]],
-    ):
-        with pytest.raises(MlflowException, match="Failed to download artifact"):
-            databricks_artifact_repo.download_artifacts("a.txt")

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -2,23 +2,18 @@
 import codecs
 import filecmp
 import hashlib
-import multiprocessing
 import os
 import shutil
-from unittest import mock
 
 import jinja2.exceptions
 import pytest
 import tarfile
 import stat
 import pandas as pd
-import requests
 from pyspark.sql import SparkSession
-from requests import Response
 
 import mlflow
 from mlflow.exceptions import MissingConfigException
-from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialType
 from mlflow.utils import file_utils
 from mlflow.utils.file_utils import (
     get_parent_dir,
@@ -29,7 +24,6 @@ from mlflow.utils.file_utils import (
     TempDir,
     _handle_readonly_on_windows,
     local_file_uri_to_path,
-    parallelized_download_file_using_http_uri,
 )
 from mlflow.utils.os import is_windows
 from tests.projects.utils import TEST_PROJECT_DIR
@@ -370,95 +364,3 @@ def test_shutil_copytree_without_file_permissions(tmp_path):
     assert set(os.listdir(dst_dir.joinpath("subdir"))) == {"subdir-file.txt"}
     assert dst_dir.joinpath("subdir/subdir-file.txt").read_text() == "testing 123"
     assert dst_dir.joinpath("top-level-file.txt").read_text() == "hi"
-
-
-@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
-def test_parallelized_download_file_using_http_uri_requests_appropriate_chunks(tmp_path):
-    calls_kwargs = multiprocessing.Manager().list([])
-
-    # Get call kwargs manually. Calls are not properly stored in a MagicMock object
-    # in a multiprocessing context.
-    def mock_request_side_effect(method, url, *args, **kwargs):
-        calls_kwargs.append(kwargs)
-        response_mock = Response()
-        response_mock.status_code = 206
-        response_mock._content = b"\x01\x01"
-        return response_mock
-
-    with mock.patch("requests.Session.request", side_effect=mock_request_side_effect):
-        parallelized_download_file_using_http_uri(
-            "fake_uri",
-            tmp_path / "testfile",
-            file_size=1000,
-            uri_type=ArtifactCredentialType.AWS_PRESIGNED_URL,
-            chunk_size=100,
-            headers={},
-        )
-    requested_ranges = [call_kwargs["headers"]["Range"] for call_kwargs in calls_kwargs]
-    assert len(requested_ranges) == 10
-    expected_ranges = [f"bytes={100*i}-{(100*(i+1))-1}" for i in range(10)]
-    assert sorted(requested_ranges) == expected_ranges
-
-
-@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
-@pytest.mark.parametrize("uri_type", [ArtifactCredentialType.GCP_SIGNED_URL, None])
-def test_parallelized_download_file_using_http_uri_handles_gcp_transcoding(tmp_path, uri_type):
-    calls_kwargs = multiprocessing.Manager().list([])
-    file_content = b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"
-
-    def mock_request_side_effect(method, url, *args, **kwargs):
-        calls_kwargs.append(kwargs)
-        response_mock = Response()
-        response_mock.status_code = 200
-        # 10-byte file
-        response_mock._content = file_content
-        return response_mock
-
-    filename = tmp_path / "testfile"
-    with mock.patch("requests.Session.request") as request_mock:
-        request_mock.side_effect = mock_request_side_effect
-        failed_downloads = parallelized_download_file_using_http_uri(
-            "fake_uri",
-            filename,
-            file_size=10,
-            uri_type=uri_type,
-            chunk_size=2,
-            headers={},
-        )
-    # Should only have called once because the whole file was returned
-    assert failed_downloads == {}
-    assert len(calls_kwargs) == 1
-    with open(filename, "rb") as f:
-        f.seek(0)
-        contents = f.read()
-        assert contents == file_content
-
-
-@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
-def test_parallelized_download_file_using_http_uri_returns_errors_correctly(tmp_path):
-    calls_kwargs = multiprocessing.Manager().list([])
-    file_content = b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"
-
-    def mock_request_side_effect(method, url, *args, **kwargs):
-        calls_kwargs.append(kwargs)
-        response_mock = Response()
-        response_mock.status_code = 200
-        # 10-byte file
-        response_mock._content = file_content
-        # Randomly fail for the first chunk
-        if kwargs["headers"]["Range"].startswith("bytes=0"):
-            raise requests.HTTPError("test exception")
-        return response_mock
-
-    with mock.patch("requests.Session.request") as request_mock:
-        request_mock.side_effect = mock_request_side_effect
-        failed_downloads = parallelized_download_file_using_http_uri(
-            "fake_uri",
-            tmp_path / "testfile",
-            file_size=10,
-            uri_type=ArtifactCredentialType.AWS_PRESIGNED_URL,
-            chunk_size=2,
-            headers={},
-        )
-        assert len(failed_downloads) == 1
-        assert str(failed_downloads[0]) == "test exception"


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Revert multipart download support for Databricks due to stalling in notebook environments

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
