### PR TITLE
Added secret scope check to OpenAI credential call

### DIFF
--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -64,7 +64,10 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.types import Schema, ColSpec
 from mlflow.environment_variables import _MLFLOW_OPENAI_TESTING, MLFLOW_OPENAI_SECRET_SCOPE
 from mlflow.utils.annotations import experimental
-from mlflow.utils.databricks_utils import is_in_databricks_runtime
+from mlflow.utils.databricks_utils import (
+    check_databricks_secret_scope_access,
+    is_in_databricks_runtime,
+)
 
 FLAVOR_NAME = "openai"
 MODEL_FILENAME = "model.yaml"
@@ -344,7 +347,9 @@ def save_model(
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
 
     if is_in_databricks_runtime():
-        if scope := MLFLOW_OPENAI_SECRET_SCOPE.get():
+        if scope := MLFLOW_OPENAI_SECRET_SCOPE.get() and check_databricks_secret_scope_access(
+            scope
+        ):
             _log_secrets_yaml(path, scope)
         else:
             _logger.info(

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -347,9 +347,8 @@ def save_model(
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
 
     if is_in_databricks_runtime():
-        if scope := MLFLOW_OPENAI_SECRET_SCOPE.get() and check_databricks_secret_scope_access(
-            scope
-        ):
+        if scope := MLFLOW_OPENAI_SECRET_SCOPE.get():
+            check_databricks_secret_scope_access(scope)
             _log_secrets_yaml(path, scope)
         else:
             _logger.info(

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -353,7 +353,7 @@ def save_model(
         else:
             _logger.info(
                 "No secret scope specified, skipping logging of secrets for OpenAI credentials. "
-                "See https://mlflow.org/docs/latest/python_api/mlflow.openai.html#credential-management-for-openai-on-databricks "
+                "See https://mlflow.org/docs/latest/python_api/openai/index.html#credential-management-for-openai-on-databricks "
                 "for more information."
             )
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -637,9 +637,8 @@ def check_databricks_secret_scope_access(scope_name):
             dbutils.secrets.list(scope_name)
         except Exception as e:
             _logger.warning(
-                "Unable to access Databricks secret scope '%s'. Please verify that the current"
-                " Databricks user has the 'read' permission for this scope. Error: %s"
-                % (scope_name, str(e))
+                f"Unable to access Databricks secret scope '{scope_name}'. Please verify that the current"
+                f" Databricks user has 'READ' permission for this scope. Error: {str(e)}"
             )
 
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -636,7 +636,7 @@ def check_databricks_secret_scope_access(scope_name):
         try:
             dbutils.secrets.list(scope_name)
         except Exception as e:
-            raise MlflowException(
+            _logger.warning(
                 "Unable to access Databricks secret scope '%s'. Please verify that the current"
                 " Databricks user has the 'read' permission for this scope. Error: %s"
                 % (scope_name, str(e))

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -637,8 +637,12 @@ def check_databricks_secret_scope_access(scope_name):
             dbutils.secrets.list(scope_name)
         except Exception as e:
             _logger.warning(
-                f"Unable to access Databricks secret scope '{scope_name}'. Please verify that the current"
-                f" Databricks user has 'READ' permission for this scope. Error: {str(e)}"
+                f"Unable to access Databricks secret scope '{scope_name}' for OpenAI credentials "
+                "that will be used to deploy the model to Databricks Model Serving. "
+                "Please verify that the current Databricks user has 'READ' permission for "
+                "this scope. For more information, see "
+                "https://mlflow.org/docs/latest/python_api/openai/index.html#credential-management-for-openai-on-databricks. "  # pylint: disable=line-too-long
+                f"Error: {str(e)}"
             )
 
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -630,6 +630,19 @@ def get_databricks_workspace_info_from_uri(tracking_uri: str) -> Optional[Databr
         return None
 
 
+def check_databricks_secret_scope_access(scope_name):
+    dbutils = _get_dbutils()
+    if dbutils:
+        try:
+            dbutils.secrets.list(scope_name)
+        except Exception as e:
+            raise MlflowException(
+                "Unable to access Databricks secret scope '%s'. Please verify that the current"
+                " Databricks user has the 'read' permission for this scope. Error: %s"
+                % (scope_name, str(e))
+            )
+
+
 def _construct_databricks_run_url(
     host: str,
     experiment_id: str,

--- a/tests/openai/test_openai_model_export.py
+++ b/tests/openai/test_openai_model_export.py
@@ -293,7 +293,9 @@ def test_pyfunc_flavor_is_only_added_for_chat_completion(tmp_path):
 def test_save_model_with_secret_scope(tmp_path, monkeypatch):
     scope = "test"
     monkeypatch.setenv("MLFLOW_OPENAI_SECRET_SCOPE", scope)
-    with mock.patch("mlflow.openai.is_in_databricks_runtime", return_value=True):
+    with mock.patch("mlflow.openai.is_in_databricks_runtime", return_value=True), mock.patch(
+        "mlflow.openai.check_databricks_secret_scope_access"
+    ):
         mlflow.openai.save_model(model="gpt-3.5-turbo", task="chat.completions", path=tmp_path)
     with tmp_path.joinpath("openai.yaml").open() as f:
         creds = yaml.safe_load(f)

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -374,7 +374,7 @@ def test_check_databricks_secret_scope_access_error():
             "Unable to access Databricks secret scope 'scope' for OpenAI credentials that will be "
             "used to deploy the model to Databricks Model Serving. Please verify that the current "
             "Databricks user has 'READ' permission for this scope. For more information, see "
-            "https://mlflow.org/docs/latest/python_api/openai/index.html#credential-management-for-openai-on-databricks. " # pylint: disable=line-too-long
+            "https://mlflow.org/docs/latest/python_api/openai/index.html#credential-management-for-openai-on-databricks. "  # pylint: disable=line-too-long
             "Error: no scope access"
         )
         mock_dbutils.secrets.list.assert_called_once_with("scope")

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -365,8 +365,12 @@ def test_check_databricks_secret_scope_access():
 
 def test_check_databricks_secret_scope_access_error():
     mock_dbutils = mock.MagicMock()
-    mock_dbutils.secrets.list.side_effect = Exception()
-    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
-        with pytest.raises(MlflowException):
-            check_databricks_secret_scope_access("scope")
+    mock_dbutils.secrets.list.side_effect = Exception("no scope access")
+    with mock.patch(
+        "mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils
+    ), mock.patch("mlflow.utils.databricks_utils._logger.warning") as mock_warning:
+        check_databricks_secret_scope_access("scope")
+        mock_warning.assert_called_once_with(
+            "Unable to access Databricks secret scope 'scope'. Please verify that the current Databricks user has the 'read' permission for this scope. Error: no scope access"
+        )
         mock_dbutils.secrets.list.assert_called_once_with("scope")

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -371,8 +371,10 @@ def test_check_databricks_secret_scope_access_error():
     ), mock.patch("mlflow.utils.databricks_utils._logger.warning") as mock_warning:
         check_databricks_secret_scope_access("scope")
         mock_warning.assert_called_once_with(
-            "Unable to access Databricks secret scope 'scope'. "
-            "Please verify that the current Databricks user has 'READ' permission for this scope. "
+            "Unable to access Databricks secret scope 'scope' for OpenAI credentials that will be "
+            "used to deploy the model to Databricks Model Serving. Please verify that the current "
+            "Databricks user has 'READ' permission for this scope. For more information, see "
+            "https://mlflow.org/docs/latest/python_api/openai/index.html#credential-management-for-openai-on-databricks. " # pylint: disable=line-too-long
             "Error: no scope access"
         )
         mock_dbutils.secrets.list.assert_called_once_with("scope")

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -371,6 +371,8 @@ def test_check_databricks_secret_scope_access_error():
     ), mock.patch("mlflow.utils.databricks_utils._logger.warning") as mock_warning:
         check_databricks_secret_scope_access("scope")
         mock_warning.assert_called_once_with(
-            "Unable to access Databricks secret scope 'scope'. Please verify that the current Databricks user has the 'read' permission for this scope. Error: no scope access"
+            "Unable to access Databricks secret scope 'scope'. "
+            "Please verify that the current Databricks user has 'READ' permission for this scope. "
+            "Error: no scope access"
         )
         mock_dbutils.secrets.list.assert_called_once_with("scope")


### PR DESCRIPTION
## What changes are proposed in this pull request?

We add a check in the OpenAI flavor that the user has read access to the secret scope defined by `MLFLOW_OPENAI_SECRET_SCOPE`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

We add a check in the OpenAI flavor that the user has read access to the secret scope defined by `MLFLOW_OPENAI_SECRET_SCOPE`.
### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
