### PR TITLE
[Feature branch] Fix bug when constructing Spark datasets from file path sources

### DIFF
--- a/mlflow/data/spark_dataset.py
+++ b/mlflow/data/spark_dataset.py
@@ -260,7 +260,7 @@ def from_spark(
     Given a Spark DataFrame, constructs an MLflow :py:class:`SparkDataset` object for use with
     MLflow Tracking.
 
-    :param df: The Spark DataFrame to construct a SparkDataset from.
+    :param df: The Spark DataFrame from which to construct a SparkDataset.
     :param path: The path of the Spark or Delta source that the DataFrame originally came from.
                  Note that the path does not have to match the DataFrame exactly, since the
                  DataFrame may have been modified by Spark operations. This is used to reload the

--- a/mlflow/data/spark_delta_utils.py
+++ b/mlflow/data/spark_delta_utils.py
@@ -34,7 +34,7 @@ def _is_delta_table_path(path: str) -> bool:
 
     :return: True if the specified path is a Delta table. False otherwise.
     """
-    if os.path.exists(path) and "_delta_log" in os.listdir(path):
+    if os.path.exists(path) and os.path.isdir(path) and "_delta_log" in os.listdir(path):
         return True
     from mlflow.utils.uri import dbfs_hdfs_uri_to_fuse_path
 

--- a/tests/data/test_spark_dataset.py
+++ b/tests/data/test_spark_dataset.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pytest
 import pandas as pd
 import mlflow.data
@@ -50,6 +51,7 @@ def _check_spark_dataset(dataset, original_df, df_spark, expected_source_type, e
     assert isinstance(dataset.profile, dict)
     assert isinstance(dataset.profile.get("approx_count"), int)
     assert isinstance(dataset.source, expected_source_type)
+    _assert_dataframes_equal(dataset.source.load(), df_spark)
     if expected_name is not None:
         assert dataset.name == expected_name
 
@@ -184,12 +186,19 @@ def test_from_spark_with_sql_and_version(spark_session, tmp_path, df):
 
 def test_from_spark_path(spark_session, tmp_path, df):
     df_spark = spark_session.createDataFrame(df)
-    path = str(tmp_path / "temp.parquet")
-    df_spark.write.parquet(path)
+    dir_path = str(tmp_path / "df_dir")
+    df_spark.write.parquet(dir_path)
+    assert os.path.isdir(dir_path)
 
-    mlflow_df = mlflow.data.from_spark(df_spark, path=path)
+    mlflow_df_from_dir = mlflow.data.from_spark(df_spark, path=dir_path)
+    _check_spark_dataset(mlflow_df_from_dir, df, df_spark, SparkDatasetSource)
 
-    _check_spark_dataset(mlflow_df, df, df_spark, SparkDatasetSource)
+    file_path = str(tmp_path / "df.parquet")
+    df_spark.toPandas().to_parquet(file_path)
+    assert not os.path.isdir(file_path)
+
+    mlflow_df_from_file = mlflow.data.from_spark(df_spark, path=file_path)
+    _check_spark_dataset(mlflow_df_from_file, df, df_spark, SparkDatasetSource)
 
 
 def test_from_spark_delta_path(spark_session, tmp_path, df):

--- a/tests/data/test_spark_dataset.py
+++ b/tests/data/test_spark_dataset.py
@@ -13,7 +13,7 @@ from mlflow.types.schema import Schema
 from mlflow.types.utils import _infer_schema
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def spark_session(tmp_path):
     from pyspark.sql import SparkSession
 

--- a/tests/data/test_spark_dataset.py
+++ b/tests/data/test_spark_dataset.py
@@ -51,6 +51,10 @@ def _check_spark_dataset(dataset, original_df, df_spark, expected_source_type, e
     assert isinstance(dataset.profile, dict)
     assert isinstance(dataset.profile.get("approx_count"), int)
     assert isinstance(dataset.source, expected_source_type)
+    # NB: In real-world scenarios, Spark dataset sources may not match Spark DataFrames precisely.
+    # For example, users may transform Spark DataFrames after loading contents from source files.
+    # To ensure that source loading works properly for the purpose of the test cases in this suite,
+    # we require the source to match the DataFrame and make the following equality assertion
     _assert_dataframes_equal(dataset.source.load(), df_spark)
     if expected_name is not None:
         assert dataset.name == expected_name
@@ -257,7 +261,7 @@ def test_from_spark_delta_table_name_and_version(spark_session, tmp_path, df):
     # write to delta table
     df_spark.write.format("delta").mode("overwrite").saveAsTable("my_delta_table")
 
-    mlflow_df = mlflow.data.from_spark(df_spark, table_name="my_delta_table", version=1)
+    mlflow_df = mlflow.data.from_spark(df_spark, table_name="my_delta_table", version=0)
 
     _check_spark_dataset(mlflow_df, df, df_spark, DeltaDatasetSource)
 
@@ -291,15 +295,19 @@ def test_load_delta_path(spark_session, tmp_path, df):
 
 
 def test_load_delta_path_with_version(spark_session, tmp_path, df):
-    df_spark = spark_session.createDataFrame(df)
     path = str(tmp_path / "temp.delta")
-    df_spark.write.format("delta").mode("overwrite").save(path)
+
+    df_v0 = pd.DataFrame([[4, 5, 6], [4, 5, 6]], columns=["a", "b", "c"])
+    assert not df_v0.equals(df)
+    df_v0_spark = spark_session.createDataFrame(df_v0)
+    df_v0_spark.write.format("delta").mode("overwrite").save(path)
+
     # write again to create a new version
-    df_spark.write.format("delta").mode("overwrite").save(path)
+    df_v1_spark = spark_session.createDataFrame(df)
+    df_v1_spark.write.format("delta").mode("overwrite").save(path)
 
     mlflow_df = mlflow.data.load_delta(path=path, version=1)
-
-    _check_spark_dataset(mlflow_df, df, df_spark, DeltaDatasetSource)
+    _check_spark_dataset(mlflow_df, df, df_v1_spark, DeltaDatasetSource)
 
 
 def test_load_delta_table_name(spark_session, df):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Fix bug when constructing Spark datasets from file path sources

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
