### PR TITLE
Fix scipy skinny test

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -76,7 +76,6 @@ from mlflow.utils.autologging_utils import (
     get_autologging_config,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
-from scipy.sparse import issparse
 
 FLAVOR_NAME = "sklearn"
 
@@ -1851,6 +1850,8 @@ def _autolog(
 
     def _create_dataset(X, source, y=None, dataset_name=None):
         # create a dataset
+        from scipy.sparse import issparse
+
         if isinstance(X, pd.DataFrame):
             dataset = from_pandas(df=X, source=source)
         elif issparse(X):

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -19,7 +19,6 @@ XGBoost (native) format
 import os
 import shutil
 import json
-from scipy.sparse import issparse
 import yaml
 import tempfile
 import logging
@@ -807,6 +806,7 @@ def _log_xgboost_dataset(xgb_dataset, source, context, autologging_client, name=
     import numpy as np
     import pandas as pd
     import xgboost as xgb
+    from scipy.sparse import issparse
 
     # dmatrix has a get_data method added in 1.7. skip for earlier versions.
     if Version(xgb.__version__) >= Version("1.7.0"):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

* move scipy imports out of top level module

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

(mlflow-dev-env) sh-3.2$ pytest tests/test_skinny_client_autolog_without_scipy.py
============================================================================================================ test session starts =============================================================================================================
platform darwin -- Python 3.9.13, pytest-7.2.2, pluggy-1.0.0 -- /Users/prithvi.kannan/opt/miniconda3/envs/mlflow-dev-env/bin/python
cachedir: .pytest_cache
rootdir: /Users/prithvi.kannan/mlflow, configfile: pytest.ini
plugins: anyio-3.6.2
collected 1 item                                                                                                                                                                                                                             

tests/test_skinny_client_autolog_without_scipy.py::test_autolog_without_scipy PASSED                                                                                                                                                   [100%]

============================================================================================================ slowest 10 durations ============================================================================================================
0.00s setup    tests/test_skinny_client_autolog_without_scipy.py::test_autolog_without_scipy
0.00s call     tests/test_skinny_client_autolog_without_scipy.py::test_autolog_without_scipy
0.00s teardown tests/test_skinny_client_autolog_without_scipy.py::test_autolog_without_scipy
============================================================================================================= 1 passed in 0.01s ==============================================================================================================

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
