### PR TITLE
Set numpy package version bound for cross tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -82,7 +82,7 @@ tensorflow:
     maximum: "2.12.0"
     requirements:
       # Requirements to run tests for keras
-      ">= 0.0.0": ["scikit-learn", "pyspark", "pyarrow", "transformers"]
+      ">= 0.0.0": ["scikit-learn", "pyspark", "pyarrow", "transformers", "numpy<=1.23"]
       "< 2.6.0": ["protobuf<4.0.0"]
       "< 2.7.0": ["pandas==1.3.5"]
       # TensorFlow 2.3.4, 2.4.4, 2.5.3, and 2.6.5 are incompatible with SQLAlchemy 2.x due to
@@ -191,6 +191,8 @@ gluon:
     minimum: "1.5.1"
     maximum: "1.9.1"
     unsupported: ["1.8.0"] # MXNet 1.8.0 is a flawed release that we don't expect to work with
+    requirements:
+      ">= 0.0.0": [ "numpy<=1.23" ]
     run: |
       # Install libopenblas-dev for mxnet 1.8.0.post0
       sudo apt-get update -y
@@ -201,6 +203,8 @@ gluon:
     minimum: "1.5.1"
     maximum: "1.9.1"
     unsupported: ["1.8.0"] # MXNet 1.8.0 is a flawed release that we don't expect to work with
+    requirements:
+      ">= 0.0.0": [ "numpy<=1.23" ]
     run: |
       pytest tests/gluon/test_gluon_autolog.py
 
@@ -252,7 +256,7 @@ onnx:
     minimum: "1.7.0"
     maximum: "1.13.1"
     requirements:
-      ">= 0.0.0": ["onnxruntime", "torch", "scikit-learn", "protobuf<4.0.0"]
+      ">= 0.0.0": ["onnxruntime", "torch", "scikit-learn", "protobuf<4.0.0", "numpy<=1.23"]
     run: |
       pytest tests/onnx/test_onnx_model_export.py
 
@@ -364,6 +368,7 @@ mleap:
     requirements:
       "> 0.17.0, < 0.21.0": ["pyspark==3.0.2"]
       ">= 0.21.0": ["pyspark<3.4"]
+      ">= 0.0.0": [ "numpy<=1.23" ]
     run: |
       SAGEMAKER_OUT=$(mktemp)
       if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
@@ -440,6 +445,8 @@ shap:
   models:
     minimum: "0.41.0"
     maximum: "0.41.0"
+    requirements:
+      ">= 0.0.0": [ "numpy<=1.23" ]
     run: |
       pytest tests/shap
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Recently,
some cross tests failed , e.g. https://github.com/mlflow/mlflow/actions/runs/4883153961/jobs/8714163891#step:13:348

This is because latest numpy version drop some deprecated APIs (np.bool, np.float, np.object, etc),
but these 3rd-party packages are still using these APIs so the failure happens.

This PR restrict the numpy version in cross test to prevent the error.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
