### PR TITLE
Bugfix: don't fail UC model version creation if we cannot fetch its source run

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -315,7 +315,13 @@ class UcModelRegistryStore(BaseRestStore):
         response = http_request(
             host_creds=host_creds, endpoint=endpoint, method=method, params={"run_id": run_id}
         )
-        response = verify_rest_response(response, endpoint)
+        try:
+            verify_rest_response(response, endpoint)
+        except MlflowException:
+            _logger.exception(
+                "Unable to fetch model version's source run from tracking server. No run link "
+                "will be recorded for the model version. Exception: "
+            )
         if _DATABRICKS_ORG_ID_HEADER not in response.headers:
             _logger.warning(
                 "Unable to get model version source run's workspace ID from request headers. "

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -323,6 +323,7 @@ class UcModelRegistryStore(BaseRestStore):
                 "from tracking server. The source run may be deleted or inaccessible to the "
                 "current user. No run link will be recorded for the model version."
             )
+            return None
         if _DATABRICKS_ORG_ID_HEADER not in response.headers:
             _logger.warning(
                 "Unable to get model version source run's workspace ID from request headers. "

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -319,8 +319,9 @@ class UcModelRegistryStore(BaseRestStore):
             verify_rest_response(response, endpoint)
         except MlflowException:
             _logger.warning(
-                "Unable to fetch model version's source run from tracking server. No run link "
-                "will be recorded for the model version"
+                f"Unable to fetch model version's source run (with ID {run_id}) "
+                "from tracking server. The source run may be deleted or inaccessible to the "
+                "current user. No run link will be recorded for the model version."
             )
         if _DATABRICKS_ORG_ID_HEADER not in response.headers:
             _logger.warning(

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -318,9 +318,9 @@ class UcModelRegistryStore(BaseRestStore):
         try:
             verify_rest_response(response, endpoint)
         except MlflowException:
-            _logger.exception(
+            _logger.warning(
                 "Unable to fetch model version's source run from tracking server. No run link "
-                "will be recorded for the model version. Exception: "
+                "will be recorded for the model version"
             )
         if _DATABRICKS_ORG_ID_HEADER not in response.headers:
             _logger.warning(

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -331,7 +331,7 @@ def test_get_workspace_id_returns_none_if_no_request_header(store):
 def test_get_workspace_id_returns_none_if_request_fails(store, status_code, response_text):
     mock_response = mock.MagicMock(autospec=Response)
     mock_response.status_code = status_code
-    mock_response.headers = {}
+    mock_response.headers = {_DATABRICKS_ORG_ID_HEADER: 123}
     mock_response.text = response_text
     with mock.patch(
         "mlflow.store._unity_catalog.registry.rest_store.http_request", return_value=mock_response

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -328,11 +328,11 @@ def test_get_workspace_id_returns_none_if_no_request_header(store):
         (500, "<html><div>Not real json</div></html>"),
     ],
 )
-def test_get_workspace_id_returns_none_if_request_fails(store):
+def test_get_workspace_id_returns_none_if_request_fails(store, status_code, response_text):
     mock_response = mock.MagicMock(autospec=Response)
-    mock_response.status_code = 403
+    mock_response.status_code = status_code
     mock_response.headers = {}
-    mock_response.text = str({})
+    mock_response.text = response_text
     with mock.patch(
         "mlflow.store._unity_catalog.registry.rest_store.http_request", return_value=mock_response
     ):

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -328,7 +328,7 @@ def test_get_workspace_id_returns_none_if_no_request_header(store):
         (500, "<html><div>Not real json</div></html>"),
     ],
 )
-def test_get_workspace_id_returns_none_if_request_fails(store, status_code, response_text):
+def test_get_workspace_id_returns_none_if_request_fails(store):
     mock_response = mock.MagicMock(autospec=Response)
     mock_response.status_code = 403
     mock_response.headers = {}

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -321,6 +321,24 @@ def test_get_workspace_id_returns_none_if_no_request_header(store):
         assert store._get_workspace_id(run_id="some_run_id") is None
 
 
+@pytest.mark.parametrize(
+    "status_code,response_text",
+    [
+        (403, str({})),
+        (500, "<html><div>Not real json</div></html>"),
+    ],
+)
+def test_get_workspace_id_returns_none_if_request_fails(store, status_code, response_text):
+    mock_response = mock.MagicMock(autospec=Response)
+    mock_response.status_code = 403
+    mock_response.headers = {}
+    mock_response.text = str({})
+    with mock.patch(
+        "mlflow.store._unity_catalog.registry.rest_store.http_request", return_value=mock_response
+    ):
+        assert store._get_workspace_id(run_id="some_run_id") is None
+
+
 def test_get_workspace_id_returns_none_if_tracking_uri_not_databricks(
     mock_databricks_host_creds, tmp_path
 ):


### PR DESCRIPTION
## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fixes a bug where we currently fail UC model version creation if we cannot fetch its source run in the process of determining its workspace ID

## How is this patch tested?
Added tests, plus manually verified the fix

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

With the changes in this PR, a log line is now emitted but we don't automatically fail the creation of a model version if its source run cannot be found:
![image](https://user-images.githubusercontent.com/2358483/236962907-7c02ad69-50bc-4f37-bc0b-7339c42799e6.png)


<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
