### PR TITLE
Disable spurious autolog

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -475,7 +475,16 @@ transformers:
     maximum: "4.28.1"
     requirements:
       ">= 0.0.0":
-        ["datasets", "huggingface_hub", "torch", "torchvision", "tensorflow", "accelerate", "setfit"]
+        [
+          "datasets",
+          "huggingface_hub",
+          "torch",
+          "torchvision",
+          "tensorflow",
+          "accelerate",
+          "setfit",
+          "optuna",
+        ]
     run: |
       pytest tests/statsmodels/test_transformers_autolog.py
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -59,7 +59,7 @@ pytorch-lightning:
 
   autologging:
     minimum: "1.0.5"
-    maximum: "2.0.2"
+    maximum: "2.0.1.post0"
     requirements:
       ">= 0.0.0": ["scikit-learn", "torchvision", "protobuf<4.0.0", "tensorboard"]
       "< 1.2.0": ["torch<1.11.0"]
@@ -175,7 +175,7 @@ catboost:
 
   models:
     minimum: "0.23.1"
-    maximum: "1.2"
+    maximum: "1.1.1"
     requirements:
       ">= 0.0.0": ["scikit-learn"]
     run: |
@@ -250,7 +250,7 @@ onnx:
 
   models:
     minimum: "1.7.0"
-    maximum: "1.14.0"
+    maximum: "1.13.1"
     requirements:
       ">= 0.0.0": ["onnxruntime", "torch", "scikit-learn", "protobuf<4.0.0"]
     run: |
@@ -279,7 +279,7 @@ statsmodels:
 
   models:
     minimum: "0.11.1"
-    maximum: "0.14.0"
+    maximum: "0.13.5"
     requirements:
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
     run: |
@@ -287,7 +287,7 @@ statsmodels:
 
   autologging:
     minimum: "0.11.1"
-    maximum: "0.14.0"
+    maximum: "0.13.5"
     requirements:
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
     run: |
@@ -430,7 +430,7 @@ h2o:
     pip_release: "h2o"
   models:
     minimum: "3.40.0.1"
-    maximum: "3.40.0.4"
+    maximum: "3.40.0.3"
     run: |
       pytest tests/h2o
 
@@ -495,7 +495,7 @@ openai:
       pip install git+https://github.com/openai/openai-python
   models:
     minimum: "0.27.2"
-    maximum: "0.27.6"
+    maximum: "0.27.4"
     requirements:
       ">= 0.0.0": ["pyspark", "tiktoken", "aiohttp", "tenacity"]
     run: |
@@ -510,7 +510,7 @@ langchain:
       pip install git+https://github.com/hwchase17/langchain
   models:
     minimum: "0.0.139"
-    maximum: "0.0.159"
+    maximum: "0.0.143"
     requirements:
       ">= 0.0.0": ["pyspark", "transformers", "tensorflow", "openai"]
     run: |

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -486,7 +486,7 @@ transformers:
           "optuna",
         ]
     run: |
-      pytest tests/statsmodels/test_transformers_autolog.py
+      pytest tests/transformers/test_transformers_autolog.py
 
 openai:
   package_info:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -59,7 +59,7 @@ pytorch-lightning:
 
   autologging:
     minimum: "1.0.5"
-    maximum: "2.0.1.post0"
+    maximum: "2.0.2"
     requirements:
       ">= 0.0.0": ["scikit-learn", "torchvision", "protobuf<4.0.0", "tensorboard"]
       "< 1.2.0": ["torch<1.11.0"]
@@ -175,7 +175,7 @@ catboost:
 
   models:
     minimum: "0.23.1"
-    maximum: "1.1.1"
+    maximum: "1.2"
     requirements:
       ">= 0.0.0": ["scikit-learn"]
     run: |
@@ -250,7 +250,7 @@ onnx:
 
   models:
     minimum: "1.7.0"
-    maximum: "1.13.1"
+    maximum: "1.14.0"
     requirements:
       ">= 0.0.0": ["onnxruntime", "torch", "scikit-learn", "protobuf<4.0.0"]
     run: |
@@ -279,7 +279,7 @@ statsmodels:
 
   models:
     minimum: "0.11.1"
-    maximum: "0.13.5"
+    maximum: "0.14.0"
     requirements:
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
     run: |
@@ -287,7 +287,7 @@ statsmodels:
 
   autologging:
     minimum: "0.11.1"
-    maximum: "0.13.5"
+    maximum: "0.14.0"
     requirements:
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
     run: |
@@ -430,7 +430,7 @@ h2o:
     pip_release: "h2o"
   models:
     minimum: "3.40.0.1"
-    maximum: "3.40.0.3"
+    maximum: "3.40.0.4"
     run: |
       pytest tests/h2o
 
@@ -470,6 +470,14 @@ transformers:
         ["datasets", "huggingface_hub", "torch", "torchvision", "tensorflow", "accelerate"]
     run: |
       pytest tests/transformers/test_transformers_model_export.py
+  autologging:
+    minimum: "4.25.1"
+    maximum: "4.28.1"
+    requirements:
+      ">= 0.0.0":
+        ["datasets", "huggingface_hub", "torch", "torchvision", "tensorflow", "accelerate", "setfit"]
+    run: |
+      pytest tests/statsmodels/test_transformers_autolog.py
 
 openai:
   package_info:
@@ -478,7 +486,7 @@ openai:
       pip install git+https://github.com/openai/openai-python
   models:
     minimum: "0.27.2"
-    maximum: "0.27.4"
+    maximum: "0.27.6"
     requirements:
       ">= 0.0.0": ["pyspark", "tiktoken", "aiohttp", "tenacity"]
     run: |
@@ -493,7 +501,7 @@ langchain:
       pip install git+https://github.com/hwchase17/langchain
   models:
     minimum: "0.0.139"
-    maximum: "0.0.143"
+    maximum: "0.0.159"
     requirements:
       ">= 0.0.0": ["pyspark", "transformers", "tensorflow", "openai"]
     run: |

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -225,6 +225,10 @@ _ML_PACKAGE_VERSIONS = {
         "models": {
             "minimum": "4.25.1",
             "maximum": "4.28.1"
+        },
+        "autologging": {
+            "minimum": "4.25.1",
+            "maximum": "4.28.1"
         }
     },
     "openai": {

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1726,6 +1726,7 @@ def autolog(
         sklearn,
         fastai,
         pytorch,
+        transformers,
     )
 
     locals_copy = locals().items()
@@ -1745,6 +1746,8 @@ def autolog(
         # TODO: Broaden this beyond pytorch_lightning as we add autologging support for more
         # Pytorch frameworks under mlflow.pytorch.autolog
         "pytorch_lightning": pytorch.autolog,
+        "setfit": transformers.autolog,
+        "transformers": transformers.autolog,
     }
 
     def get_autologging_params(autolog_fn):

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -21,6 +21,7 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.types.schema import Schema, ColSpec
 from mlflow.types.utils import _validate_input_dictionary_contains_only_strings_and_lists_of_strings
 from mlflow.utils.annotations import experimental
+from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 from mlflow.utils.docstring_utils import (
     format_docstring,
     LOG_MODEL_PARAM_DOCS,
@@ -1998,3 +1999,21 @@ class _TransformersWrapper:
                 else:
                     parsed_data.append(entry)
             return parsed_data
+
+
+@autologging_integration(FLAVOR_NAME)
+def autolog():
+
+    try:
+        import transformers
+    except ImportError:
+        pass
+
+    # patch Trainer
+
+    # patch the SetFitTrainer
+
+    # TODO: create the patched train functions
+
+    # TODO: investigate any other ways of initiating training and ensure that we patch those too!
+    pass

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -2022,7 +2022,7 @@ def autolog(
     # A list of other flavors whose base autologging config would be automatically logged due to
     # training a model that would otherwise create a run and be logged internally within the
     # transformers-supported trainer calls.
-    DISABLED_ANCILLARY_FLAVOR_AUTOLOGGING = ["sklearn"]
+    DISABLED_ANCILLARY_FLAVOR_AUTOLOGGING = ["sklearn", "tensorflow", "pytorch"]
 
     def train(original, *args, **kwargs):
         with mlflow.utils.autologging_utils.disable_discrete_autologging(

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -1,4 +1,5 @@
 import ast
+import contextlib
 import json
 import logging
 import pathlib
@@ -2030,22 +2031,18 @@ def autolog(
         ):
             return original(*args, **kwargs)
 
-    try:
+    with contextlib.suppress(ImportError):
         import setfit
 
         safe_patch(
             FLAVOR_NAME, setfit.SetFitTrainer, "train", functools.partial(train), manage_run=False
         )
-    except ImportError:
-        pass
 
-    try:
+    with contextlib.suppress(ImportError):
         import transformers
 
         classes = [transformers.Trainer, transformers.Seq2SeqTrainer]
-        methods = ["train", "hyperparameter_search"]
+        methods = ["train"]
         for clazz in classes:
             for method in methods:
                 safe_patch(FLAVOR_NAME, clazz, method, functools.partial(train), manage_run=False)
-    except ImportError:
-        pass

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -477,15 +477,15 @@ def disable_autologging():
 
 
 @contextlib.contextmanager
-def disable_discrete_autologging(flavors_to_disable: List[str]):
+def disable_discrete_autologging(flavors_to_disable: List[str]) -> None:
     """
     Context manager for disabling specific autologging integrations temporarily while another
     flavor's autologging is activated. This context wrapper is useful in the event that, for
     example, a particular library calls upon another library within a training API that has a
     current MLflow autologging integration.
     For instance, the transformers library's Trainer class, when running metric scoring,
-    builds an sklearn model and runs evaluations as part of its accuracy scoring. Without this
-    temporary autologging disabling, a new run will be generated that contains an sklearn model
+    builds a sklearn model and runs evaluations as part of its accuracy scoring. Without this
+    temporary autologging disabling, a new run will be generated that contains a sklearn model
     that holds no use for tracking purposes as it is only used during the metric evaluation phase
     of training.
     :param flavors_to_disable: A list of flavors that need to be temporarily disabled while

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -498,7 +498,7 @@ def disable_discrete_autologging(flavors_to_disable: List[str]) -> None:
             enabled_flavors.append(flavor)
             autolog_func = getattr(mlflow, flavor)
             autolog_func.autolog(disable=True)
-    yield None
+    yield
     for flavor in enabled_flavors:
         autolog_func = getattr(mlflow, flavor)
         autolog_func.autolog(disable=False)

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -492,18 +492,16 @@ def disable_discrete_autologging(flavors_to_disable: List[str]) -> None:
                                executing another flavor's autologging to prevent spurious run
                                logging of unrelated models, metrics, and parameters.
     """
-    existing_states = {
-        module: mlflow.utils.autologging_utils.get_autologging_config(module, "disable")
-        for module in flavors_to_disable
-    }
+    enabled_flavors = []
     for flavor in flavors_to_disable:
-        autolog_func = getattr(mlflow, flavor)
-        autolog_func.autolog(disable=True)
-    yield None
-    for flavor, state in existing_states.items():
-        if state is not None and not state:
+        if not autologging_is_disabled(flavor):
+            enabled_flavors.append(flavor)
             autolog_func = getattr(mlflow, flavor)
-            autolog_func.autolog(disable=False)
+            autolog_func.autolog(disable=True)
+    yield None
+    for flavor in enabled_flavors:
+        autolog_func = getattr(mlflow, flavor)
+        autolog_func.autolog(disable=False)
 
 
 def _get_new_training_session_class():

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -48,6 +48,7 @@ diviner
 # Required by mlflow.transformers
 transformers
 sentencepiece
+setfit
 # Required by mlflow.openai
 openai
 tiktoken

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -747,6 +747,10 @@ _module_version_info_dict_patch = {
         "package_info": {"pip_release": "pyspark"},
         "autologging": {"minimum": "3.0.1", "maximum": "3.1.1"},
     },
+    "transformers": {
+        "package_info": {"pip_release": "transformers"},
+        "autologging": {"minimum": "1.25.1", "maximum": "1.28.1"}
+    }
 }
 
 
@@ -777,6 +781,8 @@ _module_version_info_dict_patch = {
         ("pytorch", "1.5.99", False),
         ("pyspark.ml", "3.1.0", True),
         ("pyspark.ml", "3.0.0", False),
+        ("transformers", "1.28.1", True),
+        ("transformers", "1.1.1", False),
     ],
 )
 @mock.patch(

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -749,8 +749,8 @@ _module_version_info_dict_patch = {
     },
     "transformers": {
         "package_info": {"pip_release": "transformers"},
-        "autologging": {"minimum": "1.25.1", "maximum": "1.28.1"}
-    }
+        "autologging": {"minimum": "1.25.1", "maximum": "1.28.1"},
+    },
 }
 
 

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -21,6 +21,8 @@ import mxnet.gluon
 import pyspark
 import pyspark.ml
 import pytorch_lightning
+import transformers
+import setfit
 
 from tests.autologging.fixtures import test_mode_off, test_mode_on
 from tests.autologging.fixtures import reset_stderr  # pylint: disable=unused-import
@@ -36,6 +38,8 @@ library_to_mlflow_module_without_spark_datasource = {
     mxnet.gluon: mlflow.gluon,
     pyspark.ml: mlflow.pyspark.ml,
     pytorch_lightning: mlflow.pytorch,
+    transformers: mlflow.transformers,
+    setfit: mlflow.transformers,
 }
 
 library_to_mlflow_module = {

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -7,7 +7,6 @@ from sentence_transformers.losses import CosineSimilarityLoss
 from setfit import SetFitModel, SetFitTrainer, sample_dataset
 
 
-
 def test_with_autolog():
     mlflow.autolog()
 

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -11,6 +11,8 @@ from setfit import SetFitModel, SetFitTrainer, sample_dataset
 def test_with_autolog():
     mlflow.autolog()
 
+    # mlflow.sklearn.autolog(disable=True)
+
     dataset = load_dataset("sst2")
 
     train_dataset = sample_dataset(dataset["train"], label_column="label", num_samples=8)
@@ -44,3 +46,6 @@ def test_with_autolog():
     print(preds)
 
 
+# TODO: just patch the Trainer object's .train() method and add it to the list of autologging
+#  entries. Within that patch, disable tensorflow, pytorch, and sklearn autologging so that we're
+#  not logging models that we don't care about.

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -1,17 +1,34 @@
 import pytest
+import numpy as np
+import random
 
 import mlflow
+from mlflow import MlflowException
 
 from datasets import load_dataset
+import optuna
 from sentence_transformers.losses import CosineSimilarityLoss
 from setfit import SetFitModel, SetFitTrainer, sample_dataset
+import sklearn
+import sklearn.cluster
+import torch
+from transformers import (
+    Trainer,
+    DistilBertTokenizerFast,
+    DistilBertForSequenceClassification,
+    TrainingArguments,
+    pipeline,
+)
 
 
-def test_with_autolog():
-    mlflow.autolog()
+@pytest.fixture()
+def iris_data():
+    iris = sklearn.datasets.load_iris()
+    return iris.data[:, :2], iris.target
 
-    # mlflow.sklearn.autolog(disable=True)
 
+@pytest.fixture()
+def setfit_trainer():
     dataset = load_dataset("sst2")
 
     train_dataset = sample_dataset(dataset["train"], label_column="label", num_samples=8)
@@ -19,32 +36,476 @@ def test_with_autolog():
 
     model = SetFitModel.from_pretrained("sentence-transformers/paraphrase-mpnet-base-v2")
 
-    # Create trainer
-    trainer = SetFitTrainer(
+    return SetFitTrainer(
         model=model,
         train_dataset=train_dataset,
         eval_dataset=eval_dataset,
         loss_class=CosineSimilarityLoss,
         metric="accuracy",
         batch_size=16,
-        num_iterations=20,  # The number of text pairs to generate for contrastive learning
-        num_epochs=1,  # The number of epochs to use for contrastive learning
-        column_mapping={"sentence": "text", "label": "label"}
-        # Map dataset columns to text/label expected by trainer
+        num_iterations=20,
+        num_epochs=1,
+        column_mapping={"sentence": "text", "label": "label"},
     )
 
-    # Train and evaluate
-    trainer.train()
-    metrics = trainer.evaluate()
 
-    print(metrics)
+@pytest.fixture()
+def transformers_trainer(tmp_path):
+    random.seed(8675309)
+    np.random.seed(8675309)
+    torch.manual_seed(8675309)
+
+    tokenizer = DistilBertTokenizerFast.from_pretrained("distilbert-base-uncased")
+    model = DistilBertForSequenceClassification.from_pretrained(
+        "distilbert-base-uncased", num_labels=2
+    )
+
+    train_texts = ["I love this product!", "This is terrible."]
+    train_labels = [1, 0]
+
+    train_encodings = tokenizer(train_texts, truncation=True, padding=True)
+
+    class CustomDataset(torch.utils.data.Dataset):
+        def __init__(self, encodings, labels):
+            self.encodings = encodings
+            self.labels = labels
+
+        def __getitem__(self, idx):
+            item = {key: torch.tensor(val[idx]) for key, val in self.encodings.items()}
+            item["labels"] = torch.tensor(self.labels[idx])
+            return item
+
+        def __len__(self):
+            return len(self.labels)
+
+    train_dataset = CustomDataset(train_encodings, train_labels)
+
+    training_args = TrainingArguments(
+        output_dir=str(tmp_path.joinpath("results")),
+        num_train_epochs=1,
+        per_device_train_batch_size=4,
+        logging_dir=str(tmp_path.joinpath("logs")),
+    )
+
+    return Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_dataset,
+    )
+
+
+@pytest.fixture()
+def transformers_hyperparameter_trainer(tmp_path):
+    random.seed(555)
+    np.random.seed(555)
+    torch.manual_seed(555)
+
+    tokenizer = DistilBertTokenizerFast.from_pretrained("distilbert-base-uncased")
+    model = DistilBertForSequenceClassification.from_pretrained(
+        "distilbert-base-uncased", num_labels=2
+    )
+
+    train_texts = ["I love this product!", "This is terrible."]
+    train_labels = [1, 0]
+
+    train_encodings = tokenizer(train_texts, truncation=True, padding=True)
+
+    class CustomDataset(torch.utils.data.Dataset):
+        def __init__(self, encodings, labels):
+            self.encodings = encodings
+            self.labels = labels
+
+        def __getitem__(self, idx):
+            item = {key: torch.tensor(val[idx]) for key, val in self.encodings.items()}
+            item["labels"] = torch.tensor(self.labels[idx])
+            return item
+
+        def __len__(self):
+            return len(self.labels)
+
+    train_dataset = CustomDataset(train_encodings, train_labels)
+
+    def model_init():
+        return DistilBertForSequenceClassification.from_pretrained(
+            "distilbert-base-uncased", num_labels=2
+        )
+
+    def objective(trial):
+        learning_rate = trial.suggest_float("learning_rate", 1e-7, 1e-1, log=True)
+
+        training_args = TrainingArguments(
+            output_dir=str(tmp_path.joinpath("results")),
+            num_train_epochs=1,
+            per_device_train_batch_size=4,
+            learning_rate=learning_rate,
+            logging_dir=str(tmp_path.joinpath("logs")),
+            report_to="none",
+        )
+
+        trainer = Trainer(
+            model_init=model_init,
+            args=training_args,
+            train_dataset=train_dataset,
+        )
+
+        train_result = trainer.train()
+        return train_result.training_loss
+
+    study = optuna.create_study(direction="minimize")
+    study.optimize(objective, n_trials=2)
+
+    best_params = study.best_params
+
+    best_training_args = TrainingArguments(
+        output_dir=str(tmp_path.joinpath("results")),
+        num_train_epochs=3,
+        per_device_train_batch_size=4,
+        learning_rate=best_params["learning_rate"],
+        logging_dir=str(tmp_path.joinpath("logs")),
+    )
+
+    return Trainer(
+        model=model,
+        args=best_training_args,
+        train_dataset=train_dataset,
+    )
+
+
+@pytest.fixture()
+def transformers_hyperparameter_functional(tmp_path):
+    random.seed(555)
+    np.random.seed(555)
+    torch.manual_seed(555)
+
+    tokenizer = DistilBertTokenizerFast.from_pretrained("distilbert-base-uncased")
+
+    train_texts = [
+        "I simply adore artisinal baked goods!",
+        "I thoroughly dislike artisinal bathroom cleaning.",
+    ]
+    train_labels = [1, 0]
+    eval_texts = [
+        "It was an excellent experience.",
+        "I'd rather pick my teeth with a rusty pitchfork.",
+    ]
+    eval_labels = [1, 0]
+
+    train_encodings = tokenizer(train_texts, truncation=True, padding=True)
+    eval_encodings = tokenizer(eval_texts, truncation=True, padding=True)
+
+    class CustomDataset(torch.utils.data.Dataset):
+        def __init__(self, encodings, labels):
+            self.encodings = encodings
+            self.labels = labels
+
+        def __getitem__(self, idx):
+            item = {key: torch.tensor(val[idx]) for key, val in self.encodings.items()}
+            item["labels"] = torch.tensor(self.labels[idx])
+            return item
+
+        def __len__(self):
+            return len(self.labels)
+
+    train_dataset = CustomDataset(train_encodings, train_labels)
+    eval_dataset = CustomDataset(eval_encodings, eval_labels)
+
+    training_args = TrainingArguments(
+        output_dir=str(tmp_path.joinpath("results")),
+        num_train_epochs=1,
+        per_device_train_batch_size=4,
+        logging_dir=str(tmp_path.joinpath("logs")),
+        report_to="none",
+    )
+
+    def model_init():
+        return DistilBertForSequenceClassification.from_pretrained(
+            "distilbert-base-uncased", num_labels=2
+        )
+
+    trainer = Trainer(
+        model_init=model_init,
+        args=training_args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+    )
+
+    def my_hp_space_optuna(trial):
+        return {
+            "learning_rate": trial.suggest_float("learning_rate", 1e-5, 1e-1, log=True),
+        }
+
+    best_run = trainer.hyperparameter_search(
+        hp_space=my_hp_space_optuna,
+        backend="optuna",
+        n_trials=2,
+        direction="minimize",
+    )
+
+    best_training_args = TrainingArguments(
+        output_dir=str(tmp_path.joinpath("best_results")),
+        num_train_epochs=1,
+        per_device_train_batch_size=4,
+        learning_rate=best_run.hyperparameters["learning_rate"],
+        logging_dir=str(tmp_path.joinpath("best_logs")),
+    )
+
+    return Trainer(
+        model=model_init(),
+        args=best_training_args,
+        train_dataset=train_dataset,
+    )
+
+
+def test_setfit_does_not_autolog(setfit_trainer):
+    mlflow.autolog()
+
+    setfit_trainer.train()
+
+    last_run = mlflow.last_active_run()
+    assert not last_run
+    preds = setfit_trainer.model(
+        ["Always carry a towel!", "The hobbits are going to Isengard", "What's tatoes, precious?"]
+    )
+    assert len(preds) == 3
+
+
+def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
+    mlflow.autolog()
+
+    transformers_trainer.train()
+
+    last_run = mlflow.last_active_run()
+    assert last_run.data.metrics is not None
+    assert last_run.data.params is not None
+
+    pipe = pipeline(
+        task="text-classification",
+        model=transformers_trainer.model,
+        tokenizer=DistilBertTokenizerFast.from_pretrained("distilbert-base-uncased"),
+    )
+    assert pipe("This is wonderful!")[0]["label"] == "LABEL_1"
+
+
+def test_transformers_autolog_adheres_to_global_behavior_using_setfit(setfit_trainer):
+    mlflow.transformers.autolog(disable=False)
+
+    setfit_trainer.train()
+    # setfit does not have an MLflow callback. There should be no active run.
+    with pytest.raises(MlflowException, match="Run with id"):
+        mlflow.last_active_run()
+    preds = setfit_trainer.model(["Jim, I'm a doctor, not an archaeologist!"])
+    assert len(preds) == 1
+
+
+def test_transformers_autolog_adheres_to_global_behavior_using_trainer(transformers_trainer):
+    mlflow.transformers.autolog()
+
+    transformers_trainer.train()
+
+    last_run = mlflow.last_active_run()
+    assert last_run.data.metrics is not None
+    assert last_run.data.params is not None
+
+    pipe = pipeline(
+        task="text-classification",
+        model=transformers_trainer.model,
+        tokenizer=DistilBertTokenizerFast.from_pretrained("distilbert-base-uncased"),
+    )
+    preds = pipe(["This is pretty ok, I guess", "I came here to chew bubblegum"])
+    assert len(preds) == 2
+    assert all(x["score"] > 0 for x in preds)
+
+
+def test_active_autolog_no_setfit_logging_followed_by_successful_sklearn_autolog(
+    iris_data, setfit_trainer
+):
+    mlflow.autolog()
+
+    exp_id = mlflow.create_experiment("setfit_with_sklearn")
+
+    # Train and evaluate
+    setfit_trainer.train()
+    metrics = setfit_trainer.evaluate()
+    assert metrics["accuracy"] > 0
 
     # Run inference
-    preds = trainer.model(["i loved the spiderman movie!", "pineapple on pizza is the worst 🤮"])
+    preds = setfit_trainer.model(
+        [
+            "i loved the new Star Trek show!",
+            "That burger was gross; it tasted like it was made from cat food!",
+        ]
+    )
+    assert len(preds) == 2
 
-    print(preds)
+    # Test that autologging works for a simple sklearn model (local disabling functions)
+    with mlflow.start_run(experiment_id=exp_id) as run:
+        model = sklearn.cluster.KMeans()
+        X, y = iris_data
+        model.fit(X, y)
+
+    logged_sklearn_data = mlflow.get_run(run.info.run_id)
+    assert logged_sklearn_data.data.tags["estimator_name"] == "KMeans"
+
+    # Assert only the sklearn KMeans model was logged to the experiment
+
+    client = mlflow.MlflowClient()
+    runs = client.search_runs([exp_id])
+    assert len(runs) == 1
+    assert runs[0].info == logged_sklearn_data.info
 
 
-# TODO: just patch the Trainer object's .train() method and add it to the list of autologging
-#  entries. Within that patch, disable tensorflow, pytorch, and sklearn autologging so that we're
-#  not logging models that we don't care about.
+def test_active_autolog_allows_subsequent_sklearn_autolog(iris_data, transformers_trainer):
+    mlflow.autolog()
+
+    exp_id = mlflow.create_experiment("trainer_with_sklearn")
+
+    transformers_trainer.train()
+
+    last_run = mlflow.last_active_run()
+    assert last_run.data.metrics is not None
+    assert last_run.data.params is not None
+
+    pipe = pipeline(
+        task="text-classification",
+        model=transformers_trainer.model,
+        tokenizer=DistilBertTokenizerFast.from_pretrained("distilbert-base-uncased"),
+    )
+    preds = pipe(["This is pretty ok, I guess", "I came here to chew bubblegum"])
+    assert len(preds) == 2
+    assert all(x["score"] > 0 for x in preds)
+
+    with mlflow.start_run(experiment_id=exp_id) as run:
+        model = sklearn.cluster.KMeans()
+        X, y = iris_data
+        model.fit(X, y)
+
+    logged_sklearn_data = mlflow.get_run(run.info.run_id)
+    assert logged_sklearn_data.data.tags["estimator_name"] == "KMeans"
+
+    # Assert only the sklearn KMeans model was logged to the experiment
+
+    client = mlflow.MlflowClient()
+    runs = client.search_runs([exp_id])
+    assert len(runs) == 1
+    assert runs[0].info == logged_sklearn_data.info
+
+
+def test_disabled_sklearn_autologging_does_not_revert_to_enabled_with_setfit(
+    iris_data, setfit_trainer
+):
+    mlflow.autolog()
+    mlflow.sklearn.autolog(disable=True)
+
+    exp_id = mlflow.create_experiment("setfit_with_sklearn_no_autologging")
+
+    # Train and evaluate
+    setfit_trainer.train()
+    metrics = setfit_trainer.evaluate()
+    assert metrics["accuracy"] > 0
+
+    # Run inference
+    preds = setfit_trainer.model(
+        [
+            "i loved the new Star Trek show!",
+            "That burger was gross; it tasted like it was made from cat food!",
+        ]
+    )
+    assert len(preds) == 2
+
+    # Test that autologging does not log since it is manually disabled above.
+    with mlflow.start_run(experiment_id=exp_id) as run:
+        model = sklearn.cluster.KMeans()
+        X, y = iris_data
+        model.fit(X, y)
+
+    # Assert that only the run info is logged
+    logged_sklearn_data = mlflow.get_run(run.info.run_id)
+
+    assert not logged_sklearn_data.data.params
+    assert not logged_sklearn_data.data.metrics
+
+    client = mlflow.MlflowClient()
+    runs = client.search_runs([exp_id])
+
+    assert len(runs) == 1
+    assert runs[0].info == logged_sklearn_data.info
+
+
+def test_disable_sklearn_autologging_does_not_revert_with_trainer(iris_data, transformers_trainer):
+    mlflow.autolog()
+    mlflow.sklearn.autolog(disable=True)
+
+    exp_id = mlflow.create_experiment("trainer_with_sklearn")
+
+    transformers_trainer.train()
+
+    last_run = mlflow.last_active_run()
+    assert last_run.data.metrics is not None
+    assert last_run.data.params is not None
+
+    pipe = pipeline(
+        task="text-classification",
+        model=transformers_trainer.model,
+        tokenizer=DistilBertTokenizerFast.from_pretrained("distilbert-base-uncased"),
+    )
+    preds = pipe(
+        ["Did you hear that guitar solo? Brilliant!", "That band should avoid playing live."]
+    )
+    assert len(preds) == 2
+    assert all(x["score"] > 0 for x in preds)
+
+    # Test that autologging does not log since it is manually disabled above.
+    with mlflow.start_run(experiment_id=exp_id) as run:
+        model = sklearn.cluster.KMeans()
+        X, y = iris_data
+        model.fit(X, y)
+
+    # Assert that only the run info is logged
+    logged_sklearn_data = mlflow.get_run(run.info.run_id)
+
+    assert not logged_sklearn_data.data.params
+    assert not logged_sklearn_data.data.metrics
+
+    client = mlflow.MlflowClient()
+    runs = client.search_runs([exp_id])
+
+    assert len(runs) == 1
+    assert runs[0].info == logged_sklearn_data.info
+
+
+def test_trainer_hyperparameter_tuning_does_not_log_sklearn_model(
+    transformers_hyperparameter_trainer,
+):
+    mlflow.autolog()
+
+    transformers_hyperparameter_trainer.train()
+
+    last_run = mlflow.last_active_run()
+    assert last_run.data.metrics is not None
+    assert last_run.data.params is not None
+
+    pipe = pipeline(
+        task="text-classification",
+        model=transformers_hyperparameter_trainer.model,
+        tokenizer=DistilBertTokenizerFast.from_pretrained("distilbert-base-uncased"),
+    )
+    assert pipe("This is wonderful!")[0]["label"] == "LABEL_1"
+
+
+def test_trainer_hyperparameter_tuning_functional_does_not_log_sklearn_model(
+    transformers_hyperparameter_functional,
+):
+    mlflow.autolog()
+
+    transformers_hyperparameter_functional.train()
+
+    last_run = mlflow.last_active_run()
+    assert last_run.data.metrics is not None
+    assert last_run.data.params is not None
+
+    pipe = pipeline(
+        task="text-classification",
+        model=transformers_hyperparameter_functional.model,
+        tokenizer=DistilBertTokenizerFast.from_pretrained("distilbert-base-uncased"),
+    )
+    assert pipe("This is wonderful!")[0]["label"] == "LABEL_1"

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -270,13 +270,15 @@ def test_setfit_does_not_autolog(setfit_trainer):
 
 
 def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
-    mlflow.autolog()
+    mlflow.sklearn.autolog()
+
+    exp = mlflow.set_experiment(experiment_name="trainer_autolog_test")
 
     transformers_trainer.train()
 
     last_run = mlflow.last_active_run()
-    assert last_run.data.metrics is not None
-    assert last_run.data.params is not None
+    assert last_run.data.metrics["epoch"] == 1.0
+    assert last_run.data.params["_name_or_path"] == "distilbert-base-uncased"
 
     pipe = pipeline(
         task="text-classification",
@@ -284,6 +286,10 @@ def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
         tokenizer=DistilBertTokenizerFast.from_pretrained("distilbert-base-uncased"),
     )
     assert len(pipe("This is wonderful!")[0]["label"]) > 5  # Checking for 'LABEL_0' or 'LABEL_1'
+
+    client = mlflow.MlflowClient()
+    runs = client.search_runs([exp.experiment_id])
+    assert len(runs) == 1
 
 
 def test_transformers_autolog_adheres_to_global_behavior_using_setfit(setfit_trainer):
@@ -300,11 +306,13 @@ def test_transformers_autolog_adheres_to_global_behavior_using_setfit(setfit_tra
 def test_transformers_autolog_adheres_to_global_behavior_using_trainer(transformers_trainer):
     mlflow.transformers.autolog()
 
+    exp = mlflow.set_experiment(experiment_name="autolog_with_trainer")
+
     transformers_trainer.train()
 
     last_run = mlflow.last_active_run()
-    assert last_run.data.metrics is not None
-    assert last_run.data.params is not None
+    assert last_run.data.metrics["epoch"] == 1.0
+    assert last_run.data.params["model_type"] == "distilbert"
 
     pipe = pipeline(
         task="text-classification",
@@ -315,13 +323,17 @@ def test_transformers_autolog_adheres_to_global_behavior_using_trainer(transform
     assert len(preds) == 2
     assert all(x["score"] > 0 for x in preds)
 
+    client = mlflow.MlflowClient()
+    runs = client.search_runs([exp.experiment_id])
+    assert len(runs) == 1
+
 
 def test_active_autolog_no_setfit_logging_followed_by_successful_sklearn_autolog(
     iris_data, setfit_trainer
 ):
     mlflow.autolog()
 
-    exp_id = mlflow.create_experiment("setfit_with_sklearn")
+    exp = mlflow.set_experiment(experiment_name="setfit_with_sklearn")
 
     # Train and evaluate
     setfit_trainer.train()
@@ -338,7 +350,7 @@ def test_active_autolog_no_setfit_logging_followed_by_successful_sklearn_autolog
     assert len(preds) == 2
 
     # Test that autologging works for a simple sklearn model (local disabling functions)
-    with mlflow.start_run(experiment_id=exp_id) as run:
+    with mlflow.start_run(experiment_id=exp.experiment_id) as run:
         model = sklearn.cluster.KMeans()
         X, y = iris_data
         model.fit(X, y)
@@ -349,7 +361,7 @@ def test_active_autolog_no_setfit_logging_followed_by_successful_sklearn_autolog
     # Assert only the sklearn KMeans model was logged to the experiment
 
     client = mlflow.MlflowClient()
-    runs = client.search_runs([exp_id])
+    runs = client.search_runs([exp.experiment_id])
     assert len(runs) == 1
     assert runs[0].info == logged_sklearn_data.info
 
@@ -357,13 +369,13 @@ def test_active_autolog_no_setfit_logging_followed_by_successful_sklearn_autolog
 def test_active_autolog_allows_subsequent_sklearn_autolog(iris_data, transformers_trainer):
     mlflow.autolog()
 
-    exp_id = mlflow.create_experiment("trainer_with_sklearn")
+    exp = mlflow.set_experiment(experiment_name="trainer_with_sklearn")
 
     transformers_trainer.train()
 
     last_run = mlflow.last_active_run()
-    assert last_run.data.metrics is not None
-    assert last_run.data.params is not None
+    assert last_run.data.metrics["epoch"] == 1.0
+    assert last_run.data.params["model_type"] == "distilbert"
 
     pipe = pipeline(
         task="text-classification",
@@ -374,7 +386,7 @@ def test_active_autolog_allows_subsequent_sklearn_autolog(iris_data, transformer
     assert len(preds) == 2
     assert all(x["score"] > 0 for x in preds)
 
-    with mlflow.start_run(experiment_id=exp_id) as run:
+    with mlflow.start_run(experiment_id=exp.experiment_id) as run:
         model = sklearn.cluster.KMeans()
         X, y = iris_data
         model.fit(X, y)
@@ -385,9 +397,10 @@ def test_active_autolog_allows_subsequent_sklearn_autolog(iris_data, transformer
     # Assert only the sklearn KMeans model was logged to the experiment
 
     client = mlflow.MlflowClient()
-    runs = client.search_runs([exp_id])
-    assert len(runs) == 1
-    assert runs[0].info == logged_sklearn_data.info
+    runs = client.search_runs([exp.experiment_id])
+    assert len(runs) == 2
+    sklearn_run = [x for x in runs if x.info.run_id == run.info.run_id]
+    assert sklearn_run[0].info == logged_sklearn_data.info
 
 
 def test_disabled_sklearn_autologging_does_not_revert_to_enabled_with_setfit(
@@ -396,7 +409,7 @@ def test_disabled_sklearn_autologging_does_not_revert_to_enabled_with_setfit(
     mlflow.autolog()
     mlflow.sklearn.autolog(disable=True)
 
-    exp_id = mlflow.create_experiment("setfit_with_sklearn_no_autologging")
+    exp = mlflow.set_experiment(experiment_name="setfit_with_sklearn_no_autologging")
 
     # Train and evaluate
     setfit_trainer.train()
@@ -413,7 +426,7 @@ def test_disabled_sklearn_autologging_does_not_revert_to_enabled_with_setfit(
     assert len(preds) == 2
 
     # Test that autologging does not log since it is manually disabled above.
-    with mlflow.start_run(experiment_id=exp_id) as run:
+    with mlflow.start_run(experiment_id=exp.experiment_id) as run:
         model = sklearn.cluster.KMeans()
         X, y = iris_data
         model.fit(X, y)
@@ -421,13 +434,13 @@ def test_disabled_sklearn_autologging_does_not_revert_to_enabled_with_setfit(
     # Assert that only the run info is logged
     logged_sklearn_data = mlflow.get_run(run.info.run_id)
 
-    assert not logged_sklearn_data.data.params
-    assert not logged_sklearn_data.data.metrics
+    assert logged_sklearn_data.data.params == {}
+    assert logged_sklearn_data.data.metrics == {}
 
     client = mlflow.MlflowClient()
-    runs = client.search_runs([exp_id])
+    runs = client.search_runs([exp.experiment_id])
 
-    assert len(runs) == 1
+    assert len(runs) == 1  # SetFit should not create a run in the experiment
     assert runs[0].info == logged_sklearn_data.info
 
 
@@ -435,13 +448,13 @@ def test_disable_sklearn_autologging_does_not_revert_with_trainer(iris_data, tra
     mlflow.autolog()
     mlflow.sklearn.autolog(disable=True)
 
-    exp_id = mlflow.create_experiment("trainer_with_sklearn")
+    exp = mlflow.set_experiment(experiment_name="trainer_with_sklearn")
 
     transformers_trainer.train()
 
     last_run = mlflow.last_active_run()
-    assert last_run.data.metrics is not None
-    assert last_run.data.params is not None
+    assert last_run.data.metrics["epoch"] == 1.0
+    assert last_run.data.params["model_type"] == "distilbert"
 
     pipe = pipeline(
         task="text-classification",
@@ -455,7 +468,7 @@ def test_disable_sklearn_autologging_does_not_revert_with_trainer(iris_data, tra
     assert all(x["score"] > 0 for x in preds)
 
     # Test that autologging does not log since it is manually disabled above.
-    with mlflow.start_run(experiment_id=exp_id) as run:
+    with mlflow.start_run(experiment_id=exp.experiment_id) as run:
         model = sklearn.cluster.KMeans()
         X, y = iris_data
         model.fit(X, y)
@@ -463,14 +476,15 @@ def test_disable_sklearn_autologging_does_not_revert_with_trainer(iris_data, tra
     # Assert that only the run info is logged
     logged_sklearn_data = mlflow.get_run(run.info.run_id)
 
-    assert not logged_sklearn_data.data.params
-    assert not logged_sklearn_data.data.metrics
+    assert logged_sklearn_data.data.params == {}
+    assert logged_sklearn_data.data.metrics == {}
 
     client = mlflow.MlflowClient()
-    runs = client.search_runs([exp_id])
+    runs = client.search_runs([exp.experiment_id])
 
-    assert len(runs) == 1
-    assert runs[0].info == logged_sklearn_data.info
+    assert len(runs) == 2
+    sklearn_run = [x for x in runs if x.info.run_id == run.info.run_id]
+    assert sklearn_run[0].info == logged_sklearn_data.info
 
 
 def test_trainer_hyperparameter_tuning_does_not_log_sklearn_model(
@@ -478,11 +492,13 @@ def test_trainer_hyperparameter_tuning_does_not_log_sklearn_model(
 ):
     mlflow.autolog()
 
+    exp = mlflow.set_experiment(experiment_name="hyperparam_trainer")
+
     transformers_hyperparameter_trainer.train()
 
     last_run = mlflow.last_active_run()
-    assert last_run.data.metrics is not None
-    assert last_run.data.params is not None
+    assert last_run.data.metrics["epoch"] == 3.0
+    assert last_run.data.params["model_type"] == "distilbert"
 
     pipe = pipeline(
         task="text-classification",
@@ -491,17 +507,24 @@ def test_trainer_hyperparameter_tuning_does_not_log_sklearn_model(
     )
     assert len(pipe("This is wonderful!")[0]["label"]) > 5  # checking for 'LABEL_0' or 'LABEL_1'
 
+    client = mlflow.MlflowClient()
+    runs = client.search_runs([exp.experiment_id])
+
+    assert len(runs) == 1
+
 
 def test_trainer_hyperparameter_tuning_functional_does_not_log_sklearn_model(
     transformers_hyperparameter_functional,
 ):
     mlflow.autolog()
 
+    exp = mlflow.set_experiment(experiment_name="hyperparam_trainer_functional")
+
     transformers_hyperparameter_functional.train()
 
     last_run = mlflow.last_active_run()
-    assert last_run.data.metrics is not None
-    assert last_run.data.params is not None
+    assert last_run.data.metrics["epoch"] == 1.0
+    assert last_run.data.params["model_type"] == "distilbert"
 
     pipe = pipeline(
         task="text-classification",
@@ -509,3 +532,8 @@ def test_trainer_hyperparameter_tuning_functional_does_not_log_sklearn_model(
         tokenizer=DistilBertTokenizerFast.from_pretrained("distilbert-base-uncased"),
     )
     assert len(pipe("This is wonderful!")[0]["label"]) > 5  # checking for 'LABEL_0' or 'LABEL_1'
+
+    client = mlflow.MlflowClient()
+    runs = client.search_runs([exp.experiment_id])
+
+    assert len(runs) == 1

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -1,0 +1,7 @@
+import pytest
+
+import mlflow
+
+
+def test_with_autolog():
+    mlflow.autolog()

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -283,7 +283,7 @@ def test_transformers_trainer_does_not_autolog_sklearn(transformers_trainer):
         model=transformers_trainer.model,
         tokenizer=DistilBertTokenizerFast.from_pretrained("distilbert-base-uncased"),
     )
-    assert pipe("This is wonderful!")[0]["label"] == "LABEL_1"
+    assert len(pipe("This is wonderful!")[0]["label"]) > 5  # Checking for 'LABEL_0' or 'LABEL_1'
 
 
 def test_transformers_autolog_adheres_to_global_behavior_using_setfit(setfit_trainer):
@@ -489,7 +489,7 @@ def test_trainer_hyperparameter_tuning_does_not_log_sklearn_model(
         model=transformers_hyperparameter_trainer.model,
         tokenizer=DistilBertTokenizerFast.from_pretrained("distilbert-base-uncased"),
     )
-    assert pipe("This is wonderful!")[0]["label"] == "LABEL_1"
+    assert len(pipe("This is wonderful!")[0]["label"]) > 5  # checking for 'LABEL_0' or 'LABEL_1'
 
 
 def test_trainer_hyperparameter_tuning_functional_does_not_log_sklearn_model(
@@ -508,4 +508,4 @@ def test_trainer_hyperparameter_tuning_functional_does_not_log_sklearn_model(
         model=transformers_hyperparameter_functional.model,
         tokenizer=DistilBertTokenizerFast.from_pretrained("distilbert-base-uncased"),
     )
-    assert pipe("This is wonderful!")[0]["label"] == "LABEL_1"
+    assert len(pipe("This is wonderful!")[0]["label"]) > 5  # checking for 'LABEL_0' or 'LABEL_1'

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -2,6 +2,45 @@ import pytest
 
 import mlflow
 
+from datasets import load_dataset
+from sentence_transformers.losses import CosineSimilarityLoss
+from setfit import SetFitModel, SetFitTrainer, sample_dataset
+
+
 
 def test_with_autolog():
     mlflow.autolog()
+
+    dataset = load_dataset("sst2")
+
+    train_dataset = sample_dataset(dataset["train"], label_column="label", num_samples=8)
+    eval_dataset = dataset["validation"]
+
+    model = SetFitModel.from_pretrained("sentence-transformers/paraphrase-mpnet-base-v2")
+
+    # Create trainer
+    trainer = SetFitTrainer(
+        model=model,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        loss_class=CosineSimilarityLoss,
+        metric="accuracy",
+        batch_size=16,
+        num_iterations=20,  # The number of text pairs to generate for contrastive learning
+        num_epochs=1,  # The number of epochs to use for contrastive learning
+        column_mapping={"sentence": "text", "label": "label"}
+        # Map dataset columns to text/label expected by trainer
+    )
+
+    # Train and evaluate
+    trainer.train()
+    metrics = trainer.evaluate()
+
+    print(metrics)
+
+    # Run inference
+    preds = trainer.model(["i loved the spiderman movie!", "pineapple on pizza is the worst 🤮"])
+
+    print(preds)
+
+


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Disables autologging of sklearn models when transformers Trainer or SetFitTrainer trains. Without disabling this, the internal sklearn model that is created for evaluation purposes causes a new run to be created, the sklearn model logged, and useless parameters and metrics to be logged to this new run. 
This PR disables that logging.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

Local testing with multiple different training API paradigms.

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Training a transformers model with autologging turned on will no longer create a new run with the internal sklearn model used within the transformers Trainer object when the `train()` method is called.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
