### PR TITLE
Change Python lists to numpy arrays and add model signatures in documentation

### DIFF
--- a/examples/catboost/train.py
+++ b/examples/catboost/train.py
@@ -2,12 +2,14 @@
 # https://catboost.ai/docs/concepts/python-usages-examples.html#regression
 
 import mlflow
+from mlflow.models.signature import infer_signature
 from catboost import CatBoostRegressor
+import numpy as np
 
 # Initialize data
-train_data = [[1, 4, 5, 6], [4, 5, 6, 7], [30, 40, 50, 60]]
-train_labels = [10, 20, 30]
-eval_data = [[2, 4, 6, 8], [1, 4, 50, 60]]
+train_data = np.array([[1, 4, 5, 6], [4, 5, 6, 7], [30, 40, 50, 60]])
+train_labels = np.array([10, 20, 30])
+eval_data = np.array([[2, 4, 6, 8], [1, 4, 50, 60]])
 
 # Initialize CatBoostRegressor
 params = {
@@ -23,8 +25,9 @@ model.fit(train_data, train_labels)
 
 # Log parameters and fitted model
 with mlflow.start_run() as run:
+    signature = infer_signature(eval_data, model.predict(eval_data))
     mlflow.log_params(params)
-    mlflow.catboost.log_model(model, artifact_path="model")
+    mlflow.catboost.log_model(model, artifact_path="model", signature=signature)
     model_uri = mlflow.get_artifact_uri("model")
 
 # Load model

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -44,6 +44,8 @@ def register_model(
         :caption: Example
 
         import mlflow.sklearn
+        from mlflow.models.signature import infer_signature
+        from sklearn.datasets import make_regression
         from sklearn.ensemble import RandomForestRegressor
 
         mlflow.set_tracking_uri("sqlite:////tmp/mlruns.db")
@@ -51,9 +53,10 @@ def register_model(
 
         # Log MLflow entities
         with mlflow.start_run() as run:
-            rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+            rfr = RandomForestRegressor(**params).fit(X, y)
+            signature = infer_signature(X, rfr.predict(X))
             mlflow.log_params(params)
-            mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model")
+            mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
         model_uri = "runs:/{}/sklearn-model".format(run.info.run_id)
         mv = mlflow.register_model(model_uri, "RandomForestRegressionModel")

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -50,6 +50,7 @@ def register_model(
 
         mlflow.set_tracking_uri("sqlite:////tmp/mlruns.db")
         params = {"n_estimators": 3, "random_state": 42}
+        X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=False)
 
         # Log MLflow entities
         with mlflow.start_run() as run:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2658,7 +2658,7 @@ class MlflowClient:
             client.create_registered_model(name)
 
             # Create a new version of the rfr model under the registered model name
-            model_uri = "runs:/{}/models/sklearn-model".format(run.info.run_id)
+            model_uri = "runs:/{}/sklearn-model".format(run.info.run_id)
             mv = client.create_model_version(name, model_uri, run.info.run_id)
             artifact_uri = client.get_model_version_download_uri(name, mv.version)
             print("Download URI: {}".format(artifact_uri))
@@ -2666,7 +2666,7 @@ class MlflowClient:
         .. code-block:: text
             :caption: Output
 
-            Download URI: runs:/44e04097ac364cd895f2039eaccca9ac/models/sklearn-model
+            Download URI: runs:/027d7bbe81924c5a82b3e4ce979fcab7/sklearn-model
         """
         return self._get_registry_client().get_model_version_download_uri(name, version)
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2055,6 +2055,8 @@ class MlflowClient:
 
             import mlflow.sklearn
             from mlflow import MlflowClient
+            from mlflow.models.signature import infer_signature
+            from sklearn.datasets import make_regression
             from sklearn.ensemble import RandomForestRegressor
 
 
@@ -2067,19 +2069,22 @@ class MlflowClient:
 
 
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
+            X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=False)
 
             # Create two runs Log MLflow entities
             with mlflow.start_run() as run1:
                 params = {"n_estimators": 3, "random_state": 42}
-                rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+                rfr = RandomForestRegressor(**params).fit(X, y)
+                signature = infer_signature(X, rfr.predict(X))
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             with mlflow.start_run() as run2:
                 params = {"n_estimators": 6, "random_state": 42}
-                rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+                rfr = RandomForestRegressor(**params).fit(X, y)
+                signature = infer_signature(X, rfr.predict(X))
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             # Register model name in the model registry
             name = "RandomForestRegression"
@@ -2242,16 +2247,21 @@ class MlflowClient:
             import mlflow.sklearn
             from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
             from mlflow import MlflowClient
+            from mlflow.models.signature import infer_signature
+            from sklearn.datasets import make_regression
             from sklearn.ensemble import RandomForestRegressor
 
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
             params = {"n_estimators": 3, "random_state": 42}
             name = "RandomForestRegression"
-            rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+            X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=False)
+            rfr = RandomForestRegressor(**params).fit(X, y)
+            signature = infer_signature(X, rfr.predict(X))
+
             # Log MLflow entities
             with mlflow.start_run() as run:
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             # Register model name in the model registry
             client = MlflowClient()
@@ -2336,6 +2346,8 @@ class MlflowClient:
 
             import mlflow.sklearn
             from mlflow import MlflowClient
+            from mlflow.models.signature import infer_signature
+            from sklearn.datasets import make_regression
             from sklearn.ensemble import RandomForestRegressor
 
 
@@ -2348,12 +2360,14 @@ class MlflowClient:
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
             params = {"n_estimators": 3, "random_state": 42}
             name = "RandomForestRegression"
-            rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+            X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=False)
+            rfr = RandomForestRegressor(**params).fit(X, y)
+            signature = infer_signature(X, rfr.predict(X))
 
             # Log MLflow entities
             with mlflow.start_run() as run:
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             # Register model name in the model registry
             client = MlflowClient()
@@ -2408,6 +2422,8 @@ class MlflowClient:
 
             import mlflow.sklearn
             from mlflow import MlflowClient
+            from mlflow.models.signature import infer_signature
+            from sklearn.datasets import make_regression
             from sklearn.ensemble import RandomForestRegressor
 
 
@@ -2422,12 +2438,14 @@ class MlflowClient:
             params = {"n_estimators": 3, "random_state": 42}
             name = "RandomForestRegression"
             desc = "A new version of the model using ensemble trees"
-            rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+            X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=False)
+            rfr = RandomForestRegressor(**params).fit(X, y)
+            signature = infer_signature(X, rfr.predict(X))
 
             # Log MLflow entities
             with mlflow.start_run() as run:
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             # Register model name in the model registry
             client = MlflowClient()
@@ -2472,6 +2490,8 @@ class MlflowClient:
 
             import mlflow.sklearn
             from mlflow import MlflowClient
+            from mlflow.models.signature import infer_signature
+            from sklearn.datasets import make_regression
             from sklearn.ensemble import RandomForestRegressor
 
 
@@ -2484,19 +2504,22 @@ class MlflowClient:
 
 
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
+            X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=False)
 
             # Create two runs and log MLflow entities
             with mlflow.start_run() as run1:
                 params = {"n_estimators": 3, "random_state": 42}
-                rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+                rfr = RandomForestRegressor(**params).fit(X, y)
+                signature = infer_signature(X, rfr.predict(X))
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             with mlflow.start_run() as run2:
                 params = {"n_estimators": 6, "random_state": 42}
-                rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+                rfr = RandomForestRegressor(**params).fit(X, y)
+                signature = infer_signature(X, rfr.predict(X))
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             # Register model name in the model registry
             name = "RandomForestRegression"
@@ -2552,20 +2575,26 @@ class MlflowClient:
 
             import mlflow.sklearn
             from mlflow import MlflowClient
+            from mlflow.models.signature import infer_signature
+            from sklearn.datasets import make_regression
             from sklearn.ensemble import RandomForestRegressor
+
+            X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=False)
 
             # Create two runs Log MLflow entities
             with mlflow.start_run() as run1:
                 params = {"n_estimators": 3, "random_state": 42}
-                rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+                rfr = RandomForestRegressor(**params).fit(X, y)
+                signature = infer_signature(X, rfr.predict(X))
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             with mlflow.start_run() as run2:
                 params = {"n_estimators": 6, "random_state": 42}
-                rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+                rfr = RandomForestRegressor(**params).fit(X, y)
+                signature = infer_signature(X, rfr.predict(X))
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             # Register model name in the model registry
             name = "RandomForestRegression"
@@ -2581,7 +2610,8 @@ class MlflowClient:
 
             # Fetch the last version; this will be version 2
             mv = client.get_model_version(name, mv.version)
-            print_model_version_info(mv)
+            print("Name: {}".format(mv.name))
+            print("Version: {}".format(mv.version))
 
         .. code-block:: text
             :caption: Output
@@ -2607,17 +2637,21 @@ class MlflowClient:
 
             import mlflow.sklearn
             from mlflow import MlflowClient
+            from mlflow.models.signature import infer_signature
+            from sklearn.datasets import make_regression
             from sklearn.ensemble import RandomForestRegressor
 
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
             params = {"n_estimators": 3, "random_state": 42}
             name = "RandomForestRegression"
-            rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+            X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=False)
+            rfr = RandomForestRegressor(**params).fit(X, y)
+            signature = infer_signature(X, rfr.predict(X))
 
             # Log MLflow entities
             with mlflow.start_run() as run:
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="models/sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             # Register model name in the model registry
             client = MlflowClient()
@@ -2725,17 +2759,21 @@ class MlflowClient:
 
             import mlflow.sklearn
             from mlflow import MlflowClient
+            from mlflow.models.signature import infer_signature
+            from sklearn.datasets import make_regression
             from sklearn.ensemble import RandomForestRegressor
 
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
             params = {"n_estimators": 3, "random_state": 42}
             name = "RandomForestRegression"
-            rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+            X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=False)
+            rfr = RandomForestRegressor(**params).fit(X, y)
+            signature = infer_signature(X, rfr.predict(X))
 
             # Log MLflow entities
             with mlflow.start_run() as run:
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="models/sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             # Register model name in the model registry
             client = MlflowClient()
@@ -2775,6 +2813,8 @@ class MlflowClient:
 
             import mlflow.sklearn
             from mlflow import MlflowClient
+            from mlflow.models.signature import infer_signature
+            from sklearn.datasets import make_regression
             from sklearn.ensemble import RandomForestRegressor
 
 
@@ -2787,12 +2827,14 @@ class MlflowClient:
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
             params = {"n_estimators": 3, "random_state": 42}
             name = "RandomForestRegression"
-            rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+            X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=False)
+            rfr = RandomForestRegressor(**params).fit(X, y)
+            signature = infer_signature(X, rfr.predict(X))
 
             # Log MLflow entities
             with mlflow.start_run() as run:
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             # Register model name in the model registry
             client = MlflowClient()
@@ -2853,6 +2895,8 @@ class MlflowClient:
 
             import mlflow.sklearn
             from mlflow import MlflowClient
+            from mlflow.models.signature import infer_signature
+            from sklearn.datasets import make_regression
             from sklearn.ensemble import RandomForestRegressor
 
 
@@ -2865,12 +2909,14 @@ class MlflowClient:
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
             params = {"n_estimators": 3, "random_state": 42}
             name = "RandomForestRegression"
-            rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+            X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=False)
+            rfr = RandomForestRegressor(**params).fit(X, y)
+            signature = infer_signature(X, rfr.predict(X))
 
             # Log MLflow entities
             with mlflow.start_run() as run:
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             # Register model name in the model registry
             client = MlflowClient()
@@ -2924,6 +2970,8 @@ class MlflowClient:
 
             import mlflow
             from mlflow import MlflowClient
+            from mlflow.models.signature import infer_signature
+            from sklearn.datasets import make_regression
             from sklearn.ensemble import RandomForestRegressor
 
             def print_model_info(rm):
@@ -2940,12 +2988,14 @@ class MlflowClient:
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
             params = {"n_estimators": 3, "random_state": 42}
             name = "RandomForestRegression"
-            rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+            X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=False)
+            rfr = RandomForestRegressor(**params).fit(X, y)
+            signature = infer_signature(X, rfr.predict(X))
 
             # Log MLflow entities
             with mlflow.start_run() as run:
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             # Register model name in the model registry
             client = MlflowClient()
@@ -3001,6 +3051,8 @@ class MlflowClient:
 
             import mlflow
             from mlflow import MlflowClient
+            from mlflow.models.signature import infer_signature
+            from sklearn.datasets import make_regression
             from sklearn.ensemble import RandomForestRegressor
 
             def print_model_info(rm):
@@ -3017,12 +3069,14 @@ class MlflowClient:
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
             params = {"n_estimators": 3, "random_state": 42}
             name = "RandomForestRegression"
-            rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+            X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=False)
+            rfr = RandomForestRegressor(**params).fit(X, y)
+            signature = infer_signature(X, rfr.predict(X))
 
             # Log MLflow entities
             with mlflow.start_run() as run:
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             # Register model name in the model registry
             client = MlflowClient()
@@ -3091,6 +3145,8 @@ class MlflowClient:
 
             import mlflow
             from mlflow import MlflowClient
+            from mlflow.models.signature import infer_signature
+            from sklearn.datasets import make_regression
             from sklearn.ensemble import RandomForestRegressor
 
             def print_model_info(rm):
@@ -3107,12 +3163,14 @@ class MlflowClient:
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
             params = {"n_estimators": 3, "random_state": 42}
             name = "RandomForestRegression"
-            rfr = RandomForestRegressor(**params).fit([[0, 1]], [1])
+            X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=False)
+            rfr = RandomForestRegressor(**params).fit(X, y)
+            signature = infer_signature(X, rfr.predict(X))
 
             # Log MLflow entities
             with mlflow.start_run() as run:
                 mlflow.log_params(params)
-                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model")
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
             # Register model name in the model registry
             client = MlflowClient()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Many of our documentation examples train on Python lists, which prevents them from having valid model signatures. This PR migrates those examples to numpy arrays and then adds model signatures to them.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

Manually ran the examples to make sure they work.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
