### PR TITLE
Add support for setting torch_dtype in transformers pipelines

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2621,6 +2621,8 @@ A common configuration for lowering the total memory pressure for pytorch models
 processing data type. This is achieved through setting the ``torch_dtype`` argument when creating a ``Pipeline``.
 For a full reference of these tunable arguments for configuration of pipelines, see the `training docs <https://huggingface.co/docs/transformers/v4.28.1/en/perf_train_gpu_one#floating-data-types>`_ .
 
+.. note:: This feature does not exist in versions of ``transformers`` < 4.26.x
+
 In order to apply these configurations to a saved or logged run, there are two options:
 
 * Save a pipeline with the `torch_dtype` argument set to the encoding type of your choice.

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2654,24 +2654,24 @@ Example:
         )
 
     # Illustrate that the torch data type is recorded in the flavor configuration
-    model_info.flavors["transformers"]
+    print(model_info.flavors["transformers"])
 
 
 Result:
 
 .. code-block:: bash
 
-    $ {'transformers_version': '4.28.1',
-       'code': None,
-       'task': 'translation_en_to_fr',
-       'instance_type': 'TranslationPipeline',
-       'source_model_name': 't5-small',
-       'pipeline_model_type': 'T5ForConditionalGeneration',
-       'framework': 'pt',
-       'torch_dtype': 'torch.bfloat16',
-       'tokenizer_type': 'T5TokenizerFast',
-       'components': ['tokenizer'],
-       'pipeline': 'pipeline'}
+    {'transformers_version': '4.28.1',
+     'code': None,
+     'task': 'translation_en_to_fr',
+     'instance_type': 'TranslationPipeline',
+     'source_model_name': 't5-small',
+     'pipeline_model_type': 'T5ForConditionalGeneration',
+     'framework': 'pt',
+     'torch_dtype': 'torch.bfloat16',
+     'tokenizer_type': 'T5TokenizerFast',
+     'components': ['tokenizer'],
+     'pipeline': 'pipeline'}
 
 
 * Specify the `torch_dtype` argument when loading the model to override any values set during logging or saving.
@@ -2706,14 +2706,14 @@ Example:
         model_info.model_uri, return_type="pipeline", torch_dtype=torch.float64
     )
 
-    loaded_pipeline.torch_dtype
+    print(loaded_pipeline.torch_dtype)
 
 
 Result:
 
 .. code-block:: bash
 
-    $ torch.float64
+    torch.float64
 
 
 .. note:: Logging or saving a model in 'components' mode (using a dictionary to declare components) does not support setting the data type for a constructed pipeline.

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -892,7 +892,7 @@ def _deserialize_torch_dtype_if_exists(flavor_config):
         raise MlflowException(
             "The pipeline being loaded was saved with pytorch specific "
             "properties but the current environment does not have pytorch "
-            "installed. Please run 'pip install torch' before loading"
+            "installed. Please run 'pip install torch' before loading "
             "this model."
         ) from e
 
@@ -1051,9 +1051,7 @@ def _extract_torch_dtype_if_set(pipeline):
     """
     Extract the torch datatype argument if set and return as a string encoded value.
     """
-    torch_dtype = getattr(pipeline, _TORCH_DTYPE_KEY, None)
-
-    if torch_dtype:
+    if torch_dtype := getattr(pipeline, _TORCH_DTYPE_KEY, None):
         return str(torch_dtype)
 
 

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -52,31 +52,36 @@ from mlflow.utils.model_utils import (
 from mlflow.utils.requirements_utils import _get_pinned_requirement
 
 FLAVOR_NAME = "transformers"
-_PIPELINE_BINARY_KEY = "pipeline"
-_PIPELINE_BINARY_FILE_NAME = "pipeline"
-_COMPONENTS_BINARY_KEY = "components"
-_INFERENCE_CONFIG_BINARY_KEY = "inference_config.txt"
-_MODEL_KEY = "model"
-_TOKENIZER_KEY = "tokenizer"
-_FEATURE_EXTRACTOR_KEY = "feature_extractor"
-_IMAGE_PROCESSOR_KEY = "image_processor"
-_PROCESSOR_KEY = "processor"
-_TOKENIZER_TYPE_KEY = "tokenizer_type"
-_FEATURE_EXTRACTOR_TYPE_KEY = "feature_extractor_type"
-_IMAGE_PROCESSOR_TYPE_KEY = "image_processor_type"
-_PROCESSOR_TYPE_KEY = "processor_type"
+
 _CARD_TEXT_FILE_NAME = "model_card.md"
 _CARD_DATA_FILE_NAME = "model_card_data.yaml"
-_TASK_KEY = "task"
+_COMPONENTS_BINARY_KEY = "components"
+_FEATURE_EXTRACTOR_KEY = "feature_extractor"
+_FEATURE_EXTRACTOR_TYPE_KEY = "feature_extractor_type"
+_FRAMEWORK_KEY = "framework"
+_IMAGE_PROCESSOR_KEY = "image_processor"
+_IMAGE_PROCESSOR_TYPE_KEY = "image_processor_type"
+_INFERENCE_CONFIG_BINARY_KEY = "inference_config.txt"
 _INSTANCE_TYPE_KEY = "instance_type"
-_PIPELINE_MODEL_TYPE_KEY = "pipeline_model_type"
+_MODEL_KEY = "model"
 _MODEL_PATH_OR_NAME_KEY = "source_model_name"
-_SUPPORTED_SAVE_KEYS = {_MODEL_KEY, _TOKENIZER_KEY, _FEATURE_EXTRACTOR_KEY, _IMAGE_PROCESSOR_KEY}
+_PIPELINE_BINARY_KEY = "pipeline"
+_PIPELINE_BINARY_FILE_NAME = "pipeline"
+_PIPELINE_MODEL_TYPE_KEY = "pipeline_model_type"
+_PROCESSOR_KEY = "processor"
+_PROCESSOR_TYPE_KEY = "processor_type"
 _SUPPORTED_RETURN_TYPES = {"pipeline", "components"}
 # The default device id for CPU is -1 and GPU IDs are ordinal starting at 0, as documented here:
 # https://huggingface.co/transformers/v4.7.0/main_classes/pipelines.html
 _TRANSFORMERS_DEFAULT_CPU_DEVICE_ID = -1
 _TRANSFORMERS_DEFAULT_GPU_DEVICE_ID = 0
+_TASK_KEY = "task"
+_TOKENIZER_KEY = "tokenizer"
+_TOKENIZER_TYPE_KEY = "tokenizer_type"
+_TORCH_DTYPE_KEY = "torch_dtype"
+_METADATA_PIPELINE_SCALAR_CONFIG_KEYS = {_FRAMEWORK_KEY}
+_SUPPORTED_SAVE_KEYS = {_MODEL_KEY, _TOKENIZER_KEY, _FEATURE_EXTRACTOR_KEY, _IMAGE_PROCESSOR_KEY}
+
 _logger = logging.getLogger(__name__)
 
 
@@ -854,11 +859,42 @@ def _load_model(path: str, flavor_config, return_type: str, device=None, **kwarg
         component_type = flavor_config[component_type_key]
         conf[component_key] = _load_component(local_path, component_key, component_type)
 
+    if _TORCH_DTYPE_KEY in flavor_config:
+        conf[_TORCH_DTYPE_KEY] = _deserialize_torch_dtype_if_exists(flavor_config)
+
+    for key in _METADATA_PIPELINE_SCALAR_CONFIG_KEYS:
+        if key in flavor_config:
+            conf[key] = flavor_config[key]
+
     if return_type == "pipeline":
         conf.update(**kwargs)
         return transformers.pipeline(**conf)
     elif return_type == "components":
         return conf
+
+
+def _deserialize_torch_dtype_if_exists(flavor_config):
+    """
+    Convert the string-encoded `torch_dtype` pipeline argument back to the correct `torch.dtype`
+    instance value for applying to a loaded pipeline instance.
+    """
+
+    try:
+        import torch
+
+        dtype_mapping = {
+            str(dtype): dtype
+            for name, dtype in torch.__dict__.items()
+            if isinstance(dtype, torch.dtype)
+        }
+        return dtype_mapping[flavor_config["torch_dtype"]]
+    except ImportError as e:
+        raise MlflowException(
+            "The pipeline being loaded was saved with pytorch specific "
+            "properties but the current environment does not have pytorch "
+            "installed. Please run 'pip install torch' before loading"
+            "this model."
+        ) from e
 
 
 def _fetch_model_card(model_or_pipeline):
@@ -967,7 +1003,7 @@ def _load_component(root_path: pathlib.Path, component_key: str, component_type)
 
 
 def _generate_base_flavor_configuration(
-    model,
+    pipeline,
     task: str,
 ) -> Dict[str, str]:
     """
@@ -983,12 +1019,42 @@ def _generate_base_flavor_configuration(
 
     flavor_configuration = {
         _TASK_KEY: task,
-        _INSTANCE_TYPE_KEY: _get_instance_type(model),
-        _MODEL_PATH_OR_NAME_KEY: _get_base_model_architecture(model),
-        _PIPELINE_MODEL_TYPE_KEY: _get_instance_type(model.model),
+        _INSTANCE_TYPE_KEY: _get_instance_type(pipeline),
+        _MODEL_PATH_OR_NAME_KEY: _get_base_model_architecture(pipeline),
+        _PIPELINE_MODEL_TYPE_KEY: _get_instance_type(pipeline.model),
     }
 
+    # Extract and add to the configuration the scalar serializable arguments for pipeline args
+    for arg_key in _METADATA_PIPELINE_SCALAR_CONFIG_KEYS:
+        entry = _get_scalar_argument_from_pipeline(pipeline, arg_key)
+        if entry:
+            flavor_configuration[arg_key] = entry
+
+    # Extract a serialized representation of torch_dtype if provided
+    torch_dtype = _extract_torch_dtype_if_set(pipeline)
+    if torch_dtype:
+        flavor_configuration[_TORCH_DTYPE_KEY] = torch_dtype
+
     return flavor_configuration
+
+
+def _get_scalar_argument_from_pipeline(pipeline, arg_key):
+    """
+    Retrieve provided pipeline arguments for the purposes of instantiating a pipeline object upon
+    loading.
+    """
+
+    return getattr(pipeline, arg_key, None)
+
+
+def _extract_torch_dtype_if_set(pipeline):
+    """
+    Extract the torch datatype argument if set and return as a string encoded value.
+    """
+    torch_dtype = getattr(pipeline, _TORCH_DTYPE_KEY, None)
+
+    if torch_dtype:
+        return str(torch_dtype)
 
 
 def _get_or_infer_task_type(model, task: Optional[str] = None) -> str:

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -2500,11 +2500,14 @@ def test_deserialization_of_configuration_torch_dtype_entry(dtype):
     assert parsed == dtype
 
 
+@pytest.mark.parametrize(
+    "dtype", [torch.bfloat16, torch.float16, torch.float64, torch.float, torch.cfloat]
+)
 @pytest.mark.skipcacheclean
 @pytest.mark.skipif(
     Version(transformers.__version__) < Version("4.26.1"), reason="Feature does not exist"
 )
-def test_extraction_of_base_flavor_config():
+def test_extraction_of_base_flavor_config(dtype):
     task = "translation_en_to_fr"
 
     # Many of the 'full configuration' arguments specified are not stored as instance arguments
@@ -2516,7 +2519,7 @@ def test_extraction_of_base_flavor_config():
         model=transformers.T5ForConditionalGeneration.from_pretrained("t5-small"),
         tokenizer=transformers.T5TokenizerFast.from_pretrained("t5-small", model_max_length=100),
         framework="pt",
-        torch_dtype=torch.bfloat16,
+        torch_dtype=dtype,
         device_map="auto",
         use_auth_token=True,
         trust_remote_code=True,
@@ -2532,7 +2535,7 @@ def test_extraction_of_base_flavor_config():
         "source_model_name": "t5-small",
         "pipeline_model_type": "T5ForConditionalGeneration",
         "framework": "pt",
-        "torch_dtype": "torch.bfloat16",
+        "torch_dtype": str(dtype),
     }
 
 

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -2471,6 +2471,9 @@ def test_signature_inference(pipeline_name, data, result, request):
     "dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64, torch.int32, torch.int64]
 )
 @pytest.mark.skipcacheclean
+@pytest.mark.skipif(
+    "Version(transformers.__version__) < Version('4.26.1')", reason="Feature does not exist"
+)
 def test_extraction_of_torch_dtype_from_pipeline(dtype):
     pipe = transformers.pipeline(
         task="translation_en_to_fr",
@@ -2498,6 +2501,9 @@ def test_deserialization_of_configuration_torch_dtype_entry(dtype):
 
 
 @pytest.mark.skipcacheclean
+@pytest.mark.skipif(
+    "Version(transformers.__version__) < Version('4.26.1')", reason="Feature does not exist"
+)
 def test_extraction_of_base_flavor_config():
     task = "translation_en_to_fr"
 
@@ -2531,6 +2537,9 @@ def test_extraction_of_base_flavor_config():
 
 
 @pytest.mark.skipcacheclean
+@pytest.mark.skipif(
+    "Version(transformers.__version__) < Version('4.26.1')", reason="Feature does not exist"
+)
 def test_load_as_pipeline_preserves_framework_and_dtype(model_path):
     task = "translation_en_to_fr"
 
@@ -2566,6 +2575,9 @@ def test_load_as_pipeline_preserves_framework_and_dtype(model_path):
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float64, torch.int16])
 @pytest.mark.skipcacheclean
+@pytest.mark.skipif(
+    "Version(transformers.__version__) < Version('4.26.1')", reason="Feature does not exist"
+)
 def test_load_pyfunc_mutate_torch_dtype(model_path, dtype):
     task = "translation_en_to_fr"
 

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -2472,7 +2472,7 @@ def test_signature_inference(pipeline_name, data, result, request):
 )
 @pytest.mark.skipcacheclean
 @pytest.mark.skipif(
-    "Version(transformers.__version__) < Version('4.26.1')", reason="Feature does not exist"
+    Version(transformers.__version__) < Version("4.26.1"), reason="Feature does not exist"
 )
 def test_extraction_of_torch_dtype_from_pipeline(dtype):
     pipe = transformers.pipeline(
@@ -2502,7 +2502,7 @@ def test_deserialization_of_configuration_torch_dtype_entry(dtype):
 
 @pytest.mark.skipcacheclean
 @pytest.mark.skipif(
-    "Version(transformers.__version__) < Version('4.26.1')", reason="Feature does not exist"
+    Version(transformers.__version__) < Version("4.26.1"), reason="Feature does not exist"
 )
 def test_extraction_of_base_flavor_config():
     task = "translation_en_to_fr"
@@ -2538,7 +2538,7 @@ def test_extraction_of_base_flavor_config():
 
 @pytest.mark.skipcacheclean
 @pytest.mark.skipif(
-    "Version(transformers.__version__) < Version('4.26.1')", reason="Feature does not exist"
+    Version(transformers.__version__) < Version("4.26.1"), reason="Feature does not exist"
 )
 def test_load_as_pipeline_preserves_framework_and_dtype(model_path):
     task = "translation_en_to_fr"
@@ -2576,7 +2576,7 @@ def test_load_as_pipeline_preserves_framework_and_dtype(model_path):
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float64, torch.int16])
 @pytest.mark.skipcacheclean
 @pytest.mark.skipif(
-    "Version(transformers.__version__) < Version('4.26.1')", reason="Feature does not exist"
+    Version(transformers.__version__) < Version("4.26.1"), reason="Feature does not exist"
 )
 def test_load_pyfunc_mutate_torch_dtype(model_path, dtype):
     task = "translation_en_to_fr"


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add support for preserving (through saving / logging) of the pipeline argument `torch_dtype` and `framework`. Added the ability to load a pipeline with the as-saved configuration and to permit overriding the `torch_dtype` specified value on load with a named argument.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

Verified functionality in DB hosted MLflow.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added support for storing and overriding the `torch_dtype` argument for transformers pipelines for both saving and loading.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
