### PR TITLE
Add support for feature extraction pipelines to transformers

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2428,6 +2428,7 @@ ZeroShot Classification*          Dict[str, [List[str] | str]*   str or List[str
 Table Question Answering**        Dict[str, [List[str] | str]**  str or List[str]
 Question Answering***             Dict[str, str]***              str or List[str]
 Fill Mask****                     str or List[str]****           str or List[str]
+Feature Extraction                str or List[str]               np.ndarray
 ================================= ============================== =================
 
 \* A collection of these inputs can also be passed. The standard required key names are 'sequences' and 'candidate_labels', but these may vary.

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -1814,15 +1814,20 @@ class _TransformersWrapper:
     @staticmethod
     def _parse_feature_extraction_output(output_data):
         """
-        Parse the return type from a FeatureExtractionPipeline output.
+        Parse the return type from a FeatureExtractionPipeline output. The mixed types for
+        input are present depending on how the pyfunc is instantiated. For model serving usage,
+        the returned type from MLServer will be a numpy.ndarray type, otherwise, the return
+        within a manually executed pyfunc (i.e., for udf usage), the return will be a collection
+        of nested lists.
+
         Examples:
 
-        Input: [[[0.11, 0.98, 0.76]]] or np.ndarray(0.11, 0.98, 0.76)
-        Output: np.ndarray(0.11, 0.98, 0.76)
+        Input: [[[0.11, 0.98, 0.76]]] or np.array([0.11, 0.98, 0.76])
+        Output: np.array([0.11, 0.98, 0.76])
 
         Input: [[[[0.1, 0.2], [0.3, 0.4]]]] or
-            np.ndarray(np.ndarray(0.1, 0.2), np.ndarray(0.3, 0.4))
-        Output: np.ndarray(np.ndarray(0.1, 0.2), np.ndarray(0.3, 0.4))
+            np.array([np.array([0.1, 0.2]), np.array([0.3, 0.4])])
+        Output: np.array([np.array([0.1, 0.2]), np.array([0.3, 0.4])])
         """
         if isinstance(output_data, np.ndarray):
             return output_data

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -19,7 +19,7 @@ from mlflow.models.signature import ModelSignature, infer_signature
 from mlflow.models.utils import _save_example
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, BAD_REQUEST
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
-from mlflow.types.schema import Schema, ColSpec
+from mlflow.types.schema import Schema, ColSpec, TensorSpec
 from mlflow.types.utils import _validate_input_dictionary_contains_only_strings_and_lists_of_strings
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
@@ -1209,7 +1209,11 @@ def _get_default_pipeline_signature(pipeline, example=None) -> ModelSignature:
                 ),
                 outputs=Schema([ColSpec("string")]),
             )
-
+        elif isinstance(pipeline, transformers.FeatureExtractionPipeline):
+            return ModelSignature(
+                inputs=Schema([ColSpec("string")]),
+                outputs=Schema([TensorSpec(np.dtype("float64"), [-1], "double")]),
+            )
         else:
             _logger.warning(
                 "An unsupported Pipeline type was supplied for signature inference. "
@@ -1473,6 +1477,9 @@ class _TransformersWrapper:
             data = self._parse_json_encoded_dict_payload_to_dict(data, "table")
         elif isinstance(self.pipeline, transformers.TokenClassificationPipeline):
             output_key = {"entity_group", "entity"}
+        elif isinstance(self.pipeline, transformers.FeatureExtractionPipeline):
+            output_key = None
+            data = self._parse_feature_extraction_input(data)
         elif isinstance(self.pipeline, transformers.ConversationalPipeline):
             output_key = None
             if not self._conversation:
@@ -1521,6 +1528,8 @@ class _TransformersWrapper:
                 include_prompt,
                 collapse_whitespace,
             )
+        elif isinstance(self.pipeline, transformers.FeatureExtractionPipeline):
+            return self._parse_feature_extraction_output(raw_output)
         elif isinstance(self.pipeline, transformers.FillMaskPipeline):
             output = self._parse_list_of_multiple_dicts(raw_output, output_key)
         elif isinstance(self.pipeline, transformers.ZeroShotClassificationPipeline):
@@ -1794,6 +1803,31 @@ class _TransformersWrapper:
             return output_coll
         else:
             return output_data[target_dict_key]
+
+    @staticmethod
+    def _parse_feature_extraction_input(input_data):
+        if isinstance(input_data, list) and isinstance(input_data[0], dict):
+            return [list(data.values())[0] for data in input_data]
+        else:
+            return input_data
+
+    @staticmethod
+    def _parse_feature_extraction_output(output_data):
+        """
+        Parse the return type from a FeatureExtractionPipeline output.
+        Examples:
+
+        Input: [[[0.11, 0.98, 0.76]]] or np.ndarray(0.11, 0.98, 0.76)
+        Output: np.ndarray(0.11, 0.98, 0.76)
+
+        Input: [[[[0.1, 0.2], [0.3, 0.4]]]] or
+            np.ndarray(np.ndarray(0.1, 0.2), np.ndarray(0.3, 0.4))
+        Output: np.ndarray(np.ndarray(0.1, 0.2), np.ndarray(0.3, 0.4))
+        """
+        if isinstance(output_data, np.ndarray):
+            return output_data
+        else:
+            return np.array(output_data[0][0])
 
     def _parse_tokenizer_output(self, output_data, target_set):
         """


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Adds support for FeatureExtractionPipelines (sentence-transformers, per popular request) to the transformers flavor.  

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

Validated in DBR, both native and pyfunc instantiations of saved models

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add support for feature extraction pipelines to the transformers flavor.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
