### PR TITLE
Avoid incrementing step in lightning autologger

### DIFF
--- a/mlflow/pytorch/_lightning_autolog.py
+++ b/mlflow/pytorch/_lightning_autolog.py
@@ -213,7 +213,7 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
         ]
         self._step_metrics.update(name for (name, _) in metric_items)
         step = trainer.global_step
-        if (step + 1) % self.log_every_n_step == 0:
+        if step > 0 and step % self.log_every_n_step == 0:
             self._log_metrics(trainer, step, metric_items)
 
     @rank_zero_only


### PR DESCRIPTION
When using manual optimization in lightning (with multiple optimizers), the `global_step` can be incremented multiple times per training batch. In this case, this line causes no MLflow logging when `log_every_n_step` is set.

Is there any reason for incrementing the step here other than avoiding logging on the first iteration before any training has been done?
