### PR TITLE
add ort session options

### DIFF
--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -139,7 +139,7 @@ def save_model(
                                  'inter_op_num_threads': 1,
                                  'execution_mode': 'sequential'
                                  }``
-                                 'execution_mode' can be set ot 'sequential' or 'parallel'.
+                                 'execution_mode' can be set to 'sequential' or 'parallel'.
                                  See onnxruntime API for further descriptions:
                                  https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions
     :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
@@ -502,7 +502,7 @@ def log_model(
                                  'inter_op_num_threads': 1,
                                  'execution_mode': 'sequential'
                                  }``
-                                 'execution_mode' can be set ot 'sequential' or 'parallel'.
+                                 'execution_mode' can be set to 'sequential' or 'parallel'.
                                  See onnxruntime API for further descriptions:
                                  https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions
     :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -134,11 +134,11 @@ def save_model(
     :param onnx_session_options: Dictionary of options to be passed to onnxruntime.InferenceSession.
                                  For example:
                                  ``{
-                                    'graph_optimization_level': 99,
-                                    'intra_op_num_threads': 1,
-                                    'inter_op_num_threads': 1,
-                                    'execution_mode': 'sequential'
-                                    }``
+                                 'graph_optimization_level': 99,
+                                 'intra_op_num_threads': 1,
+                                 'inter_op_num_threads': 1,
+                                 'execution_mode': 'sequential'
+                                 }``
                                  'execution_mode' can be set ot 'sequential' or 'parallel'.
                                  See onnxruntime API for further descriptions:
                                  https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions
@@ -497,11 +497,11 @@ def log_model(
     :param onnx_session_options: Dictionary of options to be passed to onnxruntime.InferenceSession.
                                  For example:
                                  ``{
-                                    'graph_optimization_level': 99,
-                                    'intra_op_num_threads': 1,
-                                    'inter_op_num_threads': 1,
-                                    'execution_mode': 'sequential'
-                                    }``
+                                 'graph_optimization_level': 99,
+                                 'intra_op_num_threads': 1,
+                                 'inter_op_num_threads': 1,
+                                 'execution_mode': 'sequential'
+                                 }``
                                  'execution_mode' can be set ot 'sequential' or 'parallel'.
                                  See onnxruntime API for further descriptions:
                                  https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -42,6 +42,7 @@ from mlflow.utils.model_utils import (
     _validate_and_copy_code_paths,
     _add_code_from_conf_to_system_path,
     _validate_and_prepare_target_save_path,
+    _validate_onnx_session_options,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
@@ -183,6 +184,9 @@ def save_model(
         python_env=_PYTHON_ENV_FILE_NAME,
         code=code_dir_subpath,
     )
+
+    _validate_onnx_session_options(onnx_session_options)
+
     mlflow_model.add_flavor(
         FLAVOR_NAME,
         onnx_version=onnx.__version__,

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -241,7 +241,7 @@ class _OnnxModelWrapper:
         # If not, then default to the predefined list.
         else:
             providers = ONNX_EXECUTION_PROVIDERS
-        
+
         sess_options = onnxruntime.SessionOptions()
         if "options" in model_meta.flavors.get(FLAVOR_NAME).keys():
             options = model_meta.flavors.get(FLAVOR_NAME)["options"]
@@ -260,7 +260,9 @@ class _OnnxModelWrapper:
                 elif execution_mode == 1:
                     sess_options.execution_mode = onnxruntime.ExecutionMode.ORT_PARALLEL
             if graph_optimization_level:
-                sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel(graph_optimization_level)
+                sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel(
+                    graph_optimization_level
+                )
             if extra_session_config:
                 for key, value in extra_session_config.items():
                     sess_options.add_session_config_entry(key, value)
@@ -290,7 +292,9 @@ class _OnnxModelWrapper:
         try:
             self.rt = onnxruntime.InferenceSession(path, sess_options=sess_options)
         except ValueError:
-            self.rt = onnxruntime.InferenceSession(path, providers=providers, sess_options=sess_options)
+            self.rt = onnxruntime.InferenceSession(
+                path, providers=providers, sess_options=sess_options
+            )
 
         assert len(self.rt.get_inputs()) >= 1
         self.inputs = [(inp.name, inp.type) for inp in self.rt.get_inputs()]

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -131,7 +131,17 @@ def save_model(
                                      This uses GPU preferentially over CPU.
                                      See onnxruntime API for further descriptions:
                                      https://onnxruntime.ai/docs/execution-providers/
-    :param onnx_session_options: Dictionary of options to be passed to the onnxruntime
+    :param onnx_session_options: Dictionary of options to be passed to onnxruntime.InferenceSession.
+                                 For example:
+                                 ``{
+                                    'graph_optimization_level': 99,
+                                    'intra_op_num_threads': 1,
+                                    'inter_op_num_threads': 1,
+                                    'execution_mode': 'sequential'
+                                    }``
+                                 'execution_mode' can be set ot 'sequential' or 'parallel'.
+                                 See onnxruntime API for further descriptions:
+                                 https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions
     :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
                      .. Note:: Experimental: This parameter may change or be removed in a future
@@ -484,7 +494,17 @@ def log_model(
                                      This uses GPU preferentially over CPU.
                                      See onnxruntime API for further descriptions:
                                      https://onnxruntime.ai/docs/execution-providers/
-    :param onnx_session_options: Dictionary of options to be passed to onnxruntime.InferenceSession
+    :param onnx_session_options: Dictionary of options to be passed to onnxruntime.InferenceSession.
+                                 For example:
+                                 ``{
+                                    'graph_optimization_level': 99,
+                                    'intra_op_num_threads': 1,
+                                    'inter_op_num_threads': 1,
+                                    'execution_mode': 'sequential'
+                                    }``
+                                 'execution_mode' can be set ot 'sequential' or 'parallel'.
+                                 See onnxruntime API for further descriptions:
+                                 https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions
     :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
                      .. Note:: Experimental: This parameter may change or be removed in a future

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -89,6 +89,7 @@ def save_model(
     pip_requirements=None,
     extra_pip_requirements=None,
     onnx_execution_providers=None,
+    onnx_session_options=None,
     metadata=None,
 ):
     """
@@ -130,6 +131,7 @@ def save_model(
                                      This uses GPU preferentially over CPU.
                                      See onnxruntime API for further descriptions:
                                      https://onnxruntime.ai/docs/execution-providers/
+    :param onnx_session_options: Dictionary of options to be passed to the onnxruntime
     :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
                      .. Note:: Experimental: This parameter may change or be removed in a future
@@ -176,6 +178,7 @@ def save_model(
         onnx_version=onnx.__version__,
         data=model_data_subpath,
         providers=onnx_execution_providers,
+        options=onnx_session_options,
         code=code_dir_subpath,
     )
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
@@ -238,6 +241,29 @@ class _OnnxModelWrapper:
         # If not, then default to the predefined list.
         else:
             providers = ONNX_EXECUTION_PROVIDERS
+        
+        sess_options = onnxruntime.SessionOptions()
+        if "options" in model_meta.flavors.get(FLAVOR_NAME).keys():
+            options = model_meta.flavors.get(FLAVOR_NAME)["options"]
+            inter_op_num_threads = options.get("inter_op_num_threads")
+            intra_op_num_threads = options.get("intra_op_num_threads")
+            execution_mode = options.get("execution_mode")
+            graph_optimization_level = options.get("graph_optimization_level")
+            extra_session_config = options.get("extra_session_config")
+            if inter_op_num_threads:
+                sess_options.inter_op_num_threads = inter_op_num_threads
+            if intra_op_num_threads:
+                sess_options.intra_op_num_threads = intra_op_num_threads
+            if execution_mode:
+                if execution_mode == 0:
+                    sess_options.execution_mode = onnxruntime.ExecutionMode.ORT_SEQUENTIAL
+                elif execution_mode == 1:
+                    sess_options.execution_mode = onnxruntime.ExecutionMode.ORT_PARALLEL
+            if graph_optimization_level:
+                sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel(graph_optimization_level)
+            if extra_session_config:
+                for key, value in extra_session_config.items():
+                    sess_options.add_session_config_entry(key, value)
 
         # NOTE: Some distributions of onnxruntime require the specification of the providers
         # argument on calling. E.g. onnxruntime-gpu. The package import call does not differentiate
@@ -262,9 +288,9 @@ class _OnnxModelWrapper:
         #
 
         try:
-            self.rt = onnxruntime.InferenceSession(path)
+            self.rt = onnxruntime.InferenceSession(path, sess_options=sess_options)
         except ValueError:
-            self.rt = onnxruntime.InferenceSession(path, providers=providers)
+            self.rt = onnxruntime.InferenceSession(path, providers=providers, sess_options=sess_options)
 
         assert len(self.rt.get_inputs()) >= 1
         self.inputs = [(inp.name, inp.type) for inp in self.rt.get_inputs()]
@@ -407,6 +433,7 @@ def log_model(
     pip_requirements=None,
     extra_pip_requirements=None,
     onnx_execution_providers=None,
+    onnx_session_options=None,
     metadata=None,
 ):
     """
@@ -453,6 +480,7 @@ def log_model(
                                      This uses GPU preferentially over CPU.
                                      See onnxruntime API for further descriptions:
                                      https://onnxruntime.ai/docs/execution-providers/
+    :param onnx_session_options: Dictionary of options to be passed to onnxruntime.InferenceSession
     :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
                      .. Note:: Experimental: This parameter may change or be removed in a future
@@ -473,5 +501,6 @@ def log_model(
         pip_requirements=pip_requirements,
         extra_pip_requirements=extra_pip_requirements,
         onnx_execution_providers=onnx_execution_providers,
+        onnx_session_options=onnx_session_options,
         metadata=metadata,
     )

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -178,7 +178,7 @@ def save_model(
         onnx_version=onnx.__version__,
         data=model_data_subpath,
         providers=onnx_execution_providers,
-        options=onnx_session_options,
+        onnx_session_options=onnx_session_options,
         code=code_dir_subpath,
     )
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
@@ -243,8 +243,8 @@ class _OnnxModelWrapper:
             providers = ONNX_EXECUTION_PROVIDERS
 
         sess_options = onnxruntime.SessionOptions()
-        if "options" in model_meta.flavors.get(FLAVOR_NAME).keys():
-            options = model_meta.flavors.get(FLAVOR_NAME)["options"]
+        options = model_meta.flavors.get(FLAVOR_NAME)["onnx_session_options"]
+        if options:
             inter_op_num_threads = options.get("inter_op_num_threads")
             intra_op_num_threads = options.get("intra_op_num_threads")
             execution_mode = options.get("execution_mode")
@@ -255,9 +255,9 @@ class _OnnxModelWrapper:
             if intra_op_num_threads:
                 sess_options.intra_op_num_threads = intra_op_num_threads
             if execution_mode:
-                if execution_mode == 0:
+                if execution_mode.upper() == "SEQUENTIAL":
                     sess_options.execution_mode = onnxruntime.ExecutionMode.ORT_SEQUENTIAL
-                elif execution_mode == 1:
+                elif execution_mode.upper() == "PARALLEL":
                     sess_options.execution_mode = onnxruntime.ExecutionMode.ORT_PARALLEL
             if graph_optimization_level:
                 sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel(

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -149,3 +149,54 @@ def _add_code_from_conf_to_system_path(local_path, conf, code_key=FLAVOR_CONFIG_
     if code_key in conf and conf[code_key]:
         code_path = os.path.join(local_path, conf[code_key])
         _add_code_to_system_path(code_path)
+
+
+def _validate_onnx_session_options(onnx_session_options):
+    """
+    Validates that the specified onnx_session_options dict is valid.
+
+    :param ort_session_options: The onnx_session_options dict to validate.
+    """
+    import onnxruntime as ort
+
+    if onnx_session_options is not None:
+        if not isinstance(onnx_session_options, dict):
+            raise TypeError(
+                "Argument onnx_session_options should be a dict, not {}".format(
+                    type(onnx_session_options)
+                )
+            )
+        for key, value in onnx_session_options.items():
+            if key != "extra_session_config" and not hasattr(ort.SessionOptions, key):
+                raise ValueError(
+                    "Key {} in onnx_session_options is not a valid ONNX Runtime session options key".format(
+                        key
+                    )
+                )
+            elif key == "extra_session_config" and not isinstance(value, dict):
+                raise TypeError(
+                    "Value for key {} in onnx_session_options should be a dict, not {}".format(
+                        key, type(value)
+                    )
+                )
+            elif key == "execution_mode":
+                if value.upper() not in ["PARALLEL", "SEQUENTIAL"]:
+                    raise ValueError(
+                        "Value for key {} in onnx_session_options should be 'parallel' or 'sequential', not {}".format(
+                            key, value
+                        )
+                    )
+            elif key == "graph_optimization_level":
+                if value not in [0, 1, 2, 99]:
+                    raise ValueError(
+                        "Value for key {} in onnx_session_options should be 0, 1, 2, or 99, not {}".format(
+                            key, value
+                        )
+                    )
+            elif key in ["intra_op_num_threads", "intra_op_num_threads"]:
+                if value < 0:
+                    raise ValueError(
+                        "Value for key {} in onnx_session_options should be >= 0, not {}".format(
+                            key, value
+                        )
+                    )

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -169,34 +169,25 @@ def _validate_onnx_session_options(onnx_session_options):
         for key, value in onnx_session_options.items():
             if key != "extra_session_config" and not hasattr(ort.SessionOptions, key):
                 raise ValueError(
-                    "Key {} in onnx_session_options is not a valid ONNX Runtime session options key".format(
-                        key
-                    )
+                    f"Key {key} in onnx_session_options is not a valid \
+                        ONNX Runtime session options key"
                 )
             elif key == "extra_session_config" and not isinstance(value, dict):
                 raise TypeError(
-                    "Value for key {} in onnx_session_options should be a dict, not {}".format(
-                        key, type(value)
-                    )
+                    f"Value for key {key} in onnx_session_options should be a dict, \
+                        not {type(value)}"
                 )
-            elif key == "execution_mode":
-                if value.upper() not in ["PARALLEL", "SEQUENTIAL"]:
-                    raise ValueError(
-                        "Value for key {} in onnx_session_options should be 'parallel' or 'sequential', not {}".format(
-                            key, value
-                        )
-                    )
-            elif key == "graph_optimization_level":
-                if value not in [0, 1, 2, 99]:
-                    raise ValueError(
-                        "Value for key {} in onnx_session_options should be 0, 1, 2, or 99, not {}".format(
-                            key, value
-                        )
-                    )
-            elif key in ["intra_op_num_threads", "intra_op_num_threads"]:
-                if value < 0:
-                    raise ValueError(
-                        "Value for key {} in onnx_session_options should be >= 0, not {}".format(
-                            key, value
-                        )
-                    )
+            elif key == "execution_mode" and value.upper() not in ["PARALLEL", "SEQUENTIAL"]:
+                raise ValueError(
+                    f"Value for key {key} in onnx_session_options should be \
+                        'parallel' or 'sequential', not {value}"
+                )
+            elif key == "graph_optimization_level" and value not in [0, 1, 2, 99]:
+                raise ValueError(
+                    f"Value for key {key} in onnx_session_options should be 0, 1, 2, or 99,\
+                        not {value}"
+                )
+            elif key in ["intra_op_num_threads", "intra_op_num_threads"] and value < 0:
+                raise ValueError(
+                    f"Value for key {key} in onnx_session_options should be >= 0, not {value}"
+                )

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -318,12 +318,13 @@ def test_model_save_load_evaluate_pyfunc_format(onnx_model, model_path, data, pr
         atol=1e-05,
     )
 
+
 def test_model_save_load_pyfunc_format_with_session_options(onnx_model, model_path):
     onnx_session_options = {
         "execution_mode": 0,
-        "graph_optimization_level": 99, 
-        "intra_op_num_threads": 19
-        }
+        "graph_optimization_level": 99,
+        "intra_op_num_threads": 19,
+    }
     mlflow.onnx.save_model(onnx_model, model_path, onnx_session_options=onnx_session_options)
 
     # Loading pyfunc model
@@ -333,6 +334,7 @@ def test_model_save_load_pyfunc_format_with_session_options(onnx_model, model_pa
     assert session_options.execution_mode == ort.ExecutionMode.ORT_SEQUENTIAL
     assert session_options.graph_optimization_level == ort.GraphOptimizationLevel.ORT_ENABLE_ALL
     assert session_options.intra_op_num_threads == 19
+
 
 def test_model_save_load_multiple_inputs(onnx_model_multiple_inputs_float64, model_path):
     mlflow.onnx.save_model(onnx_model_multiple_inputs_float64, model_path)

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -5,6 +5,7 @@ import pytest
 from unittest import mock
 
 import onnx
+import onnxruntime as ort
 import torch
 from torch import nn
 import torch.onnx
@@ -317,6 +318,21 @@ def test_model_save_load_evaluate_pyfunc_format(onnx_model, model_path, data, pr
         atol=1e-05,
     )
 
+def test_model_save_load_pyfunc_format_with_session_options(onnx_model, model_path):
+    onnx_session_options = {
+        "execution_mode": 0,
+        "graph_optimization_level": 99, 
+        "intra_op_num_threads": 19
+        }
+    mlflow.onnx.save_model(onnx_model, model_path, onnx_session_options=onnx_session_options)
+
+    # Loading pyfunc model
+    pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
+    session_options = pyfunc_loaded._model_impl.rt.get_session_options()
+
+    assert session_options.execution_mode == ort.ExecutionMode.ORT_SEQUENTIAL
+    assert session_options.graph_optimization_level == ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+    assert session_options.intra_op_num_threads == 19
 
 def test_model_save_load_multiple_inputs(onnx_model_multiple_inputs_float64, model_path):
     mlflow.onnx.save_model(onnx_model_multiple_inputs_float64, model_path)

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -321,7 +321,7 @@ def test_model_save_load_evaluate_pyfunc_format(onnx_model, model_path, data, pr
 
 def test_model_save_load_pyfunc_format_with_session_options(onnx_model, model_path):
     onnx_session_options = {
-        "execution_mode": 0,
+        "execution_mode": "sequential",
         "graph_optimization_level": 99,
         "intra_op_num_threads": 19,
     }


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #8413 

## What changes are proposed in this pull request?

Add onnxruntime session options when saving and loading onnx model with pyfunc

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

User can provide onnxruntime session options when saving and loading onnx model with pyfunc. 

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
