### PR TITLE
Print warning when models are logged without signatures to databricks

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -564,7 +564,7 @@ class Model:
             tracking_uri = _resolve_tracking_uri()
             if (
                 tracking_uri == "databricks" or get_uri_scheme(tracking_uri) == "databricks"
-            ) and kwargs["signature"] is None:
+            ) and kwargs.get("signature") is None:
                 _logger.warning(_LOG_MODEL_MISSING_SIGNATURE_WARNING)
             try:
                 mlflow.tracking.fluent._record_logged_model(mlflow_model)

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -559,15 +559,15 @@ class Model:
             local_path = tmp.path("model")
             run_id = mlflow.tracking.fluent._get_or_start_run().info.run_id
             mlflow_model = cls(artifact_path=artifact_path, run_id=run_id, metadata=metadata)
+            flavor.save_model(
+                path=local_path, mlflow_model=mlflow_model, signature=signature, **kwargs
+            )
+            mlflow.tracking.fluent.log_artifacts(local_path, mlflow_model.artifact_path)
             tracking_uri = _resolve_tracking_uri()
             if (
                 tracking_uri == "databricks" or get_uri_scheme(tracking_uri) == "databricks"
             ) and signature is None:
                 _logger.warning(_LOG_MODEL_MISSING_SIGNATURE_WARNING)
-            flavor.save_model(
-                path=local_path, mlflow_model=mlflow_model, signature=signature, **kwargs
-            )
-            mlflow.tracking.fluent.log_artifacts(local_path, mlflow_model.artifact_path)
             try:
                 mlflow.tracking.fluent._record_logged_model(mlflow_model)
             except MlflowException:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -506,7 +506,6 @@ class Model:
         artifact_path,
         flavor,
         registered_model_name=None,
-        signature=None,
         await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
         metadata=None,
         **kwargs,
@@ -560,14 +559,12 @@ class Model:
             local_path = tmp.path("model")
             run_id = mlflow.tracking.fluent._get_or_start_run().info.run_id
             mlflow_model = cls(artifact_path=artifact_path, run_id=run_id, metadata=metadata)
-            flavor.save_model(
-                path=local_path, mlflow_model=mlflow_model, signature=signature, **kwargs
-            )
+            flavor.save_model(path=local_path, mlflow_model=mlflow_model, **kwargs)
             mlflow.tracking.fluent.log_artifacts(local_path, mlflow_model.artifact_path)
             tracking_uri = _resolve_tracking_uri()
             if (
                 tracking_uri == "databricks" or get_uri_scheme(tracking_uri) == "databricks"
-            ) and signature is None:
+            ) and kwargs["signature"] is None:
                 _logger.warning(_LOG_MODEL_MISSING_SIGNATURE_WARNING)
             try:
                 mlflow.tracking.fluent._record_logged_model(mlflow_model)

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -31,8 +31,9 @@ _LOG_MODEL_METADATA_WARNING_TEMPLATE = (
 _LOG_MODEL_MISSING_SIGNATURE_WARNING = (
     "Model logged without a signature. Signatures will be required for upcoming model registry "
     "features as they validate model inputs and denote the expected schema of model outputs. "
-    "Please visit https://www.mlflow.org/docs/latest/models.html#set-signature-on-mv "
-    "for instructions on setting a model signature on your logged model."
+    f"Please visit https://www.mlflow.org/docs/{mlflow.__version__.replace('.dev0', '')}/"
+    "models.html#set-signature-on-logged-model for instructions on setting a model signature on "
+    "your logged model."
 )
 # NOTE: The _MLFLOW_VERSION_KEY constant is considered @developer_stable
 _MLFLOW_VERSION_KEY = "mlflow_version"

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -13,9 +13,11 @@ import mlflow
 from mlflow.artifacts import download_artifacts
 from mlflow.exceptions import MlflowException
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+from mlflow.tracking._tracking_service.utils import _resolve_tracking_uri
 from mlflow.utils.annotations import experimental
 from mlflow.utils.file_utils import TempDir
-from mlflow.utils.databricks_utils import get_databricks_runtime, is_in_databricks_runtime
+from mlflow.utils.databricks_utils import get_databricks_runtime
+from mlflow.utils.uri import get_uri_scheme
 
 _logger = logging.getLogger(__name__)
 
@@ -27,7 +29,10 @@ _LOG_MODEL_METADATA_WARNING_TEMPLATE = (
     '`logging.getLogger("mlflow").setLevel(logging.DEBUG)` to see the full traceback.'
 )
 _LOG_MODEL_MISSING_SIGNATURE_WARNING = (
-    "Missing model signature. Please add signature with `mlflow.models.add_signature`."
+    "Model logged without a signature. Signatures will be required for upcoming model registry "
+    "features as they validate model inputs and denote the expected schema of model outputs. "
+    "Please visit https://www.mlflow.org/docs/latest/models.html#set-signature-on-mv "
+    "for instructions on setting a model signature on your logged model."
 )
 # NOTE: The _MLFLOW_VERSION_KEY constant is considered @developer_stable
 _MLFLOW_VERSION_KEY = "mlflow_version"
@@ -554,7 +559,10 @@ class Model:
             local_path = tmp.path("model")
             run_id = mlflow.tracking.fluent._get_or_start_run().info.run_id
             mlflow_model = cls(artifact_path=artifact_path, run_id=run_id, metadata=metadata)
-            if is_in_databricks_runtime() and signature == None:
+            tracking_uri = _resolve_tracking_uri()
+            if (
+                tracking_uri == "databricks" or get_uri_scheme(tracking_uri) == "databricks"
+            ) and signature is None:
                 _logger.warning(_LOG_MODEL_MISSING_SIGNATURE_WARNING)
             flavor.save_model(
                 path=local_path, mlflow_model=mlflow_model, signature=signature, **kwargs


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

This PR adds a warning when models are logged to Databricks tracking without specifying a model signature.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

I ran the feature branch both on Databricks and locally against a Databricks workspace. See screenshots
<img width="1627" alt="Screenshot 2023-05-22 at 2 52 11 PM" src="https://github.com/mlflow/mlflow/assets/66143562/e97f38be-d9a1-484d-bfdc-31f4df43b61d">

<img width="1370" alt="Screenshot 2023-05-22 at 2 48 26 PM" src="https://github.com/mlflow/mlflow/assets/66143562/bf1e7b46-be61-47a7-8865-eff95945dd49">


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
