### PR TITLE
Support subclasses of chains for langchain flavor

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -343,9 +343,9 @@ def _save_model(model, path):
     model_data_path = os.path.join(path, _MODEL_DATA_FILE_NAME)
     model_data_kwargs = {_MODEL_DATA_KEY: _MODEL_DATA_FILE_NAME}
 
-    if type(model) == langchain.chains.llm.LLMChain:
+    if isinstance(model, langchain.chains.llm.LLMChain):
         model.save(model_data_path)
-    elif type(model) == langchain.agents.agent.AgentExecutor:
+    elif isinstance(model, langchain.agents.agent.AgentExecutor):
         if model.agent and model.agent.llm_chain:
             model.agent.llm_chain.save(model_data_path)
 

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -304,7 +304,9 @@ def log_model(
     """
     import langchain
 
-    if not isinstance(lc_model, (langchain.chains.Chain, langchain.agents.agent.AgentExecutor)):
+    if not isinstance(
+        lc_model, (langchain.chains.base.Chain, langchain.agents.agent.AgentExecutor)
+    ):
         raise mlflow.MlflowException.invalid_parameter_value(
             _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=str(type(lc_model)))
         )
@@ -379,6 +381,12 @@ def _save_model(model, path):
             json.dump(temp_dict, config_file, indent=4)
 
         model_data_kwargs[_AGENT_PRIMITIVES_DATA_KEY] = _AGENT_PRIMITIVES_FILE_NAME
+    elif isinstance(model, langchain.chains.base.Chain):
+        logger.warning(
+            _UNSUPPORTED_MODEL_WARNING_MESSAGE,
+            type(model).__name__,
+        )
+        model.save(model_data_path)
     else:
         raise mlflow.MlflowException.invalid_parameter_value(
             _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=str(type(model)))

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -13,7 +13,7 @@ LangChain (native) format
 """
 import logging
 import os
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
 import pandas as pd
 import cloudpickle
@@ -428,19 +428,22 @@ class _LangChainModelWrapper:
     def __init__(self, lc_model):
         self.lc_model = lc_model
 
-    def predict(self, data: Union[pd.DataFrame, List[Union[str, Dict[str, str]]]]) -> List[str]:
+    def predict(self, data: Union[pd.DataFrame, List[Union[str, Dict[str, Any]]]]) -> List[str]:
         from mlflow.langchain.api_request_parallel_processor import process_api_requests
 
         if isinstance(data, pd.DataFrame):
+            logger.debug(f"Input pandas data: {data.to_string(line_width=100000)}")
             messages = data.to_dict(orient="records")
         elif isinstance(data, list) and (
             all(isinstance(d, str) for d in data) or all(isinstance(d, dict) for d in data)
         ):
+            logger.debug(f"Input data: {data}")
             messages = data
         else:
             raise mlflow.MlflowException.invalid_parameter_value(
                 "Input must be a pandas DataFrame or a list of strings or a list of dictionaries",
             )
+        logger.debug(f"messages = {messages}")
         return process_api_requests(lc_model=self.lc_model, requests=messages)
 
 

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -432,18 +432,15 @@ class _LangChainModelWrapper:
         from mlflow.langchain.api_request_parallel_processor import process_api_requests
 
         if isinstance(data, pd.DataFrame):
-            logger.debug(f"Input pandas data: {data.to_string(line_width=100000)}")
             messages = data.to_dict(orient="records")
         elif isinstance(data, list) and (
             all(isinstance(d, str) for d in data) or all(isinstance(d, dict) for d in data)
         ):
-            logger.debug(f"Input data: {data}")
             messages = data
         else:
             raise mlflow.MlflowException.invalid_parameter_value(
                 "Input must be a pandas DataFrame or a list of strings or a list of dictionaries",
             )
-        logger.debug(f"messages = {messages}")
         return process_api_requests(lc_model=self.lc_model, requests=messages)
 
 

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -66,16 +66,15 @@ _TOOLS_DATA_FILE_NAME = "tools.pkl"
 _TOOLS_DATA_KEY = "tools_data"
 _MODEL_TYPE_KEY = "model_type"
 _UNSUPPORTED_MODEL_ERROR_MESSAGE = (
-    "MLflow langchain flavor only supports logging "
-    + "subclasses of langchain.chains.base.Chain and langchain.agents.agent.AgentExecutor "
-    + "instances, found {instance_type}"
+    "MLflow langchain flavor only supports logging subclasses of "
+    "langchain.chains.base.Chain and langchain.agents.agent.AgentExecutor instances, "
+    "found {instance_type}"
 )
 _UNSUPPORTED_LLM_WARNING_MESSAGE = (
-    "MLflow does not guarantee support for LLMs outside " + "of HuggingFaceHub and OpenAI, found %s"
+    "MLflow does not guarantee support for LLMs outside of HuggingFaceHub and OpenAI, found %s"
 )
 _UNSUPPORTED_MODEL_WARNING_MESSAGE = (
-    "MLflow does not guarantee support for Chains outside "
-    + "of the subclasses of LLMChain, found %s"
+    "MLflow does not guarantee support for Chains outside of the subclasses of LLMChain, found %s"
 )
 
 
@@ -308,7 +307,7 @@ def log_model(
         lc_model, (langchain.chains.base.Chain, langchain.agents.agent.AgentExecutor)
     ):
         raise mlflow.MlflowException.invalid_parameter_value(
-            _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=str(type(lc_model)))
+            _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=type(lc_model).__name__)
         )
 
     _SUPPORTED_LLMS = {langchain.llms.openai.OpenAI, langchain.llms.huggingface_hub.HuggingFaceHub}
@@ -389,7 +388,7 @@ def _save_model(model, path):
         model.save(model_data_path)
     else:
         raise mlflow.MlflowException.invalid_parameter_value(
-            _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=str(type(model)))
+            _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=type(model).__name__)
         )
 
     return model_data_kwargs

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -22,6 +22,7 @@ import queue
 import time
 from dataclasses import dataclass
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, List, Union
 
 import langchain
 import mlflow
@@ -68,7 +69,7 @@ class APIRequest:
     """
 
     index: int
-    lc_model: langchain.chains.llm.LLMChain
+    lc_model: langchain.chains.base.Chain
     request_json: dict
     results: list[tuple[int, str]]
 
@@ -76,7 +77,7 @@ class APIRequest:
         """
         Calls the LangChain API and stores results.
         """
-        _logger.debug(f"Request #{self.index} started")
+        _logger.debug(f"Request #{self.index} started, request_json: {self.request_json}")
         try:
             response = self.lc_model.run(**self.request_json)
             _logger.debug(f"Request #{self.index} succeeded")
@@ -90,7 +91,7 @@ class APIRequest:
 
 def process_api_requests(
     lc_model,
-    requests: list[dict[str, any]] = None,
+    requests: List[Union[str, Dict[str, Any]]] = None,
     max_workers: int = 10,
 ):
     """
@@ -104,6 +105,7 @@ def process_api_requests(
 
     results: list[tuple[int, str]] = []
     requests_iter = enumerate(requests)
+    _logger.debug(f"requests = {requests}")
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         while True:
             # get next request (if one is not already waiting for capacity)

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -77,7 +77,7 @@ class APIRequest:
         """
         Calls the LangChain API and stores results.
         """
-        _logger.debug(f"Request #{self.index} started, request_json: {self.request_json}")
+        _logger.debug(f"Request #{self.index} started")
         try:
             response = self.lc_model.run(**self.request_json)
             _logger.debug(f"Request #{self.index} succeeded")
@@ -105,7 +105,6 @@ def process_api_requests(
 
     results: list[tuple[int, str]] = []
     requests_iter = enumerate(requests)
-    _logger.debug(f"requests = {requests}")
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         while True:
             # get next request (if one is not already waiting for capacity)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -411,13 +411,8 @@ class PyFuncModel:
         :return: Model predictions as one of pandas.DataFrame, pandas.Series, numpy.ndarray or list.
         """
         input_schema = self.metadata.get_input_schema()
-        _logger.debug("Data before _enforce_schema: %s", data)
-        _logger.debug("Input schema: %s", input_schema)
-        # Input schema: ['input_documents': string]
-        # Expected: ['input_documents': string (Document?), 'question': string]
         if input_schema is not None:
             data = _enforce_schema(data, input_schema)
-        _logger.debug("Data after _enforce_schema: %s", data)
 
         if "openai" in sys.modules and MLFLOW_OPENAI_RETRIES_ENABLED.get():
             from mlflow.openai.retry import openai_auto_retry_patch

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -411,8 +411,13 @@ class PyFuncModel:
         :return: Model predictions as one of pandas.DataFrame, pandas.Series, numpy.ndarray or list.
         """
         input_schema = self.metadata.get_input_schema()
+        _logger.debug("Data before _enforce_schema: %s", data)
+        _logger.debug("Input schema: %s", input_schema)
+        # Input schema: ['input_documents': string]
+        # Expected: ['input_documents': string (Document?), 'question': string]
         if input_schema is not None:
             data = _enforce_schema(data, input_schema)
+        _logger.debug("Data after _enforce_schema: %s", data)
 
         if "openai" in sys.modules and MLFLOW_OPENAI_RETRIES_ENABLED.get():
             from mlflow.openai.retry import openai_auto_retry_patch

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -77,6 +77,7 @@ def create_qa_eval_chain():
 
 
 def create_qa_with_sources_chain():
+    # StuffDocumentsChain
     return load_qa_with_sources_chain(OpenAI(temperature=0), chain_type="stuff")
 
 
@@ -293,13 +294,12 @@ def test_langchain_native_log_and_load_qaevalchain():
 
 
 def test_langchain_native_log_and_load_qa_with_sources_chain():
-    model = create_model("qa_with_sources_chain")  # StuffDocumentsChain
+    model = create_model("qa_with_sources_chain")
     with mlflow.start_run():
-        logged_model = mlflow.langchain.log_model(model, "langchain_model")  # works
+        logged_model = mlflow.langchain.log_model(model, "langchain_model")
 
-    loaded_model = mlflow.langchain.load_model(logged_model.model_uri)  # works
+    loaded_model = mlflow.langchain.load_model(logged_model.model_uri)
     assert model == loaded_model
-    # TODO: this fails, loaded_model is LLMChain instead of StuffDocumentsChain
 
 
 def test_unsupported_chain_types():

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -107,8 +107,6 @@ def create_model(model_type, model_path=None):
         return create_qa_with_sources_chain()
     if model_type == "openaiagent":
         return create_openai_llmagent()
-    if model_type == "fake":
-        return FakeLLM()
     raise NotImplementedError("This model is not supported yet.")
 
 

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -302,12 +302,22 @@ def test_langchain_native_log_and_load_qa_with_sources_chain():
     assert model == loaded_model
 
 
-def test_unsupported_chain_types():
+def test_saving_not_implemented_chain_type():
     chain = FakeChain()
+    with pytest.raises(
+        NotImplementedError,
+        match="Saving not supported for this chain type",
+    ):
+        with mlflow.start_run():
+            mlflow.langchain.log_model(chain, "fake_chain")
+
+
+def test_unsupported_class():
+    llm = FakeLLM()
     with pytest.raises(
         MlflowException,
         match="MLflow langchain flavor only supports logging subclasses of "
         + "langchain.chains.base.Chain",
     ):
         with mlflow.start_run():
-            mlflow.langchain.log_model(chain, "fake_chain_model")
+            mlflow.langchain.log_model(llm, "fake_llm")

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -293,7 +293,7 @@ def test_qa_with_sources_chain_predict():
     with mlflow.start_run():
         logged_model = mlflow.langchain.log_model(model, "langchain_model")
 
-    loaded_model = mlflow.langchain.load_model(logged_model.model_uri)
+    loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
     json_strings = [
         '{"page_content": "I love MLflow.", "metadata": {"source": "/path/to/mlflow.txt"}}',
         '{"page_content": "I love langchain.", "metadata": {"source": "/path/to/langchain.txt"}}',

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -5,7 +5,7 @@ import transformers
 import json
 
 from contextlib import contextmanager
-from langchain.chains import LLMChain, ConversationChain
+from langchain.chains import ConversationChain, LLMChain, SimpleSequentialChain
 from langchain.chains.base import Chain
 from langchain.chains.qa_with_sources import load_qa_with_sources_chain
 from langchain.evaluation.qa import QAEvalChain
@@ -79,6 +79,32 @@ def create_qa_eval_chain():
 def create_qa_with_sources_chain():
     # StuffDocumentsChain
     return load_qa_with_sources_chain(OpenAI(temperature=0), chain_type="stuff")
+
+
+def create_simple_sequential_chain():
+    # This is an LLMChain to write a synopsis given a title of a play.
+    llm = OpenAI(temperature=0.7)
+    template = """You are a playwright. Given the title of play, it is your job to 
+    write a synopsis for that title.
+
+    Title: {title}
+    Playwright: This is a synopsis for the above play:"""
+    prompt_template = PromptTemplate(input_variables=["title"], template=template)
+    synopsis_chain = LLMChain(llm=llm, prompt=prompt_template)
+
+    # This is an LLMChain to write a review of a play given a synopsis.
+    llm = OpenAI(temperature=0.7)
+    template = """You are a play critic from the New York Times. Given the synopsis 
+    of play, it is your job to write a review for that play.
+
+    Play Synopsis:
+    {synopsis}
+    Review from a New York Times play critic of the above play:"""
+    prompt_template = PromptTemplate(input_variables=["synopsis"], template=template)
+    review_chain = LLMChain(llm=llm, prompt=prompt_template)
+
+    # This is the overall chain where we run these two chains in sequence.
+    return SimpleSequentialChain(chains=[synopsis_chain, review_chain], verbose=True)
 
 
 def create_openai_llmagent():
@@ -192,6 +218,16 @@ def test_langchain_model_predict():
             logged_model = mlflow.langchain.log_model(model, "langchain_model")
         loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
         result = loaded_model.predict([{"product": "MLflow"}])
+        assert result == [TEST_CONTENT]
+
+
+def test_simple_sequential_chain_predict():
+    with _mock_request(return_value=_mock_chat_completion_response()):
+        model = create_simple_sequential_chain()
+        with mlflow.start_run():
+            logged_model = mlflow.langchain.log_model(model, "langchain_model")
+        loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
+        result = loaded_model.predict([{"title": "Tragedy at sunset on the beach"}])
         assert result == [TEST_CONTENT]
 
 

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -96,20 +96,6 @@ def create_openai_llmagent():
     return initialize_agent(tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True)
 
 
-def create_model(model_type, model_path=None):
-    if model_type == "openai":
-        return create_openai_llmchain()
-    if model_type == "huggingfacehub":
-        return create_huggingface_model(model_path)
-    if model_type == "qaevalchain":
-        return create_qa_eval_chain()
-    if model_type == "qa_with_sources_chain":
-        return create_qa_with_sources_chain()
-    if model_type == "openaiagent":
-        return create_openai_llmagent()
-    raise NotImplementedError("This model is not supported yet.")
-
-
 class FakeLLM(LLM):
     """Fake LLM wrapper for testing purposes."""
 
@@ -161,7 +147,7 @@ class FakeChain(Chain):
 
 
 def test_langchain_native_save_and_load_model(model_path):
-    model = create_model("openai")
+    model = create_openai_llmchain()
     mlflow.langchain.save_model(model, model_path)
 
     loaded_model = mlflow.langchain.load_model(model_path)
@@ -172,7 +158,7 @@ def test_langchain_native_save_and_load_model(model_path):
 
 
 def test_langchain_native_log_and_load_model():
-    model = create_model("openai")
+    model = create_openai_llmchain()
     with mlflow.start_run():
         logged_model = mlflow.langchain.log_model(model, "langchain_model")
 
@@ -189,7 +175,7 @@ def test_langchain_native_log_and_load_model():
 
 
 def test_pyfunc_load_openai_model():
-    model = create_model("openai")
+    model = create_openai_llmchain()
     with mlflow.start_run():
         logged_model = mlflow.langchain.log_model(model, "langchain_model")
 
@@ -201,7 +187,7 @@ def test_pyfunc_load_openai_model():
 
 def test_langchain_model_predict():
     with _mock_request(return_value=_mock_chat_completion_response()):
-        model = create_model("openai")
+        model = create_openai_llmchain()
         with mlflow.start_run():
             logged_model = mlflow.langchain.log_model(model, "langchain_model")
         loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
@@ -210,7 +196,7 @@ def test_langchain_model_predict():
 
 
 def test_pyfunc_spark_udf_with_langchain_model(spark):
-    model = create_model("openai")
+    model = create_openai_llmchain()
     with mlflow.start_run():
         logged_model = mlflow.langchain.log_model(model, "langchain_model")
     loaded_model = mlflow.pyfunc.spark_udf(spark, logged_model.model_uri, result_type="string")
@@ -221,7 +207,7 @@ def test_pyfunc_spark_udf_with_langchain_model(spark):
 
 
 def test_langchain_log_huggingface_hub_model_metadata(model_path):
-    model = create_model("huggingfacehub", model_path)
+    model = create_huggingface_model(model_path)
     with mlflow.start_run():
         logged_model = mlflow.langchain.log_model(model, "langchain_model")
 
@@ -251,7 +237,7 @@ def test_langchain_agent_model_predict():
         ],
         "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
     }
-    model = create_model("openaiagent")
+    model = create_openai_llmagent()
     with mlflow.start_run():
         logged_model = mlflow.langchain.log_model(model, "langchain_model")
     loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
@@ -284,7 +270,7 @@ def test_langchain_agent_model_predict():
 
 def test_langchain_native_log_and_load_qaevalchain():
     # QAEvalChain is a subclass of LLMChain
-    model = create_model("qaevalchain")
+    model = create_qa_eval_chain()
     with mlflow.start_run():
         logged_model = mlflow.langchain.log_model(model, "langchain_model")
 
@@ -294,7 +280,7 @@ def test_langchain_native_log_and_load_qaevalchain():
 
 def test_langchain_native_log_and_load_qa_with_sources_chain():
     # StuffDocumentsChain is a subclass of Chain
-    model = create_model("qa_with_sources_chain")
+    model = create_qa_with_sources_chain()
     with mlflow.start_run():
         logged_model = mlflow.langchain.log_model(model, "langchain_model")
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?
This PR extends the mlflow langchain flavor to support saving and loading all subclasses of Chain.

Before:
| **class of model** | **model log<br>& load<br>(langchain<br>& pyfunc)** | **extract llm<br>type in model<br>metadata** | **model<br>predict** | **pyfunc<br>spark_udf** |
|--------------|--------------|--------------|--------------|--------------|
| LLMChain  | ✅  | ✅  | ✅ | ✅ |
| AgentExecutor  | ✅  | ✅  | ✅ | ✅ |
| other  | ❌  | ❌  |❌ | ❌ |

After:

| **class of model** | **model log<br>& load<br>(langchain<br>& pyfunc)** | **extract llm<br>info in model<br>metadata** | **model<br>predict** | **pyfunc<br>spark_udf** |
|--------------|--------------|--------------|--------------|--------------|
| subclasses of<br>LLMChain  | ✅  | ✅  | ✅ | ✅ |
| subclasses of<br>AgentExecutor  | ✅  | ✅  | ✅ | ✅ |
| subclasses<br>of Chain<br>(see known<br>exceptions<br>below)  | ✅  | ❌ (llm info<br>exists in<br>model.yaml) | ✅* | ✅* |
| Chains<br>containing<br>memory  | ❌  | ❌  |❌ | ❌ |

\* Given all the Chains have some bugs in SerDe, we cannot test any concrete Chains. It should work and we can add tests after langchain fixed the bugs.


Here is a list of Chains that langchain supports loading. 
https://github.com/hwchase17/langchain/blob/0c3de0a0b32fadb8caf3e6d803287229409f9da9/langchain/chains/loading.py#L409
```python
type_to_loader_dict = {
    "api_chain": _load_api_chain, # ❌ SISO requires "requests_wrapper" in kwargs
    "hyde_chain": _load_hyde_chain, # ❌ SISO requires "embeddings" in kwargs
    "llm_chain": _load_llm_chain, # SISO ✅
    "llm_bash_chain": _load_llm_bash_chain, # SISO ❌ Bug, fixing by langchain
    "llm_checker_chain": _load_llm_checker_chain, # ❌ SISO, but contains SequentialChain, which does not support saving
    "llm_math_chain": _load_llm_math_chain, # SISO ❌ Bug, fixing by langchain
    "llm_requests_chain": _load_llm_requests_chain, # ❌ SISO requires "requests_wrapper" in kwargs
    "pal_chain": _load_pal_chain, # SIMO ❌ Bug, reported to langchain ["result", "intermediate_steps"]
    "qa_with_sources_chain": _load_qa_with_sources_chain, # ❌ MIMO [self.input_docs_key, self.question_key] -> [self.answer_key, self.sources_answer_key, "source_documents"]
    "stuff_documents_chain": _load_stuff_documents_chain, # MISO ❌ Bug, fixing by langchain
    "map_reduce_documents_chain": _load_map_reduce_documents_chain, # ❌ MIMO ["result", "intermediate_steps"]
    "map_rerank_documents_chain": _load_map_rerank_documents_chain, # ❌ MIMO ["result", "intermediate_steps"]
    "refine_documents_chain": _load_refine_documents_chain, # ❌ MIMO ["result", "intermediate_steps"]
    "sql_database_chain": _load_sql_database_chain, # ❌ SIMO ["result", "intermediate_steps"], requires "database" in kwargs 
    "vector_db_qa_with_sources_chain": _load_vector_db_qa_with_sources_chain, # ❌ SIMO requires "vectorstore" in kwargs
    "vector_db_qa": _load_vector_db_qa, # ❌ SIMO requires "vectorstore" in kwargs
}
```

Among them, MLflow cannot support the following number of chains and reasons:
1. Multiple Outputs: 8 chains are blocked. mlflow plans to have a follow-up PR to support it.
2. Needs `kwargs` during mlflow.pyfunc.load_model: 6 chains are blocked. mlflow plans to have a follow-up PR to support it.
3. langchain bug: 4 chains are blocked (LLMBashChain, LLMMathChain, StuffDocumentsChain, PALChain). Filed https://github.com/hwchase17/langchain/issues/5131, https://github.com/hwchase17/langchain/issues/5160, https://github.com/hwchase17/langchain/issues/5224

### Known exceptions
Examples of Chain classes that are known to be not supported as of `langchain==0.0.176`:
1. `class ConversationChain(LLMChain): Chain to have a conversation and load context from memory.` Reason: (from `langchain`) Saving of memory is not yet supported.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

mlflow langchain flavor allows logging and loading all subclasses of Chain, as long as their serialization / deserialization methods are implemented by langchain.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
