### PR TITLE
Don't use `max_age` if Flask version is <2.0

### DIFF
--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -1,19 +1,19 @@
-import importlib.metadata
 import os
 import shlex
 import sys
 import textwrap
+import importlib.metadata
 
 from flask import __version__ as flask_version
-from flask import Flask, Response, send_from_directory
+from flask import Flask, send_from_directory, Response
 from mlflow.exceptions import MlflowException
 from mlflow.server import handlers
 from mlflow.server.handlers import (
-    _add_static_prefix,
     get_artifact_handler,
     get_metric_history_bulk_handler,
-    get_model_version_artifact_handler,
     STATIC_PREFIX_ENV_VAR,
+    _add_static_prefix,
+    get_model_version_artifact_handler,
 )
 from mlflow.utils.process import _exec_cmd
 from mlflow.version import VERSION

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -4,6 +4,7 @@ import sys
 import textwrap
 import importlib.metadata
 
+from packaging.version import Version
 from flask import __version__ as flask_version
 from flask import Flask, send_from_directory, Response
 from mlflow.exceptions import MlflowException
@@ -17,7 +18,6 @@ from mlflow.server.handlers import (
 )
 from mlflow.utils.process import _exec_cmd
 from mlflow.version import VERSION
-from packaging.version import Version
 
 # NB: These are internal environment variables used for communication between
 # the cli and the forked gunicorn processes.

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -33,6 +33,7 @@ REL_STATIC_DIR = "js/build"
 
 app = Flask(__name__, static_folder=REL_STATIC_DIR)
 STATIC_DIR = os.path.join(app.root_path, REL_STATIC_DIR)
+IS_FLASK_V1 = Version(flask_version) < Version("2.0")
 
 
 for http_path, handler, methods in handlers.get_endpoints():
@@ -82,10 +83,10 @@ def serve_get_metric_history_bulk():
 # The files are hashed based on source code, so ok to send Cache-Control headers via max_age.
 @app.route(_add_static_prefix("/static-files/<path:path>"))
 def serve_static_file(path):
-    if Version(flask_version) >= Version("2.0"):
-        return send_from_directory(STATIC_DIR, path, max_age=2419200)
-    else:
+    if IS_FLASK_V1:
         return send_from_directory(STATIC_DIR, path, cache_timeout=2419200)
+    else:
+        return send_from_directory(STATIC_DIR, path, max_age=2419200)
 
 
 # Serve the index.html for the React App for all other routes.


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Resolve #8456 

## What changes are proposed in this pull request?

The `max_age` keyword in `flask.send_from_directory` was introduced in Flask 2.0, which makes MLflow currently require Flask>=2.0. This PR checks what version of Flask is running and uses the old kwarg name if Flask is older than 2.0.

## How is this patch tested?

(1) Run `yarn build` in `mlflow/server/js` to build the artifacts needed to run the UI
(2) Create a Dockerfile:
```
FROM python:3.8.10

RUN pip install flask==1.* && \
    # Other pins needed to get Flask<2 to work (with MLflow<2.3 but not 2.3)
    pip install jinja2==3.0.3 && \
    pip install itsdangerous==2.0.1 && \
    pip install werkzeug==2.0.3 && \
    pip install markupsafe==2.0.1

# RUN pip install mlflow==2.3.1
COPY mlflow/ ./mlflow
RUN pip install ./mlflow

EXPOSE 5000

CMD mlflow server --host 0.0.0.0 --port 5000
```
Build and run the image:
```
docker build -f Dockerfile . -t mlflow-issue-8456
docker run -p 5000:5000 mlflow-issue-8456:latest
```

Then navigate to 0.0.0.0:5000. Without this change there is an error and a blank page is shown. With this change the UI is shown.

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix a bug that made MLflow mistakenly require Flask>=2.0

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
