### PR TITLE
Add sentence-transformers as a named flavor

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -68,6 +68,7 @@ def pytest_ignore_collect(path, config):
             "tests/pmdarima",
             "tests/diviner",
             "tests/transformers",
+            "tests/sentence_transformers",
             "tests/openai",
             "tests/langchain",
             "tests/test_mlflow_lazily_imports_ml_packages.py",

--- a/docs/source/python_api/mlflow.sentence_transformers.rst
+++ b/docs/source/python_api/mlflow.sentence_transformers.rst
@@ -1,0 +1,7 @@
+mlflow.sentence_transformers
+============================
+
+.. automodule:: mlflow.sentence_transformers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -75,6 +75,7 @@ try:
     from mlflow import langchain
     from mlflow import llm
     from mlflow import openai
+    from mlflow import sentence_transformers
 
     _model_flavors_supported = [
         "catboost",
@@ -102,6 +103,7 @@ try:
         "langchain",
         "llm",
         "openai",
+        "sentence_transformers",
     ]
 except ImportError as e:
     # We are conditional loading these commands since the skinny client does

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -550,4 +550,3 @@ sentence_transformers:
         ">= 0.0.0": ["torch>1.6", "transformers>4.25"]
       run: |
         pytest tests/sentence_transformers/test_sentence_transformers_model_export.py
-      

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -537,3 +537,17 @@ langchain:
       export OPENAI_API_KEY=test
       export SERPAPI_API_KEY=test
       pytest tests/langchain/test_langchain_model_export.py
+
+sentence_transformers:
+  package_info:
+    pip_release: "sentence-transformers"
+    install_dev: |
+      pip install -e git+https://github.com/UKPLab/sentence-transformers
+    models:
+      minimum: "2.2.2"
+      maximum: "2.2.2"
+      requirements:
+        ">= 0.0.0": ["torch>1.6", "transformers>4.25"]
+      run: |
+        pytest tests/sentence_transformers/test_sentence_transformers_model_export.py
+      

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -248,5 +248,14 @@ _ML_PACKAGE_VERSIONS = {
             "minimum": "0.0.169",
             "maximum": "0.0.169"
         }
+    },
+    "sentence-transformers": {
+        "package_info": {
+            "pip_release": "sentence-transformers"
+        },
+        "models": {
+            "minimum": "2.2.2",
+            "maximum": "2.2.2"
+        }
     }
 }

--- a/mlflow/sentence_transformers.py
+++ b/mlflow/sentence_transformers.py
@@ -1,0 +1,312 @@
+import json
+import logging
+import numpy as np
+import pathlib
+from typing import List, Optional, Dict, Any, Union
+import yaml
+
+import mlflow
+from mlflow import pyfunc
+from mlflow.exceptions import MlflowException
+from mlflow.models import ModelInputExample, Model, infer_pip_requirements
+from mlflow.models.model import MLMODEL_FILE_NAME
+from mlflow.models.signature import ModelSignature, infer_signature
+from mlflow.models.utils import _save_example
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, BAD_REQUEST
+from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+from mlflow.types.schema import Schema, ColSpec, TensorSpec
+from mlflow.utils.annotations import experimental
+from mlflow.utils.docstring_utils import (
+    format_docstring,
+    LOG_MODEL_PARAM_DOCS,
+    docstring_version_compatibility_warning,
+)
+from mlflow.utils.environment import (
+    _mlflow_conda_env,
+    _validate_env_arguments,
+    _CONDA_ENV_FILE_NAME,
+    _PYTHON_ENV_FILE_NAME,
+    _process_conda_env,
+    _process_pip_requirements,
+    _CONSTRAINTS_FILE_NAME,
+    _REQUIREMENTS_FILE_NAME,
+    _PythonEnv,
+)
+from mlflow.utils.file_utils import write_to
+from mlflow.utils.model_utils import (
+    _validate_and_copy_code_paths,
+    _validate_and_prepare_target_save_path,
+    _download_artifact_from_uri,
+    _get_flavor_configuration,
+    _get_flavor_configuration_from_uri,
+    _add_code_from_conf_to_system_path,
+)
+from mlflow.utils.requirements_utils import _get_pinned_requirement
+
+FLAVOR_NAME = "sentence_transformers"
+SENTENCE_TRANSFORMERS_DATA_PATH = "model.sentence_transformer"
+_INFERENCE_CONFIG_PATH = "inference_config"
+
+_logger = logging.getLogger(__name__)
+
+
+@experimental
+def get_default_pip_requirements() -> List[str]:
+    """
+    Retrieves the set of minimal dependencies for the sentence_transformers flavor.
+    :return: A list of default pip requirements for MLflow Models that have been produced with the
+             ``sentence-transformers`` flavor. Calls to :py:func:`save_model()` and
+             :py:func:`log_model()` produce a pip environment that contain these
+             requirements at a minimum.
+    """
+    base_reqs = ["sentence-transformers", "transformers", "torch"]
+    return [_get_pinned_requirement(module) for module in base_reqs]
+
+
+@experimental
+def get_default_conda_env():
+    """
+    :return: The default Conda environment for MLflow Models produced with the
+             ``sentence_transformers`` flavor.
+    """
+    return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
+
+
+@experimental
+@docstring_version_compatibility_warning(integration_name=FLAVOR_NAME)
+@format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
+def save_model(
+    model,
+    path: str,
+    inference_config: Optional[Dict[str, Any]] = None,
+    code_paths: Optional[List[str]] = None,
+    mlflow_model: Optional[Model] = None,
+    signature: Optional[ModelSignature] = None,
+    input_example: Optional[ModelInputExample] = None,
+    pip_requirements: Optional[Union[List[str], str]] = None,
+    extra_pip_requirements: Optional[Union[List[str], str]] = None,
+    conda_env=None,
+    metadata: Dict[str, Any] = None,
+    **kwargs,
+) -> None:
+    """
+    Save a trained sentence-transformers model to a path on the local file system.
+
+    :param model: A trained sentence-transformers model.
+    :param path: Local path destination for the serialized model to be saved.
+    :param inference_config:
+        A dict of valid overrides that can be applied to a sentence-transformer model instance
+        during inference.
+        These arguments are used exclusively for the case of loading the model as a ``pyfunc``
+        Model or for use in Spark.
+        These values are not applied to a returned Pipeline from a call to
+        ``mlflow.sentence_transformers.load_model()``
+    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
+                       containing file dependencies). These files are *prepended* to the system
+                       path when the model is loaded.
+    :param mlflow_model: An MLflow model object that specifies the flavor that this model is being
+                         added to.
+    :param signature: A Model Signature object that describes the input and output Schema of the
+                      model. The model signature can be inferred using `infer_signature` function
+                      of `mlflow.models.signature`.
+
+                      If an input_example is provided and the signature is not, a signature will
+                      be inferred automatically and applied to the MLmodel file.
+
+    :param input_example: An example of valid input that the model can accept. The example can be
+                          used as a hint of what data to feed the model. The given example will be
+                          converted to a `Pandas DataFrame` and then serialized to JSON using the
+                          `Pandas` split-oriented format.
+    :param pip_requirements: {{ pip_requirements }}
+    :param extra_pip_requirements: {{ extra_pip_requirements }}
+    :param conda_env: {{ conda_env }}
+    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
+
+                     .. Note:: Experimental: This parameter may change or be removed in a future
+                                             release without warning.
+
+    :param kwargs: Optional additional configurations for sentence-transformers serialization.
+    :return: None
+    """
+    import sentence_transformers
+
+    _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
+
+    path = pathlib.Path(path).absolute()
+    model_data_path = path.joinpath(SENTENCE_TRANSFORMERS_DATA_PATH)
+
+    _validate_and_prepare_target_save_path(str(path))
+
+    code_dir_subpath = _validate_and_copy_code_paths(code_paths, str(path))
+
+    if mlflow_model is None:
+        mlflow_model = Model()
+    if signature is not None:
+        mlflow_model.signature = signature
+    if input_example is not None:
+        _save_example(mlflow_model, input_example, str(path))
+    if metadata is not None:
+        mlflow_model.metadata = metadata
+
+    model.save(str(model_data_path))
+
+    pyfunc.add_to_model(
+        mlflow_model,
+        loader_module="mlflow.sentence_transformers",
+        data=SENTENCE_TRANSFORMERS_DATA_PATH,
+        conda_env=_CONDA_ENV_FILE_NAME,
+        python_env=_PYTHON_ENV_FILE_NAME,
+        code=code_dir_subpath,
+    )
+    mlflow_model.add_flavor(
+        FLAVOR_NAME,
+        sentence_transformers_version=sentence_transformers.__version__,
+        code=code_dir_subpath,
+    )
+    mlflow_model.save(str(path.joinpath(MLMODEL_FILE_NAME)))
+
+    if inference_config:
+        path.joinpath(_INFERENCE_CONFIG_PATH).write_text(json.dumps(inference_config))
+
+    if conda_env is None:
+        if pip_requirements is None:
+            default_reqs = get_default_pip_requirements()
+            inferred_reqs = infer_pip_requirements(str(path), FLAVOR_NAME, fallback=default_reqs)
+            default_reqs = sorted(set(inferred_reqs).union(default_reqs))
+        else:
+            default_reqs = None
+        conda_env, pip_requirements, pip_constraints = _process_pip_requirements(
+            default_reqs, pip_requirements, extra_pip_requirements
+        )
+    else:
+        conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+
+    with path.joinpath(_CONDA_ENV_FILE_NAME).open("w") as f:
+        yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
+
+    if pip_constraints:
+        write_to(str(path.joinpath(_CONSTRAINTS_FILE_NAME)), "\n".join(pip_constraints))
+
+    write_to(str(path.joinpath(_REQUIREMENTS_FILE_NAME)), "\n".join(pip_requirements))
+
+    _PythonEnv.current().to_yaml(str(path.joinpath(_PYTHON_ENV_FILE_NAME)))
+
+
+@experimental
+@docstring_version_compatibility_warning(integration_name=FLAVOR_NAME)
+@format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
+def log_model(
+    model,
+    artifact_path: str,
+    inference_config: Optional[Dict[str, Any]] = None,
+    code_paths: Optional[List[str]] = None,
+    registered_model_name: str = None,
+    signature: Optional[ModelSignature] = None,
+    input_example: Optional[ModelInputExample] = None,
+    await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
+    pip_requirements: Optional[Union[List[str], str]] = None,
+    extra_pip_requirements: Optional[Union[List[str], str]] = None,
+    conda_env=None,
+    metadata: Dict[str, Any] = None,
+    **kwargs,
+):
+    """
+    Log a ``sentence_transformers`` model as an MLflow artifact for the current run.
+
+    :param model: A trained sentence-transformers model.
+    :param artifact_path: Local path destination for the serialized model to be saved.
+    :param inference_config:
+        A dict of valid overrides that can be applied to a sentence-transformer model instance
+        during inference.
+        These arguments are used exclusively for the case of loading the model as a ``pyfunc``
+        Model or for use in Spark.
+        These values are not applied to a returned Pipeline from a call to
+        ``mlflow.sentence_transformers.load_model()``
+    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
+                       containing file dependencies). These files are *prepended* to the system
+                       path when the model is loaded.
+    :param registered_model_name: This argument may change or be removed in a
+                                  future release without warning. If given, create a model
+                                  version under ``registered_model_name``, also creating a
+                                  registered model if one with the given name does not exist.
+    :param signature: A Model Signature object that describes the input and output Schema of the
+                      model. The model signature can be inferred using `infer_signature` function
+                      of `mlflow.models.signature`.
+
+                      If an input_example is provided and the signature is not, a signature will
+                      be inferred automatically and applied to the MLmodel file.
+
+    :param input_example: An example of valid input that the model can accept. The example can be
+                          used as a hint of what data to feed the model. The given example will be
+                          converted to a `Pandas DataFrame` and then serialized to JSON using the
+                          `Pandas` split-oriented format.
+    :param pip_requirements: {{ pip_requirements }}
+    :param extra_pip_requirements: {{ extra_pip_requirements }}
+    :param conda_env: {{ conda_env }}
+    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
+
+                     .. Note:: Experimental: This parameter may change or be removed in a future
+                                             release without warning.
+
+    :param kwargs: Optional additional configurations for sentence-transformers serialization.
+    """
+    return Model.log(
+        artifact_path=artifact_path,
+        flavor=mlflow.sentence_transformers,
+        registered_model_name=registered_model_name,
+        await_registration_for=await_registration_for,
+        metadata=metadata,
+        model=model,
+        inference_config=inference_config,
+        conda_env=conda_env,
+        code_paths=code_paths,
+        signature=signature,
+        input_example=input_example,
+        pip_requirements=pip_requirements,
+        extra_pip_requirements=extra_pip_requirements,
+        **kwargs,
+    )
+
+@experimental
+@docstring_version_compatibility_warning(integration_name=FLAVOR_NAME)
+def load_model(model_uri: str, dst_path: str = None, **kwargs):
+    """
+    Load a ``sentence_transformers`` object from a local file or a run.
+
+    :param model_uri: The location, in URI format, of the MLflow model. For example:
+
+                      - ``/Users/me/path/to/local/model``
+                      - ``relative/path/to/local/model``
+                      - ``s3://my_bucket/path/to/model``
+                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+                      - ``mlflow-artifacts:/path/to/model``
+
+                      For more information about supported URI schemes, see
+                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
+                      artifact-locations>`_.
+    :param dst_path: The local filesystem path to utilize for downloading the model artifact.
+                     This directory must already exist if provided. If unspecified, a local output
+                     path will be created.
+    :param kwargs: Optional configuration options for loading of a ``transformers`` object.
+                   For information on parameters and their usage, see
+                   `transformers documentation <https://huggingface.co/docs/transformers/index>`_.
+    :return: A ``sentence_transformers`` model instance
+    """
+
+    import sentence_transformers
+
+    model_uri = str(model_uri)
+
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
+
+    local_model_dir = pathlib.Path(local_model_path).joinpath(SENTENCE_TRANSFORMERS_DATA_PATH)
+
+    flavor_config = _get_flavor_configuration_from_uri(model_uri, FLAVOR_NAME, _logger)
+
+    _add_code_from_conf_to_system_path(local_model_path, flavor_config)
+
+    return sentence_transformers.SentenceTransformer.load(local_model_dir)
+
+
+
+

--- a/mlflow/sentence_transformers.py
+++ b/mlflow/sentence_transformers.py
@@ -51,7 +51,7 @@ _logger = logging.getLogger(__name__)
 def get_default_pip_requirements() -> List[str]:
     """
     Retrieves the set of minimal dependencies for the ``sentence_transformers`` flavor.
-    
+
     :return: A list of default pip requirements for MLflow Models that have been produced with the
              ``sentence-transformers`` flavor. Calls to :py:func:`save_model()` and
              :py:func:`log_model()` produce a pip environment that contain these
@@ -93,8 +93,8 @@ def save_model(
     :param model: A trained ``sentence-transformers`` model.
     :param path: Local path destination for the serialized model to be saved.
     :param inference_config:
-        A dict of valid overrides that can be applied to a ``sentence-transformer`` model instance
-        during inference.
+        A dict of valid inference parameters that can be applied to a ``sentence-transformer``
+        model instance during inference.
         These arguments are used exclusively for the case of loading the model as a ``pyfunc``
         Model or for use in Spark.
         These values are not applied to a returned model from a call to

--- a/mlflow/sentence_transformers.py
+++ b/mlflow/sentence_transformers.py
@@ -51,6 +51,7 @@ _logger = logging.getLogger(__name__)
 def get_default_pip_requirements() -> List[str]:
     """
     Retrieves the set of minimal dependencies for the ``sentence_transformers`` flavor.
+    
     :return: A list of default pip requirements for MLflow Models that have been produced with the
              ``sentence-transformers`` flavor. Calls to :py:func:`save_model()` and
              :py:func:`log_model()` produce a pip environment that contain these

--- a/mlflow/sentence_transformers.py
+++ b/mlflow/sentence_transformers.py
@@ -85,7 +85,6 @@ def save_model(
     extra_pip_requirements: Optional[Union[List[str], str]] = None,
     conda_env=None,
     metadata: Dict[str, Any] = None,
-    **kwargs,
 ) -> None:
     """
     Save a trained ``sentence-transformers`` model to a path on the local file system.
@@ -123,7 +122,6 @@ def save_model(
                      .. Note:: Experimental: This parameter may change or be removed in a future
                                              release without warning.
 
-    :param kwargs: Optional additional configurations for ``sentence-transformers`` serialization.
     :return: None
     """
     import sentence_transformers
@@ -208,7 +206,6 @@ def log_model(
     extra_pip_requirements: Optional[Union[List[str], str]] = None,
     conda_env=None,
     metadata: Dict[str, Any] = None,
-    **kwargs,
 ):
     """
     Log a ``sentence_transformers`` model as an MLflow artifact for the current run.
@@ -248,7 +245,6 @@ def log_model(
                      .. Note:: Experimental: This parameter may change or be removed in a future
                                              release without warning.
 
-    :param kwargs: Optional additional configurations for sentence-transformers serialization.
     """
     return Model.log(
         artifact_path=artifact_path,
@@ -264,13 +260,12 @@ def log_model(
         input_example=input_example,
         pip_requirements=pip_requirements,
         extra_pip_requirements=extra_pip_requirements,
-        **kwargs,
     )
 
 
 @experimental
 @docstring_version_compatibility_warning(integration_name=FLAVOR_NAME)
-def load_model(model_uri: str, dst_path: str = None, **kwargs):
+def load_model(model_uri: str, dst_path: str = None):
     """
     Load a ``sentence_transformers`` object from a local file or a run.
 
@@ -288,9 +283,6 @@ def load_model(model_uri: str, dst_path: str = None, **kwargs):
     :param dst_path: The local filesystem path to utilize for downloading the model artifact.
                      This directory must already exist if provided. If unspecified, a local output
                      path will be created.
-    :param kwargs: Optional configuration options for loading of a ``transformers`` object.
-                   For information on parameters and their usage, see
-                   `transformers documentation <https://huggingface.co/docs/transformers/index>`_.
     :return: A ``sentence_transformers`` model instance
     """
 

--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -19,6 +19,7 @@ FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY = {
     "pytorch": ("torch", "pytorch"),
     "pyspark.ml": ("pyspark", "spark"),
     "transformers": ("transformers", "transformers"),
+    "sentence_transformers": ("sentence_transformers", "sentence-transformers"),
 }
 
 

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -57,3 +57,5 @@ tiktoken
 tenacity
 # Required by mlflow.langchain
 langchain
+# Required by mlflow.sentence_transformers
+sentence-transformers

--- a/tests/check_mlflow_lazily_imports_ml_packages.py
+++ b/tests/check_mlflow_lazily_imports_ml_packages.py
@@ -33,6 +33,7 @@ def main():
         "pmdarima",
         "diviner",
         "transformers",
+        "sentence-transformers",
     }
     imported = ml_packages.intersection(set(sys.modules))
     assert imported == set(), f"mlflow imports {imported} when it's imported but it should not"

--- a/tests/check_mlflow_lazily_imports_ml_packages.py
+++ b/tests/check_mlflow_lazily_imports_ml_packages.py
@@ -33,7 +33,7 @@ def main():
         "pmdarima",
         "diviner",
         "transformers",
-        "sentence-transformers",
+        "sentence_transformers",
     }
     imported = ml_packages.intersection(set(sys.modules))
     assert imported == set(), f"mlflow imports {imported} when it's imported but it should not"

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -1,0 +1,37 @@
+import numpy as np
+from sentence_transformers import SentenceTransformer
+import pytest
+
+import mlflow
+
+
+@pytest.fixture
+def model_path(tmp_path):
+    return tmp_path.joinpath("model")
+
+@pytest.fixture
+def basic_model():
+    return SentenceTransformer("all-MiniLM-L6-v2")
+
+# def test_dependency_inference():
+
+
+
+def test_model_save_and_load(model_path, basic_model):
+
+    mlflow.sentence_transformers.save_model(
+        model=basic_model,
+        path=model_path
+    )
+
+    loaded_model = mlflow.sentence_transformers.load_model(model_path)
+
+    encoded_single = loaded_model.encode("I'm just a simple string; nothing to see here.")
+    encoded_multi = loaded_model.encode(["I'm a string", "I'm also a string", "Please encode me"])
+
+    assert isinstance(encoded_single, np.ndarray)
+    assert len(encoded_single) == 384
+    assert isinstance(encoded_multi, np.ndarray)
+    assert len(encoded_multi) == 3
+    assert all(len(x) == 384 for x in encoded_multi)
+

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -1,28 +1,34 @@
 import numpy as np
+import os
 from sentence_transformers import SentenceTransformer
 import pytest
+from unittest import mock
+import yaml
 
 import mlflow
+from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
+from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+from mlflow.utils.environment import _mlflow_conda_env
+
+from tests.helper_functions import (
+    _assert_pip_requirements,
+    _compare_logged_code_paths,
+    _mlflow_major_version_string,
+)
 
 
 @pytest.fixture
 def model_path(tmp_path):
     return tmp_path.joinpath("model")
 
+
 @pytest.fixture
 def basic_model():
     return SentenceTransformer("all-MiniLM-L6-v2")
 
-# def test_dependency_inference():
-
-
 
 def test_model_save_and_load(model_path, basic_model):
-
-    mlflow.sentence_transformers.save_model(
-        model=basic_model,
-        path=model_path
-    )
+    mlflow.sentence_transformers.save_model(model=basic_model, path=model_path)
 
     loaded_model = mlflow.sentence_transformers.load_model(model_path)
 
@@ -35,3 +41,247 @@ def test_model_save_and_load(model_path, basic_model):
     assert len(encoded_multi) == 3
     assert all(len(x) == 384 for x in encoded_multi)
 
+
+def test_dependency_mapping(model_path, basic_model):
+    pip_requirements = mlflow.sentence_transformers.get_default_pip_requirements()
+
+    expected_requirements = {"sentence-transformers", "torch", "transformers"}
+    assert {package.split("=")[0] for package in pip_requirements}.intersection(
+        expected_requirements
+    ) == expected_requirements
+
+    conda_requirements = mlflow.sentence_transformers.get_default_conda_env()
+    pip_in_conda = {
+        package.split("=")[0] for package in conda_requirements["dependencies"][2]["pip"]
+    }
+    expected_conda = {"mlflow"}
+    expected_conda.update(expected_requirements)
+    assert pip_in_conda.intersection(expected_conda) == expected_conda
+
+
+def test_logged_data_structure(model_path, basic_model):
+    mlflow.sentence_transformers.save_model(model=basic_model, path=model_path)
+
+    with model_path.joinpath("requirements.txt").open() as file:
+        requirements = file.read()
+    reqs = {req.split("==")[0] for req in requirements.split("\n")}
+    expected_requirements = {"sentence-transformers", "torch", "transformers"}
+    assert reqs.intersection(expected_requirements) == expected_requirements
+    conda_env = yaml.safe_load(model_path.joinpath("conda.yaml").read_bytes())
+    assert {req.split("==")[0] for req in conda_env["dependencies"][2]["pip"]}.intersection(
+        expected_requirements
+    ) == expected_requirements
+
+    mlmodel = yaml.safe_load(model_path.joinpath("MLmodel").read_bytes())
+    assert mlmodel["flavors"]["python_function"]["loader_module"] == "mlflow.sentence_transformers"
+    assert (
+        mlmodel["flavors"]["python_function"]["data"]
+        == mlflow.sentence_transformers.SENTENCE_TRANSFORMERS_DATA_PATH
+    )
+
+
+def test_model_logging_and_inference(basic_model):
+    artifact_path = "sentence_transformer"
+    with mlflow.start_run():
+        model_info = mlflow.sentence_transformers.log_model(
+            model=basic_model, artifact_path=artifact_path
+        )
+
+    model = mlflow.sentence_transformers.load_model(model_info.model_uri)
+
+    encoded_single = model.encode(
+        "Encodings provide a fixed width output regardless of input size."
+    )
+    encoded_multi = model.encode(
+        [
+            "Just a small town girl",
+            "livin in a lonely world",
+            "she took the midnight train",
+            "goin anywhere",
+        ]
+    )
+
+    assert isinstance(encoded_single, np.ndarray)
+    assert len(encoded_single) == 384
+    assert isinstance(encoded_multi, np.ndarray)
+    assert len(encoded_multi) == 4
+    assert all(len(x) == 384 for x in encoded_multi)
+
+
+def test_load_from_remote_uri(model_path, basic_model, mock_s3_bucket):
+    mlflow.sentence_transformers.save_model(model=basic_model, path=model_path)
+    artifact_root = f"s3://{mock_s3_bucket}"
+    artifact_path = "model"
+    artifact_repo = S3ArtifactRepository(artifact_root)
+    artifact_repo.log_artifacts(model_path, artifact_path=artifact_path)
+    model_uri = os.path.join(artifact_root, artifact_path)
+    loaded = mlflow.sentence_transformers.load_model(model_uri=str(model_uri))
+
+    encoding = loaded.encode(
+        "I can see why these are useful when you do distance calculations on them!"
+    )
+
+    assert len(encoding) == 384
+
+
+def test_log_model_calls_register_model(tmp_path, basic_model):
+    artifact_path = "sentence_transformer"
+    register_model_patch = mock.patch("mlflow.register_model")
+    with mlflow.start_run(), register_model_patch:
+        conda_env = tmp_path.joinpath("conda_env.yaml")
+        _mlflow_conda_env(
+            conda_env, additional_pip_deps=["transformers", "torch", "sentence-transformers"]
+        )
+        mlflow.sentence_transformers.log_model(
+            model=basic_model,
+            artifact_path=artifact_path,
+            conda_env=str(conda_env),
+            registered_model_name="My super cool encoder",
+        )
+        model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
+        mlflow.register_model.assert_called_once_with(
+            model_uri,
+            "My super cool encoder",
+            await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
+        )
+
+
+def test_log_model_with_no_registered_model_name(tmp_path, basic_model):
+    artifact_path = "sentence_transformer"
+    register_model_patch = mock.patch("mlflow.register_model")
+    with mlflow.start_run(), register_model_patch:
+        conda_env = tmp_path.joinpath("conda_env.yaml")
+        _mlflow_conda_env(
+            conda_env, additional_pip_deps=["transformers", "torch", "sentence-transformers"]
+        )
+        mlflow.sentence_transformers.log_model(
+            model=basic_model,
+            artifact_path=artifact_path,
+            conda_env=str(conda_env),
+        )
+        mlflow.register_model.assert_not_called()
+
+
+def test_log_with_pip_requirements(tmp_path, basic_model):
+    expected_mlflow_version = _mlflow_major_version_string()
+
+    requirements_file = tmp_path.joinpath("requirements.txt")
+    requirements_file.write_text("some-clever-package")
+    with mlflow.start_run():
+        mlflow.sentence_transformers.log_model(
+            basic_model, "model", pip_requirements=str(requirements_file)
+        )
+        _assert_pip_requirements(
+            mlflow.get_artifact_uri("model"),
+            [expected_mlflow_version, "some-clever-package"],
+            strict=True,
+        )
+    with mlflow.start_run():
+        mlflow.sentence_transformers.log_model(
+            basic_model,
+            "model",
+            pip_requirements=[f"-r {requirements_file}", "a-hopefully-useful-package"],
+        )
+        _assert_pip_requirements(
+            mlflow.get_artifact_uri("model"),
+            [expected_mlflow_version, "some-clever-package", "a-hopefully-useful-package"],
+            strict=True,
+        )
+    with mlflow.start_run():
+        mlflow.sentence_transformers.log_model(
+            basic_model,
+            "model",
+            pip_requirements=[f"-c {requirements_file}", "i-dunno-maybe-its-good"],
+        )
+        _assert_pip_requirements(
+            mlflow.get_artifact_uri("model"),
+            [expected_mlflow_version, "i-dunno-maybe-its-good", "-c constraints.txt"],
+            ["some-clever-package"],
+            strict=True,
+        )
+
+
+def test_log_with_extra_pip_requirements(basic_model, tmp_path):
+    expected_mlflow_version = _mlflow_major_version_string()
+    default_requirements = mlflow.sentence_transformers.get_default_pip_requirements()
+    requirements_file = tmp_path.joinpath("requirements.txt")
+    requirements_file.write_text("effective-package")
+    with mlflow.start_run():
+        mlflow.sentence_transformers.log_model(
+            basic_model, "model", extra_pip_requirements=str(requirements_file)
+        )
+        _assert_pip_requirements(
+            mlflow.get_artifact_uri("model"),
+            [expected_mlflow_version, *default_requirements, "effective-package"],
+            strict=True,
+        )
+    with mlflow.start_run():
+        mlflow.sentence_transformers.log_model(
+            basic_model,
+            "model",
+            extra_pip_requirements=[f"-r {requirements_file}", "useful-package"],
+        )
+        _assert_pip_requirements(
+            mlflow.get_artifact_uri("model"),
+            [expected_mlflow_version, *default_requirements, "effective-package", "useful-package"],
+            strict=True,
+        )
+    with mlflow.start_run():
+        mlflow.sentence_transformers.log_model(
+            basic_model,
+            "model",
+            extra_pip_requirements=[f"-c {requirements_file}", "constrained-pkg"],
+        )
+        _assert_pip_requirements(
+            mlflow.get_artifact_uri("model"),
+            [
+                expected_mlflow_version,
+                *default_requirements,
+                "constrained-pkg",
+                "-c constraints.txt",
+            ],
+            ["effective-package"],
+            strict=True,
+        )
+
+
+def test_model_save_without_conda_env_uses_default_env_with_expected_dependencies(
+    basic_model, model_path
+):
+    mlflow.sentence_transformers.save_model(basic_model, model_path)
+    _assert_pip_requirements(
+        model_path, mlflow.sentence_transformers.get_default_pip_requirements()
+    )
+
+
+def test_model_log_without_conda_env_uses_default_env_with_expected_dependencies(
+    basic_model,
+):
+    artifact_path = "model"
+    with mlflow.start_run():
+        mlflow.sentence_transformers.log_model(basic_model, artifact_path)
+        model_uri = mlflow.get_artifact_uri(artifact_path)
+    _assert_pip_requirements(model_uri, mlflow.sentence_transformers.get_default_pip_requirements())
+
+
+def test_log_model_with_code_paths(basic_model):
+    artifact_path = "model"
+    with mlflow.start_run(), mock.patch(
+        "mlflow.sentence_transformers._add_code_from_conf_to_system_path"
+    ) as add_mock:
+        mlflow.sentence_transformers.log_model(basic_model, artifact_path, code_paths=[__file__])
+        model_uri = mlflow.get_artifact_uri(artifact_path)
+        _compare_logged_code_paths(__file__, model_uri, mlflow.sentence_transformers.FLAVOR_NAME)
+        mlflow.sentence_transformers.load_model(model_uri)
+        add_mock.assert_called()
+
+
+def test_default_signature_assignment(model_path, basic_model):
+    expected_signature = {
+        "inputs": '[{"type": "string"}]',
+        "outputs": '[{"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": ' "[-1]}}]",
+    }
+
+    default_signature = mlflow.sentence_transformers._get_default_signature()
+
+    assert default_signature.to_dict() == expected_signature


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add basic serialization (save_model, load_model, log_model) and signature default assignment for the sentence-transformers package. 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introduce a sentence-transformers flavor.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
