### PR TITLE
Suppress torch/torchvision local version warning on databricks

### DIFF
--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -444,8 +444,7 @@ def _get_pinned_requirement(package, version=None, module=None):
         version_raw = _get_installed_version(package, module)
         local_version_label = _get_local_version_label(version_raw)
         if local_version_label and not (
-            is_in_databricks_runtime() and
-            package in ("torch", "torchvision")
+            is_in_databricks_runtime() and package in ("torch", "torchvision")
         ):
             version = _strip_local_version_label(version_raw)
             msg = (

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -443,7 +443,10 @@ def _get_pinned_requirement(package, version=None, module=None):
     if version is None:
         version_raw = _get_installed_version(package, module)
         local_version_label = _get_local_version_label(version_raw)
-        if local_version_label:
+        if local_version_label and not (
+            is_in_databricks_runtime() and
+            package in ("torch", "torchvision")
+        ):
             version = _strip_local_version_label(version_raw)
             msg = (
                 f"Found {package} version ({version_raw}) contains a local version label "

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -443,18 +443,17 @@ def _get_pinned_requirement(package, version=None, module=None):
     if version is None:
         version_raw = _get_installed_version(package, module)
         local_version_label = _get_local_version_label(version_raw)
-        if local_version_label and not (
-            is_in_databricks_runtime() and package in ("torch", "torchvision")
-        ):
+        if local_version_label:
             version = _strip_local_version_label(version_raw)
-            msg = (
-                f"Found {package} version ({version_raw}) contains a local version label "
-                f"(+{local_version_label}). MLflow logged a pip requirement for this package as "
-                f"'{package}=={version}' without the local version label to make it "
-                "installable from PyPI. To specify pip requirements containing local version "
-                "labels, please use `conda_env` or `pip_requirements`."
-            )
-            _logger.warning(msg)
+            if not (is_in_databricks_runtime() and package in ("torch", "torchvision")):
+                msg = (
+                    f"Found {package} version ({version_raw}) contains a local version label "
+                    f"(+{local_version_label}). MLflow logged a pip requirement for this package "
+                    f"as '{package}=={version}' without the local version label to make it "
+                    "installable from PyPI. To specify pip requirements containing local version "
+                    "labels, please use `conda_env` or `pip_requirements`."
+                )
+                _logger.warning(msg)
 
         else:
             version = version_raw


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Suppress torch/torchvision local version warning on databricks.

## How is this patch tested?

Manually

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
