### PR TITLE
Add documentation for setting model signatures

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -217,7 +217,7 @@ To include a signature with your model, pass a :py:class:`signature object
 :py:func:`sklearn.log_model() <mlflow.sklearn.log_model>`
 (see the :ref:`How to log models with signatures <how-to-log-models-with-signatures>` section for more details).
 The model signature is stored in JSON format in the :ref:`MLmodel file <pyfunc-model-config>` in your
-model artifacts, together with other model metadata. To set a signature on an already logged or
+model artifacts, together with other model metadata. To set a signature on a logged or
 saved model, use the :py:func:`set_signature() <mlflow.models.set_signature>` API
 (see the :ref:`How to set signatures on models <how-to-set-signatures-on-models>` section for more details).
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -465,11 +465,10 @@ Suppose you've logged a sklearn model without a signature like below:
     from sklearn.ensemble import RandomForestClassifier
     import mlflow
 
-    iris = datasets.load_iris()
-    iris_train = pd.DataFrame(iris.data, columns=iris.feature_names)
+    X, y = datasets.load_iris(return_X_y=True, as_frame=True)
     clf = RandomForestClassifier(max_depth=7, random_state=0)
     with mlflow.start_run() as run:
-        clf.fit(iris_train, iris.target)
+        clf.fit(X, y)
         mlflow.sklearn.log_model(clf, "iris_rf")
 
 You can set a signature on the logged model as follows:
@@ -487,9 +486,8 @@ You can set a signature on the logged model as follows:
     model = mlflow.pyfunc.load_model(model_uri)
 
     # construct the model signature from test dataset
-    iris = datasets.load_iris()
-    iris_test = pd.DataFrame(iris.data, columns=iris.feature_names)
-    signature = infer_signature(iris_train, model.predict(iris_train))
+    X_test, _ = datasets.load_iris(return_X_y=True, as_frame=True)
+    signature = infer_signature(X_test, model.predict(X_test))
 
     # set the signature for the logged model
     set_signature(model_uri, signature)
@@ -497,44 +495,9 @@ You can set a signature on the logged model as follows:
     # now when you load the model again, it will have the desired signature
     assert get_model_info(model_uri).signature == signature
 
-Set Signature on Saved Model
-""""""""""""""""""""""""""""
-
-You can also set the model signature on a model saved outside of MLflow tracking. The following
-example demonstrates how to do so.
-
-Suppose you've saved a dummy sklearn model without a signature like below:
-
-.. code-block:: python
-
-    import tempfile
-    from sklearn.ensemble import RandomForestClassifier
-    import mlflow
-
-    model_path = tempfile.mkdtemp()
-
-    mlflow.sklearn.save_model(
-        RandomForestClassifier(),
-        model_path,
-        serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE,
-    )
-
-You can set a dummy signature on the saved model as follows:
-
-.. code-block:: python
-
-    import numpy as np
-    from mlflow.models import Model
-    from mlflow.models.signature import infer_signature, set_signature
-
-    # construct a dummy model signature
-    signature = infer_signature(np.array([1]))
-
-    # set the signature on the saved model
-    set_signature(model_path, signature)
-
-    # now when you load the saved model, it will have the desired signature
-    assert Model.load(model_path).signature == signature
+Note that model signatures can also be set on model artifacts saved outside of MLflow Tracking. As
+an example, you can easily set a signature on a locally saved iris model by altering the model_uri
+variable in the previous code snippet to point to the model's local directory.
 
 .. _set-signature-on-mv:
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -583,9 +583,8 @@ as follows:
     # create a new model version with the updated source
     client.create_model_version(name=model_name, source=mv.source, run_id=mv.run_id)
 
-.. note::
-    This procedure overwrites the model artifacts of the model version 1's source run with a
-    new model signature.
+Note that this process overwrites the model artifacts from the source run of model version 1
+with a new model signature.
 
 .. _input-example:
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -226,9 +226,9 @@ saved model, use the :py:func:`set_signature() <mlflow.models.set_signature>` AP
     Function (pyfunc) flavor of MLflow models. Hence, it is recommended that you assign your model
     a signature that matches its PyFunc flavor. Usually, generating the model signature involves calling
     :py:func:`infer_signature() <mlflow.models.infer_signature>` on your raw model's test dataset
-    and predicted output of that dataset. However, in scenarios like the :ref:`pmdarima model flavor <pmdarima-flavor>`,
-    where the Pyfunc inference input schema differs from that of the test dataset, it's necessary to
-    construct a signature to match it.
+    and predicted output of that dataset. However, in certain cases (such as the :ref:`pmdarima model flavor <pmdarima-flavor>`)
+    the schema of the PyFunc model input may differ from that of the test dataset. In such situations,
+    it is necessary to create a signature that represents the inputs and outputs of the PyFunc flavor.
 
 Model Signature Types
 ~~~~~~~~~~~~~~~~~~~~~

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -262,7 +262,9 @@ def set_signature(
     Furthermore, as model registry artifacts are read-only, model artifacts located in the
     model registry and represented by ``models:/`` URI schemes are not compatible with this API.
     To set a signature on a model version, first set the signature on the source model artifacts.
-    Following this, generate a new model version using the updated model artifacts.
+    Following this, generate a new model version using the updated model artifacts. For more
+    information about setting signatures on model versions, see
+    `this doc section <https://www.mlflow.org/docs/latest/models.html#set-signature-on-mv>`_.
 
     :param model_uri: The location, in URI format, of the MLflow model. For example:
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

https://github.com/mlflow/mlflow/pull/8476

## What changes are proposed in this pull request?

This PR adds documentation to demonstrate how to set model signatures on logged models, saved models, and model versions. It also improves model signature documentation to clarify use-cases, moving content around, and emphasizing that users set a signatures corresponding to the PyFunc model flavor.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

Built the doc locally and manually inspected that it looks good.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
