### PR TITLE
Add support for audio classification pipelines to transformers

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2436,6 +2436,7 @@ Question Answering***             Dict[str, str]***              str or List[str
 Fill Mask****                     str or List[str]****           str or List[str]
 Feature Extraction                str or List[str]               np.ndarray
 AutomaticSpeechRecognition        bytes***** or np.ndarray       str
+AudioClassification               bytes***** or np.ndarray       pd.DataFrame
 ================================= ============================== =================
 
 \* A collection of these inputs can also be passed. The standard required key names are 'sequences' and 'candidate_labels', but these may vary.

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -1197,7 +1197,6 @@ def _should_add_pyfunc_to_model(pipeline) -> bool:
         "ZeroShotImageClassificationPipeline",
         "ZeroShotObjectDetectionPipeline",
         "ZeroShotAudioClassificationPipeline",
-        "AudioClassificationPipeline",
     ]
 
     impermissible_attrs = {"image_processor"}
@@ -1282,6 +1281,11 @@ def _get_default_pipeline_signature(pipeline, example=None) -> ModelSignature:
             return ModelSignature(
                 inputs=Schema([ColSpec("binary")]),
                 outputs=Schema([ColSpec("string")]),
+            )
+        elif isinstance(pipeline, transformers.AudioClassificationPipeline):
+            return ModelSignature(
+                inputs=Schema([ColSpec("binary")]),
+                outputs=Schema([ColSpec("double", name="score"), ColSpec("string", name="label")]),
             )
         elif isinstance(
             pipeline,
@@ -1597,7 +1601,10 @@ class _TransformersWrapper:
                 output_key = None
             else:
                 output_key = "text"
-            data = self._convert_automatic_speech_recognition_input(data)
+            data = self._convert_audio_input(data)
+        elif isinstance(self.pipeline, transformers.AudioClassificationPipeline):
+            data = self._convert_audio_input(data)
+            output_key = None
         else:
             raise MlflowException(
                 f"The loaded pipeline type {type(self.pipeline).__name__} is "
@@ -1651,6 +1658,8 @@ class _TransformersWrapper:
             self.pipeline, transformers.AutomaticSpeechRecognitionPipeline
         ) and self.inference_config.get("return_timestamps", None) in ["word", "char"]:
             output = json.dumps(raw_output)
+        elif isinstance(self.pipeline, transformers.AudioClassificationPipeline):
+            return pd.DataFrame(raw_output)
         else:
             output = self._parse_lists_of_dict_to_list_of_str(raw_output, output_key)
 
@@ -2196,7 +2205,7 @@ class _TransformersWrapper:
             return parsed_data
 
     @staticmethod
-    def _convert_automatic_speech_recognition_input(data):
+    def _convert_audio_input(data):
         """
         Conversion utility for decoding the base64 encoded bytes data of a raw soundfile when
         parsed through model serving, if applicable. Direct usage of the pyfunc implementation

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -338,6 +338,11 @@ def whisper_pipeline():
 
 
 @pytest.fixture()
+def audio_classification_pipeline():
+    return transformers.pipeline("audio-classification", model="superb/wav2vec2-base-superb-ks")
+
+
+@pytest.fixture()
 def feature_extraction_pipeline():
     st_arch = "sentence-transformers/all-MiniLM-L6-v2"
     model = transformers.AutoModel.from_pretrained(st_arch)
@@ -2907,3 +2912,63 @@ def test_whisper_model_serve_and_score_with_timestamps(whisper_pipeline, raw_aud
             "text"
         ]
     )
+
+
+def test_audio_classification_pipeline(audio_classification_pipeline, raw_audio_file):
+    artifact_path = "audio_classification"
+    signature = infer_signature(
+        raw_audio_file,
+        mlflow.transformers.generate_signature_output(
+            audio_classification_pipeline, raw_audio_file
+        ),
+    )
+
+    with mlflow.start_run():
+        model_info = mlflow.transformers.log_model(
+            transformers_model=audio_classification_pipeline,
+            artifact_path=artifact_path,
+            signature=signature,
+            input_example=raw_audio_file,
+        )
+
+    inference_payload = json.dumps({"inputs": [base64.b64encode(raw_audio_file).decode("ascii")]})
+
+    response = pyfunc_serve_and_score_model(
+        model_info.model_uri,
+        data=inference_payload,
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+
+    values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
+    assert isinstance(values, pd.DataFrame)
+    assert len(values) > 1
+    assert list(values.columns) == ["score", "label"]
+
+
+def test_audio_classification_with_default_schema(audio_classification_pipeline, raw_audio_file):
+    artifact_path = "audio_classification"
+
+    with mlflow.start_run():
+        model_info = mlflow.transformers.log_model(
+            transformers_model=audio_classification_pipeline,
+            artifact_path=artifact_path,
+        )
+
+    inference_df = pd.DataFrame(
+        pd.Series([base64.b64encode(raw_audio_file).decode("ascii")], name="audio")
+    )
+    split_dict = {"dataframe_split": inference_df.to_dict(orient="split")}
+    split_json = json.dumps(split_dict)
+
+    response = pyfunc_serve_and_score_model(
+        model_info.model_uri,
+        data=split_json,
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+
+    values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
+    assert isinstance(values, pd.DataFrame)
+    assert len(values) > 1
+    assert list(values.columns) == ["score", "label"]


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add support for audio classification pipelines to the transformers flavor.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add support for audio classification pipelines in the transformers flavor

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
