### PR TITLE
Disallow suppressing pylint rules with IDs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,13 @@ repos:
         args: ["--rcfile=pylintrc"]
         stages: [commit]
 
+      - id: disallow-rule-ids
+        name: disallow-rule-ids
+        entry: python ./dev/disallow_rule_ids.py
+        language: system
+        types: [python]
+        stages: [commit]
+
       - id: rstcheck
         name: rstcheck
         entry: rstcheck

--- a/dev/disallow_rule_ids.py
+++ b/dev/disallow_rule_ids.py
@@ -4,7 +4,7 @@ import sys
 import tokenize
 
 
-def extract_comments(f):
+def iter_comments(f):
     for tok_type, tok, start, _, _ in tokenize.generate_tokens(f.readline):
         if tok_type == tokenize.COMMENT:
             yield tok, start
@@ -36,7 +36,7 @@ def main():
     msg = "Use rule name (e.g. unused-variable) instead of rule ID (e.g. W0612)"
     for path in args.files:
         with open(path) as f:
-            for comment, (row, col) in extract_comments(f):
+            for comment, (row, col) in iter_comments(f):
                 if codes := extract_codes(comment):
                     if code := next(filter(is_rule_id, codes), None):
                         print(f"{path}:{row}:{col}: {code}:", msg)

--- a/dev/disallow_rule_ids.py
+++ b/dev/disallow_rule_ids.py
@@ -38,7 +38,7 @@ def main():
         with open(path) as f:
             for comment, (row, col) in extract_comments(f):
                 if codes := extract_codes(comment):
-                    if any(is_rule_id(c) for c in codes):
+                    if any(map(is_rule_id, codes)):
                         print(f"{path}:{row}:{col}:", msg)
                         exit_code = 1
     sys.exit(exit_code)

--- a/dev/disallow_rule_ids.py
+++ b/dev/disallow_rule_ids.py
@@ -39,7 +39,7 @@ def main():
             for comment, (row, col) in iter_comments(f):
                 if codes := extract_codes(comment):
                     if code := next(filter(is_rule_id, codes), None):
-                        print(f"{path}:{row}:{col}: {code}:", msg)
+                        print(f"{path}:{row}:{col}: {code}: {msg}")
                         exit_code = 1
     sys.exit(exit_code)
 

--- a/dev/disallow_rule_ids.py
+++ b/dev/disallow_rule_ids.py
@@ -10,7 +10,7 @@ def extract_comments(f):
             yield tok, start
 
 
-RULE_ID_REGEX = re.compile(r"[A-Z][0-9_]*")
+RULE_ID_REGEX = re.compile(r"[A-Z][0-9]*")
 
 
 def is_rule_id(s):

--- a/dev/disallow_rule_ids.py
+++ b/dev/disallow_rule_ids.py
@@ -17,7 +17,7 @@ def is_rule_id(s):
     return bool(RULE_ID_REGEX.fullmatch(s))
 
 
-DISABLE_COMMENT_REGEX = re.compile(r"pylint:\s+disable=([\w\-,]+)")
+DISABLE_COMMENT_REGEX = re.compile(r"pylint:\s+disable=([\w\s\-,]+)")
 DELIMITER_REGEX = re.compile(r"\s*,\s*")
 
 

--- a/dev/disallow_rule_ids.py
+++ b/dev/disallow_rule_ids.py
@@ -38,8 +38,8 @@ def main():
         with open(path) as f:
             for comment, (row, col) in extract_comments(f):
                 if codes := extract_codes(comment):
-                    if any(map(is_rule_id, codes)):
-                        print(f"{path}:{row}:{col}:", msg)
+                    if code := next(filter(is_rule_id, codes), None):
+                        print(f"{path}:{row}:{col}: {code}:", msg)
                         exit_code = 1
     sys.exit(exit_code)
 

--- a/dev/disallow_rule_ids.py
+++ b/dev/disallow_rule_ids.py
@@ -1,0 +1,48 @@
+import argparse
+import re
+import sys
+import tokenize
+
+
+def extract_comments(f):
+    for tok_type, tok, start, _, _ in tokenize.generate_tokens(f.readline):
+        if tok_type == tokenize.COMMENT:
+            yield tok, start
+
+
+RULE_ID_REGEX = re.compile(r"[A-Z][0-9_]*")
+
+
+def is_rule_id(s):
+    return bool(RULE_ID_REGEX.fullmatch(s))
+
+
+DISABLE_COMMENT_REGEX = re.compile(r"pylint:\s+disable=([\w\-,]+)")
+DELIMITER_REGEX = re.compile(r"\s*,\s*")
+
+
+def extract_codes(comment):
+    if m := DISABLE_COMMENT_REGEX.search(comment):
+        return DELIMITER_REGEX.split(m.group(1))
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("files", nargs="*")
+    args = parser.parse_args()
+
+    exit_code = 0
+    msg = "Use rule name (e.g. unused-variable) instead of rule ID (e.g. W0612)"
+    for path in args.files:
+        with open(path) as f:
+            for comment, (row, col) in extract_comments(f):
+                if codes := extract_codes(comment):
+                    if any(is_rule_id(c) for c in codes):
+                        print(f"{path}:{row}:{col}:", msg)
+                        exit_code = 1
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/mlflow/deployments/base.py
+++ b/mlflow/deployments/base.py
@@ -15,7 +15,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import developer_stable
 
 
-def run_local(target, name, model_uri, flavor=None, config=None):  # pylint: disable=W0613
+def run_local(target, name, model_uri, flavor=None, config=None):  # pylint: disable=unused-argument
     """
     .. Note::
         This function is kept here only for documentation purpose and not implementing the

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -555,7 +555,7 @@ def autolog(
                     "early_stop_comp": callback.comp.__name__,
                 }
                 mlflow.log_params(earlystopping_params)
-            except Exception:  # pylint: disable=W0703
+            except Exception:
                 return
 
     def _log_model_info(learner):

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -169,7 +169,7 @@ class PyFuncBackend(FlavorBackend):
         synchronous=True,
         stdout=None,
         stderr=None,
-    ):  # pylint: disable=W0221
+    ):
         """
         Serve pyfunc model locally.
         """

--- a/mlflow/recipes/steps/evaluate.py
+++ b/mlflow/recipes/steps/evaluate.py
@@ -414,8 +414,8 @@ class EvaluateStep(BaseStep):
             shap_plot_tab.add_image("SHAP_BEESWARM_PLOT", shap_beeswarm_plot_path, width=800)
 
         try:
-            import shap  # pylint: disable=W0611
-            from matplotlib import pyplot  # pylint: disable=W0611
+            import shap  # pylint: disable=unused-import
+            from matplotlib import pyplot  # pylint: disable=unused-import
 
             _add_shap_plots(card)
         except ImportError:

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -208,7 +208,7 @@ def _upgrade_db(engine):
     # https://alembic.sqlalchemy.org/en/latest/cookbook.html#sharing-a-
     # connection-with-a-series-of-migration-commands-and-environments
     with engine.begin() as connection:
-        config.attributes["connection"] = connection  # pylint: disable=E1137
+        config.attributes["connection"] = connection
         command.upgrade(config, "heads")
 
 

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -989,7 +989,7 @@ def autolog(
     saved_model_kwargs=None,
     keras_model_kwargs=None,
 ):  # pylint: disable=unused-argument
-    # pylint: disable=E0611
+    # pylint: disable=no-name-in-module
     """
     Enables autologging for ``tf.keras`` and ``keras``.
     Note that only ``tensorflow>=2.3`` are supported.
@@ -1086,13 +1086,13 @@ def autolog(
                     "restore_best_weights": callback.restore_best_weights,
                 }
                 mlflow.log_params(earlystopping_params)
-            except Exception:  # pylint: disable=W0703
+            except Exception:
                 return
 
     def _get_early_stop_callback_attrs(callback):
         try:
             return callback.stopped_epoch, callback.restore_best_weights, callback.patience
-        except Exception:  # pylint: disable=W0703
+        except Exception:
             return None
 
     def _log_early_stop_callback_metrics(callback, history, metrics_logger):

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -155,7 +155,7 @@ def _set_experiment_primary_metric(
     )
 
 
-class ActiveRun(Run):  # pylint: disable=W0223
+class ActiveRun(Run):  # pylint: disable=abstract-method
     """Wrapper around :py:class:`mlflow.entities.Run` to enable using Python ``with`` syntax."""
 
     def __init__(self, run):

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -2285,7 +2285,7 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
-):  # pylint: disable=W0102,unused-argument
+):  # pylint: disable=unused-argument
     """
     This autologging integration is solely used for disabling spurious autologging of irrelevant
     sub-models that are created during the training and evaluation of transformers-based models.

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -101,7 +101,7 @@ def get_mlflow_run_params_for_fn_args(fn, args, kwargs, unlogged=None):
     return params_to_log
 
 
-def log_fn_args_as_params(fn, args, kwargs, unlogged=None):  # pylint: disable=W0102
+def log_fn_args_as_params(fn, args, kwargs, unlogged=None):
     """
     Log arguments explicitly passed to a function as MLflow Run parameters to the current active
     MLflow Run.

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -492,7 +492,7 @@ def settings(**kwargs):
     return decorator
 
 
-def filter(value):  # pylint: disable=W0622
+def filter(value):  # pylint: disable=redefined-builtin
     """Modifier decorator to force the inclusion or exclusion of an attribute.
 
     This only modifies the behaviour of the :func:`create_patches` function

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -188,7 +188,7 @@ class NumpyEncoder(JSONEncoder):
             return o.isoformat(), True
         return o, False
 
-    def default(self, o):  # pylint: disable=E0202
+    def default(self, o):
         res, converted = self.try_convert(o)
         if converted:
             return res

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -385,7 +385,7 @@ def autolog(
     silent=False,
     registered_model_name=None,
     model_format="xgb",
-):  # pylint: disable=W0102,unused-argument
+):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging from XGBoost to MLflow. Logs the following:
 

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -91,7 +91,7 @@ def start_run():
     mlflow.end_run()
 
 
-def dummy_fn(arg1, arg2="value2", arg3="value3"):  # pylint: disable=W0613
+def dummy_fn(arg1, arg2="value2", arg3="value3"):  # pylint: disable=unused-argument
     pass
 
 
@@ -110,7 +110,9 @@ log_test_args = [
 
 
 @pytest.mark.parametrize(("args", "kwargs", "expected"), log_test_args)
-def test_log_fn_args_as_params(args, kwargs, expected, start_run):  # pylint: disable=W0613
+def test_log_fn_args_as_params(
+    args, kwargs, expected, start_run
+):  # pylint: disable=unused-argument
     log_fn_args_as_params(dummy_fn, args, kwargs)
     client = MlflowClient()
     params = client.get_run(mlflow.active_run().info.run_id).data.params
@@ -119,7 +121,9 @@ def test_log_fn_args_as_params(args, kwargs, expected, start_run):  # pylint: di
         assert params[arg] == value
 
 
-def test_log_fn_args_as_params_ignores_unwanted_parameters(start_run):  # pylint: disable=W0613
+def test_log_fn_args_as_params_ignores_unwanted_parameters(
+    start_run,
+):  # pylint: disable=unused-argument
     args, kwargs, unlogged = ("arg1", {"arg2": "value"}, ["arg1", "arg2", "arg3"])
     log_fn_args_as_params(dummy_fn, args, kwargs, unlogged)
     client = MlflowClient()

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -117,7 +117,7 @@ def get_subclassed_model_definition():
     can be invoked within a module to define the class in the module's scope.
     """
 
-    # pylint: disable=W0223
+    # pylint: disable=abstract-method
     class SubclassedModel(torch.nn.Module):
         def __init__(self):
             super().__init__()
@@ -143,7 +143,7 @@ def main_scoped_subclassed_model(data):
     return model
 
 
-# pylint: disable=W0223
+# pylint: disable=abstract-method
 class ModuleScopedSubclassedModel(get_subclassed_model_definition()):
     """
     A custom PyTorch model class defined in the test module scope. This is a subclass of

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -24,7 +24,7 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
-from tests.conftest import tracking_uri_mock  # pylint: disable=unused-import, E0611
+from tests.conftest import tracking_uri_mock  # pylint: disable=unused-import,no-name-in-module
 from tests.helper_functions import (
     pyfunc_serve_and_score_model,
     _compare_conda_env_requirements,

--- a/tests/statsmodels/model_fixtures.py
+++ b/tests/statsmodels/model_fixtures.py
@@ -102,7 +102,9 @@ def recursivels_model():
 
     # To the regressors in the dataset, we add a column of ones for an intercept
     exog = sm.add_constant(
-        dta[["COPPERPRICE", "INCOMEINDEX", "ALUMPRICE", "INVENTORYINDEX"]]  # pylint: disable=E1136
+        dta[
+            ["COPPERPRICE", "INCOMEINDEX", "ALUMPRICE", "INVENTORYINDEX"]
+        ]  # pylint: disable=unsubscriptable-object
     )
     rls = sm.RecursiveLS(endog, exog)
     model = rls.fit()

--- a/tests/utils/test_docstring_utils.py
+++ b/tests/utils/test_docstring_utils.py
@@ -24,7 +24,6 @@ def test_get_minimum_indentation():
 
 
 def test_format_docstring():
-    # pylint: disable=W
     @format_docstring({"p": "param doc"})
     def single_param(p):
         """

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -96,4 +96,4 @@ def test_add_code_to_system_path(sklearn_knn_model, model_path):
     # If this raises an exception it's because dummy_package.test imported
     # dummy_package.operator and not the built-in operator module. This only
     # happens if MLflow is misconfiguring the system path.
-    from dummy_package import base  # pylint: disable=W0611
+    from dummy_package import base  # pylint: disable=unused-import

--- a/tests/utils/test_resources/dummy_package/base.py
+++ b/tests/utils/test_resources/dummy_package/base.py
@@ -1,3 +1,3 @@
 # This call should import the **system** operator, not the dummy_package.operator
 # module that is adjacent to this file
-import operator  # pylint: disable=W0611
+import operator  # pylint: disable=unused-import


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Disallow suppressing pylint rules with IDs like this:

```
# pylint: disable=W123
```

Instead, suggest using the rule name:

```
# pylint: disable=unused-variable
```


Why?

- `# pylint: disable=W123`: requires googling `pylint W123` (unless you have a id-to-rule mapping in your brain).
- `# pylint: disable=unused-variable`: we can tell what's disable from the name.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
