### PR TITLE
Add `--dev` option to `mlflow server`

### DIFF
--- a/dev/run-dev-server.sh
+++ b/dev/run-dev-server.sh
@@ -30,6 +30,6 @@ if [ ! -d "mlflow/server/js/node_modules" ]; then
   popd
 fi
 
-mlflow server $backend_store_uri $default_artifact_root --gunicorn-opts="--log-level debug --reload" &
+mlflow server $backend_store_uri $default_artifact_root --dev &
 wait_server_ready localhost:5000/health
 yarn --cwd mlflow/server/js start

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -366,7 +366,7 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
     help=(
         "If enabled, run the server with debug logging and auto-reload. "
         "Should only be used for development purposes. "
-        "Cannot be used with --gunicorn-opts."
+        "Cannot be used with '--gunicorn-opts'."
     ),
 )
 def server(

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -25,6 +25,7 @@ from mlflow.tracking import _get_store
 from mlflow.utils import cli_args
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.process import ShellCommandException
+from mlflow.utils.os import is_windows
 from mlflow.utils.server_cli_utils import (
     resolve_default_artifact_root,
     artifacts_only_config_validation,
@@ -366,7 +367,8 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
     help=(
         "If enabled, run the server with debug logging and auto-reload. "
         "Should only be used for development purposes. "
-        "Cannot be used with '--gunicorn-opts'."
+        "Cannot be used with '--gunicorn-opts'. "
+        "Unsupported on Windows."
     ),
 )
 def server(
@@ -396,6 +398,9 @@ def server(
     """
     from mlflow.server import _run_server
     from mlflow.server.handlers import initialize_backend_stores
+
+    if dev and is_windows():
+        raise click.UsageError("'--dev' is not supported on Windows.")
 
     if dev and gunicorn_opts:
         raise click.UsageError("'--dev' and '--gunicorn-opts' cannot be specified together.")

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -358,6 +358,17 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
         "If not specified, 'mlflow.server:app' will be used."
     ),
 )
+@click.option(
+    "--dev",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help=(
+        "If enabled, run the server with debug logging and auto-reload. "
+        "Should only be used for development purposes. "
+        "Cannot be used with --gunicorn-opts."
+    ),
+)
 def server(
     backend_store_uri,
     registry_store_uri,
@@ -373,6 +384,7 @@ def server(
     waitress_opts,
     expose_prometheus,
     app_name,
+    dev,
 ):
     """
     Run the MLflow tracking server.
@@ -385,6 +397,10 @@ def server(
     from mlflow.server import _run_server
     from mlflow.server.handlers import initialize_backend_stores
 
+    if dev and gunicorn_opts:
+        raise click.UsageError("'--dev' and '--gunicorn-opts' cannot be specified together.")
+
+    gunicorn_opts = "--log-level debug --reload" if dev else gunicorn_opts
     _validate_server_args(gunicorn_opts=gunicorn_opts, workers=workers, waitress_opts=waitress_opts)
 
     # Ensure that both backend_store_uri and default_artifact_uri are set correctly.


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add `--dev` option to `mlflow server` to quickly launch a tracking server with options that are useful for development.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
