### PR TITLE
Shut down spark callback server when spark autologging is disabled or spark session is shut down

### DIFF
--- a/mlflow/_spark_autologging.py
+++ b/mlflow/_spark_autologging.py
@@ -102,9 +102,7 @@ def _stop_listen_for_spark_activity(spark_context):
     try:
         gw.shutdown_callback_server()
     except Exception as e:
-        _logger.warning(
-            "Failed to shut down Spark callback server for autologging: %s", e
-        )
+        _logger.warning("Failed to shut down Spark callback server for autologging: %s", e)
 
 
 def _listen_for_spark_activity(spark_context):

--- a/mlflow/_spark_autologging.py
+++ b/mlflow/_spark_autologging.py
@@ -103,7 +103,7 @@ def _stop_listen_for_spark_activity(spark_context):
         gw.shutdown_callback_server()
     except Exception as e:
         _logger.warning(
-            "Failed to shut down Spark callback server for autologging: %s", str(e)
+            "Failed to shut down Spark callback server for autologging: %s", e
         )
 
 

--- a/mlflow/_spark_autologging.py
+++ b/mlflow/_spark_autologging.py
@@ -97,6 +97,16 @@ def _set_run_tag(run_id, path, version, data_format):
     client.set_tag(run_id, _SPARK_TABLE_INFO_TAG_NAME, new_tag_value)
 
 
+def _stop_listen_for_spark_activity(spark_context):
+    gw = spark_context._gateway
+    try:
+        gw.shutdown_callback_server()
+    except Exception as e:
+        _logger.warning(
+            "Failed to shut down Spark callback server for autologging: %s", str(e)
+        )
+
+
 def _listen_for_spark_activity(spark_context):
     global _spark_table_info_listener
     if _get_current_listener() is not None:

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -1006,8 +1006,6 @@ def autolog(disable=False, silent=False):  # pylint: disable=unused-argument
     )
     from pyspark.sql import SparkSession
 
-    global _atexit_hook_registered
-
     def __init__(original, self, *args, **kwargs):
         original(self, *args, **kwargs)
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -934,9 +934,6 @@ class _PyFuncModelWrapper:
         ]
 
 
-_atexit_hook_registered = False
-
-
 @autologging_integration(FLAVOR_NAME)
 def autolog(disable=False, silent=False):  # pylint: disable=unused-argument
     """

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -18,7 +18,6 @@ Spark MLlib (native) format
     ``mlflow/java`` package. This flavor is produced only if you specify
     MLeap-compatible arguments.
 """
-import atexit
 import os
 import logging
 import posixpath

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -1033,15 +1033,3 @@ def autolog(disable=False, silent=False):  # pylint: disable=unused-argument
             _stop_listen_for_spark_activity(sc)
         else:
             _listen_for_spark_activity(sc)
-
-    if not _atexit_hook_registered:
-        # Register an "atexit" hook to disable spark autologging,
-        # so that before python process exits, we can shut down
-        # spark callback server properly.
-        def shut_down_spark_callback_server():
-            active_session = _get_active_spark_session()
-            if active_session is not None:
-                _stop_listen_for_spark_activity(active_session.sparkContext)
-
-        atexit.register(shut_down_spark_callback_server)
-        _atexit_hook_registered = True


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx
Closes https://github.com/mlflow/mlflow/issues/8502

## What changes are proposed in this pull request?

Shutdown spark callback server when spark autologging is disabled or spark session is shut down.

If we do not shut down spark callback server, even when spark session is shut down, the callback server is still running in background and it blocks python process exiting when python main thread exits.


## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
