### PR TITLE
Add support for returning classifier scores in transformers output

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2419,25 +2419,25 @@ data type inputs and outputs.
 Supported transformers Pipeline types for Pyfunc
 """"""""""""""""""""""""""""""""""""""""""""""""
 
-================================= ============================== =================
+================================= ============================== ==========================================================================
 Pipeline Type                     Input Type                     Output Type
-================================= ============================== =================
+================================= ============================== ==========================================================================
 Instructional Text Generation     str or List[str]               str or List[str]
 Conversational                    str or List[str]               str or List[str]
 Summarization                     str or List[str]               str or List[str]
-Text Classification               str or List[str]               pd.DataFrame
+Text Classification               str or List[str]               pd.DataFrame (dtypes: {'label': str, 'score': double})
 Text Generation                   str or List[str]               str or List[str]
 Text2Text Generation              str or List[str]               str or List[str]
 Token Classification              str or List[str]               str or List[str]
 Translation                       str or List[str]               str or List[str]
-ZeroShot Classification*          Dict[str, [List[str] | str]*   pd.DataFrame
+ZeroShot Classification*          Dict[str, [List[str] | str]*   pd.DataFrame (dtypes: {'sequence': str, 'labels': str, 'scores': double})
 Table Question Answering**        Dict[str, [List[str] | str]**  str or List[str]
 Question Answering***             Dict[str, str]***              str or List[str]
 Fill Mask****                     str or List[str]****           str or List[str]
 Feature Extraction                str or List[str]               np.ndarray
-AutomaticSpeechRecognition        bytes***** or np.ndarray       str
-AudioClassification               bytes***** or np.ndarray       pd.DataFrame
-================================= ============================== =================
+AutomaticSpeechRecognition        bytes*****, str, or np.ndarray str
+AudioClassification               bytes*****, str, or np.ndarray pd.DataFrame (dtypes: {'label': str, 'score': double})
+================================= ============================== ==========================================================================
 
 \* A collection of these inputs can also be passed. The standard required key names are 'sequences' and 'candidate_labels', but these may vary.
 Check the input requirments for the architecture that you're using to ensure that the correct dictionary key names are provided.
@@ -2450,7 +2450,7 @@ expected input to the model to ensure your inference request can be read properl
 \**** The mask syntax for the model that you've chosen is going to be specific to that model's implementation. Some are '[MASK]', while others are '<mask>'. Verify the expected syntax to
 avoid failed inference requests.
 
-\***** If using the `pyfunc` in MLflow Model Serving for realtime inference, the raw audio in bytes format must be base64 encoded prior to submitting to the endpoint.
+\***** If using `pyfunc` in MLflow Model Serving for realtime inference, the raw audio in bytes format must be base64 encoded prior to submitting to the endpoint. String inputs will be interpreted as uri locations.
 
 Example of loading a transformers model as a python function
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2425,12 +2425,12 @@ Pipeline Type                     Input Type                     Output Type
 Instructional Text Generation     str or List[str]               str or List[str]
 Conversational                    str or List[str]               str or List[str]
 Summarization                     str or List[str]               str or List[str]
-Text Classification               str or List[str]               str or List[str]
+Text Classification               str or List[str]               pd.DataFrame
 Text Generation                   str or List[str]               str or List[str]
 Text2Text Generation              str or List[str]               str or List[str]
 Token Classification              str or List[str]               str or List[str]
 Translation                       str or List[str]               str or List[str]
-ZeroShot Classification*          Dict[str, [List[str] | str]*   str or List[str]
+ZeroShot Classification*          Dict[str, [List[str] | str]*   pd.DataFrame
 Table Question Answering**        Dict[str, [List[str] | str]**  str or List[str]
 Question Answering***             Dict[str, str]***              str or List[str]
 Fill Mask****                     str or List[str]****           str or List[str]

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -1257,7 +1257,6 @@ def _get_default_pipeline_signature(pipeline, example=None) -> ModelSignature:
                 transformers.TokenClassificationPipeline,
                 transformers.ConversationalPipeline,
                 transformers.TranslationPipeline,
-                transformers.TextClassificationPipeline,
                 transformers.FillMaskPipeline,
                 transformers.TextGenerationPipeline,
                 transformers.Text2TextGenerationPipeline,
@@ -1265,6 +1264,11 @@ def _get_default_pipeline_signature(pipeline, example=None) -> ModelSignature:
         ):
             return ModelSignature(
                 inputs=Schema([ColSpec("string")]), outputs=Schema([ColSpec("string")])
+            )
+        elif isinstance(pipeline, transformers.TextClassificationPipeline):
+            return ModelSignature(
+                inputs=Schema([ColSpec("string")]),
+                outputs=Schema([ColSpec("string", name="label"), ColSpec("double", name="score")]),
             )
         elif isinstance(pipeline, transformers.ZeroShotClassificationPipeline):
             return ModelSignature(
@@ -1275,7 +1279,13 @@ def _get_default_pipeline_signature(pipeline, example=None) -> ModelSignature:
                         ColSpec("string", name="hypothesis_template"),
                     ]
                 ),
-                outputs=Schema([ColSpec("string")]),
+                outputs=Schema(
+                    [
+                        ColSpec("string", name="sequence"),
+                        ColSpec("string", name="labels"),
+                        ColSpec("double", name="score"),
+                    ]
+                ),
             )
         elif isinstance(pipeline, transformers.AutomaticSpeechRecognitionPipeline):
             return ModelSignature(
@@ -1650,15 +1660,19 @@ class _TransformersWrapper:
         elif isinstance(self.pipeline, transformers.FillMaskPipeline):
             output = self._parse_list_of_multiple_dicts(raw_output, output_key)
         elif isinstance(self.pipeline, transformers.ZeroShotClassificationPipeline):
-            interim_output = self._parse_lists_of_dict_to_list_of_str(raw_output, output_key)
-            output = self._parse_list_output_for_multiple_candidate_pipelines(interim_output)
+            return self._parse_zero_shot_text_classifier_output_to_df(raw_output)
+            # interim_output = self._parse_lists_of_dict_to_list_of_str(raw_output, output_key)
+            # output = self._parse_list_output_for_multiple_candidate_pipelines(interim_output)
         elif isinstance(self.pipeline, transformers.TokenClassificationPipeline):
             output = self._parse_tokenizer_output(raw_output, output_key)
         elif isinstance(
             self.pipeline, transformers.AutomaticSpeechRecognitionPipeline
         ) and self.inference_config.get("return_timestamps", None) in ["word", "char"]:
             output = json.dumps(raw_output)
-        elif isinstance(self.pipeline, transformers.AudioClassificationPipeline):
+        elif isinstance(
+            self.pipeline,
+            (transformers.AudioClassificationPipeline, transformers.TextClassificationPipeline),
+        ):
             return pd.DataFrame(raw_output)
         else:
             output = self._parse_lists_of_dict_to_list_of_str(raw_output, output_key)
@@ -1734,34 +1748,27 @@ class _TransformersWrapper:
         Parses the result of Pandas DataFrame.to_dict(orient="records") from pyfunc
         signature validation to coerce the output to the required format for a
         Pipeline that requires a single dict with list elements such as
-        ZeroShotClassifierPipeline.
+        TableQuestionAnsweringPipeline.
         Example input:
 
         [
-         {'sequences': 'My dog loves to eat spaghetti',
-          'candidate_labels': ['happy', 'sad'],
-          'hypothesis_template': 'This example talks about how the dog is {}'},
-         {'sequences': 'My dog hates going to the vet',
-          'candidate_labels': ['happy', 'sad'],
-         'hypothesis_template': 'This example talks about how the dog is {}'},
+          {"answer": "We should order more pizzas to meet the demand."},
+          {"answer": "The venue size should be updated to handle the number of guests."},
         ]
 
         Output:
 
-        {'sequences': ['My dog loves to eat spaghetti',
-          'My dog hates going to the vet'],
-         'candidate_labels': ['happy', 'sad'],
-         'hypothesis_template': 'This example talks about how the dog is {}'}
+        [
+          "We should order more pizzas to meet the demand.",
+          "The venue size should be updated to handle the number of guests.",
+        ]
 
         """
         import transformers
 
         if not isinstance(
             self.pipeline,
-            (
-                transformers.ZeroShotClassificationPipeline,
-                transformers.TableQuestionAnsweringPipeline,
-            ),
+            transformers.TableQuestionAnsweringPipeline,
         ):
             return data
         elif isinstance(data, list) and all(isinstance(item, dict) for item in data):
@@ -1799,6 +1806,52 @@ class _TransformersWrapper:
             return parsed
         else:
             return data
+
+    def _parse_zero_shot_text_classifier_output_to_df(self, data):
+        """
+        Converts the output of sequences, labels, and scores to a Pandas DataFrame output.
+
+        Example input:
+
+        [{'sequence': 'My dog loves to eat spaghetti',
+          'labels': ['happy', 'sad'],
+          'scores': [0.9896970987319946, 0.010302911512553692]},
+         {'sequence': 'My dog hates going to the vet',
+          'labels': ['sad', 'happy'],
+          'scores': [0.957074761390686, 0.042925238609313965]}]
+
+        Output:
+
+        pd.DataFrame in a fully normalized (flattened) format with each sequence, label, and score
+        having a row entry.
+        For example, here is the DataFrame cast to a dictionary after conversion:
+
+        {'sequence': {0: 'My dog loves to eat spaghetti',
+          1: 'My dog loves to eat spaghetti',
+          2: 'My dog hates going to the vet',
+          3: 'My dog hates going to the vet'},
+         'label': {0: 'happy', 1: 'sad', 2: 'sad', 3: 'happy'},
+         'score': {0: 0.9896970987319946,
+          1: 0.010302911512553692,
+          2: 0.957074761390686,
+          3: 0.042925238609313965}}
+        """
+        if isinstance(data, list) and not all(isinstance(item, dict) for item in data):
+            raise MlflowException(
+                "Encountered an unknown return type from the pipeline type "
+                f"{type(self.pipeline).__name__}. Expecting a List[Dict]",
+                error_code=BAD_REQUEST,
+            )
+        if isinstance(data, dict):
+            data = [data]
+
+        flattened_data = []
+        for entry in data:
+            for label, score in zip(entry["labels"], entry["scores"]):
+                flattened_data.append(
+                    {"sequence": entry["sequence"], "labels": label, "score": score}
+                )
+        return pd.DataFrame(flattened_data)
 
     def _strip_input_from_response_in_instruction_pipelines(
         self,

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -1283,7 +1283,7 @@ def _get_default_pipeline_signature(pipeline, example=None) -> ModelSignature:
                     [
                         ColSpec("string", name="sequence"),
                         ColSpec("string", name="labels"),
-                        ColSpec("double", name="score"),
+                        ColSpec("double", name="scores"),
                     ]
                 ),
             )
@@ -1660,9 +1660,7 @@ class _TransformersWrapper:
         elif isinstance(self.pipeline, transformers.FillMaskPipeline):
             output = self._parse_list_of_multiple_dicts(raw_output, output_key)
         elif isinstance(self.pipeline, transformers.ZeroShotClassificationPipeline):
-            return self._parse_zero_shot_text_classifier_output_to_df(raw_output)
-            # interim_output = self._parse_lists_of_dict_to_list_of_str(raw_output, output_key)
-            # output = self._parse_list_output_for_multiple_candidate_pipelines(interim_output)
+            return self._flatten_zero_shot_text_classifier_output_to_df(raw_output)
         elif isinstance(self.pipeline, transformers.TokenClassificationPipeline):
             output = self._parse_tokenizer_output(raw_output, output_key)
         elif isinstance(
@@ -1807,7 +1805,7 @@ class _TransformersWrapper:
         else:
             return data
 
-    def _parse_zero_shot_text_classifier_output_to_df(self, data):
+    def _flatten_zero_shot_text_classifier_output_to_df(self, data):
         """
         Converts the output of sequences, labels, and scores to a Pandas DataFrame output.
 
@@ -1824,17 +1822,13 @@ class _TransformersWrapper:
 
         pd.DataFrame in a fully normalized (flattened) format with each sequence, label, and score
         having a row entry.
-        For example, here is the DataFrame cast to a dictionary after conversion:
+        For example, here is the DataFrame output:
 
-        {'sequence': {0: 'My dog loves to eat spaghetti',
-          1: 'My dog loves to eat spaghetti',
-          2: 'My dog hates going to the vet',
-          3: 'My dog hates going to the vet'},
-         'label': {0: 'happy', 1: 'sad', 2: 'sad', 3: 'happy'},
-         'score': {0: 0.9896970987319946,
-          1: 0.010302911512553692,
-          2: 0.957074761390686,
-          3: 0.042925238609313965}}
+                                sequence labels    scores
+        0  My dog loves to eat spaghetti  happy  0.989697
+        1  My dog loves to eat spaghetti    sad  0.010303
+        2  My dog hates going to the vet    sad  0.957075
+        3  My dog hates going to the vet  happy  0.042925
         """
         if isinstance(data, list) and not all(isinstance(item, dict) for item in data):
             raise MlflowException(
@@ -1849,7 +1843,7 @@ class _TransformersWrapper:
         for entry in data:
             for label, score in zip(entry["labels"], entry["scores"]):
                 flattened_data.append(
-                    {"sequence": entry["sequence"], "labels": label, "score": score}
+                    {"sequence": entry["sequence"], "labels": label, "scores": score}
                 )
         return pd.DataFrame(flattened_data)
 

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1435,26 +1435,20 @@ def test_invalid_input_to_fill_mask_pipeline(fill_mask_pipeline, invalid_data):
 
 
 @pytest.mark.parametrize(
-    "data, result",
+    "data",
     [
-        (
-            {
-                "sequences": "I love the latest update to this IDE!",
-                "candidate_labels": ["happy", "sad"],
-            },
-            "happy",
-        ),
-        (
-            {
-                "sequences": ["My dog loves to eat spaghetti", "My dog hates going to the vet"],
-                "candidate_labels": '["happy", "sad"]',
-                "hypothesis_template": "This example talks about how the dog is {}",
-            },
-            ["happy", "sad"],
-        ),
+        {
+            "sequences": "I love the latest update to this IDE!",
+            "candidate_labels": ["happy", "sad"],
+        },
+        {
+            "sequences": ["My dog loves to eat spaghetti", "My dog hates going to the vet"],
+            "candidate_labels": ["happy", "sad"],
+            "hypothesis_template": "This example talks about how the dog is {}",
+        },
     ],
 )
-def test_zero_shot_classification_pipeline(zero_shot_pipeline, model_path, data, result):
+def test_zero_shot_classification_pipeline(zero_shot_pipeline, model_path, data):
     # NB: The list submission for this pipeline type can accept json-encoded lists or lists within
     # the values of the dictionary.
     signature = infer_signature(
@@ -1466,15 +1460,11 @@ def test_zero_shot_classification_pipeline(zero_shot_pipeline, model_path, data,
     loaded_pyfunc = mlflow.pyfunc.load_model(model_path)
     inference = loaded_pyfunc.predict(data)
 
-    assert inference == result
-
-    if all(isinstance(value, str) for value in data.values()):
-        pd_input = pd.DataFrame(data, index=[0])
+    assert isinstance(inference, pd.DataFrame)
+    if isinstance(data["sequences"], str):
+        assert len(inference) == len(data["candidate_labels"])
     else:
-        pd_input = pd.DataFrame(data)
-    pd_inference = loaded_pyfunc.predict(pd_input)
-
-    assert pd_inference == result
+        assert len(inference) == len(data["sequences"]) * len(data["candidate_labels"])
 
 
 @pytest.mark.parametrize(
@@ -1614,21 +1604,18 @@ def test_summarization_pipeline(summarizer_pipeline, model_path, data):
 
 
 @pytest.mark.parametrize(
-    "data, result",
+    "data",
     [
-        ("I'm telling you that Han shot first!", "POSITIVE"),
-        (
-            [
-                "I think this sushi might have gone off",
-                "That gym smells like feet, hot garbage, and sadness",
-                "I love that we have a moon",
-            ],
-            ["NEGATIVE", "NEGATIVE", "POSITIVE"],
-        ),
+        "I'm telling you that Han shot first!",
+        [
+            "I think this sushi might have gone off",
+            "That gym smells like feet, hot garbage, and sadness",
+            "I love that we have a moon",
+        ],
     ],
 )
 @pytest.mark.skipif(RUNNING_IN_GITHUB_ACTIONS, reason=GITHUB_ACTIONS_SKIP_REASON)
-def test_classifier_pipeline(text_classification_pipeline, model_path, data, result):
+def test_classifier_pipeline(text_classification_pipeline, model_path, data):
     signature = infer_signature(
         data, mlflow.transformers.generate_signature_output(text_classification_pipeline, data)
     )
@@ -1638,17 +1625,11 @@ def test_classifier_pipeline(text_classification_pipeline, model_path, data, res
 
     pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
     inference = pyfunc_loaded.predict(data)
-    assert inference == result
 
-    if len(data) > 1 and isinstance(data, list):
-        pd_input = pd.DataFrame([{"inputs": v} for v in data])
-    elif isinstance(data, list) and len(data) == 1:
-        pd_input = pd.DataFrame([{"inputs": v} for v in data], index=[0])
+    if isinstance(data, str):
+        assert len(inference) == 1
     else:
-        pd_input = pd.DataFrame({"inputs": data}, index=[0])
-
-    pd_inference = pyfunc_loaded.predict(pd_input)
-    assert pd_inference == result
+        assert len(inference) == len(data)
 
 
 @pytest.mark.parametrize(
@@ -1742,7 +1723,11 @@ def test_conversational_pipeline(conversational_pipeline, model_path):
                 {"name": "candidate_labels", "type": "string"},
                 {"name": "hypothesis_template", "type": "string"},
             ],
-            [{"type": "string"}],
+            [
+                {"name": "sequence", "type": "string"},
+                {"name": "labels", "type": "string"},
+                {"name": "score", "type": "double"},
+            ],
         ),
     ],
 )
@@ -1859,12 +1844,8 @@ def test_classifier_pipeline_pyfunc_predict(text_classification_pipeline, tmp_pa
     )
     values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
 
-    assert values.to_dict(orient="records") == [
-        {0: "NEGATIVE"},
-        {0: "NEGATIVE"},
-        {0: "POSITIVE"},
-        {0: "POSITIVE"},
-    ]
+    assert len(values.to_dict()) == 2
+    assert len(values.to_dict()["score"]) == 4
 
     inference_payload = json.dumps({"inputs": ["I really love MLflow!"]})
     response = pyfunc_serve_and_score_model(
@@ -1875,7 +1856,8 @@ def test_classifier_pipeline_pyfunc_predict(text_classification_pipeline, tmp_pa
     )
     values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
 
-    assert values.to_dict(orient="records") == [{0: "POSITIVE"}]
+    assert len(values.to_dict()) == 2
+    assert len(values.to_dict()["score"]) == 1
 
 
 def test_zero_shot_pipeline_pyfunc_predict(zero_shot_pipeline, tmp_path):
@@ -1906,7 +1888,9 @@ def test_zero_shot_pipeline_pyfunc_predict(zero_shot_pipeline, tmp_path):
     )
     values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
 
-    assert values.to_dict(orient="records") == [{0: "happy"}]
+    # The length is 3 because it's a single row df cast to dict.
+    assert len(values.to_dict()) == 3
+    assert len(values.to_dict()["labels"]) == 2
 
     inference_payload = json.dumps(
         {
@@ -1929,7 +1913,8 @@ def test_zero_shot_pipeline_pyfunc_predict(zero_shot_pipeline, tmp_path):
     )
     values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
 
-    assert values.to_dict(orient="records") == [{0: "happy"}, {0: "sad"}, {0: "happy"}]
+    assert len(values.to_dict()) == 3
+    assert len(values.to_dict()["labels"]) == 6
 
 
 def test_table_question_answering_pyfunc_predict(table_question_answering_pipeline, tmp_path):
@@ -2542,13 +2527,18 @@ def test_instructional_pipeline_with_prompt_in_output(model_path):
                 "inputs": '[{"name": "sequences", "type": "string"}, {"name": '
                 '"candidate_labels", "type": "string"}, {"name": '
                 '"hypothesis_template", "type": "string"}]',
-                "outputs": '[{"type": "string"}]',
+                "outputs": '[{"name": "sequence", "type": "string"}, {"name": "labels", '
+                '"type": "string"}, {"name": "score", "type": "double"}]',
             },
         ),
         (
             "text_classification_pipeline",
             "We're just going to have to agree to disagree, then.",
-            {"inputs": '[{"type": "string"}]', "outputs": '[{"type": "string"}]'},
+            {
+                "inputs": '[{"type": "string"}]',
+                "outputs": '[{"name": "label", "type": "string"}, {"name": "score", "type": '
+                '"double"}]',
+            },
         ),
         (
             "table_question_answering_pipeline",

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -2528,7 +2528,7 @@ def test_instructional_pipeline_with_prompt_in_output(model_path):
                 '"candidate_labels", "type": "string"}, {"name": '
                 '"hypothesis_template", "type": "string"}]',
                 "outputs": '[{"name": "sequence", "type": "string"}, {"name": "labels", '
-                '"type": "string"}, {"name": "score", "type": "double"}]',
+                '"type": "string"}, {"name": "scores", "type": "double"}]',
             },
         ),
         (

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1726,7 +1726,7 @@ def test_conversational_pipeline(conversational_pipeline, model_path):
             [
                 {"name": "sequence", "type": "string"},
                 {"name": "labels", "type": "string"},
-                {"name": "score", "type": "double"},
+                {"name": "scores", "type": "double"},
             ],
         ),
     ],


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add support for returning score attributes for label classification in text-based LLM classification pipelines for transformers

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

Validation that serving works correctly for ZeroShotClassificationPipelines and TextClassificationPipelines. Existing unit tests and integration tests have been updated to conform to the updated return types.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added return scores for text-based classification pipelines in transformers

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
