### PR TITLE
Type-annotate `experimental` decorator

### DIFF
--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -2,10 +2,12 @@ import inspect
 import types
 import warnings
 from functools import wraps
-from typing import Any, Union
+from typing import Any, Union, Callable, TypeVar
+
+C = TypeVar("C", bound=Callable[..., Any])
 
 
-def experimental(api_or_type: Union[callable, str]):
+def experimental(api_or_type: Union[C, str]) -> C:
     """
     Decorator / decorator creator for marking APIs experimental in the docstring.
 
@@ -14,7 +16,11 @@ def experimental(api_or_type: Union[callable, str]):
              the specified API type (if ``api_or_type`` is a typestring).
     """
     if isinstance(api_or_type, str):
-        return lambda api: _experimental(api=api, api_type=api_or_type)
+
+        def f(api: C) -> C:
+            return _experimental(api=api, api_type=api_or_type)
+
+        return f
     elif inspect.isclass(api_or_type):
         return _experimental(api=api_or_type, api_type="class")
     elif inspect.isfunction(api_or_type):
@@ -25,7 +31,7 @@ def experimental(api_or_type: Union[callable, str]):
         return _experimental(api=api_or_type, api_type=str(type(api_or_type)))
 
 
-def _experimental(api: Any, api_type: str):
+def _experimental(api: C, api_type: str) -> C:
     notice = (
         f"    .. Note:: Experimental: This {api_type} may change or "
         + "be removed in a future release without warning.\n\n"


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Type-annotate the `experimental` decorator to show the correct function signature on hover.

### Before:

<img width="495" alt="Screen Shot 2023-05-24 at 14 57 54" src="https://github.com/mlflow/mlflow/assets/17039389/efc9ce53-b1a0-47fd-a68e-9d2716ab66ee">

### After:

<img width="495" alt="Screen Shot 2023-05-24 at 13 13 34" src="https://github.com/mlflow/mlflow/assets/17039389/d438478f-966c-4119-b3ea-a8ab243afacb">

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
