### PR TITLE
Basic auth: filter search experiment / registered model results

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -441,10 +441,10 @@ def filter_search_experiments(resp: Response):
 
     response_message = SearchExperiments.Response()
     parse_dict(resp.json, response_message)
-    username = request.authorization.username
-    perms = store.list_experiment_permissions(username)
 
     # fetch explicit permissions
+    username = request.authorization.username
+    perms = store.list_experiment_permissions(username)
     can_read = {p.experiment_id: get_permission(p.permission).can_read for p in perms}
     default_can_read = get_permission(auth_config.default_permission).can_read
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -455,7 +455,10 @@ def filter_search_experiments(resp: Response):
 
     # re-fetch to fill max results
     request_message = _get_request_message(SearchExperiments())
-    while len(response_message.experiments) < request_message.max_results and response_message.next_page_token != "":
+    while (
+        len(response_message.experiments) < request_message.max_results
+        and response_message.next_page_token != ""
+    ):
         refetched: PagedList[Experiment] = _get_tracking_store().search_experiments(
             view_type=request_message.view_type,
             max_results=request_message.max_results,
@@ -463,16 +466,20 @@ def filter_search_experiments(resp: Response):
             filter_string=request_message.filter,
             page_token=response_message.next_page_token,
         )
-        refetched = refetched[:request_message.max_results - len(response_message.experiments)]
+        refetched = refetched[: request_message.max_results - len(response_message.experiments)]
         if len(refetched) == 0:
             response_message.next_page_token = ""
             break
 
-        refetched_readable_proto = [e.to_proto() for e in refetched if can_read.get(e.experiment_id, default_can_read)]
+        refetched_readable_proto = [
+            e.to_proto() for e in refetched if can_read.get(e.experiment_id, default_can_read)
+        ]
         response_message.experiments.extend(refetched_readable_proto)
 
         # recalculate next page token
-        start_offset = SearchUtils.parse_start_offset_from_page_token(response_message.next_page_token)
+        start_offset = SearchUtils.parse_start_offset_from_page_token(
+            response_message.next_page_token
+        )
         final_offset = start_offset + len(refetched)
         response_message.next_page_token = SearchUtils.create_page_token(final_offset)
 
@@ -499,23 +506,34 @@ def filter_search_registered_models(resp: Response):
 
     # re-fetch to fill max results
     request_message = _get_request_message(SearchRegisteredModels())
-    while len(response_message.registered_models) < request_message.max_results and response_message.next_page_token != "":
-        refetched: PagedList[RegisteredModel] = _get_model_registry_store().search_registered_models(
+    while (
+        len(response_message.registered_models) < request_message.max_results
+        and response_message.next_page_token != ""
+    ):
+        refetched: PagedList[
+            RegisteredModel
+        ] = _get_model_registry_store().search_registered_models(
             filter_string=request_message.filter,
             max_results=request_message.max_results,
             order_by=request_message.order_by,
             page_token=response_message.next_page_token,
         )
-        refetched = refetched[:request_message.max_results - len(response_message.registered_models)]
+        refetched = refetched[
+            : request_message.max_results - len(response_message.registered_models)
+        ]
         if len(refetched) == 0:
             response_message.next_page_token = ""
             break
 
-        refetched_readable_proto = [rm.to_proto() for rm in refetched if can_read.get(rm.name, default_can_read)]
+        refetched_readable_proto = [
+            rm.to_proto() for rm in refetched if can_read.get(rm.name, default_can_read)
+        ]
         response_message.registered_models.extend(refetched_readable_proto)
 
         # recalculate next page token
-        start_offset = SearchUtils.parse_start_offset_from_page_token(response_message.next_page_token)
+        start_offset = SearchUtils.parse_start_offset_from_page_token(
+            response_message.next_page_token
+        )
         final_offset = start_offset + len(refetched)
         response_message.next_page_token = SearchUtils.create_page_token(final_offset)
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -25,17 +25,17 @@ from mlflow.server.auth.permissions import get_permission, Permission, MANAGE
 from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
 from mlflow.server.handlers import (
     _get_rest_path,
+    _get_request_message,
     _get_tracking_store,
+    _get_model_registry_store,
     catch_mlflow_exception,
-    get_endpoints, _get_request_message,
+    get_endpoints,
 )
 from mlflow.store.entities import PagedList
 from mlflow.tracking._tracking_service.utils import (
     _TRACKING_USERNAME_ENV_VAR,
     _TRACKING_PASSWORD_ENV_VAR,
-    _get_store as _get_tracking_store,
 )
-from mlflow.tracking._model_registry.utils import _get_store as _get_model_registry_store
 from mlflow.protos.databricks_pb2 import (
     ErrorCode,
     BAD_REQUEST,

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -86,8 +86,10 @@ def test_authenticate(client, monkeypatch):
 
 def test_search_experiments(client, monkeypatch):
     """
-    Use user1 to create 10 experiments, grant READ permission to user2 on experiments [0, 3, 4, 5, 6, 8].
-    Test whether user2 can search only and all the readable experiments, both paged and un-paged.
+    Use user1 to create 10 experiments,
+    grant READ permission to user2 on experiments [0, 3, 4, 5, 6, 8].
+    Test whether user2 can search only and all the readable experiments,
+    both paged and un-paged.
     """
     username1, password1 = signup(client)
     username2, password2 = signup(client)
@@ -167,8 +169,10 @@ def test_search_experiments(client, monkeypatch):
 
 def test_search_registered_models(client, monkeypatch):
     """
-    Use user1 to create 10 registered_models, grant READ permission to user2 on registered_models [0, 3, 4, 5, 6, 8].
-    Test whether user2 can search only and all the readable registered_models, both paged and un-paged.
+    Use user1 to create 10 registered_models,
+    grant READ permission to user2 on registered_models [0, 3, 4, 5, 6, 8].
+    Test whether user2 can search only and all the readable registered_models,
+    both paged and un-paged.
     """
     username1, password1 = signup(client)
     username2, password2 = signup(client)

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -37,14 +37,7 @@ def client(tmp_path):
     _terminate_server(process)
 
 
-def test_authenticate(client, monkeypatch):
-    # unauthenticated
-    monkeypatch.delenvs([_TRACKING_USERNAME_ENV_VAR, _TRACKING_PASSWORD_ENV_VAR], raising=False)
-    with pytest.raises(MlflowException, match=r"You are not authenticated.") as exception_context:
-        client.search_experiments()
-    assert exception_context.value.error_code == ErrorCode.Name(UNAUTHENTICATED)
-
-    # sign up
+def signup(client):
     username = random_str()
     password = random_str()
     _send_rest_tracking_post_request(
@@ -55,12 +48,118 @@ def test_authenticate(client, monkeypatch):
             "password": password,
         },
     )
+    return username, password
+
+
+class User:
+    def __init__(self, username, password, monkeypatch):
+        self.username = username
+        self.password = password
+        self.monkeypatch = monkeypatch
+
+    def __enter__(self):
+        self.monkeypatch.setenvs(
+            {
+                _TRACKING_USERNAME_ENV_VAR: self.username,
+                _TRACKING_PASSWORD_ENV_VAR: self.password,
+            }
+        )
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.monkeypatch.delenvs(
+            [_TRACKING_USERNAME_ENV_VAR, _TRACKING_PASSWORD_ENV_VAR], raising=False
+        )
+
+
+def test_authenticate(client, monkeypatch):
+    # unauthenticated
+    monkeypatch.delenvs([_TRACKING_USERNAME_ENV_VAR, _TRACKING_PASSWORD_ENV_VAR], raising=False)
+    with pytest.raises(MlflowException, match=r"You are not authenticated.") as exception_context:
+        client.search_experiments()
+    assert exception_context.value.error_code == ErrorCode.Name(UNAUTHENTICATED)
 
     # authenticated
-    monkeypatch.setenvs(
-        {
-            _TRACKING_USERNAME_ENV_VAR: username,
-            _TRACKING_PASSWORD_ENV_VAR: password,
-        }
-    )
-    client.search_experiments()
+    username, password = signup(client)
+    with User(username, password, monkeypatch):
+        client.search_experiments()
+
+
+def test_search_experiments(client, monkeypatch):
+    """
+    Use user1 to create 10 experiments, grant READ permission to user2 on experiments [0, 3, 4, 5, 6, 8].
+    Test whether user2 can search only and all the readable experiments, both paged and un-paged.
+    """
+    username1, password1 = signup(client)
+    username2, password2 = signup(client)
+
+    readable = [0, 3, 4, 5, 6, 8]
+
+    with User(username1, password1, monkeypatch):
+        for i in range(10):
+            experiment_id = client.create_experiment(f"exp{i}")
+            _send_rest_tracking_post_request(
+                client.tracking_uri,
+                "/api/2.0/mlflow/experiments/permissions/create",
+                json_payload={
+                    "experiment_id": experiment_id,
+                    "username": username2,
+                    "permission": "READ" if i in readable else "NO_PERMISSIONS",
+                },
+                auth=(username1, password1),
+            )
+
+    # test un-paged search
+    with User(username1, password1, monkeypatch):
+        experiments = client.search_experiments(
+            max_results=100,
+            filter_string="name LIKE 'exp%'",
+            order_by=["name ASC"],
+        )
+        names = sorted([exp.name for exp in experiments])
+        assert names == [f"exp{i}" for i in range(10)]
+
+    with User(username2, password2, monkeypatch):
+        experiments = client.search_experiments(
+            max_results=100,
+            filter_string="name LIKE 'exp%'",
+            order_by=["name ASC"],
+        )
+        names = sorted([exp.name for exp in experiments])
+        assert names == [f"exp{i}" for i in readable]
+
+    # test paged search
+    with User(username1, password1, monkeypatch):
+        page_token = ""
+        experiments = []
+        while True:
+            res = client.search_experiments(
+                max_results=4,
+                filter_string="name LIKE 'exp%'",
+                order_by=["name ASC"],
+                page_token=page_token,
+            )
+            experiments.extend(res)
+            page_token = res.token
+            if not page_token:
+                break
+
+        names = sorted([exp.name for exp in experiments])
+        assert names == [f"exp{i}" for i in range(10)]
+
+    with User(username2, password2, monkeypatch):
+        page_token = ""
+        experiments = []
+        while True:
+            res = client.search_experiments(
+                max_results=4,
+                filter_string="name LIKE 'exp%'",
+                order_by=["name ASC"],
+                page_token=page_token,
+            )
+            experiments.extend(res)
+            page_token = res.token
+            if not page_token:
+                break
+
+        names = sorted([exp.name for exp in experiments])
+        assert names == [f"exp{i}" for i in readable]

--- a/tests/tracking/integration_test_utils.py
+++ b/tests/tracking/integration_test_utils.py
@@ -67,7 +67,7 @@ def _init_server(backend_uri, root_artifact_uri, extra_env=None, app_module="mlf
     return url, process
 
 
-def _send_rest_tracking_post_request(tracking_server_uri, api_path, json_payload):
+def _send_rest_tracking_post_request(tracking_server_uri, api_path, json_payload, auth=None):
     """
     Make a POST request to the specified MLflow Tracking API and retrieve the
     corresponding `requests.Response` object
@@ -75,5 +75,5 @@ def _send_rest_tracking_post_request(tracking_server_uri, api_path, json_payload
     import requests
 
     url = tracking_server_uri + api_path
-    response = requests.post(url, json=json_payload)
+    response = requests.post(url, json=json_payload, auth=auth)
     return response


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

#8286 

## What changes are proposed in this pull request?

Add filter in `after_request` to filter out unreadable experiments and registered models

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Experiments and registered models unreadable to an user will be excluded from the search result.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
