### PR TITLE
Reload `openai` after setting `OPENAI_API_KEY`

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -18,13 +18,18 @@ class _EnvironmentVariable:
     def is_defined(self):
         return self.name in os.environ
 
+    def get_raw(self):
+        return os.getenv(self.name)
+
+    def set(self, value):
+        os.environ[self.name] = value
+
     def get(self):
         """
         Reads the value of the environment variable if it exists and converts it to the desired
         type. Otherwise, returns the default value.
         """
-        val = os.getenv(self.name)
-        if val is not None:
+        if (val := self.get_raw()) is not None:
             try:
                 return self.type(val)
             except Exception as e:

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -955,6 +955,7 @@ def spark_udf(spark, model_uri, result_type="double", env_manager=_EnvManager.LO
     # Used in test to force install local version of mlflow when starting a model server
     mlflow_home = os.environ.get("MLFLOW_HOME")
     openai_env_vars = mlflow.openai._OpenAIEnvVar.read_environ()
+    mlflow_openai_testing = _MLFLOW_OPENAI_TESTING.get_raw()
 
     _EnvManager.validate(env_manager)
 
@@ -1185,6 +1186,8 @@ def spark_udf(spark, model_uri, result_type="double", env_manager=_EnvManager.LO
             os.environ["MLFLOW_HOME"] = mlflow_home
         if openai_env_vars:
             os.environ.update(openai_env_vars)
+        if mlflow_openai_testing:
+            _MLFLOW_OPENAI_TESTING.set(mlflow_openai_testing)
         scoring_server_proc = None
 
         if env_manager != _EnvManager.LOCAL:

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -3,7 +3,9 @@ import mlflow
 import pytest
 import transformers
 import json
+import importlib
 
+import openai
 from contextlib import contextmanager
 from langchain.prompts import PromptTemplate
 from langchain.chains import LLMChain
@@ -49,6 +51,7 @@ def set_envs(monkeypatch):
             "SERPAPI_API_KEY": "test",
         }
     )
+    importlib.reload(openai)
 
 
 def create_huggingface_model(model_path):

--- a/tests/openai/test_openai_model_export.py
+++ b/tests/openai/test_openai_model_export.py
@@ -1,5 +1,6 @@
 import yaml
 import json
+import importlib
 from unittest import mock
 
 from pyspark.sql import SparkSession
@@ -30,6 +31,7 @@ def set_envs(monkeypatch):
             "OPENAI_API_KEY": "test",
         }
     )
+    importlib.reload(openai)
 
 
 def test_log_model():


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #8514 

## What changes are proposed in this pull request?

Reload `openai` after setting `OPENAI_API_KEY`.


```python
# openai/__init__.py looks like this:

...
    Moderation,
)
from openai.error import APIError, InvalidRequestError, OpenAIError

if TYPE_CHECKING:
    from aiohttp import ClientSession

api_key = os.environ.get("OPENAI_API_KEY")
# this is set when openai is imported
# just updating os.environ doesn't update api_key
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
