### PR TITLE
Fix the transformers whisper example and add uri validation

### DIFF
--- a/examples/transformers/whisper.py
+++ b/examples/transformers/whisper.py
@@ -46,7 +46,7 @@ print(f"\nWhisper native output transcription:\n{transcription}")
 # Load the pipeline as a pyfunc with the audio file being encoded as base64
 pyfunc_transcriber = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)
 
-pyfunc_transcription = pyfunc_transcriber.predict(base64.b64encode(audio).decode("ascii"))
+pyfunc_transcription = pyfunc_transcriber.predict([audio])
 
 # Note: the pyfunc return type if `return_timestamps` is set is a JSON encoded string.
 print(f"\nPyfunc output transcription:\n{pyfunc_transcription}")

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -2364,9 +2364,9 @@ class _TransformersWrapper:
         for an invalid uri input.
         """
 
-        def is_uri(_input):
+        def is_uri(s):
             try:
-                result = urlparse(_input)
+                result = urlparse(s)
                 return all([result.scheme, result.netloc])
             except ValueError:
                 return False

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3064,8 +3064,16 @@ def test_whisper_model_pyfunc_with_invalid_uri_input(whisper_pipeline):
 
     pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
 
-    with pytest.raises(MlflowException, match="An invalid string input was provided. String"):
+    bad_uri_msg = "An invalid string input was provided. String"
+
+    with pytest.raises(MlflowException, match=bad_uri_msg):
         pyfunc_model.predict("An invalid path")
+
+    with pytest.raises(MlflowException, match=bad_uri_msg):
+        pyfunc_model.predict("//www.invalid.net/audio.wav")
+
+    with pytest.raises(MlflowException, match=bad_uri_msg):
+        pyfunc_model.predict("https:///my/audio.mp3")
 
 
 @pytest.mark.skipif(

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3043,6 +3043,35 @@ def test_whisper_model_with_url(whisper_pipeline):
     Version(transformers.__version__) < Version("4.29.0"), reason="Feature does not exist"
 )
 @pytest.mark.skipcacheclean
+def test_whisper_model_pyfunc_with_invalid_uri_input(whisper_pipeline):
+    artifact_path = "whisper_url"
+
+    url = (
+        "https://raw.githubusercontent.com/mlflow/mlflow/master/tests/datasets/apollo11_launch.wav"
+    )
+
+    signature = infer_signature(
+        url,
+        mlflow.transformers.generate_signature_output(whisper_pipeline, url),
+    )
+
+    with mlflow.start_run():
+        model_info = mlflow.transformers.log_model(
+            transformers_model=whisper_pipeline,
+            artifact_path=artifact_path,
+            signature=signature,
+        )
+
+    pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
+
+    with pytest.raises(MlflowException, match="An invalid string input was provided. String"):
+        pyfunc_model.predict("An invalid path")
+
+
+@pytest.mark.skipif(
+    Version(transformers.__version__) < Version("4.29.0"), reason="Feature does not exist"
+)
+@pytest.mark.skipcacheclean
 def test_whisper_model_using_uri_with_default_signature_raises(whisper_pipeline):
     artifact_path = "whisper_url"
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix the whisper example and add uri validation to string input

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

Manual execution of example

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
