### PR TITLE
Convert transformers scalar string output to list of strings for batch inference

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2528,7 +2528,7 @@ to formats that are compatible with json serialization and casting to Pandas Dat
     types that can be loaded as ``pyfunc``.
 
     In the current version, text-based large language
-    models are supported for use with ``pyfunc``, while computer vision, audio, multi-modal, timeseries,
+    models are supported for use with ``pyfunc``, while computer vision, multi-modal, timeseries,
     reinforcement learning, and graph models are only supported for native type loading via :py:func:`mlflow.transformers.load_model()`
 
     Future releases of MLflow will introduce ``pyfunc`` support for these additional types.
@@ -2551,20 +2551,20 @@ Supported transformers Pipeline types for Pyfunc
 ================================= ============================== ==========================================================================
 Pipeline Type                     Input Type                     Output Type
 ================================= ============================== ==========================================================================
-Instructional Text Generation     str or List[str]               str or List[str]
-Conversational                    str or List[str]               str or List[str]
-Summarization                     str or List[str]               str or List[str]
+Instructional Text Generation     str or List[str]               List[str]
+Conversational                    str or List[str]               List[str]
+Summarization                     str or List[str]               List[str]
 Text Classification               str or List[str]               pd.DataFrame (dtypes: {'label': str, 'score': double})
-Text Generation                   str or List[str]               str or List[str]
-Text2Text Generation              str or List[str]               str or List[str]
-Token Classification              str or List[str]               str or List[str]
-Translation                       str or List[str]               str or List[str]
+Text Generation                   str or List[str]               List[str]
+Text2Text Generation              str or List[str]               List[str]
+Token Classification              str or List[str]               List[str]
+Translation                       str or List[str]               List[str]
 ZeroShot Classification*          Dict[str, [List[str] | str]*   pd.DataFrame (dtypes: {'sequence': str, 'labels': str, 'scores': double})
-Table Question Answering**        Dict[str, [List[str] | str]**  str or List[str]
-Question Answering***             Dict[str, str]***              str or List[str]
-Fill Mask****                     str or List[str]****           str or List[str]
+Table Question Answering**        Dict[str, [List[str] | str]**  List[str]
+Question Answering***             Dict[str, str]***              List[str]
+Fill Mask****                     str or List[str]****           List[str]
 Feature Extraction                str or List[str]               np.ndarray
-AutomaticSpeechRecognition        bytes*****, str, or np.ndarray str
+AutomaticSpeechRecognition        bytes*****, str, or np.ndarray List[str]
 AudioClassification               bytes*****, str, or np.ndarray pd.DataFrame (dtypes: {'label': str, 'score': double})
 ================================= ============================== ==========================================================================
 
@@ -2620,7 +2620,7 @@ loaded as a ``pyfunc`` and used to generate a response from a passed-in list of 
 
     print(response)
 
-    # >> It's a new thing that's been around for a while.
+    # >> [It's a new thing that's been around for a while.]
 
 
 Save and Load options for transformers

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2527,7 +2527,7 @@ to formats that are compatible with json serialization and casting to Pandas Dat
     Not all ``transformers`` pipeline types are supported. See the table below for the list of currently supported Pipeline
     types that can be loaded as ``pyfunc``.
 
-    In the current version, text-based large language
+    In the current version, audio and text-based large language
     models are supported for use with ``pyfunc``, while computer vision, multi-modal, timeseries,
     reinforcement learning, and graph models are only supported for native type loading via :py:func:`mlflow.transformers.load_model()`
 

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -1745,7 +1745,8 @@ class _TransformersWrapper:
         else:
             output = self._parse_lists_of_dict_to_list_of_str(raw_output, output_key)
 
-        return self._sanitize_output(output, data)
+        sanitized = self._sanitize_output(output, data)
+        return self._wrap_strings_as_list_if_scalar(sanitized)
 
     def _parse_raw_pipeline_input(self, data):
         """
@@ -2009,6 +2010,18 @@ class _TransformersWrapper:
             return {k: v.strip() for k, v in output.items()}
         else:
             return output
+
+    @staticmethod
+    def _wrap_strings_as_list_if_scalar(output_data):
+        """
+        Wraps single string outputs in a list to support batch processing logic in serving.
+        Scalar values are not supported for processing in batch logic as they cannot be coerced
+        to DataFrame representations.
+        """
+        if isinstance(output_data, str):
+            return [output_data]
+        else:
+            return output_data
 
     def _parse_lists_of_dict_to_list_of_str(self, output_data, target_dict_key) -> List[str]:
         """

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1209,10 +1209,8 @@ def test_qa_pipeline_pyfunc_load_and_infer(small_qa_pipeline, model_path, infere
 
     inference = pyfunc_loaded.predict(inference_payload)
 
-    if isinstance(inference_payload, dict):
-        assert isinstance(inference, str)
-    else:
-        assert isinstance(inference, list)
+    assert isinstance(inference, list)
+    assert all(isinstance(element, str) for element in inference)
 
     if isinstance(inference_payload, dict):
         pd_input = pd.DataFrame(inference_payload, index=[0])
@@ -1220,16 +1218,14 @@ def test_qa_pipeline_pyfunc_load_and_infer(small_qa_pipeline, model_path, infere
         pd_input = pd.DataFrame(inference_payload)
     pd_inference = pyfunc_loaded.predict(pd_input)
 
-    if isinstance(inference_payload, dict):
-        assert isinstance(pd_inference, str)
-    else:
-        assert isinstance(pd_inference, list)
+    assert isinstance(pd_inference, list)
+    assert all(isinstance(element, str) for element in inference)
 
 
 @pytest.mark.parametrize(
     "data, result",
     [
-        ("muppet keyboard type", "A muppet is typing on a keyboard."),
+        ("muppet keyboard type", ["A muppet is typing on a keyboard."]),
         (
             ["pencil draw paper", "pie apple eat"],
             # NB: The result of this test case, without inference config overrides is:
@@ -1284,10 +1280,9 @@ def test_text2text_generation_pipeline_with_inferred_schema(text2text_generation
         )
     pyfunc_loaded = mlflow.pyfunc.load_model(model_info.model_uri)
 
-    assert (
-        pyfunc_loaded.predict("muppet board nails hammer")
-        == "A muppet is hammering nails on a board."
-    )
+    assert pyfunc_loaded.predict("muppet board nails hammer") == [
+        "A muppet is hammering nails on a board."
+    ]
 
 
 @pytest.mark.parametrize(
@@ -1345,7 +1340,7 @@ def test_text_generation_pipeline(text_generation_pipeline, model_path, data):
         assert inference[0].startswith(data[0])
         assert inference[1].startswith(data[1])
     else:
-        assert inference.startswith(data)
+        assert inference[0].startswith(data)
 
     if isinstance(data, str):
         pd_input = pd.DataFrame([data], index=[0])
@@ -1357,7 +1352,7 @@ def test_text_generation_pipeline(text_generation_pipeline, model_path, data):
         assert pd_inference[0].startswith(data[0])
         assert pd_inference[1].startswith(data[1])
     else:
-        assert pd_inference.startswith(data)
+        assert pd_inference[0].startswith(data)
 
 
 @pytest.mark.parametrize(
@@ -1384,8 +1379,8 @@ def test_invalid_input_to_text_generation_pipeline(text_generation_pipeline, inv
 @pytest.mark.parametrize(
     "inference_payload, result",
     [
-        ("Riding a <mask> on the beach is fun!", "bike"),
-        (["If I had <mask>, I would fly to the top of a mountain"], "wings"),
+        ("Riding a <mask> on the beach is fun!", ["bike"]),
+        (["If I had <mask>, I would fly to the top of a mountain"], ["wings"]),
         (
             ["I use stacks of <mask> to buy things", "I <mask> the whole bowl of cherries"],
             ["cash", "ate"],
@@ -1470,7 +1465,7 @@ def test_zero_shot_classification_pipeline(zero_shot_pipeline, model_path, data)
 @pytest.mark.parametrize(
     "query, result",
     [
-        ({"query": "What should we order more of?"}, "apples"),
+        ({"query": "What should we order more of?"}, ["apples"]),
         (
             {
                 "query": [
@@ -1516,7 +1511,7 @@ def test_table_question_answering_pipeline(
 @pytest.mark.parametrize(
     "data, result",
     [
-        ("I've got a lovely bunch of coconuts!", "Ich habe eine schöne Haufe von Kokos!"),
+        ("I've got a lovely bunch of coconuts!", ["Ich habe eine schöne Haufe von Kokos!"]),
         (
             [
                 "I am the very model of a modern major general",
@@ -1582,9 +1577,9 @@ def test_summarization_pipeline(summarizer_pipeline, model_path, data):
         for i, entry in enumerate(data):
             assert inference[i].strip().startswith(entry)
     elif isinstance(data, list) and len(data) == 1:
-        assert inference.strip().startswith(data[0])
+        assert inference[0].strip().startswith(data[0])
     else:
-        assert inference.strip().startswith(data)
+        assert inference[0].strip().startswith(data)
 
     if len(data) > 1 and isinstance(data, list):
         pd_input = pd.DataFrame([{"inputs": v} for v in data])
@@ -1598,9 +1593,9 @@ def test_summarization_pipeline(summarizer_pipeline, model_path, data):
         for i, entry in enumerate(data):
             assert pd_inference[i].strip().startswith(entry)
     elif isinstance(data, list) and len(data) == 1:
-        assert pd_inference.strip().startswith(data[0])
+        assert pd_inference[0].strip().startswith(data[0])
     else:
-        assert pd_inference.strip().startswith(data)
+        assert pd_inference[0].strip().startswith(data)
 
 
 @pytest.mark.parametrize(
@@ -1637,9 +1632,9 @@ def test_classifier_pipeline(text_classification_pipeline, model_path, data):
     [
         (
             "I have a dog and his name is Willy!",
-            "PRON,VERB,DET,NOUN,CCONJ,PRON,NOUN,AUX,PROPN,PUNCT",
+            ["PRON,VERB,DET,NOUN,CCONJ,PRON,NOUN,AUX,PROPN,PUNCT"],
         ),
-        (["I like turtles"], "PRON,VERB,NOUN"),
+        (["I like turtles"], ["PRON,VERB,NOUN"]),
         (
             ["We are the knights who say nee!", "Houston, we may have a problem."],
             [
@@ -2456,8 +2451,8 @@ def test_instructional_pipeline_no_prompt_in_output(model_path):
 
     inference = pyfunc_loaded.predict("What is MLflow?")
 
-    assert not inference.startswith("What is MLflow?")
-    assert "\n" in inference
+    assert not inference[0].startswith("What is MLflow?")
+    assert "\n" in inference[0]
 
 
 @pytest.mark.skipif(RUNNING_IN_GITHUB_ACTIONS, reason=GITHUB_ACTIONS_SKIP_REASON)
@@ -2478,8 +2473,8 @@ def test_instructional_pipeline_no_prompt_in_output_and_removal_of_newlines(mode
 
     inference = pyfunc_loaded.predict("What is MLflow?")
 
-    assert not inference.startswith("What is MLflow?")
-    assert "\n" not in inference
+    assert not inference[0].startswith("What is MLflow?")
+    assert "\n" not in inference[0]
 
 
 @pytest.mark.skipif(RUNNING_IN_GITHUB_ACTIONS, reason=GITHUB_ACTIONS_SKIP_REASON)
@@ -2500,8 +2495,8 @@ def test_instructional_pipeline_with_prompt_in_output(model_path):
 
     inference = pyfunc_loaded.predict("What is MLflow?")
 
-    assert inference.startswith("What is MLflow?")
-    assert "\n\n" in inference
+    assert inference[0].startswith("What is MLflow?")
+    assert "\n\n" in inference[0]
 
 
 @pytest.mark.parametrize(
@@ -2511,8 +2506,8 @@ def test_instructional_pipeline_with_prompt_in_output(model_path):
             "small_qa_pipeline",
             {"question": "Who's house?", "context": "The house is owned by Run."},
             {
-                "inputs": '[{"name": "question", "type": "string"}, {"name": "context", '
-                '"type": "string"}]',
+                "inputs": '[{"type": "string", "name": "question"}, {"type": "string", '
+                '"name": "context"}]',
                 "outputs": '[{"type": "string"}]',
             },
         ),
@@ -2524,11 +2519,11 @@ def test_instructional_pipeline_with_prompt_in_output(model_path):
                 "hypothesis_template": "This example talks about how pipelines are {}",
             },
             {
-                "inputs": '[{"name": "sequences", "type": "string"}, {"name": '
-                '"candidate_labels", "type": "string"}, {"name": '
-                '"hypothesis_template", "type": "string"}]',
-                "outputs": '[{"name": "sequence", "type": "string"}, {"name": "labels", '
-                '"type": "string"}, {"name": "scores", "type": "double"}]',
+                "inputs": '[{"type": "string", "name": "sequences"}, {"type": "string", '
+                '"name": "candidate_labels"}, {"type": "string", "name": '
+                '"hypothesis_template"}]',
+                "outputs": '[{"type": "string", "name": "sequence"}, {"type": "string", '
+                '"name": "labels"}, {"type": "double", "name": "scores"}]',
             },
         ),
         (
@@ -2536,8 +2531,8 @@ def test_instructional_pipeline_with_prompt_in_output(model_path):
             "We're just going to have to agree to disagree, then.",
             {
                 "inputs": '[{"type": "string"}]',
-                "outputs": '[{"name": "label", "type": "string"}, {"name": "score", "type": '
-                '"double"}]',
+                "outputs": '[{"type": "string", "name": "label"}, {"type": "double", "name": '
+                '"score"}]',
             },
         ),
         (
@@ -2547,8 +2542,8 @@ def test_instructional_pipeline_with_prompt_in_output(model_path):
                 "table": json.dumps({"units": ["100", "200"], "widgets": ["500", "500"]}),
             },
             {
-                "inputs": '[{"name": "query", "type": "string"}, {"name": "table", "type": '
-                '"string"}]',
+                "inputs": '[{"type": "string", "name": "query"}, {"type": "string", "name": '
+                '"table"}]',
                 "outputs": '[{"type": "string"}]',
             },
         ),
@@ -2741,7 +2736,7 @@ def test_load_pyfunc_mutate_torch_dtype(model_path, dtype):
 
     prediction = loaded_pipeline.predict("Hello there. How are you today?")
 
-    assert prediction.startswith("Bonjour")
+    assert prediction[0].startswith("Bonjour")
 
 
 @pytest.mark.skipif(
@@ -2777,7 +2772,7 @@ def test_whisper_model_save_and_load(model_path, whisper_pipeline, sound_file_fo
 
     loaded_pyfunc = mlflow.pyfunc.load_model(model_path)
 
-    pyfunc_transcription = json.loads(loaded_pyfunc.predict(sound_file_for_test))
+    pyfunc_transcription = json.loads(loaded_pyfunc.predict(sound_file_for_test)[0])
 
     assert transcription["text"] == pyfunc_transcription["text"]
     # Due to the choice of using tuples within the return type, equivalency validation for the
@@ -3038,7 +3033,7 @@ def test_whisper_model_with_url(whisper_pipeline):
     values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
     payload_output = values.loc[0, 0]
 
-    assert url_inference == payload_output
+    assert url_inference[0] == payload_output
 
 
 @pytest.mark.skipif(
@@ -3098,7 +3093,7 @@ def test_whisper_model_using_uri_with_default_signature_raises(whisper_pipeline)
 
     url_inference = pyfunc_model.predict(url)
 
-    assert url_inference.startswith("30 seconds and counting. Astronauts report it feels ")
+    assert url_inference[0].startswith("30 seconds and counting. Astronauts report it feels ")
     # Ensure that direct pyfunc calling even with a conflicting signature still functions
     inference_payload = json.dumps({"inputs": [url]})
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Changes the output of transformers models that previously would return `str` to return `List[str]` with a single element to support batch inference processing. 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Changes the output of transformers models that previously would return `str` to return `List[str]` with a single element to support batch inference processing. 

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
