### PR TITLE
Avoid mutating input `base_dict` in `_to_dict`

### DIFF
--- a/mlflow/data/huggingface_dataset.py
+++ b/mlflow/data/huggingface_dataset.py
@@ -76,15 +76,13 @@ class HuggingFaceDataset(Dataset, PyFuncConvertibleDatasetMixin):
                  digest, source, source type, schema (optional), profile
                  (optional).
         """
-        base_dict.update(
-            {
-                "schema": json.dumps({"mlflow_colspec": self.schema.to_dict()})
-                if self.schema
-                else None,
-                "profile": json.dumps(self.profile),
-            }
-        )
-        return base_dict
+        return {
+            **base_dict,
+            "schema": json.dumps({"mlflow_colspec": self.schema.to_dict()})
+            if self.schema
+            else None,
+            "profile": json.dumps(self.profile),
+        }
 
     @property
     def ds(self) -> datasets.Dataset:

--- a/mlflow/data/numpy_dataset.py
+++ b/mlflow/data/numpy_dataset.py
@@ -61,13 +61,11 @@ class NumpyDataset(Dataset, PyFuncConvertibleDatasetMixin):
                  digest, source, source type, schema (optional), profile
                  (optional).
         """
-        base_dict.update(
-            {
-                "schema": json.dumps(self.schema.to_dict()) if self.schema else None,
-                "profile": json.dumps(self.profile),
-            }
-        )
-        return base_dict
+        return {
+            **base_dict,
+            "schema": json.dumps(self.schema.to_dict()) if self.schema else None,
+            "profile": json.dumps(self.profile),
+        }
 
     @property
     def source(self) -> DatasetSource:

--- a/mlflow/data/pandas_dataset.py
+++ b/mlflow/data/pandas_dataset.py
@@ -67,15 +67,13 @@ class PandasDataset(Dataset, PyFuncConvertibleDatasetMixin):
                  digest, source, source type, schema (optional), profile
                  (optional).
         """
-        base_dict.update(
-            {
-                "schema": json.dumps({"mlflow_colspec": self.schema.to_dict()})
-                if self.schema
-                else None,
-                "profile": json.dumps(self.profile),
-            }
-        )
-        return base_dict
+        return {
+            **base_dict,
+            "schema": json.dumps({"mlflow_colspec": self.schema.to_dict()})
+            if self.schema
+            else None,
+            "profile": json.dumps(self.profile),
+        }
 
     @property
     def df(self) -> pd.DataFrame:

--- a/mlflow/data/spark_dataset.py
+++ b/mlflow/data/spark_dataset.py
@@ -63,15 +63,13 @@ class SparkDataset(Dataset, PyFuncConvertibleDatasetMixin):
                  digest, source, source type, schema (optional), profile
                  (optional).
         """
-        base_dict.update(
-            {
-                "schema": json.dumps({"mlflow_colspec": self.schema.to_dict()})
-                if self.schema
-                else None,
-                "profile": json.dumps(self.profile),
-            }
-        )
-        return base_dict
+        return {
+            **base_dict,
+            "schema": json.dumps({"mlflow_colspec": self.schema.to_dict()})
+            if self.schema
+            else None,
+            "profile": json.dumps(self.profile),
+        }
 
     @property
     def df(self):

--- a/mlflow/data/tensorflow_dataset.py
+++ b/mlflow/data/tensorflow_dataset.py
@@ -96,13 +96,11 @@ class TensorFlowDataset(Dataset, PyFuncConvertibleDatasetMixin):
                  digest, source, source type, schema (optional), profile
                  (optional).
         """
-        base_dict.update(
-            {
-                "schema": json.dumps(self.schema.to_dict()) if self.schema else None,
-                "profile": json.dumps(self.profile),
-            }
-        )
-        return base_dict
+        return {
+            **base_dict,
+            "schema": json.dumps(self.schema.to_dict()) if self.schema else None,
+            "profile": json.dumps(self.profile),
+        }
 
     @property
     def data(self):

--- a/tests/resources/data/dataset.py
+++ b/tests/resources/data/dataset.py
@@ -43,13 +43,11 @@ class TestDataset(Dataset):
                  digest, source, source type, schema (optional), profile
                  (optional).
         """
-        base_dict.update(
-            {
-                "schema": json.dumps({"mlflow_colspec": self.schema.to_dict()}),
-                "profile": json.dumps(self.profile),
-            }
-        )
-        return base_dict
+        return {
+            **base_dict,
+            "schema": json.dumps({"mlflow_colspec": self.schema.to_dict()}),
+            "profile": json.dumps(self.profile),
+        }
 
     @property
     def data_list(self) -> List[int]:

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_dataset.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_dataset.py
@@ -38,13 +38,11 @@ class DummyDataset(Dataset):
                  digest, source, source type, schema (optional), profile
                  (optional).
         """
-        base_dict.update(
-            {
-                "schema": json.dumps({"mlflow_colspec": self.schema.to_dict()}),
-                "profile": json.dumps(self.profile),
-            }
-        )
-        return base_dict
+        return {
+            **base_dict,
+            "schema": json.dumps({"mlflow_colspec": self.schema.to_dict()}),
+            "profile": json.dumps(self.profile),
+        }
 
     @property
     def data_list(self) -> List[int]:


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Avoid mutating `base_dict` in `_to_dict`. This type of mutation can lead to unexpected results or hard-to-debug errors and should be avoided unless it's really needed.

```python
def mutate_dict(d):
    d.update({"a": 1})
    return d


empty = {}
mutate_dict(empty)
print(empty)  # {'a': 1}

```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
