### PR TITLE
Skip displaying card in recipe tests

### DIFF
--- a/mlflow/recipes/utils/step.py
+++ b/mlflow/recipes/utils/step.py
@@ -97,7 +97,14 @@ def display_html(html_data: str = None, html_file_path: str = None) -> None:
         else:
             open_tool = None
 
-        if os.path.exists(html_file_path) and open_tool is not None:
+        if (
+            os.path.exists(html_file_path)
+            and open_tool is not None
+            # On Windows, attempting to clean up the card while it's being accessed by
+            # the process running `open_tool` results in a PermissionError. To avoid this,
+            # skip displaying the card.
+            and "GITHUB_ACTIONS" not in os.environ
+        ):
             _logger.info(f"Opening HTML file at: '{html_file_path}'")
             try:
                 subprocess.run([open_tool, html_file_path], check=True)

--- a/tests/recipes/test_step_utils.py
+++ b/tests/recipes/test_step_utils.py
@@ -29,12 +29,13 @@ def test_display_html_opens_html_data():
             patched_display.assert_called_once()
 
 
-def test_display_html_opens_html_file(tmp_path):
+def test_display_html_opens_html_file(tmp_path, monkeypatch):
     html_file = tmp_path / "test.html"
     html_file.write_text("<!DOCTYPE html><html><body><p>Hey</p></body></html>")
     with mock.patch("subprocess.run") as patched_subprocess, mock.patch(
         "shutil.which", return_value=True
     ):
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
         display_html(html_file_path=html_file)
         patched_subprocess.assert_called_once()
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

On Windows, a file being accessed by another process can't be removed (it can on Unix). This limitation causes the following error in mlflow recipes tests:

https://github.com/mlflow/mlflow/actions/runs/5172351009/jobs/9316619127

```
E                   PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-runneradmin\\pytest-0\\test_recipes_execution_directo1\\custom\\steps\\split\\outputs\\card.html'
```

This PR fixes it by skipping displaying the card.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
