### PR TITLE
[WIP] Unpin pandas in TF Estimator compatibility suite

### DIFF
--- a/tests/tensorflow/mlflow-128-tf-23-env.yaml
+++ b/tests/tensorflow/mlflow-128-tf-23-env.yaml
@@ -7,8 +7,5 @@ dependencies:
       - mlflow==1.28.0
       - h5py<3.0.0
       - tensorflow==2.3.0
-      # pin pandas version to avoid pickling error
-      # AttributeError: Can't get attribute '_unpickle_block'
-      - pandas==1.3.5
       - protobuf<4.0.0
 name: mlflow-128-tf-23-env

--- a/tests/tensorflow/save_tf_estimator_model.py
+++ b/tests/tensorflow/save_tf_estimator_model.py
@@ -31,12 +31,13 @@ args = parser.parse_args()
 
 mlflow.set_tracking_uri(args.tracking_uri)
 
+
 class SavedModelInfo(NamedTuple):
-    meta_graph_tags 
-    signature_def_key 
-    inference_df 
-    raw_results 
-    raw_df 
+    meta_graph_tags
+    signature_def_key
+    inference_df
+    raw_results
+    raw_df
     expected_results_df
 
     def save(self, path):
@@ -44,14 +45,16 @@ class SavedModelInfo(NamedTuple):
             "meta_graph_tags": self.meta_graph_tags,
             "signature_def_key": self.signature_def_key,
             "raw_results": self.raw_results,
-            "run_id": run_id, 
+            "run_id": run_id,
         }
         with open(os.path.join(path, "info.json"), "w") as f:
             json.dump(info_dict, f)
 
         self.inference_df.to_json(os.path.join(path, "inference_df.json"), orient="split")
         self.raw_df.to_json(os.path.join(path, "raw_df.json"), orient="split")
-        self.expected_results_df.to_json(os.path.join(path, "expected_results_df.json"), orient="split")
+        self.expected_results_df.to_json(
+            os.path.join(path, "expected_results_df.json"), orient="split"
+        )
 
 
 def save_tf_iris_model(tmp_path):

--- a/tests/tensorflow/test_load_saved_tensorflow_estimator.py
+++ b/tests/tensorflow/test_load_saved_tensorflow_estimator.py
@@ -49,7 +49,9 @@ class ModelDataInfo(NamedTuple):
 
         inference_df = pd.read_json(os.path.join(path, "inference_df.json"), orient="split")
         raw_df = pd.read_json(os.path.join(path, "raw_df.json"), orient="split")
-        expected_results_df = pd.read_json(os.path.join(path, "expected_results_df.json"), orient="split")
+        expected_results_df = pd.read_json(
+            os.path.join(path, "expected_results_df.json"), orient="split"
+        )
 
         return cls(
             raw_results=info["raw_results"],


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Unpin pandas in TF Estimator compatibility suite

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
