### PR TITLE
extend timeout duration of waiting flask server

### DIFF
--- a/tests/tracking/integration_test_utils.py
+++ b/tests/tracking/integration_test_utils.py
@@ -13,7 +13,7 @@ from tests.helper_functions import LOCALHOST, get_safe_port
 _logger = logging.getLogger(__name__)
 
 
-def _await_server_up_or_die(port, timeout=60):
+def _await_server_up_or_die(port, timeout=30):
     """Waits until the local flask server is listening on the given port."""
     _logger.info(f"Awaiting server to be up on {LOCALHOST}:{port}")
     start_time = time.time()

--- a/tests/tracking/integration_test_utils.py
+++ b/tests/tracking/integration_test_utils.py
@@ -13,7 +13,7 @@ from tests.helper_functions import LOCALHOST, get_safe_port
 _logger = logging.getLogger(__name__)
 
 
-def _await_server_up_or_die(port, timeout=20):
+def _await_server_up_or_die(port, timeout=60):
     """Waits until the local flask server is listening on the given port."""
     _logger.info(f"Awaiting server to be up on {LOCALHOST}:{port}")
     start_time = time.time()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

extend the timeout duration for waiting for the Flask server from 20 seconds to 60 seconds. Waiting for only 20 seconds or failing is too restrictive.

```text
=================================== ERRORS ====================================
___________ ERROR at setup of test_update_model_version_flow[file] ____________

request = <SubRequest 'client' for <Function test_update_model_version_flow[file]>>
tmp_path = WindowsPath('C:/Users/runneradmin/AppData/Local/Temp/pytest-of-runneradmin/pytest-0/test_update_model_version_flow0')

    @pytest.fixture(params=["file", "sqlalchemy"])
    def client(request, tmp_path):
        if request.param == "file":
            backend_uri = tmp_path.joinpath("file").as_uri()
        else:
            path = tmp_path.joinpath("sqlalchemy.db").as_uri()
            backend_uri = ("sqlite://" if is_windows() else "sqlite:////") + path[len("file://") :]
    
>       url, process = _init_server(
            backend_uri=backend_uri, root_artifact_uri=tmp_path.joinpath("artifacts").as_uri()
        )

backend_uri = 'file:///C:/Users/runneradmin/AppData/Local/Temp/pytest-of-runneradmin/pytest-0/test_update_model_version_flow0/file'
request    = <SubRequest 'client' for <Function test_update_model_version_flow[file]>>
tmp_path   = WindowsPath('C:/Users/runneradmin/AppData/Local/Temp/pytest-of-runneradmin/pytest-0/test_update_model_version_flow0')

tests\tracking\test_model_registry.py:24: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests\tracking\integration_test_utils.py:64: in _init_server
    _await_server_up_or_die(server_port)
        app_module = 'mlflow.server'
        backend_uri = 'file:///C:/Users/runneradmin/AppData/Local/Temp/pytest-of-runneradmin/pytest-0/test_update_model_version_flow0/file'
        extra_env  = None
        process    = <subprocess.Popen object at 0x000001F0F64C95B0>
        root_artifact_uri = 'file:///C:/Users/runneradmin/AppData/Local/Temp/pytest-of-runneradmin/pytest-0/test_update_model_version_flow0/artifacts'
        server_port = 61073
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

port = 61073, timeout = 20

    def _await_server_up_or_die(port, timeout=20):
        """Waits until the local flask server is listening on the given port."""
        _logger.info(f"Awaiting server to be up on {LOCALHOST}:{port}")
        start_time = time.time()
        while time.time() - start_time < timeout:
            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
                sock.settimeout(2)
                if sock.connect_ex((LOCALHOST, port)) == 0:
                    _logger.info(f"Server is up on {LOCALHOST}:{port}!")
                    break
            _logger.info("Server not yet up, waiting...")
            time.sleep(0.5)
        else:
>           raise Exception(f"Failed to connect on {LOCALHOST}:{port} within {timeout} seconds")
E           Exception: Failed to connect on 127.0.0.1:61073 within 20 seconds

....

=========================== short test summary info ===========================
ERROR tests/tracking/test_model_registry.py::test_update_model_version_flow[file] - Exception: Failed to connect on 127.0.0.1:61073 within 20 seconds
==== 2561 passed, 84 skipped, 111 warnings, 1 error in 3570.51s (0:59:30) =====
```


<img width="422" alt="截圖 2023-06-07 上午9 33 28" src="https://github.com/mlflow/mlflow/assets/13614761/e1a76237-510f-45e4-8797-5f56c9fdc634">


## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)



<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
