### PR TITLE
Monitor disk usage in transformers tests

### DIFF
--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -1,6 +1,7 @@
 import re
 import shutil
 import os
+import sys
 from pathlib import Path
 
 import mlflow
@@ -8,15 +9,10 @@ from mlflow import cli
 from mlflow.utils import process
 from mlflow.utils.virtualenv import _get_mlflow_virtualenv_root
 import pytest
-from tests.helper_functions import clear_hub_cache
+from tests.helper_functions import clear_hub_cache, get_free_disk_space_in_GiB
 from tests.integration.utils import invoke_cli_runner
 
 EXAMPLES_DIR = "examples"
-
-
-def get_free_disk_space_in_GiB():
-    # https://stackoverflow.com/a/48929832/6943581
-    return shutil.disk_usage("/")[-1] / (2**30)
 
 
 def find_python_env_yaml(directory: Path) -> Path:
@@ -30,13 +26,12 @@ def replace_mlflow_with_dev_version(yml_path: Path) -> None:
     yml_path.write_text(new_src)
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def report_free_disk_space(capsys):
     yield
 
     with capsys.disabled():
-        # pylint: disable-next=print-function
-        print(" | Free disk space: {:.1f} GiB".format(get_free_disk_space_in_GiB()), end="")
+        sys.stdout.write(f" | Free disk space: {get_free_disk_space_in_GiB():.1f} GiB")
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -1,6 +1,7 @@
 import os
 import random
 import functools
+import shutil
 from unittest import mock
 from contextlib import ExitStack, contextmanager
 from packaging.version import Version
@@ -614,3 +615,7 @@ def clear_hub_cache():
     except ImportError:
         # Local import check for mlflow-skinny not including huggingface_hub
         pass
+
+
+def get_free_disk_space_in_GiB():
+    return shutil.disk_usage("/").free / (1024**3)

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -8,6 +8,7 @@ import pandas as pd
 from packaging.version import Version
 import pathlib
 import pytest
+import sys
 import textwrap
 from unittest import mock
 import yaml
@@ -56,6 +57,7 @@ from tests.helper_functions import (
     _mlflow_major_version_string,
     pyfunc_serve_and_score_model,
     _get_deps_from_requirement_file,
+    get_free_disk_space_in_GiB,
 )
 
 pytestmark = pytest.mark.large
@@ -77,6 +79,14 @@ GITHUB_ACTIONS_SKIP_REASON = "Test consumes too much memory"
 # - TextClassifier pipeline tests
 # - Text2TextGeneration pipeline tests
 # - Conversational pipeline tests
+
+
+@pytest.fixture(autouse=True)
+def report_free_disk_space(capsys):
+    yield
+
+    with capsys.disabled():
+        sys.stdout.write(f" | Free disk space: {get_free_disk_space_in_GiB():.1f} GiB", end="")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -86,7 +86,7 @@ def report_free_disk_space(capsys):
     yield
 
     with capsys.disabled():
-        sys.stdout.write(f" | Free disk space: {get_free_disk_space_in_GiB():.1f} GiB", end="")
+        sys.stdout.write(f" | Free disk space: {get_free_disk_space_in_GiB():.1f} GiB")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Monitor disk usage in transformers tests to find tests that consume lots of disk space and prevent a no-space-left-on-disk error beforehand.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
