### PR TITLE
Import `datasets` lazily in `mlflow.data`

### DIFF
--- a/mlflow/data/huggingface_dataset.py
+++ b/mlflow/data/huggingface_dataset.py
@@ -1,9 +1,8 @@
 import json
 import logging
 from functools import cached_property
-from typing import Any, Union, Optional, Mapping, Sequence, Dict
+from typing import Any, Union, Optional, Mapping, Sequence, Dict, TYPE_CHECKING
 
-import datasets
 
 from mlflow.data.dataset import Dataset
 from mlflow.data.digest_utils import compute_pandas_digest
@@ -20,6 +19,9 @@ _logger = logging.getLogger(__name__)
 
 _MAX_ROWS_FOR_DIGEST_COMPUTATION_AND_SCHEMA_INFERENCE = 10000
 
+if TYPE_CHECKING:
+    import datasets
+
 
 @experimental
 class HuggingFaceDataset(Dataset, PyFuncConvertibleDatasetMixin):
@@ -29,7 +31,7 @@ class HuggingFaceDataset(Dataset, PyFuncConvertibleDatasetMixin):
 
     def __init__(
         self,
-        ds: datasets.Dataset,
+        ds: "datasets.Dataset",
         source: HuggingFaceDatasetSource,
         targets: Optional[str] = None,
         name: Optional[str] = None,
@@ -85,7 +87,7 @@ class HuggingFaceDataset(Dataset, PyFuncConvertibleDatasetMixin):
         }
 
     @property
-    def ds(self) -> datasets.Dataset:
+    def ds(self) -> "datasets.Dataset":
         """
         The Hugging Face ``datasets.Dataset`` instance.
 
@@ -219,6 +221,7 @@ def from_huggingface(
     :param digest: The digest (hash, fingerprint) of the dataset. If unspecified, a digest
                    is automatically computed.
     """
+    import datasets
     from mlflow.data.code_dataset_source import CodeDatasetSource
     from mlflow.tracking.context import registry
 

--- a/mlflow/data/huggingface_dataset_source.py
+++ b/mlflow/data/huggingface_dataset_source.py
@@ -1,9 +1,11 @@
-import datasets
-
-from typing import Any, Union, Optional, Mapping, Sequence, Dict
+from typing import Any, Union, Optional, Mapping, Sequence, Dict, TYPE_CHECKING
 
 from mlflow.data.dataset_source import DatasetSource
 from mlflow.utils.annotations import experimental
+
+
+if TYPE_CHECKING:
+    import datasets
 
 
 @experimental
@@ -20,9 +22,9 @@ class HuggingFaceDatasetSource(DatasetSource):
         data_files: Optional[
             Union[str, Sequence[str], Mapping[str, Union[str, Sequence[str]]]]
         ] = None,
-        split: Optional[Union[str, datasets.Split]] = None,
-        revision: Optional[Union[str, datasets.Version]] = None,
-        task: Optional[Union[str, datasets.TaskTemplate]] = None,
+        split: Optional[Union[str, "datasets.Split"]] = None,
+        revision: Optional[Union[str, "datasets.Version"]] = None,
+        task: Optional[Union[str, "datasets.TaskTemplate"]] = None,
     ):
         """
         :param path: The path of the Hugging Face dataset.
@@ -56,6 +58,8 @@ class HuggingFaceDatasetSource(DatasetSource):
                        ``data_dir``, ``data_files``, ``split``, ``revision``, ``task``.
         :return: An instance of ``datasets.Dataset``.
         """
+        import datasets
+
         load_kwargs = {
             "path": self._path,
             "name": self._config_name,


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Resolve #8641

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

Build an image from this dockerfile:

```dockerfile
FROM python:3.8

# Repro
# RUN pip install git+https://github.com/mlflow/mlflow.git
# Fixed
RUN pip install git+https://github.com/harupy/mlflow.git@lazily-import-datasets
RUN mkdir datasets
RUN python -c "import mlflow"
```

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
