### PR TITLE
Cancel GitHub Actions runs when a PR is closed or merged

### DIFF
--- a/.github/workflows/cancel.js
+++ b/.github/workflows/cancel.js
@@ -1,0 +1,32 @@
+module.exports = async ({ context, github }) => {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const prNumber = context.payload.pull_request.number;
+  const headSha = context.payload.pull_request.head.sha;
+
+  // Get all workflow runs associated with the PR.
+  const prRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+    owner,
+    repo,
+    head_sha: headSha,
+    event: "pull_request",
+    per_page: 100,
+  });
+
+  const unfinishedRuns = prRuns.filter((run) => run.status !== "completed");
+
+  // Cancel the runs
+  for (const run of unfinishedRuns) {
+    try {
+      // Some runs may have already completed, so we need to handle errors.
+      await github.rest.actions.cancelWorkflowRun({
+        owner,
+        repo,
+        run_id: run.id,
+      });
+      console.log(`Cancelled run ${run.id}`);
+    } catch (error) {
+      console.error(`Failed to cancel run ${run.id}`, error);
+    }
+  }
+};

--- a/.github/workflows/cancel.js
+++ b/.github/workflows/cancel.js
@@ -9,7 +9,7 @@ module.exports = async ({ context, github }) => {
     event: "pull_request",
     per_page: 100,
   });
-  const unfinishedRuns = prRuns.filter((run) => run.status !== "completed");
+  const unfinishedRuns = prRuns.filter(({ status }) => status !== "completed");
   for (const run of unfinishedRuns) {
     try {
       // Some runs may have already completed, so we need to handle errors.

--- a/.github/workflows/cancel.js
+++ b/.github/workflows/cancel.js
@@ -1,10 +1,7 @@
 module.exports = async ({ context, github }) => {
   const owner = context.repo.owner;
   const repo = context.repo.repo;
-  const prNumber = context.payload.pull_request.number;
   const headSha = context.payload.pull_request.head.sha;
-
-  // Get all workflow runs associated with the PR.
   const prRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
     owner,
     repo,
@@ -12,10 +9,7 @@ module.exports = async ({ context, github }) => {
     event: "pull_request",
     per_page: 100,
   });
-
   const unfinishedRuns = prRuns.filter((run) => run.status !== "completed");
-
-  // Cancel the runs
   for (const run of unfinishedRuns) {
     try {
       // Some runs may have already completed, so we need to handle errors.

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,22 @@
+# Cancel workflow runs on pull request close
+name: Cancel
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.MLFLOW_AUTOMATION_TOKEN }}
+          script: |
+            const script = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/workflows/cancel.js`
+            );
+            await script({ context, github });

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,4 +1,4 @@
-# Cancel workflow runs on pull request close
+# Cancel workflow runs associated with a pull request when it is closed or merged.
 name: Cancel
 
 on:


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Cancel GitHub Actions runs when a PR is closed or merged. For example, when we file a PR to update `CHANGELOG`, we can merge that PR without waiting for CI to pass. Currently, this would leave zombie GitHub Actions runs. The proposed workflow in this PR eliminates them.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
