### PR TITLE
Ignore encoding errors with transformers model cards

### DIFF
--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -2,7 +2,6 @@ import base64
 import gc
 import json
 
-import huggingface_hub
 import librosa
 import numpy as np
 import os
@@ -16,7 +15,7 @@ from unittest import mock
 import yaml
 
 import transformers
-import huggingface_hub as hub
+import huggingface_hub
 from huggingface_hub import ModelCard, scan_cache_dir
 from datasets import load_dataset
 
@@ -3152,12 +3151,12 @@ def test_save_model_card_with_non_utf_characters(tmp_path, model_name):
         "\U0001F970 \U0001F60E \U0001F917 \U0001F9D0"
     )
 
-    card_data: ModelCard = hub.ModelCard.load(model_name)
+    card_data: ModelCard = huggingface_hub.ModelCard.load(model_name)
     card_data.text = card_data.text + "\n\n" + test_text
     custom_data = card_data.data.to_dict()
     custom_data["emojis"] = test_text
 
-    card_data.data = hub.CardData(**custom_data)
+    card_data.data = huggingface_hub.CardData(**custom_data)
     _write_card_data(card_data, tmp_path)
 
     txt = tmp_path.joinpath(_CARD_TEXT_FILE_NAME).read_text()

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1,6 +1,8 @@
 import base64
 import gc
 import json
+
+import huggingface_hub
 import librosa
 import numpy as np
 import os
@@ -14,6 +16,7 @@ from unittest import mock
 import yaml
 
 import transformers
+import huggingface_hub as hub
 from huggingface_hub import ModelCard, scan_cache_dir
 from datasets import load_dataset
 
@@ -47,6 +50,9 @@ from mlflow.transformers import (
     _should_add_pyfunc_to_model,
     _TransformersModel,
     _FRAMEWORK_KEY,
+    _write_card_data,
+    _CARD_TEXT_FILE_NAME,
+    _CARD_DATA_FILE_NAME,
 )
 from mlflow.utils.environment import _mlflow_conda_env
 import torch
@@ -3134,3 +3140,27 @@ def test_whisper_model_with_malformed_audio(whisper_pipeline):
 
     with pytest.raises(MlflowException, match="Failed to process the input audio data. Either"):
         pyfunc_model.predict([invalid_audio])
+
+
+@pytest.mark.parametrize(
+    "model_name", ["tiiuae/falcon-7b", "databricks/dolly-v2-7b", "runwayml/stable-diffusion-v1-5"]
+)
+def test_save_model_card_with_non_utf_characters(tmp_path, model_name):
+    # non-ascii unicode characters
+    test_text = (
+        "Emoji testing! \u2728 \U0001F600 \U0001F609 \U0001F606 "
+        "\U0001F970 \U0001F60E \U0001F917 \U0001F9D0"
+    )
+
+    card_data: ModelCard = hub.ModelCard.load(model_name)
+    card_data.text = card_data.text + "\n\n" + test_text
+    custom_data = card_data.data.to_dict()
+    custom_data["emojis"] = test_text
+
+    card_data.data = hub.CardData(**custom_data)
+    _write_card_data(card_data, tmp_path)
+
+    txt = tmp_path.joinpath(_CARD_TEXT_FILE_NAME).read_text()
+    assert txt == card_data.text
+    data = yaml.safe_load(tmp_path.joinpath(_CARD_DATA_FILE_NAME).read_text())
+    assert data == card_data.data.to_dict()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Handle unicode values in model cards that can cause serialization issues for certain cards in transformers

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
