### PR TITLE
Revert 8561 do not use subprocess with no session cache

### DIFF
--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -60,7 +60,7 @@ from mlflow.utils.uri import (
 )
 
 _logger = logging.getLogger(__name__)
-_DOWNLOAD_CHUNK_SIZE = 10_000_000  # 10 MB
+_DOWNLOAD_CHUNK_SIZE = 100_000_000  # 100 MB
 _MULTIPART_UPLOAD_CHUNK_SIZE = 10_000_000  # 10 MB
 _MAX_CREDENTIALS_REQUEST_SIZE = 2000  # Max number of artifact paths in a single credentials request
 _SERVICE_AND_METHOD_TO_INFO = {
@@ -432,13 +432,20 @@ class DatabricksArtifactRepository(ArtifactRepository):
     def _parallelized_download_from_cloud(
         self, cloud_credential_info, file_size, dst_local_file_path, dst_run_relative_artifact_path
     ):
+        from mlflow.utils.databricks_utils import get_databricks_env_vars
+
         try:
+            parallel_download_subproc_env = os.environ.copy()
+            parallel_download_subproc_env.update(
+                get_databricks_env_vars(self.databricks_profile_uri)
+            )
             failed_downloads = parallelized_download_file_using_http_uri(
                 http_uri=cloud_credential_info.signed_uri,
                 download_path=dst_local_file_path,
                 file_size=file_size,
                 uri_type=cloud_credential_info.type,
                 chunk_size=_DOWNLOAD_CHUNK_SIZE,
+                env=parallel_download_subproc_env,
                 headers=self._extract_headers_from_credentials(cloud_credential_info.headers),
             )
             download_errors = [
@@ -456,14 +463,11 @@ class DatabricksArtifactRepository(ArtifactRepository):
                 )[0]
                 new_signed_uri = new_cloud_creds.signed_uri
                 new_headers = self._extract_headers_from_credentials(new_cloud_creds.headers)
-                for index in failed_downloads:
-                    download_chunk(
-                        index,
-                        _DOWNLOAD_CHUNK_SIZE,
-                        new_headers,
-                        dst_local_file_path,
-                        new_signed_uri,
-                    )
+
+            for i in failed_downloads:
+                download_chunk(
+                    i, _DOWNLOAD_CHUNK_SIZE, new_headers, dst_local_file_path, new_signed_uri
+                )
         except Exception as err:
             if os.path.exists(dst_local_file_path):
                 os.remove(dst_local_file_path)

--- a/mlflow/store/artifact/databricks_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_models_artifact_repo.py
@@ -8,7 +8,6 @@ from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
-from mlflow.store.artifact.databricks_artifact_repo import _DOWNLOAD_CHUNK_SIZE
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.file_utils import (
     download_file_using_http_uri,
@@ -23,6 +22,7 @@ from mlflow.store.artifact.utils.models import (
 )
 
 _logger = logging.getLogger(__name__)
+_DOWNLOAD_CHUNK_SIZE = 100_000_000  # 100 MB
 # The constant REGISTRY_LIST_ARTIFACT_ENDPOINT is defined as @developer_stable
 REGISTRY_LIST_ARTIFACTS_ENDPOINT = "/api/2.0/mlflow/model-versions/list-artifacts"
 # The constant REGISTRY_ARTIFACT_PRESIGNED_URI_ENDPOINT is defined as @developer_stable
@@ -128,7 +128,13 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
     def _parallelized_download_from_cloud(
         self, signed_uri, headers, file_size, dst_local_file_path, dst_run_relative_artifact_path
     ):
+        from mlflow.utils.databricks_utils import get_databricks_env_vars
+
         try:
+            parallel_download_subproc_env = os.environ.copy()
+            parallel_download_subproc_env.update(
+                get_databricks_env_vars(self.databricks_profile_uri)
+            )
             failed_downloads = parallelized_download_file_using_http_uri(
                 http_uri=signed_uri,
                 download_path=dst_local_file_path,
@@ -136,25 +142,25 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
                 # URI type is not known in this context
                 uri_type=None,
                 chunk_size=_DOWNLOAD_CHUNK_SIZE,
+                env=parallel_download_subproc_env,
                 headers=headers,
             )
-            if any(e.response.status_code not in (401, 403) for e in failed_downloads.values()):
+            download_errors = [
+                e for e in failed_downloads.values() if e["error_status_code"] not in (401, 403)
+            ]
+            if download_errors:
                 raise MlflowException(
                     f"Failed to download artifact {dst_run_relative_artifact_path}: "
-                    f"{failed_downloads}"
+                    f"{download_errors}"
                 )
             if failed_downloads:
                 new_signed_uri, new_headers = self._get_signed_download_uri(
                     dst_run_relative_artifact_path
                 )
-                for index in failed_downloads:
-                    download_chunk(
-                        index=index,
-                        chunk_size=_DOWNLOAD_CHUNK_SIZE,
-                        headers=new_headers,
-                        download_path=dst_local_file_path,
-                        http_uri=new_signed_uri,
-                    )
+            for i in failed_downloads:
+                download_chunk(
+                    i, _DOWNLOAD_CHUNK_SIZE, new_headers, dst_local_file_path, new_signed_uri
+                )
         except Exception as err:
             if os.path.exists(dst_local_file_path):
                 os.remove(dst_local_file_path)

--- a/mlflow/utils/download_cloud_file_chunk.py
+++ b/mlflow/utils/download_cloud_file_chunk.py
@@ -1,0 +1,56 @@
+"""
+This script should be executed in a fresh python interpreter process using `subprocess`.
+"""
+import argparse
+import importlib.util
+import json
+import os
+import requests
+import sys
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--range-start", required=True, type=int)
+    parser.add_argument("--range-end", required=True, type=int)
+    parser.add_argument("--headers", required=True, type=str)
+    parser.add_argument("--download-path", required=True, type=str)
+    parser.add_argument("--http-uri", required=True, type=str)
+    parser.add_argument("--temp-file", required=True, type=str)
+    return parser.parse_args()
+
+
+def main():
+    file_path = os.path.join(os.path.dirname(__file__), "request_utils.py")
+    module_name = "mlflow.utils.request_utils"
+
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    download_chunk = module.download_chunk
+
+    args = parse_args()
+
+    try:
+        download_chunk(
+            range_start=args.range_start,
+            range_end=args.range_end,
+            headers=json.loads(args.headers),
+            download_path=args.download_path,
+            http_uri=args.http_uri,
+        )
+    except requests.HTTPError as e:
+        temp_file = args.temp_file
+        with open(temp_file, "w") as f:
+            json.dump(
+                {
+                    "error_status_code": e.response.status_code,
+                    "error_text": str(e),
+                },
+                f,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -20,7 +20,7 @@ import urllib.parse
 import urllib.request
 from urllib.parse import unquote
 from urllib.request import pathname2url
-import requests
+
 
 import atexit
 
@@ -36,10 +36,11 @@ from mlflow.exceptions import MissingConfigException
 from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialType
 from mlflow.utils.rest_utils import augmented_raise_for_status
 from mlflow.utils.request_utils import cloud_storage_http_request
-from mlflow.utils.process import cache_return_value_per_process
+from mlflow.utils.process import cache_return_value_per_process, _exec_cmd
 from mlflow.utils import merge_dicts
 from mlflow.utils.databricks_utils import _get_dbutils
 from mlflow.utils.os import is_windows
+from mlflow.utils import download_cloud_file_chunk
 from mlflow.utils.request_utils import download_chunk
 
 
@@ -597,7 +598,7 @@ def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, 
 
 
 def parallelized_download_file_using_http_uri(
-    http_uri, download_path, file_size, uri_type, chunk_size, headers=None
+    http_uri, download_path, file_size, uri_type, chunk_size, env, headers=None
 ):
     """
     Downloads a file specified using the `http_uri` to a local `download_path`. This function
@@ -610,18 +611,58 @@ def parallelized_download_file_using_http_uri(
     Returns a dict of chunk index : exception, if one was thrown for that index.
     """
 
+    def run_download(range_start, range_end):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_file = os.path.join(tmpdir, "error_messages.txt")
+            download_proc = _exec_cmd(
+                cmd=[
+                    sys.executable,
+                    download_cloud_file_chunk.__file__,
+                    "--range-start",
+                    range_start,
+                    "--range-end",
+                    range_end,
+                    "--headers",
+                    json.dumps(headers or {}),
+                    "--download-path",
+                    download_path,
+                    "--http-uri",
+                    http_uri,
+                    "--temp-file",
+                    temp_file,
+                ],
+                throw_on_error=True,
+                synchronous=False,
+                capture_output=True,
+                stream_output=False,
+                env=env,
+            )
+            _, stderr = download_proc.communicate()
+            if download_proc.returncode != 0:
+                if os.path.exists(temp_file):
+                    with open(temp_file, "r") as f:
+                        file_contents = f.read()
+                        if file_contents:
+                            return json.loads(file_contents)
+                        else:
+                            raise Exception(
+                                "Error from download_cloud_file_chunk not captured, "
+                                f"return code {download_proc.returncode}, stderr {stderr}"
+                            )
+
+    num_requests = int(math.ceil(file_size / float(chunk_size)))
     # Create file if it doesn't exist or erase the contents if it does. We should do this here
     # before sending to the workers so they can each individually seek to their respective positions
     # and write chunks without overwriting.
-    open(download_path, "wb").close()
+    open(download_path, "w").close()
     starting_index = 0
     if uri_type == ArtifactCredentialType.GCP_SIGNED_URL or uri_type is None:
         # GCP files could be transcoded, in which case the range header is ignored.
         # Test if this is the case by downloading one chunk and seeing if it's larger than the
         # requested size. If yes, let that be the file; if not, continue downloading more chunks.
         download_chunk(
-            index=0,
-            chunk_size=chunk_size,
+            range_start=0,
+            range_end=chunk_size - 1,
             headers=headers,
             download_path=download_path,
             http_uri=http_uri,
@@ -634,27 +675,26 @@ def parallelized_download_file_using_http_uri(
         else:
             starting_index = 1
 
-    num_requests = int(math.ceil(file_size / float(chunk_size)))
     with ThreadPoolExecutor(max_workers=MAX_PARALLEL_DOWNLOAD_WORKERS) as p:
         futures = {}
-        for index in range(starting_index, num_requests):
-            future = p.submit(
-                download_chunk,
-                index=index,
-                chunk_size=chunk_size,
-                headers=headers,
-                download_path=download_path,
-                http_uri=http_uri,
-            )
-            futures[future] = index
+        for i in range(starting_index, num_requests):
+            range_start = i * chunk_size
+            range_end = range_start + chunk_size - 1
+            futures[p.submit(run_download, range_start, range_end)] = i
 
         failed_downloads = {}
         for future in as_completed(futures):
+            index = futures[future]
             try:
-                future.result()
-            except requests.HTTPError as e:
-                index = futures[future]
-                failed_downloads[index] = e
+                result = future.result()
+                if result is not None:
+                    failed_downloads[index] = result
+
+            except Exception as e:
+                failed_downloads[index] = {
+                    "error_status_code": 500,
+                    "error_text": repr(e),
+                }
 
     return failed_downloads
 

--- a/mlflow/utils/request_utils.py
+++ b/mlflow/utils/request_utils.py
@@ -1,3 +1,6 @@
+# DO NO IMPORT MLFLOW IN THIS FILE.
+# This file is imported by download_cloud_file_chunk.py.
+# Importing mlflow is time-consuming and we want to avoid that in artifact download subprocesses.
 import os
 import requests
 import urllib3
@@ -36,20 +39,18 @@ def augmented_raise_for_status(response):
             raise e
 
 
-def download_chunk(index, chunk_size, headers, download_path, http_uri):
-    range_start = index * chunk_size
-    range_end = range_start + chunk_size - 1
-    ranged_headers = {"Range": f"bytes={range_start}-{range_end}", **headers}
+def download_chunk(range_start, range_end, headers, download_path, http_uri):
+    combined_headers = {**headers, "Range": f"bytes={range_start}-{range_end}"}
+
     with cloud_storage_http_request(
-        "get", http_uri, stream=True, headers=ranged_headers
+        "get", http_uri, stream=False, headers=combined_headers
     ) as response:
         # File will have been created upstream. Use r+b to ensure chunks
         # don't overwrite the entire file.
         augmented_raise_for_status(response)
         with open(download_path, "r+b") as f:
             f.seek(range_start)
-            for content in response.iter_content(chunk_size=1_000_000):
-                f.write(content)
+            f.write(response.content)
 
 
 @lru_cache(maxsize=64)

--- a/mlflow/utils/request_utils.py
+++ b/mlflow/utils/request_utils.py
@@ -5,7 +5,7 @@ import os
 import requests
 import urllib3
 
-from functools import lru_cache
+# from functools import lru_cache
 from packaging.version import Version
 from requests.adapters import HTTPAdapter
 from requests.exceptions import HTTPError
@@ -53,7 +53,7 @@ def download_chunk(range_start, range_end, headers, download_path, http_uri):
             f.write(response.content)
 
 
-@lru_cache(maxsize=64)
+# @lru_cache(maxsize=64)
 def _cached_get_request_session(
     max_retries,
     backoff_factor,

--- a/tests/utils/test_request_utils.py
+++ b/tests/utils/test_request_utils.py
@@ -1,0 +1,28 @@
+import subprocess
+import sys
+
+
+def test_request_utils_does_not_import_mlflow(tmp_path):
+    import mlflow.utils.request_utils
+
+    file_content = f"""
+import importlib.util
+import os
+import sys
+
+file_path = r"{mlflow.utils.request_utils.__file__}"
+module_name = "mlflow.utils.request_utils"
+
+spec = importlib.util.spec_from_file_location(module_name, file_path)
+module = importlib.util.module_from_spec(spec)
+sys.modules[module_name] = module
+spec.loader.exec_module(module)
+
+assert "mlflow" not in sys.modules
+assert "mlflow.utils.request_utils" in sys.modules
+"""
+
+    test_file = tmp_path.joinpath("test_request_utils_does_not_import_mlflow.py")
+    test_file.write_text(file_content)
+
+    subprocess.run([sys.executable, str(test_file)], check=True)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
