### PR TITLE
Add duplicate requirements validation

### DIFF
--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -34,6 +34,7 @@ from mlflow.utils.docstring_utils import (
     LOG_MODEL_PARAM_DOCS,
     docstring_version_compatibility_warning,
 )
+from mlflow.utils.environment import _find_duplicate_requirements
 from mlflow.environment_variables import (
     MLFLOW_DEFAULT_PREDICTION_DEVICE,
     MLFLOW_HUGGINGFACE_DISABLE_ACCELERATE_FEATURES,
@@ -504,6 +505,14 @@ def save_model(
         )
     else:
         conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
+
+    if duplicates := _find_duplicate_requirements(pip_requirements):
+        _logger.warning(
+            "Duplicate packages are present within the pip requirements. Duplicate packages: "
+            f"{duplicates}. Please manually specify the requirements by using the "
+            "`pip_requirements` argument in order to prevent unexpected installation "
+            "issues for this model."
+        )
 
     with path.joinpath(_CONDA_ENV_FILE_NAME).open("w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import yaml
 import os
 import logging
@@ -498,6 +499,26 @@ def _process_pip_requirements(
     # Set `install_mlflow` to False because `pip_reqs` already contains `mlflow`
     conda_env = _mlflow_conda_env(additional_pip_deps=pip_reqs, install_mlflow=False)
     return conda_env, pip_reqs, constraints
+
+
+def _find_duplicate_requirements(requirements):
+    """
+    Checks if duplicate base package requirements are specified in any list of requirements
+    and returns the list of duplicate base package names.
+    Note that git urls and paths to local files are not being considered for duplication checking.
+    """
+    base_package_names = []
+
+    for package in requirements:
+        try:
+            base_package_names.append(Requirement(package).name)
+        except InvalidRequirement:
+            # Skip anything that's not a valid package requirement
+            continue
+
+    package_counts = Counter(base_package_names)
+    duplicates = [package for package, count in package_counts.items() if count > 1]
+    return duplicates
 
 
 def _process_conda_env(conda_env):

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1015,6 +1015,38 @@ def test_transformers_log_with_extra_pip_requirements(small_multi_modal_pipeline
         )
 
 
+def test_transformers_log_with_duplicate_pip_requirements(
+    small_multi_modal_pipeline, tmp_path, capsys
+):
+    with mlflow.start_run():
+        mlflow.transformers.log_model(
+            small_multi_modal_pipeline,
+            "model",
+            pip_requirements=["transformers==99.99.99", "transformers", "mlflow"],
+        )
+    captured = capsys.readouterr()
+    assert (
+        "Duplicate packages are present within the pip requirements. "
+        "Duplicate packages: ['transformers']" in captured.err
+    )
+
+
+def test_transformers_log_with_duplicate_extra_pip_requirements(
+    small_multi_modal_pipeline, tmp_path, capsys
+):
+    with mlflow.start_run():
+        mlflow.transformers.log_model(
+            small_multi_modal_pipeline,
+            "model",
+            extra_pip_requirements=["transformers==99.99.99"],
+        )
+    captured = capsys.readouterr()
+    assert (
+        "Duplicate packages are present within the pip requirements. "
+        "Duplicate packages: ['transformers']" in captured.err
+    )
+
+
 def test_transformers_tf_model_save_without_conda_env_uses_default_env_with_expected_dependencies(
     small_seq2seq_pipeline, model_path
 ):

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -14,6 +14,7 @@ from mlflow.utils.environment import (
     _process_pip_requirements,
     _process_conda_env,
     _get_pip_requirement_specifier,
+    _find_duplicate_requirements,
 )
 from tests.helper_functions import _mlflow_major_version_string
 
@@ -326,3 +327,31 @@ def test_process_conda_env(tmpdir):
 
     with pytest.raises(TypeError, match=r"Expected .+, but got `int`"):
         _process_conda_env(0)
+
+
+def test_duplicate_pip_requirements():
+    packages = [
+        "numpy==1.21.0",  # specific version
+        "pandas>=1.3.0",  # minimum version
+        "scikit-learn",  # any version
+        "matplotlib<=3.4.2",  # maximum version
+        "seaborn",  # any version
+        "package!=1.2.3",  # any version but this one
+        "package~=1.2.3",  # compatible version (i.e., >= 1.2.3, == 1.2.*)
+        "package>1.2.3",  # version greater than
+        "package<1.2.3",  # version less than
+        "package[extra]==1.2.3",  # specific version with extras
+        "fastapi ===0.21.0",  # specific version (PEP 440: version with spaces around ===)
+        "fastapi @ https://my.package.repo/fastapi-0.21.0-py3-none-any.whl",  # private repo
+        "-e git+https://github.com/mlflow/mlflow@master",  # editable mode, direct from a git repo
+        "-r requirements.txt",  # from a requirements file
+        "pytest-cov; python_version < '3.8'",  # conditional requirements
+        "fastapi @ file:///local/path/to/numpy-0.22.0-py3-none-any.whl",  # wheel from a local file
+        "-c constraints.txt",  # constraint file
+        "--no-binary :all:",  # no binary packages, source code only
+        "--prefer-binary",  # prefer binary packages over source code
+        "numpy<1.24.0",  # maximum version
+        "numpy",  # any version
+    ]
+    evaluation = _find_duplicate_requirements(packages)
+    assert sorted(evaluation) == ["fastapi", "numpy", "package"]


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Validates duplicate entries in pip_requirements and extra_pip_requirements that cause install errors by emitting a warning

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Warnings are now provided in the transformers flavor if duplicated pip dependencies are going to be logged.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
