### PR TITLE
Replace `tmpdir` with `tmp_path`

### DIFF
--- a/tests/gluon/test_gluon_model_export.py
+++ b/tests/gluon/test_gluon_model_export.py
@@ -176,57 +176,49 @@ def test_model_save_persists_requirements_in_mlflow_model_directory(
     _compare_conda_env_requirements(gluon_custom_env, saved_pip_req_path)
 
 
-def test_save_model_with_pip_requirements(gluon_model, tmpdir):
+def test_save_model_with_pip_requirements(gluon_model, tmp_path):
     expected_mlflow_version = _mlflow_major_version_string()
     # Path to a requirements file
-    tmpdir1 = tmpdir.join("1")
-    req_file = tmpdir.join("requirements.txt")
-    req_file.write("a")
-    mlflow.gluon.save_model(gluon_model, tmpdir1.strpath, pip_requirements=req_file.strpath)
-    _assert_pip_requirements(tmpdir1.strpath, [expected_mlflow_version, "a"], strict=True)
+    tmpdir1 = tmp_path.joinpath("1")
+    req_file = tmp_path.joinpath("requirements.txt")
+    req_file.write_text("a")
+    mlflow.gluon.save_model(gluon_model, tmpdir1, pip_requirements=str(req_file))
+    _assert_pip_requirements(tmpdir1, [expected_mlflow_version, "a"], strict=True)
 
     # List of requirements
-    tmpdir2 = tmpdir.join("2")
-    mlflow.gluon.save_model(
-        gluon_model, tmpdir2.strpath, pip_requirements=[f"-r {req_file.strpath}", "b"]
-    )
-    _assert_pip_requirements(tmpdir2.strpath, [expected_mlflow_version, "a", "b"], strict=True)
+    tmpdir2 = tmp_path.joinpath("2")
+    mlflow.gluon.save_model(gluon_model, tmpdir2, pip_requirements=[f"-r {req_file}", "b"])
+    _assert_pip_requirements(tmpdir2, [expected_mlflow_version, "a", "b"], strict=True)
 
     # Constraints file
-    tmpdir3 = tmpdir.join("3")
-    mlflow.gluon.save_model(
-        gluon_model, tmpdir3.strpath, pip_requirements=[f"-c {req_file.strpath}", "b"]
-    )
+    tmpdir3 = tmp_path.joinpath("3")
+    mlflow.gluon.save_model(gluon_model, tmpdir3, pip_requirements=[f"-c {req_file}", "b"])
     _assert_pip_requirements(
-        tmpdir3.strpath, [expected_mlflow_version, "b", "-c constraints.txt"], ["a"], strict=True
+        tmpdir3, [expected_mlflow_version, "b", "-c constraints.txt"], ["a"], strict=True
     )
 
 
-def test_save_model_with_extra_pip_requirements(gluon_model, tmpdir):
+def test_save_model_with_extra_pip_requirements(gluon_model, tmp_path):
     expected_mlflow_version = _mlflow_major_version_string()
     default_reqs = mlflow.gluon.get_default_pip_requirements()
 
     # Path to a requirements file
-    tmpdir1 = tmpdir.join("1")
-    req_file = tmpdir.join("requirements.txt")
-    req_file.write("a")
-    mlflow.gluon.save_model(gluon_model, tmpdir1.strpath, extra_pip_requirements=req_file.strpath)
-    _assert_pip_requirements(tmpdir1.strpath, [expected_mlflow_version, *default_reqs, "a"])
+    tmpdir1 = tmp_path.joinpath("1")
+    req_file = tmp_path.joinpath("requirements.txt")
+    req_file.write_text("a")
+    mlflow.gluon.save_model(gluon_model, tmpdir1, extra_pip_requirements=str(req_file))
+    _assert_pip_requirements(tmpdir1, [expected_mlflow_version, *default_reqs, "a"])
 
     # List of requirements
-    tmpdir2 = tmpdir.join("2")
-    mlflow.gluon.save_model(
-        gluon_model, tmpdir2.strpath, extra_pip_requirements=[f"-r {req_file.strpath}", "b"]
-    )
-    _assert_pip_requirements(tmpdir2.strpath, [expected_mlflow_version, *default_reqs, "a", "b"])
+    tmpdir2 = tmp_path.joinpath("2")
+    mlflow.gluon.save_model(gluon_model, tmpdir2, extra_pip_requirements=[f"-r {req_file}", "b"])
+    _assert_pip_requirements(tmpdir2, [expected_mlflow_version, *default_reqs, "a", "b"])
 
     # Constraints file
-    tmpdir3 = tmpdir.join("3")
-    mlflow.gluon.save_model(
-        gluon_model, tmpdir3.strpath, extra_pip_requirements=[f"-c {req_file.strpath}", "b"]
-    )
+    tmpdir3 = tmp_path.joinpath("3")
+    mlflow.gluon.save_model(gluon_model, tmpdir3, extra_pip_requirements=[f"-c {req_file}", "b"])
     _assert_pip_requirements(
-        tmpdir3.strpath, [expected_mlflow_version, *default_reqs, "b", "-c constraints.txt"], ["a"]
+        tmpdir3, [expected_mlflow_version, *default_reqs, "b", "-c constraints.txt"], ["a"]
     )
 
 

--- a/tests/johnsnowlabs/test_johnsnowlabs_model_export.py
+++ b/tests/johnsnowlabs/test_johnsnowlabs_model_export.py
@@ -237,15 +237,15 @@ def test_log_model_with_signature_and_examples(jsl_model):
 
 @pytest.mark.parametrize("should_start_run", [False, True])
 @pytest.mark.parametrize("use_dfs_tmpdir", [False, True])
-def test_johnsnowlabs_model_log(tmpdir, jsl_model, should_start_run, use_dfs_tmpdir):
+def test_johnsnowlabs_model_log(tmp_path, jsl_model, should_start_run, use_dfs_tmpdir):
     old_tracking_uri = mlflow.get_tracking_uri()
     if use_dfs_tmpdir:
         dfs_tmpdir = None
     else:
-        dfs_tmpdir = tmpdir.join("test").strpath
+        dfs_tmpdir = tmp_path.joinpath("test")
 
     try:
-        tracking_dir = os.path.abspath(str(tmpdir.join("mlruns")))
+        tracking_dir = tmp_path.joinpath("mlruns")
         mlflow.set_tracking_uri("file://%s" % tracking_dir)
         if should_start_run:
             mlflow.start_run()
@@ -266,9 +266,9 @@ def test_johnsnowlabs_model_log(tmpdir, jsl_model, should_start_run, use_dfs_tmp
         mlflow.set_tracking_uri(old_tracking_uri)
 
 
-def test_log_model_calls_register_model(tmpdir, jsl_model):
+def test_log_model_calls_register_model(tmp_path, jsl_model):
     artifact_path = "model"
-    dfs_tmp_dir = Path(str(tmpdir)) / "test"
+    dfs_tmp_dir = tmp_path.joinpath("test")
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch:
         mlflow.johnsnowlabs.log_model(

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -662,7 +662,7 @@ def test_log_model_with_extra_pip_requirements(
             "model",
             python_model=python_model,
             artifacts={"sk_model": sklearn_model_path},
-            extra_pip_requirements=req_file,
+            extra_pip_requirements=str(req_file),
         )
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a"]

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -648,7 +648,7 @@ def test_log_model_with_extra_pip_requirements(
     sklearn_knn_model, main_scoped_model_class, tmp_path
 ):
     expected_mlflow_version = _mlflow_major_version_string()
-    sklearn_model_path = tmp_path.joinpath("sklearn_model")
+    sklearn_model_path = str(tmp_path.joinpath("sklearn_model"))
     mlflow.sklearn.save_model(sk_model=sklearn_knn_model, path=sklearn_model_path)
 
     python_model = main_scoped_model_class(predict_fn=None)

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -998,7 +998,7 @@ def test_save_model_emits_deprecation_warning_for_requirements_file(tmp_path):
         mlflow.pytorch.save_model(
             get_sequential_model(),
             tmp_path.joinpath("model"),
-            requirements_file=reqs_file,
+            requirements_file=str(reqs_file),
         )
 
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -385,60 +385,54 @@ def test_model_save_persists_requirements_in_mlflow_model_directory(
 
 
 @pytest.mark.parametrize("scripted_model", [False])
-def test_save_model_with_pip_requirements(sequential_model, tmpdir):
+def test_save_model_with_pip_requirements(sequential_model, tmp_path):
     expected_mlflow_version = _mlflow_major_version_string()
     # Path to a requirements file
-    tmpdir1 = tmpdir.join("1")
-    req_file = tmpdir.join("requirements.txt")
-    req_file.write("a")
-    mlflow.pytorch.save_model(sequential_model, tmpdir1.strpath, pip_requirements=req_file.strpath)
-    _assert_pip_requirements(tmpdir1.strpath, [expected_mlflow_version, "a"], strict=True)
+    tmpdir1 = tmp_path.joinpath("1")
+    req_file = tmp_path.joinpath("requirements.txt")
+    req_file.write_text("a")
+    mlflow.pytorch.save_model(sequential_model, tmpdir1, pip_requirements=str(req_file))
+    _assert_pip_requirements(tmpdir1, [expected_mlflow_version, "a"], strict=True)
 
     # List of requirements
-    tmpdir2 = tmpdir.join("2")
-    mlflow.pytorch.save_model(
-        sequential_model, tmpdir2.strpath, pip_requirements=[f"-r {req_file.strpath}", "b"]
-    )
-    _assert_pip_requirements(tmpdir2.strpath, [expected_mlflow_version, "a", "b"], strict=True)
+    tmpdir2 = tmp_path.joinpath("2")
+    mlflow.pytorch.save_model(sequential_model, tmpdir2, pip_requirements=[f"-r {req_file}", "b"])
+    _assert_pip_requirements(tmpdir2, [expected_mlflow_version, "a", "b"], strict=True)
 
     # Constraints file
-    tmpdir3 = tmpdir.join("3")
-    mlflow.pytorch.save_model(
-        sequential_model, tmpdir3.strpath, pip_requirements=[f"-c {req_file.strpath}", "b"]
-    )
+    tmpdir3 = tmp_path.joinpath("3")
+    mlflow.pytorch.save_model(sequential_model, tmpdir3, pip_requirements=[f"-c {req_file}", "b"])
     _assert_pip_requirements(
-        tmpdir3.strpath, [expected_mlflow_version, "b", "-c constraints.txt"], ["a"], strict=True
+        tmpdir3, [expected_mlflow_version, "b", "-c constraints.txt"], ["a"], strict=True
     )
 
 
 @pytest.mark.parametrize("scripted_model", [False])
-def test_save_model_with_extra_pip_requirements(sequential_model, tmpdir):
+def test_save_model_with_extra_pip_requirements(sequential_model, tmp_path):
     expected_mlflow_version = _mlflow_major_version_string()
     default_reqs = mlflow.pytorch.get_default_pip_requirements()
 
     # Path to a requirements file
-    tmpdir1 = tmpdir.join("1")
-    req_file = tmpdir.join("requirements.txt")
-    req_file.write("a")
-    mlflow.pytorch.save_model(
-        sequential_model, tmpdir1.strpath, extra_pip_requirements=req_file.strpath
-    )
-    _assert_pip_requirements(tmpdir1.strpath, [expected_mlflow_version, *default_reqs, "a"])
+    tmpdir1 = tmp_path.joinpath("1")
+    req_file = tmp_path.joinpath("requirements.txt")
+    req_file.write_text("a")
+    mlflow.pytorch.save_model(sequential_model, tmpdir1, extra_pip_requirements=str(req_file))
+    _assert_pip_requirements(tmpdir1, [expected_mlflow_version, *default_reqs, "a"])
 
     # List of requirements
-    tmpdir2 = tmpdir.join("2")
+    tmpdir2 = tmp_path.joinpath("2")
     mlflow.pytorch.save_model(
-        sequential_model, tmpdir2.strpath, extra_pip_requirements=[f"-r {req_file.strpath}", "b"]
+        sequential_model, tmpdir2, extra_pip_requirements=[f"-r {req_file}", "b"]
     )
-    _assert_pip_requirements(tmpdir2.strpath, [expected_mlflow_version, *default_reqs, "a", "b"])
+    _assert_pip_requirements(tmpdir2, [expected_mlflow_version, *default_reqs, "a", "b"])
 
     # Constraints file
-    tmpdir3 = tmpdir.join("3")
+    tmpdir3 = tmp_path.joinpath("3")
     mlflow.pytorch.save_model(
-        sequential_model, tmpdir3.strpath, extra_pip_requirements=[f"-c {req_file.strpath}", "b"]
+        sequential_model, tmpdir3, extra_pip_requirements=[f"-c {req_file}", "b"]
     )
     _assert_pip_requirements(
-        tmpdir3.strpath, [expected_mlflow_version, *default_reqs, "b", "-c constraints.txt"], ["a"]
+        tmpdir3, [expected_mlflow_version, *default_reqs, "b", "-c constraints.txt"], ["a"]
     )
 
 
@@ -904,12 +898,12 @@ def test_pyfunc_serve_and_score_transformers():
 
 
 @pytest.fixture
-def create_requirements_file(tmpdir):
+def create_requirements_file(tmp_path):
     requirement_file_name = "requirements.txt"
-    fp = tmpdir.join(requirement_file_name)
+    fp = tmp_path.joinpath(requirement_file_name)
     test_string = "mlflow"
-    fp.write(test_string)
-    return fp.strpath, test_string
+    fp.write_text(test_string)
+    return str(fp), test_string
 
 
 @pytest.mark.parametrize("scripted_model", [True, False])
@@ -997,24 +991,24 @@ def test_log_model_invalid_requirement_file_type(sequential_model):
         )
 
 
-def test_save_model_emits_deprecation_warning_for_requirements_file(tmpdir):
-    reqs_file = tmpdir.join("requirements.txt")
-    reqs_file.write("torch")
+def test_save_model_emits_deprecation_warning_for_requirements_file(tmp_path):
+    reqs_file = tmp_path.joinpath("requirements.txt")
+    reqs_file.write_text("torch")
     with pytest.warns(FutureWarning, match="`requirements_file` has been deprecated"):
         mlflow.pytorch.save_model(
             get_sequential_model(),
-            tmpdir.join("model"),
-            requirements_file=reqs_file.strpath,
+            tmp_path.joinpath("model"),
+            requirements_file=reqs_file,
         )
 
 
 @pytest.fixture
-def create_extra_files(tmpdir):
-    fp1 = tmpdir.join("extra1.txt")
-    fp2 = tmpdir.join("extra2.txt")
-    fp1.write("1")
-    fp2.write("2")
-    return [fp1.strpath, fp2.strpath], ["1", "2"]
+def create_extra_files(tmp_path):
+    fp1 = tmp_path.joinpath("extra1.txt")
+    fp2 = tmp_path.joinpath("extra2.txt")
+    fp1.write_text("1")
+    fp2.write_text("2")
+    return [str(fp1), str(fp2)], ["1", "2"]
 
 
 @pytest.mark.parametrize("scripted_model", [True, False])

--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -158,7 +158,7 @@ def test_log_explanation_doesnt_create_autologged_run():
         mlflow.sklearn.autolog(disable=True)
 
 
-def test_load_pyfunc(tmpdir):
+def test_load_pyfunc(tmp_path):
     X, y = get_housing_data()
 
     model = sklearn.ensemble.RandomForestRegressor(n_estimators=100)
@@ -166,7 +166,7 @@ def test_load_pyfunc(tmpdir):
 
     explainer_original = shap.Explainer(model.predict, X, algorithm="permutation")
     shap_values_original = explainer_original(X[:2])
-    path = tmpdir.join("pyfunc_test").strpath
+    path = str(tmp_path.joinpath("pyfunc_test"))
     mlflow.shap.save_explainer(explainer_original, path)
 
     explainer_pyfunc = mlflow.shap._load_pyfunc(path)
@@ -223,14 +223,14 @@ def test_merge_environment():
     assert sorted(expected_conda_deps) == sorted(actual_conda_deps)
 
 
-def test_log_model_with_pip_requirements(shap_model, tmpdir):
+def test_log_model_with_pip_requirements(shap_model, tmp_path):
     expected_mlflow_version = _mlflow_major_version_string()
     sklearn_default_reqs = mlflow.sklearn.get_default_pip_requirements(include_cloudpickle=True)
     # Path to a requirements file
-    req_file = tmpdir.join("requirements.txt")
-    req_file.write("a")
+    req_file = tmp_path.joinpath("requirements.txt")
+    req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.shap.log_explainer(shap_model, "model", pip_requirements=req_file.strpath)
+        mlflow.shap.log_explainer(shap_model, "model", pip_requirements=str(req_file))
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"),
             [expected_mlflow_version, "a", *sklearn_default_reqs],
@@ -239,9 +239,7 @@ def test_log_model_with_pip_requirements(shap_model, tmpdir):
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.shap.log_explainer(
-            shap_model, "model", pip_requirements=[f"-r {req_file.strpath}", "b"]
-        )
+        mlflow.shap.log_explainer(shap_model, "model", pip_requirements=[f"-r {req_file}", "b"])
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"),
             [expected_mlflow_version, "a", "b", *sklearn_default_reqs],
@@ -250,9 +248,7 @@ def test_log_model_with_pip_requirements(shap_model, tmpdir):
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.shap.log_explainer(
-            shap_model, "model", pip_requirements=[f"-c {req_file.strpath}", "b"]
-        )
+        mlflow.shap.log_explainer(shap_model, "model", pip_requirements=[f"-c {req_file}", "b"])
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"),
             [expected_mlflow_version, "b", "-c constraints.txt", *sklearn_default_reqs],
@@ -261,16 +257,16 @@ def test_log_model_with_pip_requirements(shap_model, tmpdir):
         )
 
 
-def test_log_model_with_extra_pip_requirements(shap_model, tmpdir):
+def test_log_model_with_extra_pip_requirements(shap_model, tmp_path):
     expected_mlflow_version = _mlflow_major_version_string()
     shap_default_reqs = mlflow.shap.get_default_pip_requirements()
     sklearn_default_reqs = mlflow.sklearn.get_default_pip_requirements(include_cloudpickle=True)
 
     # Path to a requirements file
-    req_file = tmpdir.join("requirements.txt")
-    req_file.write("a")
+    req_file = tmp_path.joinpath("requirements.txt")
+    req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.shap.log_explainer(shap_model, "model", extra_pip_requirements=req_file.strpath)
+        mlflow.shap.log_explainer(shap_model, "model", extra_pip_requirements=str(req_file))
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"),
             [expected_mlflow_version, *shap_default_reqs, "a", *sklearn_default_reqs],
@@ -279,7 +275,7 @@ def test_log_model_with_extra_pip_requirements(shap_model, tmpdir):
     # List of requirements
     with mlflow.start_run():
         mlflow.shap.log_explainer(
-            shap_model, "model", extra_pip_requirements=[f"-r {req_file.strpath}", "b"]
+            shap_model, "model", extra_pip_requirements=[f"-r {req_file}", "b"]
         )
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"),
@@ -289,7 +285,7 @@ def test_log_model_with_extra_pip_requirements(shap_model, tmpdir):
     # Constraints file
     with mlflow.start_run():
         mlflow.shap.log_explainer(
-            shap_model, "model", extra_pip_requirements=[f"-c {req_file.strpath}", "b"]
+            shap_model, "model", extra_pip_requirements=[f"-c {req_file}", "b"]
         )
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"),
@@ -360,8 +356,8 @@ def test_log_model_with_code_paths(shap_model):
         add_mock.assert_called()
 
 
-def test_model_save_load_with_metadata(shap_model, tmpdir):
-    model_path = tmpdir.join("pyfunc_test").strpath
+def test_model_save_load_with_metadata(shap_model, tmp_path):
+    model_path = str(tmp_path.joinpath("pyfunc_test"))
     mlflow.shap.save_explainer(
         shap_model, path=model_path, metadata={"metadata_key": "metadata_value"}
     )

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -187,69 +187,67 @@ def test_model_save_persists_requirements_in_mlflow_model_directory(
     _compare_conda_env_requirements(spacy_custom_env, saved_pip_req_path)
 
 
-def test_save_model_with_pip_requirements(spacy_model_with_data, tmpdir):
+def test_save_model_with_pip_requirements(spacy_model_with_data, tmp_path):
     expected_mlflow_version = _mlflow_major_version_string()
     # Path to a requirements file
-    tmpdir1 = tmpdir.join("1")
-    req_file = tmpdir.join("requirements.txt")
-    req_file.write("a")
-    mlflow.spacy.save_model(
-        spacy_model_with_data.model, tmpdir1.strpath, pip_requirements=req_file.strpath
-    )
-    _assert_pip_requirements(tmpdir1.strpath, [expected_mlflow_version, "a"], strict=True)
+    tmpdir1 = tmp_path.joinpath("1")
+    req_file = tmp_path.joinpath("requirements.txt")
+    req_file.write_text("a")
+    mlflow.spacy.save_model(spacy_model_with_data.model, tmpdir1, pip_requirements=str(req_file))
+    _assert_pip_requirements(tmpdir1, [expected_mlflow_version, "a"], strict=True)
 
     # List of requirements
-    tmpdir2 = tmpdir.join("2")
+    tmpdir2 = tmp_path.joinpath("2")
     mlflow.spacy.save_model(
         spacy_model_with_data.model,
-        tmpdir2.strpath,
-        pip_requirements=[f"-r {req_file.strpath}", "b"],
+        tmpdir2,
+        pip_requirements=[f"-r {req_file}", "b"],
     )
-    _assert_pip_requirements(tmpdir2.strpath, [expected_mlflow_version, "a", "b"], strict=True)
+    _assert_pip_requirements(tmpdir2, [expected_mlflow_version, "a", "b"], strict=True)
 
     # Constraints file
-    tmpdir3 = tmpdir.join("3")
+    tmpdir3 = tmp_path.joinpath("3")
     mlflow.spacy.save_model(
         spacy_model_with_data.model,
-        tmpdir3.strpath,
-        pip_requirements=[f"-c {req_file.strpath}", "b"],
+        tmpdir3,
+        pip_requirements=[f"-c {req_file}", "b"],
     )
     _assert_pip_requirements(
-        tmpdir3.strpath, [expected_mlflow_version, "b", "-c constraints.txt"], ["a"], strict=True
+        tmpdir3, [expected_mlflow_version, "b", "-c constraints.txt"], ["a"], strict=True
     )
 
 
-def test_save_model_with_extra_pip_requirements(spacy_model_with_data, tmpdir):
+def test_save_model_with_extra_pip_requirements(spacy_model_with_data, tmp_path):
     expected_mlflow_version = _mlflow_major_version_string()
     default_reqs = mlflow.spacy.get_default_pip_requirements()
 
     # Path to a requirements file
-    tmpdir1 = tmpdir.join("1")
-    req_file = tmpdir.join("requirements.txt")
-    req_file.write("a")
+    tmpdir1 = tmp_path.joinpath("1")
+    req_file = tmp_path.joinpath("requirements.txt")
+    req_file.write_text("a")
     mlflow.spacy.save_model(
-        spacy_model_with_data.model, tmpdir1.strpath, extra_pip_requirements=req_file.strpath
+        spacy_model_with_data.model, tmpdir1, extra_pip_requirements=str(req_file)
     )
-    _assert_pip_requirements(tmpdir1.strpath, [expected_mlflow_version, *default_reqs, "a"])
+    _assert_pip_requirements(tmpdir1, [expected_mlflow_version, *default_reqs, "a"])
 
     # List of requirements
-    tmpdir2 = tmpdir.join("2")
+    tmpdir2 = tmp_path.joinpath("2")
     mlflow.spacy.save_model(
         spacy_model_with_data.model,
-        tmpdir2.strpath,
-        extra_pip_requirements=[f"-r {req_file.strpath}", "b"],
+        tmpdir2,
+        extra_pip_requirements=[f"-r {req_file}", "b"],
     )
-    _assert_pip_requirements(tmpdir2.strpath, [expected_mlflow_version, *default_reqs, "a", "b"])
+    _assert_pip_requirements(tmpdir2, [expected_mlflow_version, *default_reqs, "a", "b"])
 
     # Constraints file
-    tmpdir3 = tmpdir.join("3")
+    tmpdir3 = tmp_path.joinpath("3")
     mlflow.spacy.save_model(
         spacy_model_with_data.model,
-        tmpdir3.strpath,
-        extra_pip_requirements=[f"-c {req_file.strpath}", "b"],
+        tmpdir3,
+        extra_pip_requirements=[f"-c {req_file}", "b"],
     )
     _assert_pip_requirements(
-        tmpdir3.strpath, [expected_mlflow_version, *default_reqs, "b", "-c constraints.txt"], ["a"]
+        tmpdir3, [expected_mlflow_version, *default_reqs, "b", "-c constraints.txt"], ["a"]
     )
 
 

--- a/tests/spark/autologging/datasource/test_spark_datasource_autologging.py
+++ b/tests/spark/autologging/datasource/test_spark_datasource_autologging.py
@@ -220,7 +220,7 @@ def test_autologging_slow_api_requests(spark_session, format_to_file_path):
     )
 
 
-def test_autologging_truncates_datasource_tag_to_maximum_supported_value(tmpdir, spark_session):
+def test_autologging_truncates_datasource_tag_to_maximum_supported_value(tmp_path, spark_session):
     rows = [Row(100)]
     schema = StructType([StructField("number2", IntegerType())])
     rdd = spark_session.sparkContext.parallelize(rows)
@@ -228,7 +228,7 @@ def test_autologging_truncates_datasource_tag_to_maximum_supported_value(tmpdir,
 
     # Save a Spark Dataframe to multiple paths with an aggregate path length
     # exceeding the maximum length of an MLflow tag (`MAX_TAG_VAL_LENGTH`)
-    long_path_base = str(tmpdir.join("a" * 150))
+    long_path_base = str(tmp_path.joinpath("a" * 150))
     saved_df_paths = []
     for path_suffix in range(int(MAX_TAG_VAL_LENGTH / len(long_path_base)) + 5):
         long_path = long_path_base + str(path_suffix)

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -342,10 +342,10 @@ def test_sparkml_model_log(tmp_path, spark_model_iris, should_start_run, use_dfs
     if use_dfs_tmpdir:
         dfs_tmpdir = None
     else:
-        dfs_tmpdir = str(tmp_path.join("test"))
+        dfs_tmpdir = tmp_path.joinpath("test")
 
     try:
-        tracking_dir = os.path.abspath(str(tmp_path.joinpath("mlruns")))
+        tracking_dir = tmp_path.joinpath("mlruns")
         mlflow.set_tracking_uri("file://%s" % tracking_dir)
         if should_start_run:
             mlflow.start_run()
@@ -377,10 +377,10 @@ def test_sparkml_estimator_model_log(
     if use_dfs_tmpdir:
         dfs_tmpdir = None
     else:
-        dfs_tmpdir = str(tmp_path.joinpath("test"))
+        dfs_tmpdir = tmp_path.joinpath("test")
 
     try:
-        tracking_dir = os.path.abspath(str(tmp_path.joinpath("mlruns")))
+        tracking_dir = tmp_path.joinpath("mlruns")
         mlflow.set_tracking_uri("file://%s" % tracking_dir)
         if should_start_run:
             mlflow.start_run()
@@ -405,7 +405,7 @@ def test_sparkml_estimator_model_log(
 
 def test_log_model_calls_register_model(tmp_path, spark_model_iris):
     artifact_path = "model"
-    dfs_tmp_dir = os.path.join(tmp_path, "test")
+    dfs_tmp_dir = tmp_path.joinpath("test")
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch:
         sparkm.log_model(

--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -142,12 +142,12 @@ def _test_model_log(statsmodels_model, model_path, *predict_args):
             mlflow.end_run()
 
 
-def test_models_save_load(tmpdir):
-    _test_models_list(tmpdir, _test_model_save_load)
+def test_models_save_load(tmp_path):
+    _test_models_list(tmp_path, _test_model_save_load)
 
 
-def test_models_log(tmpdir):
-    _test_models_list(tmpdir, _test_model_log)
+def test_models_log(tmp_path):
+    _test_models_list(tmp_path, _test_model_log)
 
 
 def test_signature_and_examples_are_saved_correctly():
@@ -255,32 +255,28 @@ def test_model_save_persists_requirements_in_mlflow_model_directory(
     _compare_conda_env_requirements(statsmodels_custom_env, saved_pip_req_path)
 
 
-def test_log_model_with_pip_requirements(tmpdir):
+def test_log_model_with_pip_requirements(tmp_path):
     expected_mlflow_version = _mlflow_major_version_string()
     ols = ols_model()
     # Path to a requirements file
-    req_file = tmpdir.join("requirements.txt")
-    req_file.write("a")
+    req_file = tmp_path.joinpath("requirements.txt")
+    req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(ols.model, "model", pip_requirements=req_file.strpath)
+        mlflow.statsmodels.log_model(ols.model, "model", pip_requirements=str(req_file))
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a"], strict=True
         )
 
     # List of requirements
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(
-            ols.model, "model", pip_requirements=[f"-r {req_file.strpath}", "b"]
-        )
+        mlflow.statsmodels.log_model(ols.model, "model", pip_requirements=[f"-r {req_file}", "b"])
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a", "b"], strict=True
         )
 
     # Constraints file
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(
-            ols.model, "model", pip_requirements=[f"-c {req_file.strpath}", "b"]
-        )
+        mlflow.statsmodels.log_model(ols.model, "model", pip_requirements=[f"-c {req_file}", "b"])
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"),
             [expected_mlflow_version, "b", "-c constraints.txt"],
@@ -289,16 +285,16 @@ def test_log_model_with_pip_requirements(tmpdir):
         )
 
 
-def test_log_model_with_extra_pip_requirements(tmpdir):
+def test_log_model_with_extra_pip_requirements(tmp_path):
     expected_mlflow_version = _mlflow_major_version_string()
     ols = ols_model()
     default_reqs = mlflow.statsmodels.get_default_pip_requirements()
 
     # Path to a requirements file
-    req_file = tmpdir.join("requirements.txt")
-    req_file.write("a")
+    req_file = tmp_path.joinpath("requirements.txt")
+    req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.statsmodels.log_model(ols.model, "model", extra_pip_requirements=req_file.strpath)
+        mlflow.statsmodels.log_model(ols.model, "model", extra_pip_requirements=str(req_file))
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a"]
         )
@@ -306,7 +302,7 @@ def test_log_model_with_extra_pip_requirements(tmpdir):
     # List of requirements
     with mlflow.start_run():
         mlflow.statsmodels.log_model(
-            ols.model, "model", extra_pip_requirements=[f"-r {req_file.strpath}", "b"]
+            ols.model, "model", extra_pip_requirements=[f"-r {req_file}", "b"]
         )
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a", "b"]
@@ -315,7 +311,7 @@ def test_log_model_with_extra_pip_requirements(tmpdir):
     # Constraints file
     with mlflow.start_run():
         mlflow.statsmodels.log_model(
-            ols.model, "model", extra_pip_requirements=[f"-c {req_file.strpath}", "b"]
+            ols.model, "model", extra_pip_requirements=[f"-c {req_file}", "b"]
         )
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"),

--- a/tests/tensorflow/test_keras_model_export.py
+++ b/tests/tensorflow/test_keras_model_export.py
@@ -411,13 +411,13 @@ def test_model_save_persists_requirements_in_mlflow_model_directory(
     _compare_conda_env_requirements(keras_custom_env, saved_pip_req_path)
 
 
-def test_log_model_with_pip_requirements(model, tmpdir):
+def test_log_model_with_pip_requirements(model, tmp_path):
     expected_mlflow_version = _mlflow_major_version_string()
     # Path to a requirements file
-    req_file = tmpdir.join("requirements.txt")
-    req_file.write("a")
+    req_file = tmp_path.joinpath("requirements.txt")
+    req_file.write_text("a")
     with mlflow.start_run():
-        mlflow.tensorflow.log_model(model, artifact_path="model", pip_requirements=req_file.strpath)
+        mlflow.tensorflow.log_model(model, artifact_path="model", pip_requirements=str(req_file))
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a"], strict=True
         )
@@ -427,7 +427,7 @@ def test_log_model_with_pip_requirements(model, tmpdir):
         mlflow.tensorflow.log_model(
             model,
             artifact_path="model",
-            pip_requirements=[f"-r {req_file.strpath}", "b"],
+            pip_requirements=[f"-r {req_file}", "b"],
         )
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"), [expected_mlflow_version, "a", "b"], strict=True
@@ -438,7 +438,7 @@ def test_log_model_with_pip_requirements(model, tmpdir):
         mlflow.tensorflow.log_model(
             model,
             artifact_path="model",
-            pip_requirements=[f"-c {req_file.strpath}", "b"],
+            pip_requirements=[f"-c {req_file}", "b"],
         )
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"),
@@ -448,15 +448,15 @@ def test_log_model_with_pip_requirements(model, tmpdir):
         )
 
 
-def test_log_model_with_extra_pip_requirements(model, tmpdir):
+def test_log_model_with_extra_pip_requirements(model, tmp_path):
     expected_mlflow_version = _mlflow_major_version_string()
     default_reqs = mlflow.tensorflow.get_default_pip_requirements()
     # Path to a requirements file
-    req_file = tmpdir.join("requirements.txt")
-    req_file.write("a")
+    req_file = tmp_path.joinpath("requirements.txt")
+    req_file.write_text("a")
     with mlflow.start_run():
         mlflow.tensorflow.log_model(
-            model, artifact_path="model", extra_pip_requirements=req_file.strpath
+            model, artifact_path="model", extra_pip_requirements=str(req_file)
         )
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a"]
@@ -467,7 +467,7 @@ def test_log_model_with_extra_pip_requirements(model, tmpdir):
         mlflow.tensorflow.log_model(
             model,
             artifact_path="model",
-            extra_pip_requirements=[f"-r {req_file.strpath}", "b"],
+            extra_pip_requirements=[f"-r {req_file}", "b"],
         )
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"), [expected_mlflow_version, *default_reqs, "a", "b"]
@@ -478,7 +478,7 @@ def test_log_model_with_extra_pip_requirements(model, tmpdir):
         mlflow.tensorflow.log_model(
             model,
             artifact_path="model",
-            extra_pip_requirements=[f"-c {req_file.strpath}", "b"],
+            extra_pip_requirements=[f"-c {req_file}", "b"],
         )
         _assert_pip_requirements(
             mlflow.get_artifact_uri("model"),

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -919,7 +919,7 @@ def test_tf_keras_autolog_non_early_stop_callback_no_log(tf_keras_random_data_ru
 
 @pytest.mark.parametrize("positional", [True, False])
 def test_tf_keras_autolog_does_not_mutate_original_callbacks_list(
-    tmpdir, random_train_data, random_one_hot_labels, positional
+    tmp_path, random_train_data, random_one_hot_labels, positional
 ):
     """
     TensorFlow autologging passes new callbacks to the `fit()` / `fit_generator()` function. If
@@ -929,7 +929,7 @@ def test_tf_keras_autolog_does_not_mutate_original_callbacks_list(
     """
     mlflow.tensorflow.autolog()
 
-    tensorboard_callback = tf.keras.callbacks.TensorBoard(log_dir=tmpdir)
+    tensorboard_callback = tf.keras.callbacks.TensorBoard(log_dir=tmp_path)
     callbacks = [tensorboard_callback]
 
     model = create_tf_keras_model()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Replace `tmpdir` with `tmp_path` (again).

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
