### PR TITLE
Replace `tmpdir` with `tmp_path` (part 4)

### DIFF
--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -38,8 +38,8 @@ def spark_session():
         yield session
 
 
-def test_yaml_read_and_write(tmpdir):
-    temp_dir = str(tmpdir)
+def test_yaml_read_and_write(tmp_path):
+    temp_dir = str(tmp_path)
     yaml_file = random_file("yaml")
     long_value = 1  # pylint: disable=undefined-variable
     data = {
@@ -73,14 +73,14 @@ def test_yaml_read_and_write(tmpdir):
     assert "more_text" not in file_utils.read_yaml(temp_dir, yaml_file)
 
 
-def test_render_and_merge_yaml(tmpdir):
+def test_render_and_merge_yaml(tmp_path, monkeypatch):
     json_file = random_file("json")
     extra_config = {"key": 123}
-    with open(tmpdir / json_file, "w") as f:
+    with open(tmp_path / json_file, "w") as f:
         json.dump(extra_config, f)
 
     template_yaml_file = random_file("yaml")
-    with open(tmpdir / template_yaml_file, "w") as f:
+    with open(tmp_path / template_yaml_file, "w") as f:
         f.write(
             """
             steps:
@@ -96,7 +96,7 @@ def test_render_and_merge_yaml(tmpdir):
             + rf"test_5: {{{{ ('{json_file}' | from_json)['key'] }}}}"
         )
     context_yaml_file = random_file("yaml")
-    with open(tmpdir / context_yaml_file, "w") as f:
+    with open(tmp_path / context_yaml_file, "w") as f:
         f.write(
             """
             MY_MLFLOW_SERVER: "./mlruns"
@@ -106,8 +106,8 @@ def test_render_and_merge_yaml(tmpdir):
             + rf"TEST_VAR_4: {{{{ ('{json_file}' | from_json)['key'] }}}}"
         )
 
-    with tmpdir.as_cwd():
-        result = file_utils.render_and_merge_yaml(tmpdir, template_yaml_file, context_yaml_file)
+    monkeypatch.chdir(tmp_path)
+    result = file_utils.render_and_merge_yaml(tmp_path, template_yaml_file, context_yaml_file)
     expected = {
         "MY_MLFLOW_SERVER": "./mlruns",
         "TEST_VAR_1": ["a", 1.2],
@@ -123,9 +123,9 @@ def test_render_and_merge_yaml(tmpdir):
     assert result == expected
 
 
-def test_render_and_merge_yaml_raise_on_duplicate_keys(tmpdir):
+def test_render_and_merge_yaml_raise_on_duplicate_keys(tmp_path):
     template_yaml_file = random_file("yaml")
-    with open(tmpdir / template_yaml_file, "w") as f:
+    with open(tmp_path / template_yaml_file, "w") as f:
         f.write(
             """
             steps: 1
@@ -135,42 +135,42 @@ def test_render_and_merge_yaml_raise_on_duplicate_keys(tmpdir):
         )
 
     context_yaml_file = random_file("yaml")
-    file_utils.write_yaml(str(tmpdir), context_yaml_file, {"TEST_VAR_1": 3})
+    file_utils.write_yaml(str(tmp_path), context_yaml_file, {"TEST_VAR_1": 3})
 
     with pytest.raises(ValueError, match="Duplicate 'steps' key found"):
-        file_utils.render_and_merge_yaml(tmpdir, template_yaml_file, context_yaml_file)
+        file_utils.render_and_merge_yaml(tmp_path, template_yaml_file, context_yaml_file)
 
 
-def test_render_and_merge_yaml_raise_on_non_existent_yamls(tmpdir):
+def test_render_and_merge_yaml_raise_on_non_existent_yamls(tmp_path):
     template_yaml_file = random_file("yaml")
-    with open(tmpdir / template_yaml_file, "w") as f:
+    with open(tmp_path / template_yaml_file, "w") as f:
         f.write("""test_1: {{ TEST_VAR_1 }}""")
 
     context_yaml_file = random_file("yaml")
-    file_utils.write_yaml(str(tmpdir), context_yaml_file, {"TEST_VAR_1": 3})
+    file_utils.write_yaml(str(tmp_path), context_yaml_file, {"TEST_VAR_1": 3})
 
     with pytest.raises(MissingConfigException, match="does not exist"):
-        file_utils.render_and_merge_yaml(tmpdir, "invalid_name", context_yaml_file)
+        file_utils.render_and_merge_yaml(tmp_path, "invalid_name", context_yaml_file)
     with pytest.raises(MissingConfigException, match="does not exist"):
         file_utils.render_and_merge_yaml("invalid_path", template_yaml_file, context_yaml_file)
     with pytest.raises(MissingConfigException, match="does not exist"):
-        file_utils.render_and_merge_yaml(tmpdir, template_yaml_file, "invalid_name")
+        file_utils.render_and_merge_yaml(tmp_path, template_yaml_file, "invalid_name")
 
 
-def test_render_and_merge_yaml_raise_on_not_found_key(tmpdir):
+def test_render_and_merge_yaml_raise_on_not_found_key(tmp_path):
     template_yaml_file = random_file("yaml")
-    with open(tmpdir / template_yaml_file, "w") as f:
+    with open(tmp_path / template_yaml_file, "w") as f:
         f.write("""test_1: {{ TEST_VAR_1 }}""")
 
     context_yaml_file = random_file("yaml")
-    file_utils.write_yaml(str(tmpdir), context_yaml_file, {})
+    file_utils.write_yaml(str(tmp_path), context_yaml_file, {})
 
     with pytest.raises(jinja2.exceptions.UndefinedError, match="'TEST_VAR_1' is undefined"):
-        file_utils.render_and_merge_yaml(tmpdir, template_yaml_file, context_yaml_file)
+        file_utils.render_and_merge_yaml(tmp_path, template_yaml_file, context_yaml_file)
 
 
-def test_yaml_write_sorting(tmpdir):
-    temp_dir = str(tmpdir)
+def test_yaml_write_sorting(tmp_path):
+    temp_dir = str(tmp_path)
     data = {
         "a": 1,
         "c": 2,
@@ -200,8 +200,8 @@ b: 3
     assert actual_unsorted == expected_unsorted
 
 
-def test_mkdir(tmpdir):
-    temp_dir = str(tmpdir)
+def test_mkdir(tmp_path):
+    temp_dir = str(tmp_path)
     new_dir_name = "mkdir_test_%d" % random_int()
     file_utils.mkdir(temp_dir, new_dir_name)
     assert os.listdir(temp_dir) == [new_dir_name]
@@ -213,23 +213,23 @@ def test_mkdir(tmpdir):
     file_utils.mkdir(temp_dir, new_dir_name)
 
     # raises if it exists already but is a file
-    dummy_file_path = str(tmpdir.join("dummy_file"))
+    dummy_file_path = str(tmp_path.joinpath("dummy_file"))
     open(dummy_file_path, "a").close()
     with pytest.raises(OSError, match="exists"):
         file_utils.mkdir(dummy_file_path)
 
 
-def test_make_tarfile(tmpdir):
+def test_make_tarfile(tmp_path):
     # Tar a local project
-    tarfile0 = str(tmpdir.join("first-tarfile"))
+    tarfile0 = str(tmp_path.joinpath("first-tarfile"))
     file_utils.make_tarfile(
         output_filename=tarfile0, source_dir=TEST_PROJECT_DIR, archive_name="some-archive"
     )
     # Copy local project into a temp dir
-    dst_dir = str(tmpdir.join("project-directory"))
+    dst_dir = str(tmp_path.joinpath("project-directory"))
     shutil.copytree(TEST_PROJECT_DIR, dst_dir)
     # Tar the copied project
-    tarfile1 = str(tmpdir.join("second-tarfile"))
+    tarfile1 = str(tmp_path.joinpath("second-tarfile"))
     file_utils.make_tarfile(
         output_filename=tarfile1, source_dir=dst_dir, archive_name="some-archive"
     )
@@ -242,7 +242,7 @@ def test_make_tarfile(tmpdir):
             == hashlib.sha256(second_tar.read()).hexdigest()
         )
     # Extract the TAR and check that its contents match the original directory
-    extract_dir = str(tmpdir.join("extracted-tar"))
+    extract_dir = str(tmp_path.joinpath("extracted-tar"))
     os.makedirs(extract_dir)
     with tarfile.open(tarfile0, "r:gz") as handle:
         handle.extractall(path=extract_dir)
@@ -253,9 +253,10 @@ def test_make_tarfile(tmpdir):
     assert len(dir_comparison.funny_files) == 0
 
 
-def test_get_parent_dir(tmpdir):
-    child_dir = tmpdir.join("dir").mkdir()
-    assert str(tmpdir) == get_parent_dir(str(child_dir))
+def test_get_parent_dir(tmp_path):
+    child_dir = tmp_path.joinpath("dir")
+    child_dir.mkdir()
+    assert str(tmp_path) == get_parent_dir(str(child_dir))
 
 
 def test_file_copy():
@@ -314,8 +315,8 @@ def test_write_spark_df_to_parquet(spark_session, tmp_path):
 
 
 @pytest.mark.skipif(not is_windows(), reason="requires Windows")
-def test_handle_readonly_on_windows(tmpdir):
-    tmp_path = tmpdir.join("file").strpath
+def test_handle_readonly_on_windows(tmp_path):
+    tmp_path = tmp_path.joinpath("file")
     with open(tmp_path, "w"):
         pass
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Replace `tmpdir` with `tmp_path`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
