### PR TITLE
Remove modifications to sys.modules

### DIFF
--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from pathlib import Path
 
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
@@ -113,15 +112,6 @@ def _validate_and_copy_code_paths(code_paths, path, default_subpath="code"):
 
 def _add_code_to_system_path(code_path):
     sys.path = [code_path] + sys.path
-    # Delete cached modules so they will get reloaded anew from the correct code path
-    # Otherwise python will use the cached modules
-    modules = [
-        p.stem
-        for p in Path(code_path).rglob("*.py")
-        if p.is_file() and p.name != "__init__.py" and p.name != "__main__.py"
-    ]
-    for module in modules:
-        sys.modules.pop(module, None)
 
 
 def _validate_and_prepare_target_save_path(path):

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1060,56 +1060,6 @@ def test_save_and_load_model_with_special_chars(
     )
 
 
-class CustomModel(mlflow.pyfunc.PythonModel):
-    def __init__(self):
-        pass
-
-    def predict(self, context, model_input):
-        import custom_module
-
-        return custom_module.predict()
-
-
-def test_model_with_code_path_does_not_use_cached_module(tmp_path):
-    dir1 = tmp_path.joinpath("1")
-    dir2 = tmp_path.joinpath("2")
-    dir1.mkdir()
-    dir2.mkdir()
-    mod1 = dir1.joinpath("custom_module.py")
-    mod2 = dir2.joinpath("custom_module.py")
-    mod1.write_text(
-        """
-def predict():
-    return 1
-"""
-    )
-    mod2.write_text(
-        """
-def predict():
-    return 2
-"""
-    )
-
-    custom_model = CustomModel()
-    with mlflow.start_run():
-        model_info1 = mlflow.pyfunc.log_model(
-            artifact_path="model1",
-            python_model=custom_model,
-            code_path=[str(mod1)],
-        )
-        model_info2 = mlflow.pyfunc.log_model(
-            artifact_path="model2",
-            python_model=custom_model,
-            code_path=[str(mod2)],
-        )
-
-    model_input = pd.DataFrame([[1, 2, 3]])
-    loaded_model1 = mlflow.pyfunc.load_model(model_info1.model_uri)
-    assert loaded_model1.predict(model_input) == 1
-    loaded_model2 = mlflow.pyfunc.load_model(model_info2.model_uri)
-    assert loaded_model2.predict(model_input) == 2
-
-
 def test_model_with_code_path_containing_main(tmp_path):
     """Test that the __main__ module is unaffected by model loading"""
     directory = tmp_path.joinpath("model_with_main")

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import pytest
 from sklearn import datasets
@@ -97,3 +98,9 @@ def test_add_code_to_system_path(sklearn_knn_model, model_path):
     # dummy_package.operator and not the built-in operator module. This only
     # happens if MLflow is misconfiguring the system path.
     from dummy_package import base  # pylint: disable=unused-import
+
+    # Ensure that the custom tests/utils/test_resources/dummy_package/pandas.py is not
+    # overwriting the 3rd party `pandas` package
+    assert "dummy_package" in sys.modules
+    assert "pandas" in sys.modules
+    assert "site-packages" in sys.modules["pandas"].__file__

--- a/tests/utils/test_resources/dummy_package/pandas.py
+++ b/tests/utils/test_resources/dummy_package/pandas.py
@@ -1,0 +1,5 @@
+# This module is meant to test shadowing of the 3rd party module
+raise Exception(
+    "This package should not have been imported! "
+    "This means that the sys.path was not configured correctly"
+)


### PR DESCRIPTION
## Related Issues/PRs



<!-- Resolve --> #8708 
## What changes are proposed in this pull request?

MLflow was removing any packages from sys.modules if there was any naming conflict in custom python modules found in `code_path`. This change was introduced in https://github.com/mlflow/mlflow/pull/5926. This PR seeks to remove that change as we should not modify that global variable due to unintended side effects.


## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Users of MLflow models may have had their custom python modules replacing common 3rd party and/or built-in python packages. This change removes the modification to `sys.modules`.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
