### PR TITLE
Replace `tmpdir` with `tmp_path` (part 6)

### DIFF
--- a/tests/deployments/test_cli.py
+++ b/tests/deployments/test_cli.py
@@ -86,13 +86,11 @@ def test_get():
     "MLFLOW_SKINNY" in os.environ,
     reason="Skinny Client does not support predict due to the pandas dependency",
 )
-def test_predict(tmpdir):
-    temp_input_file_path = tmpdir.join("input.json").strpath
-    with open(temp_input_file_path, "w") as temp_input_file:
-        temp_input_file.write('{"data": [5000]}')
+def test_predict(tmp_path):
+    temp_input_file_path = tmp_path.joinpath("input.json")
+    temp_input_file_path.write_text('{"data": [5000]}')
 
-    temp_output_file_path = tmpdir.join("output.json").strpath
-
+    temp_output_file_path = tmp_path.joinpath("output.json")
     res = runner.invoke(
         cli.predict, ["--target", f_target, "--name", f_name, "--input-path", temp_input_file_path]
     )
@@ -133,20 +131,18 @@ def test_run_local():
     "MLFLOW_SKINNY" in os.environ,
     reason="Skinny Client does not support explain due to the pandas dependency",
 )
-def test_explain(tmpdir):
-    temp_input_file_path = tmpdir.join("input.json").strpath
-    with open(temp_input_file_path, "w") as temp_input_file:
-        temp_input_file.write('{"data": [5000]}')
+def test_explain(tmp_path):
+    temp_input_file_path = tmp_path.joinpath("input.json")
+    temp_input_file_path.write_text('{"data": [5000]}')
     res = runner.invoke(
         cli.explain, ["--target", f_target, "--name", f_name, "--input-path", temp_input_file_path]
     )
     assert "1" in res.stdout
 
 
-def test_explain_with_no_target_implementation(tmpdir):
-    file_path = tmpdir.join("input.json").strpath
-    with open(file_path, "w") as temp_input_file:
-        temp_input_file.write('{"data": [5000]}')
+def test_explain_with_no_target_implementation(tmp_path):
+    file_path = tmp_path.joinpath("input.json")
+    file_path.write_text('{"data": [5000]}')
     mock_error = MlflowException("MOCK ERROR")
     with mock.patch.object(CliRunner, "invoke", return_value=mock_error) as mock_explain:
         res = runner.invoke(

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -71,15 +71,15 @@ def databricks_cluster_mlflow_run_cmd_mock():
 
 
 @pytest.fixture()
-def cluster_spec_mock(tmpdir):
-    cluster_spec_handle = tmpdir.join("cluster_spec.json")
-    cluster_spec_handle.write(json.dumps({}))
+def cluster_spec_mock(tmp_path):
+    cluster_spec_handle = tmp_path.joinpath("cluster_spec.json")
+    cluster_spec_handle.write_text("{}")
     yield str(cluster_spec_handle)
 
 
 @pytest.fixture()
-def dbfs_root_mock(tmpdir):
-    yield str(tmpdir.join("dbfs-root"))
+def dbfs_root_mock(tmp_path):
+    yield str(tmp_path.joinpath("dbfs-root"))
 
 
 @pytest.fixture()

--- a/tests/projects/test_project_spec.py
+++ b/tests/projects/test_project_spec.py
@@ -70,8 +70,8 @@ def test_load_project(tmpdir, mlproject, conda_env_path, conda_env_contents, mlp
         assert open(project.env_config_path).read() == conda_env_contents
 
 
-def test_load_docker_project(tmpdir):
-    tmpdir.join("MLproject").write(
+def test_load_docker_project(tmp_path):
+    tmp_path.joinpath("MLproject").write_text(
         textwrap.dedent(
             """
     docker_env:
@@ -79,7 +79,7 @@ def test_load_docker_project(tmpdir):
     """
         )
     )
-    project = _project_spec.load_project(tmpdir.strpath)
+    project = _project_spec.load_project(str(tmp_path))
     assert project._entry_points == {}
     assert project.env_config_path is None
     assert project.docker_env.get("image") == "some-image"

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -235,9 +235,9 @@ def test_run_with_parent():
     assert run.data.tags[MLFLOW_PARENT_RUN_ID] == parent_run_id
 
 
-def test_run_with_artifact_path(tmpdir):
-    artifact_file = tmpdir.join("model.pkl")
-    artifact_file.write("Hello world")
+def test_run_with_artifact_path(tmp_path):
+    artifact_file = tmp_path.joinpath("model.pkl")
+    artifact_file.write_text("Hello world")
     with mlflow.start_run() as run:
         mlflow.log_artifact(artifact_file)
         submitted_run = mlflow.projects.run(

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -142,13 +142,13 @@ def test_run_git_ssh_from_release_version():
 
 
 @pytest.mark.notrackingurimock
-def test_run_databricks_cluster_spec(tmpdir):
+def test_run_databricks_cluster_spec(tmp_path):
     cluster_spec = {
         "spark_version": "5.0.x-scala2.11",
         "num_workers": 2,
         "node_type_id": "i3.xlarge",
     }
-    cluster_spec_path = str(tmpdir.join("cluster-spec.json"))
+    cluster_spec_path = tmp_path.joinpath("cluster-spec.json")
     with open(cluster_spec_path, "w") as handle:
         json.dump(cluster_spec, handle)
 

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -44,7 +44,7 @@ def zipped_repo(tmp_path):
             for file_name in files:
                 file_path = os.path.join(root, file_name)
                 zip_file.write(file_path, file_path[len(TEST_PROJECT_DIR) + len(os.sep) :])
-    return zip_name
+    return str(zip_name)
 
 
 def test_is_zip_uri():
@@ -134,7 +134,9 @@ def test_dont_remove_mlruns(tmp_path):
     # Fetching a directory containing an "mlruns" folder doesn't remove the "mlruns" folder
     src_dir = tmp_path.joinpath("mlruns-src-dir")
     src_dir.mkdir()
-    src_dir.joinpath("mlruns", "some-file.txt").write_text("hi")
+    mlruns = src_dir.joinpath("mlruns")
+    mlruns.mkdir()
+    mlruns.joinpath("some-file.txt").write_text("hi")
     src_dir.joinpath("MLproject").write_text("dummy MLproject contents")
     dst_dir = _fetch_project(uri=str(src_dir), version=None)
     assert_dirs_equal(expected=str(src_dir), actual=dst_dir)

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -37,8 +37,8 @@ def _build_uri(base_uri, subdirectory):
 
 
 @pytest.fixture
-def zipped_repo(tmpdir):
-    zip_name = tmpdir.join("%s.zip" % TEST_PROJECT_NAME).strpath
+def zipped_repo(tmp_path):
+    zip_name = tmp_path.joinpath("%s.zip" % TEST_PROJECT_NAME)
     with zipfile.ZipFile(zip_name, "w", zipfile.ZIP_DEFLATED) as zip_file:
         for root, _, files in os.walk(TEST_PROJECT_DIR):
             for file_name in files:
@@ -130,13 +130,14 @@ def test_fetch_project_validations(local_git_repo_uri):
         _fetch_project(uri=TEST_PROJECT_DIR, version="version")
 
 
-def test_dont_remove_mlruns(tmpdir):
+def test_dont_remove_mlruns(tmp_path):
     # Fetching a directory containing an "mlruns" folder doesn't remove the "mlruns" folder
-    src_dir = tmpdir.mkdir("mlruns-src-dir")
-    src_dir.mkdir("mlruns").join("some-file.txt").write("hi")
-    src_dir.join("MLproject").write("dummy MLproject contents")
-    dst_dir = _fetch_project(uri=src_dir.strpath, version=None)
-    assert_dirs_equal(expected=src_dir.strpath, actual=dst_dir)
+    src_dir = tmp_path.joinpath("mlruns-src-dir")
+    src_dir.mkdir()
+    src_dir.joinpath("mlruns", "some-file.txt").write_text("hi")
+    src_dir.joinpath("MLproject").write_text("dummy MLproject contents")
+    dst_dir = _fetch_project(uri=str(src_dir), version=None)
+    assert_dirs_equal(expected=str(src_dir), actual=dst_dir)
 
 
 def test_parse_subdirectory():
@@ -158,12 +159,12 @@ def test_parse_subdirectory():
         _parse_subdirectory(period_fail_uri)
 
 
-def test_storage_dir(tmpdir):
+def test_storage_dir(tmp_path):
     """
     Test that we correctly handle the `storage_dir` argument, which specifies where to download
     distributed artifacts passed to arguments of type `path`.
     """
-    assert os.path.dirname(_get_storage_dir(tmpdir.strpath)) == tmpdir.strpath
+    assert os.path.dirname(_get_storage_dir(tmp_path)) == str(tmp_path)
     assert os.path.dirname(_get_storage_dir(None)) == tempfile.gettempdir()
 
 
@@ -172,7 +173,7 @@ def test_is_valid_branch_name(local_git_repo):
     assert not _is_valid_branch_name(local_git_repo, "dev")
 
 
-def test_fetch_create_and_log(tmpdir):
+def test_fetch_create_and_log(tmp_path):
     entry_point_name = "entry_point"
     parameters = {
         "method_name": "string",
@@ -186,7 +187,7 @@ def test_fetch_create_and_log(tmpdir):
         name="my_project",
     )
     experiment_id = mlflow.create_experiment("test_fetch_project")
-    expected_dir = tmpdir
+    expected_dir = str(tmp_path)
     project_uri = "http://someuri/myproject.git"
     user_param = {"method_name": "newton"}
     with mock.patch("mlflow.projects.utils._fetch_project", return_value=expected_dir):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Replace `tmpdir` with `tmp_path` (part 6).

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
