### PR TITLE
[DO NOT MERGE] Adding the ability to log latency and token_count

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -39,6 +39,7 @@ from functools import partial
 import logging
 from packaging.version import Version
 import pathlib
+import time
 
 _logger = logging.getLogger(__name__)
 
@@ -1113,7 +1114,31 @@ class DefaultEvaluator(ModelEvaluator):
             else:
                 self.y_probs = None
         else:
-            self.y_pred = self.model.predict(self.X.copy_to_avoid_mutation())
+            y_pred = []
+            token_count = []
+            latency = []
+            for _, input_x in self.X.copy_to_avoid_mutation().iterrows():
+                start = time.time()
+                intermediate_output = self.model.predict(
+                    pd.DataFrame(input_x).T.reset_index(drop=True)
+                )
+                output = None
+                if isinstance(intermediate_output, list):
+                    output = intermediate_output[0]
+                if isinstance(intermediate_output, str):
+                    output = intermediate_output
+                if isinstance(intermediate_output, dict):
+                    output = intermediate_output["answer"]
+                else:
+                    _logger.error(
+                        f"predict function should return either list or string. Given: {intermediate_output}"
+                    )
+                latency.append(round((time.time() - start) * 1000, 2))
+                token_count.append(math.ceil((len(input_x) + len(output)) * 1.2))
+                y_pred.append(output)
+            self.y_pred = y_pred
+            self.token_count = token_count
+            self.latency = latency
 
     def _compute_builtin_metrics(self):
         """
@@ -1163,12 +1188,24 @@ class DefaultEvaluator(ModelEvaluator):
 
     def _log_eval_table(self):
         metric_prefix = self.evaluator_config.get("metric_prefix", "")
+        extra_columns = {}
+        if self.token_count is not None:
+            extra_columns = {
+                **extra_columns,
+                "MLFLOW_INTERNAL_token_count_column": self.token_count,
+            }
+        if self.latency is not None:
+            extra_columns = {**extra_columns, "MLFLOW_INTERNAL_latency_column": self.latency}
         if self.dataset.has_targets:
             data = self.dataset.features_data.assign(
-                **{self.dataset.targets_name or "target": self.y, "outputs": self.y_pred}
+                **{
+                    self.dataset.targets_name or "target": self.y,
+                    "outputs": self.y_pred,
+                    **extra_columns,
+                }
             )
         else:
-            data = self.dataset.features_data.assign(outputs=self.y_pred)
+            data = self.dataset.features_data.assign(outputs=self.y_pred, **extra_columns)
         mlflow.log_table(data, artifact_file=f"{metric_prefix}{_EVAL_TABLE_FILE_NAME}")
 
     def _evaluate_question_answering(self):


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adding the ability to log latency and token_count

## How is this patch tested?
<img width="2355" alt="image" src="https://github.com/mlflow/mlflow/assets/5621432/f4ae8c1a-9aa7-4ccf-b399-eefdc20ec5c4">


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
