### PR TITLE
Add query to client and fluent apis

### DIFF
--- a/mlflow/gateway/__init__.py
+++ b/mlflow/gateway/__init__.py
@@ -1,4 +1,4 @@
-from mlflow.gateway.fluent import get_route, search_routes
+from mlflow.gateway.fluent import get_route, search_routes, query
 from mlflow.gateway.utils import set_gateway_uri, get_gateway_uri
 from mlflow.gateway.client import MlflowGatewayClient
 
@@ -6,6 +6,7 @@ __all__ = [
     "get_route",
     "get_gateway_uri",
     "MlflowGatewayClient",
+    "query",
     "search_routes",
     "set_gateway_uri",
 ]

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -128,6 +128,7 @@ class MlflowGatewayClient:
         For chat, the structure should be:
 
         .. code-block:: python
+
           from mlflow.gateway import MlflowGatewayClient
 
           gateway_client = MlflowGatewayClient("http://my.gateway:8888")
@@ -140,11 +141,14 @@ class MlflowGatewayClient:
         For completions, the structure should be:
 
         .. code-block:: python
+
           from mlflow.gateway import MlflowGatewayClient
 
           gateway_client = MlflowGatewayClient("http://my.gateway:8888")
 
-          response = gateway_client.query("my-chat-route", {"prompt": "It's one small step for"})
+          response = gateway_client.query(
+              "my-completions-route", {"prompt": "It's one small step for"}
+          )
 
         For embeddings, the structure should be:
 
@@ -154,7 +158,8 @@ class MlflowGatewayClient:
           gateway_client = MlflowGatewayClient("http://my.gateway:8888")
 
           response = gateway_client.query(
-              "my-chat-route", {"text": ["It was the best of times", "It was the worst of times"]}
+              "my-embeddings-route",
+              {"text": ["It was the best of times", "It was the worst of times"]},
           )
 
         :return: The route's response as a dictionary, standardized to the route type.

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -116,3 +116,18 @@ class MlflowGatewayClient:
             )
         response = self._call_endpoint("GET", self._route_base).json()["routes"]
         return [Route(**resp) for resp in response]
+
+    def query(self, route: str, data):
+        """
+        Submit a query to a configured provider route.
+
+        :param route: The name of the route to submit the query to.
+        :param data: The data to send in the query. The format of the input data is route specific.
+        :return: The route's response as a dictionary
+        """
+
+        data = json.dumps(data)
+
+        route = urljoin(self._route_base, route)
+
+        return self._call_endpoint("POST", route, data).json()

--- a/mlflow/gateway/fluent.py
+++ b/mlflow/gateway/fluent.py
@@ -16,11 +16,8 @@ def get_route(name: str) -> Route:
     This function creates an instance of MlflowGatewayClient and uses it to fetch a route by its
     name from the Gateway service.
 
-    Args:
-        name (str): The name of the route to fetch.
-
-    Returns:
-        Route: An instance of the Route class representing the fetched route.
+    :param name: The name of the route to fetch.
+    :return: An instance of the Route class representing the fetched route.
     """
     return MlflowGatewayClient().get_route(name)
 
@@ -37,12 +34,9 @@ def search_routes(search_filter: Optional[str] = None) -> List[Route]:
         Search is currently not implemented. Providing a `search_filter` term will raise an
         exception. Leave the arguments empty to get a listing of all configured routes.
 
-    Args:
-        search_filter (str, optional): A string to filter the results of the search. If None, all
-                                       routes are returned. Defaults to None.
-
-    Returns:
-        List[Route]: A list of Route instances representing the found routes.
+    :param search_filter: A string to filter the results of the search. If None, all
+                          routes are returned. Defaults to None.
+    :return: A list of Route instances representing the found routes.
     """
     return MlflowGatewayClient().search_routes(search_filter)
 
@@ -52,14 +46,42 @@ def query(route: str, data):
     """
     Issues a query request to a configured service through a named route on the Gateway Server.
 
-    This function creates an instance of MlflowGatewayClient and uses it to issue the query to the
-    provided route with the provided data.
+    This function will interface with a configured route name (examples below) and return the
+    response from the provider in a standardized format.
 
-    Args:
-        route (str): The name of the configured route. Route names can be obtained by running
-        `mlflow.gateway.search_routes()`
-        data: The request payload to be submitted to the route. The exact configuration of
-        the expected structure varies based on the route configuration.
+    Chat example:
 
+    .. code-block:: python
+      from mlflow.gateway import query, set_gateway_uri
+
+      set_gateway_uri(gateway_uri="http://my.gateway:9000")
+      response = query(
+          "my_chat_route",
+          {"messages": [{"role": "user", "content": "What is the best day of the week?"}]},
+      )
+
+    Completions example:
+
+    .. code-block:: python
+      from mlflow.gateway import query, set_gateway_uri
+
+      set_gateway_uri(gateway_uri="http://my.gateway:9000")
+      response = query("a_completions_route", {"prompt": "Where do we go from"})
+
+    Embeddings example:
+
+    .. code-block:: python
+      from mlflow.gateway import query, set_gateway_uri
+
+      set_gateway_uri(gateway_uri="http://my.gateway:9000")
+      response = query(
+          "embeddings_route", {"text": ["I like spaghetti", "and sushi", "but not together"]}
+      )
+
+    :param route: The name of the configured route. Route names can be obtained by running
+                  `mlflow.gateway.search_routes()`
+    :param data: The request payload to be submitted to the route. The exact configuration of
+                 the expected structure varies based on the route configuration.
+    :return: The response from the configured route endpoint provider in a standardized format.
     """
     return MlflowGatewayClient().query(route, data)

--- a/mlflow/gateway/fluent.py
+++ b/mlflow/gateway/fluent.py
@@ -52,6 +52,7 @@ def query(route: str, data):
     Chat example:
 
     .. code-block:: python
+
       from mlflow.gateway import query, set_gateway_uri
 
       set_gateway_uri(gateway_uri="http://my.gateway:9000")
@@ -63,6 +64,7 @@ def query(route: str, data):
     Completions example:
 
     .. code-block:: python
+
       from mlflow.gateway import query, set_gateway_uri
 
       set_gateway_uri(gateway_uri="http://my.gateway:9000")
@@ -71,6 +73,7 @@ def query(route: str, data):
     Embeddings example:
 
     .. code-block:: python
+
       from mlflow.gateway import query, set_gateway_uri
 
       set_gateway_uri(gateway_uri="http://my.gateway:9000")

--- a/mlflow/gateway/fluent.py
+++ b/mlflow/gateway/fluent.py
@@ -45,3 +45,21 @@ def search_routes(search_filter: Optional[str] = None) -> List[Route]:
         List[Route]: A list of Route instances representing the found routes.
     """
     return MlflowGatewayClient().search_routes(search_filter)
+
+
+@experimental
+def query(route: str, data):
+    """
+    Issues a query request to a configured service through a named route on the Gateway Server.
+
+    This function creates an instance of MlflowGatewayClient and uses it to issue the query to the
+    provided route with the provided data.
+
+    Args:
+        route (str): The name of the configured route. Route names can be obtained by running
+        `mlflow.gateway.search_routes()`
+        data: The request payload to be submitted to the route. The exact configuration of
+        the expected structure varies based on the route configuration.
+
+    """
+    return MlflowGatewayClient().query(route, data)

--- a/tests/gateway/test_client.py
+++ b/tests/gateway/test_client.py
@@ -276,29 +276,25 @@ def test_client_query_embeddings(gateway):
     routes = gateway_client.search_routes()
 
     expected_output = {
-        "object": "list",
-        "data": [
-            {
-                "object": "embedding",
-                "embedding": [
-                    0.8,
-                    0.6,
-                    0.7,
-                ],
-                "index": 0,
-            },
-            {
-                "object": "embedding",
-                "embedding": [
-                    0.5,
-                    0.3,
-                    0.0,
-                ],
-                "index": 0,
-            },
+        "embeddings": [
+            [
+                0.1,
+                0.2,
+                0.3,
+            ],
+            [
+                0.4,
+                0.5,
+                0.6,
+            ],
         ],
-        "model": "text-embedding-ada-002",
-        "usage": {"prompt_tokens": 8, "total_tokens": 8},
+        "metadata": {
+            "input_tokens": 8,
+            "output_tokens": 0,
+            "total_tokens": 8,
+            "model": "text-embedding-ada-002",
+            "route_type": "llm/v1/embeddings",
+        },
     }
     data = {"text": ["Jenny", "What's her number?"]}
 

--- a/tests/gateway/test_client.py
+++ b/tests/gateway/test_client.py
@@ -16,10 +16,10 @@ def basic_config_dict():
     return {
         "routes": [
             {
-                "name": "completions-gpt4",
+                "name": "completions",
                 "type": "llm/v1/completions",
                 "model": {
-                    "name": "gpt-4",
+                    "name": "text-davinci-003",
                     "provider": "openai",
                     "config": {
                         "openai_api_key": "mykey",
@@ -30,12 +30,24 @@ def basic_config_dict():
                 },
             },
             {
-                "name": "chat-gpt4",
+                "name": "chat",
                 "type": "llm/v1/chat",
                 "model": {
-                    "name": "gpt-4",
+                    "name": "gpt-3.5-turbo",
                     "provider": "openai",
-                    "config": {"openai_api_key": "MY_API_KEY"},
+                    "config": {"openai_api_key": "mykey"},
+                },
+            },
+            {
+                "name": "embeddings",
+                "type": "llm/v1/embeddings",
+                "model": {
+                    "provider": "openai",
+                    "name": "text-embedding-ada-002",
+                    "config": {
+                        "openai_api_base": "https://api.openai.com/v1",
+                        "openai_api_key": "mykey",
+                    },
                 },
             },
         ]
@@ -106,7 +118,7 @@ def test_non_running_server_raises_when_called():
 def test_create_gateway_client_with_declared_url(gateway):
     gateway_client = MlflowGatewayClient(gateway_uri=gateway.url)
     assert gateway_client.gateway_uri == gateway.url
-    assert isinstance(gateway_client.get_route("chat-gpt4"), Route)
+    assert isinstance(gateway_client.get_route("chat"), Route)
 
 
 def test_set_gateway_uri_from_utils(gateway):
@@ -114,7 +126,7 @@ def test_set_gateway_uri_from_utils(gateway):
 
     gateway_client = MlflowGatewayClient()
     assert gateway_client.gateway_uri == gateway.url
-    assert isinstance(gateway_client.get_route("completions-gpt4"), Route)
+    assert isinstance(gateway_client.get_route("completions"), Route)
 
 
 def test_create_gateway_client_with_environment_variable(gateway, monkeypatch):
@@ -122,7 +134,7 @@ def test_create_gateway_client_with_environment_variable(gateway, monkeypatch):
 
     gateway_client = MlflowGatewayClient()
     assert gateway_client.gateway_uri == gateway.url
-    assert isinstance(gateway_client.get_route("completions-gpt4"), Route)
+    assert isinstance(gateway_client.get_route("completions"), Route)
 
 
 def test_create_gateway_client_with_overriden_env_variable(gateway, monkeypatch):
@@ -139,7 +151,7 @@ def test_create_gateway_client_with_overriden_env_variable(gateway, monkeypatch)
     gateway_client = MlflowGatewayClient()
 
     assert gateway_client.gateway_uri == gateway.url
-    assert gateway_client.get_route("chat-gpt4").type == "llm/v1/chat"
+    assert gateway_client.get_route("chat").type == "llm/v1/chat"
 
 
 def test_query_individual_route(gateway, monkeypatch):
@@ -147,19 +159,19 @@ def test_query_individual_route(gateway, monkeypatch):
 
     gateway_client = MlflowGatewayClient()
 
-    route1 = gateway_client.get_route(name="completions-gpt4")
+    route1 = gateway_client.get_route(name="completions")
     assert isinstance(route1, Route)
     assert route1.dict() == {
-        "model": {"name": "gpt-4", "provider": "openai"},
-        "name": "completions-gpt4",
+        "model": {"name": "text-davinci-003", "provider": "openai"},
+        "name": "completions",
         "type": "llm/v1/completions",
     }
 
-    route2 = gateway_client.get_route(name="chat-gpt4")
+    route2 = gateway_client.get_route(name="chat")
     assert isinstance(route2, Route)
     assert route2.dict() == {
-        "model": {"name": "gpt-4", "provider": "openai"},
-        "name": "chat-gpt4",
+        "model": {"name": "gpt-3.5-turbo", "provider": "openai"},
+        "name": "chat",
         "type": "llm/v1/chat",
     }
 
@@ -181,12 +193,118 @@ def test_list_all_configured_routes(gateway):
     routes = gateway_client.search_routes()
     assert all(isinstance(x, Route) for x in routes)
     assert routes[0].dict() == {
-        "model": {"name": "gpt-4", "provider": "openai"},
-        "name": "completions-gpt4",
+        "model": {"name": "text-davinci-003", "provider": "openai"},
+        "name": "completions",
         "type": "llm/v1/completions",
     }
     assert routes[1].dict() == {
-        "model": {"name": "gpt-4", "provider": "openai"},
-        "name": "chat-gpt4",
+        "model": {"name": "gpt-3.5-turbo", "provider": "openai"},
+        "name": "chat",
         "type": "llm/v1/chat",
     }
+
+
+def test_client_query_chat(gateway):
+    gateway_client = MlflowGatewayClient(gateway_uri=gateway.url)
+
+    routes = gateway_client.search_routes()
+
+    data = {"messages": [{"role": "user", "content": "How hot is the core of the sun?"}]}
+
+    expected_output = {
+        "candidates": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "The core of the sun is estimated to have a temperature of about "
+                    "15 million degrees Celsius (27 million degrees Fahrenheit).",
+                },
+                "metadata": {"finish_reason": "stop"},
+            }
+        ],
+        "metadata": {
+            "input_tokens": 17,
+            "output_tokens": 24,
+            "total_tokens": 41,
+            "model": "gpt-3.5-turbo-0301",
+            "route_type": "llm/v1/chat",
+        },
+    }
+    mock_response = mock.Mock()
+    mock_response.json.return_value = expected_output
+
+    with mock.patch.object(gateway_client, "_call_endpoint", return_value=mock_response):
+        response = gateway_client.query(route=routes[1].name, data=data)
+
+        assert response == expected_output
+
+
+def test_client_query_completions(gateway):
+    gateway_client = MlflowGatewayClient(gateway_uri=gateway.url)
+
+    routes = gateway_client.search_routes()
+
+    expected_output = {
+        "candidates": [
+            {
+                "text": " car\n\nDriving fast can be dangerous and is not recommended. It is",
+                "metadata": {"finish_reason": "length"},
+            }
+        ],
+        "metadata": {
+            "input_tokens": 7,
+            "output_tokens": 16,
+            "total_tokens": 23,
+            "model": "text-davinci-003",
+            "route_type": "llm/v1/completions",
+        },
+    }
+
+    data = {"prompt": "I like to drive fast in my"}
+
+    mock_response = mock.Mock()
+    mock_response.json.return_value = expected_output
+
+    with mock.patch.object(gateway_client, "_call_endpoint", return_value=mock_response):
+        response = gateway_client.query(route=routes[0].name, data=data)
+        assert response == expected_output
+
+
+def test_client_query_embeddings(gateway):
+    gateway_client = MlflowGatewayClient(gateway_uri=gateway.url)
+
+    routes = gateway_client.search_routes()
+
+    expected_output = {
+        "object": "list",
+        "data": [
+            {
+                "object": "embedding",
+                "embedding": [
+                    0.8,
+                    0.6,
+                    0.7,
+                ],
+                "index": 0,
+            },
+            {
+                "object": "embedding",
+                "embedding": [
+                    0.5,
+                    0.3,
+                    0.0,
+                ],
+                "index": 0,
+            },
+        ],
+        "model": "text-embedding-ada-002",
+        "usage": {"prompt_tokens": 8, "total_tokens": 8},
+    }
+    data = {"text": ["Jenny", "What's her number?"]}
+
+    mock_response = mock.Mock()
+    mock_response.json.return_value = expected_output
+
+    with mock.patch.object(gateway_client, "_call_endpoint", return_value=mock_response):
+        response = gateway_client.query(route=routes[2].name, data=data)
+        assert response == expected_output

--- a/tests/gateway/test_fluent.py
+++ b/tests/gateway/test_fluent.py
@@ -158,16 +158,11 @@ def test_fluent_query_chat(gateway):
 
     data = {"messages": [{"role": "user", "content": "How hot is the core of the sun?"}]}
 
-    mock_query = mock.Mock(return_value=expected_output)
-
     with mock.patch(
-        "mlflow.gateway.fluent.MlflowGatewayClient", return_value=mock.Mock(query=mock_query)
-    ) as MockClient:
+        "mlflow.gateway.fluent.MlflowGatewayClient.query", return_value=expected_output
+    ):
         response = query(route=routes[1].name, data=data)
         assert response == expected_output
-
-        MockClient.assert_called_with()
-        mock_query.assert_called_with(routes[1].name, data)
 
 
 def test_fluent_query_completions(gateway):
@@ -191,13 +186,8 @@ def test_fluent_query_completions(gateway):
 
     data = {"prompt": "I like to drive fast in my"}
 
-    mock_query = mock.Mock(return_value=expected_output)
-
     with mock.patch(
-        "mlflow.gateway.fluent.MlflowGatewayClient", return_value=mock.Mock(query=mock_query)
-    ) as MockClient:
+        "mlflow.gateway.fluent.MlflowGatewayClient.query", return_value=expected_output
+    ):
         response = query(route=routes[0].name, data=data)
         assert response == expected_output
-
-        MockClient.assert_called_with()
-        mock_query.assert_called_with(routes[0].name, data)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Adds 'query' to fluent and MlflowGatewayClient APIs

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

Changed the route config so that it's easy enough to comment out the mocks and supply a local env var API key to validate. The responses being tested are the actual responses of using the client when querying openai endpoints (except for the encoding; that's a joke) :) 

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
