### PR TITLE
Improve error messages when using stage-based APIs with models in UC

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -272,11 +272,10 @@ class UcModelRegistryStore(BaseRestStore):
         _raise_unsupported_method(
             method="get_latest_versions",
             message="If seeing this error while attempting to "
-            "load a models:/ URI of the form models:/<name>/<stage>, note that "
-            "staged-based model URIs are unsupported for models in UC. Future "
-            "MLflow Python client versions will include support for model "
-            "aliases and alias-based 'models:/' URIs "
-            "of the form models:/<name>@<alias> as an alternative.",
+            "load a model version by alias, use the syntax 'models:/model_name@alias_name', where"
+            "model_name is the full name of your registered model and alias_name is the "
+            "name of your alias. To set aliases, you can use the "
+            "MlflowClient().set_registered_model_alias(name, alias, version) API",
         )
 
     def set_registered_model_tag(self, name, tag):
@@ -480,7 +479,15 @@ class UcModelRegistryStore(BaseRestStore):
             when ``stage`` is ``"staging"`` or ``"production"`` otherwise an error will be raised.
 
         """
-        _raise_unsupported_method(method="transition_model_version_stage")
+        _raise_unsupported_method(
+            method="transition_model_version_stage",
+            message="Setting model version stages is unsupported for ML models in the Unity Catalog. "
+            "We recommend using aliases instead for more flexible model deployment management. "
+            "You can set an alias on a registered model using "
+            "MlflowClient().set_registered_model_alias(name, alias, version). "
+            "See https://mlflow.org/docs/latest/model-registry.html#using-registered-model-aliases "
+            "for more info",
+        )
 
     def update_model_version(self, name, version, description):
         """

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -272,7 +272,10 @@ class UcModelRegistryStore(BaseRestStore):
         _raise_unsupported_method(
             method="get_latest_versions",
             message="If seeing this error while attempting to "
-            "load a model version by stage, use the syntax 'models:/your_model_name@your_alias_name'. "
+            "load a model version by stage, note that setting stages and loading model versions "
+            "by stage is unsupported in Unity Catalog. Instead, we recommend using aliases for "
+            "flexible model deployment. If trying to load a model version by alias, use the syntax "
+            "'models:/your_model_name@your_alias_name'. "
             "To set aliases, you can use the `MlflowClient().set_registered_model_alias(name, alias, version)` "
             "API.",
         )

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -272,10 +272,9 @@ class UcModelRegistryStore(BaseRestStore):
         _raise_unsupported_method(
             method="get_latest_versions",
             message="If seeing this error while attempting to "
-            "load a model version by alias, use the syntax 'models:/model_name@alias_name', where"
-            "model_name is the full name of your registered model and alias_name is the "
-            "name of your alias. To set aliases, you can use the "
-            "MlflowClient().set_registered_model_alias(name, alias, version) API",
+            "load a model version by alias, use the syntax 'models:/your_model_name@your_alias_name'. "
+            "To set aliases, you can use the `MlflowClient().set_registered_model_alias(name, alias, version)` "
+            "API.",
         )
 
     def set_registered_model_tag(self, name, tag):
@@ -481,12 +480,11 @@ class UcModelRegistryStore(BaseRestStore):
         """
         _raise_unsupported_method(
             method="transition_model_version_stage",
-            message="Setting model version stages is unsupported for ML models in the Unity Catalog. "
-            "We recommend using aliases instead for more flexible model deployment management. "
-            "You can set an alias on a registered model using "
-            "MlflowClient().set_registered_model_alias(name, alias, version). "
-            "See https://mlflow.org/docs/latest/model-registry.html#using-registered-model-aliases "
-            "for more info",
+            message="We recommend using aliases instead of stages for more flexible model deployment "
+            "management. You can set an alias on a registered model using "
+            "`MlflowClient().set_registered_model_alias(name, alias, version)` and load a model "
+            "version by alias using the URI 'models:/your_model_name@your_alias', e.g. "
+            "`mlflow.pyfunc.load_model('models:/your_model_name@your_alias')`.",
         )
 
     def update_model_version(self, name, version, description):

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -274,10 +274,10 @@ class UcModelRegistryStore(BaseRestStore):
             message="If seeing this error while attempting to "
             "load a model version by stage, note that setting stages and loading model versions "
             "by stage is unsupported in Unity Catalog. Instead, we recommend using aliases for "
-            "flexible model deployment. If trying to load a model version by alias, use the syntax "
-            "'models:/your_model_name@your_alias_name'. "
-            "To set aliases, you can use the `MlflowClient().set_registered_model_alias(name, alias, version)` "
-            "API.",
+            "flexible model deployment. If trying to load a model version by alias, use the "
+            "syntax 'models:/your_model_name@your_alias_name'. "
+            "To set aliases, you can use the "
+            "`MlflowClient().set_registered_model_alias(name, alias, version)` API.",
         )
 
     def set_registered_model_tag(self, name, tag):
@@ -483,8 +483,8 @@ class UcModelRegistryStore(BaseRestStore):
         """
         _raise_unsupported_method(
             method="transition_model_version_stage",
-            message="We recommend using aliases instead of stages for more flexible model deployment "
-            "management. You can set an alias on a registered model using "
+            message="We recommend using aliases instead of stages for more flexible model "
+            "deployment management. You can set an alias on a registered model using "
             "`MlflowClient().set_registered_model_alias(name, alias, version)` and load a model "
             "version by alias using the URI 'models:/your_model_name@your_alias', e.g. "
             "`mlflow.pyfunc.load_model('models:/your_model_name@your_alias')`.",

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -272,7 +272,7 @@ class UcModelRegistryStore(BaseRestStore):
         _raise_unsupported_method(
             method="get_latest_versions",
             message="If seeing this error while attempting to "
-            "load a model version by alias, use the syntax 'models:/your_model_name@your_alias_name'. "
+            "load a model version by stage, use the syntax 'models:/your_model_name@your_alias_name'. "
             "To set aliases, you can use the `MlflowClient().set_registered_model_alias(name, alias, version)` "
             "API.",
         )

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -339,9 +339,9 @@ def test_get_latest_versions_unsupported(store):
         f"load a model version by alias, use the syntax 'models:/model_name@alias_name'"
     )
     expected_err_msg = _expected_unsupported_method_error_message("get_latest_versions")
-    with pytest.raises(MlflowException, match=expected_err_msg):
+    with pytest.raises(MlflowException, match=expected_error):
         store.get_latest_versions(name=name)
-    with pytest.raises(MlflowException, match=expected_err_msg):
+    with pytest.raises(MlflowException, match=expected_error):
         store.get_latest_versions(name=name, stages=["Production"])
 
 

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -339,10 +339,9 @@ def test_get_latest_versions_unsupported(store):
         "note that setting stages and loading model versions by stage is unsupported "
         "in Unity Catalog."
     )
-    expected_err_msg = _expected_unsupported_method_error_message("get_latest_versions")
-    with pytest.raises(MlflowException, match=expected_err_msg):
+    with pytest.raises(MlflowException, match=expected_error):
         store.get_latest_versions(name=name)
-    with pytest.raises(MlflowException, match=expected_err_msg):
+    with pytest.raises(MlflowException, match=expected_error):
         store.get_latest_versions(name=name, stages=["Production"])
 
 

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -340,9 +340,9 @@ def test_get_latest_versions_unsupported(store):
         "in Unity Catalog."
     )
     expected_err_msg = _expected_unsupported_method_error_message("get_latest_versions")
-    with pytest.raises(MlflowException, match=expected_error):
+    with pytest.raises(MlflowException, match=expected_err_msg):
         store.get_latest_versions(name=name)
-    with pytest.raises(MlflowException, match=expected_error):
+    with pytest.raises(MlflowException, match=expected_err_msg):
         store.get_latest_versions(name=name, stages=["Production"])
 
 

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -335,7 +335,7 @@ def test_get_latest_versions_unsupported(store):
     name = "model_1"
     expected_error = (
         f"{_expected_unsupported_method_error_message('get_latest_versions')}. "
-        f"If seeing this error while attempting to load a model version by alias, "
+        f"If seeing this error while attempting to load a model version by stage, "
         f"use the syntax 'models:/your_model_name@your_alias_name'."
     )
     expected_err_msg = _expected_unsupported_method_error_message("get_latest_versions")

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -732,7 +732,8 @@ def test_transition_model_version_stage_unsupported(store):
     version = "5"
     expected_error = (
         f"{_expected_unsupported_method_error_message('transition_model_version_stage')}. "
-        f"We recommend using aliases instead of stages for more flexible model deployment management."
+        f"We recommend using aliases instead of stages for more flexible model deployment "
+        f"management."
     )
     with pytest.raises(
         MlflowException,

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -335,8 +335,9 @@ def test_get_latest_versions_unsupported(store):
     name = "model_1"
     expected_error = (
         f"{_expected_unsupported_method_error_message('get_latest_versions')}. "
-        f"If seeing this error while attempting to load a model version by stage, "
-        f"use the syntax 'models:/your_model_name@your_alias_name'."
+        "If seeing this error while attempting to load a model version by stage, "
+        "note that setting stages and loading model versions by stage is unsupported "
+        "in Unity Catalog."
     )
     expected_err_msg = _expected_unsupported_method_error_message("get_latest_versions")
     with pytest.raises(MlflowException, match=expected_error):

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -333,6 +333,11 @@ def test_get_registered_model(mock_http, store):
 
 def test_get_latest_versions_unsupported(store):
     name = "model_1"
+    expected_error = (
+        f"{_expected_unsupported_method_error_message('get_latest_versions')}. "
+        f"If seeing this error while attempting to "
+        f"load a model version by alias, use the syntax 'models:/model_name@alias_name'"
+    )
     expected_err_msg = _expected_unsupported_method_error_message("get_latest_versions")
     with pytest.raises(MlflowException, match=expected_err_msg):
         store.get_latest_versions(name=name)
@@ -725,9 +730,13 @@ def test_create_model_version_unsupported_fields(store):
 def test_transition_model_version_stage_unsupported(store):
     name = "model_1"
     version = "5"
+    expected_error = (
+        f"{_expected_unsupported_method_error_message('transition_model_version_stage')}. "
+        f"Setting model version stages is unsupported for ML models in the Unity Catalog"
+    )
     with pytest.raises(
         MlflowException,
-        match=_expected_unsupported_method_error_message("transition_model_version_stage"),
+        match=expected_error,
     ):
         store.transition_model_version_stage(
             name=name, version=version, stage="prod", archive_existing_versions=True

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -335,8 +335,8 @@ def test_get_latest_versions_unsupported(store):
     name = "model_1"
     expected_error = (
         f"{_expected_unsupported_method_error_message('get_latest_versions')}. "
-        f"If seeing this error while attempting to "
-        f"load a model version by alias, use the syntax 'models:/model_name@alias_name'"
+        f"If seeing this error while attempting to load a model version by alias, "
+        f"use the syntax 'models:/your_model_name@your_alias_name'."
     )
     expected_err_msg = _expected_unsupported_method_error_message("get_latest_versions")
     with pytest.raises(MlflowException, match=expected_error):
@@ -732,7 +732,7 @@ def test_transition_model_version_stage_unsupported(store):
     version = "5"
     expected_error = (
         f"{_expected_unsupported_method_error_message('transition_model_version_stage')}. "
-        f"Setting model version stages is unsupported for ML models in the Unity Catalog"
+        f"We recommend using aliases instead of stages for more flexible model deployment management."
     )
     with pytest.raises(
         MlflowException,

--- a/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
+++ b/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
@@ -81,7 +81,9 @@ def test_uc_models_artifact_repo_with_stage_uri_raises(
 ):
     model_uri = "models:/MyModel/Staging"
     with pytest.raises(
-        MlflowException, match="staged-based model URIs are unsupported for models in UC"
+        MlflowException,
+        match="If seeing this error while attempting to load a model version by stage, note that "
+        "setting stages and loading model versions by stage is unsupported in Unity Catalog",
     ):
         UnityCatalogModelsArtifactRepository(
             artifact_uri=model_uri, registry_uri=_DATABRICKS_UNITY_CATALOG_SCHEME


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Improves the user-facing error messages seen when calling stage-based model registry APIs like `transition_model_version_stage` or `mlflow.pyfunc.load_model("models:/catalog.schema.model/Production")` against models in UC, to recommend using aliases instead

## How is this patch tested?
Updated unit tests, and manually verified exception output format:

![image](https://github.com/mlflow/mlflow/assets/2358483/15bfdb4a-6347-4f7b-a1de-219e6adbc045)


- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
