### PR TITLE
Update models docs to include signature inference

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -572,8 +572,15 @@ Similar to model signatures, model inputs can be column-based (i.e DataFrames) o
 How To Log Model With Column-based Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 For models accepting column-based inputs, an example can be a single record or a batch of records. The
-sample input can be passed in as a Pandas DataFrame, list or dictionary. The given
-example will be converted to a Pandas DataFrame and then serialized to json using the Pandas split-oriented
+sample input can be in the following formats:
+
+* Pandas DataFrame
+* Python ``dict`` (of scalars, strings, or lists of scalars values)
+* Python ``list``
+* Python ``str``
+* Python ``bytes``
+
+The given example will be converted to a Pandas DataFrame and then serialized to json using the Pandas split-oriented
 format. Bytes are base64-encoded. The following example demonstrates how you can log a column-based
 input example with your model:
 
@@ -590,9 +597,15 @@ input example with your model:
 How To Log Model With Tensor-based Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 For models accepting tensor-based inputs, an example must be a batch of inputs. By default, the axis 0
-is the batch axis unless specified otherwise in the model signature. The sample input can be passed in as
-a numpy ndarray or a dictionary mapping a string to a numpy array. The following example demonstrates how
-you can log a tensor-based input example with your model:
+is the batch axis unless specified otherwise in the model signature. The sample input can be passed in
+as any of the following formats:
+
+* numpy ndarray
+* Python ``dict`` mapping a string to a numpy array
+* Scipy ``csr_matrix`` (sparse matrix)
+* Scipy ``csc_matrix`` (sparse matrix).
+
+The following example demonstrates how you can log a tensor-based input example with your model:
 
 .. code-block:: python
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -206,7 +206,7 @@ downstream tooling:
 Model Signature
 ^^^^^^^^^^^^^^^
 Model signatures define input and output schemas for MLflow models, providing a standard 
-interface to codify and enforce the correct use of your models. Sigatures are fetched by the MLflow Tracking
+interface to codify and enforce the correct use of your models. Signatures are fetched by the MLflow Tracking
 UI and Model Registry UI to display model inputs and outputs. They are also utilized by
 :ref:`MLflow model deployment tools <built-in-deployment>` to validate inference inputs according to
 the model's assigned signature (see the :ref:`Signature enforcement <signature-enforcement>` section
@@ -240,8 +240,6 @@ Tensor-based schemas are a sequence of (optionally) named tensors with type spec
 
 Column-based Signature Example
 """"""""""""""""""""""""""""""
-All flavors support column-based signatures.
-
 Each column-based input and output is represented by a type corresponding to one of
 :py:class:`MLflow data types <mlflow.types.DataType>` and an optional name. Input columns can also be marked
 as ``optional``, indicating whether they are required as input to the model or can be omitted. The following example
@@ -260,8 +258,6 @@ The output is an unnamed integer specifying the predicted class.
 
 Tensor-based Signature Example
 """"""""""""""""""""""""""""""
-Only DL flavors support tensor-based signatures (i.e TensorFlow, Keras, PyTorch, Onnx, and Gluon).
-
 Each tensor-based input and output is represented by a dtype corresponding to one of
 `numpy data types <https://numpy.org/devdocs/user/basics.types.html>`_, shape and an optional name.
 Tensor-based signatures do not support optional inputs.
@@ -351,6 +347,11 @@ To include a signature with your model, pass :py:class:`signature object
 by hand or :py:func:`inferred <mlflow.models.infer_signature>` from datasets with valid model inputs
 (e.g. the training dataset with target column omitted) and valid model outputs (e.g. model
 predictions generated on the training dataset).
+
+You may also include a signature with your model by omitting the :py:class:`signature object
+<mlflow.models.ModelSignature>` from the log_model call and instead passing an :ref:`input example <input-example>`.
+Then, for supported MLflow flavors (sklearn, xgboost, tensorflow, and spark), log_model will automatically
+infer the signature from the input example and the model's predicted output of the input example.
 
 Column-based Signature Example
 """"""""""""""""""""""""""""""
@@ -558,13 +559,14 @@ with a new model signature.
 
 Model Input Example
 ^^^^^^^^^^^^^^^^^^^
-Similar to model signatures, model inputs can be column-based (i.e DataFrames) or tensor-based
-(i.e numpy.ndarrays). A model input example provides an instance of a valid model input.
-Input examples are stored with the model as separate artifacts and are referenced in the the
-:ref:`MLmodel file <pyfunc-model-config>`.
-
+A model input example provides an instance of a valid model input. Input examples are stored with 
+the model as separate artifacts and are referenced in the :ref:`MLmodel file <pyfunc-model-config>`.
 To include an input example with your model, add it to the appropriate log_model call, e.g.
-:py:func:`sklearn.log_model() <mlflow.sklearn.log_model>`.
+:py:func:`sklearn.log_model() <mlflow.sklearn.log_model>`. Input examples are also used to infer
+model signatures in log_model calls when signatures aren't specified.
+
+Similar to model signatures, model inputs can be column-based (i.e DataFrames) or tensor-based
+(i.e numpy.ndarrays). See examples below:
 
 How To Log Model With Column-based Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -575,10 +575,10 @@ For models accepting column-based inputs, an example can be a single record or a
 sample input can be in the following formats:
 
 * Pandas DataFrame
-* Python ``dict`` (of scalars, strings, or lists of scalars values)
-* Python ``list``
-* Python ``str``
-* Python ``bytes``
+* ``dict`` (of scalars, strings, or lists of scalar values)
+* ``list``
+* ``str``
+* ``bytes``
 
 The given example will be converted to a Pandas DataFrame and then serialized to json using the Pandas split-oriented
 format. Bytes are base64-encoded. The following example demonstrates how you can log a column-based

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -350,8 +350,9 @@ predictions generated on the training dataset).
 
 You may also include a signature with your model by omitting the :py:class:`signature object
 <mlflow.models.ModelSignature>` from the log_model call and instead passing an :ref:`input example <input-example>`.
-Then, for supported MLflow flavors (sklearn, xgboost, tensorflow, and spark), log_model will automatically
-infer the signature from the input example and the model's predicted output of the input example.
+Then, for supported MLflow flavors (``sklearn``, ``xgboost``, ``tensorflow``, ``transformers``, and
+``spark``), log_model will automatically infer the signature from the input example and the model's
+predicted output of the input example.
 
 Column-based Signature Example
 """"""""""""""""""""""""""""""

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -349,10 +349,10 @@ by hand or :py:func:`inferred <mlflow.models.infer_signature>` from datasets wit
 predictions generated on the training dataset).
 
 You may also include a signature with your model by omitting the :py:class:`signature object
-<mlflow.models.ModelSignature>` from the log_model call and instead passing an :ref:`input example <input-example>`.
-Then, for supported MLflow flavors (``sklearn``, ``xgboost``, ``tensorflow``, ``transformers``, and
-``spark``), log_model will automatically infer the signature from the input example and the model's
-predicted output of the input example.
+<mlflow.models.ModelSignature>` from the log_model or save_model call and instead passing
+an :ref:`input example <input-example>`. Then, for most MLflow flavors, log_model or save_model
+will automatically infer the signature from the input example and the model's predicted output of
+the input example.
 
 Column-based Signature Example
 """"""""""""""""""""""""""""""

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -159,9 +159,17 @@ class _Example:
                 except ImportError:
                     pass
                 raise TypeError(
-                    "Unexpected type of input_example. Expected one of "
-                    "(pandas.DataFrame, numpy.ndarray, dict, list), "
-                    "got {}".format(type(input_example))
+                    "Expected one of the following types:\n"
+                    "- pandas.DataFrame\n"
+                    "- numpy.ndarray\n"
+                    "- dictionary of (name -> numpy.ndarray)\n"
+                    "- scipy.sparse.csr_matrix\n"
+                    "- scipy.sparse.csc_matrix\n"
+                    "- dict\n"
+                    "- list\n"
+                    "- str\n"
+                    "- bytes\n"
+                    "but got '{}'".format(type(input_example)),
                 )
             result = _handle_dataframe_nans(input_ex).to_dict(orient="split")
             # Do not include row index


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Builds off of this PR: https://github.com/mlflow/mlflow/pull/8725

## What changes are proposed in this pull request?

This PR improves input example documentation in the models docs and adds content on automatic signature inference.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
