### PR TITLE
Fix downloading MLmodel files from alias-based models:/ URIs

### DIFF
--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -16,8 +16,8 @@ def is_using_databricks_registry(uri):
 def _improper_model_uri_msg(uri):
     return (
         "Not a proper models:/ URI: %s. " % uri
-        + "Models URIs must be of the form 'models:/<model_name>/<suffix>' "
-        + "or 'models:/<model_name>@<alias>' where suffix is a model version, stage, "
+        + "Models URIs must be of the form 'models:/model_name/suffix' "
+        + "or 'models:/model_name@alias' where suffix is a model version, stage, "
         + "or the string '%s' and where alias is a registered model alias. "
         % _MODELS_URI_SUFFIX_LATEST
         + "Only one of suffix or alias can be defined at a time."

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -5,6 +5,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, RESOURCE_ALREADY_EXISTS
+from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -74,8 +75,8 @@ def _get_flavor_configuration_from_uri(model_uri, flavor_name, logger):
                 f"Falling back to downloading from original model URI {model_uri}",
                 exc_info=True,
             )
-            ml_model_file = _download_artifact_from_uri(
-                artifact_uri=append_to_uri_path(model_uri, MLMODEL_FILE_NAME)
+            ml_model_file = get_artifact_repository(artifact_uri=model_uri).download_artifacts(
+                artifact_path=MLMODEL_FILE_NAME
             )
     except Exception as ex:
         raise MlflowException(

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -411,12 +411,12 @@ def test_load_spark_model_from_models_uri(
             mock.call("", None),
         ]
         mock_download_artifacts.reset_mock()
-        mlflow.spark.load_model("models:/mycatalog.myschema.mymodel@Champion")
+        mlflow.spark.load_model(f"models:/{model_name}@Champion")
         assert mock_download_artifacts.mock_calls == [
             mock.call("MLmodel", None),
             mock.call("", None),
         ]
-        assert get_model_version_by_alias_mock.called_with("mycatalog.myschema.mymodel", "Champion")
+        assert get_model_version_by_alias_mock.called_with(model_name, "Champion")
 
 
 @pytest.mark.parametrize("should_start_run", [False, True])

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -397,7 +397,7 @@ def test_load_spark_model_from_models_uri(
         "mlflow.get_registry_uri", return_value=registry_uri
     ), mock.patch.object(
         mlflow.tracking.MlflowClient, "get_model_version_by_alias", return_value=fake_model_version
-    ):
+    ) as get_model_version_by_alias_mock:
         sparkm.save_model(
             path=model_dir,
             spark_model=spark_model_estimator.model,
@@ -416,6 +416,7 @@ def test_load_spark_model_from_models_uri(
             mock.call("MLmodel", None),
             mock.call("", None),
         ]
+        assert get_model_version_by_alias_mock.called_with("mycatalog.myschema.mymodel", "Champion")
 
 
 @pytest.mark.parametrize("should_start_run", [False, True])

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -18,6 +18,7 @@ import yaml
 from packaging.version import Version
 
 import mlflow
+from mlflow.entities.model_registry import ModelVersion
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.tracking
 import mlflow.utils.file_utils
@@ -374,12 +375,6 @@ def test_sparkml_model_log(tmp_path, spark_model_iris, should_start_run, use_dfs
         mlflow.set_tracking_uri(old_tracking_uri)
 
 
-# Test that we can load a transformers model from a models:/ URI with databricks UC registry URI
-# Mock the return value of download_artifacts
-# from mlflow.store.artifact.unity_catalog_models_artifact_repo import (
-#     UnityCatalogModelsArtifactRepository,
-# )
-# But also need to mock the value of ModelsArtifactRepository.get_underlying_uri
 @pytest.mark.parametrize(
     "registry_uri,artifact_repo_class",
     [
@@ -391,21 +386,32 @@ def test_load_spark_model_from_models_uri(
     tmp_path, spark_model_estimator, registry_uri, artifact_repo_class
 ):
     model_dir = str(tmp_path.joinpath("spark_model"))
+    model_name = "mycatalog.myschema.mymodel"
+    fake_model_version = ModelVersion(name=model_name, version=str(3), creation_timestamp=0)
+
     with mock.patch(
         f"{MODELS_ARTIFACT_REPOSITORY}.get_underlying_uri"
     ) as mock_get_underlying_uri, mock.patch.object(
         artifact_repo_class, "download_artifacts", return_value=model_dir
     ) as mock_download_artifacts, mock.patch(
         "mlflow.get_registry_uri", return_value=registry_uri
+    ), mock.patch.object(
+        mlflow.tracking.MlflowClient, "get_model_version_by_alias", return_value=fake_model_version
     ):
         sparkm.save_model(
             path=model_dir,
             spark_model=spark_model_estimator.model,
         )
         mock_get_underlying_uri.return_value = "nonexistentscheme://fakeuri"
-        mlflow.spark.load_model("models:/mycatalog.myschema.mymodel/1")
+        mlflow.spark.load_model(f"models:/{model_name}/1")
         # Assert that we downloaded both the MLmodel file and the whole model itself using
         # the models:/ URI
+        assert mock_download_artifacts.mock_calls == [
+            mock.call("MLmodel", None),
+            mock.call("", None),
+        ]
+        mock_download_artifacts.reset_mock()
+        mlflow.spark.load_model("models:/mycatalog.myschema.mymodel@Champion")
         assert mock_download_artifacts.mock_calls == [
             mock.call("MLmodel", None),
             mock.call("", None),


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Follow-up to https://github.com/mlflow/mlflow/pull/8728, this PR fixes downloading MLmodel files when loading models with URIs like `models:/mymodel@alias`. The current logic for this attempts to append the MLmodel file path to the URI and then download from an artifact URI like `models:/mymodel@alias/MLmodel`, which is not a valid URI and cannot be parsed. 

## How is this patch tested?
Updated unit tests. Also manually verified the PR fixes a bug in a DAIS demo 😅 

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
