### PR TITLE
Prevent `tmpdir` fixture usage in tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --color=yes --durations=10 --showlocals -vv
+addopts = -p no:legacypath --color=yes --durations=10 --showlocals -vv
 filterwarnings =
   # Prevent deprecated numpy type aliases from being used
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:mlflow

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -13,7 +13,7 @@ from mlflow.projects import _project_spec
 
 
 TEST_DIR = "tests"
-TEST_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_project")
+TEST_PROJECT_DIR = os.path.abspath(os.path.join(TEST_DIR, "resources", "example_project"))
 TEST_DOCKER_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_docker_project")
 TEST_VIRTUALENV_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_virtualenv_project")
 TEST_VIRTUALENV_CONDA_PROJECT_DIR = os.path.join(

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -113,22 +113,19 @@ def test_parse_pip_requirements(tmp_path):
     assert _parse_pip_requirements([str(fake_whl)]) == ([str(fake_whl)], [])
 
 
-def test_parse_pip_requirements_with_relative_requirements_files(request, tmp_path):
-    try:
-        os.chdir(tmp_path)
-        f1 = tmp_path.joinpath("requirements1.txt")
-        f1.write_text("b")
-        assert _parse_pip_requirements(f1.name) == (["b"], [])
-        assert _parse_pip_requirements(["a", f"-r {f1.name}"]) == (["a", "b"], [])
+def test_parse_pip_requirements_with_relative_requirements_files(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    f1 = tmp_path.joinpath("requirements1.txt")
+    f1.write_text("b")
+    assert _parse_pip_requirements(f1.name) == (["b"], [])
+    assert _parse_pip_requirements(["a", f"-r {f1.name}"]) == (["a", "b"], [])
 
-        f2 = tmp_path.joinpath("requirements2.txt")
-        f3 = tmp_path.joinpath("requirements3.txt")
-        f2.write_text(f"b\n-r {f3.name}")
-        f3.write_text("c")
-        assert _parse_pip_requirements(f2.name) == (["b", "c"], [])
-        assert _parse_pip_requirements(["a", f"-r {f2.name}"]) == (["a", "b", "c"], [])
-    finally:
-        os.chdir(request.config.invocation_dir)
+    f2 = tmp_path.joinpath("requirements2.txt")
+    f3 = tmp_path.joinpath("requirements3.txt")
+    f2.write_text(f"b\n-r {f3.name}")
+    f3.write_text("c")
+    assert _parse_pip_requirements(f2.name) == (["b", "c"], [])
+    assert _parse_pip_requirements(["a", f"-r {f2.name}"]) == (["a", "b", "c"], [])
 
 
 def test_parse_pip_requirements_with_absolute_requirements_files(tmp_path):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

The `tmpdir` fixture is legacy and should not be used.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
