### PR TITLE
Disable HTTP request retry to run tests faster

### DIFF
--- a/tests/gateway/test_client.py
+++ b/tests/gateway/test_client.py
@@ -105,7 +105,8 @@ def test_databricks_base_route_modification(uri, base_start):
         assert client._route_base.startswith(base_start)
 
 
-def test_non_running_server_raises_when_called():
+def test_non_running_server_raises_when_called(monkeypatch):
+    monkeypatch.setenv("MLFLOW_HTTP_REQUEST_MAX_RETRIES", "0")
     set_gateway_uri("http://invalid.server:6000")
     client = MlflowGatewayClient()
     with pytest.raises(

--- a/tests/gateway/test_fluent.py
+++ b/tests/gateway/test_fluent.py
@@ -68,7 +68,8 @@ def test_fluent_apis_with_no_server_set():
         get_route("claude-chat")
 
 
-def test_fluent_health_check_on_non_running_server():
+def test_fluent_health_check_on_non_running_server(monkeypatch):
+    monkeypatch.setenv("MLFLOW_HTTP_REQUEST_MAX_RETRIES", "0")
     set_gateway_uri("http://not.real:1000")
     with pytest.raises(
         MlflowException,


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

`test_fluent_health_check_on_non_running_server` and `test_non_running_server_raises_when_called` take too long because of HTTP request timeout. This PR disables it.

https://github.com/mlflow/mlflow/actions/runs/5278995502/jobs/9549073928#step:5:97

```
============================= slowest 10 durations =============================
60.42s call     tests/gateway/test_fluent.py::test_fluent_health_check_on_non_running_server
60.30s call     tests/gateway/test_client.py::test_non_running_server_raises_when_called
11.29s call     tests/gateway/test_runner.py::test_server_update_config_removed_then_recreated
9.37s call     tests/gateway/test_runner.py::test_server_update_with_invalid_config
9.30s call     tests/gateway/test_runner.py::test_server_update
```

With request disabled:

```
============================= slowest 10 durations =============================
0.08s call     tests/gateway/test_fluent.py::test_fluent_health_check_on_non_running_server
0.05s call     tests/gateway/test_client.py::test_non_running_server_raises_when_called
```

# 🚀 About 750.0x faster

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
