### PR TITLE
Automatic code transfomration to replace `mock.patch.dict(os.environ, ...)` with `monkeypatch.{setenv|delenv}` using OpenAI's chat completions API

### DIFF
--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from unittest import mock
 import pytest
@@ -217,10 +216,11 @@ def test_databricks_params_throws_errors(ProfileConfigProvider):
         databricks_utils.get_databricks_host_creds()
 
 
-def test_is_in_databricks_runtime():
-    with mock.patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "11.x"}):
-        assert databricks_utils.is_in_databricks_runtime()
+def test_is_in_databricks_runtime(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "11.x")
+    assert databricks_utils.is_in_databricks_runtime()
 
+    monkeypatch.delenv("DATABRICKS_RUNTIME_VERSION")
     assert not databricks_utils.is_in_databricks_runtime()
 
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Automatic code transfomration to remove mock.patch.dict(os.environ, ...) with monkeypatch.{setenv|delenv} using OpenAI's chat completions API.

<details><summary>The code I used</summary>

````python
from __future__ import annotations

import subprocess
import ast
import openai
import asyncio
import re
import textwrap
import sys
from typing import Iterator


def get_indent(s: str) -> int:
    return len(s) - len(s.lstrip())


class MockPatchDictVisitor(ast.NodeVisitor):
    """
    Finds function nodes that contain a mock.patch.dict call
    """

    def __init__(self, filename):
        self.filename = filename
        self.funcs = []
        self.bad_funcs = []

    def node_to_location(self, node) -> str:
        return f"{self.filename}:{node.lineno}:{node.col_offset}"

    def visit_FunctionDef(self, node) -> None:
        self.funcs.append(node)
        super().generic_visit(node)
        self.funcs.pop()

    @property
    def current_func(self) -> ast.FunctionDef | None:
        if self.funcs:
            return self.funcs[-1]
        return None

    def visit_With(self, node) -> None:
        for item in node.items:
            call = item.context_expr
            if (
                isinstance(call, ast.Call)
                and isinstance(call.func, ast.Attribute)
                and call.func.attr == "dict"
                and isinstance(call.func.value, ast.Attribute)
                and call.func.value.attr == "patch"
                and isinstance(call.func.value.value, ast.Name)
                and call.func.value.value.id == "mock"
            ):
                for arg in call.args:
                    # Find os.environ
                    if (
                        isinstance(arg, ast.Attribute)
                        and arg.attr == "environ"
                        and isinstance(arg.value, ast.Name)
                        and arg.value.id == "os"
                    ):
                        print(self.node_to_location(self.funcs[-1]))
                        if self.current_func and self.current_func not in self.bad_funcs:
                            self.bad_funcs.append(self.funcs[-1])
                        break
        self.generic_visit(node)


async def complete(prompt: str) -> str:
    resp = await openai.ChatCompletion.acreate(
        model="gpt-3.5-turbo-0613",
        messages=[{"role": "user", "content": prompt}],
        temperature=0.0,
    )
    return resp["choices"][0]["message"]["content"]


def extract_code_from_block(s: str) -> str:
    if m := re.search(r"```(?:python)?\n(.*)\n```", s, re.DOTALL):
        return m.group(1)
    return None


class Patch:
    def __init__(self, lineno: int, end_lineno: int, lines: list[str]):
        """
        lineno and end_lineno start from 0
        """
        self.lineno = lineno
        self.end_lineno = end_lineno
        self.lines = lines


def apply_patches(lines: list[str], patches: list[Patch]) -> list[str]:
    offset = 0
    for patch in patches:
        lines = lines[: patch.lineno + offset] + patch.lines + lines[patch.end_lineno + offset :]
        offset += len(patch.lines) - (patch.end_lineno - patch.lineno)
    return lines


def is_valid_code(code: str) -> bool:
    try:
        ast.parse(code)
        return True
    except SyntaxError:
        return False


def is_import(line: str) -> bool:
    return line.strip().startswith(("import ", "from "))


def remove_imports(lines: list[str]) -> list[str]:
    return [l for l in lines if not is_import(l)]


async def create_patch(lines: list[str], func: ast.FunctionDef, indent: int) -> Patch | None:
    prompt_template = """
The following pytest function contains `with mock.patch.dict(os.environ, dictionary, ...):`. We can use
`monkeypatch.setenv` (if `dictionary` contains items) or `monkepatch.delenv`
(if `dictionary` is empty) instead. Please rewrite the function using `monkeypatch.setenv` or
`monkeypatch.delenv`. If the function arguments doesn't contain `monkeypatch`, please add it.
You might be tempted to add missing import statements. Please don't do that.

```python
{code}
```

The output should look like this:

```python
<new_code>
```
"""
    resp = await complete(prompt_template.format(code="\n".join(lines)))
    new_code = extract_code_from_block(resp)
    if new_code is None:
        return None
    if not is_valid_code(new_code):
        return None

    new_lines = textwrap.indent(new_code, " " * indent).split("\n")
    return Patch(
        lineno=func.lineno - 1,
        end_lineno=func.end_lineno,
        lines=remove_imports(new_lines),
    )


def batched(iterable: Iterator[str], n: int) -> Iterator[list[str]]:
    batch = []
    for item in iterable:
        batch.append(item)
        if len(batch) == n:
            yield batch
            batch = []
    if batch:
        yield batch


def create_task_from_func(func: ast.FunctionDef, lines: list[str]):
    func_lines = lines[func.lineno - 1 : func.end_lineno]
    indent = get_indent(func_lines[0])
    return create_patch(func_lines, func, indent)


async def main():
    files = sys.argv[1:]
    tasks_by_file = {}
    print("Collecting functions to fix")
    for file in files:
        with open(file) as f:
            code = f.read()
            lines = code.split("\n")

        tree = ast.parse(code)
        visitor = MockPatchDictVisitor(file)
        visitor.visit(tree)

        for func in visitor.bad_funcs:
            # indent = get_indent(lines[func.lineno - 1])
            tasks_by_file.setdefault(file, []).append(func)

    print("=" * 30)
    print("Generating patches")
    for file, funcs in tasks_by_file.items():
        # Apply patches
        with open(file) as f:
            lines = f.read().split("\n")

        patches = []
        for batch in batched(funcs, 5):
            for _ in range(3):  # Retry 3 times
                tasks = {create_task_from_func(f, lines): f for f in batch}
                failed = []
                for cor in asyncio.as_completed(tasks):
                    try:
                        patch = await cor
                    except Exception:
                        print(f"Failed to create a patch for {file}:{patch.lineno}")
                        func = tasks[cor]
                        failed.append(func)
                    else:
                        if patch:
                            print(f"Succeeded to create a patch for {file}:{patch.lineno}")
                            patches.append(patch)
                if not failed:
                    break
                # Retry failed functions
                batch = failed

        # Sort patches by lineno
        patches.sort(key=lambda patch: patch.lineno)
        new_lines = apply_patches(lines, patches)
        with open(file, "w") as f:
            f.write("\n".join(new_lines))


if __name__ == "__main__":
    asyncio.run(main())

````

<p>



</p>
</details> 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
