### PR TITLE
[Gateway] Fix the anthropic provider

### DIFF
--- a/examples/gateway/anthropic.yaml
+++ b/examples/gateway/anthropic.yaml
@@ -1,0 +1,9 @@
+routes:
+  - name: completions
+    route_type: llm/v1/completions
+    model:
+      provider: anthropic
+      name: claude-1.3-100k
+      config:
+        anthropic_api_base: https://api.anthropic.com/v1
+        anthropic_api_key: $ANTHROPIC_API_KEY

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -17,7 +17,7 @@ class AnthropicProvider(BaseProvider):
         self.base_url = self.anthropic_config.anthropic_api_base
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
-        payload = jsonable_encoder(payload)
+        payload = jsonable_encoder(payload, exclude_none=True)
         if "top_p" in payload:
             raise HTTPException(
                 status_code=400,
@@ -40,11 +40,6 @@ class AnthropicProvider(BaseProvider):
         payload = rename_payload_keys(
             payload, {"max_tokens": "max_tokens_to_sample", "stop": "stop_sequences"}
         )
-
-        if not payload.get("stop_sequences", None):
-            # NB: A value of None will throw in Anthropic's endpoint. Not applying this
-            # defaulted parameter will revert to the default value of "\n\nHuman:"
-            payload.pop("stop_sequences")
 
         payload["prompt"] = f"\n\nHuman: {payload['prompt']}\n\nAssistant:"
 

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -24,7 +24,7 @@ class AnthropicProvider(BaseProvider):
                 detail="Cannot set both 'temperature' and 'top_p' parameters. "
                 "Please use only the temperature parameter for your query.",
             )
-        if payload["max_tokens"] is None:
+        if "max_tokens" not in payload:
             raise HTTPException(
                 status_code=400,
                 detail="You must set an integer value for 'max_tokens' for the Anthropic provider "

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -38,8 +38,13 @@ class AnthropicProvider(BaseProvider):
             )
 
         payload = rename_payload_keys(
-            payload, {"max_tokens_to_sample": "max_tokens", "stop_sequences": "stop"}
+            payload, {"max_tokens": "max_tokens_to_sample", "stop": "stop_sequences"}
         )
+
+        if not payload.get("stop_sequences", None):
+            # NB: A value of None will throw in Anthropic's endpoint. Not applying this
+            # defaulted parameter will revert to the default value of "\n\nHuman:"
+            payload.pop("stop_sequences")
 
         payload["prompt"] = f"\n\nHuman: {payload['prompt']}\n\nAssistant:"
 

--- a/tests/gateway/test_client.py
+++ b/tests/gateway/test_client.py
@@ -382,3 +382,35 @@ def test_client_delete_route_raises(gateway):
     # This API is available only in Databricks for route deletion
     with pytest.raises(MlflowException, match="The delete_route API is only available when"):
         gateway_client.delete_route("some-route")
+
+
+def test_client_query_anthropic_completions(mixed_gateway):
+    gateway_client = MlflowGatewayClient(gateway_uri=mixed_gateway.url)
+
+    route = gateway_client.get_route(name="completions")
+    assert route.model.provider == "anthropic"
+
+    expected_output = {
+        "candidates": [
+            {
+                "text": "Here are the steps for making a peanut butter sandwich:\n\n1. Get bread. "
+                "\n\n2. Spread peanut butter on bread.",
+                "metadata": {"finish_reason": "length"},
+            }
+        ],
+        "metadata": {
+            "model": "claude-instant-1.1",
+            "route_type": "llm/v1/completions",
+            "input_tokens": None,
+            "output_tokens": None,
+            "total_tokens": None,
+        },
+    }
+    data = {"prompt": "Can you tell me how to make a peanut butter sandwich?", "max_tokens": 500}
+
+    mock_response = mock.Mock()
+    mock_response.json.return_value = expected_output
+
+    with mock.patch.object(gateway_client, "_call_endpoint", return_value=mock_response):
+        response = gateway_client.query(route=route.name, data=data)
+        assert response == expected_output


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix an issue with field casting in the Anthropic provider

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
