### PR TITLE
Remove useless test classes

### DIFF
--- a/tests/store/artifact/test_dbfs_fuse_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_fuse_artifact_repo.py
@@ -65,71 +65,74 @@ def test_dir(files_dir):
     return files_dir
 
 
-class TestDbfsFuseArtifactRepository:
-    @pytest.mark.parametrize("artifact_path", [None, "output", ""])
-    def test_log_artifact(self, dbfs_fuse_artifact_repo, test_file, artifact_path, artifact_dir):
-        dbfs_fuse_artifact_repo.log_artifact(test_file, artifact_path)
-        expected_file_path = os.path.join(
-            artifact_dir,
-            artifact_path if artifact_path else "",
-            os.path.basename(test_file),
-        )
-        with open(expected_file_path, "rb") as handle:
-            data = handle.read()
-        assert data == TEST_FILE_1_CONTENT
-
-    def test_log_artifact_empty_file(self, dbfs_fuse_artifact_repo, test_dir, artifact_dir):
-        dbfs_fuse_artifact_repo.log_artifact(os.path.join(test_dir, "empty-file"))
-        expected_file_path = os.path.join(artifact_dir, "empty-file")
-        with open(expected_file_path, "rb") as handle:
-            data = handle.read()
-        assert data == b""
-
-    @pytest.mark.parametrize(
-        "artifact_path",
-        [
-            None,
-            "",  # should behave like '/' and exclude base name of logged_dir
-            "abc",
-            # We should add '.',
-        ],
+@pytest.mark.parametrize("artifact_path", [None, "output", ""])
+def test_log_artifact(dbfs_fuse_artifact_repo, test_file, artifact_path, artifact_dir):
+    dbfs_fuse_artifact_repo.log_artifact(test_file, artifact_path)
+    expected_file_path = os.path.join(
+        artifact_dir,
+        artifact_path if artifact_path else "",
+        os.path.basename(test_file),
     )
-    def test_log_artifacts(self, dbfs_fuse_artifact_repo, test_dir, artifact_path, artifact_dir):
-        dbfs_fuse_artifact_repo.log_artifacts(test_dir, artifact_path)
-        artifact_dst_path = os.path.join(artifact_dir, artifact_path if artifact_path else "")
-        assert os.path.exists(artifact_dst_path)
-        expected_contents = {
-            "subdir/test.txt": TEST_FILE_2_CONTENT,
-            "test.txt": TEST_FILE_3_CONTENT,
-            "empty-file": b"",
-        }
-        for filename, contents in expected_contents.items():
-            with open(os.path.join(artifact_dst_path, filename), "rb") as handle:
-                assert handle.read() == contents
+    with open(expected_file_path, "rb") as handle:
+        data = handle.read()
+    assert data == TEST_FILE_1_CONTENT
 
-    def test_list_artifacts(self, dbfs_fuse_artifact_repo, test_dir):
-        assert len(dbfs_fuse_artifact_repo.list_artifacts()) == 0
-        dbfs_fuse_artifact_repo.log_artifacts(test_dir)
-        artifacts = dbfs_fuse_artifact_repo.list_artifacts()
-        assert len(artifacts) == 3
-        assert artifacts[0].path == "empty-file"
-        assert artifacts[0].is_dir is False
-        assert artifacts[0].file_size == 0
-        assert artifacts[1].path == "subdir"
-        assert artifacts[1].is_dir is True
-        assert artifacts[1].file_size is None
-        assert artifacts[2].path == "test.txt"
-        assert artifacts[2].is_dir is False
-        assert artifacts[2].file_size == 23
 
-    def test_download_artifacts(self, dbfs_fuse_artifact_repo, test_dir):
-        dbfs_fuse_artifact_repo.log_artifacts(test_dir)
-        local_download_dir = dbfs_fuse_artifact_repo.download_artifacts("")
-        expected_contents = {
-            "subdir/test.txt": TEST_FILE_2_CONTENT,
-            "test.txt": TEST_FILE_3_CONTENT,
-            "empty-file": b"",
-        }
-        for filename, contents in expected_contents.items():
-            with open(os.path.join(local_download_dir, filename), "rb") as handle:
-                assert handle.read() == contents
+def test_log_artifact_empty_file(dbfs_fuse_artifact_repo, test_dir, artifact_dir):
+    dbfs_fuse_artifact_repo.log_artifact(os.path.join(test_dir, "empty-file"))
+    expected_file_path = os.path.join(artifact_dir, "empty-file")
+    with open(expected_file_path, "rb") as handle:
+        data = handle.read()
+    assert data == b""
+
+
+@pytest.mark.parametrize(
+    "artifact_path",
+    [
+        None,
+        "",  # should behave like '/' and exclude base name of logged_dir
+        "abc",
+        # We should add '.',
+    ],
+)
+def test_log_artifacts(dbfs_fuse_artifact_repo, test_dir, artifact_path, artifact_dir):
+    dbfs_fuse_artifact_repo.log_artifacts(test_dir, artifact_path)
+    artifact_dst_path = os.path.join(artifact_dir, artifact_path if artifact_path else "")
+    assert os.path.exists(artifact_dst_path)
+    expected_contents = {
+        "subdir/test.txt": TEST_FILE_2_CONTENT,
+        "test.txt": TEST_FILE_3_CONTENT,
+        "empty-file": b"",
+    }
+    for filename, contents in expected_contents.items():
+        with open(os.path.join(artifact_dst_path, filename), "rb") as handle:
+            assert handle.read() == contents
+
+
+def test_list_artifacts(dbfs_fuse_artifact_repo, test_dir):
+    assert len(dbfs_fuse_artifact_repo.list_artifacts()) == 0
+    dbfs_fuse_artifact_repo.log_artifacts(test_dir)
+    artifacts = dbfs_fuse_artifact_repo.list_artifacts()
+    assert len(artifacts) == 3
+    assert artifacts[0].path == "empty-file"
+    assert artifacts[0].is_dir is False
+    assert artifacts[0].file_size == 0
+    assert artifacts[1].path == "subdir"
+    assert artifacts[1].is_dir is True
+    assert artifacts[1].file_size is None
+    assert artifacts[2].path == "test.txt"
+    assert artifacts[2].is_dir is False
+    assert artifacts[2].file_size == 23
+
+
+def test_download_artifacts(dbfs_fuse_artifact_repo, test_dir):
+    dbfs_fuse_artifact_repo.log_artifacts(test_dir)
+    local_download_dir = dbfs_fuse_artifact_repo.download_artifacts("")
+    expected_contents = {
+        "subdir/test.txt": TEST_FILE_2_CONTENT,
+        "test.txt": TEST_FILE_3_CONTENT,
+        "empty-file": b"",
+    }
+    for filename, contents in expected_contents.items():
+        with open(os.path.join(local_download_dir, filename), "rb") as handle:
+            assert handle.read() == contents

--- a/tests/store/artifact/test_dbfs_rest_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_rest_artifact_repo.py
@@ -62,202 +62,211 @@ LIST_ARTIFACTS_SINGLE_FILE_RESPONSE = {
 }
 
 
-class TestDbfsArtifactRepository:
-    def test_init_validation_and_cleaning(self):
-        with mock.patch(
-            DBFS_ARTIFACT_REPOSITORY_PACKAGE + "._get_host_creds_from_default_store",
-            return_value=lambda: MlflowHostCreds("http://host"),
-        ):
-            repo = get_artifact_repository("dbfs:/test/")
-            assert repo.artifact_uri == "dbfs:/test"
-            match = "DBFS URI must be of the form dbfs:/<path>"
-            with pytest.raises(MlflowException, match=match):
-                DbfsRestArtifactRepository("s3://test")
-            with pytest.raises(MlflowException, match=match):
-                DbfsRestArtifactRepository("dbfs://profile@notdatabricks/test/")
-
-    def test_init_get_host_creds_with_databricks_profile_uri(self):
-        databricks_host = "https://something.databricks.com"
-        default_host = "http://host"
-        with mock.patch(
-            DBFS_ARTIFACT_REPOSITORY_PACKAGE + "._get_host_creds_from_default_store",
-            return_value=lambda: MlflowHostCreds(default_host),
-        ), mock.patch(
-            DBFS_ARTIFACT_REPOSITORY_PACKAGE + ".get_databricks_host_creds",
-            return_value=MlflowHostCreds(databricks_host),
-        ):
-            repo = DbfsRestArtifactRepository("dbfs://profile@databricks/test/")
-            assert repo.artifact_uri == "dbfs:/test/"
-            creds = repo.get_host_creds()
-            assert creds.host == databricks_host
-            # no databricks_profile_uri given
-            repo = DbfsRestArtifactRepository("dbfs:/test/")
-            creds = repo.get_host_creds()
-            assert creds.host == default_host
-
-    @pytest.mark.parametrize(
-        ("artifact_path", "expected_endpoint"),
-        [(None, "/dbfs/test/test.txt"), ("output", "/dbfs/test/output/test.txt")],
-    )
-    def test_log_artifact(self, dbfs_artifact_repo, test_file, artifact_path, expected_endpoint):
-        with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
-            endpoints = []
-            data = []
-
-            def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
-                endpoints.append(kwargs["endpoint"])
-                data.append(kwargs["data"].read())
-                return Mock(status_code=200, text="{}")
-
-            http_request_mock.side_effect = my_http_request
-            dbfs_artifact_repo.log_artifact(test_file, artifact_path)
-            assert endpoints == [expected_endpoint]
-            assert data == [TEST_FILE_1_CONTENT]
-
-    def test_log_artifact_empty_file(self, dbfs_artifact_repo, test_dir):
-        with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
-
-            def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
-                assert kwargs["endpoint"] == "/dbfs/test/empty-file"
-                assert kwargs["data"] == ""
-                return Mock(status_code=200, text="{}")
-
-            http_request_mock.side_effect = my_http_request
-            dbfs_artifact_repo.log_artifact(os.path.join(test_dir, "empty-file"))
-
-    def test_log_artifact_empty_artifact_path(self, dbfs_artifact_repo, test_file):
-        with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
-
-            def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
-                assert kwargs["endpoint"] == "/dbfs/test/test.txt"
-                assert kwargs["data"].read() == TEST_FILE_1_CONTENT
-                return Mock(status_code=200, text="{}")
-
-            http_request_mock.side_effect = my_http_request
-            dbfs_artifact_repo.log_artifact(test_file, "")
-
-    def test_log_artifact_error(self, dbfs_artifact_repo, test_file):
-        with mock.patch(
-            "mlflow.utils.rest_utils.http_request", return_value=Mock(status_code=409, text="")
-        ):
-            with pytest.raises(MlflowException, match=r"API request to endpoint .+ failed"):
-                dbfs_artifact_repo.log_artifact(test_file)
-
-    @pytest.mark.parametrize(
-        "artifact_path",
-        [
-            None,
-            "",  # should behave like '/' and exclude base name of logged_dir
-            # We should add '.',
-        ],
-    )
-    def test_log_artifacts(self, dbfs_artifact_repo, test_dir, artifact_path):
-        with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
-            endpoints = []
-            data = []
-
-            def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
-                endpoints.append(kwargs["endpoint"])
-                if kwargs["endpoint"] == "/dbfs/test/empty-file":
-                    data.append(kwargs["data"])
-                else:
-                    data.append(kwargs["data"].read())
-                return Mock(status_code=200, text="{}")
-
-            http_request_mock.side_effect = my_http_request
-            dbfs_artifact_repo.log_artifacts(test_dir, artifact_path)
-            assert set(endpoints) == {
-                "/dbfs/test/subdir/test.txt",
-                "/dbfs/test/test.txt",
-                "/dbfs/test/empty-file",
-            }
-            assert set(data) == {
-                TEST_FILE_2_CONTENT,
-                TEST_FILE_3_CONTENT,
-                "",
-            }
-
-    def test_log_artifacts_error(self, dbfs_artifact_repo, test_dir):
-        with mock.patch(
-            "mlflow.utils.rest_utils.http_request", return_value=Mock(status_code=409, text="")
-        ):
-            with pytest.raises(MlflowException, match=r"API request to endpoint .+ failed"):
-                dbfs_artifact_repo.log_artifacts(test_dir)
-
-    @pytest.mark.parametrize(
-        ("artifact_path", "expected_endpoints"),
-        [
-            (
-                "a",
-                {
-                    "/dbfs/test/a/subdir/test.txt",
-                    "/dbfs/test/a/test.txt",
-                    "/dbfs/test/a/empty-file",
-                },
-            ),
-            (
-                "a/",
-                {
-                    "/dbfs/test/a/subdir/test.txt",
-                    "/dbfs/test/a/test.txt",
-                    "/dbfs/test/a/empty-file",
-                },
-            ),
-            ("/", {"/dbfs/test/subdir/test.txt", "/dbfs/test/test.txt", "/dbfs/test/empty-file"}),
-        ],
-    )
-    def test_log_artifacts_with_artifact_path(
-        self, dbfs_artifact_repo, test_dir, artifact_path, expected_endpoints
+def test_init_validation_and_cleaning():
+    with mock.patch(
+        DBFS_ARTIFACT_REPOSITORY_PACKAGE + "._get_host_creds_from_default_store",
+        return_value=lambda: MlflowHostCreds("http://host"),
     ):
-        with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
-            endpoints = []
+        repo = get_artifact_repository("dbfs:/test/")
+        assert repo.artifact_uri == "dbfs:/test"
+        match = "DBFS URI must be of the form dbfs:/<path>"
+        with pytest.raises(MlflowException, match=match):
+            DbfsRestArtifactRepository("s3://test")
+        with pytest.raises(MlflowException, match=match):
+            DbfsRestArtifactRepository("dbfs://profile@notdatabricks/test/")
 
-            def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
-                endpoints.append(kwargs["endpoint"])
-                return Mock(status_code=200, text="{}")
 
-            http_request_mock.side_effect = my_http_request
-            dbfs_artifact_repo.log_artifacts(test_dir, artifact_path)
-            assert set(endpoints) == expected_endpoints
+def test_init_get_host_creds_with_databricks_profile_uri():
+    databricks_host = "https://something.databricks.com"
+    default_host = "http://host"
+    with mock.patch(
+        DBFS_ARTIFACT_REPOSITORY_PACKAGE + "._get_host_creds_from_default_store",
+        return_value=lambda: MlflowHostCreds(default_host),
+    ), mock.patch(
+        DBFS_ARTIFACT_REPOSITORY_PACKAGE + ".get_databricks_host_creds",
+        return_value=MlflowHostCreds(databricks_host),
+    ):
+        repo = DbfsRestArtifactRepository("dbfs://profile@databricks/test/")
+        assert repo.artifact_uri == "dbfs:/test/"
+        creds = repo.get_host_creds()
+        assert creds.host == databricks_host
+        # no databricks_profile_uri given
+        repo = DbfsRestArtifactRepository("dbfs:/test/")
+        creds = repo.get_host_creds()
+        assert creds.host == default_host
 
-    def test_list_artifacts(self, dbfs_artifact_repo):
-        with mock.patch(DBFS_ARTIFACT_REPOSITORY_PACKAGE + ".http_request") as http_request_mock:
-            http_request_mock.return_value.text = json.dumps(LIST_ARTIFACTS_RESPONSE)
-            artifacts = dbfs_artifact_repo.list_artifacts()
-            assert len(artifacts) == 2
-            assert artifacts[0].path == "a.txt"
-            assert artifacts[0].is_dir is False
-            assert artifacts[0].file_size == 100
-            assert artifacts[1].path == "dir"
-            assert artifacts[1].is_dir is True
-            assert artifacts[1].file_size is None
-            # Calling list_artifacts() on a path that's a file should return an empty list
-            http_request_mock.return_value.text = json.dumps(LIST_ARTIFACTS_SINGLE_FILE_RESPONSE)
-            list_on_file = dbfs_artifact_repo.list_artifacts("a.txt")
-            assert len(list_on_file) == 0
 
-    def test_download_artifacts(self, dbfs_artifact_repo):
-        with mock.patch(DBFS_ARTIFACT_REPOSITORY + "._dbfs_is_dir") as is_dir_mock, mock.patch(
-            DBFS_ARTIFACT_REPOSITORY + "._dbfs_list_api"
-        ) as list_mock, mock.patch(DBFS_ARTIFACT_REPOSITORY + "._dbfs_download") as download_mock:
-            is_dir_mock.side_effect = [
-                True,
-                False,
-                True,
-            ]
-            list_mock.side_effect = [
-                Mock(text=json.dumps(LIST_ARTIFACTS_RESPONSE)),
-                Mock(text="{}"),  # this call is for listing `/dir`.
-                Mock(text="{}"),  # this call is for listing `/dir/a.txt`.
-            ]
-            dbfs_artifact_repo.download_artifacts("/")
-            assert list_mock.call_count == 2
-            assert download_mock.call_count == 1
-            chronological_download_calls = list(download_mock.call_args_list)
-            # Calls are in reverse chronological order by default
-            chronological_download_calls.reverse()
-            _, kwargs_call = chronological_download_calls[0]
-            assert kwargs_call["endpoint"] == "/dbfs/test/a.txt"
+@pytest.mark.parametrize(
+    ("artifact_path", "expected_endpoint"),
+    [(None, "/dbfs/test/test.txt"), ("output", "/dbfs/test/output/test.txt")],
+)
+def test_log_artifact(dbfs_artifact_repo, test_file, artifact_path, expected_endpoint):
+    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
+        endpoints = []
+        data = []
+
+        def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
+            endpoints.append(kwargs["endpoint"])
+            data.append(kwargs["data"].read())
+            return Mock(status_code=200, text="{}")
+
+        http_request_mock.side_effect = my_http_request
+        dbfs_artifact_repo.log_artifact(test_file, artifact_path)
+        assert endpoints == [expected_endpoint]
+        assert data == [TEST_FILE_1_CONTENT]
+
+
+def test_log_artifact_empty_file(dbfs_artifact_repo, test_dir):
+    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
+
+        def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
+            assert kwargs["endpoint"] == "/dbfs/test/empty-file"
+            assert kwargs["data"] == ""
+            return Mock(status_code=200, text="{}")
+
+        http_request_mock.side_effect = my_http_request
+        dbfs_artifact_repo.log_artifact(os.path.join(test_dir, "empty-file"))
+
+
+def test_log_artifact_empty_artifact_path(dbfs_artifact_repo, test_file):
+    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
+
+        def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
+            assert kwargs["endpoint"] == "/dbfs/test/test.txt"
+            assert kwargs["data"].read() == TEST_FILE_1_CONTENT
+            return Mock(status_code=200, text="{}")
+
+        http_request_mock.side_effect = my_http_request
+        dbfs_artifact_repo.log_artifact(test_file, "")
+
+
+def test_log_artifact_error(dbfs_artifact_repo, test_file):
+    with mock.patch(
+        "mlflow.utils.rest_utils.http_request", return_value=Mock(status_code=409, text="")
+    ):
+        with pytest.raises(MlflowException, match=r"API request to endpoint .+ failed"):
+            dbfs_artifact_repo.log_artifact(test_file)
+
+
+@pytest.mark.parametrize(
+    "artifact_path",
+    [
+        None,
+        "",  # should behave like '/' and exclude base name of logged_dir
+        # We should add '.',
+    ],
+)
+def test_log_artifacts(dbfs_artifact_repo, test_dir, artifact_path):
+    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
+        endpoints = []
+        data = []
+
+        def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
+            endpoints.append(kwargs["endpoint"])
+            if kwargs["endpoint"] == "/dbfs/test/empty-file":
+                data.append(kwargs["data"])
+            else:
+                data.append(kwargs["data"].read())
+            return Mock(status_code=200, text="{}")
+
+        http_request_mock.side_effect = my_http_request
+        dbfs_artifact_repo.log_artifacts(test_dir, artifact_path)
+        assert set(endpoints) == {
+            "/dbfs/test/subdir/test.txt",
+            "/dbfs/test/test.txt",
+            "/dbfs/test/empty-file",
+        }
+        assert set(data) == {
+            TEST_FILE_2_CONTENT,
+            TEST_FILE_3_CONTENT,
+            "",
+        }
+
+
+def test_log_artifacts_error(dbfs_artifact_repo, test_dir):
+    with mock.patch(
+        "mlflow.utils.rest_utils.http_request", return_value=Mock(status_code=409, text="")
+    ):
+        with pytest.raises(MlflowException, match=r"API request to endpoint .+ failed"):
+            dbfs_artifact_repo.log_artifacts(test_dir)
+
+
+@pytest.mark.parametrize(
+    ("artifact_path", "expected_endpoints"),
+    [
+        (
+            "a",
+            {
+                "/dbfs/test/a/subdir/test.txt",
+                "/dbfs/test/a/test.txt",
+                "/dbfs/test/a/empty-file",
+            },
+        ),
+        (
+            "a/",
+            {
+                "/dbfs/test/a/subdir/test.txt",
+                "/dbfs/test/a/test.txt",
+                "/dbfs/test/a/empty-file",
+            },
+        ),
+        ("/", {"/dbfs/test/subdir/test.txt", "/dbfs/test/test.txt", "/dbfs/test/empty-file"}),
+    ],
+)
+def test_log_artifacts_with_artifact_path(
+    dbfs_artifact_repo, test_dir, artifact_path, expected_endpoints
+):
+    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
+        endpoints = []
+
+        def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
+            endpoints.append(kwargs["endpoint"])
+            return Mock(status_code=200, text="{}")
+
+        http_request_mock.side_effect = my_http_request
+        dbfs_artifact_repo.log_artifacts(test_dir, artifact_path)
+        assert set(endpoints) == expected_endpoints
+
+
+def test_list_artifacts(dbfs_artifact_repo):
+    with mock.patch(DBFS_ARTIFACT_REPOSITORY_PACKAGE + ".http_request") as http_request_mock:
+        http_request_mock.return_value.text = json.dumps(LIST_ARTIFACTS_RESPONSE)
+        artifacts = dbfs_artifact_repo.list_artifacts()
+        assert len(artifacts) == 2
+        assert artifacts[0].path == "a.txt"
+        assert artifacts[0].is_dir is False
+        assert artifacts[0].file_size == 100
+        assert artifacts[1].path == "dir"
+        assert artifacts[1].is_dir is True
+        assert artifacts[1].file_size is None
+        # Calling list_artifacts() on a path that's a file should return an empty list
+        http_request_mock.return_value.text = json.dumps(LIST_ARTIFACTS_SINGLE_FILE_RESPONSE)
+        list_on_file = dbfs_artifact_repo.list_artifacts("a.txt")
+        assert len(list_on_file) == 0
+
+
+def test_download_artifacts(dbfs_artifact_repo):
+    with mock.patch(DBFS_ARTIFACT_REPOSITORY + "._dbfs_is_dir") as is_dir_mock, mock.patch(
+        DBFS_ARTIFACT_REPOSITORY + "._dbfs_list_api"
+    ) as list_mock, mock.patch(DBFS_ARTIFACT_REPOSITORY + "._dbfs_download") as download_mock:
+        is_dir_mock.side_effect = [
+            True,
+            False,
+            True,
+        ]
+        list_mock.side_effect = [
+            Mock(text=json.dumps(LIST_ARTIFACTS_RESPONSE)),
+            Mock(text="{}"),  # this call is for listing `/dir`.
+            Mock(text="{}"),  # this call is for listing `/dir/a.txt`.
+        ]
+        dbfs_artifact_repo.download_artifacts("/")
+        assert list_mock.call_count == 2
+        assert download_mock.call_count == 1
+        chronological_download_calls = list(download_mock.call_args_list)
+        # Calls are in reverse chronological order by default
+        chronological_download_calls.reverse()
+        _, kwargs_call = chronological_download_calls[0]
+        assert kwargs_call["endpoint"] == "/dbfs/test/a.txt"
 
 
 def test_get_host_creds_from_default_store_file_store():


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Remove useless test classes.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
