### PR TITLE
Coerce input examples into PyFunc compatible format to use for signature inference

### DIFF
--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -269,10 +269,7 @@ def _infer_signature_from_input_example(
         `wrapped_model`.
     """
     try:
-        if isinstance(input_example, pd.Series):
-            input_ex = input_example
-        else:
-            input_ex = _Example(input_example).inference_data
+        input_ex = _Example(input_example).inference_data
         input_schema = _infer_schema(input_ex)
         # Copy the input example so that it is not mutated by predict()
         prediction = wrapped_model.predict(deepcopy(input_ex))

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -665,7 +665,7 @@ def _enforce_schema(pf_input: PyFuncInput, input_schema: Schema):
     if not input_schema.is_tensor_spec():
         if isinstance(pf_input, (list, np.ndarray, dict, pd.Series, str, bytes)):
             try:
-                if isinstance(pf_input, str) or isinstance(pf_input, bytes):
+                if isinstance(pf_input, (str, bytes)):
                     pf_input = pd.DataFrame([pf_input])
                 elif isinstance(pf_input, dict) and all(
                     _is_scalar(value) for value in pf_input.values()

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -663,9 +663,9 @@ def _enforce_schema(pf_input: PyFuncInput, input_schema: Schema):
     if isinstance(pf_input, pd.Series):
         pf_input = pd.DataFrame(pf_input)
     if not input_schema.is_tensor_spec():
-        if isinstance(pf_input, (list, np.ndarray, dict, pd.Series, str)):
+        if isinstance(pf_input, (list, np.ndarray, dict, pd.Series, str, bytes)):
             try:
-                if isinstance(pf_input, str):
+                if isinstance(pf_input, str) or isinstance(pf_input, bytes):
                     pf_input = pd.DataFrame([pf_input])
                 elif isinstance(pf_input, dict) and all(
                     _is_scalar(value) for value in pf_input.values()

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -672,6 +672,7 @@ def save_model(
                 prediction = pd.Series(wrapped_model.predict(input_ex))
                 signature = infer_signature(input_ex, prediction)
         except Exception as e:
+            raise
             _logger.warning(_LOG_MODEL_INFER_SIGNATURE_WARNING_TEMPLATE, repr(e))
             _logger.debug("", exc_info=True)
     elif signature is False:

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -34,7 +34,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelInputExample, ModelSignature, infer_signature
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import _LOG_MODEL_INFER_SIGNATURE_WARNING_TEMPLATE
-from mlflow.models.utils import _save_example
+from mlflow.models.utils import _Example, _save_example
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracking.artifact_utils import (
     _download_artifact_from_uri,
@@ -657,7 +657,10 @@ def save_model(
     if metadata is not None:
         mlflow_model.metadata = metadata
 
+    # for automatic signature inference, we use an inline implementation rather than the
+    # API because we need to convert model outputs from a list into a Pandas series.
     if signature is None and input_example is not None:
+        input_ex = _Example(input_example).inference_data
         try:
             spark = _get_active_spark_session()
             if spark is not None:
@@ -665,9 +668,10 @@ def save_model(
                 # We cast the predictions to a Pandas series because the Spark _PyFuncModelWrapper
                 # returns predictions as a list, which the `infer_signature` API does not support
                 # (unless it is a list of strings).
-                prediction = pd.Series(wrapped_model.predict(input_example))
-                signature = infer_signature(input_example, prediction)
+                prediction = pd.Series(wrapped_model.predict(input_ex))
+                signature = infer_signature(input_ex, prediction)
         except Exception as e:
+            raise e
             _logger.warning(_LOG_MODEL_INFER_SIGNATURE_WARNING_TEMPLATE, repr(e))
             _logger.debug("", exc_info=True)
     elif signature is False:

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -658,7 +658,8 @@ def save_model(
         mlflow_model.metadata = metadata
 
     # for automatic signature inference, we use an inline implementation rather than the
-    # API because we need to convert model outputs from a list into a Pandas series.
+    # `_infer_signature_from_input_example` API because we need to convert model predictions from a
+    # list into a Pandas series for signature inference.
     if signature is None and input_example is not None:
         input_ex = _Example(input_example).inference_data
         try:
@@ -671,7 +672,6 @@ def save_model(
                 prediction = pd.Series(wrapped_model.predict(input_ex))
                 signature = infer_signature(input_ex, prediction)
         except Exception as e:
-            raise e
             _logger.warning(_LOG_MODEL_INFER_SIGNATURE_WARNING_TEMPLATE, repr(e))
             _logger.debug("", exc_info=True)
     elif signature is False:

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -672,7 +672,6 @@ def save_model(
                 prediction = pd.Series(wrapped_model.predict(input_ex))
                 signature = infer_signature(input_ex, prediction)
         except Exception as e:
-            raise
             _logger.warning(_LOG_MODEL_INFER_SIGNATURE_WARNING_TEMPLATE, repr(e))
             _logger.debug("", exc_info=True)
     elif signature is False:

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -672,7 +672,6 @@ def save_model(
                 prediction = pd.Series(wrapped_model.predict(input_ex))
                 signature = infer_signature(input_ex, prediction)
         except Exception as e:
-            raise e
             _logger.warning(_LOG_MODEL_INFER_SIGNATURE_WARNING_TEMPLATE, repr(e))
             _logger.debug("", exc_info=True)
     elif signature is False:

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -672,6 +672,7 @@ def save_model(
                 prediction = pd.Series(wrapped_model.predict(input_ex))
                 signature = infer_signature(input_ex, prediction)
         except Exception as e:
+            raise e
             _logger.warning(_LOG_MODEL_INFER_SIGNATURE_WARNING_TEMPLATE, repr(e))
             _logger.debug("", exc_info=True)
     elif signature is False:

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -1619,7 +1619,7 @@ class _TransformersWrapper:
             input_data = data
         else:
             raise MlflowException(
-                "Input data must be either a pandas.DataFrame, a string, List[str], "
+                "Input data must be either a pandas.DataFrame, a string, bytes, List[str], "
                 "List[Dict[str, str]], List[Dict[str, Union[str, List[str]]]], "
                 "or Dict[str, Union[str, List[str]]].",
                 error_code=INVALID_PARAMETER_VALUE,

--- a/tests/models/test_model_input_examples.py
+++ b/tests/models/test_model_input_examples.py
@@ -359,7 +359,7 @@ def test_infer_signature_on_multi_column_input_examples(input_example, iris_mode
     "input_example",
     ["some string", bytes([1, 2, 3])],
 )
-def test_infer_signature_on_single_column_input_examples(input_example):
+def test_infer_signature_on_scalar_input_examples(input_example):
     class IdentitySklearnModel(BaseEstimator, ClassifierMixin):
         def fit(self, X, y=None):
             return self

--- a/tests/models/test_model_input_examples.py
+++ b/tests/models/test_model_input_examples.py
@@ -357,7 +357,7 @@ def test_infer_signature_on_multi_column_input_examples(input_example, iris_mode
 
 @pytest.mark.parametrize(
     "input_example",
-    ["string input example", bytes([1, 2, 3])],
+    ["some string", bytes([1, 2, 3])],
 )
 def test_infer_signature_on_single_column_input_examples(input_example):
     class IdentitySklearnModel(BaseEstimator, ClassifierMixin):
@@ -378,13 +378,18 @@ def test_infer_signature_on_single_column_input_examples(input_example):
         model_uri = mlflow.get_artifact_uri(artifact_path)
 
     mlflow_model = Model.load(model_uri)
+    signature = mlflow_model.signature
+    assert isinstance(signature, ModelSignature)
+    assert signature.inputs.inputs[0].name == 0
     if isinstance(input_example, str):
-        mlflow_model.signature == ModelSignature(
-            inputs=Schema([ColSpec(name="0", type=DataType.string)]),
+        signature == ModelSignature(
+            inputs=Schema([ColSpec(name=0, type=DataType.string)]),
             outputs=Schema([ColSpec(type=DataType.string)]),
         )
     else:
-        mlflow_model.signature == ModelSignature(
-            inputs=Schema([ColSpec(name="0", type=DataType.binary)]),
+        signature == ModelSignature(
+            inputs=Schema([ColSpec(name=0, type=DataType.binary)]),
             outputs=Schema([ColSpec(type=DataType.binary)]),
         )
+    # test that a single string still passes pyfunc schema enforcement
+    mlflow.pyfunc.load_model(model_uri).predict(input_example)

--- a/tests/models/test_model_input_examples.py
+++ b/tests/models/test_model_input_examples.py
@@ -312,9 +312,7 @@ def test_infer_signature_silently_fails():
 @pytest.fixture(scope="module")
 def iris_model():
     X, y = datasets.load_iris(return_X_y=True, as_frame=True)
-    knn_model = knn.KNeighborsClassifier()
-    knn_model.fit(X, y)
-    return knn_model
+    return knn.KNeighborsClassifier().fit(X, y)
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_model_input_examples.py
+++ b/tests/models/test_model_input_examples.py
@@ -382,14 +382,14 @@ def test_infer_signature_on_single_column_input_examples(input_example):
     assert isinstance(signature, ModelSignature)
     assert signature.inputs.inputs[0].name == 0
     if isinstance(input_example, str):
-        signature == ModelSignature(
+        assert signature == ModelSignature(
             inputs=Schema([ColSpec(name=0, type=DataType.string)]),
-            outputs=Schema([ColSpec(type=DataType.string)]),
+            outputs=Schema([ColSpec(name=0, type=DataType.string)]),
         )
     else:
-        signature == ModelSignature(
+        assert signature == ModelSignature(
             inputs=Schema([ColSpec(name=0, type=DataType.binary)]),
-            outputs=Schema([ColSpec(type=DataType.binary)]),
+            outputs=Schema([ColSpec(name=0, type=DataType.binary)]),
         )
     # test that a single string still passes pyfunc schema enforcement
     mlflow.pyfunc.load_model(model_uri).predict(input_example)

--- a/tests/models/test_model_input_examples.py
+++ b/tests/models/test_model_input_examples.py
@@ -350,8 +350,7 @@ def test_infer_signature_on_multi_column_input_examples(input_example, iris_mode
     mlflow_model = Model.load(model_uri)
     input_columns = mlflow_model.signature.inputs.inputs
     assert len(input_columns) == 4
-    for col in input_columns:
-        assert col.type == DataType.double
+    assert all(col.type == DataType.double for col in input_columns)
     assert mlflow_model.signature.outputs == Schema([ColSpec(type=DataType.long)])
 
 
@@ -381,15 +380,10 @@ def test_infer_signature_on_scalar_input_examples(input_example):
     signature = mlflow_model.signature
     assert isinstance(signature, ModelSignature)
     assert signature.inputs.inputs[0].name == 0
-    if isinstance(input_example, str):
-        assert signature == ModelSignature(
-            inputs=Schema([ColSpec(name=0, type=DataType.string)]),
-            outputs=Schema([ColSpec(name=0, type=DataType.string)]),
-        )
-    else:
-        assert signature == ModelSignature(
-            inputs=Schema([ColSpec(name=0, type=DataType.binary)]),
-            outputs=Schema([ColSpec(name=0, type=DataType.binary)]),
-        )
+    t = DataType.string if isinstance(input_example, str) else DataType.binary
+    assert signature == ModelSignature(
+        inputs=Schema([ColSpec(name=0, type=t)]),
+        outputs=Schema([ColSpec(name=0, type=t)]),
+    )
     # test that a single string still passes pyfunc schema enforcement
     mlflow.pyfunc.load_model(model_uri).predict(input_example)

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 from unittest import mock
 import numpy as np
-import pandas as pd
 import pyspark
 from pyspark.ml.classification import LogisticRegression
 from pyspark.ml.feature import VectorAssembler

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -112,17 +112,23 @@ spark.executor.extraJavaOptions="-Dio.netty.tryReflectionSetAccessible=true"
     spark.stop()
 
 
-@pytest.fixture(scope="module")
-def iris_df(spark_context):
+def iris_pandas_df():
     iris = datasets.load_iris()
     X = iris.data
     y = iris.target
+    df = pd.DataFrame(X)  # to make spark_udf work
+    df.columns = df.columns.astype(str)
+    df["label"] = pd.Series(y)
+    return df
+
+
+@pytest.fixture(scope="module")
+def iris_df(spark_context):
+    pdf = iris_pandas_df()
     feature_names = ["0", "1", "2", "3"]
-    iris_pandas_df = pd.DataFrame(X, columns=feature_names)  # to make spark_udf work
-    iris_pandas_df["label"] = pd.Series(y)
     spark_session = pyspark.sql.SparkSession(spark_context)
-    iris_spark_df = spark_session.createDataFrame(iris_pandas_df)
-    return feature_names, iris_pandas_df, iris_spark_df
+    iris_spark_df = spark_session.createDataFrame(pdf)
+    return feature_names, pdf, iris_spark_df
 
 
 @pytest.fixture(scope="module")
@@ -956,34 +962,30 @@ def test_model_log_with_metadata(spark_model_iris):
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"
 
 
-def test_model_log_with_signature_inference(spark_model_iris, iris_signature):
+_df_input_example = iris_pandas_df().drop("label", axis=1).iloc[[0]]
+_dict_input_example = _df_input_example.iloc[0].to_dict()
+_array_input_example = list(_dict_input_example.values())
+
+
+@pytest.mark.parametrize(
+    "input_example",
+    [_df_input_example, _dict_input_example, _array_input_example],
+)
+def test_model_log_with_signature_inference(spark_model_iris, input_example):
     artifact_path = "model"
-    X = spark_model_iris.pandas_df
-    X.drop("label", axis=1, inplace=True)
-    example = X.iloc[[0]]
-    example_dict = X.iloc[0].to_dict()
-    example_array = list(example_dict.values())
 
-    # test various input example data types
-    for input_ex in (example, example_dict, example_array):
-        with mlflow.start_run():
-            mlflow.spark.log_model(
-                spark_model_iris.model, artifact_path=artifact_path, input_example=input_ex
-            )
-            model_uri = mlflow.get_artifact_uri(artifact_path)
+    with mlflow.start_run():
+        mlflow.spark.log_model(
+            spark_model_iris.model, artifact_path=artifact_path, input_example=input_example
+        )
+        model_uri = mlflow.get_artifact_uri(artifact_path)
 
-        mlflow_model = Model.load(model_uri)
-        if isinstance(input_ex, list):
-            assert mlflow_model.signature == ModelSignature(
-                inputs=Schema(
-                    [
-                        ColSpec(name=0, type=DataType.double),
-                        ColSpec(name=1, type=DataType.double),
-                        ColSpec(name=2, type=DataType.double),
-                        ColSpec(name=3, type=DataType.double),
-                    ]
-                ),
-                outputs=Schema([ColSpec(type=DataType.double)]),
-            )
-        else:
-            assert mlflow_model.signature == iris_signature
+    mlflow_model = Model.load(model_uri)
+    input_columns = mlflow_model.signature.inputs.inputs
+    assert all(col.type == DataType.double for col in input_columns)
+    column_names = [col.name for col in input_columns]
+    if isinstance(input_example, list):
+        assert column_names == [0, 1, 2, 3]
+    else:
+        assert column_names == ["0", "1", "2", "3"]
+    assert mlflow_model.signature.outputs == Schema([ColSpec(type=DataType.double)])

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -113,19 +113,16 @@ spark.executor.extraJavaOptions="-Dio.netty.tryReflectionSetAccessible=true"
 
 
 def iris_pandas_df():
-    iris = datasets.load_iris()
-    X = iris.data
-    y = iris.target
-    df = pd.DataFrame(X)  # to make spark_udf work
-    df.columns = df.columns.astype(str)
-    df["label"] = pd.Series(y)
-    return df
+    X, y = datasets.load_iris(return_X_y=True, as_frame=True)
+    X.columns = ["0", "1", "2", "3"]  # so that an array is a valid input example
+    X["label"] = y
+    return X
 
 
 @pytest.fixture(scope="module")
 def iris_df(spark_context):
     pdf = iris_pandas_df()
-    feature_names = ["0", "1", "2", "3"]
+    feature_names = list(pdf.drop("label", axis=1).columns)
     spark_session = pyspark.sql.SparkSession(spark_context)
     iris_spark_df = spark_session.createDataFrame(pdf)
     return feature_names, pdf, iris_spark_df


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Because some input example data types cannot be scored by PyFunc-wrapped MLflow models, we reuse functionality in the `_Example` class to coerce input examples into Pandas DataFrames, when possible.

## How is this patch tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
