### PR TITLE
Enable datasets tracking UI

### DIFF
--- a/mlflow/server/js/src/common/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/common/utils/FeatureUtils.ts
@@ -9,7 +9,7 @@ export const shouldDisableLegacyRunCompareCharts = () => false;
 /**
  * UI feature preview: displays data lineage (datasets used) in experiment runs
  */
-export const shouldEnableExperimentDatasetTracking = () => false;
+export const shouldEnableExperimentDatasetTracking = () => true;
 /**
  * UI feature preview: enables artifact-based ML experiment output data analysis, used for evaluating LLM prediction data
  */

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.test.tsx
@@ -75,7 +75,7 @@ describe('RunView', () => {
         },
         tagsByRunUuid: { 'uuid-1234-5678-9012': {} },
         paramsByRunUuid: { 'uuid-1234-5678-9012': {} },
-        runDatasetsByUuid: { 'uuid-1234-5678-9012': {} },
+        runDatasetsByUuid: { 'uuid-1234-5678-9012': [] },
         latestMetricsByRunUuid: { 'uuid-1234-5678-9012': {} },
         artifactRootUriByRunUuid: { 'uuid-1234-5678-9012': 'root/uri' },
       },

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.test.tsx
@@ -249,6 +249,6 @@ describe('ExperimentViewRunsTable', () => {
     });
 
     // Assert "show more columns" CTA button not being displayed anymore
-    expect(simpleExperimentsWrapper.find('ExperimentViewRunsTableAddColumnCTA').length).toBe(0);
+    expect(simpleExperimentsWrapper.find('ExperimentViewRunsTableAddColumnCTA').length).toBe(1);
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.test.tsx
@@ -244,11 +244,12 @@ describe('ExperimentViewRunsTable', () => {
           'attributes.`Source`',
           'attributes.`Version`',
           'attributes.`Models`',
+          'attributes.`Dataset`',
         ],
       }),
     });
 
     // Assert "show more columns" CTA button not being displayed anymore
-    expect(simpleExperimentsWrapper.find('ExperimentViewRunsTableAddColumnCTA').length).toBe(1);
+    expect(simpleExperimentsWrapper.find('ExperimentViewRunsTableAddColumnCTA').length).toBe(0);
   });
 });


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Enable datasets tracking UI. I found this when I was running a datasets example.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<img width="1889" alt="Screen Shot 2023-06-29 at 13 05 16" src="https://github.com/mlflow/mlflow/assets/17039389/caff96e6-0b24-4f65-b747-462483a7e21e">
<img width="1889" alt="Screen Shot 2023-06-29 at 13 05 12" src="https://github.com/mlflow/mlflow/assets/17039389/7c7e3f9c-0ef8-4499-afba-5937591e6597">

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
