### PR TITLE
Avoid using `to_json` in keras tests

### DIFF
--- a/tests/tensorflow/test_keras_model_export.py
+++ b/tests/tensorflow/test_keras_model_export.py
@@ -593,7 +593,7 @@ def test_save_model_with_tf_save_format(model_path):
     assert not args[0].endswith(".h5")
 
 
-def test_save_and_load_model_with_tf_save_format(tf_keras_model, model_path):
+def test_save_and_load_model_with_tf_save_format(tf_keras_model, model_path, data):
     """Ensures that keras models saved with save_format="tf" can be loaded."""
     mlflow.tensorflow.save_model(
         tf_keras_model, path=model_path, keras_model_kwargs={"save_format": "tf"}
@@ -611,10 +611,10 @@ def test_save_and_load_model_with_tf_save_format(tf_keras_model, model_path):
     ), "Expected directory containing saved_model.pb"
 
     model_loaded = mlflow.tensorflow.load_model(model_path)
-    assert tf_keras_model.to_json() == model_loaded.to_json()
+    np.testing.assert_allclose(model_loaded.predict(data[0]), tf_keras_model.predict(data[0]))
 
 
-def test_load_without_save_format(tf_keras_model, model_path):
+def test_load_without_save_format(tf_keras_model, model_path, data):
     """Ensures that keras models without save_format can still be loaded."""
     mlflow.tensorflow.save_model(
         tf_keras_model, path=model_path, keras_model_kwargs={"save_format": "h5"}
@@ -627,7 +627,7 @@ def test_load_without_save_format(tf_keras_model, model_path):
     model_conf.save(model_conf_path)
 
     model_loaded = mlflow.tensorflow.load_model(model_path)
-    assert tf_keras_model.to_json() == model_loaded.to_json()
+    np.testing.assert_allclose(model_loaded.predict(data[0]), tf_keras_model.predict(data[0]))
 
 
 # TODO: Remove skipif condition `not Version(tf.__version__).is_devrelease` once


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fixes the following error:

https://github.com/mlflow/mlflow/actions/runs/5401491880/jobs/9811432019#step:14:234

```
tf_keras_model = <keras.src.engine.sequential.Sequential object at 0x7fd3d6515310>
model_path = '/tmp/pytest-of-runner/pytest-0/test_load_without_save_format0/model'

    def test_load_without_save_format(tf_keras_model, model_path):
        """Ensures that keras models without save_format can still be loaded."""
        mlflow.tensorflow.save_model(
            tf_keras_model, path=model_path, keras_model_kwargs={"save_format": "h5"}
        )
        model_conf_path = os.path.join(model_path, "MLmodel")
        model_conf = Model.load(model_conf_path)
        flavor_conf = model_conf.flavors.get(mlflow.tensorflow.FLAVOR_NAME)
        assert flavor_conf is not None
        del flavor_conf["save_format"]
        model_conf.save(model_conf_path)
    
        model_loaded = mlflow.tensorflow.load_model(model_path)
>       assert tf_keras_model.to_json() == model_loaded.to_json()
E       assert '{"class_name": "Sequential", "config": {"name": "sequential_8", "layers": [{"class_name": "InputLayer", "config": {"batch_input_shape": [null, 4], "dtype": "float32", "sparse": false, "ragged": false, "name": "dense_15_input"}}, {"class_name": "Dense", "config": {"name": "dense_15", "trainable": true, "dtype": "float32", "batch_input_shape": [null, 4], "units": 3, "activation": "linear", "use_bias": true, "kernel_initializer": {"module": "keras.initializers", "class_name": "GlorotUniform", "config": {"seed": null}, "registered_name": null}, "bias_initializer": {"module": "keras.initializers", "class_name": "Zeros", "config": {}, "registered_name": null}, "kernel_regularizer": null, "bias_regularizer": null, "activity_regularizer": null, "kernel_constraint": null, "bias_constraint": null}}, {"class_name": "Dense", "config": {"name": "dense_16", "trainable": true, "dtype": "float32", "units": 1, "activation": "linear", "use_bias": true, "kernel_initializer": {"module": "keras.initializers", "class_name": "GlorotUniform", "config": {"seed": null}, "registered_name": null}, "bias_initializer": {"module": "keras.initializers", "class_name": "Zeros", "config": {}, "registered_name": null}, "kernel_regularizer": null, "bias_regularizer": null, "activity_regularizer": null, "kernel_constraint": null, "bias_constraint": null}}]}, "keras_version": "2.14.0", "backend": "tensorflow"}' == '{"class_name": "Sequential", "config": {"name": "sequential_8", "layers": [{"module": "keras.layers", "class_name": "InputLayer", "config": {"batch_input_shape": [null, 4], "dtype": "float32", "sparse": false, "ragged": false, "name": "dense_15_input"}, "registered_name": null}, {"module": "keras.layers", "class_name": "Dense", "config": {"name": "dense_15", "trainable": true, "dtype": "float32", "batch_input_shape": [null, 4], "units": 3, "activation": "linear", "use_bias": true, "kernel_initializer": {"module": "keras.initializers", "class_name": "GlorotUniform", "config": {"seed": null}, "registered_name": null}, "bias_initializer": {"module": "keras.initializers", "class_name": "Zeros", "config": {}, "registered_name": null}, "kernel_regularizer": null, "bias_regularizer": null, "activity_regularizer": null, "kernel_constraint": null, "bias_constraint": null}, "registered_name": null, "build_config": {"input_shape": [null, 4]}}, {"module": "keras.layers", "class_name": "Dense", "config": {"name": "dense_16", "trainable": true, "dtype": "float32", "units": 1, "activation": "linear", "use_bias": true, "kernel_initializer": {"module": "keras.initializers", "class_name": "GlorotUniform", "config": {"seed": null}, "registered_name": null}, "bias_initializer": {"module": "keras.initializers", "class_name": "Zeros", "config": {}, "registered_name": null}, "kernel_regularizer": null, "bias_regularizer": null, "activity_regularizer": null, "kernel_constraint": null, "bias_constraint": null}, "registered_name": null, "build_config": {"input_shape": [null, 3]}}]}, "keras_version": "2.14.0", "backend": "tensorflow"}'
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
