### PR TITLE
Respect preexisting file ACLs in overwrite YAML utility routine

### DIFF
--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -199,8 +199,8 @@ def overwrite_yaml(root, file_name, data):
             overwrite=True,
             sort_keys=True,
         )
-        # Ensure temporary file contains ACLs of preexisting yaml
-        # file before move-replacing.
+        # Preserve the ACLs of the preexisting yaml file
+        # in the temporary file before replacing it.
         dst_file_path = os.path.join(root, file_name)
         shutil.copystat(dst_file_path, tmp_file_path)
         shutil.move(

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -199,9 +199,13 @@ def overwrite_yaml(root, file_name, data):
             overwrite=True,
             sort_keys=True,
         )
+        # Ensure temporary file contains ACLs of preexisting yaml
+        # file before move-replacing.
+        dst_file_path = os.path.join(root, file_name)
+        shutil.copystat(dst_file_path, tmp_file_path)
         shutil.move(
             tmp_file_path,
-            os.path.join(root, file_name),
+            dst_file_path,
         )
     finally:
         if tmp_file_path is not None and os.path.exists(tmp_file_path):

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -373,4 +373,4 @@ def test_overwrite_yaml_preserves_preexisting_permissions(tmp_path):
     # ensure temporary file does not have elevated permissions
     os.chmod(str(yaml_path), expected_mode)
     file_utils.overwrite_yaml(tmp_dir, yaml_path.name, {"bar": "foo"})
-    assert os.stat(str(yaml_path)).st_mode == expected_mode
+    assert yaml_path.stat().st_mode == expected_mode

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -366,6 +366,7 @@ def test_shutil_copytree_without_file_permissions(tmp_path):
 
 
 def test_overwrite_yaml_preserves_preexisting_permissions(tmp_path):
+    # Given
     tmp_dir = str(tmp_path)
     yaml_path = tmp_path / random_file("yaml")
     file_utils.write_yaml(tmp_dir, yaml_path.name, {"foo": "bar"})

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -2,6 +2,7 @@
 import codecs
 import filecmp
 import hashlib
+import logging
 import os
 import shutil
 import json
@@ -369,8 +370,12 @@ def test_overwrite_yaml_preserves_preexisting_permissions(tmp_path):
     tmp_dir = str(tmp_path)
     yaml_path = tmp_path / random_file("yaml")
     file_utils.write_yaml(tmp_dir, yaml_path.name, {"foo": "bar"})
-    # Set OS-independent permissions on temporary testing file
-    expected_mode = 0o100666
-    yaml_path.chmod(expected_mode)
+    expected_mode = yaml_path.stat().st_mode
+    if oct(expected_mode) == 0o100600:
+        logging.warning(
+            "Preexisting file under inspection already has elevated "
+            "permissions. Test to preserve permissions upon update "
+            "may not be reliable."
+        )
     file_utils.overwrite_yaml(tmp_dir, yaml_path.name, {"bar": "foo"})
     assert yaml_path.stat().st_mode == expected_mode

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -363,3 +363,18 @@ def test_shutil_copytree_without_file_permissions(tmp_path):
     assert set(os.listdir(dst_dir.joinpath("subdir"))) == {"subdir-file.txt"}
     assert dst_dir.joinpath("subdir/subdir-file.txt").read_text() == "testing 123"
     assert dst_dir.joinpath("top-level-file.txt").read_text() == "hi"
+
+
+def test_overwrite_yaml_preserves_preexisting_permissions(tmp_path):
+    tmp_dir = str(tmp_path)
+    yaml_path = tmp_path / random_file("yaml")
+    file_utils.write_yaml(tmp_dir, yaml_path.name, {"foo": "bar"})
+    expected_mode = 0o100660
+    # ensure temporary file does not have elevated permissions
+    os.chmod(str(yaml_path), expected_mode)
+
+    # When
+    file_utils.overwrite_yaml(tmp_dir, yaml_path.name, {"bar": "foo"})
+
+    # Then
+    assert os.stat(str(yaml_path)).st_mode == expected_mode

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -369,8 +369,8 @@ def test_overwrite_yaml_preserves_preexisting_permissions(tmp_path):
     tmp_dir = str(tmp_path)
     yaml_path = tmp_path / random_file("yaml")
     file_utils.write_yaml(tmp_dir, yaml_path.name, {"foo": "bar"})
-    expected_mode = 0o100660
-    # ensure temporary file does not have elevated permissions
-    os.chmod(str(yaml_path), expected_mode)
+    # Set OS-independent permissions on temporary testing file
+    expected_mode = 0o100666
+    yaml_path.chmod(expected_mode)
     file_utils.overwrite_yaml(tmp_dir, yaml_path.name, {"bar": "foo"})
     assert yaml_path.stat().st_mode == expected_mode

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -2,10 +2,10 @@
 import codecs
 import filecmp
 import hashlib
-import logging
 import os
 import shutil
 import json
+import warnings
 
 import jinja2.exceptions
 import pytest
@@ -371,11 +371,11 @@ def test_overwrite_yaml_preserves_preexisting_permissions(tmp_path):
     yaml_path = tmp_path / random_file("yaml")
     file_utils.write_yaml(tmp_dir, yaml_path.name, {"foo": "bar"})
     expected_mode = yaml_path.stat().st_mode
-    if oct(expected_mode) == 0o100600:
-        logging.warning(
+    if expected_mode == 33152:
+        warnings.warn(
             "Preexisting file under inspection already has elevated "
-            "permissions. Test to preserve permissions upon update "
-            "may not be reliable."
+            f"permissions: {oct(expected_mode)}. Outcome of test to "
+            "preserve permissions upon update may not be reliable."
         )
     file_utils.overwrite_yaml(tmp_dir, yaml_path.name, {"bar": "foo"})
     assert yaml_path.stat().st_mode == expected_mode

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -366,16 +366,11 @@ def test_shutil_copytree_without_file_permissions(tmp_path):
 
 
 def test_overwrite_yaml_preserves_preexisting_permissions(tmp_path):
-    # Given
     tmp_dir = str(tmp_path)
     yaml_path = tmp_path / random_file("yaml")
     file_utils.write_yaml(tmp_dir, yaml_path.name, {"foo": "bar"})
     expected_mode = 0o100660
     # ensure temporary file does not have elevated permissions
     os.chmod(str(yaml_path), expected_mode)
-
-    # When
     file_utils.overwrite_yaml(tmp_dir, yaml_path.name, {"bar": "foo"})
-
-    # Then
     assert os.stat(str(yaml_path)).st_mode == expected_mode


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

#8878 

## What changes are proposed in this pull request?

The ACLs of the preexisting yaml are copied over to the temporary file via `shutil.copystat` before it is moved to replace the preexisting file in `overwrite_yaml`.

By doing so we retain the atomicity of the update operation (although `shutil.move` is not _purely_ atomic anyway), so that the file permissions of the preexisting yaml remain unchanged throughout.

A regression test is also added that will fail on `master`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Bug fix for `PermissionError` exceptions reported by multiple users in a NFS-backed tracking store after experiments are renamed or deleted. Solution ensures that ACLs of preexisting experiment `meta.yaml` files are respected when performing updates.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
