### PR TITLE
Bug/best estimator params

### DIFF
--- a/mlflow/recipes/steps/train.py
+++ b/mlflow/recipes/steps/train.py
@@ -371,6 +371,7 @@ class TrainStep(BaseStep):
                 estimator = self._resolve_estimator(
                     X_train, y_train, validation_df, run, output_directory
                 )
+                best_estimator_params = estimator.get_params()
                 fitted_estimator, additional_fitted_args = self._fitted_estimator(
                     estimator, X_train, y_train
                 )

--- a/tests/recipes/test_train_step.py
+++ b/tests/recipes/test_train_step.py
@@ -546,6 +546,27 @@ def test_train_step_with_tuning_output_yaml_correct(
         assert len(lines) == 19 + num_sections * 2
 
 
+@pytest.mark.parametrize("with_hardcoded_params", [(True), (False)])
+def test_train_step_with_tuning_trials_card_tab(
+    tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path, with_hardcoded_params
+):
+    train_step_output_dir = setup_train_dataset(tmp_recipe_exec_path)
+    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
+    recipe_steps_dir.mkdir(parents=True)
+    train_step = setup_train_step_with_tuning(
+        tmp_recipe_root_path, use_tuning=True, with_hardcoded_params=with_hardcoded_params
+    )
+    m_train = Mock()
+    m_train.estimator_fn = estimator_fn
+    with mock.patch.dict("sys.modules", {"steps.train": m_train}):
+        train_step.run(str(train_step_output_dir))
+    assert (train_step_output_dir / "card.html").exists()
+    with open(train_step_output_dir / "card.html") as f:
+        step_card_content = f.read()
+
+    assert "Tuning Trials" in step_card_content
+
+
 def test_train_step_with_tuning_child_runs_and_early_stop(
     tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path
 ):

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from unittest import mock, TestCase
+from unittest import mock
 
 from mlflow.store.db import utils
 from sqlalchemy.pool import NullPool
@@ -62,48 +62,49 @@ def test_alembic_escape_logic():
     assert config.get_main_option("sqlalchemy.url") == url
 
 
-class TestCreateSqlAlchemyEngineWithRetry(TestCase):
-    def test_create_sqlalchemy_engine_with_retry_success(self):
-        with mock.patch.dict(os.environ, {}):
-            with mock.patch("sqlalchemy.inspect") as mock_sqlalchemy_inspect:
-                with mock.patch(
-                    "mlflow.store.db.utils.create_sqlalchemy_engine"
-                ) as mock_create_sqlalchemy_engine:
-                    with mock.patch("time.sleep") as mock_sleep:
-                        mock_create_sqlalchemy_engine.return_value = "Engine"
-                        engine = utils.create_sqlalchemy_engine_with_retry("mydb://host:port/")
-                        mock_create_sqlalchemy_engine.assert_called_once_with("mydb://host:port/")
-                        mock_sqlalchemy_inspect.assert_called_once()
-                        mock_sleep.assert_not_called()
-                        assert engine == "Engine"
+def test_create_sqlalchemy_engine_with_retry_success():
+    with mock.patch.dict(os.environ, {}):
+        with mock.patch("sqlalchemy.inspect") as mock_sqlalchemy_inspect:
+            with mock.patch(
+                "mlflow.store.db.utils.create_sqlalchemy_engine"
+            ) as mock_create_sqlalchemy_engine:
+                with mock.patch("time.sleep") as mock_sleep:
+                    mock_create_sqlalchemy_engine.return_value = "Engine"
+                    engine = utils.create_sqlalchemy_engine_with_retry("mydb://host:port/")
+                    mock_create_sqlalchemy_engine.assert_called_once_with("mydb://host:port/")
+                    mock_sqlalchemy_inspect.assert_called_once()
+                    mock_sleep.assert_not_called()
+                    assert engine == "Engine"
 
-    def test_create_sqlalchemy_engine_with_retry_success_after_third_call(self):
-        with mock.patch.dict(os.environ, {}):
-            with mock.patch("sqlalchemy.inspect") as mock_sqlalchemy_inspect:
-                with mock.patch(
-                    "mlflow.store.db.utils.create_sqlalchemy_engine"
-                ) as mock_create_sqlalchemy_engine:
-                    with mock.patch("time.sleep"):
-                        mock_sqlalchemy_inspect.side_effect = [Exception, Exception, "Inspect"]
-                        mock_create_sqlalchemy_engine.return_value = "Engine"
-                        engine = utils.create_sqlalchemy_engine_with_retry("mydb://host:port/")
-                        assert (
-                            mock_create_sqlalchemy_engine.mock_calls
-                            == [mock.call("mydb://host:port/")] * 3
-                        )
-                        assert engine == "Engine"
 
-    def test_create_sqlalchemy_engine_with_retry_fail(self):
-        with mock.patch.dict(os.environ, {}), mock.patch(
-            "sqlalchemy.inspect", side_effect=[Exception("failed")] * utils.MAX_RETRY_COUNT
-        ), mock.patch(
-            "mlflow.store.db.utils.create_sqlalchemy_engine", return_value="Engine"
-        ) as mock_create_sqlalchemy_engine, mock.patch(
-            "time.sleep"
-        ):
-            with pytest.raises(Exception, match=r"failed"):
-                utils.create_sqlalchemy_engine_with_retry("mydb://host:port/")
-            assert (
-                mock_create_sqlalchemy_engine.mock_calls
-                == [mock.call("mydb://host:port/")] * utils.MAX_RETRY_COUNT
-            )
+def test_create_sqlalchemy_engine_with_retry_success_after_third_call():
+    with mock.patch.dict(os.environ, {}):
+        with mock.patch("sqlalchemy.inspect") as mock_sqlalchemy_inspect:
+            with mock.patch(
+                "mlflow.store.db.utils.create_sqlalchemy_engine"
+            ) as mock_create_sqlalchemy_engine:
+                with mock.patch("time.sleep"):
+                    mock_sqlalchemy_inspect.side_effect = [Exception, Exception, "Inspect"]
+                    mock_create_sqlalchemy_engine.return_value = "Engine"
+                    engine = utils.create_sqlalchemy_engine_with_retry("mydb://host:port/")
+                    assert (
+                        mock_create_sqlalchemy_engine.mock_calls
+                        == [mock.call("mydb://host:port/")] * 3
+                    )
+                    assert engine == "Engine"
+
+
+def test_create_sqlalchemy_engine_with_retry_fail():
+    with mock.patch.dict(os.environ, {}), mock.patch(
+        "sqlalchemy.inspect", side_effect=[Exception("failed")] * utils.MAX_RETRY_COUNT
+    ), mock.patch(
+        "mlflow.store.db.utils.create_sqlalchemy_engine", return_value="Engine"
+    ) as mock_create_sqlalchemy_engine, mock.patch(
+        "time.sleep"
+    ):
+        with pytest.raises(Exception, match=r"failed"):
+            utils.create_sqlalchemy_engine_with_retry("mydb://host:port/")
+        assert (
+            mock_create_sqlalchemy_engine.mock_calls
+            == [mock.call("mydb://host:port/")] * utils.MAX_RETRY_COUNT
+        )

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -43,75 +43,71 @@ pytestmark = pytest.mark.notrackingurimock
 
 def test_get_store_file_store(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    env = {}
-    with mock.patch.dict(os.environ, env):
-        store = _get_store()
-        assert isinstance(store, FileStore)
-        assert os.path.abspath(store.root_directory) == os.path.abspath("mlruns")
+    store = _get_store()
+    assert isinstance(store, FileStore)
+    assert os.path.abspath(store.root_directory) == os.path.abspath("mlruns")
 
 
 def test_get_store_file_store_from_arg(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    env = {}
-    with mock.patch.dict(os.environ, env):
-        store = _get_store("other/path")
-        assert isinstance(store, FileStore)
-        assert os.path.abspath(store.root_directory) == os.path.abspath("other/path")
+    store = _get_store("other/path")
+    assert isinstance(store, FileStore)
+    assert os.path.abspath(store.root_directory) == os.path.abspath("other/path")
 
 
 @pytest.mark.parametrize("uri", ["other/path", "file:other/path"])
 def test_get_store_file_store_from_env(tmp_path, monkeypatch, uri):
     monkeypatch.chdir(tmp_path)
-    env = {MLFLOW_TRACKING_URI.name: uri}
-    with mock.patch.dict(os.environ, env):
-        store = _get_store()
-        assert isinstance(store, FileStore)
-        assert os.path.abspath(store.root_directory) == os.path.abspath("other/path")
+    monkeypatch.setenv(MLFLOW_TRACKING_URI.name, uri)
+    store = _get_store()
+    assert isinstance(store, FileStore)
+    assert os.path.abspath(store.root_directory) == os.path.abspath("other/path")
 
 
-def test_get_store_basic_rest_store():
-    env = {MLFLOW_TRACKING_URI.name: "https://my-tracking-server:5050"}
-    with mock.patch.dict(os.environ, env):
-        store = _get_store()
-        assert isinstance(store, RestStore)
-        assert store.get_host_creds().host == "https://my-tracking-server:5050"
-        assert store.get_host_creds().token is None
+def test_get_store_basic_rest_store(monkeypatch):
+    monkeypatch.setenv(MLFLOW_TRACKING_URI.name, "https://my-tracking-server:5050")
+    store = _get_store()
+    assert isinstance(store, RestStore)
+    assert store.get_host_creds().host == "https://my-tracking-server:5050"
+    assert store.get_host_creds().token is None
 
 
-def test_get_store_rest_store_with_password():
-    env = {
+def test_get_store_rest_store_with_password(monkeypatch):
+    for k, v in {
         MLFLOW_TRACKING_URI.name: "https://my-tracking-server:5050",
         MLFLOW_TRACKING_USERNAME.name: "Bob",
         MLFLOW_TRACKING_PASSWORD.name: "Ross",
-    }
-    with mock.patch.dict(os.environ, env):
-        store = _get_store()
-        assert isinstance(store, RestStore)
-        assert store.get_host_creds().host == "https://my-tracking-server:5050"
-        assert store.get_host_creds().username == "Bob"
-        assert store.get_host_creds().password == "Ross"
+    }.items():
+        monkeypatch.setenv(k, v)
+
+    store = _get_store()
+    assert isinstance(store, RestStore)
+    assert store.get_host_creds().host == "https://my-tracking-server:5050"
+    assert store.get_host_creds().username == "Bob"
+    assert store.get_host_creds().password == "Ross"
 
 
-def test_get_store_rest_store_with_token():
-    env = {
+def test_get_store_rest_store_with_token(monkeypatch):
+    for k, v in {
         MLFLOW_TRACKING_URI.name: "https://my-tracking-server:5050",
         MLFLOW_TRACKING_TOKEN.name: "my-token",
-    }
-    with mock.patch.dict(os.environ, env):
-        store = _get_store()
-        assert isinstance(store, RestStore)
-        assert store.get_host_creds().token == "my-token"
+    }.items():
+        monkeypatch.setenv(k, v)
+
+    store = _get_store()
+    assert isinstance(store, RestStore)
+    assert store.get_host_creds().token == "my-token"
 
 
-def test_get_store_rest_store_with_insecure():
-    env = {
+def test_get_store_rest_store_with_insecure(monkeypatch):
+    for k, v in {
         MLFLOW_TRACKING_URI.name: "https://my-tracking-server:5050",
         MLFLOW_TRACKING_INSECURE_TLS.name: "true",
-    }
-    with mock.patch.dict(os.environ, env):
-        store = _get_store()
-        assert isinstance(store, RestStore)
-        assert store.get_host_creds().ignore_tls_verification
+    }.items():
+        monkeypatch.setenv(k, v)
+    store = _get_store()
+    assert isinstance(store, RestStore)
+    assert store.get_host_creds().ignore_tls_verification
 
 
 def test_get_store_rest_store_with_no_insecure(monkeypatch):
@@ -140,8 +136,8 @@ def test_get_store_sqlalchemy_store(tmp_path, monkeypatch, db_type):
     patch_create_engine = mock.patch("sqlalchemy.create_engine")
 
     uri = f"{db_type}://hostname/database"
-    env = {MLFLOW_TRACKING_URI.name: uri}
-    with mock.patch.dict(os.environ, env), patch_create_engine as mock_create_engine, mock.patch(
+    monkeypatch.setenv(MLFLOW_TRACKING_URI.name, uri)
+    with patch_create_engine as mock_create_engine, mock.patch(
         "mlflow.store.db.utils._verify_schema"
     ), mock.patch("mlflow.store.db.utils._initialize_tables"), mock.patch(
         # In sqlalchemy 1.4.0, `SqlAlchemyStore.search_experiments`, which is called when fetching
@@ -270,13 +266,10 @@ def test_standard_store_registry_with_installed_plugin(tmp_path, monkeypatch):
 
     from mlflow_test_plugin.file_store import PluginFileStore
 
-    env = {
-        MLFLOW_TRACKING_URI.name: "file-plugin:test-path",
-    }
-    with mock.patch.dict(os.environ, env):
-        plugin_file_store = mlflow.tracking._tracking_service.utils._get_store()
-        assert isinstance(plugin_file_store, PluginFileStore)
-        assert plugin_file_store.is_plugin
+    monkeypatch.setenv(MLFLOW_TRACKING_URI.name, "file-plugin:test-path")
+    plugin_file_store = mlflow.tracking._tracking_service.utils._get_store()
+    assert isinstance(plugin_file_store, PluginFileStore)
+    assert plugin_file_store.is_plugin
 
 
 def test_plugin_registration():

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -47,7 +47,6 @@ from mlflow.tracking.fluent import (
     get_run,
 )
 from mlflow.utils import mlflow_tags, get_results_from_paginated_fn
-from mlflow.utils.file_utils import TempDir
 from mlflow.utils.time_utils import get_current_time_millis
 from mlflow.environment_variables import (
     MLFLOW_RUN_ID,
@@ -211,94 +210,86 @@ def test_get_experiment_id_from_env():
     assert _get_experiment_id_from_env() is None
 
     # set only ID
-    with TempDir(chdr=True):
-        name = "random experiment %d" % random.randint(1, 1e6)
-        exp_id = mlflow.create_experiment(name)
-        assert exp_id is not None
-        HelperEnv.set_values(experiment_id=exp_id)
-        HelperEnv.assert_values(exp_id, None)
-        assert _get_experiment_id_from_env() == exp_id
+    name = "random experiment %d" % random.randint(1, 1e6)
+    exp_id = mlflow.create_experiment(name)
+    assert exp_id is not None
+    HelperEnv.set_values(experiment_id=exp_id)
+    HelperEnv.assert_values(exp_id, None)
+    assert _get_experiment_id_from_env() == exp_id
 
     # set only name
-    with TempDir(chdr=True):
-        name = "random experiment %d" % random.randint(1, 1e6)
-        exp_id = mlflow.create_experiment(name)
-        assert exp_id is not None
-        HelperEnv.set_values(name=name)
-        HelperEnv.assert_values(None, name)
-        assert _get_experiment_id_from_env() == exp_id
+    name = "random experiment %d" % random.randint(1, 1e6)
+    exp_id = mlflow.create_experiment(name)
+    assert exp_id is not None
+    HelperEnv.set_values(name=name)
+    HelperEnv.assert_values(None, name)
+    assert _get_experiment_id_from_env() == exp_id
 
     # create experiment from env name
-    with TempDir(chdr=True):
-        name = "random experiment %d" % random.randint(1, 1e6)
-        HelperEnv.set_values(name=name)
-        HelperEnv.assert_values(None, name)
-        assert MlflowClient().get_experiment_by_name(name) is None
-        assert _get_experiment_id_from_env() is not None
+    name = "random experiment %d" % random.randint(1, 1e6)
+    HelperEnv.set_values(name=name)
+    HelperEnv.assert_values(None, name)
+    assert MlflowClient().get_experiment_by_name(name) is None
+    assert _get_experiment_id_from_env() is not None
 
     # assert experiment creation from encapsulating function
-    with TempDir(chdr=True):
-        name = "random experiment %d" % random.randint(1, 1e6)
-        HelperEnv.set_values(name=name)
-        HelperEnv.assert_values(None, name)
-        assert MlflowClient().get_experiment_by_name(name) is None
-        assert _get_experiment_id() is not None
+    name = "random experiment %d" % random.randint(1, 1e6)
+    HelperEnv.set_values(name=name)
+    HelperEnv.assert_values(None, name)
+    assert MlflowClient().get_experiment_by_name(name) is None
+    assert _get_experiment_id() is not None
 
     # assert raises from conflicting experiment_ids
-    with TempDir(chdr=True):
-        name = "random experiment %d" % random.randint(1, 1e6)
-        exp_id = mlflow.create_experiment(name)
-        random_id = random.randint(100, 1e6)
-        assert exp_id != random_id
-        HelperEnv.set_values(experiment_id=random_id)
-        HelperEnv.assert_values(str(random_id), None)
-        with pytest.raises(
-            MlflowException,
-            match=(
-                f"The provided {MLFLOW_EXPERIMENT_ID.name} environment variable value "
-                f"`{random_id}` does not exist in the tracking server"
-            ),
-        ):
-            _get_experiment_id_from_env()
+    name = "random experiment %d" % random.randint(1, 1e6)
+    exp_id = mlflow.create_experiment(name)
+    random_id = random.randint(100, 1e6)
+    assert exp_id != random_id
+    HelperEnv.set_values(experiment_id=random_id)
+    HelperEnv.assert_values(str(random_id), None)
+    with pytest.raises(
+        MlflowException,
+        match=(
+            f"The provided {MLFLOW_EXPERIMENT_ID.name} environment variable value "
+            f"`{random_id}` does not exist in the tracking server"
+        ),
+    ):
+        _get_experiment_id_from_env()
 
     # assert raises from name to id mismatch
-    with TempDir(chdr=True):
-        name = "random experiment %d" % random.randint(1, 1e6)
-        exp_id = mlflow.create_experiment(name)
-        random_id = random.randint(100, 1e6)
-        assert exp_id != random_id
-        HelperEnv.set_values(experiment_id=random_id, name=name)
-        HelperEnv.assert_values(str(random_id), name)
-        with pytest.raises(
-            MlflowException,
-            match=(
-                f"The provided {MLFLOW_EXPERIMENT_ID.name} environment variable value "
-                f"`{random_id}` does not match the experiment id"
-            ),
-        ):
-            _get_experiment_id_from_env()
+    name = "random experiment %d" % random.randint(1, 1e6)
+    exp_id = mlflow.create_experiment(name)
+    random_id = random.randint(100, 1e6)
+    assert exp_id != random_id
+    HelperEnv.set_values(experiment_id=random_id, name=name)
+    HelperEnv.assert_values(str(random_id), name)
+    with pytest.raises(
+        MlflowException,
+        match=(
+            f"The provided {MLFLOW_EXPERIMENT_ID.name} environment variable value "
+            f"`{random_id}` does not match the experiment id"
+        ),
+    ):
+        _get_experiment_id_from_env()
 
     # assert does not raise if active experiment is set with invalid env variables
-    with TempDir(chdr=True):
-        invalid_name = "invalid experiment"
-        name = "random experiment %d" % random.randint(1, 1e6)
-        exp_id = mlflow.create_experiment(name)
-        assert exp_id is not None
-        random_id = random.randint(100, 1e6)
-        HelperEnv.set_values(name=invalid_name, experiment_id=random_id)
-        HelperEnv.assert_values(str(random_id), invalid_name)
-        mlflow.set_experiment(experiment_id=exp_id)
-        assert _get_experiment_id() == exp_id
+    invalid_name = "invalid experiment"
+    name = "random experiment %d" % random.randint(1, 1e6)
+    exp_id = mlflow.create_experiment(name)
+    assert exp_id is not None
+    random_id = random.randint(100, 1e6)
+    HelperEnv.set_values(name=invalid_name, experiment_id=random_id)
+    HelperEnv.assert_values(str(random_id), invalid_name)
+    mlflow.set_experiment(experiment_id=exp_id)
+    assert _get_experiment_id() == exp_id
 
 
 def test_get_experiment_id_with_active_experiment_returns_active_experiment_id():
     # Create a new experiment and set that as active experiment
-    with TempDir(chdr=True):
-        name = "Random experiment %d" % random.randint(1, 1e6)
-        exp_id = mlflow.create_experiment(name)
-        assert exp_id is not None
-        mlflow.set_experiment(name)
-        assert _get_experiment_id() == exp_id
+    name = "Random experiment %d" % random.randint(1, 1e6)
+    exp_id = mlflow.create_experiment(name)
+    assert exp_id is not None
+    mlflow.set_experiment(name)
+    assert _get_experiment_id() == exp_id
 
 
 def test_get_experiment_id_with_no_active_experiments_returns_zero():
@@ -316,11 +307,10 @@ def test_get_experiment_id_in_databricks_detects_notebook_id_by_default():
 
 
 def test_get_experiment_id_in_databricks_with_active_experiment_returns_active_experiment_id():
-    with TempDir(chdr=True):
-        exp_name = "random experiment %d" % random.randint(1, 1e6)
-        exp_id = mlflow.create_experiment(exp_name)
-        mlflow.set_experiment(exp_name)
-        notebook_id = str(int(exp_id) + 73)
+    exp_name = "random experiment %d" % random.randint(1, 1e6)
+    exp_id = mlflow.create_experiment(exp_name)
+    mlflow.set_experiment(exp_name)
+    notebook_id = str(int(exp_id) + 73)
 
     with mock.patch(
         "mlflow.tracking.fluent.default_experiment_registry.get_experiment_id",
@@ -331,11 +321,10 @@ def test_get_experiment_id_in_databricks_with_active_experiment_returns_active_e
 
 
 def test_get_experiment_id_in_databricks_with_experiment_defined_in_env_returns_env_experiment_id():
-    with TempDir(chdr=True):
-        exp_name = "random experiment %d" % random.randint(1, 1e6)
-        exp_id = mlflow.create_experiment(exp_name)
-        notebook_id = str(int(exp_id) + 73)
-        HelperEnv.set_values(experiment_id=exp_id)
+    exp_name = "random experiment %d" % random.randint(1, 1e6)
+    exp_id = mlflow.create_experiment(exp_name)
+    notebook_id = str(int(exp_id) + 73)
+    HelperEnv.set_values(experiment_id=exp_id)
 
     with mock.patch(
         "mlflow.tracking.fluent.default_experiment_registry.get_experiment_id",
@@ -346,12 +335,11 @@ def test_get_experiment_id_in_databricks_with_experiment_defined_in_env_returns_
 
 
 def test_get_experiment_by_id():
-    with TempDir(chdr=True):
-        name = "Random experiment %d" % random.randint(1, 1e6)
-        exp_id = mlflow.create_experiment(name)
+    name = "Random experiment %d" % random.randint(1, 1e6)
+    exp_id = mlflow.create_experiment(name)
 
-        experiment = mlflow.get_experiment(exp_id)
-        assert experiment.experiment_id == exp_id
+    experiment = mlflow.get_experiment(exp_id)
+    assert experiment.experiment_id == exp_id
 
 
 def test_get_experiment_by_id_with_is_in_databricks_job():
@@ -364,12 +352,11 @@ def test_get_experiment_by_id_with_is_in_databricks_job():
 
 
 def test_get_experiment_by_name():
-    with TempDir(chdr=True):
-        name = "Random experiment %d" % random.randint(1, 1e6)
-        exp_id = mlflow.create_experiment(name)
+    name = "Random experiment %d" % random.randint(1, 1e6)
+    exp_id = mlflow.create_experiment(name)
 
-        experiment = mlflow.get_experiment_by_name(name)
-        assert experiment.experiment_id == exp_id
+    experiment = mlflow.get_experiment_by_name(name)
+    assert experiment.experiment_id == exp_id
 
 
 def test_search_experiments(tmp_path):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #8859

## What changes are proposed in this pull request?

This bug prevents the "Tuning Trials" tab from being added to the Train html card for MLflow Recipes. The variable `best_estimator_params` was never assigned after being initialized to `None` so a later call to `best_estimator_params.keys()` (L599) causes an error `'NoneType' object has no attribute 'keys'`. See Issue linked above for more details.

I have added the line 
```python
best_estimator_params = estimator.get_params()
```
after the estimator is defined and after hyperparameter tuning is run, to get the best params which are then used to create the `tuning_df`

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Previously the "Tuning Trials" Tab of the Train card was not available to users because of this bug, although the rest of the functionality is already in place. This one liner will allow this tab to be added to the card displayed

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
