### PR TITLE
Remove unused arguments - 1

### DIFF
--- a/mlflow/recipes/steps/train.py
+++ b/mlflow/recipes/steps/train.py
@@ -605,7 +605,6 @@ class TrainStep(BaseStep):
             card = self._build_step_card(
                 eval_metrics=eval_metrics,
                 pred_and_error_df=pred_and_error_df,
-                model=model,
                 model_schema=model_schema,
                 run_id=run.info.run_id,
                 model_uri=model_uri,
@@ -825,7 +824,6 @@ class TrainStep(BaseStep):
         self,
         eval_metrics,
         pred_and_error_df,
-        model,
         model_schema,
         run_id,
         model_uri,

--- a/tests/data/test_dataset_registry.py
+++ b/tests/data/test_dataset_registry.py
@@ -31,13 +31,20 @@ def test_register_constructor_function_performs_validation():
     registry = DatasetRegistry()
 
     def from_good_function(
-        path: str, name: Optional[str] = None, digest: Optional[str] = None
+        # pylint: disable=unused-argument
+        path: str,
+        name: Optional[str] = None,
+        digest: Optional[str] = None,
     ) -> Dataset:
         pass
 
     registry.register_constructor(from_good_function)
 
-    def bad_name_fn(name: Optional[str] = None, digest: Optional[str] = None) -> Dataset:
+    def bad_name_fn(
+        # pylint: disable=unused-argument
+        name: Optional[str] = None,
+        digest: Optional[str] = None,
+    ) -> Dataset:
         pass
 
     with pytest.raises(MlflowException, match="Constructor name must start with"):
@@ -48,27 +55,39 @@ def test_register_constructor_function_performs_validation():
             constructor_fn=from_good_function, constructor_name="bad_name"
         )
 
-    def from_no_name_fn(digest: Optional[str] = None) -> Dataset:
+    def from_no_name_fn(
+        digest: Optional[str] = None,  # pylint: disable=unused-argument
+    ) -> Dataset:
         pass
 
     with pytest.raises(MlflowException, match="must define an optional parameter named 'name'"):
         registry.register_constructor(from_no_name_fn)
 
-    def from_no_digest_fn(name: Optional[str] = None) -> Dataset:
+    def from_no_digest_fn(
+        name: Optional[str] = None,  # pylint: disable=unused-argument
+    ) -> Dataset:
         pass
 
     with pytest.raises(MlflowException, match="must define an optional parameter named 'digest'"):
         registry.register_constructor(from_no_digest_fn)
 
     def from_bad_return_type_fn(
-        path: str, name: Optional[str] = None, digest: Optional[str] = None
+        # pylint: disable=unused-argument
+        path: str,
+        name: Optional[str] = None,
+        digest: Optional[str] = None,
     ) -> str:
         pass
 
     with pytest.raises(MlflowException, match="must have a return type annotation.*Dataset"):
         registry.register_constructor(from_bad_return_type_fn)
 
-    def from_no_return_type_fn(path: str, name: Optional[str] = None, digest: Optional[str] = None):
+    def from_no_return_type_fn(
+        # pylint: disable=unused-argument
+        path: str,
+        name: Optional[str] = None,
+        digest: Optional[str] = None,
+    ):
         pass
 
     with pytest.raises(MlflowException, match="must have a return type annotation.*Dataset"):

--- a/tests/data/test_spark_dataset.py
+++ b/tests/data/test_spark_dataset.py
@@ -214,7 +214,7 @@ def test_from_spark_delta_path(spark_session, tmp_path, df):
     _check_spark_dataset(mlflow_df, df, df_spark, DeltaDatasetSource)
 
 
-def test_from_spark_sql(spark_session, tmp_path, df):
+def test_from_spark_sql(spark_session, df):
     df_spark = spark_session.createDataFrame(df)
     df_spark.createOrReplaceTempView("table")
 
@@ -223,7 +223,7 @@ def test_from_spark_sql(spark_session, tmp_path, df):
     _check_spark_dataset(mlflow_df, df, df_spark, SparkDatasetSource)
 
 
-def test_from_spark_table_name(spark_session, tmp_path, df):
+def test_from_spark_table_name(spark_session, df):
     df_spark = spark_session.createDataFrame(df)
     df_spark.createOrReplaceTempView("my_spark_table")
 
@@ -232,7 +232,7 @@ def test_from_spark_table_name(spark_session, tmp_path, df):
     _check_spark_dataset(mlflow_df, df, df_spark, SparkDatasetSource)
 
 
-def test_from_spark_table_name_with_version(spark_session, tmp_path, df):
+def test_from_spark_table_name_with_version(spark_session, df):
     df_spark = spark_session.createDataFrame(df)
     df_spark.createOrReplaceTempView("my_spark_table")
 
@@ -244,7 +244,7 @@ def test_from_spark_table_name_with_version(spark_session, tmp_path, df):
         mlflow.data.from_spark(df_spark, table_name="my_spark_table", version=1)
 
 
-def test_from_spark_delta_table_name(spark_session, tmp_path, df):
+def test_from_spark_delta_table_name(spark_session, df):
     df_spark = spark_session.createDataFrame(df)
     # write to delta table
     df_spark.write.format("delta").mode("overwrite").saveAsTable("my_delta_table")
@@ -254,7 +254,7 @@ def test_from_spark_delta_table_name(spark_session, tmp_path, df):
     _check_spark_dataset(mlflow_df, df, df_spark, DeltaDatasetSource)
 
 
-def test_from_spark_delta_table_name_and_version(spark_session, tmp_path, df):
+def test_from_spark_delta_table_name_and_version(spark_session, df):
     df_spark = spark_session.createDataFrame(df)
     # write to delta table
     df_spark.write.format("delta").mode("overwrite").saveAsTable("my_delta_table")
@@ -264,7 +264,7 @@ def test_from_spark_delta_table_name_and_version(spark_session, tmp_path, df):
     _check_spark_dataset(mlflow_df, df, df_spark, DeltaDatasetSource)
 
 
-def test_load_delta_with_no_source_info(spark_session, tmp_path):
+def test_load_delta_with_no_source_info():
     with pytest.raises(
         MlflowException,
         match="Must specify exactly one of `table_name` or `path`.",
@@ -272,7 +272,7 @@ def test_load_delta_with_no_source_info(spark_session, tmp_path):
         mlflow.data.load_delta()
 
 
-def test_load_delta_with_both_table_name_and_path(spark_session, tmp_path):
+def test_load_delta_with_both_table_name_and_path():
     with pytest.raises(
         MlflowException,
         match="Must specify exactly one of `table_name` or `path`.",

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1212,7 +1212,7 @@ def test_evaluate_terminates_model_servers(multiclass_logistic_regressor_model_u
         os_mock.assert_has_calls([mock.call(1, signal.SIGTERM), mock.call(2, signal.SIGTERM)])
 
 
-def test_evaluate_stdin_scoring_server(monkeypatch):
+def test_evaluate_stdin_scoring_server():
     X, y = sklearn.datasets.load_iris(return_X_y=True)
     X = X[::5]
     y = y[::5]

--- a/tests/johnsnowlabs/test_johnsnowlabs_model_export.py
+++ b/tests/johnsnowlabs/test_johnsnowlabs_model_export.py
@@ -102,7 +102,7 @@ def validate_model(original_model, new_model):
 
 
 @pytest.fixture
-def jsl_model(model_path, load_and_init_model):
+def jsl_model(load_and_init_model):
     yield load_and_init_model
 
 

--- a/tests/models/test_model_input_examples.py
+++ b/tests/models/test_model_input_examples.py
@@ -223,7 +223,7 @@ class DummySklearnModel(BaseEstimator, ClassifierMixin):
     def __init__(self, output_shape=(1,)):
         self.output_shape = output_shape
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None):  # pylint: disable=unused-argument
         return self
 
     def predict(self, X):
@@ -297,7 +297,7 @@ def test_infer_signature_silently_fails(monkeypatch):
     monkeypatch.setenv("MLFLOW_TESTING", "false")
 
     class ErrorModel(BaseEstimator, ClassifierMixin):
-        def fit(self, X, y=None):
+        def fit(self, X, y=None):  # pylint: disable=unused-argument
             return self
 
         def predict(self, X):
@@ -360,7 +360,7 @@ def test_infer_signature_on_multi_column_input_examples(input_example, iris_mode
 )
 def test_infer_signature_on_scalar_input_examples(input_example):
     class IdentitySklearnModel(BaseEstimator, ClassifierMixin):
-        def fit(self, X, y=None):
+        def fit(self, X, y=None):  # pylint: disable=unused-argument
             return self
 
         def predict(self, X):

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -733,7 +733,7 @@ def test_spark_udf_with_col_spec_type_input(spark):
         np.testing.assert_almost_equal(res.c_float.tolist(), [1.5])
 
 
-def test_spark_udf_stdin_scoring_server(spark, monkeypatch):
+def test_spark_udf_stdin_scoring_server(spark):
     X, y = datasets.load_iris(return_X_y=True, as_frame=True)
     X = X[::5]
     y = y[::5]

--- a/tests/recipes/test_train_step.py
+++ b/tests/recipes/test_train_step.py
@@ -219,7 +219,7 @@ def test_train_step(tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path):
 
 
 @mock.patch("mlflow.recipes.steps.train._REBALANCING_CUTOFF", 50)
-def test_train_step_imbalanced_data(tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path, capsys):
+def test_train_step_imbalanced_data(tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path):
     train_step_output_dir = setup_train_dataset(
         tmp_recipe_exec_path, recipe="classification/multiclass"
     )
@@ -359,13 +359,13 @@ def classifier_estimator_fn(estimator_params=None):
     return SGDClassifier(random_state=42, **(estimator_params or {}))
 
 
-def classifier_with_predict_proba_estimator_fn(estimator_params=None):
+def sklearn_logistic_regression():
     from sklearn.linear_model import LogisticRegression
 
     return LogisticRegression()
 
 
-def classifier_with_xgboost_model(estimator_params=None):
+def xgb_classifier():
     import xgboost as xgb
 
     return xgb.XGBClassifier()
@@ -714,10 +714,7 @@ def test_train_step_with_predict_probability(
             tracking_uri=mlflow.get_tracking_uri()
         )
     )
-    with mock.patch(
-        "steps.train.estimator_fn",
-        classifier_with_predict_proba_estimator_fn,
-    ):
+    with mock.patch("steps.train.estimator_fn", return_value=sklearn_logistic_regression()):
         recipe_config = read_yaml(tmp_recipe_root_path, _RECIPE_CONFIG_FILE_NAME)
         train_step = TrainStep.from_recipe_config(recipe_config, str(tmp_recipe_root_path))
         train_step.run(str(train_step_output_dir))
@@ -789,10 +786,7 @@ def test_train_step_with_predict_probability_with_custom_prefix(
             tracking_uri=mlflow.get_tracking_uri()
         )
     )
-    with mock.patch(
-        "steps.train.estimator_fn",
-        classifier_with_predict_proba_estimator_fn,
-    ):
+    with mock.patch("steps.train.estimator_fn", return_value=sklearn_logistic_regression()):
         recipe_config = read_yaml(tmp_recipe_root_path, _RECIPE_CONFIG_FILE_NAME)
         train_step = TrainStep.from_recipe_config(recipe_config, str(tmp_recipe_root_path))
         train_step.run(str(train_step_output_dir))
@@ -846,10 +840,7 @@ def test_train_step_with_label_encoding(tmp_recipe_root_path: Path, tmp_recipe_e
             tracking_uri=mlflow.get_tracking_uri()
         )
     )
-    with mock.patch(
-        "steps.train.estimator_fn",
-        classifier_with_xgboost_model,
-    ):
+    with mock.patch("steps.train.estimator_fn", return_value=xgb_classifier()):
         recipe_config = read_yaml(tmp_recipe_root_path, _RECIPE_CONFIG_FILE_NAME)
         train_step = TrainStep.from_recipe_config(recipe_config, str(tmp_recipe_root_path))
         train_step.run(str(train_step_output_dir))
@@ -906,10 +897,7 @@ def test_train_step_with_probability_calibration(
             tracking_uri=mlflow.get_tracking_uri()
         )
     )
-    with mock.patch(
-        "steps.train.estimator_fn",
-        classifier_with_predict_proba_estimator_fn,
-    ):
+    with mock.patch("steps.train.estimator_fn", return_value=sklearn_logistic_regression()):
         recipe_config = read_yaml(tmp_recipe_root_path, _RECIPE_CONFIG_FILE_NAME)
         train_step = TrainStep.from_recipe_config(recipe_config, str(tmp_recipe_root_path))
         train_step.run(str(train_step_output_dir))

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -59,7 +59,7 @@ def test_model_save_and_load(model_path, basic_model):
     assert all(len(x) == 384 for x in encoded_multi)
 
 
-def test_dependency_mapping(model_path, basic_model):
+def test_dependency_mapping():
     pip_requirements = mlflow.sentence_transformers.get_default_pip_requirements()
 
     expected_requirements = {"sentence-transformers", "torch", "transformers"}
@@ -290,7 +290,7 @@ def test_log_model_with_code_paths(basic_model):
         add_mock.assert_called()
 
 
-def test_default_signature_assignment(model_path, basic_model):
+def test_default_signature_assignment():
     expected_signature = {
         "inputs": '[{"type": "string"}]',
         "outputs": '[{"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": ' "[-1]}}]",
@@ -323,7 +323,7 @@ def test_model_pyfunc_save_load(basic_model, model_path):
     np.testing.assert_array_equal(emb1, emb3)
 
 
-def test_spark_udf(basic_model, model_path, spark):
+def test_spark_udf(basic_model, spark):
     with mlflow.start_run():
         model_info = mlflow.sentence_transformers.log_model(basic_model, "my_model")
 

--- a/tests/store/artifact/test_azure_data_lake_artifact_repo.py
+++ b/tests/store/artifact/test_azure_data_lake_artifact_repo.py
@@ -110,7 +110,7 @@ def test_list_artifacts_single_file(mock_data_lake_client):
     assert repo.list_artifacts("file") == []
 
 
-def test_list_artifacts(mock_data_lake_client, mock_filesystem_client):
+def test_list_artifacts(mock_filesystem_client):
     repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)
 
     # Create some files to return
@@ -134,9 +134,7 @@ def test_list_artifacts(mock_data_lake_client, mock_filesystem_client):
     )
 
 
-def test_log_artifacts(
-    mock_data_lake_client, mock_filesystem_client, mock_directory_client, mock_file_client, tmp_path
-):
+def test_log_artifacts(mock_filesystem_client, mock_directory_client, tmp_path):
     repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)
 
     parentd = tmp_path.joinpath("data")
@@ -163,9 +161,7 @@ def test_log_artifacts(
     mock_directory_client.get_file_client("subdir/empty-file.txt").create_file.assert_called()
 
 
-def test_download_file_artifact(
-    mock_data_lake_client, mock_filesystem_client, mock_directory_client, mock_file_client, tmp_path
-):
+def test_download_file_artifact(mock_directory_client, mock_file_client, tmp_path):
     repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)
 
     def create_file(file):

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -1235,7 +1235,7 @@ def extract_part_number(url):
     return int(re.search(r"partNumber=(\d+)", url).group(1))
 
 
-def mock_request(method, url, *args, **kwargs):
+def mock_request(method, url, *_args, **_kwargs):
     resp = Response()
     resp.status_code = 200
     resp.close = lambda: None
@@ -1309,7 +1309,7 @@ def test_multipart_upload(databricks_artifact_repo, large_file, mock_chunk_size)
 STATUS_CODE_GENERATOR = (s for s in (403, 200))
 
 
-def mock_request_retry(method, url, *args, **kwargs):
+def mock_request_retry(method, url, *_args, **_kwargs):
     resp = Response()
     resp.status_code = 200
     resp.close = lambda: None

--- a/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
+++ b/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
@@ -56,10 +56,9 @@ def test_uc_models_artifact_repo_init_not_using_databricks_registry_raises():
         UnityCatalogModelsArtifactRepository(model_uri, non_databricks_uri)
 
 
-@mock.patch("databricks_cli.configure.provider.get_config")
-def test_uc_models_artifact_repo_with_stage_uri_raises(get_config):
+def test_uc_models_artifact_repo_with_stage_uri_raises():
     model_uri = "models:/MyModel/Staging"
-    with pytest.raises(
+    with mock.patch("databricks_cli.configure.provider.get_config"), pytest.raises(
         MlflowException,
         match="If seeing this error while attempting to load a model version by stage, note that "
         "setting stages and loading model versions by stage is unsupported in Unity Catalog",
@@ -87,8 +86,7 @@ def _mock_temporary_creds_response(temporary_creds):
     return mock_response
 
 
-@mock.patch("databricks_cli.configure.provider.get_config")
-def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_aws(get_config):
+def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_aws():
     artifact_location = "s3://blah_bucket/"
     fake_key_id = "fake_key_id"
     fake_secret_access_key = "fake_secret_access_key"
@@ -101,7 +99,7 @@ def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_aws(get
         }
     }
     fake_local_path = "/tmp/fake_path"
-    with mock.patch.object(
+    with mock.patch("databricks_cli.configure.provider.get_config"), mock.patch.object(
         MlflowClient, "get_model_version_download_uri", return_value=artifact_location
     ), mock.patch("mlflow.utils.rest_utils.http_request") as request_mock, mock.patch(
         "mlflow.store.artifact.s3_artifact_repo.S3ArtifactRepository"
@@ -129,8 +127,7 @@ def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_aws(get
         )
 
 
-@mock.patch("databricks_cli.configure.provider.get_config")
-def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_azure(get_config):
+def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_azure():
     artifact_location = "abfss://filesystem@account.dfs.core.windows.net"
     fake_sas_token = "fake_session_token"
     temporary_creds = {
@@ -139,7 +136,7 @@ def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_azure(g
         },
     }
     fake_local_path = "/tmp/fake_path"
-    with mock.patch.object(
+    with mock.patch("databricks_cli.configure.provider.get_config"), mock.patch.object(
         MlflowClient, "get_model_version_download_uri", return_value=artifact_location
     ), mock.patch("mlflow.utils.rest_utils.http_request") as request_mock, mock.patch(
         "mlflow.store.artifact.azure_data_lake_artifact_repo.AzureDataLakeArtifactRepository"
@@ -167,8 +164,7 @@ def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_azure(g
         )
 
 
-@mock.patch("databricks_cli.configure.provider.get_config")
-def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_gcp(get_config):
+def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_gcp():
     artifact_location = "gs://test_bucket/some/path"
     fake_oauth_token = "fake_session_token"
     temporary_creds = {
@@ -177,7 +173,7 @@ def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_gcp(get
         },
     }
     fake_local_path = "/tmp/fake_path"
-    with mock.patch.object(
+    with mock.patch("databricks_cli.configure.provider.get_config"), mock.patch.object(
         MlflowClient, "get_model_version_download_uri", return_value=artifact_location
     ), mock.patch("mlflow.utils.rest_utils.http_request") as request_mock, mock.patch(
         "google.cloud.storage.Client"
@@ -229,8 +225,7 @@ def test_uc_models_artifact_repo_uses_active_catalog_and_schema():
         assert models_repo.model_name == "main.default.MyModel"
 
 
-@mock.patch("databricks_cli.configure.provider.get_config")
-def test_uc_models_artifact_repo_list_artifacts_uses_temporary_creds(get_config):
+def test_uc_models_artifact_repo_list_artifacts_uses_temporary_creds():
     artifact_location = "abfss://filesystem@account.dfs.core.windows.net"
     fake_sas_token = "fake_session_token"
     temporary_creds = {
@@ -239,7 +234,7 @@ def test_uc_models_artifact_repo_list_artifacts_uses_temporary_creds(get_config)
         },
     }
     fake_local_path = "/tmp/fake_path"
-    with mock.patch.object(
+    with mock.patch("databricks_cli.configure.provider.get_config"), mock.patch.object(
         MlflowClient, "get_model_version_download_uri", return_value=artifact_location
     ), mock.patch("mlflow.utils.rest_utils.http_request") as request_mock, mock.patch(
         "mlflow.store.artifact.azure_data_lake_artifact_repo.AzureDataLakeArtifactRepository"

--- a/tests/store/model_registry/test_file_store.py
+++ b/tests/store/model_registry/test_file_store.py
@@ -103,7 +103,8 @@ def test_list_registered_model(store, registered_model_names, rm_data):
         assert name == rm_data[name]["name"]
 
 
-def test_rename_registered_model(store, registered_model_names, rm_data):
+@pytest.mark.usefixtures(rm_data.__name__)
+def test_rename_registered_model(store, registered_model_names):
     # Error cases
     model_name = registered_model_names[0]
     with pytest.raises(MlflowException, match=r"Registered model name cannot be empty\."):
@@ -125,7 +126,8 @@ def _extract_names(registered_models):
     return [rm.name for rm in registered_models]
 
 
-def test_delete_registered_model(store, registered_model_names, rm_data):
+@pytest.mark.usefixtures(rm_data.__name__)
+def test_delete_registered_model(store, registered_model_names):
     model_name = registered_model_names[random_int(0, len(registered_model_names) - 1)]
 
     # Error cases

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -408,8 +408,7 @@ class TestRestStore:
         mock_response.status_code = 200
         return mock_response
 
-    @mock.patch("requests.Session.request")
-    def test_get_metric_history_paginated(self, request):
+    def test_get_metric_history_paginated(self):
         creds = MlflowHostCreds("https://hello")
         store = RestStore(lambda: creds)
 
@@ -467,8 +466,7 @@ class TestRestStore:
             assert metrics[1] == Metric(key="a_metric", value=56, timestamp=123456897, step=3)
             assert metrics.token is None
 
-    @mock.patch("requests.Session.request")
-    def test_get_metric_history_on_non_existent_metric_key(self, request):
+    def test_get_metric_history_on_non_existent_metric_key(self):
         creds = MlflowHostCreds("https://hello")
         rest_store = RestStore(lambda: creds)
         empty_metric_response = self._mock_response_with_200_status_code()

--- a/tests/tracking/_model_registry/test_utils.py
+++ b/tests/tracking/_model_registry/test_utils.py
@@ -125,7 +125,7 @@ def test_get_store_caches_on_store_uri(tmp_path):
 
 
 @pytest.mark.parametrize("store_uri", ["databricks-uc", "databricks-uc://profile"])
-def test_get_store_uc_registry_uri(store_uri, reset_registry_uri):
+def test_get_store_uc_registry_uri(store_uri):
     assert isinstance(_get_store(store_uri), UcModelRegistryStore)
 
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -1041,7 +1041,10 @@ def test_get_metric_history_bulk_calls_optimized_impl_when_expected(tmp_path):
         def __init__(self, args_dict):
             self.args_dict = args_dict
 
-        def to_dict(self, flat):
+        def to_dict(
+            self,
+            flat,  # pylint: disable=unused-argument
+        ):
             return self.args_dict
 
         def get(self, key, default=None):

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -1028,7 +1028,7 @@ def test_get_metric_history_bulk_respects_max_results(mlflow_client):
     ]
 
 
-def test_get_metric_history_bulk_calls_optimized_impl_when_expected(monkeypatch, tmp_path):
+def test_get_metric_history_bulk_calls_optimized_impl_when_expected(tmp_path):
     from mlflow.server.handlers import get_metric_history_bulk_handler
 
     path = path_to_local_file_uri(str(tmp_path.joinpath("sqlalchemy.db")))
@@ -1175,7 +1175,7 @@ def test_create_model_version_with_path_source(mlflow_client):
     assert "To use a local path as a model version" in response.json()["message"]
 
 
-def test_create_model_version_with_non_local_source(mlflow_client, monkeypatch):
+def test_create_model_version_with_non_local_source(mlflow_client):
     name = "model"
     mlflow_client.create_registered_model(name)
     exp_id = mlflow_client.create_experiment("test")

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -842,7 +842,7 @@ def test_multi_modal_component_save_and_load(component_multi_modal, model_path, 
 
 @flaky()
 def test_pipeline_saved_model_with_processor_cannot_be_loaded_as_pipeline(
-    component_multi_modal, model_path, image_for_test
+    component_multi_modal, model_path
 ):
     invalid_pipeline = transformers.pipeline(
         task="visual-question-answering", **component_multi_modal
@@ -1071,9 +1071,7 @@ def test_transformers_log_with_extra_pip_requirements(small_multi_modal_pipeline
         )
 
 
-def test_transformers_log_with_duplicate_pip_requirements(
-    small_multi_modal_pipeline, tmp_path, capsys
-):
+def test_transformers_log_with_duplicate_pip_requirements(small_multi_modal_pipeline, capsys):
     with mlflow.start_run():
         mlflow.transformers.log_model(
             small_multi_modal_pipeline,
@@ -1087,9 +1085,7 @@ def test_transformers_log_with_duplicate_pip_requirements(
     )
 
 
-def test_transformers_log_with_duplicate_extra_pip_requirements(
-    small_multi_modal_pipeline, tmp_path, capsys
-):
+def test_transformers_log_with_duplicate_extra_pip_requirements(small_multi_modal_pipeline, capsys):
     with mlflow.start_run():
         mlflow.transformers.log_model(
             small_multi_modal_pipeline,
@@ -1855,7 +1851,7 @@ def test_infer_signature_from_example_only(
         assert model.saved_input_example_info is None
 
 
-def test_qa_pipeline_pyfunc_predict(small_qa_pipeline, tmp_path):
+def test_qa_pipeline_pyfunc_predict(small_qa_pipeline):
     artifact_path = "qa_model"
     with mlflow.start_run():
         mlflow.transformers.log_model(
@@ -1911,7 +1907,7 @@ def test_qa_pipeline_pyfunc_predict(small_qa_pipeline, tmp_path):
     assert values.to_dict(orient="records") == [{0: "Run"}]
 
 
-def test_classifier_pipeline_pyfunc_predict(text_classification_pipeline, tmp_path):
+def test_classifier_pipeline_pyfunc_predict(text_classification_pipeline):
     artifact_path = "text_classifier_model"
     with mlflow.start_run():
         mlflow.transformers.log_model(
@@ -1955,7 +1951,7 @@ def test_classifier_pipeline_pyfunc_predict(text_classification_pipeline, tmp_pa
     assert len(values.to_dict()["score"]) == 1
 
 
-def test_zero_shot_pipeline_pyfunc_predict(zero_shot_pipeline, tmp_path):
+def test_zero_shot_pipeline_pyfunc_predict(zero_shot_pipeline):
     artifact_path = "zero_shot_classifier_model"
     with mlflow.start_run():
         mlflow.transformers.log_model(
@@ -2012,7 +2008,7 @@ def test_zero_shot_pipeline_pyfunc_predict(zero_shot_pipeline, tmp_path):
     assert len(values.to_dict()["labels"]) == 6
 
 
-def test_table_question_answering_pyfunc_predict(table_question_answering_pipeline, tmp_path):
+def test_table_question_answering_pyfunc_predict(table_question_answering_pipeline):
     artifact_path = "table_qa_model"
     with mlflow.start_run():
         mlflow.transformers.log_model(

--- a/tests/utils/test_docstring_utils.py
+++ b/tests/utils/test_docstring_utils.py
@@ -25,7 +25,7 @@ def test_get_minimum_indentation():
 
 def test_format_docstring():
     @format_docstring({"p": "param doc"})
-    def single_param(p):
+    def single_param(_p):
         """
         :param p:{{ p }}
         """
@@ -38,7 +38,7 @@ def test_format_docstring():
     assert single_param.__name__ == "single_param"
 
     @format_docstring({"p1": "param1 doc", "p2": "param2 doc"})
-    def multiple_params(p1, p2):
+    def multiple_params(_p1, _p2):
         """
         :param p1:{{ p1 }}
         :param p2:{{ p2 }}

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -71,7 +71,7 @@ def test_join_continued_lines():
     assert list(_join_continued_lines(["\\", "a"])) == ["a"]
 
 
-def test_parse_requirements(request, tmp_path, monkeypatch):
+def test_parse_requirements(tmp_path, monkeypatch):
     """
     Ensures `_parse_requirements` returns the same result as `pip._internal.req.parse_requirements`
     """

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -375,22 +375,22 @@ def test_http_request_request_headers_user_agent_and_extra_header(request):
         )
 
 
-@mock.patch("requests.Session.request", side_effect=requests.exceptions.InvalidURL)
-def test_http_request_with_invalid_url_raise_invalid_url_exception(request):
+def test_http_request_with_invalid_url_raise_invalid_url_exception():
     """InvalidURL exception can be caught by a custom InvalidUrlException"""
     host_only = MlflowHostCreds("http://my-host")
 
     with pytest.raises(InvalidUrlException, match="Invalid url: http://my-host/invalid_url"):
-        http_request(host_only, "/invalid_url", "GET")
+        with mock.patch("requests.Session.request", side_effect=requests.exceptions.InvalidURL):
+            http_request(host_only, "/invalid_url", "GET")
 
 
-@mock.patch("requests.Session.request", side_effect=requests.exceptions.InvalidURL)
-def test_http_request_with_invalid_url_raise_mlflow_exception(request):
+def test_http_request_with_invalid_url_raise_mlflow_exception():
     """The InvalidUrlException can be caught by the MlflowException"""
     host_only = MlflowHostCreds("http://my-host")
 
     with pytest.raises(MlflowException, match="Invalid url: http://my-host/invalid_url"):
-        http_request(host_only, "/invalid_url", "GET")
+        with mock.patch("requests.Session.request", side_effect=requests.exceptions.InvalidURL):
+            http_request(host_only, "/invalid_url", "GET")
 
 
 def test_ignore_tls_verification_not_server_cert_path():


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

I found the `unused-argument` rule was disabled:

https://github.com/mlflow/mlflow/blob/ae2bf62a8b3ca50b671aa784b115577769974ff6/pylintrc#L147

This means unused arguments are allowed, but they should not be allowed. This PR removes some of them. I'll file a few more PRs to remove them, then enable the rule.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
