### PR TITLE
[Gateway] Support Azure OpenAI

### DIFF
--- a/examples/gateway/azure_openai.yaml
+++ b/examples/gateway/azure_openai.yaml
@@ -3,7 +3,7 @@ routes:
     route_type: llm/v1/chat
     model:
       provider: openai
-      name: gpt-3.5-turbo
+      name: gpt-35-turbo
       config:
         openai_api_type: "azure"
         openai_api_key: $OPENAI_API_KEY
@@ -15,7 +15,7 @@ routes:
     route_type: llm/v1/completions
     model:
       provider: openai
-      name: gpt-3.5-turbo
+      name: gpt-35-turbo
       config:
         openai_api_type: "azuread"
         openai_api_key: $AZURE_AAD_TOKEN

--- a/examples/gateway/azure_openai.yaml
+++ b/examples/gateway/azure_openai.yaml
@@ -1,0 +1,36 @@
+routes:
+  - name: chat
+    route_type: llm/v1/chat
+    model:
+      provider: openai
+      name: gpt-3.5-turbo
+      config:
+        openai_api_type: "azure"
+        openai_api_key: $OPENAI_API_KEY
+        openai_deployment_name: "{your_deployment_name}"
+        openai_api_base: "https://{your_resource_name}-azureopenai.openai.azure.com/"
+        openai_api_version: "2023-05-15"
+
+  - name: completions
+    route_type: llm/v1/completions
+    model:
+      provider: openai
+      name: gpt-3.5-turbo
+      config:
+        openai_api_type: "azuread"
+        openai_api_key: $AZURE_AAD_TOKEN
+        openai_deployment_name: "{your_deployment_name}"
+        openai_api_base: "https://{your_resource_name}-azureopenai.openai.azure.com/"
+        openai_api_version: "2023-05-15"
+
+  - name: embeddings
+    route_type: llm/v1/embeddings
+    model:
+      provider: openai
+      name: text-embedding-ada-002
+      config:
+        openai_api_type: "azure"
+        openai_api_key: $OPENAI_API_KEY
+        openai_deployment_name: "{your_deployment_name}"
+        openai_api_base: "https://{your_resource_name}-azureopenai.openai.azure.com/"
+        openai_api_version: "2023-05-15"

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -49,6 +49,7 @@ class OpenAIConfig(BaseModel, extra=Extra.forbid):
     openai_api_type: Optional[str] = None
     openai_api_base: str = "https://api.openai.com/v1"
     openai_api_version: Optional[str] = None
+    openai_deployment_name: Optional[str] = None
     openai_organization: Optional[str] = None
 
     # pylint: disable=no-self-argument

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -74,7 +74,7 @@ class OpenAIConfig(BaseModel, extra=Extra.allow):
 
     @root_validator(pre=False)
     def validate_field_compatibility(cls, config: "OpenAIConfig"):
-        api_type = config["openai_api_type"]
+        api_type = config.get("openai_api_type")
         if api_type == OpenAIAPIType.OPENAI:
             if config.get("openai_deployment_name") is not None:
                 raise MlflowException.invalid_parameter_value(

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -81,6 +81,8 @@ class OpenAIConfig(BaseModel, extra=Extra.allow):
                     f"'openai_deployment_name' if 'openai_api_type' is '{OpenAIAPIType.AZURE}' "
                     f"or '{OpenAIAPIType.AZUREAD}'. Found type: '{api_type}'"
                 )
+            if config.get("openai_api_base") is None:
+                config["openai_api_base"] = "https://api.openai.com/v1"
         elif api_type in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD):
             if config.get("openai_organization") is not None:
                 raise MlflowException.invalid_parameter_value(

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -58,6 +58,8 @@ class OpenAIAPIType(str, Enum):
             if api_type.value == value.lower():
                 return api_type
 
+        raise MlflowException.invalid_parameter_value(f"Invalid OpenAI API type '{value}'")
+
 
 class OpenAIConfig(BaseModel, extra=Extra.allow):
     openai_api_key: str

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -49,6 +49,15 @@ class OpenAIAPIType(str, Enum):
     AZURE = "azure"
     AZUREAD = "azuread"
 
+    @classmethod
+    def _missing_(cls, value):
+        """
+        Implements case-insensitive matching of API type strings
+        """
+        for api_type in cls:
+            if api_type.value == value.lower():
+                return api_type
+
 
 class OpenAIConfig(BaseModel, extra=Extra.allow):
     openai_api_key: str
@@ -62,14 +71,6 @@ class OpenAIConfig(BaseModel, extra=Extra.allow):
     @validator("openai_api_key", pre=True)
     def validate_openai_api_key(cls, value):
         return _resolve_api_key_from_input(value)
-
-    # pylint: disable=no-self-argument
-    @validator("openai_api_type", pre=True)
-    def validate_openai_api_type(cls, value):
-        api_type = value.lower()
-        if api_type not in [api_type.value for api_type in OpenAIAPIType]:
-            raise MlflowException.invalid_parameter_value(f"Invalid OpenAI API type '{api_type}'")
-        return api_type
 
     @root_validator(pre=False)
     def validate_field_compatibility(cls, config: "OpenAIConfig"):

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -52,7 +52,7 @@ class OpenAIAPIType(str, Enum):
 
 class OpenAIConfig(BaseModel, extra=Extra.allow):
     openai_api_key: str
-    openai_api_type: str = OpenAIAPIType.OPENAI
+    openai_api_type: OpenAIAPIType = OpenAIAPIType.OPENAI
     openai_api_base: Optional[str] = None
     openai_api_version: Optional[str] = None
     openai_deployment_name: Optional[str] = None

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 from pydantic import BaseModel, validator, root_validator, parse_obj_as, Extra, ValidationError
 from pydantic.json import pydantic_encoder
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Dict, Any
 import yaml
 
 from mlflow.exceptions import MlflowException
@@ -73,7 +73,7 @@ class OpenAIConfig(BaseModel, extra=Extra.allow):
         return _resolve_api_key_from_input(value)
 
     @root_validator(pre=False)
-    def validate_field_compatibility(cls, config: "OpenAIConfig"):
+    def validate_field_compatibility(cls, config: Dict[str, Any]):
         api_type = config.get("openai_api_type")
         if api_type == OpenAIAPIType.OPENAI:
             if config.get("openai_deployment_name") is not None:

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -1,10 +1,17 @@
 from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 
+from mlflow.exceptions import MlflowException
+from mlflow.utils.uri import append_to_uri_path, append_to_uri_query_params
+
 from .base import BaseProvider
 from .utils import send_request, rename_payload_keys
 from ..schemas import chat, completions, embeddings
 from ..config import OpenAIConfig, RouteConfig
+
+_API_TYPE_OPENAI = "openai"
+_API_TYPE_AZURE = "azure"
+_API_TYPE_AZUREAD = "azuread"
 
 
 class OpenAIProvider(BaseProvider):
@@ -12,12 +19,77 @@ class OpenAIProvider(BaseProvider):
         super().__init__(config)
         if config.model.config is None or not isinstance(config.model.config, OpenAIConfig):
             # Should be unreachable
-            raise TypeError(f"Invalid config type {config.model.config}")
+            raise MlflowException.invalid_parameter_value("Invalid config type {config.model.config}")
         self.openai_config: OpenAIConfig = config.model.config
-        self.headers = {"Authorization": f"Bearer {self.openai_config.openai_api_key}"}
-        if org := self.openai_config.openai_organization:
-            self.headers["OpenAI-Organization"] = org
-        self.base_url = self.openai_config.openai_api_base
+        self.openai_api_type = (self.openai_config.openai_api_type or _API_TYPE_OPENAI).lower()
+        self._validate_openai_config()
+
+    def _validate_openai_config(self):
+        if not self.openai_api_key:
+            raise MlflowException.invalid_parameter_value("'openai_api_key' must be specified")
+
+        if self.openai_api_type == _API_TYPE_OPENAI:
+            if self.openai_config.openai_deployment_name is not None:
+                raise MlflowException.invalid_parameter_value(
+                    f"OpenAI route configuration can only specify a value for "
+                    f"'openai_deployment_name' if 'openai_api_type' is '{_API_TYPE_AZURE}' or "
+                    f"'{_API_TYPE_AZUREAD}'. Found type: '{self.openai_api_type}'"
+                )
+        elif self.openai_api_type in (_API_TYPE_AZURE, _API_TYPE_AZUREAD):
+            base_url = self.openai_config.openai_api_base
+            deployment_name = self.openai_config.openai_deployment_name
+            api_version = self.openai_config.openai_api_version
+            if (base_url, deployment_name, api_version).count(None) >= 0:
+                raise MlflowException.invalid_parameter_value(
+                    f"OpenAI route configuration must specify 'openai_api_base', "
+                    f"'openai_deployment_name', and 'openai_api_version' if 'openai_api_type' is "
+                    f"'{_API_TYPE_AZURE}' or '{_API_TYPE_AZUREAD}'."
+                )
+        else:
+            raise MlflowException.invalid_parameter_value(f"Invalid OpenAI API type '{self.openai_api_type}'")
+
+    @property
+    def _request_base_url(self):
+        if self.openai_api_type == _API_TYPE_OPENAI:
+            return self.openai_config.openai_api_base or "https://api.openai.com/v1"
+        elif self.openai_api_type in (_API_TYPE_AZURE, _API_TYPE_AZUREAD):
+            if self.openai_config.openai_api_base is None:
+                raise MlflowException.invalid_parameter_value(
+                    f"'openai_api_base' must be specified when 'openai_api_type' is "
+                    f"'{_API_TYPE_AZURE}' or '{_API_TYPE_AZUREAD}'."
+                )
+            openai_url = append_to_uri_path(
+                self.openai_config.openai_api_base,
+                "openai",
+                "deployment",
+                self.openai_config.openai_deployment_name
+            )
+            return append_to_uri_query_params(
+                openai_url,
+                ("api-version", self.openai_config.openai_api_version),
+            )
+        else:
+            raise MlflowException.invalid_parameter_value(f"Invalid OpenAI API type '{self.openai_api_type}'")
+
+    @property
+    def _request_headers(self):
+        if self.openai_api_type == _API_TYPE_OPENAI:
+            headers = {
+                "Authorization": f"Bearer {self.openai_config.openai_api_key}",
+            }
+            if org := self.openai_config.openai_organization:
+                headers["OpenAI-Organization"] = org
+            return headers
+        elif self.openai_api_type == _API_TYPE_AZUREAD:
+            return {
+                "Authorization": f"Bearer {self.openai_config.openai_api_key}",
+            }
+        elif self.openai_api_type == _API_TYPE_AZURE:
+            return {
+                "api-key": self.openai_config.openai_api_key,
+            }
+        else:
+            raise MlflowException.invalid_parameter_value(f"Invalid OpenAI API type '{self.openai_api_type}'")
 
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
         payload = jsonable_encoder(payload, exclude_none=True)
@@ -34,8 +106,8 @@ class OpenAIProvider(BaseProvider):
         payload["temperature"] = 2 * payload["temperature"]
 
         resp = await send_request(
-            headers=self.headers,
-            base_url=self.base_url,
+            headers=self._request_headers,
+            base_url=self._request_base_url,
             path="chat/completions",
             payload={"model": self.config.model.name, **payload},
         )
@@ -101,8 +173,8 @@ class OpenAIProvider(BaseProvider):
         payload["temperature"] = 2 * payload["temperature"]
         payload["messages"] = [{"role": "user", "content": payload.pop("prompt")}]
         resp = await send_request(
-            headers=self.headers,
-            base_url=self.base_url,
+            headers=self._request_headers,
+            base_url=self._request_base_url,
             path="chat/completions",
             payload={"model": self.config.model.name, **payload},
         )
@@ -153,8 +225,8 @@ class OpenAIProvider(BaseProvider):
             {"text": "input"},
         )
         resp = await send_request(
-            headers=self.headers,
-            base_url=self.base_url,
+            headers=self._request_headers,
+            base_url=self._request_base_url,
             path="embeddings",
             payload={"model": self.config.model.name, **payload},
         )

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -30,11 +30,6 @@ class OpenAIProvider(BaseProvider):
             else:
                 return base_url
         elif api_type in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD):
-            if self.openai_config.openai_api_base is None:
-                raise MlflowException.invalid_parameter_value(
-                    f"OpenAI route configuration must specify 'openai_api_base' when"
-                    f"'openai_api_type' is '{OpenAIAPIType.AZURE}' or '{OpenAIAPIType.AZUREAD}'."
-                )
             openai_url = append_to_uri_path(
                 self.openai_config.openai_api_base,
                 "openai",
@@ -91,7 +86,12 @@ class OpenAIProvider(BaseProvider):
             headers=self._request_headers,
             base_url=self._request_base_url,
             path="chat/completions",
-            payload={"model": self.config.model.name, **payload},
+            payload=(
+                {"model": self.config.model.name, **payload}
+                if self.openai_config.openai_api_type
+                in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD)
+                else payload
+            ),
         )
         # Response example (https://platform.openai.com/docs/api-reference/chat/create)
         # ```

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -87,6 +87,9 @@ class OpenAIProvider(BaseProvider):
             base_url=self._request_base_url,
             path="chat/completions",
             payload=(
+                # For Azure OpenAI, the deployment name (which is included in the URL) specifies
+                # the model; it is not specified in the payoad. For OpenAI outside of Azure, the
+                # model is always specified in the payload
                 payload
                 if self.openai_config.openai_api_type
                 in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD)
@@ -159,6 +162,9 @@ class OpenAIProvider(BaseProvider):
             base_url=self._request_base_url,
             path="chat/completions",
             payload=(
+                # For Azure OpenAI, the deployment name (which is included in the URL) specifies
+                # the model; it is not specified in the payoad. For OpenAI outside of Azure, the
+                # model is always specified in the payload
                 payload
                 if self.openai_config.openai_api_type
                 in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD)
@@ -216,6 +222,9 @@ class OpenAIProvider(BaseProvider):
             base_url=self._request_base_url,
             path="embeddings",
             payload=(
+                # For Azure OpenAI, the deployment name (which is included in the URL) specifies
+                # the model; it is not specified in the payoad. For OpenAI outside of Azure, the
+                # model is always specified in the payload
                 payload
                 if self.openai_config.openai_api_type
                 in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD)

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -68,6 +68,15 @@ class OpenAIProvider(BaseProvider):
                 f"Invalid OpenAI API type '{self.openai_api_type}'"
             )
 
+    def _add_model_to_payload_if_necessary(self, payload):
+        # NB: For Azure OpenAI, the deployment name (which is included in the URL) specifies
+        # the model; it is not specified in the payoad. For OpenAI outside of Azure, the
+        # model is always specified in the payload
+        if self.openai_config.openai_api_type not in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD):
+            return {"model": self.config.model.name, **payload}
+        else:
+            return payload
+
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
         payload = jsonable_encoder(payload, exclude_none=True)
         if "n" in payload:
@@ -86,15 +95,7 @@ class OpenAIProvider(BaseProvider):
             headers=self._request_headers,
             base_url=self._request_base_url,
             path="chat/completions",
-            payload=(
-                # For Azure OpenAI, the deployment name (which is included in the URL) specifies
-                # the model; it is not specified in the payoad. For OpenAI outside of Azure, the
-                # model is always specified in the payload
-                payload
-                if self.openai_config.openai_api_type
-                in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD)
-                else {"model": self.config.model.name, **payload}
-            ),
+            payload=self._add_model_to_payload_if_necessary(payload),
         )
         # Response example (https://platform.openai.com/docs/api-reference/chat/create)
         # ```
@@ -161,15 +162,7 @@ class OpenAIProvider(BaseProvider):
             headers=self._request_headers,
             base_url=self._request_base_url,
             path="chat/completions",
-            payload=(
-                # For Azure OpenAI, the deployment name (which is included in the URL) specifies
-                # the model; it is not specified in the payoad. For OpenAI outside of Azure, the
-                # model is always specified in the payload
-                payload
-                if self.openai_config.openai_api_type
-                in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD)
-                else {"model": self.config.model.name, **payload}
-            ),
+            payload=self._add_model_to_payload_if_necessary(payload),
         )
         # Response example (https://platform.openai.com/docs/api-reference/completions/create)
         # ```
@@ -221,15 +214,7 @@ class OpenAIProvider(BaseProvider):
             headers=self._request_headers,
             base_url=self._request_base_url,
             path="embeddings",
-            payload=(
-                # For Azure OpenAI, the deployment name (which is included in the URL) specifies
-                # the model; it is not specified in the payoad. For OpenAI outside of Azure, the
-                # model is always specified in the payload
-                payload
-                if self.openai_config.openai_api_type
-                in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD)
-                else {"model": self.config.model.name, **payload}
-            ),
+            payload=self._add_model_to_payload_if_necessary(payload),
         )
         # Response example (https://platform.openai.com/docs/api-reference/embeddings/create):
         # ```

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -27,8 +27,10 @@ class OpenAIProvider(BaseProvider):
         self._validate_openai_config()
 
     def _validate_openai_config(self):
-        if not self.openai_api_key:
-            raise MlflowException.invalid_parameter_value("'openai_api_key' must be specified")
+        if not self.openai_config.openai_api_key:
+            raise MlflowException.invalid_parameter_value(
+                "OpenAI route configuration must specify 'openai_api_key'"
+            )
 
         if self.openai_api_type == _API_TYPE_OPENAI:
             if self.openai_config.openai_deployment_name is not None:
@@ -41,7 +43,7 @@ class OpenAIProvider(BaseProvider):
             base_url = self.openai_config.openai_api_base
             deployment_name = self.openai_config.openai_deployment_name
             api_version = self.openai_config.openai_api_version
-            if (base_url, deployment_name, api_version).count(None) >= 0:
+            if (base_url, deployment_name, api_version).count(None) > 0:
                 raise MlflowException.invalid_parameter_value(
                     f"OpenAI route configuration must specify 'openai_api_base', "
                     f"'openai_deployment_name', and 'openai_api_version' if 'openai_api_type' is "
@@ -59,13 +61,13 @@ class OpenAIProvider(BaseProvider):
         elif self.openai_api_type in (_API_TYPE_AZURE, _API_TYPE_AZUREAD):
             if self.openai_config.openai_api_base is None:
                 raise MlflowException.invalid_parameter_value(
-                    f"'openai_api_base' must be specified when 'openai_api_type' is "
-                    f"'{_API_TYPE_AZURE}' or '{_API_TYPE_AZUREAD}'."
+                    f"OpenAI route configuration must specify 'openai_api_base' when"
+                    f"'openai_api_type' is '{_API_TYPE_AZURE}' or '{_API_TYPE_AZUREAD}'."
                 )
             openai_url = append_to_uri_path(
                 self.openai_config.openai_api_base,
                 "openai",
-                "deployment",
+                "deployments",
                 self.openai_config.openai_deployment_name,
             )
             return append_to_uri_query_params(

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -87,10 +87,10 @@ class OpenAIProvider(BaseProvider):
             base_url=self._request_base_url,
             path="chat/completions",
             payload=(
-                {"model": self.config.model.name, **payload}
+                payload
                 if self.openai_config.openai_api_type
                 in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD)
-                else payload
+                else {"model": self.config.model.name, **payload}
             ),
         )
         # Response example (https://platform.openai.com/docs/api-reference/chat/create)
@@ -158,7 +158,12 @@ class OpenAIProvider(BaseProvider):
             headers=self._request_headers,
             base_url=self._request_base_url,
             path="chat/completions",
-            payload={"model": self.config.model.name, **payload},
+            payload=(
+                payload
+                if self.openai_config.openai_api_type
+                in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD)
+                else {"model": self.config.model.name, **payload}
+            ),
         )
         # Response example (https://platform.openai.com/docs/api-reference/completions/create)
         # ```
@@ -210,7 +215,12 @@ class OpenAIProvider(BaseProvider):
             headers=self._request_headers,
             base_url=self._request_base_url,
             path="embeddings",
-            payload={"model": self.config.model.name, **payload},
+            payload=(
+                payload
+                if self.openai_config.openai_api_type
+                in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD)
+                else {"model": self.config.model.name, **payload}
+            ),
         )
         # Response example (https://platform.openai.com/docs/api-reference/embeddings/create):
         # ```

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -19,7 +19,9 @@ class OpenAIProvider(BaseProvider):
         super().__init__(config)
         if config.model.config is None or not isinstance(config.model.config, OpenAIConfig):
             # Should be unreachable
-            raise MlflowException.invalid_parameter_value("Invalid config type {config.model.config}")
+            raise MlflowException.invalid_parameter_value(
+                "Invalid config type {config.model.config}"
+            )
         self.openai_config: OpenAIConfig = config.model.config
         self.openai_api_type = (self.openai_config.openai_api_type or _API_TYPE_OPENAI).lower()
         self._validate_openai_config()
@@ -46,7 +48,9 @@ class OpenAIProvider(BaseProvider):
                     f"'{_API_TYPE_AZURE}' or '{_API_TYPE_AZUREAD}'."
                 )
         else:
-            raise MlflowException.invalid_parameter_value(f"Invalid OpenAI API type '{self.openai_api_type}'")
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid OpenAI API type '{self.openai_api_type}'"
+            )
 
     @property
     def _request_base_url(self):
@@ -62,14 +66,16 @@ class OpenAIProvider(BaseProvider):
                 self.openai_config.openai_api_base,
                 "openai",
                 "deployment",
-                self.openai_config.openai_deployment_name
+                self.openai_config.openai_deployment_name,
             )
             return append_to_uri_query_params(
                 openai_url,
                 ("api-version", self.openai_config.openai_api_version),
             )
         else:
-            raise MlflowException.invalid_parameter_value(f"Invalid OpenAI API type '{self.openai_api_type}'")
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid OpenAI API type '{self.openai_api_type}'"
+            )
 
     @property
     def _request_headers(self):
@@ -89,7 +95,9 @@ class OpenAIProvider(BaseProvider):
                 "api-key": self.openai_config.openai_api_key,
             }
         else:
-            raise MlflowException.invalid_parameter_value(f"Invalid OpenAI API type '{self.openai_api_type}'")
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid OpenAI API type '{self.openai_api_type}'"
+            )
 
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
         payload = jsonable_encoder(payload, exclude_none=True)

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -40,6 +40,12 @@ class OpenAIProvider(BaseProvider):
                     f"'{_API_TYPE_AZUREAD}'. Found type: '{self.openai_api_type}'"
                 )
         elif self.openai_api_type in (_API_TYPE_AZURE, _API_TYPE_AZUREAD):
+            if self.openai_config.openai_organization is not None:
+                raise MlflowException.invalid_parameter_value(
+                    f"OpenAI route configuration can only specify a value for "
+                    f"'openai_organization' if 'openai_api_type' is '{_API_TYPE_OPENAI}'"
+                )
+
             base_url = self.openai_config.openai_api_base
             deployment_name = self.openai_config.openai_deployment_name
             api_version = self.openai_config.openai_api_version

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -1,6 +1,8 @@
-from typing import Dict, Any
 import aiohttp
+from typing import Dict, Any
 from fastapi import HTTPException
+
+from mlflow.utils.uri import append_to_uri_path
 
 
 async def send_request(headers: Dict[str, str], base_url: str, path: str, payload: Dict[str, Any]):
@@ -15,7 +17,7 @@ async def send_request(headers: Dict[str, str], base_url: str, path: str, payloa
     :raise: HTTPException if the HTTP request fails.
     """
     async with aiohttp.ClientSession(headers=headers) as session:
-        url = "/".join([base_url.rstrip("/"), path.lstrip("/")])
+        url = append_to_uri_path(base_url, path) 
         async with session.post(url, json=payload) as response:
             js = await response.json()
             try:

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -17,7 +17,7 @@ async def send_request(headers: Dict[str, str], base_url: str, path: str, payloa
     :raise: HTTPException if the HTTP request fails.
     """
     async with aiohttp.ClientSession(headers=headers) as session:
-        url = append_to_uri_path(base_url, path) 
+        url = append_to_uri_path(base_url, path)
         async with session.post(url, json=payload) as response:
             js = await response.json()
             try:

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -266,7 +266,7 @@ def append_to_uri_query_params(uri, *query_params: Tuple[Any]):
                          be a 2-element tuple. For example, ``("key", "value")``.
     """
     parsed_uri = urllib.parse.urlparse(uri)
-    parsed_query = urllib.parse.parse_qsl(parsed_uri)
+    parsed_query = urllib.parse.parse_qsl(parsed_uri.query)
     new_parsed_query = parsed_query + list(query_params)
     new_query = urllib.parse.urlencode(new_parsed_query)
     new_parsed_uri = parsed_uri._replace(query=new_query)

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -2,6 +2,7 @@ import pathlib
 import posixpath
 import urllib.parse
 import uuid
+from typing import Tuple, Any
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
@@ -254,6 +255,22 @@ def append_to_uri_path(uri, *paths):
     new_uri_path = _join_posixpaths_and_append_absolute_suffixes(parsed_uri.path, path)
     new_parsed_uri = parsed_uri._replace(path=new_uri_path)
     return prefix + urllib.parse.urlunparse(new_parsed_uri)
+
+
+def append_to_uri_query_params(uri, *query_params: Tuple[Any]):
+    """
+    Appends the specified query parameters to an existing URI.
+
+    :param uri: The URI to which to append query parameters.
+    :param query_params: Query parameters to append. Each parameter should
+                         be a 2-element tuple. For example, ``("key", "value")``.
+    """
+    parsed_uri = urllib.parse.urlparse(uri)
+    parsed_query = urllib.parse.parse_qsl(parsed_uri)
+    new_parsed_query = parsed_query + list(query_params)
+    new_query = urllib.parse.urlencode(new_parsed_query)
+    new_parsed_uri = parsed_uri._replace(query=new_query)
+    return urllib.parse.urlunparse(new_parsed_uri)
 
 
 def _join_posixpaths_and_append_absolute_suffixes(prefix_path, suffix_path):

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -257,7 +257,7 @@ def append_to_uri_path(uri, *paths):
     return prefix + urllib.parse.urlunparse(new_parsed_uri)
 
 
-def append_to_uri_query_params(uri, *query_params: Tuple[Any]):
+def append_to_uri_query_params(uri, *query_params: Tuple[str, Any]) -> str:
     """
     Appends the specified query parameters to an existing URI.
 

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -436,66 +436,6 @@ async def test_azuread_openai():
 
 
 @pytest.mark.parametrize(
-    ("api_type", "api_base", "deployment_name", "api_version", "organization", "exception_type"),
-    [
-        # Invalid API Types
-        ("invalidtype", None, None, None, None, MlflowException),
-        # OpenAI API type
-        ("openai", None, None, None, None, None),
-        ("openai", "https://api.openai.com/v1", None, None, None, None),
-        ("openai", "https://api.openai.com/v1", None, "2023-05-15", None, None),
-        ("openAI", "https://api.openai.com/v1", None, "2023-05-15", None, None),
-        ("openAI", "https://api.openai.com/v1", None, "2023-05-15", "test-organization", None),
-        # Deployment name is specified when API type is not 'azure' or 'azuread'
-        ("openai", None, "mock-deployment", None, None, MlflowException),
-        # Azure API type
-        ("azure", "https://test.openai.azure.com", "mock-dep", "2023-05-15", None, None),
-        ("AZURe", "https://test.openai.azure.com", "mock-dep", "2023-04-12", None, None),
-        # Missing required API base, deployment name, and / or api version fields
-        ("azure", None, None, None, None, MlflowException),
-        ("azure", "https://test.openai.azure.com", "mock-dep", None, None, MlflowException),
-        # Organization is specified when API type is not 'openai'
-        ("azure", "https://test.openai.azure.com", "mock-dep", "2023", "test-org", MlflowException),
-        # AzureAD API type
-        ("azuread", "https://test.openai.azure.com", "mock-dep", "2023-05-15", None, None),
-        ("azureAD", "https://test.openai.azure.com", "mock-dep", "2023-04-12", None, None),
-        # Missing required API base, deployment name, and / or api version fields
-        ("azuread", None, None, None, None, MlflowException),
-        ("azuread", "https://test.openai.azure.com", "mock-dep", None, None, MlflowException),
-        # Organization is specified when API type is not 'openai'
-        ("azuread", "https://test.openai.azure.com", "mock", "2023", "test-org", MlflowException),
-    ],
-)
-def test_openai_provider_validates_openai_config(
-    api_type,
-    api_base,
-    deployment_name,
-    api_version,
-    organization,
-    exception_type,
-):
-    if exception_type is not None:
-        with pytest.raises(exception_type, match="OpenAI"):
-            OpenAIConfig(
-                openai_api_key="mock-api-key",
-                openai_api_type=api_type,
-                openai_api_base=api_base,
-                openai_deployment_name=deployment_name,
-                openai_api_version=api_version,
-                openai_organization=organization,
-            )
-    else:
-        OpenAIConfig(
-            openai_api_key="mock-api-key",
-            openai_api_type=api_type,
-            openai_api_base=api_base,
-            openai_deployment_name=deployment_name,
-            openai_api_version=api_version,
-            openai_organization=organization,
-        )
-
-
-@pytest.mark.parametrize(
     ("api_type", "api_base", "deployment_name", "api_version", "organization"),
     [
         # OpenAI API type

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -436,30 +436,35 @@ async def test_azuread_openai():
 
 
 @pytest.mark.parametrize(
-    ("api_type", "api_base", "deployment_name", "api_version", "exception_type"),
+    ("api_type", "api_base", "deployment_name", "api_version", "organization", "exception_type"),
     [
         # Invalid API Types
-        ("invalidtype", None, None, None, MlflowException),
-        (0, None, None, None, MlflowException),
+        ("invalidtype", None, None, None, None, MlflowException),
+        (0, None, None, None, None, MlflowException),
         # OpenAI API type
-        ("openai", None, None, None, None),
-        ("openai", "https://api.openai.com/v1", None, None, None),
-        ("openai", "https://api.openai.com/v1", None, "2023-05-15", None),
-        ("openAI", "https://api.openai.com/v1", None, "2023-05-15", None),
+        ("openai", None, None, None, None, None),
+        ("openai", "https://api.openai.com/v1", None, None, None, None),
+        ("openai", "https://api.openai.com/v1", None, "2023-05-15", None, None),
+        ("openAI", "https://api.openai.com/v1", None, "2023-05-15", None, None),
+        ("openAI", "https://api.openai.com/v1", None, "2023-05-15", "test-organization", None),
         # Deployment name is specified when API type is not 'azure' or 'azuread'
-        ("openai", None, "mock-deployment", None, MlflowException),
+        ("openai", None, "mock-deployment", None, None, MlflowException),
         # Azure API type
-        ("azure", "https://test-azureopenai.openai.azure.com", "mock-dep", "2023-05-15", None),
-        ("AZURe", "https://test-azureopenai.openai.azure.com", "mock-dep", "2023-04-12", None),
+        ("azure", "https://test.openai.azure.com", "mock-dep", "2023-05-15", None, None),
+        ("AZURe", "https://test.openai.azure.com", "mock-dep", "2023-04-12", None, None),
         # Missing required API base, deployment name, and / or api version fields
-        ("azure", None, None, None, MlflowException),
-        ("azure", "https://test-azureopenai.openai.azure.com", "mock-dep", None, MlflowException),
+        ("azure", None, None, None, None, MlflowException),
+        ("azure", "https://test.openai.azure.com", "mock-dep", None, None, MlflowException),
+        # Organization is specified when API type is not 'openai'
+        ("azure", "https://test.openai.azure.com", "mock-dep", "2023", "test-org", MlflowException),
         # AzureAD API type
-        ("azuread", "https://test-azureopenai.openai.azure.com", "mock-dep", "2023-05-15", None),
-        ("azureAD", "https://test-azureopenai.openai.azure.com", "mock-dep", "2023-04-12", None),
+        ("azuread", "https://test.openai.azure.com", "mock-dep", "2023-05-15", None, None),
+        ("azureAD", "https://test.openai.azure.com", "mock-dep", "2023-04-12", None, None),
         # Missing required API base, deployment name, and / or api version fields
-        ("azuread", None, None, None, MlflowException),
-        ("azuread", "https://test-azureopenai.openai.azure.com", "mock-dep", None, MlflowException),
+        ("azuread", None, None, None, None, MlflowException),
+        ("azuread", "https://test.openai.azure.com", "mock-dep", None, None, MlflowException),
+        # Organization is specified when API type is not 'openai'
+        ("azuread", "https://test.openai.azure.com", "mock", "2023", "test-org", MlflowException),
     ],
 )
 def test_openai_provider_validates_openai_config(
@@ -467,6 +472,7 @@ def test_openai_provider_validates_openai_config(
     api_base,
     deployment_name,
     api_version,
+    organization,
     exception_type,
 ):
     openai_config = OpenAIConfig(
@@ -475,6 +481,7 @@ def test_openai_provider_validates_openai_config(
         openai_api_base=api_base,
         openai_deployment_name=deployment_name,
         openai_api_version=api_version,
+        openai_organization=organization,
     )
     route_config = RouteConfig(
         name="completions",

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -567,7 +567,7 @@ def test_invalid_openai_configs_throw_on_construction(
     organization,
 ):
     with pytest.raises(MlflowException, match="OpenAI"):
-        openai_config = OpenAIConfig(
+        OpenAIConfig(
             openai_api_key="mock-api-key",
             openai_api_type=api_type,
             openai_api_base=api_base,

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -388,7 +388,6 @@ async def test_azure_openai():
                 "/chat/completions?api-version=2023-05-15"
             ),
             json={
-                "model": "gpt-35-turbo",
                 "temperature": 0,
                 "messages": [{"role": "user", "content": "This is a test"}],
             },
@@ -428,7 +427,6 @@ async def test_azuread_openai():
                 "/chat/completions?api-version=2023-05-15"
             ),
             json={
-                "model": "gpt-35-turbo",
                 "temperature": 0,
                 "messages": [{"role": "user", "content": "This is a test"}],
             },

--- a/tests/gateway/test_client.py
+++ b/tests/gateway/test_client.py
@@ -24,7 +24,7 @@ def basic_config_dict():
                         "openai_api_key": "mykey",
                         "openai_api_base": "https://api.openai.com/v1",
                         "openai_api_version": "2023-05-10",
-                        "openai_api_type": "openai/v1/chat/completions",
+                        "openai_api_type": "openai",
                     },
                 },
             },
@@ -183,6 +183,7 @@ def test_query_individual_route(gateway, monkeypatch):
         "model": {"name": "text-davinci-003", "provider": "openai"},
         "name": "completions",
         "route_type": "llm/v1/completions",
+        "route_url": None,
     }
 
     route2 = gateway_client.get_route(name="chat")
@@ -191,6 +192,7 @@ def test_query_individual_route(gateway, monkeypatch):
         "model": {"name": "gpt-3.5-turbo", "provider": "openai"},
         "name": "chat",
         "route_type": "llm/v1/chat",
+        "route_url": None,
     }
 
 
@@ -247,11 +249,13 @@ def test_list_all_configured_routes(gateway):
         "model": {"name": "text-davinci-003", "provider": "openai"},
         "name": "completions",
         "route_type": "llm/v1/completions",
+        "route_url": None,
     }
     assert routes[1].dict() == {
         "model": {"name": "gpt-3.5-turbo", "provider": "openai"},
         "name": "chat",
         "route_type": "llm/v1/chat",
+        "route_url": None,
     }
 
 
@@ -370,7 +374,7 @@ def test_client_create_route_raises(gateway):
                 "provider": "openai",
                 "config": {
                     "openai_api_key": "mykey",
-                    "openai_api_type": "openai/v1/chat/completions",
+                    "openai_api_type": "openai",
                 },
             },
         )

--- a/tests/gateway/test_fluent.py
+++ b/tests/gateway/test_fluent.py
@@ -100,6 +100,7 @@ def test_fluent_get_valid_route(gateway):
         "model": {"name": "text-davinci-003", "provider": "openai"},
         "name": "completions",
         "route_type": "llm/v1/completions",
+        "route_url": None,
     }
 
 
@@ -122,11 +123,13 @@ def test_fluent_search_routes(gateway):
         "model": {"name": "text-davinci-003", "provider": "openai"},
         "name": "completions",
         "route_type": "llm/v1/completions",
+        "route_url": None,
     }
     assert routes[1].dict() == {
         "model": {"name": "gpt-3.5-turbo", "provider": "openai"},
         "name": "chat",
         "route_type": "llm/v1/chat",
+        "route_url": None,
     }
 
 

--- a/tests/gateway/test_fluent.py
+++ b/tests/gateway/test_fluent.py
@@ -32,7 +32,7 @@ def basic_config_dict():
                         "openai_api_key": "mykey",
                         "openai_api_base": "https://api.openai.com/v1",
                         "openai_api_version": "2023-05-10",
-                        "openai_api_type": "openai/v1/chat/completions",
+                        "openai_api_type": "openai",
                     },
                 },
             },

--- a/tests/gateway/test_gateway_app.py
+++ b/tests/gateway/test_gateway_app.py
@@ -72,7 +72,6 @@ def test_search_routes(client: TestClient):
                     "name": "gpt-4",
                     "provider": "openai",
                 },
-                "route_url": None,
             },
             {
                 "name": "chat-gpt4",
@@ -82,7 +81,6 @@ def test_search_routes(client: TestClient):
                     "name": "gpt-4",
                     "provider": "openai",
                 },
-                "route_url": None,
             },
         ]
     }
@@ -99,7 +97,6 @@ def test_get_route(client: TestClient):
             "name": "gpt-4",
             "provider": "openai",
         },
-        "route_url": None,
     }
 
 

--- a/tests/gateway/test_gateway_app.py
+++ b/tests/gateway/test_gateway_app.py
@@ -25,7 +25,7 @@ def client() -> TestClient:
                             "openai_api_key": "mykey",
                             "openai_api_base": "https://api.openai.com/v1",
                             "openai_api_version": "2023-05-10",
-                            "openai_api_type": "openai/v1/chat/completions",
+                            "openai_api_type": "openai",
                         },
                     },
                 },
@@ -71,6 +71,7 @@ def test_search_routes(client: TestClient):
                     "name": "gpt-4",
                     "provider": "openai",
                 },
+                "route_url": None,
             },
             {
                 "name": "chat-gpt4",
@@ -79,6 +80,7 @@ def test_search_routes(client: TestClient):
                     "name": "gpt-4",
                     "provider": "openai",
                 },
+                "route_url": None,
             },
         ]
     }
@@ -94,6 +96,7 @@ def test_get_route(client: TestClient):
             "name": "gpt-4",
             "provider": "openai",
         },
+        "route_url": None,
     }
 
 

--- a/tests/gateway/test_gateway_config_parsing.py
+++ b/tests/gateway/test_gateway_config_parsing.py
@@ -28,7 +28,7 @@ def basic_config_dict():
                         "openai_api_key": "mykey",
                         "openai_api_base": "https://api.openai.com/v1",
                         "openai_api_version": "2023-05-10",
-                        "openai_api_type": "openai/v1/chat/completions",
+                        "openai_api_type": "openai",
                         "openai_organization": "my_company",
                     },
                 },
@@ -142,7 +142,7 @@ def test_route_configuration_parsing(basic_config_dict, tmp_path, monkeypatch):
     assert completions_conf.openai_api_key == "mykey"
     assert completions_conf.openai_api_base == "https://api.openai.com/v1"
     assert completions_conf.openai_api_version == "2023-05-10"
-    assert completions_conf.openai_api_type == "openai/v1/chat/completions"
+    assert completions_conf.openai_api_type == "openai"
     assert completions_conf.openai_organization == "my_company"
 
     chat_gpt4 = loaded_from_save.routes[1]
@@ -154,8 +154,8 @@ def test_route_configuration_parsing(basic_config_dict, tmp_path, monkeypatch):
     assert isinstance(chat_conf, OpenAIConfig)
     assert chat_conf.openai_api_key == "sk-openai"
     assert chat_conf.openai_api_base == "https://api.openai.com/v1"
+    assert chat_conf.openai_api_type == "openai"
     assert chat_conf.openai_api_version is None
-    assert chat_conf.openai_api_type is None
     assert chat_conf.openai_organization is None
 
     claude = loaded_from_save.routes[2]
@@ -252,7 +252,7 @@ def test_invalid_model_definition(tmp_path):
                 "model": {
                     "name": "invalid",
                     "provider": "openai",
-                    "config": {"openai_api_type": "open_ai"},
+                    "config": {"openai_api_type": "openai"},
                 },
             }
         ]
@@ -274,7 +274,7 @@ def test_invalid_model_definition(tmp_path):
                 "model": {
                     "name": "invalid",
                     "provider": "openai",
-                    "config": {"openai_api_type": "open_ai", "openai_api_key": [42]},
+                    "config": {"openai_api_type": "openai", "openai_api_key": [42]},
                 },
             }
         ]
@@ -297,7 +297,7 @@ def test_invalid_model_definition(tmp_path):
                 "model": {
                     "name": "invalid",
                     "provider": "openai",
-                    "config": {"openai_api_type": "open_ai", "openai_api_key": "/not/a/real/path"},
+                    "config": {"openai_api_type": "openai", "openai_api_key": "/not/a/real/path"},
                 },
             }
         ]

--- a/tests/gateway/test_runner.py
+++ b/tests/gateway/test_runner.py
@@ -21,7 +21,7 @@ def basic_config_dict():
                         "openai_api_key": "mykey",
                         "openai_api_base": "https://api.openai.com/v1",
                         "openai_api_version": "2023-05-15",
-                        "openai_api_type": "open_ai",
+                        "openai_api_type": "openai",
                     },
                 },
             },
@@ -35,7 +35,7 @@ def basic_config_dict():
                         "openai_api_key": "mykey",
                         "openai_api_base": "https://api.openai.com/v1",
                         "openai_api_version": "2023-05-15",
-                        "openai_api_type": "open_ai",
+                        "openai_api_type": "openai",
                     },
                 },
             },
@@ -54,6 +54,7 @@ def basic_routes():
                     "name": "gpt-4",
                     "provider": "openai",
                 },
+                "route_url": None,
             },
             {
                 "name": "embeddings-gpt4",
@@ -62,6 +63,7 @@ def basic_routes():
                     "name": "gpt-4",
                     "provider": "openai",
                 },
+                "route_url": None,
             },
         ]
     }
@@ -81,7 +83,7 @@ def update_config_dict():
                         "openai_api_key": "mykey",
                         "openai_api_base": "https://api.openai.com/v1",
                         "openai_api_version": "2023-05-15",
-                        "openai_api_type": "open_ai",
+                        "openai_api_type": "openai",
                     },
                 },
             },
@@ -100,6 +102,7 @@ def update_routes():
                     "name": "gpt-4",
                     "provider": "openai",
                 },
+                "route_url": None,
             },
         ]
     }

--- a/tests/gateway/test_runner.py
+++ b/tests/gateway/test_runner.py
@@ -55,7 +55,6 @@ def basic_routes():
                     "name": "gpt-4",
                     "provider": "openai",
                 },
-                "route_url": None,
             },
             {
                 "name": "embeddings-gpt4",
@@ -65,7 +64,6 @@ def basic_routes():
                     "name": "gpt-4",
                     "provider": "openai",
                 },
-                "route_url": None,
             },
         ]
     }
@@ -105,7 +103,6 @@ def update_routes():
                     "name": "gpt-4",
                     "provider": "openai",
                 },
-                "route_url": None,
             },
         ]
     }

--- a/tests/gateway/tools.py
+++ b/tests/gateway/tools.py
@@ -99,18 +99,18 @@ class MockAsyncResponse:
         pass
 
 
+class MockHttpClient(mock.Mock):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return
+
+
 def mock_http_client(mock_response: MockAsyncResponse):
-    class MockHttpClient(mock.Mock):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            # self.post = mock.Mock(return_value=MockAsyncResponse(resp))
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            return
-
     mock_http_client = MockHttpClient()
     mock_http_client.post = mock.Mock(return_value=mock_response)
     return mock_http_client

--- a/tests/gateway/tools.py
+++ b/tests/gateway/tools.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import time
 from typing import Any, Union, Dict
+from unittest import mock
 
 import requests
 import yaml
@@ -96,3 +97,20 @@ class MockAsyncResponse:
 
     async def __aexit__(self, exc_type, exc, traceback):
         pass
+
+
+def mock_http_client(mock_response: MockAsyncResponse):
+    class MockHttpClient(mock.Mock):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            # self.post = mock.Mock(return_value=MockAsyncResponse(resp))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return
+
+    mock_http_client = MockHttpClient()
+    mock_http_client.post = mock.Mock(return_value=mock_response)
+    return mock_http_client


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Support Azure OpenAI in MLflow AI Gateway

## How is this patch tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

1. Created an Azure OpenAI deployment via Azure Portal

2. Created a gateway YAML config file with an Azure OpenAI completions endpoint and started the gateway

```
routes:
  - name: completions
    route_type: llm/v1/completions
    model:
      provider: openai
      name: gpt-3.5-turbo
      config:
        openai_api_type: "azure"
        openai_api_key: "<REDACTED>"
        openai_deployment_name: "corey-gpt35"
        openai_api_base: "https://corey-azureopenai.openai.azure.com/"
        openai_api_version: "2023-05-15"
```

```
mlflow gateway start --config-path azopenai.yaml --port 7777
```

3. Queried the gateway

```
import mlflow.gateway


def main():
    mlflow.gateway.set_gateway_uri("http://127.0.0.1:7777")
    print("Completions")
    print(
        mlflow.gateway.query(
            "completions",
            data={
                "prompt": "Hello, my name is",
            },
        )
    )

if __name__ == "__main__":
    main()
```

```
Completions
{'candidates': [{'text': 'OpenAI. I am an AI language model designed to assist with various tasks such as generating text, answering questions, and providing information. How can I assist you today?', 'metadata': {'finish_reason': 'stop'}}], 'metadata': {'input_tokens': 13, 'output_tokens': 34, 'total_tokens': 47, 'model': 'gpt-35-turbo', 'route_type': 'llm/v1/completions'}}
```

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
