### PR TITLE
Remove useless variable assignment

### DIFF
--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -42,7 +42,7 @@ def _check_spark_version_in_range(ver, min_ver, max_ver):
 
 def _violates_pep_440(ver):
     try:
-        _ = Version(ver)
+        Version(ver)
         return False
     except InvalidVersion:
         return True

--- a/tests/evaluate/test_validation.py
+++ b/tests/evaluate/test_validation.py
@@ -344,11 +344,9 @@ def test_validation_value_threshold_should_fail(
         expected_failure_message = message_separator.join(
             map(str, list(expected_validation_results.values()))
         )
-        with mock.patch.object(
-            MockEvaluator, "can_evaluate", return_value=True
-        ) as _, mock.patch.object(
+        with mock.patch.object(MockEvaluator, "can_evaluate", return_value=True), mock.patch.object(
             MockEvaluator, "evaluate", return_value=evaluator1_return_value
-        ) as _:
+        ):
             with pytest.raises(
                 ModelValidationFailedException,
                 match=expected_failure_message,
@@ -388,11 +386,9 @@ def test_validation_value_threshold_should_pass(
         evaluator1_return_value = EvaluationResult(
             metrics=metrics, artifacts={}, baseline_model_metrics=None
         )
-        with mock.patch.object(
-            MockEvaluator, "can_evaluate", return_value=True
-        ) as _, mock.patch.object(
+        with mock.patch.object(MockEvaluator, "can_evaluate", return_value=True), mock.patch.object(
             MockEvaluator, "evaluate", return_value=evaluator1_return_value
-        ) as _:
+        ):
             evaluate(
                 multiclass_logistic_regressor_model_uri,
                 data=iris_dataset._constructor_args["data"],
@@ -553,11 +549,9 @@ def test_validation_model_comparison_absolute_threshold_should_fail(
         expected_failure_message = message_separator.join(
             map(str, list(expected_validation_results.values()))
         )
-        with mock.patch.object(
-            MockEvaluator, "can_evaluate", return_value=True
-        ) as _, mock.patch.object(
+        with mock.patch.object(MockEvaluator, "can_evaluate", return_value=True), mock.patch.object(
             MockEvaluator, "evaluate", return_value=evaluator1_return_value
-        ) as _:
+        ):
             with pytest.raises(
                 ModelValidationFailedException,
                 match=expected_failure_message,
@@ -602,11 +596,9 @@ def test_validation_model_comparison_absolute_threshold_should_pass(
         evaluator1_return_value = EvaluationResult(
             metrics=metrics, artifacts={}, baseline_model_metrics=baseline_model_metrics
         )
-        with mock.patch.object(
-            MockEvaluator, "can_evaluate", return_value=True
-        ) as _, mock.patch.object(
+        with mock.patch.object(MockEvaluator, "can_evaluate", return_value=True), mock.patch.object(
             MockEvaluator, "evaluate", return_value=evaluator1_return_value
-        ) as _:
+        ):
             evaluate(
                 multiclass_logistic_regressor_model_uri,
                 data=iris_dataset._constructor_args["data"],
@@ -788,11 +780,9 @@ def test_validation_model_comparison_relative_threshold_should_fail(
         expected_failure_message = message_separator.join(
             map(str, list(expected_validation_results.values()))
         )
-        with mock.patch.object(
-            MockEvaluator, "can_evaluate", return_value=True
-        ) as _, mock.patch.object(
+        with mock.patch.object(MockEvaluator, "can_evaluate", return_value=True), mock.patch.object(
             MockEvaluator, "evaluate", return_value=evaluator1_return_value
-        ) as _:
+        ):
             with pytest.raises(
                 ModelValidationFailedException,
                 match=expected_failure_message,
@@ -838,11 +828,9 @@ def test_validation_model_comparison_relative_threshold_should_pass(
         evaluator1_return_value = EvaluationResult(
             metrics=metrics, artifacts={}, baseline_model_metrics=baseline_model_metrics
         )
-        with mock.patch.object(
-            MockEvaluator, "can_evaluate", return_value=True
-        ) as _, mock.patch.object(
+        with mock.patch.object(MockEvaluator, "can_evaluate", return_value=True), mock.patch.object(
             MockEvaluator, "evaluate", return_value=evaluator1_return_value
-        ) as _:
+        ):
             evaluate(
                 multiclass_logistic_regressor_model_uri,
                 data=iris_dataset._constructor_args["data"],

--- a/tests/recipes/test_pipeline.py
+++ b/tests/recipes/test_pipeline.py
@@ -56,7 +56,7 @@ def test_create_recipe_and_clean_works():
 @pytest.mark.parametrize("empty_profile", [None, ""])
 def test_create_recipe_fails_with_empty_profile_name(empty_profile):
     with pytest.raises(MlflowException, match="A profile name must be provided"):
-        _ = Recipe(profile=empty_profile)
+        Recipe(profile=empty_profile)
 
 
 @pytest.mark.usefixtures("enter_recipe_example_directory")

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -996,7 +996,7 @@ def test_autolog_does_not_throw_when_failing_to_sample_X():
 
     # ensure throwing_X throws when sliced
     with pytest.raises(IndexError, match="DO NOT SLICE ME"):
-        _ = throwing_X[:5]
+        throwing_X[:5]
 
     mlflow.sklearn.autolog()
     model = sklearn.linear_model.LinearRegression()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Remove useless variable assignment.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
