### PR TITLE
Migrate `TestRun`

### DIFF
--- a/tests/entities/test_run.py
+++ b/tests/entities/test_run.py
@@ -17,109 +17,110 @@ from tests.entities.test_run_info import _check as run_info_check
 from tests.entities.test_run_inputs import _check as run_inputs_check
 
 
-class TestRun:
-    def _check_run(self, run, ri, rd_metrics, rd_params, rd_tags, datasets):
-        run_info_check(
-            run.info,
-            ri.run_id,
-            ri.experiment_id,
-            ri.user_id,
-            ri.status,
-            ri.start_time,
-            ri.end_time,
-            ri.lifecycle_stage,
-            ri.artifact_uri,
-        )
-        run_data_check(run.data, rd_metrics, rd_params, rd_tags)
-        run_inputs_check(run.inputs, datasets)
+def _check_run(run, ri, rd_metrics, rd_params, rd_tags, datasets):
+    run_info_check(
+        run.info,
+        ri.run_id,
+        ri.experiment_id,
+        ri.user_id,
+        ri.status,
+        ri.start_time,
+        ri.end_time,
+        ri.lifecycle_stage,
+        ri.artifact_uri,
+    )
+    run_data_check(run.data, rd_metrics, rd_params, rd_tags)
+    run_inputs_check(run.inputs, datasets)
 
-    def test_creation_and_hydration(self, run_data, run_info, run_inputs):
-        run_data, metrics, params, tags = run_data
-        (
-            run_info,
-            run_id,
-            run_name,
-            experiment_id,
-            user_id,
-            status,
-            start_time,
-            end_time,
-            lifecycle_stage,
-            artifact_uri,
-        ) = run_info
-        run_inputs, datasets = run_inputs
 
-        run1 = Run(run_info, run_data, run_inputs)
+def test_creation_and_hydration(run_data, run_info, run_inputs):
+    run_data, metrics, params, tags = run_data
+    (
+        run_info,
+        run_id,
+        run_name,
+        experiment_id,
+        user_id,
+        status,
+        start_time,
+        end_time,
+        lifecycle_stage,
+        artifact_uri,
+    ) = run_info
+    run_inputs, datasets = run_inputs
 
-        self._check_run(run1, run_info, metrics, params, tags, datasets)
+    run1 = Run(run_info, run_data, run_inputs)
 
-        expected_info_dict = {
-            "run_uuid": run_id,
-            "run_id": run_id,
-            "run_name": run_name,
-            "experiment_id": experiment_id,
-            "user_id": user_id,
-            "status": status,
-            "start_time": start_time,
-            "end_time": end_time,
-            "lifecycle_stage": lifecycle_stage,
-            "artifact_uri": artifact_uri,
-        }
-        assert run1.to_dictionary() == {
-            "info": expected_info_dict,
-            "data": {
-                "metrics": {m.key: m.value for m in metrics},
-                "params": {p.key: p.value for p in params},
-                "tags": {t.key: t.value for t in tags},
-            },
-            "inputs": {"dataset_inputs": datasets},
-        }
+    _check_run(run1, run_info, metrics, params, tags, datasets)
 
-        proto = run1.to_proto()
-        run2 = Run.from_proto(proto)
-        self._check_run(run2, run_info, metrics, params, tags, datasets)
+    expected_info_dict = {
+        "run_uuid": run_id,
+        "run_id": run_id,
+        "run_name": run_name,
+        "experiment_id": experiment_id,
+        "user_id": user_id,
+        "status": status,
+        "start_time": start_time,
+        "end_time": end_time,
+        "lifecycle_stage": lifecycle_stage,
+        "artifact_uri": artifact_uri,
+    }
+    assert run1.to_dictionary() == {
+        "info": expected_info_dict,
+        "data": {
+            "metrics": {m.key: m.value for m in metrics},
+            "params": {p.key: p.value for p in params},
+            "tags": {t.key: t.value for t in tags},
+        },
+        "inputs": {"dataset_inputs": datasets},
+    }
 
-        run3 = Run(run_info, None, None)
-        assert run3.to_dictionary() == {"info": expected_info_dict}
+    proto = run1.to_proto()
+    run2 = Run.from_proto(proto)
+    _check_run(run2, run_info, metrics, params, tags, datasets)
 
-        run4 = Run(run_info, None)
-        assert run4.to_dictionary() == {"info": expected_info_dict}
+    run3 = Run(run_info, None, None)
+    assert run3.to_dictionary() == {"info": expected_info_dict}
 
-    def test_string_repr(self):
-        run_info = RunInfo(
-            run_uuid="hi",
-            run_id="hi",
-            run_name="name",
-            experiment_id=0,
-            user_id="user-id",
-            status=RunStatus.FAILED,
-            start_time=0,
-            end_time=1,
-            lifecycle_stage=LifecycleStage.ACTIVE,
-        )
-        metrics = [Metric(key="key-%s" % i, value=i, timestamp=0, step=i) for i in range(3)]
-        run_data = RunData(metrics=metrics, params=[], tags=[])
-        dataset_inputs = DatasetInput(
-            dataset=Dataset(
-                name="name1", digest="digest1", source_type="my_source_type", source="source"
-            ),
-            tags=[],
-        )
-        run_inputs = RunInputs(dataset_inputs=dataset_inputs)
-        run1 = Run(run_info, run_data, run_inputs)
-        expected = (
-            "<Run: data=<RunData: metrics={'key-0': 0, 'key-1': 1, 'key-2': 2}, "
-            "params={}, tags={}>, info=<RunInfo: artifact_uri=None, end_time=1, "
-            "experiment_id=0, lifecycle_stage='active', run_id='hi', run_name='name', "
-            "run_uuid='hi', start_time=0, status=4, user_id='user-id'>, inputs=<RunInputs: "
-            "dataset_inputs=<DatasetInput: dataset=<Dataset: digest='digest1', "
-            "name='name1', profile=None, schema=None, source='source', "
-            "source_type='my_source_type'>, tags=[]>>>"
-        )
-        assert str(run1) == expected
+    run4 = Run(run_info, None)
+    assert run4.to_dictionary() == {"info": expected_info_dict}
 
-    def test_creating_run_with_absent_info_throws_exception(self, run_data, run_inputs):
-        run_data = run_data[0]
-        with pytest.raises(MlflowException, match="run_info cannot be None") as no_info_exc:
-            Run(None, run_data, run_inputs)
-        assert "run_info cannot be None" in str(no_info_exc)
+
+def test_string_repr():
+    run_info = RunInfo(
+        run_uuid="hi",
+        run_id="hi",
+        run_name="name",
+        experiment_id=0,
+        user_id="user-id",
+        status=RunStatus.FAILED,
+        start_time=0,
+        end_time=1,
+        lifecycle_stage=LifecycleStage.ACTIVE,
+    )
+    metrics = [Metric(key="key-%s" % i, value=i, timestamp=0, step=i) for i in range(3)]
+    run_data = RunData(metrics=metrics, params=[], tags=[])
+    dataset_inputs = DatasetInput(
+        dataset=Dataset(
+            name="name1", digest="digest1", source_type="my_source_type", source="source"
+        ),
+        tags=[],
+    )
+    run_inputs = RunInputs(dataset_inputs=dataset_inputs)
+    run1 = Run(run_info, run_data, run_inputs)
+    expected = (
+        "<Run: data=<RunData: metrics={'key-0': 0, 'key-1': 1, 'key-2': 2}, "
+        "params={}, tags={}>, info=<RunInfo: artifact_uri=None, end_time=1, "
+        "experiment_id=0, lifecycle_stage='active', run_id='hi', run_name='name', "
+        "run_uuid='hi', start_time=0, status=4, user_id='user-id'>, inputs=<RunInputs: "
+        "dataset_inputs=<DatasetInput: dataset=<Dataset: digest='digest1', "
+        "name='name1', profile=None, schema=None, source='source', "
+        "source_type='my_source_type'>, tags=[]>>>"
+    )
+    assert str(run1) == expected
+
+
+def test_creating_run_with_absent_info_throws_exception(run_data, run_inputs):
+    run_data = run_data[0]
+    with pytest.raises(MlflowException, match="run_info cannot be None"):
+        Run(None, run_data, run_inputs)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Migrate `TestRun`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
