### PR TITLE
Remove `HelperEnv`

### DIFF
--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -153,7 +153,6 @@ def reset_experiment_id(monkeypatch):
     its included
     """
     yield
-    monkeypatch.delenvs((MLFLOW_EXPERIMENT_ID.name, MLFLOW_EXPERIMENT_NAME.name), raising=False)
     mlflow.tracking.fluent._active_experiment_id = None
 
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -147,7 +147,7 @@ def create_experiment(
 
 
 @pytest.fixture(autouse=True)
-def reset_experiment_id(monkeypatch):
+def reset_experiment_id():
     """
     This fixture resets the active experiment id *after* the execution of the test case in which
     its included

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -169,13 +169,13 @@ def create_experiment(
 
 
 @pytest.fixture(autouse=True)
-def reset_experiment_id():
+def reset_experiment_id(monkeypatch):
     """
     This fixture resets the active experiment id *after* the execution of the test case in which
     its included
     """
     yield
-    HelperEnv.set_values()
+    monkeypatch.delenvs((MLFLOW_EXPERIMENT_ID.name, MLFLOW_EXPERIMENT_NAME.name), raising=False)
     mlflow.tracking.fluent._active_experiment_id = None
 
 
@@ -204,38 +204,39 @@ def test_all_fluent_apis_are_included_in_dunder_all():
     assert set(apis).issubset(set(mlflow.__all__))
 
 
-def test_get_experiment_id_from_env():
+def test_get_experiment_id_from_env(monkeypatch):
     # When no env variables are set
-    HelperEnv.assert_values(None, None)
+    assert not MLFLOW_EXPERIMENT_NAME.is_defined
+    assert not MLFLOW_EXPERIMENT_ID.is_defined
     assert _get_experiment_id_from_env() is None
 
     # set only ID
     name = "random experiment %d" % random.randint(1, 1e6)
     exp_id = mlflow.create_experiment(name)
     assert exp_id is not None
-    HelperEnv.set_values(experiment_id=exp_id)
-    HelperEnv.assert_values(exp_id, None)
+    monkeypatch.delenv(MLFLOW_EXPERIMENT_NAME.name, raising=False)
+    monkeypatch.setenv(MLFLOW_EXPERIMENT_ID.name, exp_id)
     assert _get_experiment_id_from_env() == exp_id
 
     # set only name
     name = "random experiment %d" % random.randint(1, 1e6)
     exp_id = mlflow.create_experiment(name)
     assert exp_id is not None
-    HelperEnv.set_values(name=name)
-    HelperEnv.assert_values(None, name)
+    monkeypatch.delenv(MLFLOW_EXPERIMENT_ID.name, raising=False)
+    monkeypatch.setenv(MLFLOW_EXPERIMENT_NAME.name, name)
     assert _get_experiment_id_from_env() == exp_id
 
     # create experiment from env name
     name = "random experiment %d" % random.randint(1, 1e6)
-    HelperEnv.set_values(name=name)
-    HelperEnv.assert_values(None, name)
+    monkeypatch.delenv(MLFLOW_EXPERIMENT_ID.name, raising=False)
+    monkeypatch.setenv(MLFLOW_EXPERIMENT_NAME.name, name)
     assert MlflowClient().get_experiment_by_name(name) is None
     assert _get_experiment_id_from_env() is not None
 
     # assert experiment creation from encapsulating function
     name = "random experiment %d" % random.randint(1, 1e6)
-    HelperEnv.set_values(name=name)
-    HelperEnv.assert_values(None, name)
+    monkeypatch.delenv(MLFLOW_EXPERIMENT_ID.name, raising=False)
+    monkeypatch.setenv(MLFLOW_EXPERIMENT_NAME.name, name)
     assert MlflowClient().get_experiment_by_name(name) is None
     assert _get_experiment_id() is not None
 
@@ -244,8 +245,8 @@ def test_get_experiment_id_from_env():
     exp_id = mlflow.create_experiment(name)
     random_id = random.randint(100, 1e6)
     assert exp_id != random_id
-    HelperEnv.set_values(experiment_id=random_id)
-    HelperEnv.assert_values(str(random_id), None)
+    monkeypatch.delenv(MLFLOW_EXPERIMENT_NAME.name, raising=False)
+    monkeypatch.setenv(MLFLOW_EXPERIMENT_ID.name, random_id)
     with pytest.raises(
         MlflowException,
         match=(
@@ -260,8 +261,10 @@ def test_get_experiment_id_from_env():
     exp_id = mlflow.create_experiment(name)
     random_id = random.randint(100, 1e6)
     assert exp_id != random_id
-    HelperEnv.set_values(experiment_id=random_id, name=name)
-    HelperEnv.assert_values(str(random_id), name)
+    monkeypatch.setenvs({
+        MLFLOW_EXPERIMENT_ID.name: random_id,
+        MLFLOW_EXPERIMENT_NAME.name: name
+    })
     with pytest.raises(
         MlflowException,
         match=(
@@ -277,8 +280,10 @@ def test_get_experiment_id_from_env():
     exp_id = mlflow.create_experiment(name)
     assert exp_id is not None
     random_id = random.randint(100, 1e6)
-    HelperEnv.set_values(name=invalid_name, experiment_id=random_id)
-    HelperEnv.assert_values(str(random_id), invalid_name)
+    monkeypatch.setenvs({
+        MLFLOW_EXPERIMENT_ID.name: random_id,
+        MLFLOW_EXPERIMENT_NAME.name: invalid_name
+    })
     mlflow.set_experiment(experiment_id=exp_id)
     assert _get_experiment_id() == exp_id
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

              Is it possible to remove `HelperEnv` in a follow-up PR?

_Originally posted by @harupy in https://github.com/mlflow/mlflow/pull/8888#discussion_r1246080469_
            

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
