### PR TITLE
Migrate `TestRestStore` to function style

### DIFF
--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 
 from unittest import mock
 import pytest
@@ -64,420 +63,421 @@ def mock_http_request():
     )
 
 
-class TestRestStore:
-    @mock.patch("requests.Session.request")
-    def test_successful_http_request(self, request):
-        def mock_request(*args, **kwargs):
-            # Filter out None arguments
-            assert args == ("POST", "https://hello/api/2.0/mlflow/experiments/search")
-            kwargs = {k: v for k, v in kwargs.items() if v is not None}
-            assert kwargs == {
-                "json": {"view_type": "ACTIVE_ONLY"},
-                "headers": DefaultRequestHeaderProvider().request_headers(),
-                "verify": True,
-                "timeout": 120,
-            }
-            response = mock.MagicMock()
-            response.status_code = 200
-            response.text = '{"experiments": [{"name": "Exp!", "lifecycle_stage": "active"}]}'
-            return response
-
-        request.side_effect = mock_request
-
-        store = RestStore(lambda: MlflowHostCreds("https://hello"))
-        experiments = store.search_experiments()
-        assert experiments[0].name == "Exp!"
-
-    @mock.patch("requests.Session.request")
-    def test_failed_http_request(self, request):
-        response = mock.MagicMock()
-        response.status_code = 404
-        response.text = '{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "No experiment"}'
-        request.return_value = response
-
-        store = RestStore(lambda: MlflowHostCreds("https://hello"))
-        with pytest.raises(MlflowException, match="RESOURCE_DOES_NOT_EXIST: No experiment"):
-            store.search_experiments()
-
-    @mock.patch("requests.Session.request")
-    def test_failed_http_request_custom_handler(self, request):
-        response = mock.MagicMock()
-        response.status_code = 404
-        response.text = '{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "No experiment"}'
-        request.return_value = response
-
-        store = CustomErrorHandlingRestStore(lambda: MlflowHostCreds("https://hello"))
-        with pytest.raises(MyCoolException, match="cool"):
-            store.search_experiments()
-
-    @mock.patch("requests.Session.request")
-    def test_response_with_unknown_fields(self, request):
-        experiment_json = {
-            "experiment_id": "1",
-            "name": "My experiment",
-            "artifact_location": "foo",
-            "lifecycle_stage": "deleted",
-            "OMG_WHAT_IS_THIS_FIELD": "Hooly cow",
+@mock.patch("requests.Session.request")
+def test_successful_http_request(request):
+    def mock_request(*args, **kwargs):
+        # Filter out None arguments
+        assert args == ("POST", "https://hello/api/2.0/mlflow/experiments/search")
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        assert kwargs == {
+            "json": {"view_type": "ACTIVE_ONLY"},
+            "headers": DefaultRequestHeaderProvider().request_headers(),
+            "verify": True,
+            "timeout": 120,
         }
-
         response = mock.MagicMock()
         response.status_code = 200
-        experiments = {"experiments": [experiment_json]}
-        response.text = json.dumps(experiments)
-        request.return_value = response
+        response.text = '{"experiments": [{"name": "Exp!", "lifecycle_stage": "active"}]}'
+        return response
 
-        store = RestStore(lambda: MlflowHostCreds("https://hello"))
-        experiments = store.search_experiments()
-        assert len(experiments) == 1
-        assert experiments[0].name == "My experiment"
+    request.side_effect = mock_request
 
-    def _args(self, host_creds, endpoint, method, json_body):
-        res = {
-            "host_creds": host_creds,
-            "endpoint": "/api/2.0/mlflow/%s" % endpoint,
-            "method": method,
-        }
-        if method == "GET":
-            res["params"] = json.loads(json_body)
-        else:
-            res["json"] = json.loads(json_body)
-        return res
+    store = RestStore(lambda: MlflowHostCreds("https://hello"))
+    experiments = store.search_experiments()
+    assert experiments[0].name == "Exp!"
 
-    def _verify_requests(self, http_request, host_creds, endpoint, method, json_body):
-        http_request.assert_any_call(**(self._args(host_creds, endpoint, method, json_body)))
 
-    def test_requestor(self):
-        creds = MlflowHostCreds("https://hello")
-        store = RestStore(lambda: creds)
+@mock.patch("requests.Session.request")
+def test_failed_http_request(request):
+    response = mock.MagicMock()
+    response.status_code = 404
+    response.text = '{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "No experiment"}'
+    request.return_value = response
 
-        user_name = "mock user"
-        source_name = "rest test"
-        run_name = "my name"
+    store = RestStore(lambda: MlflowHostCreds("https://hello"))
+    with pytest.raises(MlflowException, match="RESOURCE_DOES_NOT_EXIST: No experiment"):
+        store.search_experiments()
 
-        source_name_patch = mock.patch(
-            "mlflow.tracking.context.default_context._get_source_name", return_value=source_name
-        )
-        source_type_patch = mock.patch(
-            "mlflow.tracking.context.default_context._get_source_type",
-            return_value=SourceType.LOCAL,
-        )
-        with mock_http_request() as mock_http, mock.patch(
-            "mlflow.tracking._tracking_service.utils._get_store", return_value=store
-        ), mock.patch(
-            "mlflow.tracking.context.default_context._get_user", return_value=user_name
-        ), mock.patch(
-            "time.time", return_value=13579
-        ), source_name_patch, source_type_patch:
-            with mlflow.start_run(experiment_id="43", run_name=run_name):
-                cr_body = message_to_json(
-                    CreateRun(
-                        experiment_id="43",
-                        user_id=user_name,
-                        run_name=run_name,
-                        start_time=13579000,
-                        tags=[
-                            ProtoRunTag(key="mlflow.source.name", value=source_name),
-                            ProtoRunTag(key="mlflow.source.type", value="LOCAL"),
-                            ProtoRunTag(key="mlflow.user", value=user_name),
-                            ProtoRunTag(key="mlflow.runName", value=run_name),
-                        ],
-                    )
+
+@mock.patch("requests.Session.request")
+def test_failed_http_request_custom_handler(request):
+    response = mock.MagicMock()
+    response.status_code = 404
+    response.text = '{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "No experiment"}'
+    request.return_value = response
+
+    store = CustomErrorHandlingRestStore(lambda: MlflowHostCreds("https://hello"))
+    with pytest.raises(MyCoolException, match="cool"):
+        store.search_experiments()
+
+
+@mock.patch("requests.Session.request")
+def test_response_with_unknown_fields(request):
+    experiment_json = {
+        "experiment_id": "1",
+        "name": "My experiment",
+        "artifact_location": "foo",
+        "lifecycle_stage": "deleted",
+        "OMG_WHAT_IS_THIS_FIELD": "Hooly cow",
+    }
+
+    response = mock.MagicMock()
+    response.status_code = 200
+    experiments = {"experiments": [experiment_json]}
+    response.text = json.dumps(experiments)
+    request.return_value = response
+
+    store = RestStore(lambda: MlflowHostCreds("https://hello"))
+    experiments = store.search_experiments()
+    assert len(experiments) == 1
+    assert experiments[0].name == "My experiment"
+
+
+def _args(host_creds, endpoint, method, json_body):
+    res = {
+        "host_creds": host_creds,
+        "endpoint": "/api/2.0/mlflow/%s" % endpoint,
+        "method": method,
+    }
+    if method == "GET":
+        res["params"] = json.loads(json_body)
+    else:
+        res["json"] = json.loads(json_body)
+    return res
+
+
+def _verify_requests(http_request, host_creds, endpoint, method, json_body):
+    http_request.assert_any_call(**(_args(host_creds, endpoint, method, json_body)))
+
+
+def test_requestor():
+    creds = MlflowHostCreds("https://hello")
+    store = RestStore(lambda: creds)
+
+    user_name = "mock user"
+    source_name = "rest test"
+    run_name = "my name"
+
+    source_name_patch = mock.patch(
+        "mlflow.tracking.context.default_context._get_source_name", return_value=source_name
+    )
+    source_type_patch = mock.patch(
+        "mlflow.tracking.context.default_context._get_source_type",
+        return_value=SourceType.LOCAL,
+    )
+    with mock_http_request() as mock_http, mock.patch(
+        "mlflow.tracking._tracking_service.utils._get_store", return_value=store
+    ), mock.patch(
+        "mlflow.tracking.context.default_context._get_user", return_value=user_name
+    ), mock.patch(
+        "time.time", return_value=13579
+    ), source_name_patch, source_type_patch:
+        with mlflow.start_run(experiment_id="43", run_name=run_name):
+            cr_body = message_to_json(
+                CreateRun(
+                    experiment_id="43",
+                    user_id=user_name,
+                    run_name=run_name,
+                    start_time=13579000,
+                    tags=[
+                        ProtoRunTag(key="mlflow.source.name", value=source_name),
+                        ProtoRunTag(key="mlflow.source.type", value="LOCAL"),
+                        ProtoRunTag(key="mlflow.user", value=user_name),
+                        ProtoRunTag(key="mlflow.runName", value=run_name),
+                    ],
                 )
-                expected_kwargs = self._args(creds, "runs/create", "POST", cr_body)
-
-                assert mock_http.call_count == 1
-                actual_kwargs = mock_http.call_args[1]
-
-                # Test the passed tag values separately from the rest of the request
-                # Tag order is inconsistent on Python 2 and 3, but the order does not matter
-                expected_tags = expected_kwargs["json"].pop("tags")
-                actual_tags = actual_kwargs["json"].pop("tags")
-
-                assert sorted(expected_tags, key=lambda t: t["key"]) == sorted(
-                    actual_tags, key=lambda t: t["key"]
-                )
-                assert expected_kwargs == actual_kwargs
-
-        with mock_http_request() as mock_http:
-            store.log_param("some_uuid", Param("k1", "v1"))
-            body = message_to_json(
-                LogParam(run_uuid="some_uuid", run_id="some_uuid", key="k1", value="v1")
             )
-            self._verify_requests(mock_http, creds, "runs/log-parameter", "POST", body)
+            expected_kwargs = _args(creds, "runs/create", "POST", cr_body)
 
-        with mock_http_request() as mock_http:
-            store.set_experiment_tag("some_id", ExperimentTag("t1", "abcd" * 1000))
-            body = message_to_json(
-                SetExperimentTag(experiment_id="some_id", key="t1", value="abcd" * 1000)
-            )
-            self._verify_requests(mock_http, creds, "experiments/set-experiment-tag", "POST", body)
-
-        with mock_http_request() as mock_http:
-            store.set_tag("some_uuid", RunTag("t1", "abcd" * 1000))
-            body = message_to_json(
-                SetTag(run_uuid="some_uuid", run_id="some_uuid", key="t1", value="abcd" * 1000)
-            )
-            self._verify_requests(mock_http, creds, "runs/set-tag", "POST", body)
-
-        with mock_http_request() as mock_http:
-            store.delete_tag("some_uuid", "t1")
-            body = message_to_json(DeleteTag(run_id="some_uuid", key="t1"))
-            self._verify_requests(mock_http, creds, "runs/delete-tag", "POST", body)
-
-        with mock_http_request() as mock_http:
-            store.log_metric("u2", Metric("m1", 0.87, 12345, 3))
-            body = message_to_json(
-                LogMetric(run_uuid="u2", run_id="u2", key="m1", value=0.87, timestamp=12345, step=3)
-            )
-            self._verify_requests(mock_http, creds, "runs/log-metric", "POST", body)
-
-        with mock_http_request() as mock_http:
-            metrics = [
-                Metric("m1", 0.87, 12345, 0),
-                Metric("m2", 0.49, 12345, -1),
-                Metric("m3", 0.58, 12345, 2),
-            ]
-            params = [Param("p1", "p1val"), Param("p2", "p2val")]
-            tags = [RunTag("t1", "t1val"), RunTag("t2", "t2val")]
-            store.log_batch(run_id="u2", metrics=metrics, params=params, tags=tags)
-            metric_protos = [metric.to_proto() for metric in metrics]
-            param_protos = [param.to_proto() for param in params]
-            tag_protos = [tag.to_proto() for tag in tags]
-            body = message_to_json(
-                LogBatch(run_id="u2", metrics=metric_protos, params=param_protos, tags=tag_protos)
-            )
-            self._verify_requests(mock_http, creds, "runs/log-batch", "POST", body)
-
-        with mock_http_request() as mock_http:
-            dataset = Dataset(name="name", digest="digest", source_type="st", source="source")
-            tag = InputTag(key="k1", value="v1")
-            dataset_input = DatasetInput(dataset=dataset, tags=[tag])
-            store.log_inputs("some_uuid", [dataset_input])
-            body = message_to_json(
-                LogInputs(run_id="some_uuid", datasets=[dataset_input.to_proto()])
-            )
-            self._verify_requests(mock_http, creds, "runs/log-inputs", "POST", body)
-
-        with mock_http_request() as mock_http:
-            store.delete_run("u25")
-            self._verify_requests(
-                mock_http, creds, "runs/delete", "POST", message_to_json(DeleteRun(run_id="u25"))
-            )
-
-        with mock_http_request() as mock_http:
-            store.restore_run("u76")
-            self._verify_requests(
-                mock_http, creds, "runs/restore", "POST", message_to_json(RestoreRun(run_id="u76"))
-            )
-
-        with mock_http_request() as mock_http:
-            store.delete_experiment("0")
-            self._verify_requests(
-                mock_http,
-                creds,
-                "experiments/delete",
-                "POST",
-                message_to_json(DeleteExperiment(experiment_id="0")),
-            )
-
-        with mock_http_request() as mock_http:
-            store.restore_experiment("0")
-            self._verify_requests(
-                mock_http,
-                creds,
-                "experiments/restore",
-                "POST",
-                message_to_json(RestoreExperiment(experiment_id="0")),
-            )
-
-        with mock.patch("mlflow.utils.rest_utils.http_request") as mock_http:
-            response = mock.MagicMock()
-            response.status_code = 200
-            response.text = '{"runs": ["1a", "2b", "3c"], "next_page_token": "67890fghij"}'
-            mock_http.return_value = response
-            result = store.search_runs(
-                ["0", "1"],
-                "params.p1 = 'a'",
-                ViewType.ACTIVE_ONLY,
-                max_results=10,
-                order_by=["a"],
-                page_token="12345abcde",
-            )
-
-            expected_message = SearchRuns(
-                experiment_ids=["0", "1"],
-                filter="params.p1 = 'a'",
-                run_view_type=ViewType.to_proto(ViewType.ACTIVE_ONLY),
-                max_results=10,
-                order_by=["a"],
-                page_token="12345abcde",
-            )
-            self._verify_requests(
-                mock_http, creds, "runs/search", "POST", message_to_json(expected_message)
-            )
-            assert result.token == "67890fghij"
-
-        with mock_http_request() as mock_http:
-            run_id = "run_id"
-            m = Model(artifact_path="model/path", run_id="run_id", flavors={"tf": "flavor body"})
-            store.record_logged_model("run_id", m)
-            expected_message = LogModel(run_id=run_id, model_json=m.to_json())
-            self._verify_requests(
-                mock_http, creds, "runs/log-model", "POST", message_to_json(expected_message)
-            )
-
-    def test_get_experiment_by_name(self):
-        creds = MlflowHostCreds("https://hello")
-        store = RestStore(lambda: creds)
-        with mock.patch("mlflow.utils.rest_utils.http_request") as mock_http:
-            response = mock.MagicMock()
-            response.status_code = 200
-            experiment = Experiment(
-                experiment_id="123",
-                name="abc",
-                artifact_location="/abc",
-                lifecycle_stage=LifecycleStage.ACTIVE,
-            )
-            response.text = json.dumps(
-                {"experiment": json.loads(message_to_json(experiment.to_proto()))}
-            )
-            mock_http.return_value = response
-            result = store.get_experiment_by_name("abc")
-            expected_message0 = GetExperimentByName(experiment_name="abc")
-            self._verify_requests(
-                mock_http,
-                creds,
-                "experiments/get-by-name",
-                "GET",
-                message_to_json(expected_message0),
-            )
-            assert result.experiment_id == experiment.experiment_id
-            assert result.name == experiment.name
-            assert result.artifact_location == experiment.artifact_location
-            assert result.lifecycle_stage == experiment.lifecycle_stage
-            # Test GetExperimentByName against nonexistent experiment
-            mock_http.reset_mock()
-            nonexistent_exp_response = mock.MagicMock()
-            nonexistent_exp_response.status_code = 404
-            nonexistent_exp_response.text = MlflowException(
-                "Exp doesn't exist!", RESOURCE_DOES_NOT_EXIST
-            ).serialize_as_json()
-            mock_http.return_value = nonexistent_exp_response
-            assert store.get_experiment_by_name("nonexistent-experiment") is None
-            expected_message1 = GetExperimentByName(experiment_name="nonexistent-experiment")
-            self._verify_requests(
-                mock_http,
-                creds,
-                "experiments/get-by-name",
-                "GET",
-                message_to_json(expected_message1),
-            )
             assert mock_http.call_count == 1
+            actual_kwargs = mock_http.call_args[1]
 
-    def test_search_experiments(self):
-        creds = MlflowHostCreds("https://hello")
-        store = RestStore(lambda: creds)
+            # Test the passed tag values separately from the rest of the request
+            # Tag order is inconsistent on Python 2 and 3, but the order does not matter
+            expected_tags = expected_kwargs["json"].pop("tags")
+            actual_tags = actual_kwargs["json"].pop("tags")
 
-        with mock_http_request() as mock_http:
-            store.search_experiments(
-                view_type=ViewType.DELETED_ONLY,
-                max_results=5,
-                filter_string="name",
-                order_by=["name"],
-                page_token="abc",
+            assert sorted(expected_tags, key=lambda t: t["key"]) == sorted(
+                actual_tags, key=lambda t: t["key"]
             )
-            self._verify_requests(
-                mock_http,
-                creds,
-                "experiments/search",
-                "POST",
-                message_to_json(
-                    SearchExperiments(
-                        view_type=ViewType.DELETED_ONLY,
-                        max_results=5,
-                        filter="name",
-                        order_by=["name"],
-                        page_token="abc",
-                    )
-                ),
-            )
+            assert expected_kwargs == actual_kwargs
 
-    @staticmethod
-    def _mock_response_with_200_status_code():
-        mock_response = mock.MagicMock()
-        mock_response.status_code = 200
-        return mock_response
+    with mock_http_request() as mock_http:
+        store.log_param("some_uuid", Param("k1", "v1"))
+        body = message_to_json(
+            LogParam(run_uuid="some_uuid", run_id="some_uuid", key="k1", value="v1")
+        )
+        _verify_requests(mock_http, creds, "runs/log-parameter", "POST", body)
 
-    def test_get_metric_history_paginated(self):
-        creds = MlflowHostCreds("https://hello")
-        store = RestStore(lambda: creds)
+    with mock_http_request() as mock_http:
+        store.set_experiment_tag("some_id", ExperimentTag("t1", "abcd" * 1000))
+        body = message_to_json(
+            SetExperimentTag(experiment_id="some_id", key="t1", value="abcd" * 1000)
+        )
+        _verify_requests(mock_http, creds, "experiments/set-experiment-tag", "POST", body)
 
-        response_1 = self._mock_response_with_200_status_code()
-        response_2 = self._mock_response_with_200_status_code()
-        response_payload_1 = {
-            "metrics": [
-                {"key": "a_metric", "value": 42, "timestamp": 123456777, "step": 0},
-                {"key": "a_metric", "value": 46, "timestamp": 123456797, "step": 1},
-            ],
-            "next_page_token": "AcursorForTheRestofTheData",
+    with mock_http_request() as mock_http:
+        store.set_tag("some_uuid", RunTag("t1", "abcd" * 1000))
+        body = message_to_json(
+            SetTag(run_uuid="some_uuid", run_id="some_uuid", key="t1", value="abcd" * 1000)
+        )
+        _verify_requests(mock_http, creds, "runs/set-tag", "POST", body)
+
+    with mock_http_request() as mock_http:
+        store.delete_tag("some_uuid", "t1")
+        body = message_to_json(DeleteTag(run_id="some_uuid", key="t1"))
+        _verify_requests(mock_http, creds, "runs/delete-tag", "POST", body)
+
+    with mock_http_request() as mock_http:
+        store.log_metric("u2", Metric("m1", 0.87, 12345, 3))
+        body = message_to_json(
+            LogMetric(run_uuid="u2", run_id="u2", key="m1", value=0.87, timestamp=12345, step=3)
+        )
+        _verify_requests(mock_http, creds, "runs/log-metric", "POST", body)
+
+    with mock_http_request() as mock_http:
+        metrics = [
+            Metric("m1", 0.87, 12345, 0),
+            Metric("m2", 0.49, 12345, -1),
+            Metric("m3", 0.58, 12345, 2),
+        ]
+        params = [Param("p1", "p1val"), Param("p2", "p2val")]
+        tags = [RunTag("t1", "t1val"), RunTag("t2", "t2val")]
+        store.log_batch(run_id="u2", metrics=metrics, params=params, tags=tags)
+        metric_protos = [metric.to_proto() for metric in metrics]
+        param_protos = [param.to_proto() for param in params]
+        tag_protos = [tag.to_proto() for tag in tags]
+        body = message_to_json(
+            LogBatch(run_id="u2", metrics=metric_protos, params=param_protos, tags=tag_protos)
+        )
+        _verify_requests(mock_http, creds, "runs/log-batch", "POST", body)
+
+    with mock_http_request() as mock_http:
+        dataset = Dataset(name="name", digest="digest", source_type="st", source="source")
+        tag = InputTag(key="k1", value="v1")
+        dataset_input = DatasetInput(dataset=dataset, tags=[tag])
+        store.log_inputs("some_uuid", [dataset_input])
+        body = message_to_json(LogInputs(run_id="some_uuid", datasets=[dataset_input.to_proto()]))
+        _verify_requests(mock_http, creds, "runs/log-inputs", "POST", body)
+
+    with mock_http_request() as mock_http:
+        store.delete_run("u25")
+        _verify_requests(
+            mock_http, creds, "runs/delete", "POST", message_to_json(DeleteRun(run_id="u25"))
+        )
+
+    with mock_http_request() as mock_http:
+        store.restore_run("u76")
+        _verify_requests(
+            mock_http, creds, "runs/restore", "POST", message_to_json(RestoreRun(run_id="u76"))
+        )
+
+    with mock_http_request() as mock_http:
+        store.delete_experiment("0")
+        _verify_requests(
+            mock_http,
+            creds,
+            "experiments/delete",
+            "POST",
+            message_to_json(DeleteExperiment(experiment_id="0")),
+        )
+
+    with mock_http_request() as mock_http:
+        store.restore_experiment("0")
+        _verify_requests(
+            mock_http,
+            creds,
+            "experiments/restore",
+            "POST",
+            message_to_json(RestoreExperiment(experiment_id="0")),
+        )
+
+    with mock.patch("mlflow.utils.rest_utils.http_request") as mock_http:
+        response = mock.MagicMock()
+        response.status_code = 200
+        response.text = '{"runs": ["1a", "2b", "3c"], "next_page_token": "67890fghij"}'
+        mock_http.return_value = response
+        result = store.search_runs(
+            ["0", "1"],
+            "params.p1 = 'a'",
+            ViewType.ACTIVE_ONLY,
+            max_results=10,
+            order_by=["a"],
+            page_token="12345abcde",
+        )
+
+        expected_message = SearchRuns(
+            experiment_ids=["0", "1"],
+            filter="params.p1 = 'a'",
+            run_view_type=ViewType.to_proto(ViewType.ACTIVE_ONLY),
+            max_results=10,
+            order_by=["a"],
+            page_token="12345abcde",
+        )
+        _verify_requests(mock_http, creds, "runs/search", "POST", message_to_json(expected_message))
+        assert result.token == "67890fghij"
+
+    with mock_http_request() as mock_http:
+        run_id = "run_id"
+        m = Model(artifact_path="model/path", run_id="run_id", flavors={"tf": "flavor body"})
+        store.record_logged_model("run_id", m)
+        expected_message = LogModel(run_id=run_id, model_json=m.to_json())
+        _verify_requests(
+            mock_http, creds, "runs/log-model", "POST", message_to_json(expected_message)
+        )
+
+
+def test_get_experiment_by_name():
+    creds = MlflowHostCreds("https://hello")
+    store = RestStore(lambda: creds)
+    with mock.patch("mlflow.utils.rest_utils.http_request") as mock_http:
+        response = mock.MagicMock()
+        response.status_code = 200
+        experiment = Experiment(
+            experiment_id="123",
+            name="abc",
+            artifact_location="/abc",
+            lifecycle_stage=LifecycleStage.ACTIVE,
+        )
+        response.text = json.dumps(
+            {"experiment": json.loads(message_to_json(experiment.to_proto()))}
+        )
+        mock_http.return_value = response
+        result = store.get_experiment_by_name("abc")
+        expected_message0 = GetExperimentByName(experiment_name="abc")
+        _verify_requests(
+            mock_http,
+            creds,
+            "experiments/get-by-name",
+            "GET",
+            message_to_json(expected_message0),
+        )
+        assert result.experiment_id == experiment.experiment_id
+        assert result.name == experiment.name
+        assert result.artifact_location == experiment.artifact_location
+        assert result.lifecycle_stage == experiment.lifecycle_stage
+        # Test GetExperimentByName against nonexistent experiment
+        mock_http.reset_mock()
+        nonexistent_exp_response = mock.MagicMock()
+        nonexistent_exp_response.status_code = 404
+        nonexistent_exp_response.text = MlflowException(
+            "Exp doesn't exist!", RESOURCE_DOES_NOT_EXIST
+        ).serialize_as_json()
+        mock_http.return_value = nonexistent_exp_response
+        assert store.get_experiment_by_name("nonexistent-experiment") is None
+        expected_message1 = GetExperimentByName(experiment_name="nonexistent-experiment")
+        _verify_requests(
+            mock_http,
+            creds,
+            "experiments/get-by-name",
+            "GET",
+            message_to_json(expected_message1),
+        )
+        assert mock_http.call_count == 1
+
+
+def test_search_experiments():
+    creds = MlflowHostCreds("https://hello")
+    store = RestStore(lambda: creds)
+
+    with mock_http_request() as mock_http:
+        store.search_experiments(
+            view_type=ViewType.DELETED_ONLY,
+            max_results=5,
+            filter_string="name",
+            order_by=["name"],
+            page_token="abc",
+        )
+        _verify_requests(
+            mock_http,
+            creds,
+            "experiments/search",
+            "POST",
+            message_to_json(
+                SearchExperiments(
+                    view_type=ViewType.DELETED_ONLY,
+                    max_results=5,
+                    filter="name",
+                    order_by=["name"],
+                    page_token="abc",
+                )
+            ),
+        )
+
+
+def _mock_response_with_200_status_code():
+    mock_response = mock.MagicMock()
+    mock_response.status_code = 200
+    return mock_response
+
+
+def test_get_metric_history_paginated():
+    creds = MlflowHostCreds("https://hello")
+    store = RestStore(lambda: creds)
+
+    response_1 = _mock_response_with_200_status_code()
+    response_2 = _mock_response_with_200_status_code()
+    response_payload_1 = {
+        "metrics": [
+            {"key": "a_metric", "value": 42, "timestamp": 123456777, "step": 0},
+            {"key": "a_metric", "value": 46, "timestamp": 123456797, "step": 1},
+        ],
+        "next_page_token": "AcursorForTheRestofTheData",
+    }
+    response_1.text = json.dumps(response_payload_1)
+    response_payload_2 = {
+        "metrics": [
+            {"key": "a_metric", "value": 40, "timestamp": 123456877, "step": 2},
+            {"key": "a_metric", "value": 56, "timestamp": 123456897, "step": 3},
+        ],
+        "next_page_token": "",
+    }
+    response_2.text = json.dumps(response_payload_2)
+    with mock.patch(
+        "requests.Session.request", side_effect=[response_1, response_2]
+    ) as mock_request:
+        # Fetch the first page
+        metrics = store.get_metric_history(
+            run_id="2", metric_key="a_metric", max_results=2, page_token=None
+        )
+        mock_request.assert_called_once()
+        assert mock_request.call_args.kwargs["params"] == {
+            "max_results": 2,
+            "metric_key": "a_metric",
+            "run_id": "2",
+            "run_uuid": "2",
         }
-        response_1.text = json.dumps(response_payload_1)
-        response_payload_2 = {
-            "metrics": [
-                {"key": "a_metric", "value": 40, "timestamp": 123456877, "step": 2},
-                {"key": "a_metric", "value": 56, "timestamp": 123456897, "step": 3},
-            ],
-            "next_page_token": "",
+        assert len(metrics) == 2
+        assert metrics[0] == Metric(key="a_metric", value=42, timestamp=123456777, step=0)
+        assert metrics[1] == Metric(key="a_metric", value=46, timestamp=123456797, step=1)
+        assert metrics.token == "AcursorForTheRestofTheData"
+        # Fetch the second page
+        mock_request.reset_mock()
+        metrics = store.get_metric_history(
+            run_id="2", metric_key="a_metric", max_results=2, page_token=metrics.token
+        )
+        mock_request.assert_called_once()
+        assert mock_request.call_args.kwargs["params"] == {
+            "max_results": 2,
+            "page_token": "AcursorForTheRestofTheData",
+            "metric_key": "a_metric",
+            "run_id": "2",
+            "run_uuid": "2",
         }
-        response_2.text = json.dumps(response_payload_2)
-        with mock.patch(
-            "requests.Session.request", side_effect=[response_1, response_2]
-        ) as mock_request:
-            # Fetch the first page
-            metrics = store.get_metric_history(
-                run_id="2", metric_key="a_metric", max_results=2, page_token=None
-            )
-            mock_request.assert_called_once()
-            assert mock_request.call_args.kwargs["params"] == {
-                "max_results": 2,
-                "metric_key": "a_metric",
-                "run_id": "2",
-                "run_uuid": "2",
-            }
-            assert len(metrics) == 2
-            assert metrics[0] == Metric(key="a_metric", value=42, timestamp=123456777, step=0)
-            assert metrics[1] == Metric(key="a_metric", value=46, timestamp=123456797, step=1)
-            assert metrics.token == "AcursorForTheRestofTheData"
-            # Fetch the second page
-            mock_request.reset_mock()
-            metrics = store.get_metric_history(
-                run_id="2", metric_key="a_metric", max_results=2, page_token=metrics.token
-            )
-            mock_request.assert_called_once()
-            assert mock_request.call_args.kwargs["params"] == {
-                "max_results": 2,
-                "page_token": "AcursorForTheRestofTheData",
-                "metric_key": "a_metric",
-                "run_id": "2",
-                "run_uuid": "2",
-            }
-            assert len(metrics) == 2
-            assert metrics[0] == Metric(key="a_metric", value=40, timestamp=123456877, step=2)
-            assert metrics[1] == Metric(key="a_metric", value=56, timestamp=123456897, step=3)
-            assert metrics.token is None
-
-    def test_get_metric_history_on_non_existent_metric_key(self):
-        creds = MlflowHostCreds("https://hello")
-        rest_store = RestStore(lambda: creds)
-        empty_metric_response = self._mock_response_with_200_status_code()
-        empty_metric_response.text = json.dumps({})
-        with mock.patch(
-            "requests.Session.request", side_effect=[empty_metric_response]
-        ) as mock_request:
-            metrics = rest_store.get_metric_history(run_id="1", metric_key="test_metric")
-            mock_request.assert_called_once()
-            assert metrics == []
+        assert len(metrics) == 2
+        assert metrics[0] == Metric(key="a_metric", value=40, timestamp=123456877, step=2)
+        assert metrics[1] == Metric(key="a_metric", value=56, timestamp=123456897, step=3)
+        assert metrics.token is None
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_get_metric_history_on_non_existent_metric_key():
+    creds = MlflowHostCreds("https://hello")
+    rest_store = RestStore(lambda: creds)
+    empty_metric_response = _mock_response_with_200_status_code()
+    empty_metric_response.text = json.dumps({})
+    with mock.patch(
+        "requests.Session.request", side_effect=[empty_metric_response]
+    ) as mock_request:
+        metrics = rest_store.get_metric_history(run_id="1", metric_key="test_metric")
+        mock_request.assert_called_once()
+        assert metrics == []


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Migrate `TestRestStore`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
