### PR TITLE
Enable `UP034` to remove extraneous parentheses

### DIFF
--- a/mlflow/pytorch/_lightning_autolog.py
+++ b/mlflow/pytorch/_lightning_autolog.py
@@ -349,11 +349,9 @@ def patched_fit(original, self, *args, **kwargs):
     """
     if not MIN_REQ_VERSION <= _pl_version <= MAX_REQ_VERSION:
         warnings.warn(
-            (
-                "Autologging is known to be compatible with pytorch-lightning versions between "
-                f"{MIN_REQ_VERSION} and {MAX_REQ_VERSION} and may not succeed with packages "
-                "outside this range."
-            )
+            "Autologging is known to be compatible with pytorch-lightning versions between "
+            f"{MIN_REQ_VERSION} and {MAX_REQ_VERSION} and may not succeed with packages "
+            "outside this range."
         )
 
     with _pytorch_autolog.disable_pytorch_autologging():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ select = [
   "UP004",
   "UP008",
   "UP031",
+  "UP034",
 ]
 force-exclude = true
 ignore = [

--- a/tests/recipes/test_split_step.py
+++ b/tests/recipes/test_split_step.py
@@ -297,9 +297,9 @@ def test_custom_split_method(tmp_recipe_root_path: Path, tmp_recipe_exec_path: P
     with mock.patch.dict("sys.modules", {"steps.split": m_split}):
         split_step.run(str(split_output_dir))
 
-    train_dataframe = pd.read_parquet((split_output_dir / _OUTPUT_TRAIN_FILE_NAME))
-    validation_dataframe = pd.read_parquet((split_output_dir / _OUTPUT_VALIDATION_FILE_NAME))
-    test_dataframe = pd.read_parquet((split_output_dir / _OUTPUT_TEST_FILE_NAME))
+    train_dataframe = pd.read_parquet(split_output_dir / _OUTPUT_TRAIN_FILE_NAME)
+    validation_dataframe = pd.read_parquet(split_output_dir / _OUTPUT_VALIDATION_FILE_NAME)
+    test_dataframe = pd.read_parquet(split_output_dir / _OUTPUT_TEST_FILE_NAME)
     assert len(train_dataframe.index) == 500
     assert len(validation_dataframe.index) == 300
     assert len(test_dataframe.index) == 200

--- a/tests/recipes/test_train_step.py
+++ b/tests/recipes/test_train_step.py
@@ -734,7 +734,7 @@ def test_train_step_with_predict_probability(
     transform_step_output_dir = tmp_recipe_exec_path.joinpath("steps", "transform", "outputs")
 
     validation_dataset = pd.read_parquet(
-        (str(transform_step_output_dir / "transformed_validation_data.parquet"))
+        str(transform_step_output_dir / "transformed_validation_data.parquet")
     )
 
     output = model.predict(validation_dataset.drop("y", axis=1))
@@ -800,7 +800,7 @@ def test_train_step_with_predict_probability_with_custom_prefix(
     transform_step_output_dir = tmp_recipe_exec_path.joinpath("steps", "transform", "outputs")
 
     validation_dataset = pd.read_parquet(
-        (str(transform_step_output_dir / "transformed_validation_data.parquet"))
+        str(transform_step_output_dir / "transformed_validation_data.parquet")
     )
 
     output = model.predict(validation_dataset.drop("y", axis=1))
@@ -854,7 +854,7 @@ def test_train_step_with_label_encoding(tmp_recipe_root_path: Path, tmp_recipe_e
     transform_step_output_dir = tmp_recipe_exec_path.joinpath("steps", "transform", "outputs")
 
     validation_dataset = pd.read_parquet(
-        (str(transform_step_output_dir / "transformed_validation_data.parquet"))
+        str(transform_step_output_dir / "transformed_validation_data.parquet")
     )
 
     predicted_output = model.predict(validation_dataset.drop("y", axis=1))

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -1131,7 +1131,7 @@ def test_artifact_logging_chunks_upload_list(databricks_artifact_repo, tmp_path)
         databricks_artifact_repo.log_artifacts(src_dir, "dir_artifact")
 
         assert mock_get_write_creds.call_count == 5
-        assert all((len(call[1]["paths"]) == 2 for call in mock_get_write_creds.call_args_list))
+        assert all(len(call[1]["paths"]) == 2 for call in mock_get_write_creds.call_args_list)
 
 
 def test_download_artifacts_provides_failure_info(databricks_artifact_repo):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Enable `UP034` (https://beta.ruff.rs/docs/rules/extraneous-parentheses/).

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
