### PR TITLE
Add compatibility for legacy transformers serialization

### DIFF
--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -13,7 +13,6 @@ import pandas as pd
 import re
 from typing import Union, List, Optional, Dict, Any, NamedTuple
 from urllib.parse import urlparse
-
 import yaml
 
 import mlflow
@@ -869,7 +868,13 @@ def _load_model(path: str, flavor_config, return_type: str, device=None, **kwarg
 
     model_instance = getattr(transformers, flavor_config[_PIPELINE_MODEL_TYPE_KEY])
     local_path = pathlib.Path(path)
-    model_path = local_path.joinpath(flavor_config.get(_MODEL_BINARY_KEY, _MODEL_BINARY_FILE_NAME))
+    # NB: Path resolution for models that were saved prior to 2.4.1 release when the pathing for
+    #     the saved pipeline or component artifacts was handled by duplicate entries for components
+    #     (artifacts/pipeline/* and artifacts/components/*) and pipelines were saved via the
+    #     "artifacts/pipeline/*" path. In order to load the older formats after the change, the
+    #     presence of the new path key is checked.
+    model_path = local_path.joinpath(flavor_config.get(_MODEL_BINARY_KEY, "pipeline"))
+
     conf = {
         "task": flavor_config[_TASK_KEY],
     }

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3263,7 +3263,7 @@ def test_uri_directory_renaming_handling_pipeline(model_path, small_seq2seq_pipe
 
     # remove the 'model_binary' entries to emulate older versions of MLflow
     mlmodel_file = os.path.join(model_path, "MLmodel")
-    with open(mlmodel_file, "r") as yaml_file:
+    with open(mlmodel_file) as yaml_file:
         mlmodel = yaml.safe_load(yaml_file)
 
     mlmodel["flavors"]["python_function"].pop("model_binary", None)
@@ -3274,9 +3274,7 @@ def test_uri_directory_renaming_handling_pipeline(model_path, small_seq2seq_pipe
 
     loaded_model = mlflow.pyfunc.load_model(model_path)
 
-    prediction = loaded_model.predict(
-        "Dogs should be fed spaghetti bolognese, chili, and beef stew, according to my dog."
-    )
+    prediction = loaded_model.predict("test")
     assert isinstance(prediction, pd.DataFrame)
     assert isinstance(prediction["label"][0], str)
 
@@ -3296,7 +3294,7 @@ def test_uri_directory_renaming_handling_components(model_path, small_seq2seq_pi
 
     # remove the 'model_binary' entries to emulate older versions of MLflow
     mlmodel_file = os.path.join(model_path, "MLmodel")
-    with open(mlmodel_file, "r") as yaml_file:
+    with open(mlmodel_file) as yaml_file:
         mlmodel = yaml.safe_load(yaml_file)
 
     mlmodel["flavors"]["python_function"].pop("model_binary", None)
@@ -3307,9 +3305,6 @@ def test_uri_directory_renaming_handling_components(model_path, small_seq2seq_pi
 
     loaded_model = mlflow.pyfunc.load_model(model_path)
 
-    prediction = loaded_model.predict(
-        "I'd love it if I could swim as fast as a dolphin and do backflips from jumping out of "
-        "the water. I'm good on the whole eating raw mackerel and squid, though"
-    )
+    prediction = loaded_model.predict("test")
     assert isinstance(prediction, pd.DataFrame)
     assert isinstance(prediction["label"][0], str)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add the ability to load models that were saved prior to the breaking change introduced in https://github.com/mlflow/mlflow/commit/94702887ce97153f36901f4d4567944849fd6cb9 where the default pipeline logging location changed from `pipeline` -> `model`. The change in this PR allows for reading of the previously named path.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix a pathing regression introduced in Mlflow 2.4.0 for transformers pipeline artifacts that prevented models saved in 2.3.x from being loaded in MLflow >2.4

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
