### PR TITLE
Remove `anthropic_api_base` and  `cohere_api_base`

### DIFF
--- a/examples/gateway/anthropic.yaml
+++ b/examples/gateway/anthropic.yaml
@@ -5,5 +5,4 @@ routes:
       provider: anthropic
       name: claude-1.3-100k
       config:
-        anthropic_api_base: https://api.anthropic.com/v1
         anthropic_api_key: $ANTHROPIC_API_KEY

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -37,7 +37,6 @@ class RouteType(str, Enum):
 
 class CohereConfig(ConfigModel):
     cohere_api_key: str
-    cohere_api_base: str = "https://api.cohere.ai/v1"
 
     # pylint: disable=no-self-argument
     @validator("cohere_api_key", pre=True)
@@ -110,7 +109,6 @@ class OpenAIConfig(ConfigModel):
 
 class AnthropicConfig(ConfigModel):
     anthropic_api_key: str
-    anthropic_api_base: str = "https://api.anthropic.com/"
 
     # pylint: disable=no-self-argument
     @validator("anthropic_api_key", pre=True)

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -18,7 +18,7 @@ class AnthropicProvider(BaseProvider):
             raise TypeError(f"Invalid config type {config.model.config}")
         self.anthropic_config: AnthropicConfig = config.model.config
         self.headers = {"x-api-key": self.anthropic_config.anthropic_api_key}
-        self.base_url = self.anthropic_config.anthropic_api_base
+        self.base_url = "https://api.anthropic.com/"
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
         payload = jsonable_encoder(payload, exclude_none=True)

--- a/mlflow/gateway/providers/cohere.py
+++ b/mlflow/gateway/providers/cohere.py
@@ -20,7 +20,7 @@ class CohereProvider(BaseProvider):
         headers = {"Authorization": f"Bearer {self.cohere_config.cohere_api_key}"}
         return await send_request(
             headers=headers,
-            base_url=self.cohere_config.cohere_api_base,
+            base_url="https://api.cohere.ai/v1",
             path=path,
             payload=payload,
         )

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -32,7 +32,6 @@ def completions_config():
             "provider": "anthropic",
             "name": "claude-instant-1",
             "config": {
-                "anthropic_api_base": "https://api.anthropic.com/v1",
                 "anthropic_api_key": "key",
             },
         },
@@ -152,7 +151,6 @@ def chat_config():
             "provider": "anthropic",
             "name": "claude-instant-1",
             "config": {
-                "anthropic_api_base": "https://api.anthropic.com/v1",
                 "anthropic_api_key": "key",
             },
         },
@@ -181,7 +179,6 @@ def embedding_config():
             "provider": "anthropic",
             "name": "claude-1.3-100k",
             "config": {
-                "anthropic_api_base": "https://api.anthropic.com/v1",
                 "anthropic_api_key": "key",
             },
         },

--- a/tests/gateway/test_client.py
+++ b/tests/gateway/test_client.py
@@ -74,7 +74,6 @@ def mixed_config_dict():
                     "provider": "anthropic",
                     "name": "claude-instant-1",
                     "config": {
-                        "anthropic_api_base": "https://api.anthropic.com/v1",
                         "anthropic_api_key": "key",
                     },
                 },

--- a/tests/gateway/test_gateway_config_parsing.py
+++ b/tests/gateway/test_gateway_config_parsing.py
@@ -166,7 +166,6 @@ def test_route_configuration_parsing(basic_config_dict, tmp_path, monkeypatch):
     assert claude.model.provider == "anthropic"
     claude_conf = claude.model.config
     assert claude_conf.anthropic_api_key == "api_key"
-    assert claude_conf.anthropic_api_base == "https://api.anthropic.com/"
 
 
 def test_convert_route_config_to_routes_payload(basic_config_dict, tmp_path):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Remove `anthropic_api_base` and  `cohere_api_base`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
