### PR TITLE
Activate ruff print-t20

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -83,7 +83,6 @@ enable=signature-differs,
        # --------------
        # Custom rules
        pytest-raises-without-match,
-       print-function,
        unittest-assert-raises,
        pytest-raises-multiple-statements,
        use-f-string,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,7 @@ select = [
   "UP015",
   "UP031",
   "UP034",
-  "T201",
-  "T203",
+  "T20",
 ]
 force-exclude = true
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ select = [
   "UP015",
   "UP031",
   "UP034",
+  "T201",
+  "T203",
 ]
 force-exclude = true
 ignore = [
@@ -70,3 +72,7 @@ exclude = [
   "mlflow/temporary_db_migrations_for_pre_1_users",
   "tests/protos",
 ]
+[tool.ruff.per-file-ignores]
+"dev/*" = ["T201", "T203"]
+"tests/resources/example_project/greeter.py" = ["T201", "T203"]
+"tests/resources/mlflow-test-plugin/mlflow_test_plugin/fake_deployment_plugin.py" = ["T201", "T203"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,4 @@ exclude = [
   "tests/protos",
 ]
 [tool.ruff.per-file-ignores]
-"dev/*" = ["T201", "T203"]
-"tests/resources/example_project/greeter.py" = ["T201", "T203"]
-"tests/resources/mlflow-test-plugin/mlflow_test_plugin/fake_deployment_plugin.py" = ["T201", "T203"]
+"dev/*" = ["T201"]

--- a/tests/resources/example_project/greeter.py
+++ b/tests/resources/example_project/greeter.py
@@ -14,4 +14,4 @@ if __name__ == "__main__":
     if args.excitement is not None:
         greeting.append("!" * args.excitement)
     # pylint: disable-next=print-function
-    print(" ".join(greeting))
+    print(" ".join(greeting))  # noqa: T201

--- a/tests/resources/example_project/greeter.py
+++ b/tests/resources/example_project/greeter.py
@@ -13,5 +13,4 @@ if __name__ == "__main__":
     greeting = [args.greeting, args.name]
     if args.excitement is not None:
         greeting.append("!" * args.excitement)
-    # pylint: disable-next=print-function
     print(" ".join(greeting))  # noqa: T201

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/fake_deployment_plugin.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/fake_deployment_plugin.py
@@ -53,7 +53,7 @@ class PluginDeploymentClient(BaseDeploymentClient):
 
 def run_local(name, model_uri, flavor=None, config=None):
     # pylint: disable-next=print-function
-    print(
+    print(  # noqa: T201
         f"Deployed locally at the key {name} using the model from {model_uri}. "
         f"It's flavor is {flavor} and config is {config}"
     )

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/fake_deployment_plugin.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/fake_deployment_plugin.py
@@ -52,7 +52,6 @@ class PluginDeploymentClient(BaseDeploymentClient):
 
 
 def run_local(name, model_uri, flavor=None, config=None):
-    # pylint: disable-next=print-function
     print(  # noqa: T201
         f"Deployed locally at the key {name} using the model from {model_uri}. "
         f"It's flavor is {flavor} and config is {config}"


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Resolve #8997

## What changes are proposed in this pull request?

As stated in [comment](https://github.com/mlflow/mlflow/issues/8997#issuecomment-1627591495) this PR activates ruff [T20](https://beta.ruff.rs/docs/rules/#flake8-print-t20) rule for print statements and applied to project. Necessary print statements saved by `per-file-ignores`

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
