### PR TITLE
Support nullable array type values as spark_udf return values

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -936,9 +936,15 @@ def _convert_array_values(values, elem_type, array_dim, spark_primitive_type_to_
         )
 
     if array_dim == 1:
-        return [np.array(v, dtype=np_type) for v in values]
+        return [
+            np.array(v, dtype=np_type) if v is not None else None
+            for v in values
+        ]
     else:
-        return [list(np.array(v, dtype=np_type)) for v in values]
+        return [
+            list(np.array(v, dtype=np_type)) if v is not None else None
+            for v in values
+        ]
 
 
 def _get_spark_primitive_types():

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -923,8 +923,7 @@ def _parse_spark_datatype(datatype: str):
     return udf(lambda x: x, returnType=datatype).returnType
 
 
-def _is_null_array(value):
-    # If provided value is None or NaN, regard it as a null array.
+def _is_none_or_nan(value):
     return value is None or isinstance(value, float) and np.isnan(value)
 
 
@@ -940,10 +939,12 @@ def _convert_array_values(values, elem_type, array_dim, spark_primitive_type_to_
             error_code=INVALID_PARAMETER_VALUE,
         )
 
+    # For array type result values, if provided value is None or NaN, regard it as a null array.
+    # see https://github.com/mlflow/mlflow/issues/8986
     if array_dim == 1:
-        return [None if _is_null_array(v) else np.array(v, dtype=np_type) for v in values]
+        return [None if _is_none_or_nan(v) else np.array(v, dtype=np_type) for v in values]
     else:
-        return [None if _is_null_array(v) else list(np.array(v, dtype=np_type)) for v in values]
+        return [None if _is_none_or_nan(v) else list(np.array(v, dtype=np_type)) for v in values]
 
 
 def _get_spark_primitive_types():

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -923,6 +923,11 @@ def _parse_spark_datatype(datatype: str):
     return udf(lambda x: x, returnType=datatype).returnType
 
 
+def _is_null_array(value):
+    # If provided value is None or NaN, regard it as a null array.
+    return value is None or isinstance(value, float) and np.isnan(value)
+
+
 def _convert_array_values(values, elem_type, array_dim, spark_primitive_type_to_np_type):
     """
     Convert list or numpy array values to spark dataframe column values.
@@ -936,15 +941,9 @@ def _convert_array_values(values, elem_type, array_dim, spark_primitive_type_to_
         )
 
     if array_dim == 1:
-        return [
-            np.array(v, dtype=np_type) if v is not None else None
-            for v in values
-        ]
+        return [None if _is_null_array(v) else np.array(v, dtype=np_type) for v in values]
     else:
-        return [
-            list(np.array(v, dtype=np_type)) if v is not None else None
-            for v in values
-        ]
+        return [None if _is_null_array(v) else list(np.array(v, dtype=np_type)) for v in values]
 
 
 def _get_spark_primitive_types():

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -924,6 +924,8 @@ def _parse_spark_datatype(datatype: str):
 
 
 def _is_none_or_nan(value):
+    # if value is not numeric type, `np.isnan(value)` raises error,
+    # so we add condition `isinstance(value, float)` before it.
     return value is None or isinstance(value, float) and np.isnan(value)
 
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -924,8 +924,8 @@ def _parse_spark_datatype(datatype: str):
 
 
 def _is_none_or_nan(value):
-    # if value is not numeric type, `np.isnan(value)` raises error,
-    # so we add condition `isinstance(value, float)` before it.
+    # The condition `isinstance(value, float)` is needed to avoid error
+    # from `np.isnan(value)` if value is a non-numeric type.
     return value is None or isinstance(value, float) and np.isnan(value)
 
 

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1019,20 +1019,19 @@ def test_spark_udf_array_of_structs(spark):
 def test_spark_udf_return_nullable_array_field(spark):
     class TestModel(PythonModel):
         def predict(self, context, model_input):
-            values = [np.array([1, 2])] * len(model_input)
-            values[-1] = None
-            return pd.DataFrame({'a': values})
+            values = [np.array([1, 2])] * (len(model_input) - 2) + [None, np.nan]
+            return pd.DataFrame({"a": values})
 
-    with mlflow.start_run() as run:
-        mlflow.pyfunc.log_model(
+    with mlflow.start_run():
+        mlflow_info = mlflow.pyfunc.log_model(
             "model",
             python_model=TestModel(),
         )
         udf = mlflow.pyfunc.spark_udf(
             spark,
-            f"runs:/{run.info.run_id}/model",
+            mlflow_info.model_uri,
             result_type="a array<long>",
         )
-        data1 = spark.range(2).repartition(1)
+        data1 = spark.range(3).repartition(1)
         result = data1.select(udf("id").alias("res")).select("res.a").toPandas()
-        assert list(result["a"]) == [[1, 2], None]
+        assert list(result["a"]) == [[1, 2], None, None]

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1014,3 +1014,25 @@ def test_spark_udf_array_of_structs(spark):
         )
         res = good_data.withColumn("res", udf("a")).select("res").toPandas()
         assert res["res"][0] == [("str", 0, 1, 0.0, 0.1, True)]
+
+
+def test_spark_udf_return_nullable_array_field(spark):
+    class TestModel(PythonModel):
+        def predict(self, context, model_input):
+            values = [np.array([1, 2])] * len(model_input)
+            values[-1] = None
+            return pd.DataFrame({'a': values})
+
+    with mlflow.start_run() as run:
+        mlflow.pyfunc.log_model(
+            "model",
+            python_model=TestModel(),
+        )
+        udf = mlflow.pyfunc.spark_udf(
+            spark,
+            f"runs:/{run.info.run_id}/model",
+            result_type="a array<long>",
+        )
+        data1 = spark.range(2).repartition(1)
+        result = data1.select(udf("id").alias("res")).select("res.a").toPandas()
+        assert list(result["a"]) == [[1, 2], None]

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1019,7 +1019,7 @@ def test_spark_udf_array_of_structs(spark):
 def test_spark_udf_return_nullable_array_field(spark):
     class TestModel(PythonModel):
         def predict(self, context, model_input):
-            values = [np.array([1, 2])] * (len(model_input) - 2) + [None, np.nan]
+            values = [np.array([1.0, np.nan])] * (len(model_input) - 2) + [None, np.nan]
             return pd.DataFrame({"a": values})
 
     with mlflow.start_run():
@@ -1030,8 +1030,8 @@ def test_spark_udf_return_nullable_array_field(spark):
         udf = mlflow.pyfunc.spark_udf(
             spark,
             mlflow_info.model_uri,
-            result_type="a array<long>",
+            result_type="a array<double>",
         )
         data1 = spark.range(3).repartition(1)
         result = data1.select(udf("id").alias("res")).select("res.a").toPandas()
-        assert list(result["a"]) == [[1, 2], None, None]
+        assert list(result["a"]) == [[1.0, None], None, None]


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> Closes #8986

## What changes are proposed in this pull request?

Support nullable array type values as spark_udf return values

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
