### PR TITLE
Parametrize `test_check_spark_udf_return_type`

### DIFF
--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -40,7 +40,13 @@ import mlflow.pyfunc
 import mlflow.sklearn
 from mlflow.exceptions import MlflowException
 from mlflow.models import ModelSignature
-from mlflow.pyfunc import spark_udf, PythonModel, PyFuncModel
+from mlflow.pyfunc import (
+    spark_udf,
+    PythonModel,
+    PyFuncModel,
+    _check_udf_return_type,
+    _parse_spark_datatype,
+)
 from mlflow.pyfunc.spark_model_cache import SparkModelCache
 from mlflow.types import Schema, ColSpec, TensorSpec
 from pandas.testing import assert_frame_equal
@@ -506,31 +512,33 @@ def test_spark_udf_single_long_return_type_inference(spark):
         assert result["res"].tolist() == [12] * 2
 
 
-def test_check_spark_udf_return_type(spark):
-    def _check(type_str):
-        return mlflow.pyfunc._check_udf_return_type(mlflow.pyfunc._parse_spark_datatype(type_str))
-
-    assert _check("int")
-    assert _check("bigint")
-    assert _check("float")
-    assert _check("double")
-    assert _check("boolean")
-    assert _check("string")
-
-    assert _check("array<double>")
-    assert _check("array<array<double>>")
-    assert _check("a long, b boolean, c array<double>, d array<array<double>>")
-    assert _check("array<struct<a: int, b: boolean>>")
-    assert _check("array<struct<a: array<int>>>")
-
-    assert not _check("array<array<array<float>>>")
-    assert not _check("a array<array<array<int>>>")
-    assert not _check("struct<x: struct<a: long, b: boolean>>")
-    assert not _check("struct<x: array<struct<a: long, b: boolean>>>")
-    assert not _check("struct<a: array<struct<a: int>>>")
-    assert not _check("timestamp")
-    assert not _check("array<timestamp>")
-    assert not _check("struct<a: int, b: timestamp>")
+@pytest.mark.parametrize(
+    ("type_str", "expected"),
+    [
+        ("int", True),
+        ("bigint", True),
+        ("float", True),
+        ("double", True),
+        ("boolean", True),
+        ("string", True),
+        ("array<double>", True),
+        ("array<array<double>>", True),
+        ("a long, b boolean, c array<double>, d array<array<double>>", True),
+        ("array<struct<a: int, b: boolean>>", True),
+        ("array<struct<a: array<int>>>", True),
+        ("array<array<array<float>>>", False),
+        ("a array<array<array<int>>>", False),
+        ("struct<x: struct<a: long, b: boolean>>", False),
+        ("struct<x: array<struct<a: long, b: boolean>>>", False),
+        ("struct<a: array<struct<a: int>>>", False),
+        ("timestamp", False),
+        ("array<timestamp>", False),
+        ("struct<a: int, b: timestamp>", False),
+    ],
+)
+@pytest.mark.usefixtures("spark")
+def test_check_spark_udf_return_type(type_str, expected):
+    assert _check_udf_return_type(_parse_spark_datatype(type_str)) == expected
 
 
 def test_spark_udf_autofills_no_arguments(spark):

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -515,6 +515,7 @@ def test_spark_udf_single_long_return_type_inference(spark):
 @pytest.mark.parametrize(
     ("type_str", "expected"),
     [
+        # Good
         ("int", True),
         ("bigint", True),
         ("float", True),
@@ -526,6 +527,7 @@ def test_spark_udf_single_long_return_type_inference(spark):
         ("a long, b boolean, c array<double>, d array<array<double>>", True),
         ("array<struct<a: int, b: boolean>>", True),
         ("array<struct<a: array<int>>>", True),
+        # Bad
         ("array<array<array<float>>>", False),
         ("a array<array<array<int>>>", False),
         ("struct<x: struct<a: long, b: boolean>>", False),


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Parametrize `test_check_spark_udf_return_type`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
