### PR TITLE
Add more metrics to mlflow.evaluate()

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -277,6 +277,8 @@ jobs:
         run: |
           source ./dev/install-common-deps.sh
           pip install pyspark "numpy<1.24.0"
+          pip install torch
+          pip install transformers
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -277,8 +277,6 @@ jobs:
         run: |
           source ./dev/install-common-deps.sh
           pip install pyspark "numpy<1.24.0"
-          pip install torch
-          pip install transformers
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -276,9 +276,7 @@ jobs:
       - name: Install dependencies
         run: |
           source ./dev/install-common-deps.sh
-          pip install pyspark "numpy<1.24.0"
-          pip install torch
-          pip install transformers
+          pip install pyspark "numpy<1.24.0" torch transformers
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1081,12 +1081,26 @@ def evaluate(
           precision_recall_auc), precision-recall merged curves plot, ROC merged curves plot.
 
      - For question-answering models, the default evaluator logs:
-        - **metrics**: ``exact_match``.
+        - **metrics**: ``exact_match``, mean_perplexity (requires `evaluate`_),
+          percent_toxic (requires `transformers`_), ari_mean_grade_level (requires `textstat`_),
+          flesch_kincaid_mean_grade_level (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, and targets (if the ``targets``
           argument is supplied) of the model in tabular format.
 
+        .. _evaluate:
+            https://pypi.org/project/evaluate
+
+        .. _transformers:
+            https://pypi.org/project/transformers
+
+        .. _textstat:
+            https://pypi.org/project/textstat
+
      - For text-summarization models, the default evaluator logs:
-        - **metrics**: `ROUGE`_ (requires `evaluate`_, `nltk`_, and `rouge_score` to be installed).
+        - **metrics**: `ROUGE`_ (requires `evaluate`_, `nltk`_, and `rouge_score` to be installed),
+          mean_perplexity (requires `evaluate`_), percent_toxic (requires `transformers`_),
+          ari_mean_grade_level (requires `textstat`_), flesch_kincaid_mean_grade_level
+          (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, and targets (if the ``targets``
           argument is supplied) of the model in the tabular format.
 
@@ -1102,9 +1116,27 @@ def evaluate(
         .. _rouge_score:
             https://pypi.org/project/rouge-score
 
+        .. _transformers:
+            https://pypi.org/project/transformers
+
+        .. _textstat:
+            https://pypi.org/project/textstat
+
      - For text models, the default evaluator logs:
+        - **metrics**: mean_perplexity (requires `evaluate`_), percent_toxic
+          (requires `transformers`_), ari_mean_grade_level (requires `textstat`_),
+          flesch_kincaid_mean_grade_level (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, and targets (if the ``targets``
           argument is supplied) of the model in tabular format.
+
+        .. _evaluate:
+            https://pypi.org/project/evaluate
+
+        .. _transformers:
+            https://pypi.org/project/transformers
+
+        .. _textstat:
+            https://pypi.org/project/textstat
 
      - For sklearn models, the default evaluator additionally logs the model's evaluation criterion
        (e.g. mean accuracy for a classifier) computed by `model.score` method.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1082,10 +1082,10 @@ def evaluate(
 
      - For question-answering models, the default evaluator logs:
         - **metrics**: ``exact_match``, mean_perplexity (requires `evaluate`_),
-          toxicity_ratio (requires `evaluate`_), ari_mean_grade_level (requires `textstat`_),
-          flesch_kincaid_mean_grade_level (requires `textstat`_).
-        - **artifacts**: A JSON file containing the inputs, outputs, and targets (if the ``targets``
-          argument is supplied) of the model in tabular format.
+          toxicity_ratio (requires `evaluate`_), mean_ari_grade_level (requires `textstat`_),
+          mean_flesch_kincaid_grade_level (requires `textstat`_).
+        - **artifacts**: A JSON file containing the inputs, outputs, targets (if the ``targets``
+          argument is supplied), and per-row metrics of the model in tabular format.
 
         .. _evaluate:
             https://pypi.org/project/evaluate
@@ -1096,10 +1096,10 @@ def evaluate(
      - For text-summarization models, the default evaluator logs:
         - **metrics**: `ROUGE`_ (requires `evaluate`_, `nltk`_, and `rouge_score` to be installed),
           mean_perplexity (requires `evaluate`_), toxicity_ratio (requires `evaluate`_),
-          ari_mean_grade_level (requires `textstat`_), flesch_kincaid_mean_grade_level
+          mean_ari_grade_level (requires `textstat`_), mean_flesch_kincaid_grade_level
           (requires `textstat`_).
-        - **artifacts**: A JSON file containing the inputs, outputs, and targets (if the ``targets``
-          argument is supplied) of the model in the tabular format.
+        - **artifacts**: A JSON file containing the inputs, outputs, targets (if the ``targets``
+          argument is supplied), and per-row metrics of the model in the tabular format.
 
         .. _ROUGE:
             https://huggingface.co/spaces/evaluate-metric/rouge
@@ -1118,10 +1118,10 @@ def evaluate(
 
      - For text models, the default evaluator logs:
         - **metrics**: mean_perplexity (requires `evaluate`_), toxicity_ratio
-          (requires `evaluate`_), ari_mean_grade_level (requires `textstat`_),
-          flesch_kincaid_mean_grade_level (requires `textstat`_).
-        - **artifacts**: A JSON file containing the inputs, outputs, and targets (if the ``targets``
-          argument is supplied) of the model in tabular format.
+          (requires `evaluate`_), mean_ari_grade_level (requires `textstat`_),
+          mean_flesch_kincaid_grade_level (requires `textstat`_).
+        - **artifacts**: A JSON file containing the inputs, outputs, targets (if the ``targets``
+          argument is supplied), and per-row metrics of the model in tabular format.
 
         .. _evaluate:
             https://pypi.org/project/evaluate

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1081,11 +1081,30 @@ def evaluate(
           precision_recall_auc), precision-recall merged curves plot, ROC merged curves plot.
 
      - For question-answering models, the default evaluator logs:
-        - **metrics**: ``exact_match``, mean_perplexity (requires `evaluate`_),
-          toxicity_ratio (requires `evaluate`_), mean_ari_grade_level (requires `textstat`_),
-          mean_flesch_kincaid_grade_level (requires `textstat`_).
+        - **metrics**: ``exact_match``, `mean_perplexity` (requires `evaluate`_, `pytorch`_,
+          `transformers`_), `toxicity_ratio` (requires `evaluate`_, `pytorch`_, `transformers`_),
+          `mean_ari_grade_level` (requires `textstat`_), `mean_flesch_kincaid_grade_level`
+          (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, targets (if the ``targets``
           argument is supplied), and per-row metrics of the model in tabular format.
+
+        .. _mean_perplexity:
+            https://huggingface.co/spaces/evaluate-metric/perplexity
+
+        .. _toxicity_ratio:
+            https://huggingface.co/spaces/evaluate-measurement/toxicity
+
+        .. _pytorch:
+            https://pytorch.org/get-started/locally/
+
+        .. _transformers:
+            https://huggingface.co/docs/transformers/installation
+
+        .. _mean_ari_grade_level:
+            https://en.wikipedia.org/wiki/Automated_readability_index
+
+        .. _mean_flesch_kincaid_grade_level:
+            https://en.wikipedia.org/wiki/Flesch%E2%80%93Kincaid_readability_tests#Flesch%E2%80%93Kincaid_grade_level
 
         .. _evaluate:
             https://pypi.org/project/evaluate
@@ -1095,14 +1114,33 @@ def evaluate(
 
      - For text-summarization models, the default evaluator logs:
         - **metrics**: `ROUGE`_ (requires `evaluate`_, `nltk`_, and `rouge_score` to be installed),
-          mean_perplexity (requires `evaluate`_), toxicity_ratio (requires `evaluate`_),
-          mean_ari_grade_level (requires `textstat`_), mean_flesch_kincaid_grade_level
+          `mean_perplexity` (requires `evaluate`_, `pytorch`_,
+          `transformers`_), `toxicity_ratio` (requires `evaluate`_, `pytorch`_, `transformers`_),
+          `mean_ari_grade_level` (requires `textstat`_), `mean_flesch_kincaid_grade_level`
           (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, targets (if the ``targets``
           argument is supplied), and per-row metrics of the model in the tabular format.
 
         .. _ROUGE:
             https://huggingface.co/spaces/evaluate-metric/rouge
+
+        .. _mean_perplexity:
+            https://huggingface.co/spaces/evaluate-metric/perplexity
+
+        .. _toxicity_ratio:
+            https://huggingface.co/spaces/evaluate-measurement/toxicity
+
+        .. _pytorch:
+            https://pytorch.org/get-started/locally/
+
+        .. _transformers:
+            https://huggingface.co/docs/transformers/installation
+
+        .. _mean_ari_grade_level:
+            https://en.wikipedia.org/wiki/Automated_readability_index
+
+        .. _mean_flesch_kincaid_grade_level:
+            https://en.wikipedia.org/wiki/Flesch%E2%80%93Kincaid_readability_tests#Flesch%E2%80%93Kincaid_grade_level
 
         .. _evaluate:
             https://pypi.org/project/evaluate
@@ -1117,14 +1155,33 @@ def evaluate(
             https://pypi.org/project/textstat
 
      - For text models, the default evaluator logs:
-        - **metrics**: mean_perplexity (requires `evaluate`_), toxicity_ratio
-          (requires `evaluate`_), mean_ari_grade_level (requires `textstat`_),
-          mean_flesch_kincaid_grade_level (requires `textstat`_).
+        - **metrics**: `mean_perplexity` (requires `evaluate`_, `pytorch`_,
+          `transformers`_), `toxicity_ratio` (requires `evaluate`_, `pytorch`_, `transformers`_),
+          `mean_ari_grade_level` (requires `textstat`_), `mean_flesch_kincaid_grade_level`
+          (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, targets (if the ``targets``
           argument is supplied), and per-row metrics of the model in tabular format.
 
         .. _evaluate:
             https://pypi.org/project/evaluate
+
+        .. _mean_perplexity:
+            https://huggingface.co/spaces/evaluate-metric/perplexity
+
+        .. _toxicity_ratio:
+            https://huggingface.co/spaces/evaluate-measurement/toxicity
+
+        .. _pytorch:
+            https://pytorch.org/get-started/locally/
+
+        .. _transformers:
+            https://huggingface.co/docs/transformers/installation
+
+        .. _mean_ari_grade_level:
+            https://en.wikipedia.org/wiki/Automated_readability_index
+
+        .. _mean_flesch_kincaid_grade_level:
+            https://en.wikipedia.org/wiki/Flesch%E2%80%93Kincaid_readability_tests#Flesch%E2%80%93Kincaid_grade_level
 
         .. _textstat:
             https://pypi.org/project/textstat

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1082,7 +1082,7 @@ def evaluate(
 
      - For question-answering models, the default evaluator logs:
         - **metrics**: ``exact_match``, mean_perplexity (requires `evaluate`_),
-          toxicity_ratio (requires `transformers`_), ari_mean_grade_level (requires `textstat`_),
+          toxicity_ratio (requires `evaluate`_), ari_mean_grade_level (requires `textstat`_),
           flesch_kincaid_mean_grade_level (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, and targets (if the ``targets``
           argument is supplied) of the model in tabular format.
@@ -1090,15 +1090,12 @@ def evaluate(
         .. _evaluate:
             https://pypi.org/project/evaluate
 
-        .. _transformers:
-            https://pypi.org/project/transformers
-
         .. _textstat:
             https://pypi.org/project/textstat
 
      - For text-summarization models, the default evaluator logs:
         - **metrics**: `ROUGE`_ (requires `evaluate`_, `nltk`_, and `rouge_score` to be installed),
-          mean_perplexity (requires `evaluate`_), toxicity_ratio (requires `transformers`_),
+          mean_perplexity (requires `evaluate`_), toxicity_ratio (requires `evaluate`_),
           ari_mean_grade_level (requires `textstat`_), flesch_kincaid_mean_grade_level
           (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, and targets (if the ``targets``
@@ -1116,24 +1113,18 @@ def evaluate(
         .. _rouge_score:
             https://pypi.org/project/rouge-score
 
-        .. _transformers:
-            https://pypi.org/project/transformers
-
         .. _textstat:
             https://pypi.org/project/textstat
 
      - For text models, the default evaluator logs:
         - **metrics**: mean_perplexity (requires `evaluate`_), toxicity_ratio
-          (requires `transformers`_), ari_mean_grade_level (requires `textstat`_),
+          (requires `evaluate`_), ari_mean_grade_level (requires `textstat`_),
           flesch_kincaid_mean_grade_level (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, and targets (if the ``targets``
           argument is supplied) of the model in tabular format.
 
         .. _evaluate:
             https://pypi.org/project/evaluate
-
-        .. _transformers:
-            https://pypi.org/project/transformers
 
         .. _textstat:
             https://pypi.org/project/textstat

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1082,7 +1082,7 @@ def evaluate(
 
      - For question-answering models, the default evaluator logs:
         - **metrics**: ``exact_match``, mean_perplexity (requires `evaluate`_),
-          percent_toxic (requires `transformers`_), ari_mean_grade_level (requires `textstat`_),
+          toxicity_ratio (requires `transformers`_), ari_mean_grade_level (requires `textstat`_),
           flesch_kincaid_mean_grade_level (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, and targets (if the ``targets``
           argument is supplied) of the model in tabular format.
@@ -1098,7 +1098,7 @@ def evaluate(
 
      - For text-summarization models, the default evaluator logs:
         - **metrics**: `ROUGE`_ (requires `evaluate`_, `nltk`_, and `rouge_score` to be installed),
-          mean_perplexity (requires `evaluate`_), percent_toxic (requires `transformers`_),
+          mean_perplexity (requires `evaluate`_), toxicity_ratio (requires `transformers`_),
           ari_mean_grade_level (requires `textstat`_), flesch_kincaid_mean_grade_level
           (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, and targets (if the ``targets``
@@ -1123,7 +1123,7 @@ def evaluate(
             https://pypi.org/project/textstat
 
      - For text models, the default evaluator logs:
-        - **metrics**: mean_perplexity (requires `evaluate`_), percent_toxic
+        - **metrics**: mean_perplexity (requires `evaluate`_), toxicity_ratio
           (requires `transformers`_), ari_mean_grade_level (requires `textstat`_),
           flesch_kincaid_mean_grade_level (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, and targets (if the ``targets``

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1081,9 +1081,9 @@ def evaluate(
           precision_recall_auc), precision-recall merged curves plot, ROC merged curves plot.
 
      - For question-answering models, the default evaluator logs:
-        - **metrics**: ``exact_match``, `mean_perplexity` (requires `evaluate`_, `pytorch`_,
-          `transformers`_), `toxicity_ratio` (requires `evaluate`_, `pytorch`_, `transformers`_),
-          `mean_ari_grade_level` (requires `textstat`_), `mean_flesch_kincaid_grade_level`
+        - **metrics**: ``exact_match``, `mean_perplexity`_ (requires `evaluate`_, `pytorch`_,
+          `transformers`_), `toxicity_ratio`_ (requires `evaluate`_, `pytorch`_, `transformers`_),
+          `mean_ari_grade_level`_ (requires `textstat`_), `mean_flesch_kincaid_grade_level`_
           (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, targets (if the ``targets``
           argument is supplied), and per-row metrics of the model in tabular format.
@@ -1113,10 +1113,10 @@ def evaluate(
             https://pypi.org/project/textstat
 
      - For text-summarization models, the default evaluator logs:
-        - **metrics**: `ROUGE`_ (requires `evaluate`_, `nltk`_, and `rouge_score` to be installed),
-          `mean_perplexity` (requires `evaluate`_, `pytorch`_,
-          `transformers`_), `toxicity_ratio` (requires `evaluate`_, `pytorch`_, `transformers`_),
-          `mean_ari_grade_level` (requires `textstat`_), `mean_flesch_kincaid_grade_level`
+        - **metrics**: `ROUGE`_ (requires `evaluate`_, `nltk`_, and `rouge_score`_ to be installed),
+          `mean_perplexity`_ (requires `evaluate`_, `pytorch`_,
+          `transformers`_), `toxicity_ratio`_ (requires `evaluate`_, `pytorch`_, `transformers`_),
+          `mean_ari_grade_level`_ (requires `textstat`_), `mean_flesch_kincaid_grade_level`_
           (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, targets (if the ``targets``
           argument is supplied), and per-row metrics of the model in the tabular format.
@@ -1155,9 +1155,9 @@ def evaluate(
             https://pypi.org/project/textstat
 
      - For text models, the default evaluator logs:
-        - **metrics**: `mean_perplexity` (requires `evaluate`_, `pytorch`_,
-          `transformers`_), `toxicity_ratio` (requires `evaluate`_, `pytorch`_, `transformers`_),
-          `mean_ari_grade_level` (requires `textstat`_), `mean_flesch_kincaid_grade_level`
+        - **metrics**: `mean_perplexity`_ (requires `evaluate`_, `pytorch`_,
+          `transformers`_), `toxicity_ratio`_ (requires `evaluate`_, `pytorch`_, `transformers`_),
+          `mean_ari_grade_level`_ (requires `textstat`_), `mean_flesch_kincaid_grade_level`_
           (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, targets (if the ``targets``
           argument is supplied), and per-row metrics of the model in tabular format.

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1183,19 +1183,23 @@ class DefaultEvaluator(ModelEvaluator):
             )
             return
 
-        results = perplexity.compute(predictions=predictions, model_id='gpt2')
-        self.metrics.update({'mean_perplexity': results['mean_perplexity']})
-        self.metrics_dict.update({'perplexity': results['perplexities']})
+        results = perplexity.compute(predictions=predictions, model_id="gpt2")
+        self.metrics.update({"mean_perplexity": results["mean_perplexity"]})
+        self.metrics_dict.update({"perplexity": results["perplexities"]})
 
     def _calculate_toxicity(self, predictions):
         try:
-            from transformers import AutoModelForSequenceClassification, AutoTokenizer, TextClassificationPipeline
+            from transformers import (
+                AutoModelForSequenceClassification,
+                AutoTokenizer,
+                TextClassificationPipeline,
+            )
 
             model_path = "martin-ha/toxic-comment-model"
             tokenizer = AutoTokenizer.from_pretrained(model_path)
             model = AutoModelForSequenceClassification.from_pretrained(model_path)
 
-            pipeline =  TextClassificationPipeline(model=model, tokenizer=tokenizer)
+            pipeline = TextClassificationPipeline(model=model, tokenizer=tokenizer)
         except Exception as e:
             _logger.warning(
                 f"Failed to load 'toxicity' metric (error: {e!r}), skipping metric logging."
@@ -1203,9 +1207,12 @@ class DefaultEvaluator(ModelEvaluator):
             return
 
         results = pipeline(list(predictions))
-        percent_toxic = {'percent_toxic': sum([1 if result['label'] == 'toxic' else 0 for result in results])/len(results)}
+        percent_toxic = {
+            "percent_toxic": sum([1 if result["label"] == "toxic" else 0 for result in results])
+            / len(results)
+        }
         self.metrics.update(percent_toxic)
-        self.metrics_dict.update({'toxicity': results})
+        self.metrics_dict.update({"toxicity": results})
 
     def _calculate_reading_level(self, predictions):
         try:
@@ -1217,13 +1224,17 @@ class DefaultEvaluator(ModelEvaluator):
             return
 
         metrics = [textstat.flesch_kincaid_grade(prediction) for prediction in predictions]
-        self.metrics_dict.update({'flesch_kincaid': metrics})
-        average_grade_level = {'flesch_kincaid_mean_grade_level': sum(metric for metric in metrics)/len(metrics)}
+        self.metrics_dict.update({"flesch_kincaid": metrics})
+        average_grade_level = {
+            "flesch_kincaid_mean_grade_level": sum(metric for metric in metrics) / len(metrics)
+        }
         self.metrics.update(average_grade_level)
-        
+
         metrics = [textstat.automated_readability_index(prediction) for prediction in predictions]
-        self.metrics_dict.update({'automated_readability_index': metrics})
-        average_grade_level = {'ari_mean_grade_level': sum(metric for metric in metrics)/len(metrics)}
+        self.metrics_dict.update({"automated_readability_index": metrics})
+        average_grade_level = {
+            "ari_mean_grade_level": sum(metric for metric in metrics) / len(metrics)
+        }
         self.metrics.update(average_grade_level)
 
     def _calculate_general_text_metrics(self):
@@ -1233,10 +1244,11 @@ class DefaultEvaluator(ModelEvaluator):
         for prediction in predictions:
             if not isinstance(prediction, str):
                 _logger.warning(
-                    f"Cannot calculate perplexity, toxicity, and reading level metrics for non string inputs, skipping metric logging."
+                    """Cannot calculate perplexity, toxicity, and reading level metrics 
+                    for non string inputs, skipping metric logging."""
                 )
                 return
-                
+
         self._calculate_toxicity(predictions)
         self._calculate_reading_level(predictions)
         self._calculate_perplexity(predictions)
@@ -1269,7 +1281,9 @@ class DefaultEvaluator(ModelEvaluator):
         )
         metrics = rouge.compute(predictions=predictions, references=self.y, use_aggregator=False)
         self.metrics_dict.update(metrics)
-        aggregate_metrics = rouge.compute(predictions=predictions, references=self.y, use_aggregator=True)
+        aggregate_metrics = rouge.compute(
+            predictions=predictions, references=self.y, use_aggregator=True
+        )
         self.metrics.update(aggregate_metrics)
 
     def _evaluate_text_summarization(self):

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1171,6 +1171,93 @@ class DefaultEvaluator(ModelEvaluator):
             data = self.dataset.features_data.assign(outputs=self.y_pred)
         mlflow.log_table(data, artifact_file=f"{metric_prefix}{_EVAL_TABLE_FILE_NAME}")
 
+    def _calculate_perplexity(self, predictions):
+        try:
+            import evaluate
+
+            perplexity = evaluate.load("perplexity", module_type="metric")
+        except Exception as e:
+            _logger.warning(
+                f"Failed to load 'perplexity' metric (error: {e!r}), skipping metric logging."
+            )
+            return
+                
+        results = perplexity.compute(predictions=predictions, model_id='gpt2')
+        self.metrics.update({'mean_perplexity': results['mean_perplexity']})
+
+    def _calculate_toxicity(self, predictions):
+        try:
+            from transformers import AutoModelForSequenceClassification, AutoTokenizer, TextClassificationPipeline
+
+            model_path = "martin-ha/toxic-comment-model"
+            tokenizer = AutoTokenizer.from_pretrained(model_path)
+            model = AutoModelForSequenceClassification.from_pretrained(model_path)
+
+            pipeline =  TextClassificationPipeline(model=model, tokenizer=tokenizer)
+        except Exception as e:
+            _logger.warning(
+                f"Failed to load 'toxicity' metric (error: {e!r}), skipping metric logging."
+            )
+            return
+        
+        results = pipeline(list(predictions))
+        percent_toxic = {'percent_toxic': sum([1 if result['label'] == 'toxic' else 0 for result in results])/len(results)}
+        self.metrics.update(percent_toxic)
+
+    def _calculate_reading_level(self, predictions):
+        try:
+            import nltk
+            from readability import Readability
+
+            nltk.download('punkt')
+        except Exception as e:
+            _logger.warning(
+                f"Failed to load reading level metrics (error: {e!r}), skipping metric logging."
+            )
+            return
+        
+        def _calculate_flesch_kincaid(prediction):
+            return Readability(prediction).flesch_kincaid()
+
+        try:     
+            metrics = [_calculate_flesch_kincaid(prediction) for prediction in predictions]
+        except Exception as e:
+            _logger.warning(
+                f"Failed to load 'flesch_kincaid' metric (error: {e!r}), skipping metric logging."
+            )
+            return
+        
+        average_grade_level = {'flesch_kincaid_mean_grade_level': sum(int(metric.grade_level) for metric in metrics)/len(metrics)}
+        self.metrics.update(average_grade_level)
+
+        def _calculate_ari(prediction):
+            return Readability(prediction).ari()
+        
+        try:     
+            metrics = [_calculate_ari(prediction) for prediction in predictions]
+        except Exception as e:
+            _logger.warning(
+                f"Failed to load 'ari' metric (error: {e!r}), skipping metric logging."
+            )
+            return
+        
+        average_grade_level = {'ari_mean_grade_level': sum(int(metric.grade_level) for metric in metrics)/len(metrics)}
+        self.metrics.update(average_grade_level)
+
+    def _calculate_general_text_metrics(self):
+        predictions = (
+            self.y_pred.squeeze() if isinstance(self.y_pred, pd.DataFrame) else self.y_pred
+        )
+        for prediction in predictions:
+            if not isinstance(prediction, str):
+                _logger.warning(
+                    f"Cannot calculate perplexity, toxicity, and reading level metrics for non string inputs, skipping metric logging."
+                )
+                return
+        self._calculate_toxicity(predictions)
+        self._calculate_reading_level(predictions)
+        self._calculate_perplexity(predictions)
+
     def _evaluate_question_answering(self):
         self._log_eval_table()
         name = _EVAL_TABLE_FILE_NAME.split(".", 1)[0]
@@ -1181,6 +1268,7 @@ class DefaultEvaluator(ModelEvaluator):
         if self.dataset.has_targets:
             acc = accuracy_score(y_true=self.y, y_pred=self.y_pred)
             self.metrics.update({"exact_match": acc})
+        self._calculate_general_text_metrics()
 
     def _evaluate_text_summarization(self):
         self._log_eval_table()
@@ -1204,6 +1292,7 @@ class DefaultEvaluator(ModelEvaluator):
             )
             metrics = rouge.compute(predictions=predictions, references=self.y)
             self.metrics.update(metrics)
+        self._calculate_general_text_metrics()
 
     def _evaluate_text(self):
         self._log_eval_table()
@@ -1211,6 +1300,7 @@ class DefaultEvaluator(ModelEvaluator):
         self.artifacts[name] = JsonEvaluationArtifact(
             uri=mlflow.get_artifact_uri(_EVAL_TABLE_FILE_NAME)
         )
+        self._calculate_general_text_metrics()
 
     def _evaluate(
         self,

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1226,14 +1226,14 @@ class DefaultEvaluator(ModelEvaluator):
         metrics = [textstat.flesch_kincaid_grade(prediction) for prediction in predictions]
         self.metrics_dict.update({"flesch_kincaid": metrics})
         average_grade_level = {
-            "flesch_kincaid_mean_grade_level": sum(metric for metric in metrics) / len(metrics)
+            "mean_flesch_kincaid_grade_level": sum(metrics) / len(metrics)
         }
         self.metrics.update(average_grade_level)
 
         metrics = [textstat.automated_readability_index(prediction) for prediction in predictions]
         self.metrics_dict.update({"automated_readability_index": metrics})
         average_grade_level = {
-            "ari_mean_grade_level": sum(metric for metric in metrics) / len(metrics)
+            "mean_ari_grade_level": sum(metrics) / len(metrics)
         }
         self.metrics.update(average_grade_level)
 
@@ -1241,13 +1241,15 @@ class DefaultEvaluator(ModelEvaluator):
         predictions = (
             self.y_pred.squeeze() if isinstance(self.y_pred, pd.DataFrame) else self.y_pred
         )
-        for prediction in predictions:
-            if not isinstance(prediction, str):
-                _logger.warning(
-                    """Cannot calculate perplexity, toxicity, and reading level metrics 
-                    for non string inputs, skipping metric logging."""
-                )
-                return
+        if len(predictions) == 0:
+            return
+        
+        if any(not isinstance(prediction, str) for prediction in predictions):
+            _logger.warning(
+                "Cannot calculate perplexity, toxicity, and reading level metrics "
+                "for non-string inputs, skipping metric logging."
+            )
+            return
 
         self._calculate_toxicity(predictions)
         self._calculate_reading_level(predictions)

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1174,6 +1174,7 @@ class DefaultEvaluator(ModelEvaluator):
 
     def _calculate_perplexity(self, predictions):
         try:
+            _logger.info("Loading perplexity metric:")
             import evaluate
 
             perplexity = evaluate.load("perplexity", module_type="metric")
@@ -1183,12 +1184,14 @@ class DefaultEvaluator(ModelEvaluator):
             )
             return
 
+        _logger.info("Computing perplexity metric:")
         results = perplexity.compute(predictions=predictions, model_id="gpt2")
         self.metrics.update({"mean_perplexity": results["mean_perplexity"]})
         self.metrics_dict.update({"perplexity": results["perplexities"]})
 
     def _calculate_toxicity(self, predictions):
         try:
+            _logger.info("Loading toxicity metric:")
             import evaluate
 
             toxicity = evaluate.load("toxicity", module_type="measurement")
@@ -1198,6 +1201,7 @@ class DefaultEvaluator(ModelEvaluator):
             )
             return
 
+        _logger.info("Computing toxicity metric:")
         results = toxicity.compute(predictions=predictions)
         self.metrics_dict.update({"toxicity": results["toxicity"]})
         results = toxicity.compute(predictions=predictions, aggregation="ratio")
@@ -1212,11 +1216,13 @@ class DefaultEvaluator(ModelEvaluator):
             )
             return
 
+        _logger.info("Computing flesch kincaid metric:")
         metrics = [textstat.flesch_kincaid_grade(prediction) for prediction in predictions]
         self.metrics_dict.update({"flesch_kincaid_grade_level": metrics})
         average_grade_level = {"mean_flesch_kincaid_grade_level": sum(metrics) / len(metrics)}
         self.metrics.update(average_grade_level)
 
+        _logger.info("Computing automated readability index metric:")
         metrics = [textstat.automated_readability_index(prediction) for prediction in predictions]
         self.metrics_dict.update({"ari_grade_level": metrics})
         average_grade_level = {"mean_ari_grade_level": sum(metrics) / len(metrics)}

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1224,14 +1224,14 @@ class DefaultEvaluator(ModelEvaluator):
             return
 
         metrics = [textstat.flesch_kincaid_grade(prediction) for prediction in predictions]
-        self.metrics_dict.update({"flesch_kincaid": metrics})
+        self.metrics_dict.update({"flesch_kincaid_grade_level": metrics})
         average_grade_level = {
             "mean_flesch_kincaid_grade_level": sum(metrics) / len(metrics)
         }
         self.metrics.update(average_grade_level)
 
         metrics = [textstat.automated_readability_index(prediction) for prediction in predictions]
-        self.metrics_dict.update({"automated_readability_index": metrics})
+        self.metrics_dict.update({"ari_grade_level": metrics})
         average_grade_level = {
             "mean_ari_grade_level": sum(metrics) / len(metrics)
         }

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1198,16 +1198,17 @@ class DefaultEvaluator(ModelEvaluator):
             )
             return
 
+        results = toxicity.compute(predictions=predictions)
+        self.metrics_dict.update({"toxicity": results["toxicity"]})
         results = toxicity.compute(predictions=predictions, aggregation="ratio")
         self.metrics.update({"toxicity_ratio": results["toxicity_ratio"]})
-        self.metrics_dict.update({"toxicity": results["toxicity"]})
 
     def _calculate_reading_level(self, predictions):
         try:
             import textstat
         except ImportError:
             _logger.warning(
-                f"Failed to import textstat for reading grade level metrics, skipping metric logging."
+                "Failed to import textstat (reading grade level metrics), skipping metric logging."
             )
             return
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1205,9 +1205,9 @@ class DefaultEvaluator(ModelEvaluator):
     def _calculate_reading_level(self, predictions):
         try:
             import textstat
-        except Exception as e:
+        except ImportError:
             _logger.warning(
-                f"Failed to load reading level metrics (error: {e!r}), skipping metric logging."
+                f"Failed to import textstat for reading grade level metrics, skipping metric logging."
             )
             return
 

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -34,3 +34,4 @@ shap
 evaluate
 nltk
 rouge_score
+py-readability-metrics

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -35,5 +35,3 @@ evaluate
 nltk
 rouge_score
 textstat
-transformers
-torch

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -35,3 +35,5 @@ evaluate
 nltk
 rouge_score
 textstat
+transformers
+torch

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -34,4 +34,4 @@ shap
 evaluate
 nltk
 rouge_score
-py-readability-metrics
+textstat

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2004,7 +2004,9 @@ def test_evaluate_question_answering_with_targets():
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     pd.testing.assert_frame_equal(logged_data, data.assign(outputs=["a", "b"]))
-    assert results.metrics == {"exact_match": 1.0}
+    assert set(results.metrics.keys()) == set(["exact_match", "mean_perplexity", "percent_toxic"])
+    assert results.metrics["exact_match"] == 1.0
+    assert results.metrics["percent_toxic"] == 0.0
 
 
 def question_classifier(inputs):
@@ -2049,7 +2051,8 @@ def test_evaluate_question_answering_without_targets():
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     pd.testing.assert_frame_equal(logged_data, data.assign(outputs=["a", "b"]))
-    assert results.metrics == {}
+    assert set(results.metrics.keys()) == set(["mean_perplexity", "percent_toxic"])
+    assert results.metrics["percent_toxic"] == 0.0
 
 
 def test_evaluate_text_summarization_with_targets():
@@ -2070,7 +2073,12 @@ def test_evaluate_text_summarization_with_targets():
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     pd.testing.assert_frame_equal(logged_data, data.assign(outputs=["a", "b"]))
-    assert results.metrics == {"rouge1": 1.0, "rouge2": 0.0, "rougeL": 1.0, "rougeLsum": 1.0}
+    assert set(results.metrics.keys()) == set(["rouge1", "rouge2", "rougeL", "rougeLsum", "mean_perplexity", "percent_toxic"])
+    assert results.metrics["rouge1"] == 1.0
+    assert results.metrics["rouge2"] == 0.0
+    assert results.metrics["rougeL"] == 1.0
+    assert results.metrics["rougeLsum"] == 1.0
+    assert results.metrics["percent_toxic"] == 0.0
 
 
 def another_language_model(x):
@@ -2095,7 +2103,12 @@ def test_evaluate_text_summarization_with_targets_no_type_hints():
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     pd.testing.assert_frame_equal(logged_data, data.assign(outputs=["a", "b"]))
-    assert results.metrics == {"rouge1": 1.0, "rouge2": 0.0, "rougeL": 1.0, "rougeLsum": 1.0}
+    assert set(results.metrics.keys()) == set(["rouge1", "rouge2", "rougeL", "rougeLsum", "mean_perplexity", "percent_toxic"])
+    assert results.metrics["rouge1"] == 1.0
+    assert results.metrics["rouge2"] == 0.0
+    assert results.metrics["rougeL"] == 1.0
+    assert results.metrics["rougeLsum"] == 1.0
+    assert results.metrics["percent_toxic"] == 0.0
 
 
 def test_evaluate_text_summarization_without_targets():
@@ -2115,7 +2128,8 @@ def test_evaluate_text_summarization_without_targets():
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     pd.testing.assert_frame_equal(logged_data, data.assign(outputs=["a", "b"]))
-    assert results.metrics == {}
+    assert set(results.metrics.keys()) == set(["mean_perplexity", "percent_toxic"])
+    assert results.metrics["percent_toxic"] == 0.0
 
 
 def test_evaluate_text_summarization_fails_to_load_metric():
@@ -2159,7 +2173,7 @@ def test_evaluate_text():
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     pd.testing.assert_frame_equal(logged_data, data.assign(outputs=["a", "b"]))
-    assert results.metrics == {}
+    assert set(results.metrics.keys()) == set(["mean_perplexity", "percent_toxic"])
 
 
 def accuracy(eval_df, _builtin_metrics):
@@ -2185,7 +2199,9 @@ def test_evaluate_text_custom_metrics():
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     pd.testing.assert_frame_equal(logged_data, data.assign(outputs=["a", "b"]))
-    assert results.metrics == {"accuracy": 1.0}
+    assert set(results.metrics.keys()) == set(["accuracy", "mean_perplexity", "percent_toxic"])
+    assert results.metrics["accuracy"] == 1.0
+    assert results.metrics["percent_toxic"] == 0.0
 
 
 def test_eval_results_table_json_can_be_prefixed_with_metric_prefix():

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2041,13 +2041,13 @@ def test_evaluate_question_answering_with_targets():
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     validate_question_answering_logged_data(logged_data)
-    assert set(results.metrics.keys()) == set(
+    assert set(results.metrics.keys()) == {
         "exact_match",
         "mean_perplexity",
         "percent_toxic",
         "ari_mean_grade_level",
         "flesch_kincaid_mean_grade_level",
-    )
+    }
     assert results.metrics["exact_match"] == 1.0
     assert results.metrics["percent_toxic"] == 0.0
 
@@ -2094,12 +2094,12 @@ def test_evaluate_question_answering_without_targets():
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     validate_question_answering_logged_data(logged_data, False)
-    assert set(results.metrics.keys()) == set(
+    assert set(results.metrics.keys()) == {
         "mean_perplexity",
         "percent_toxic",
         "ari_mean_grade_level",
         "flesch_kincaid_mean_grade_level",
-    )
+    }
     assert results.metrics["percent_toxic"] == 0.0
 
 
@@ -2162,7 +2162,7 @@ def test_evaluate_text_summarization_with_targets():
     validate_text_summarization_logged_data(logged_data)
 
     metrics = results.metrics
-    assert set(metrics.keys()) == set(
+    assert set(metrics.keys()) == {
         "rouge1",
         "rouge2",
         "rougeL",
@@ -2171,7 +2171,7 @@ def test_evaluate_text_summarization_with_targets():
         "percent_toxic",
         "ari_mean_grade_level",
         "flesch_kincaid_mean_grade_level",
-    )
+    }
     assert [metrics["rouge1"], metrics["rouge2"], metrics["rougeL"], metrics["rougeLsum"]] == [
         1.0,
         0.0,
@@ -2205,7 +2205,7 @@ def test_evaluate_text_summarization_with_targets_no_type_hints():
     validate_text_summarization_logged_data(logged_data)
 
     metrics = results.metrics
-    assert set(metrics.keys()) == set(
+    assert set(metrics.keys()) == {
         "rouge1",
         "rouge2",
         "rougeL",
@@ -2214,7 +2214,7 @@ def test_evaluate_text_summarization_with_targets_no_type_hints():
         "percent_toxic",
         "ari_mean_grade_level",
         "flesch_kincaid_mean_grade_level",
-    )
+    }
     assert [metrics["rouge1"], metrics["rouge2"], metrics["rougeL"], metrics["rougeLsum"]] == [
         1.0,
         0.0,
@@ -2242,12 +2242,12 @@ def test_evaluate_text_summarization_without_targets():
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     validate_text_summarization_logged_data(logged_data, with_targets=False)
 
-    assert set(results.metrics.keys()) == set(
+    assert set(results.metrics.keys()) == {
         "mean_perplexity",
         "percent_toxic",
         "ari_mean_grade_level",
         "flesch_kincaid_mean_grade_level",
-    )
+    }
     assert results.metrics["percent_toxic"] == 0.0
 
 
@@ -2314,12 +2314,12 @@ def test_evaluate_text():
     assert logged_data["outputs"].tolist() == ["sentence not", "I hate all dogs."]
     assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "toxic"]
     assert logged_data["perplexity"][0] > logged_data["perplexity"][1]
-    assert set(results.metrics.keys()) == set(
+    assert set(results.metrics.keys()) == {
         "mean_perplexity",
         "percent_toxic",
         "ari_mean_grade_level",
         "flesch_kincaid_mean_grade_level",
-    )
+    }
     assert results.metrics["percent_toxic"] == 0.5
 
 
@@ -2358,13 +2358,13 @@ def test_evaluate_text_custom_metrics():
     assert logged_data["target"].tolist() == ["a", "b"]
     assert logged_data["outputs"].tolist() == ["a", "b"]
     assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "non-toxic"]
-    assert set(results.metrics.keys()) == set(
+    assert set(results.metrics.keys()) == {
         "accuracy",
         "mean_perplexity",
         "percent_toxic",
         "ari_mean_grade_level",
         "flesch_kincaid_mean_grade_level",
-    )
+    }
     assert results.metrics["accuracy"] == 1.0
     assert results.metrics["percent_toxic"] == 0.0
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2045,8 +2045,8 @@ def test_evaluate_question_answering_with_targets():
         "exact_match",
         "mean_perplexity",
         "percent_toxic",
-        "ari_mean_grade_level",
-        "flesch_kincaid_mean_grade_level",
+        "mean_ari_grade_level",
+        "mean_flesch_kincaid_grade_level",
     }
     assert results.metrics["exact_match"] == 1.0
     assert results.metrics["percent_toxic"] == 0.0
@@ -2097,8 +2097,8 @@ def test_evaluate_question_answering_without_targets():
     assert set(results.metrics.keys()) == {
         "mean_perplexity",
         "percent_toxic",
-        "ari_mean_grade_level",
-        "flesch_kincaid_mean_grade_level",
+        "mean_ari_grade_level",
+        "mean_flesch_kincaid_grade_level",
     }
     assert results.metrics["percent_toxic"] == 0.0
 
@@ -2169,8 +2169,8 @@ def test_evaluate_text_summarization_with_targets():
         "rougeLsum",
         "mean_perplexity",
         "percent_toxic",
-        "ari_mean_grade_level",
-        "flesch_kincaid_mean_grade_level",
+        "mean_ari_grade_level",
+        "mean_flesch_kincaid_grade_level",
     }
     assert [metrics["rouge1"], metrics["rouge2"], metrics["rougeL"], metrics["rougeLsum"]] == [
         1.0,
@@ -2212,8 +2212,8 @@ def test_evaluate_text_summarization_with_targets_no_type_hints():
         "rougeLsum",
         "mean_perplexity",
         "percent_toxic",
-        "ari_mean_grade_level",
-        "flesch_kincaid_mean_grade_level",
+        "mean_ari_grade_level",
+        "mean_flesch_kincaid_grade_level",
     }
     assert [metrics["rouge1"], metrics["rouge2"], metrics["rougeL"], metrics["rougeLsum"]] == [
         1.0,
@@ -2245,8 +2245,8 @@ def test_evaluate_text_summarization_without_targets():
     assert set(results.metrics.keys()) == {
         "mean_perplexity",
         "percent_toxic",
-        "ari_mean_grade_level",
-        "flesch_kincaid_mean_grade_level",
+        "mean_ari_grade_level",
+        "mean_flesch_kincaid_grade_level",
     }
     assert results.metrics["percent_toxic"] == 0.0
 
@@ -2317,8 +2317,8 @@ def test_evaluate_text():
     assert set(results.metrics.keys()) == {
         "mean_perplexity",
         "percent_toxic",
-        "ari_mean_grade_level",
-        "flesch_kincaid_mean_grade_level",
+        "mean_ari_grade_level",
+        "mean_flesch_kincaid_grade_level",
     }
     assert results.metrics["percent_toxic"] == 0.5
 
@@ -2362,8 +2362,8 @@ def test_evaluate_text_custom_metrics():
         "accuracy",
         "mean_perplexity",
         "percent_toxic",
-        "ari_mean_grade_level",
-        "flesch_kincaid_mean_grade_level",
+        "mean_ari_grade_level",
+        "mean_flesch_kincaid_grade_level",
     }
     assert results.metrics["accuracy"] == 1.0
     assert results.metrics["percent_toxic"] == 0.0

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1988,12 +1988,27 @@ def language_model(inputs: list[str]) -> list[str]:
 
 def validate_question_answering_logged_data(logged_data, with_targets=True):
     if with_targets:
-        columns = ["question", "answer", "outputs", "toxicity", "flesch_kincaid", "automated_readability_index", "perplexity"]
+        columns = [
+            "question",
+            "answer",
+            "outputs",
+            "toxicity",
+            "flesch_kincaid",
+            "automated_readability_index",
+            "perplexity",
+        ]
     else:
-        columns = ["question", "outputs", "toxicity", "flesch_kincaid", "automated_readability_index", "perplexity"]
+        columns = [
+            "question",
+            "outputs",
+            "toxicity",
+            "flesch_kincaid",
+            "automated_readability_index",
+            "perplexity",
+        ]
 
     assert logged_data.columns.tolist() == columns
-    
+
     assert logged_data["question"].tolist() == ["words random", "This is a sentence."]
     assert logged_data["outputs"].tolist() == ["words random", "This is a sentence."]
     assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "non-toxic"]
@@ -2008,7 +2023,12 @@ def test_evaluate_question_answering_with_targets():
         model_info = mlflow.pyfunc.log_model(
             artifact_path="model", python_model=language_model, input_example=["a", "b"]
         )
-        data = pd.DataFrame({"question": ["words random", "This is a sentence."], "answer": ["words random", "This is a sentence."]})
+        data = pd.DataFrame(
+            {
+                "question": ["words random", "This is a sentence."],
+                "answer": ["words random", "This is a sentence."],
+            }
+        )
         results = mlflow.evaluate(
             model_info.model_uri,
             data,
@@ -2021,7 +2041,13 @@ def test_evaluate_question_answering_with_targets():
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     validate_question_answering_logged_data(logged_data)
-    assert set(results.metrics.keys()) == set(["exact_match", "mean_perplexity", "percent_toxic", "ari_mean_grade_level", "flesch_kincaid_mean_grade_level"])
+    assert set(results.metrics.keys()) == set(
+        "exact_match",
+        "mean_perplexity",
+        "percent_toxic",
+        "ari_mean_grade_level",
+        "flesch_kincaid_mean_grade_level",
+    )
     assert results.metrics["exact_match"] == 1.0
     assert results.metrics["percent_toxic"] == 0.0
 
@@ -2068,18 +2094,42 @@ def test_evaluate_question_answering_without_targets():
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     validate_question_answering_logged_data(logged_data, False)
-    assert set(results.metrics.keys()) == set(["mean_perplexity", "percent_toxic", "ari_mean_grade_level", "flesch_kincaid_mean_grade_level"])
+    assert set(results.metrics.keys()) == set(
+        "mean_perplexity",
+        "percent_toxic",
+        "ari_mean_grade_level",
+        "flesch_kincaid_mean_grade_level",
+    )
     assert results.metrics["percent_toxic"] == 0.0
 
 
 def validate_text_summarization_logged_data(logged_data, with_targets=True):
     if with_targets:
-        columns = ["text", "summary", "outputs", "rouge1", "rouge2", "rougeL", "rougeLsum", "toxicity", "flesch_kincaid", "automated_readability_index", "perplexity"]
+        columns = [
+            "text",
+            "summary",
+            "outputs",
+            "rouge1",
+            "rouge2",
+            "rougeL",
+            "rougeLsum",
+            "toxicity",
+            "flesch_kincaid",
+            "automated_readability_index",
+            "perplexity",
+        ]
     else:
-        columns = ["text", "outputs", "toxicity", "flesch_kincaid", "automated_readability_index", "perplexity"]
+        columns = [
+            "text",
+            "outputs",
+            "toxicity",
+            "flesch_kincaid",
+            "automated_readability_index",
+            "perplexity",
+        ]
 
     assert logged_data.columns.tolist() == columns
-    
+
     assert logged_data["text"].tolist() == ["a", "b"]
     assert logged_data["outputs"].tolist() == ["a", "b"]
     assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "non-toxic"]
@@ -2110,10 +2160,24 @@ def test_evaluate_text_summarization_with_targets():
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     validate_text_summarization_logged_data(logged_data)
-    
+
     metrics = results.metrics
-    assert set(metrics.keys()) == set(["rouge1", "rouge2", "rougeL", "rougeLsum", "mean_perplexity", "percent_toxic", "ari_mean_grade_level", "flesch_kincaid_mean_grade_level"])
-    assert [metrics["rouge1"], metrics["rouge2"], metrics["rougeL"], metrics["rougeLsum"]] == [1.0, 0.0, 1.0, 1.0]
+    assert set(metrics.keys()) == set(
+        "rouge1",
+        "rouge2",
+        "rougeL",
+        "rougeLsum",
+        "mean_perplexity",
+        "percent_toxic",
+        "ari_mean_grade_level",
+        "flesch_kincaid_mean_grade_level",
+    )
+    assert [metrics["rouge1"], metrics["rouge2"], metrics["rougeL"], metrics["rougeLsum"]] == [
+        1.0,
+        0.0,
+        1.0,
+        1.0,
+    ]
     assert metrics["percent_toxic"] == 0.0
 
 
@@ -2141,8 +2205,22 @@ def test_evaluate_text_summarization_with_targets_no_type_hints():
     validate_text_summarization_logged_data(logged_data)
 
     metrics = results.metrics
-    assert set(metrics.keys()) == set(["rouge1", "rouge2", "rougeL", "rougeLsum", "mean_perplexity", "percent_toxic", "ari_mean_grade_level", "flesch_kincaid_mean_grade_level"])
-    assert [metrics["rouge1"], metrics["rouge2"], metrics["rougeL"], metrics["rougeLsum"]] == [1.0, 0.0, 1.0, 1.0]
+    assert set(metrics.keys()) == set(
+        "rouge1",
+        "rouge2",
+        "rougeL",
+        "rougeLsum",
+        "mean_perplexity",
+        "percent_toxic",
+        "ari_mean_grade_level",
+        "flesch_kincaid_mean_grade_level",
+    )
+    assert [metrics["rouge1"], metrics["rouge2"], metrics["rougeL"], metrics["rougeLsum"]] == [
+        1.0,
+        0.0,
+        1.0,
+        1.0,
+    ]
     assert metrics["percent_toxic"] == 0.0
 
 
@@ -2164,7 +2242,12 @@ def test_evaluate_text_summarization_without_targets():
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     validate_text_summarization_logged_data(logged_data, with_targets=False)
 
-    assert set(results.metrics.keys()) == set(["mean_perplexity", "percent_toxic", "ari_mean_grade_level", "flesch_kincaid_mean_grade_level"])
+    assert set(results.metrics.keys()) == set(
+        "mean_perplexity",
+        "percent_toxic",
+        "ari_mean_grade_level",
+        "flesch_kincaid_mean_grade_level",
+    )
     assert results.metrics["percent_toxic"] == 0.0
 
 
@@ -2189,7 +2272,14 @@ def test_evaluate_text_summarization_fails_to_load_metric():
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
-    assert logged_data.columns.tolist() == ["text", "summary", "outputs", "toxicity", "flesch_kincaid", "automated_readability_index",]
+    assert logged_data.columns.tolist() == [
+        "text",
+        "summary",
+        "outputs",
+        "toxicity",
+        "flesch_kincaid",
+        "automated_readability_index",
+    ]
     assert logged_data["text"].tolist() == ["a", "b"]
     assert logged_data["summary"].tolist() == ["a", "b"]
     assert logged_data["outputs"].tolist() == ["a", "b"]
@@ -2212,12 +2302,24 @@ def test_evaluate_text():
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
-    assert logged_data.columns.tolist() == ["text", "outputs", "toxicity", "flesch_kincaid", "automated_readability_index", "perplexity"]
+    assert logged_data.columns.tolist() == [
+        "text",
+        "outputs",
+        "toxicity",
+        "flesch_kincaid",
+        "automated_readability_index",
+        "perplexity",
+    ]
     assert logged_data["text"].tolist() == ["sentence not", "I hate all dogs."]
     assert logged_data["outputs"].tolist() == ["sentence not", "I hate all dogs."]
     assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "toxic"]
     assert logged_data["perplexity"][0] > logged_data["perplexity"][1]
-    assert set(results.metrics.keys()) == set(["mean_perplexity", "percent_toxic", "ari_mean_grade_level", "flesch_kincaid_mean_grade_level"])
+    assert set(results.metrics.keys()) == set(
+        "mean_perplexity",
+        "percent_toxic",
+        "ari_mean_grade_level",
+        "flesch_kincaid_mean_grade_level",
+    )
     assert results.metrics["percent_toxic"] == 0.5
 
 
@@ -2243,12 +2345,26 @@ def test_evaluate_text_custom_metrics():
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
-    assert logged_data.columns.tolist() == ["text", "target", "outputs", "toxicity", "flesch_kincaid", "automated_readability_index", "perplexity"]
+    assert logged_data.columns.tolist() == [
+        "text",
+        "target",
+        "outputs",
+        "toxicity",
+        "flesch_kincaid",
+        "automated_readability_index",
+        "perplexity",
+    ]
     assert logged_data["text"].tolist() == ["a", "b"]
     assert logged_data["target"].tolist() == ["a", "b"]
     assert logged_data["outputs"].tolist() == ["a", "b"]
     assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "non-toxic"]
-    assert set(results.metrics.keys()) == set(["accuracy", "mean_perplexity", "percent_toxic", "ari_mean_grade_level", "flesch_kincaid_mean_grade_level"])
+    assert set(results.metrics.keys()) == set(
+        "accuracy",
+        "mean_perplexity",
+        "percent_toxic",
+        "ari_mean_grade_level",
+        "flesch_kincaid_mean_grade_level",
+    )
     assert results.metrics["accuracy"] == 1.0
     assert results.metrics["percent_toxic"] == 0.0
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2003,7 +2003,11 @@ def test_evaluate_question_answering_with_targets():
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
-    pd.testing.assert_frame_equal(logged_data, data.assign(outputs=["a", "b"]))
+    assert logged_data.columns.tolist() == ["question", "answer", "outputs", "toxicity", "perplexity"]
+    assert logged_data["question"].tolist() == ["a", "b"]
+    assert logged_data["answer"].tolist() == ["a", "b"]
+    assert logged_data["outputs"].tolist() == ["a", "b"]
+    assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "non-toxic"]
     assert set(results.metrics.keys()) == set(["exact_match", "mean_perplexity", "percent_toxic"])
     assert results.metrics["exact_match"] == 1.0
     assert results.metrics["percent_toxic"] == 0.0
@@ -2050,7 +2054,10 @@ def test_evaluate_question_answering_without_targets():
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
-    pd.testing.assert_frame_equal(logged_data, data.assign(outputs=["a", "b"]))
+    assert logged_data.columns.tolist() == ["question", "outputs", "toxicity", "perplexity"]
+    assert logged_data["question"].tolist() == ["a", "b"]
+    assert logged_data["outputs"].tolist() == ["a", "b"]
+    assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "non-toxic"]
     assert set(results.metrics.keys()) == set(["mean_perplexity", "percent_toxic"])
     assert results.metrics["percent_toxic"] == 0.0
 
@@ -2072,7 +2079,11 @@ def test_evaluate_text_summarization_with_targets():
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
-    pd.testing.assert_frame_equal(logged_data, data.assign(outputs=["a", "b"]))
+    assert logged_data.columns.tolist() == ["text", "summary", "outputs", "toxicity", "perplexity"]
+    assert logged_data["text"].tolist() == ["a", "b"]
+    assert logged_data["summary"].tolist() == ["a", "b"]
+    assert logged_data["outputs"].tolist() == ["a", "b"]
+    assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "non-toxic"]
     assert set(results.metrics.keys()) == set(["rouge1", "rouge2", "rougeL", "rougeLsum", "mean_perplexity", "percent_toxic"])
     assert results.metrics["rouge1"] == 1.0
     assert results.metrics["rouge2"] == 0.0
@@ -2102,7 +2113,11 @@ def test_evaluate_text_summarization_with_targets_no_type_hints():
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
-    pd.testing.assert_frame_equal(logged_data, data.assign(outputs=["a", "b"]))
+    assert logged_data.columns.tolist() == ["text", "summary", "outputs", "toxicity", "perplexity"]
+    assert logged_data["text"].tolist() == ["a", "b"]
+    assert logged_data["summary"].tolist() == ["a", "b"]
+    assert logged_data["outputs"].tolist() == ["a", "b"]
+    assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "non-toxic"]
     assert set(results.metrics.keys()) == set(["rouge1", "rouge2", "rougeL", "rougeLsum", "mean_perplexity", "percent_toxic"])
     assert results.metrics["rouge1"] == 1.0
     assert results.metrics["rouge2"] == 0.0
@@ -2127,7 +2142,10 @@ def test_evaluate_text_summarization_without_targets():
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
-    pd.testing.assert_frame_equal(logged_data, data.assign(outputs=["a", "b"]))
+    assert logged_data.columns.tolist() == ["text", "outputs", "toxicity", "perplexity"]
+    assert logged_data["text"].tolist() == ["a", "b"]
+    assert logged_data["outputs"].tolist() == ["a", "b"]
+    assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "non-toxic"]
     assert set(results.metrics.keys()) == set(["mean_perplexity", "percent_toxic"])
     assert results.metrics["percent_toxic"] == 0.0
 
@@ -2146,14 +2164,18 @@ def test_evaluate_text_summarization_fails_to_load_metric():
                 targets="summary",
                 model_type="text-summarization",
             )
-            mock_load.assert_called_once_with("rouge")
+            mock_load.assert_any_call("rouge")
+            mock_load.assert_any_call("perplexity", module_type="metric")
 
     client = mlflow.MlflowClient()
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
-    pd.testing.assert_frame_equal(logged_data, data.assign(outputs=["a", "b"]))
-    assert results.metrics == {}
+    assert logged_data.columns.tolist() == ["text", "summary", "outputs", "toxicity"]
+    assert logged_data["text"].tolist() == ["a", "b"]
+    assert logged_data["summary"].tolist() == ["a", "b"]
+    assert logged_data["outputs"].tolist() == ["a", "b"]
+    assert "percent_toxic" in results.metrics
 
 
 def test_evaluate_text():
@@ -2172,7 +2194,10 @@ def test_evaluate_text():
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
-    pd.testing.assert_frame_equal(logged_data, data.assign(outputs=["a", "b"]))
+    assert logged_data.columns.tolist() == ["text", "outputs", "toxicity", "perplexity"]
+    assert logged_data["text"].tolist() == ["a", "b"]
+    assert logged_data["outputs"].tolist() == ["a", "b"]
+    assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "non-toxic"]
     assert set(results.metrics.keys()) == set(["mean_perplexity", "percent_toxic"])
 
 
@@ -2198,7 +2223,11 @@ def test_evaluate_text_custom_metrics():
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
-    pd.testing.assert_frame_equal(logged_data, data.assign(outputs=["a", "b"]))
+    assert logged_data.columns.tolist() == ["text", "target", "outputs", "toxicity", "perplexity"]
+    assert logged_data["text"].tolist() == ["a", "b"]
+    assert logged_data["target"].tolist() == ["a", "b"]
+    assert logged_data["outputs"].tolist() == ["a", "b"]
+    assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "non-toxic"]
     assert set(results.metrics.keys()) == set(["accuracy", "mean_perplexity", "percent_toxic"])
     assert results.metrics["accuracy"] == 1.0
     assert results.metrics["percent_toxic"] == 0.0

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1987,27 +1987,19 @@ def language_model(inputs: list[str]) -> list[str]:
 
 
 def validate_question_answering_logged_data(logged_data, with_targets=True):
+    columns = {
+        "question",
+        "answer",
+        "outputs",
+        "toxicity",
+        "flesch_kincaid_grade_level",
+        "ari_grade_level",
+        "perplexity",
+    }
     if with_targets:
-        columns = [
-            "question",
-            "answer",
-            "outputs",
-            "toxicity",
-            "flesch_kincaid_grade_level",
-            "ari_grade_level",
-            "perplexity",
-        ]
-    else:
-        columns = [
-            "question",
-            "outputs",
-            "toxicity",
-            "flesch_kincaid_grade_level",
-            "ari_grade_level",
-            "perplexity",
-        ]
+        columns.union({"answer"})
 
-    assert logged_data.columns.tolist() == columns
+    assert set(logged_data.columns.tolist()) == columns
 
     assert logged_data["question"].tolist() == ["words random", "This is a sentence."]
     assert logged_data["outputs"].tolist() == ["words random", "This is a sentence."]
@@ -2107,31 +2099,18 @@ def test_evaluate_question_answering_without_targets():
 
 
 def validate_text_summarization_logged_data(logged_data, with_targets=True):
+    columns = {
+        "text",
+        "outputs",
+        "toxicity",
+        "flesch_kincaid_grade_level",
+        "ari_grade_level",
+        "perplexity",
+    }
     if with_targets:
-        columns = [
-            "text",
-            "summary",
-            "outputs",
-            "rouge1",
-            "rouge2",
-            "rougeL",
-            "rougeLsum",
-            "toxicity",
-            "flesch_kincaid_grade_level",
-            "ari_grade_level",
-            "perplexity",
-        ]
-    else:
-        columns = [
-            "text",
-            "outputs",
-            "toxicity",
-            "flesch_kincaid_grade_level",
-            "ari_grade_level",
-            "perplexity",
-        ]
+        columns.union({"summary", "rouge1", "rouge2", "rougeL", "rougeLsum"})
 
-    assert logged_data.columns.tolist() == columns
+    assert set(logged_data.columns.tolist()) == columns
 
     assert logged_data["text"].tolist() == ["a", "b"]
     assert logged_data["outputs"].tolist() == ["a", "b"]
@@ -2366,8 +2345,10 @@ def test_evaluate_text_custom_metrics():
     assert logged_data["outputs"].tolist() == ["a", "b"]
     assert logged_data["toxicity"][0] < 0.5
     assert logged_data["toxicity"][1] < 0.5
-    for grade in logged_data["flesch_kincaid_grade_level"] + logged_data["ari_grade_level"]:
-        assert isinstance(grade, (int, float))
+    for grade in logged_data["flesch_kincaid_grade_level"]:
+        assert isinstance(grade, float)
+    for grade in logged_data["ari_grade_level"]:
+        assert isinstance(grade, float)
     assert set(results.metrics.keys()) == {
         "accuracy",
         "mean_perplexity",

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1989,7 +1989,6 @@ def language_model(inputs: list[str]) -> list[str]:
 def validate_question_answering_logged_data(logged_data, with_targets=True):
     columns = {
         "question",
-        "answer",
         "outputs",
         "toxicity",
         "flesch_kincaid_grade_level",
@@ -1997,7 +1996,7 @@ def validate_question_answering_logged_data(logged_data, with_targets=True):
         "perplexity",
     }
     if with_targets:
-        columns.union({"answer"})
+        columns = columns.union({"answer"})
 
     assert set(logged_data.columns.tolist()) == columns
 
@@ -2110,7 +2109,7 @@ def validate_text_summarization_logged_data(logged_data, with_targets=True):
         "perplexity",
     }
     if with_targets:
-        columns.union({"summary", "rouge1", "rouge2", "rougeL", "rougeLsum"})
+        columns = columns.union({"summary", "rouge1", "rouge2", "rougeL", "rougeLsum"})
 
     assert set(logged_data.columns.tolist()) == columns
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1996,7 +1996,7 @@ def validate_question_answering_logged_data(logged_data, with_targets=True):
         "perplexity",
     }
     if with_targets:
-        columns = columns.union({"answer"})
+        columns.update({"answer"})
 
     assert set(logged_data.columns.tolist()) == columns
 
@@ -2005,10 +2005,8 @@ def validate_question_answering_logged_data(logged_data, with_targets=True):
     assert logged_data["toxicity"][0] < 0.5
     assert logged_data["toxicity"][1] < 0.5
     assert logged_data["perplexity"][0] > logged_data["perplexity"][1]
-    for grade in logged_data["flesch_kincaid_grade_level"]:
-        assert isinstance(grade, float)
-    for grade in logged_data["ari_grade_level"]:
-        assert isinstance(grade, float)
+    assert all(isinstance(grade, float) for grade in logged_data["flesch_kincaid_grade_level"])
+    assert all(isinstance(grade, float) for grade in logged_data["ari_grade_level"])
 
     if with_targets:
         assert logged_data["answer"].tolist() == ["words random", "This is a sentence."]
@@ -2109,7 +2107,7 @@ def validate_text_summarization_logged_data(logged_data, with_targets=True):
         "perplexity",
     }
     if with_targets:
-        columns = columns.union({"summary", "rouge1", "rouge2", "rougeL", "rougeLsum"})
+        columns.update({"summary", "rouge1", "rouge2", "rougeL", "rougeLsum"})
 
     assert set(logged_data.columns.tolist()) == columns
 
@@ -2117,8 +2115,8 @@ def validate_text_summarization_logged_data(logged_data, with_targets=True):
     assert logged_data["outputs"].tolist() == ["a", "b"]
     assert logged_data["toxicity"][0] < 0.5
     assert logged_data["toxicity"][1] < 0.5
-    for grade in logged_data["flesch_kincaid_grade_level"] + logged_data["ari_grade_level"]:
-        assert isinstance(grade, (int, float))
+    assert all(isinstance(grade, float) for grade in logged_data["flesch_kincaid_grade_level"])
+    assert all(isinstance(grade, float) for grade in logged_data["ari_grade_level"])
 
     if with_targets:
         assert logged_data["summary"].tolist() == ["a", "b"]
@@ -2346,10 +2344,8 @@ def test_evaluate_text_custom_metrics():
     assert logged_data["outputs"].tolist() == ["a", "b"]
     assert logged_data["toxicity"][0] < 0.5
     assert logged_data["toxicity"][1] < 0.5
-    for grade in logged_data["flesch_kincaid_grade_level"]:
-        assert isinstance(grade, float)
-    for grade in logged_data["ari_grade_level"]:
-        assert isinstance(grade, float)
+    assert all(isinstance(grade, float) for grade in logged_data["flesch_kincaid_grade_level"])
+    assert all(isinstance(grade, float) for grade in logged_data["ari_grade_level"])
     assert set(results.metrics.keys()) == {
         "accuracy",
         "mean_perplexity",

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2013,6 +2013,8 @@ def validate_question_answering_logged_data(logged_data, with_targets=True):
     assert logged_data["outputs"].tolist() == ["words random", "This is a sentence."]
     assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "non-toxic"]
     assert logged_data["perplexity"][0] > logged_data["perplexity"][1]
+    for grade in logged_data["flesch_kincaid_grade_level"] + logged_data["ari_grade_level"]:
+        assert isinstance(grade, (int, float))
 
     if with_targets:
         assert logged_data["answer"].tolist() == ["words random", "This is a sentence."]
@@ -2134,6 +2136,8 @@ def validate_text_summarization_logged_data(logged_data, with_targets=True):
     assert logged_data["text"].tolist() == ["a", "b"]
     assert logged_data["outputs"].tolist() == ["a", "b"]
     assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "non-toxic"]
+    for grade in logged_data["flesch_kincaid_grade_level"] + logged_data["ari_grade_level"]:
+        assert isinstance(grade, (int, float))
 
     if with_targets:
         assert logged_data["summary"].tolist() == ["a", "b"]
@@ -2364,6 +2368,8 @@ def test_evaluate_text_custom_metrics():
     assert logged_data["target"].tolist() == ["a", "b"]
     assert logged_data["outputs"].tolist() == ["a", "b"]
     assert [toxicity["label"] for toxicity in logged_data["toxicity"]] == ["non-toxic", "non-toxic"]
+    for grade in logged_data["flesch_kincaid_grade_level"] + logged_data["ari_grade_level"]:
+        assert isinstance(grade, (int, float))
     assert set(results.metrics.keys()) == {
         "accuracy",
         "mean_perplexity",

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2128,7 +2128,6 @@ def validate_text_summarization_logged_data(logged_data, with_targets=True):
             "toxicity",
             "flesch_kincaid_grade_level",
             "ari_grade_level",
-            "automated_readability_index",
             "perplexity",
         ]
 
@@ -2279,7 +2278,6 @@ def test_evaluate_text_summarization_fails_to_load_metric():
         "text",
         "summary",
         "outputs",
-        "toxicity",
         "flesch_kincaid_grade_level",
         "ari_grade_level",
     ]
@@ -2294,7 +2292,7 @@ def test_evaluate_text_and_text_metrics():
         model_info = mlflow.pyfunc.log_model(
             artifact_path="model", python_model=language_model, input_example=["a", "b"]
         )
-        data = pd.DataFrame({"text": ["sentence not", "I hate all people."]})
+        data = pd.DataFrame({"text": ["sentence not", "All women are bad."]})
         results = mlflow.evaluate(
             model_info.model_uri,
             data,
@@ -2313,8 +2311,8 @@ def test_evaluate_text_and_text_metrics():
         "ari_grade_level",
         "perplexity",
     ]
-    assert logged_data["text"].tolist() == ["sentence not", "I hate all people."]
-    assert logged_data["outputs"].tolist() == ["sentence not", "I hate all people."]
+    assert logged_data["text"].tolist() == ["sentence not", "All women are bad."]
+    assert logged_data["outputs"].tolist() == ["sentence not", "All women are bad."]
     # Hateful sentiments should be marked as toxic
     assert logged_data["toxicity"][0] < 0.5
     assert logged_data["toxicity"][1] > 0.5

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2253,7 +2253,7 @@ def test_evaluate_text_summarization_without_targets():
     assert results.metrics["toxicity_ratio"] == 0.0
 
 
-def test_evaluate_text_summarization_fails_to_load_metric():
+def test_evaluate_text_summarization_fails_to_load_evaluate_metrics():
     with mlflow.start_run() as run:
         model_info = mlflow.pyfunc.log_model(
             artifact_path="model", python_model=language_model, input_example=["a", "b"]
@@ -2269,6 +2269,7 @@ def test_evaluate_text_summarization_fails_to_load_metric():
             )
             mock_load.assert_any_call("rouge")
             mock_load.assert_any_call("perplexity", module_type="metric")
+            mock_load.assert_any_call("toxicity", module_type="measurement")
 
     client = mlflow.MlflowClient()
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
@@ -2284,7 +2285,6 @@ def test_evaluate_text_summarization_fails_to_load_metric():
     assert logged_data["text"].tolist() == ["a", "b"]
     assert logged_data["summary"].tolist() == ["a", "b"]
     assert logged_data["outputs"].tolist() == ["a", "b"]
-    assert "toxicity_ratio" in results.metrics
 
 
 def test_evaluate_text_and_text_metrics():

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2006,8 +2006,10 @@ def validate_question_answering_logged_data(logged_data, with_targets=True):
     assert logged_data["toxicity"][0] < 0.5
     assert logged_data["toxicity"][1] < 0.5
     assert logged_data["perplexity"][0] > logged_data["perplexity"][1]
-    for grade in logged_data["flesch_kincaid_grade_level"] + logged_data["ari_grade_level"]:
-        assert isinstance(grade, (int, float))
+    for grade in logged_data["flesch_kincaid_grade_level"]:
+        assert isinstance(grade, float)
+    for grade in logged_data["ari_grade_level"]:
+        assert isinstance(grade, float)
 
     if with_targets:
         assert logged_data["answer"].tolist() == ["words random", "This is a sentence."]


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

- log perplexity, toxicity, reading level (flesch-kincaid and automated readability index), and rouge metrics using log_table
- add aggregate metrics mean_perplexity, percent_toxic, flesch_kincaid_mean_grade_level, and ari_mean_grade_level

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
