### PR TITLE
Fix 500 server error for partial runs

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -901,6 +901,9 @@ class FileStore(AbstractStore):
                 logging.warning(
                     "Malformed run '%s'. Detailed error %s", r_id, str(rnfe), exc_info=True
                 )
+            except AttributeError as ae:
+                r_id = os.path.basename(r_dir)
+                logging.warning("Malformed run '%s'. %s", r_id, str(ae), exc_info=True)
         return run_infos
 
     def _search_runs(


### PR DESCRIPTION
## Related Issues/PRs
None that I could find.
<!-- Resolve --> 
I am using pytorch 2.0 with pytorch lightning on Ubuntu 18.04.
When force interrupting a run early during training (e.g. spamming ctrl-x), the run dir metadata is only partially saved, leading to an error:
```
  File ".../site-packages/mlflow/server/handlers.py", line 473, in wrapper                                                                                                                           
    return func(*args, **kwargs)                                                                                                                                                                                                                    
  File ".../site-packages/mlflow/server/handlers.py", line 558, in wrapper                                                                                                                           
    return func(*args, **kwargs)                                                                                                                                                                                                                    
  File ".../site-packages/mlflow/server/handlers.py", line 926, in _search_runs                                                                                                                      
    run_entities = _get_tracking_store().search_runs(                                                                                                                                                                                               
  File ".../site-packages/mlflow/store/tracking/abstract_store.py", line 297, in search_runs                                                                                                         
    runs, token = self._search_runs(                                                                                                                                                                                                                
  File ".../site-packages/mlflow/store/tracking/file_store.py", line 889, in _search_runs                                                                                                            
    run_infos = self._list_run_infos(experiment_id, run_view_type)                                                                                                                                                                                  
  File ".../site-packages/mlflow/store/tracking/file_store.py", line 857, in _list_run_infos                                                                                                         
    run_info = self._get_run_info_from_dir(r_dir)                                                                                                                                                                                                   
  File ".../site-packages/mlflow/store/tracking/file_store.py", line 669, in _get_run_info_from_dir                                                                                                  
    run_info = _read_persisted_run_info_dict(meta)                                                                                                                                                                                                  
  File ".../site-packages/mlflow/store/tracking/file_store.py", line 121, in _read_persisted_run_info_dict                                                                                           
    dict_copy = run_info_dict.copy()                                                                                                                                                                                                                
AttributeError: 'NoneType' object has no attribute 'copy'  
```
It is displayed in the UI as a 
```
500 Internal Server Error Internal Server Error 
The server encountered an internal error and was unable to complete your request. 
Either the server is overloaded or there is an error in the application.
````
This PR fixes this issue by catching this exception.

## How is this patch tested?
Unsure how to test this programmatically. However, on my machine, instead of throwing a 500 error and not showing any runs, the warning message is printed to the console. After manually deleting the directory, it goes away completely, as expected.

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [?] Manual tests (describe details, including test results, below)

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
