### PR TITLE
[Gateway] Adjust client and server timeout settings

### DIFF
--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -1,7 +1,8 @@
 import json
 import logging
-import re
 from typing import Optional, Dict, Any
+
+import requests.exceptions
 
 from mlflow import MlflowException
 from mlflow.gateway.config import Route
@@ -297,7 +298,7 @@ class MlflowGatewayClient:
         try:
             return self._call_endpoint("POST", query_route, data).json()
         except MlflowException as e:
-            if re.search(r"timeout", str(e), re.IGNORECASE):
+            if isinstance(e.__cause__, requests.exceptions.Timeout):
                 timeout_message = (
                     "The provider has timed out while generating a response to your "
                     "query. Please evaluate the available parameters for the query "

--- a/mlflow/gateway/constants.py
+++ b/mlflow/gateway/constants.py
@@ -4,6 +4,27 @@ MLFLOW_GATEWAY_ROUTE_BASE = "/gateway/"
 MLFLOW_QUERY_SUFFIX = "/invocations"
 MLFLOW_GATEWAY_SEARCH_ROUTES_PAGE_SIZE = 3000
 
+# Specifies the timeout for the Gateway server to declare a request submitted to a provider has
+# timed out.
+MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS = 300
+
+# Specifies the timeout for the MLflowGatewayClient APIs to declare a request has timed out
+MLFLOW_GATEWAY_CLIENT_QUERY_TIMEOUT_SECONDS = 300
+
+# Abridged retryable error codes for the interface to the Gateway Server.
+# These are modified from the standard MLflow Tracking server retry codes for the MLflowClient to
+# remove timeouts from the list of the retryable conditions. A long-running timeout with
+# retries for the proxied providers generally indicates an issue with the underlying query or
+# the model being served having issues responding to the query due to parameter configuration.
+MLFLOW_GATEWAY_CLIENT_QUERY_RETRY_CODES = frozenset(
+    [
+        429,  # Too many requests
+        500,  # Server Error
+        502,  # Bad Gateway
+        503,  # Service Unavailable
+    ]
+)
+
 # Provider constants
 MLFLOW_AI_GATEWAY_ANTHROPIC_MAXIMUM_MAX_TOKENS = 1_000_000
 MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS = 200_000

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -2,6 +2,7 @@ import aiohttp
 from typing import Dict, Any
 from fastapi import HTTPException
 
+from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
 from mlflow.utils.uri import append_to_uri_path
 
 
@@ -16,9 +17,10 @@ async def send_request(headers: Dict[str, str], base_url: str, path: str, payloa
     :return: The server's response as a JSON object.
     :raise: HTTPException if the HTTP request fails.
     """
+    timeout = aiohttp.ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS)
     async with aiohttp.ClientSession(headers=headers) as session:
         url = append_to_uri_path(base_url, path)
-        async with session.post(url, json=payload) as response:
+        async with session.post(url, json=payload, timeout=timeout) as response:
             js = await response.json()
             try:
                 response.raise_for_status()

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -17,9 +17,9 @@ async def send_request(headers: Dict[str, str], base_url: str, path: str, payloa
     :return: The server's response as a JSON object.
     :raise: HTTPException if the HTTP request fails.
     """
-    timeout = aiohttp.ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS)
     async with aiohttp.ClientSession(headers=headers) as session:
         url = append_to_uri_path(base_url, path)
+        timeout = aiohttp.ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS)
         async with session.post(url, json=payload, timeout=timeout) as response:
             js = await response.json()
             try:

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -106,7 +106,7 @@ def http_request(
             f"API request to {url} failed with timeout exception {to}."
             f" To increase the timeout, set the environment variable {MLFLOW_HTTP_REQUEST_TIMEOUT}"
             " to a larger value."
-        )
+        ) from to
     except requests.exceptions.InvalidURL as iu:
         raise InvalidUrlException(f"Invalid url: {url}") from iu
     except Exception as e:

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -6,10 +6,10 @@ from fastapi.encoders import jsonable_encoder
 import pytest
 
 from mlflow.exceptions import MlflowException
-from mlflow.gateway.config import OpenAIConfig
+from mlflow.gateway.config import OpenAIConfig, RouteConfig
+from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
 from mlflow.gateway.providers.openai import OpenAIProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
-from mlflow.gateway.config import RouteConfig
 from tests.gateway.tools import MockAsyncResponse, mock_http_client
 
 
@@ -94,7 +94,7 @@ async def test_chat():
                 "temperature": 0,
                 **payload,
             },
-            timeout=ClientTimeout(total=300),
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )
 
 
@@ -174,7 +174,7 @@ async def test_completions():
                 "temperature": 0,
                 "messages": [{"role": "user", "content": "This is a test"}],
             },
-            timeout=ClientTimeout(total=300),
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )
 
 
@@ -268,7 +268,7 @@ async def test_embeddings():
         mock_client.post.assert_called_once_with(
             "https://api.openai.com/v1/embeddings",
             json={"model": "text-embedding-ada-002", "input": "This is a test"},
-            timeout=ClientTimeout(total=300),
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )
 
 
@@ -338,7 +338,7 @@ async def test_embeddings_batch_input():
                 "model": "text-embedding-ada-002",
                 "input": ["1", "2"],
             },
-            timeout=ClientTimeout(total=300),
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )
 
 
@@ -396,7 +396,7 @@ async def test_azure_openai():
                 "temperature": 0,
                 "messages": [{"role": "user", "content": "This is a test"}],
             },
-            timeout=ClientTimeout(total=300),
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )
 
 
@@ -436,7 +436,7 @@ async def test_azuread_openai():
                 "temperature": 0,
                 "messages": [{"role": "user", "content": "This is a test"}],
             },
-            timeout=ClientTimeout(total=300),
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )
 
 

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from aiohttp import ClientTimeout
 from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 import pytest
@@ -93,6 +94,7 @@ async def test_chat():
                 "temperature": 0,
                 **payload,
             },
+            timeout=ClientTimeout(total=300),
         )
 
 
@@ -172,6 +174,7 @@ async def test_completions():
                 "temperature": 0,
                 "messages": [{"role": "user", "content": "This is a test"}],
             },
+            timeout=ClientTimeout(total=300),
         )
 
 
@@ -265,6 +268,7 @@ async def test_embeddings():
         mock_client.post.assert_called_once_with(
             "https://api.openai.com/v1/embeddings",
             json={"model": "text-embedding-ada-002", "input": "This is a test"},
+            timeout=ClientTimeout(total=300),
         )
 
 
@@ -334,6 +338,7 @@ async def test_embeddings_batch_input():
                 "model": "text-embedding-ada-002",
                 "input": ["1", "2"],
             },
+            timeout=ClientTimeout(total=300),
         )
 
 
@@ -391,6 +396,7 @@ async def test_azure_openai():
                 "temperature": 0,
                 "messages": [{"role": "user", "content": "This is a test"}],
             },
+            timeout=ClientTimeout(total=300),
         )
 
 
@@ -430,6 +436,7 @@ async def test_azuread_openai():
                 "temperature": 0,
                 "messages": [{"role": "user", "content": "This is a test"}],
             },
+            timeout=ClientTimeout(total=300),
         )
 
 

--- a/tests/gateway/test_client.py
+++ b/tests/gateway/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, Timeout
 from unittest import mock
 
 from mlflow.gateway.constants import MLFLOW_GATEWAY_SEARCH_ROUTES_PAGE_SIZE
@@ -471,3 +471,22 @@ def test_cllient_query_with_disallowed_param(mixed_gateway):
 
     with pytest.raises(HTTPError, match=".*The parameter 'model' is not permitted.*"):
         gateway_client.query(route=route.name, data=data)
+
+
+@mock.patch(
+    "mlflow.gateway.constants.MLFLOW_GATEWAY_CLIENT_QUERY_TIMEOUT_SECONDS", new_callable=lambda: 1
+)
+@mock.patch("requests.Session.request")
+def test_query_timeout_not_retried(mocked_request, mock_timeout, mixed_gateway):
+    mocked_request.side_effect = Timeout("Request timed out")
+    assert mock_timeout == 1
+
+    gateway_client = MlflowGatewayClient(gateway_uri=mixed_gateway.url)
+
+    data = {"prompt": "Test", "temperature": 0.4}
+    route = "completions"
+
+    with pytest.raises(MlflowException, match="The provider has timed out while generating"):
+        gateway_client.query(route=route, data=data)
+
+    mocked_request.assert_called_once()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Adjust client request timeout to 5 minutes with no retries and set timeout on server for route query requests.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
