### PR TITLE
Ignore IntegrityError when creating admin user

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -562,8 +562,8 @@ def create_admin_user(username, password):
             )
         except sqlalchemy.exc.IntegrityError:
             # When multiple workers are starting up at the same time, it's possible
-            # that multiple workers try to create the admin user at the same time and
-            # one of them will fail with an IntegrityError. We can safely ignore this
+            # that they try to create the admin user at the same time and one of them
+            # will succeed while the others will fail with an IntegrityError.
             pass
 
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

When we run `mlflow server --app-name basic-auth` and multiple workers attempt to create the admin user, only one of them can succeed while the other fails (see the following error). This PR prevents it. 

```
> mlflow server --app-name basic-auth
[2023-07-14 17:06:19 +0900] [131471] [INFO] Starting gunicorn 20.1.0
[2023-07-14 17:06:19 +0900] [131471] [INFO] Listening at: http://127.0.0.1:5000 (131471)
[2023-07-14 17:06:19 +0900] [131471] [INFO] Using worker: sync
[2023-07-14 17:06:19 +0900] [131473] [INFO] Booting worker with pid: 131473
[2023-07-14 17:06:19 +0900] [131474] [INFO] Booting worker with pid: 131474
[2023-07-14 17:06:19 +0900] [131475] [INFO] Booting worker with pid: 131475
[2023-07-14 17:06:19 +0900] [131476] [INFO] Booting worker with pid: 131476
2023/07/14 17:06:20 WARNING mlflow.server.auth: This feature is still experimental and may change in a future release without warning
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade  -> 8606fa83a998, initial_migration
2023/07/14 17:06:20 WARNING mlflow.server.auth: This feature is still experimental and may change in a future release without warning
2023/07/14 17:06:20 WARNING mlflow.server.auth: This feature is still experimental and may change in a future release without warning
[2023-07-14 17:06:20 +0900] [131474] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1965, in _exec_single_context
    self.dialect.do_execute(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 921, in do_execute
    cursor.execute(statement, parameters)
sqlite3.IntegrityError: UNIQUE constraint failed: users.username

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/haru/Desktop/repositories/mlflow/mlflow/server/auth/sqlalchemy_store.py", line 49, in create_user
    session.flush()
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/orm/session.py", line 4142, in flush
    self._flush(objects)
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/orm/session.py", line 4278, in _flush
    transaction.rollback(_capture_exception=True)
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/util/langhelpers.py", line 147, in __exit__
    raise exc_value.with_traceback(exc_tb)
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/orm/session.py", line 4238, in _flush
    flush_context.execute()
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/orm/unitofwork.py", line 466, in execute
    rec.execute(self)
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/orm/unitofwork.py", line 642, in execute
    util.preloaded.orm_persistence.save_obj(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/orm/persistence.py", line 93, in save_obj
    _emit_insert_statements(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/orm/persistence.py", line 1226, in _emit_insert_statements
    result = connection.execute(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1412, in execute
    return meth(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/sql/elements.py", line 483, in _execute_on_connection
    return connection._execute_clauseelement(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1635, in _execute_clauseelement
    ret = self._execute_context(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1844, in _execute_context
    return self._exec_single_context(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1984, in _exec_single_context
    self._handle_dbapi_exception(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 2339, in _handle_dbapi_exception
    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1965, in _exec_single_context
    self.dialect.do_execute(
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 921, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) UNIQUE constraint failed: users.username
[SQL: INSERT INTO users (username, password_hash, is_admin) VALUES (?, ?, ?)]
[parameters: ('admin', 'pbkdf2:sha256:260000$L85UCdtnf0oLL5Mw$9440fd63d945c42de437e69c423dc169e01535fa69ab2b89feda0613e6e718c4', 1)]
(Background on this error at: https://sqlalche.me/e/20/gkpj)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/gunicorn/arbiter.py", line 589, in spawn_worker
    worker.init_process()
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/gunicorn/workers/base.py", line 134, in init_process
    self.load_wsgi()
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/gunicorn/workers/base.py", line 146, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 58, in load
    return self.load_wsgiapp()
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 48, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/gunicorn/util.py", line 412, in import_app
    app = app(*args, **kwargs)
  File "/home/haru/Desktop/repositories/mlflow/mlflow/server/auth/__init__.py", line 794, in create_app
    create_admin_user(auth_config.admin_username, auth_config.admin_password)
  File "/home/haru/Desktop/repositories/mlflow/mlflow/server/auth/__init__.py", line 555, in create_admin_user
    store.create_user(username, password, is_admin=True)
  File "/home/haru/Desktop/repositories/mlflow/mlflow/server/auth/sqlalchemy_store.py", line 52, in create_user
    raise MlflowException(
mlflow.exceptions.MlflowException: User (username=admin) already exists. Error: (sqlite3.IntegrityError) UNIQUE constraint failed: users.username
[SQL: INSERT INTO users (username, password_hash, is_admin) VALUES (?, ?, ?)]
[parameters: ('admin', 'pbkdf2:sha256:260000$L85UCdtnf0oLL5Mw$9440fd63d945c42de437e69c423dc169e01535fa69ab2b89feda0613e6e718c4', 1)]
(Background on this error at: https://sqlalche.me/e/20/gkpj)
[2023-07-14 17:06:20 +0900] [131474] [INFO] Worker exiting (pid: 131474)
2023/07/14 17:06:20 WARNING mlflow.server.auth: This feature is still experimental and may change in a future release without warning
[2023-07-14 17:06:20 +0900] [131476] [INFO] Worker exiting (pid: 131476)
[2023-07-14 17:06:20 +0900] [131475] [INFO] Worker exiting (pid: 131475)
[2023-07-14 17:06:20 +0900] [131471] [INFO] Shutting down: Master
[2023-07-14 17:06:20 +0900] [131471] [INFO] Reason: Worker failed to boot.
Running the mlflow server failed. Please see the logs above for details.
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
