### PR TITLE
Separate extras and package name in requirements YAML

### DIFF
--- a/.github/actions/update-requirements/action.yml
+++ b/.github/actions/update-requirements/action.yml
@@ -15,6 +15,7 @@ runs:
       run: |
         python dev/update_requirements.py --requirements-yaml-location requirements/skinny-requirements.yaml
         python dev/update_requirements.py --requirements-yaml-location requirements/core-requirements.yaml
+        python dev/update_requirements.py --requirements-yaml-location requirements/gateway-requirements.yaml
         if [ -z "$(git status --porcelain)" ]; then
           echo "updated=false" >> $GITHUB_OUTPUT
         else
@@ -24,6 +25,9 @@ runs:
           python dev/generate_requirements.py \
             --requirements-yaml-location requirements/core-requirements.yaml \
             --requirements-txt-output-location requirements/core-requirements.txt
+          python dev/generate_requirements.py \
+            --requirements-yaml-location requirements/gateway-requirements.yaml \
+            --requirements-txt-output-location requirements/gateway-requirements.txt
           git diff --color=always
           echo "updated=true" >> $GITHUB_OUTPUT
         fi

--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - requirements/core-requirements.yaml
       - requirements/skinny-requirements.yaml
+      - requirements/gateway-requirements.yaml
   schedule:
     - cron: "0 13 * * *"
 

--- a/dev/generate_requirements.py
+++ b/dev/generate_requirements.py
@@ -84,7 +84,7 @@ def generate_requirements_txt_content(requirements_yaml):
         pip_release = package_entry["pip_release"]
         version_specs = []
 
-        extras = f"[{','.join(package_entry['extras'])}]" if package_entry.get("extras") else ""
+        extras = f"[{','.join(extras)}]" if (extras := package_entry.get("extras")) else ""
 
         max_major_version = package_entry["max_major_version"]
         version_specs += [f"<{max_major_version + 1}"]

--- a/dev/generate_requirements.py
+++ b/dev/generate_requirements.py
@@ -84,6 +84,8 @@ def generate_requirements_txt_content(requirements_yaml):
         pip_release = package_entry["pip_release"]
         version_specs = []
 
+        extras = f"[{','.join(package_entry['extras'])}]" if package_entry.get("extras") else ""
+
         max_major_version = package_entry["max_major_version"]
         version_specs += [f"<{max_major_version + 1}"]
 
@@ -96,7 +98,7 @@ def generate_requirements_txt_content(requirements_yaml):
         markers = package_entry.get("markers")
         markers = f"; {markers}" if markers else ""
 
-        requirement_str = f"{pip_release}{','.join(version_specs)}{markers}"
+        requirement_str = f"{pip_release}{extras}{','.join(version_specs)}{markers}"
         requirement_strs.append(requirement_str)
 
     return "\n".join(requirement_strs)

--- a/requirements/gateway-requirements.yaml
+++ b/requirements/gateway-requirements.yaml
@@ -11,7 +11,9 @@ fastapi:
   max_major_version: 0
 
 uvicorn:
-  pip_release: uvicorn[standard]
+  pip_release: uvicorn
+  extras:
+    - standard
   max_major_version: 0
 
 watchfiles:


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix the following error by separating package name and extras:

```
Your branch is up to date with 'origin/master'.
> python dev/update_requirements.py --requirements-yaml-location requirements/gateway-requirements.yaml
Updated pydantic.max_major_version to 2
Traceback (most recent call last):
  File "dev/update_requirements.py", line 74, in <module>
    main()
  File "dev/update_requirements.py", line 64, in main
    latest_major_version = get_latest_major_version(pip_release)
  File "dev/update_requirements.py", line 16, in get_latest_major_version
    response.raise_for_status()
  File "/home/haru/miniconda3/envs/mlflow-dev-env/lib/python3.8/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://pypi.org/pypi/uvicorn%5Bstandard%5D/json
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
