### PR TITLE
Fix the default value of `candidate_count`

### DIFF
--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -16,7 +16,7 @@ class BaseRequestPayload(RequestModel):
     temperature: float = Field(0.0, ge=0, le=1)
     candidate_count: int = Field(1, ge=1, le=5)
     stop: Optional[List[str]] = Field(None, min_items=1)
-    max_tokens: Optional[int] = Field(None, ge=0)
+    max_tokens: Optional[int] = Field(None, ge=1)
 
 
 class RequestPayload(BaseRequestPayload):

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -14,9 +14,9 @@ class RequestMessage(RequestModel):
 
 class BaseRequestPayload(RequestModel):
     temperature: float = Field(0.0, ge=0, le=1)
+    candidate_count: int = Field(1, ge=1, le=5)
     stop: Optional[List[str]] = Field(None, min_items=1)
     max_tokens: Optional[int] = Field(None, ge=0)
-    candidate_count: Optional[int] = Field(None, ge=1, le=5)
 
 
 class RequestPayload(BaseRequestPayload):

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -58,8 +58,7 @@ def parsed_completions_response():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("candidate_count", [1, None])
-async def test_completions(candidate_count):
+async def test_completions():
     resp = completions_response()
     config = completions_config()
     with mock.patch(
@@ -67,8 +66,6 @@ async def test_completions(candidate_count):
     ) as mock_post:
         provider = AnthropicProvider(RouteConfig(**config))
         payload = {"prompt": "How does a car work?", "max_tokens": 200}
-        if candidate_count is not None:
-            payload["candidate_count"] = candidate_count
         response = await provider.completions(completions.RequestPayload(**payload))
         assert jsonable_encoder(response) == parsed_completions_response()
         mock_post.assert_called_once()

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -92,6 +92,7 @@ async def test_chat():
             json={
                 "model": "gpt-3.5-turbo",
                 "temperature": 0,
+                "n": 1,
                 **payload,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
@@ -172,6 +173,7 @@ async def test_completions():
             json={
                 "model": "gpt-4-32k",
                 "temperature": 0,
+                "n": 1,
                 "messages": [{"role": "user", "content": "This is a test"}],
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
@@ -394,6 +396,7 @@ async def test_azure_openai():
             ),
             json={
                 "temperature": 0,
+                "n": 1,
                 "messages": [{"role": "user", "content": "This is a test"}],
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
@@ -434,6 +437,7 @@ async def test_azuread_openai():
             ),
             json={
                 "temperature": 0,
+                "n": 1,
                 "messages": [{"role": "user", "content": "This is a test"}],
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix the default value of `candidate_count`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
