### PR TITLE
Deflake `test_search_model_versions_order_by_simple`

### DIFF
--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1,4 +1,5 @@
 from unittest import mock
+import time
 import uuid
 import pytest
 
@@ -883,6 +884,7 @@ def test_search_model_versions_order_by_simple(store):
     for name in set(names):
         _rm_maker(store, name)
     for i in range(6):
+        time.sleep(0.001)  # sleep to ensure creation_timestamp is unique
         _mv_maker(store, name=names[i], source=sources[i], run_id=run_ids[i])
 
     # by default order by last_updated_timestamp DESC

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -884,7 +884,7 @@ def test_search_model_versions_order_by_simple(store):
     for name in set(names):
         _rm_maker(store, name)
     for i in range(6):
-        time.sleep(0.001)  # sleep to ensure creation_timestamp is unique
+        time.sleep(0.001)  # sleep to ensure each model version has a different creation_time
         _mv_maker(store, name=names[i], source=sources[i], run_id=run_ids[i])
 
     # by default order by last_updated_timestamp DESC


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix the following error:

https://github.com/mlflow/mlflow/actions/runs/5642858228/job/15283558217?pr=9086#step:9:2850

```
    def test_search_model_versions_order_by_simple(store):
        # create some model versions
        names = ["RM1", "RM2", "RM3", "RM4", "RM1", "RM4"]
        sources = ["A"] * 3 + ["B"] * 3
        run_ids = [uuid.uuid4().hex for _ in range(6)]
        for name in set(names):
            _rm_maker(store, name)
        for i in range(6):
            _mv_maker(store, name=names[i], source=sources[i], run_id=run_ids[i])
    
        # by default order by last_updated_timestamp DESC
        mvs = store.search_model_versions(filter_string=None)
>       assert [mv.name for mv in mvs] == names[::-1]
E       AssertionError: assert ['RM4', 'RM1', 'RM3', 'RM4', 'RM2', 'RM1'] == ['RM4', 'RM1', 'RM4', 'RM3', 'RM2', 'RM1']
E         At index 2 diff: 'RM3' != 'RM4'
E         Full diff:
E         - ['RM4', 'RM1', 'RM4', 'RM3', 'RM2', 'RM1']
E         ?                       -------
E         + ['RM4', 'RM1', 'RM3', 'RM4', 'RM2', 'RM1']
E         ?                +++++++
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
