### PR TITLE
Free some disk space in python job

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: ./.github/actions/untracked
 
   python:
-    # if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
@@ -104,6 +104,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-pyenv
       - uses: ./.github/actions/setup-java

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: ./.github/actions/untracked
 
   python:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    # if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -241,11 +241,13 @@ def test_mlflow_artifacts_example(tmp_path):
     # On GitHub Actions, remove generated images to save disk space
     rmi_option = "--rmi all" if is_github_actions() else ""
     cmd = f"""
-set -ex
+err=0
+trap 'err=1' ERR
 ./build.sh
 docker-compose run -v ${{PWD}}/example.py:/app/example.py client python example.py
 docker-compose logs
 docker-compose down {rmi_option} --volumes --remove-orphans
+test $err = 0
 """
     script_path = tmp_path.joinpath("test.sh")
     script_path.write_text(cmd)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix the following error in ` tests/tracking/test_mlflow_artifacts.py::test_mlflow_artifacts_example`:

https://github.com/mlflow/mlflow/actions/runs/5651381939/job/15309401913?pr=9153#step:10:3534

```
artifacts-server_1     | 2023/07/25 01:40:13 ERROR mlflow.server: Exception on /api/2.0/mlflow-artifacts/artifacts/experiments/0/0c10998073be4e8b936d401bad8abf6b/artifacts/a.txt [PUT]
artifacts-server_1     | Traceback (most recent call last):
artifacts-server_1     |   File "/usr/local/lib/python3.8/site-packages/boto3/s3/transfer.py", line 292, in upload_file
artifacts-server_1     |     future.result()
artifacts-server_1     |   File "/usr/local/lib/python3.8/site-packages/s3transfer/futures.py", line 103, in result
artifacts-server_1     |     return self._coordinator.result()
artifacts-server_1     |   File "/usr/local/lib/python3.8/site-packages/s3transfer/futures.py", line 266, in result
artifacts-server_1     |     raise self._exception
artifacts-server_1     |   File "/usr/local/lib/python3.8/site-packages/s3transfer/tasks.py", line 139, in __call__
artifacts-server_1     |     return self._execute_main(kwargs)
artifacts-server_1     |   File "/usr/local/lib/python3.8/site-packages/s3transfer/tasks.py", line 162, in _execute_main
artifacts-server_1     |     return_value = self._main(**kwargs)
artifacts-server_1     |   File "/usr/local/lib/python3.8/site-packages/s3transfer/upload.py", line 758, in _main
artifacts-server_1     |     client.put_object(Bucket=bucket, Key=key, Body=body, **extra_args)
artifacts-server_1     |   File "/usr/local/lib/python3.8/site-packages/botocore/client.py", line 534, in _api_call
artifacts-server_1     |     return self._make_api_call(operation_name, kwargs)
artifacts-server_1     |   File "/usr/local/lib/python3.8/site-packages/botocore/client.py", line 976, in _make_api_call
artifacts-server_1     |     raise error_class(parsed_response, operation_name)
artifacts-server_1     | botocore.exceptions.ClientError: An error occurred (XMinioStorageFull) when calling the PutObject operation: Storage backend has reached its minimum free drive threshold. Please delete a few objects to proceed.
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
