### PR TITLE
Enable `PT012`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,10 @@ select = [
   "C4",
   "PT001",
   "PT006",
-  # TODO: Enable commented-out rules.
   "PT007",
   "PT009",
   "PT010",
-  # "PT012",
+  "PT012",
   "PT018",
   "PT023",
   "PT026",
@@ -40,13 +39,13 @@ select = [
 ]
 force-exclude = true
 ignore = [
-  "E402",  # module-import-not-at-top-of-file
-  "E501",  # line-too-long
-  "E741",  # ambiguous-variable-name
-  "F401",  # unused-import
-  "F402",  # import-shadowed-by-loop-var
-  "F403",  # undefined-local-with-import-star
-  "F811",  # redefined-while-unused
+  "E402", # module-import-not-at-top-of-file
+  "E501", # line-too-long
+  "E741", # ambiguous-variable-name
+  "F401", # unused-import
+  "F402", # import-shadowed-by-loop-var
+  "F403", # undefined-local-with-import-star
+  "F811", # redefined-while-unused
 ]
 extend-exclude = [
   "setup.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,13 +39,13 @@ select = [
 ]
 force-exclude = true
 ignore = [
-  "E402", # module-import-not-at-top-of-file
-  "E501", # line-too-long
-  "E741", # ambiguous-variable-name
-  "F401", # unused-import
-  "F402", # import-shadowed-by-loop-var
-  "F403", # undefined-local-with-import-star
-  "F811", # redefined-while-unused
+  "E402",  # module-import-not-at-top-of-file
+  "E501",  # line-too-long
+  "E741",  # ambiguous-variable-name
+  "F401",  # unused-import
+  "F402",  # import-shadowed-by-loop-var
+  "F403",  # undefined-local-with-import-star
+  "F811",  # redefined-while-unused
 ]
 extend-exclude = [
   "setup.py",

--- a/tests/autologging/test_autologging_client.py
+++ b/tests/autologging/test_autologging_client.py
@@ -229,7 +229,7 @@ def test_client_correctly_operates_as_context_manager_for_synchronous_flush():
     assert run_tags_1 == tags_to_log
 
     exc_to_raise = Exception("test exception")
-    with pytest.raises(Exception, match=str(exc_to_raise)) as raised_exc_info:
+    with pytest.raises(Exception, match=str(exc_to_raise)) as raised_exc_info:  # noqa: PT012
         with mlflow.start_run(), MlflowAutologgingQueueingClient() as client:
             run_id_2 = mlflow.active_run().info.run_id
             client.log_params(run_id_2, params_to_log)

--- a/tests/openai/test_openai_model_export.py
+++ b/tests/openai/test_openai_model_export.py
@@ -389,11 +389,11 @@ def test_auto_request_retry_exceeds_maximum_attempts(tmp_path):
 def test_auto_request_retry_is_disabled_when_env_var_is_false(tmp_path, monkeypatch):
     mlflow.pyfunc.save_model(tmp_path, python_model=ChatCompletionModel())
     loaded_model = mlflow.pyfunc.load_model(tmp_path)
+    monkeypatch.setenv("MLFLOW_OPENAI_RETRIES_ENABLED", "false")
     with pytest.raises(openai.error.RateLimitError, match="RateLimitError"):
         with _mock_request(
             side_effect=openai.error.RateLimitError(message="RateLimitError", code=403)
         ) as mock_request:
-            monkeypatch.setenv("MLFLOW_OPENAI_RETRIES_ENABLED", "false")
             loaded_model.predict(None)
 
     assert mock_request.call_count == 1

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -668,8 +668,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         # Therefore, we check for the more generic 'SQLAlchemyError'
         with pytest.raises(MlflowException, match=regex) as exception_context:
             with self.store.ManagedSessionMaker() as session:
-                run = models.SqlRun()
-                session.add(run)
+                session.add(models.SqlRun())
         assert exception_context.value.error_code == ErrorCode.Name(BAD_REQUEST)
 
     def test_run_data_model(self):

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -173,8 +173,8 @@ def test_start_run_context_manager():
     # different
     with pytest.raises(Exception, match="Failing run!"):
         with start_run() as second_run:
-            second_run_id = second_run.info.run_id
             raise Exception("Failing run!")
+    second_run_id = second_run.info.run_id
     assert second_run_id != first_uuid
     finished_run2 = tracking.MlflowClient().get_run(second_run_id)
     assert finished_run2.info.status == RunStatus.to_string(RunStatus.FAILED)


### PR DESCRIPTION
## Related Issues/PRs

Closes #9028

## What changes are proposed in this pull request?

Enables `ruff` rule `PT012`

FYI @harupy 

I am a bit unsure about my changes [here](https://github.com/mlflow/mlflow/pull/9158/files#diff-cc0b1dce628ed6e2946d88f1c390c19939efa2519b92a71c2d0c507fec86c508R175-R181) and [here](https://github.com/mlflow/mlflow/pull/9158/files#diff-7dcb6b8ab1317bbae2dd65ce42772caa7f2ae91cac3917ce7a64cf9c400c0d07R231-R239). Do we still have to test (with `pytest.raises`) exceptions that we artificially raise in the test itself? I turned these into `try-except` for now. Please let me know if I missed something :)

## How is this patch tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)


## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
