### PR TITLE
Eliminate `with mock.patch.dict` for environment variables (3)

### DIFF
--- a/tests/projects/backend/test_local.py
+++ b/tests/projects/backend/test_local.py
@@ -20,7 +20,15 @@ def test_docker_s3_artifact_cmd_and_envs_from_env(monkeypatch):
 
 def test_docker_s3_artifact_cmd_and_envs_from_home(monkeypatch):
     mock_env = {}
-    monkeypatch.setenvs(mock_env)
+    monkeypatch.delenvs(
+        [
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_ACCESS_KEY_ID",
+            "MLFLOW_S3_ENDPOINT_URL",
+            "MLFLOW_S3_IGNORE_TLS",
+        ],
+        raising=False,
+    )
     with mock.patch("posixpath.exists", return_value=True), mock.patch(
         "posixpath.expanduser", return_value="mock_volume"
     ):
@@ -47,7 +55,6 @@ def test_docker_gcs_artifact_cmd_and_envs_from_home(monkeypatch):
         "GOOGLE_APPLICATION_CREDENTIALS": "mock_credentials_path",
     }
     gs_uri = "gs://mock_bucket"
-    monkeypatch.delenvs(["GOOGLE_APPLICATION_CREDENTIALS"], raising=False)
     monkeypatch.setenvs(mock_env)
     cmds, envs = _get_docker_artifact_storage_cmd_and_envs(gs_uri)
     assert cmds == ["-v", "mock_credentials_path:/.gcs"]
@@ -61,14 +68,6 @@ def test_docker_hdfs_artifact_cmd_and_envs_from_home(monkeypatch):
         "MLFLOW_PYARROW_EXTRA_CONF": "mock_pyarrow_extra_conf",
     }
     hdfs_uri = "hdfs://host:8020/path"
-    monkeypatch.delenvs(
-        [
-            "MLFLOW_KERBEROS_TICKET_CACHE",
-            "MLFLOW_KERBEROS_USER",
-            "MLFLOW_PYARROW_EXTRA_CONF",
-        ],
-        raising=False,
-    )
     monkeypatch.setenvs(mock_env)
     cmds, envs = _get_docker_artifact_storage_cmd_and_envs(hdfs_uri)
     assert cmds == ["-v", "/mock_ticket_cache:/mock_ticket_cache"]

--- a/tests/projects/backend/test_local.py
+++ b/tests/projects/backend/test_local.py
@@ -4,67 +4,75 @@ from unittest import mock
 from mlflow.projects.backend.local import _get_docker_artifact_storage_cmd_and_envs
 
 
-def test_docker_s3_artifact_cmd_and_envs_from_env():
+def test_docker_s3_artifact_cmd_and_envs_from_env(monkeypatch):
     mock_env = {
         "AWS_SECRET_ACCESS_KEY": "mock_secret",
         "AWS_ACCESS_KEY_ID": "mock_access_key",
         "MLFLOW_S3_ENDPOINT_URL": "mock_endpoint",
         "MLFLOW_S3_IGNORE_TLS": "false",
     }
-    with mock.patch.dict("os.environ", mock_env), mock.patch(
-        "posixpath.exists", return_value=False
-    ):
+    monkeypatch.setenvs(mock_env)
+    with mock.patch("posixpath.exists", return_value=False):
         cmds, envs = _get_docker_artifact_storage_cmd_and_envs("s3://mock_bucket")
         assert cmds == []
         assert envs == mock_env
 
 
-def test_docker_s3_artifact_cmd_and_envs_from_home():
+def test_docker_s3_artifact_cmd_and_envs_from_home(monkeypatch):
     mock_env = {}
-    with mock.patch.dict("os.environ", mock_env), mock.patch(
-        "posixpath.exists", return_value=True
-    ), mock.patch("posixpath.expanduser", return_value="mock_volume"):
+    monkeypatch.setenvs(mock_env)
+    with mock.patch("posixpath.exists", return_value=True), mock.patch(
+        "posixpath.expanduser", return_value="mock_volume"
+    ):
         cmds, envs = _get_docker_artifact_storage_cmd_and_envs("s3://mock_bucket")
         assert cmds == ["-v", "mock_volume:/.aws"]
         assert envs == mock_env
 
 
-def test_docker_wasbs_artifact_cmd_and_envs_from_home():
+def test_docker_wasbs_artifact_cmd_and_envs_from_home(monkeypatch):
     mock_env = {
         "AZURE_STORAGE_CONNECTION_STRING": "mock_connection_string",
         "AZURE_STORAGE_ACCESS_KEY": "mock_access_key",
     }
     wasbs_uri = "wasbs://container@account.blob.core.windows.net/some/path"
-    with mock.patch.dict("os.environ", mock_env), mock.patch(
-        "azure.storage.blob.BlobServiceClient"
-    ):
+    monkeypatch.setenvs(mock_env)
+    with mock.patch("azure.storage.blob.BlobServiceClient"):
         cmds, envs = _get_docker_artifact_storage_cmd_and_envs(wasbs_uri)
         assert cmds == []
         assert envs == mock_env
 
 
-def test_docker_gcs_artifact_cmd_and_envs_from_home():
+def test_docker_gcs_artifact_cmd_and_envs_from_home(monkeypatch):
     mock_env = {
         "GOOGLE_APPLICATION_CREDENTIALS": "mock_credentials_path",
     }
     gs_uri = "gs://mock_bucket"
-    with mock.patch.dict("os.environ", mock_env, clear=True):
-        cmds, envs = _get_docker_artifact_storage_cmd_and_envs(gs_uri)
-        assert cmds == ["-v", "mock_credentials_path:/.gcs"]
-        assert envs == {"GOOGLE_APPLICATION_CREDENTIALS": "/.gcs"}
+    monkeypatch.delenvs(["GOOGLE_APPLICATION_CREDENTIALS"], raising=False)
+    monkeypatch.setenvs(mock_env)
+    cmds, envs = _get_docker_artifact_storage_cmd_and_envs(gs_uri)
+    assert cmds == ["-v", "mock_credentials_path:/.gcs"]
+    assert envs == {"GOOGLE_APPLICATION_CREDENTIALS": "/.gcs"}
 
 
-def test_docker_hdfs_artifact_cmd_and_envs_from_home():
+def test_docker_hdfs_artifact_cmd_and_envs_from_home(monkeypatch):
     mock_env = {
         "MLFLOW_KERBEROS_TICKET_CACHE": "/mock_ticket_cache",
         "MLFLOW_KERBEROS_USER": "mock_krb_user",
         "MLFLOW_PYARROW_EXTRA_CONF": "mock_pyarrow_extra_conf",
     }
     hdfs_uri = "hdfs://host:8020/path"
-    with mock.patch.dict("os.environ", mock_env, clear=True):
-        cmds, envs = _get_docker_artifact_storage_cmd_and_envs(hdfs_uri)
-        assert cmds == ["-v", "/mock_ticket_cache:/mock_ticket_cache"]
-        assert envs == mock_env
+    monkeypatch.delenvs(
+        [
+            "MLFLOW_KERBEROS_TICKET_CACHE",
+            "MLFLOW_KERBEROS_USER",
+            "MLFLOW_PYARROW_EXTRA_CONF",
+        ],
+        raising=False,
+    )
+    monkeypatch.setenvs(mock_env)
+    cmds, envs = _get_docker_artifact_storage_cmd_and_envs(hdfs_uri)
+    assert cmds == ["-v", "/mock_ticket_cache:/mock_ticket_cache"]
+    assert envs == mock_env
 
 
 def test_docker_local_artifact_cmd_and_envs():

--- a/tests/projects/backend/test_local.py
+++ b/tests/projects/backend/test_local.py
@@ -19,7 +19,6 @@ def test_docker_s3_artifact_cmd_and_envs_from_env(monkeypatch):
 
 
 def test_docker_s3_artifact_cmd_and_envs_from_home(monkeypatch):
-    mock_env = {}
     monkeypatch.delenvs(
         [
             "AWS_SECRET_ACCESS_KEY",
@@ -34,7 +33,7 @@ def test_docker_s3_artifact_cmd_and_envs_from_home(monkeypatch):
     ):
         cmds, envs = _get_docker_artifact_storage_cmd_and_envs("s3://mock_bucket")
         assert cmds == ["-v", "mock_volume:/.aws"]
-        assert envs == mock_env
+        assert envs == {}
 
 
 def test_docker_wasbs_artifact_cmd_and_envs_from_home(monkeypatch):

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -106,20 +106,23 @@ def test_get_s3_client_hits_cache(s3_artifact_root):
 @pytest.mark.parametrize(
     ("ignore_tls_env", "verify"), [("0", None), ("1", False), ("true", False), ("false", None)]
 )
-def test_get_s3_client_verify_param_set_correctly(s3_artifact_root, ignore_tls_env, verify):
-    with mock.patch.dict("os.environ", {"MLFLOW_S3_IGNORE_TLS": ignore_tls_env}, clear=True):
-        with mock.patch("boto3.client") as mock_get_s3_client:
-            repo = get_artifact_repository(posixpath.join(s3_artifact_root, "some/path"))
-            repo._get_s3_client()
-            mock_get_s3_client.assert_called_with(
-                "s3",
-                config=ANY,
-                endpoint_url=ANY,
-                verify=verify,
-                aws_access_key_id=None,
-                aws_secret_access_key=None,
-                aws_session_token=None,
-            )
+def test_get_s3_client_verify_param_set_correctly(
+    s3_artifact_root, ignore_tls_env, verify, monkeypatch
+):
+    monkeypatch.delenv("MLFLOW_S3_IGNORE_TLS", raising=False)
+    monkeypatch.setenv("MLFLOW_S3_IGNORE_TLS", ignore_tls_env)
+    with mock.patch("boto3.client") as mock_get_s3_client:
+        repo = get_artifact_repository(posixpath.join(s3_artifact_root, "some/path"))
+        repo._get_s3_client()
+        mock_get_s3_client.assert_called_with(
+            "s3",
+            config=ANY,
+            endpoint_url=ANY,
+            verify=verify,
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            aws_session_token=None,
+        )
 
 
 def test_s3_creds_passed_to_client(s3_artifact_root):

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -109,7 +109,6 @@ def test_get_s3_client_hits_cache(s3_artifact_root):
 def test_get_s3_client_verify_param_set_correctly(
     s3_artifact_root, ignore_tls_env, verify, monkeypatch
 ):
-    monkeypatch.delenv("MLFLOW_S3_IGNORE_TLS", raising=False)
     monkeypatch.setenv("MLFLOW_S3_IGNORE_TLS", ignore_tls_env)
     with mock.patch("boto3.client") as mock_get_s3_client:
         repo = get_artifact_repository(posixpath.join(s3_artifact_root, "some/path"))


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #9006 

## What changes are proposed in this pull request?

Manual elimination of `with mock.patch.dict` for environment variables and use `monkeypatch.setenv` for mocking. Part 3.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.


### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
