### PR TITLE
Supporting kwargs in log figure

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1298,7 +1298,10 @@ class MlflowClient:
             elif "plotly" in sys.modules and _is_plotly_figure(figure):
                 file_extension = os.path.splitext(artifact_file)[1]
                 if file_extension == ".html":
-                    figure.write_html(tmp_path, include_plotlyjs="cdn", auto_open=False, **kwargs)
+                    kwargs.setdefault("include_plotlyjs", "cdn")
+                    kwargs.setdefault("auto_open", False)
+
+                    figure.write_html(tmp_path, **kwargs)
                 elif file_extension in [".png", ".jpeg", ".webp", ".svg", ".pdf"]:
                     figure.write_image(tmp_path, **kwargs)
                 else:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1252,6 +1252,8 @@ class MlflowClient:
         :param figure: Figure to log.
         :param artifact_file: The run-relative artifact file path in posixpath format to which
                               the figure is saved (e.g. "dir/file.png").
+        :param kwargs: Additional arguments that are being passed to the
+                       matplotlib/ plotly method when saving the figure.
 
         .. code-block:: python
             :caption: Matplotlib Example

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1289,6 +1289,7 @@ class MlflowClient:
 
             return isinstance(fig, plotly.graph_objects.Figure)
 
+        save_kwargs = save_kwargs or {}
         with self._log_artifact_helper(run_id, artifact_file) as tmp_path:
             # `is_matplotlib_figure` is executed only when `matplotlib` is found in `sys.modules`.
             # This allows logging a `plotly` figure in an environment where `matplotlib` is not

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1234,6 +1234,7 @@ class MlflowClient:
         run_id: str,
         figure: Union["matplotlib.figure.Figure", "plotly.graph_objects.Figure"],
         artifact_file: str,
+        **kwargs,
     ) -> None:
         """
         Log a figure as an artifact. The following figure objects are supported:
@@ -1291,13 +1292,13 @@ class MlflowClient:
             # This allows logging a `plotly` figure in an environment where `matplotlib` is not
             # installed.
             if "matplotlib" in sys.modules and _is_matplotlib_figure(figure):
-                figure.savefig(tmp_path)
+                figure.savefig(tmp_path, **kwargs)
             elif "plotly" in sys.modules and _is_plotly_figure(figure):
                 file_extension = os.path.splitext(artifact_file)[1]
                 if file_extension == ".html":
-                    figure.write_html(tmp_path, include_plotlyjs="cdn", auto_open=False)
+                    figure.write_html(tmp_path, include_plotlyjs="cdn", auto_open=False, **kwargs)
                 elif file_extension in [".png", ".jpeg", ".webp", ".svg", ".pdf"]:
-                    figure.write_image(tmp_path)
+                    figure.write_image(tmp_path, **kwargs)
                 else:
                     raise TypeError(
                         f"Unsupported file extension for plotly figure: '{file_extension}'"

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1234,7 +1234,8 @@ class MlflowClient:
         run_id: str,
         figure: Union["matplotlib.figure.Figure", "plotly.graph_objects.Figure"],
         artifact_file: str,
-        **kwargs,
+        *,
+        save_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Log a figure as an artifact. The following figure objects are supported:
@@ -1252,8 +1253,7 @@ class MlflowClient:
         :param figure: Figure to log.
         :param artifact_file: The run-relative artifact file path in posixpath format to which
                               the figure is saved (e.g. "dir/file.png").
-        :param kwargs: Additional arguments that are being passed to the
-                       matplotlib/ plotly method when saving the figure.
+        :param save_kwargs: Additional keyword arguments passed to the method that saves the figure.
 
         .. code-block:: python
             :caption: Matplotlib Example
@@ -1294,16 +1294,15 @@ class MlflowClient:
             # This allows logging a `plotly` figure in an environment where `matplotlib` is not
             # installed.
             if "matplotlib" in sys.modules and _is_matplotlib_figure(figure):
-                figure.savefig(tmp_path, **kwargs)
+                figure.savefig(tmp_path, **save_kwargs)
             elif "plotly" in sys.modules and _is_plotly_figure(figure):
                 file_extension = os.path.splitext(artifact_file)[1]
                 if file_extension == ".html":
-                    kwargs.setdefault("include_plotlyjs", "cdn")
-                    kwargs.setdefault("auto_open", False)
-
-                    figure.write_html(tmp_path, **kwargs)
+                    save_kwargs.setdefault("include_plotlyjs", "cdn")
+                    save_kwargs.setdefault("auto_open", False)
+                    figure.write_html(tmp_path, **save_kwargs)
                 elif file_extension in [".png", ".jpeg", ".webp", ".svg", ".pdf"]:
-                    figure.write_image(tmp_path, **kwargs)
+                    figure.write_image(tmp_path, **save_kwargs)
                 else:
                     raise TypeError(
                         f"Unsupported file extension for plotly figure: '{file_extension}'"

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -973,7 +973,10 @@ def log_dict(dictionary: Dict[str, Any], artifact_file: str) -> None:
 
 
 def log_figure(
-    figure: Union["matplotlib.figure.Figure", "plotly.graph_objects.Figure"], artifact_file: str
+    figure: Union["matplotlib.figure.Figure", "plotly.graph_objects.Figure"],
+    artifact_file: str,
+    *,
+    save_kwargs: Optional[Dict[str, Any]] = None,
 ) -> None:
     """
     Log a figure as an artifact. The following figure objects are supported:
@@ -990,6 +993,7 @@ def log_figure(
     :param figure: Figure to log.
     :param artifact_file: The run-relative artifact file path in posixpath format to which
                           the figure is saved (e.g. "dir/file.png").
+    :param save_kwargs: Additional keyword arguments passed to the method that saves the figure.
 
     .. test-code-block:: python
         :caption: Matplotlib Example
@@ -1015,7 +1019,7 @@ def log_figure(
             mlflow.log_figure(fig, "figure.html")
     """
     run_id = _get_or_start_run().info.run_id
-    MlflowClient().log_figure(run_id, figure, artifact_file)
+    MlflowClient().log_figure(run_id, figure, artifact_file, save_kwargs=save_kwargs)
 
 
 def log_image(image: Union["numpy.ndarray", "PIL.Image.Image"], artifact_file: str) -> None:

--- a/tests/tracking/test_log_figure.py
+++ b/tests/tracking/test_log_figure.py
@@ -66,6 +66,15 @@ def test_log_figure_plotly_image(extension):
         assert os.listdir(run_artifact_dir) == [filename]
 
 
+def test_log_figure_save_kwargs():
+    from plotly import graph_objects as go
+
+    fig = go.Figure(go.Scatter(x=[0, 1], y=[2, 3]))
+    fig.update_layout(title={"text": r"$\text{A line with slope}\quad \frac{3-2}{1-0}=1$"})
+    with mlflow.start_run():
+        mlflow.log_figure(fig, "figure.html", save_kwargs={"include_mathjax": "cdn"})
+
+
 @pytest.mark.parametrize("extension", ["", ".py"])
 def test_log_figure_raises_error_for_unsupported_file_extension(extension):
     from plotly import graph_objects as go

--- a/tests/tracking/test_log_figure.py
+++ b/tests/tracking/test_log_figure.py
@@ -1,5 +1,6 @@
 import os
 import posixpath
+import uuid
 
 import pytest
 
@@ -72,7 +73,13 @@ def test_log_figure_save_kwargs():
     fig = go.Figure(go.Scatter(x=[0, 1], y=[2, 3]))
     fig.update_layout(title={"text": r"$\text{A line with slope}\quad \frac{3-2}{1-0}=1$"})
     with mlflow.start_run():
-        mlflow.log_figure(fig, "figure.html", save_kwargs={"include_mathjax": "cdn"})
+        name = "figure.html"
+        div_id = uuid.uuid4().hex
+        mlflow.log_figure(fig, name, save_kwargs={"div_id": div_id})
+        artifact_uri = mlflow.get_artifact_uri(name)
+        local_path = local_file_uri_to_path(artifact_uri)
+        with open(local_path) as f:
+            assert div_id in f.read()
 
 
 @pytest.mark.parametrize("extension", ["", ".py"])

--- a/tests/tracking/test_log_figure.py
+++ b/tests/tracking/test_log_figure.py
@@ -71,7 +71,6 @@ def test_log_figure_save_kwargs():
     from plotly import graph_objects as go
 
     fig = go.Figure(go.Scatter(x=[0, 1], y=[2, 3]))
-    fig.update_layout(title={"text": r"$\text{A line with slope}\quad \frac{3-2}{1-0}=1$"})
     with mlflow.start_run():
         name = "figure.html"
         div_id = uuid.uuid4().hex


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Resolve #9149 

## What changes are proposed in this pull request?

- added `**kwargs` to `log_figure(..)` and passed them to corresponding export methods for both matplotlib and plotly
- using `setdefault` to merge previously existing arguments in `kwargs`
- updated docstring

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

- ran only tracking related unit tests (`pytest tests/tracking/test_log_figure.py`)
- manual test code based on example provided in method documentation:
```
from mlflow import MlflowClient
from plotly import graph_objects as go

client = MlflowClient()

fig = go.Figure(go.Scatter(x=[0, 1], y=[2, 3]))
fig.update_layout(
    title={
        'text': r"$\text{A line with slope}\quad \frac{3-2}{1-0}=1$",
    })

run = client.create_run(experiment_id="0")
client.log_figure(run.info.run_id, fig, "figure.html", include_mathjax="cdn")
```
- manual test results (with and without `include_mathjax="cdn"`) :
![image](https://github.com/mlflow/mlflow/assets/25545736/c4b1d6fc-3c48-414b-a291-5945f8c790a6)
![image](https://github.com/mlflow/mlflow/assets/25545736/b7bfb558-2ee9-42c5-b6bf-1b5193462eb6)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

Additional arguments can be passed to both Matplotlib and Plotly export methods. This enables specifying e.g. MathJax CDN 
 required for Plotly figures with formulas as mentioned in #9149 

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
