### PR TITLE
Add validation test for environment variable behavior

### DIFF
--- a/tests/test_environment_variables.py
+++ b/tests/test_environment_variables.py
@@ -1,4 +1,5 @@
 from mlflow.environment_variables import _BooleanEnvironmentVariable, _EnvironmentVariable
+import os
 import pytest
 
 
@@ -44,3 +45,38 @@ def test_boolean_environment_variable_invalid_value(monkeypatch, value):
 def test_empty_value(monkeypatch):
     monkeypatch.setenv("TEST_ENV_VAR", "")
     assert _EnvironmentVariable("TEST_ENV_VAR", str, None).get() == ""
+
+
+@pytest.mark.parametrize(
+    ("var_name", "var_value", "var_type", "default_value", "expected_raw", "expected_get"),
+    [
+        ("TEST_VARIABLE", "123", str, "default", "123", "123"),
+        ("NON_EXISTENT_VARIABLE", None, str, "default", None, "default"),
+        ("TEST_VARIABLE", "", str, "default", "", ""),
+        ("TEST_VARIABLE", " ", str, "default", " ", " "),
+        ("TEST_VARIABLE", "123", int, 456, "123", 123),
+        ("TEST_VARIABLE", "123.456", float, 789.0, "123.456", 123.456),
+        ("TEST_VARIABLE", "123456789123456789", int, 123, "123456789123456789", 123456789123456789),
+    ],
+)
+def test_environment_variable_functionality(
+    monkeypatch, var_name, var_value, var_type, default_value, expected_raw, expected_get
+):
+    if var_value is not None:
+        monkeypatch.setenv(var_name, var_value)
+    env_var = _EnvironmentVariable(var_name, var_type, default_value)
+
+    # Test if variable is defined
+    assert env_var.is_defined == (var_value is not None)
+
+    # Test getting raw value
+    assert env_var.get_raw() == expected_raw
+
+    # Test getting value
+    assert env_var.get() == expected_get
+
+    # Test setting and unsetting value
+    env_var.set(str(default_value))
+    assert os.getenv(var_name) == str(default_value)
+    env_var.unset()
+    assert os.getenv(var_name) is None


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add test coverage for environment variable functionality

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
