### PR TITLE
Fix LangChain compatibility with SQLDatabase

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -135,7 +135,7 @@ def _get_map_of_special_chain_class_to_loader_arg():
 
             class_name_to_loader_arg["langchain_experimental.sql.SQLDatabaseChain"] = "database"
         except ImportError:
-            # Users may not have langchain_experimental installed, which is completely normal 
+            # Users may not have langchain_experimental installed, which is completely normal
             pass
 
     class_to_loader_arg = {

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -15,7 +15,7 @@ import logging
 import os
 import shutil
 import types
-from functools import cache
+import functools 
 from packaging import version
 from typing import Any, Dict, List, Optional, Union, NamedTuple
 
@@ -117,7 +117,7 @@ def _get_special_chain_info_or_none(chain):
             return _SpecialChainInfo(loader_arg = loader_arg)
 
 
-@cache
+@functools.lru_cache
 def _get_map_of_special_chain_class_to_loader_arg():
     import langchain
 

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -119,6 +119,7 @@ def _get_special_chain_info_or_none(chain):
 @functools.lru_cache
 def _get_map_of_special_chain_class_to_loader_arg():
     import langchain
+    from mlflow.langchain.retriever_chain import _RetrieverChain
 
     class_name_to_loader_arg = {
         "langchain.chains.RetrievalQA": "retriever",
@@ -135,10 +136,12 @@ def _get_map_of_special_chain_class_to_loader_arg():
 
             class_name_to_loader_arg["langchain_experimental.sql.SQLDatabaseChain"] = "database"
         except ImportError:
-            # Users may not have langchain_experimental installed, which is completely okay
+            # Users may not have langchain_experimental installed, which is completely normal 
             pass
 
-    class_to_loader_arg = {}
+    class_to_loader_arg = {
+        _RetrieverChain: "retriever",
+    }
     for class_name, loader_arg in class_name_to_loader_arg.items():
         try:
             cls = _get_class_from_string(class_name)
@@ -150,10 +153,6 @@ def _get_map_of_special_chain_class_to_loader_arg():
                 class_name,
                 exc_info=True,
             )
-
-    from mlflow.langchain.retriever_chain import _RetrieverChain
-
-    class_to_loader_arg[_RetrieverChain] = "retriever"
 
     return class_to_loader_arg
 

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -125,7 +125,6 @@ def _get_map_of_special_chain_class_to_loader_arg():
         "langchain.chains.RetrievalQA": "retriever",
         "langchain.chains.APIChain": "requests_wrapper",
         "langchain.chains.HypotheticalDocumentEmbedder": "embeddings",
-        "langchain.chains.SQLDatabaseChain": "database",
     }
     # NB: SQLDatabaseChain was migrated to langchain_experimental beginning with version 0.0.247
     if version.parse(langchain.__version__) <= version.parse("0.0.246"):

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -15,7 +15,7 @@ import logging
 import os
 import shutil
 import types
-import functools 
+import functools
 from packaging import version
 from typing import Any, Dict, List, Optional, Union, NamedTuple
 
@@ -106,7 +106,6 @@ def get_default_conda_env():
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
 
-
 class _SpecialChainInfo(NamedTuple):
     loader_arg: str
 
@@ -114,7 +113,7 @@ class _SpecialChainInfo(NamedTuple):
 def _get_special_chain_info_or_none(chain):
     for special_chain_class, loader_arg in _get_map_of_special_chain_class_to_loader_arg().items():
         if isinstance(chain, special_chain_class):
-            return _SpecialChainInfo(loader_arg = loader_arg)
+            return _SpecialChainInfo(loader_arg=loader_arg)
 
 
 @functools.lru_cache
@@ -133,6 +132,7 @@ def _get_map_of_special_chain_class_to_loader_arg():
     else:
         try:
             import langchain.experimental
+
             class_name_to_loader_arg["langchain_experimental.sql.SQLDatabaseChain"] = "database"
         except ImportError:
             # Users may not have langchain_experimental installed, which is completely okay
@@ -148,13 +148,15 @@ def _get_map_of_special_chain_class_to_loader_arg():
                 "Unexpected import failure for class '%s'. Please file an issue at"
                 " https://github.com/mlflow/mlflow/issues/.",
                 class_name,
-                exc_info=True
+                exc_info=True,
             )
 
     from mlflow.langchain.retriever_chain import _RetrieverChain
+
     class_to_loader_arg[_RetrieverChain] = "retriever"
 
     return class_to_loader_arg
+
 
 @experimental
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
@@ -347,25 +349,23 @@ def _validate_and_wrap_lc_model(lc_model, loader_fn):
         )
 
     _SUPPORTED_LLMS = {langchain.llms.openai.OpenAI, langchain.llms.huggingface_hub.HuggingFaceHub}
-    if (
-        isinstance(lc_model, langchain.chains.llm.LLMChain)
-        and not any(isinstance(lc_model.llm, supported_llm) for supported_llm in _SUPPORTED_LLMS)
+    if isinstance(lc_model, langchain.chains.llm.LLMChain) and not any(
+        isinstance(lc_model.llm, supported_llm) for supported_llm in _SUPPORTED_LLMS
     ):
         logger.warning(
             _UNSUPPORTED_LLM_WARNING_MESSAGE,
             type(lc_model.llm).__name__,
         )
 
-    if (
-        isinstance(lc_model, langchain.agents.agent.AgentExecutor)
-        and not any(isinstance(lc_model.agent.llm_chain.llm, supported_llm) for supported_llm in _SUPPORTED_LLMS)
+    if isinstance(lc_model, langchain.agents.agent.AgentExecutor) and not any(
+        isinstance(lc_model.agent.llm_chain.llm, supported_llm) for supported_llm in _SUPPORTED_LLMS
     ):
         logger.warning(
             _UNSUPPORTED_LLM_WARNING_MESSAGE,
             type(lc_model.agent.llm_chain.llm).__name__,
         )
 
-    if special_chain_info := _get_special_chain_info_or_none(lc_model): 
+    if special_chain_info := _get_special_chain_info_or_none(lc_model):
         if isinstance(lc_model, langchain.chains.RetrievalQA) and version.parse(
             langchain.__version__
         ) < version.parse("0.0.194"):
@@ -595,7 +595,7 @@ def _save_model(model, path, loader_fn, persist_dir):
         with open(loader_fn_path, "wb") as f:
             cloudpickle.dump(loader_fn, f)
         model_data_kwargs[_LOADER_FN_KEY] = _LOADER_FN_FILE_NAME
-        model_data_kwargs[_LOADER_ARG_KEY] = special_chain_info.loader_arg 
+        model_data_kwargs[_LOADER_ARG_KEY] = special_chain_info.loader_arg
 
         if persist_dir is not None:
             if os.path.exists(persist_dir):

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -334,8 +334,6 @@ def save_model(
 def _validate_and_wrap_lc_model(lc_model, loader_fn):
     import langchain
 
-    special_chain_classes_to_loader_args = _get_map_of_special_chain_class_to_loader_arg()
-
     if not isinstance(
         lc_model,
         (

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -575,6 +575,7 @@ langchain:
           "google-search-results",
           "psutil",
           "faiss-cpu",
+          "langchain-experimental",
         ]
     run: |
       pytest tests/langchain/test_langchain_model_export.py

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -19,7 +19,6 @@ from langchain.chains import (
     LLMChain,
     RetrievalQA,
     HypotheticalDocumentEmbedder,
-    SQLDatabaseChain,
 )
 from langchain.chains.api import open_meteo_docs
 from langchain.chains.base import Chain
@@ -35,6 +34,7 @@ from langchain.prompts import PromptTemplate
 from langchain.requests import TextRequestsWrapper
 from langchain.text_splitter import CharacterTextSplitter
 from langchain.vectorstores import FAISS
+from langchain_experimental.sql import SQLDatabaseChain
 from pydantic import BaseModel
 from pyspark.sql import SparkSession
 from typing import Any, List, Mapping, Optional, Dict

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -516,7 +516,9 @@ def test_log_and_load_subclass_of_specialized_chain():
         pass
 
     llm = OpenAI(temperature=0)
-    apichain_subclass = APIChainSubclass.from_llm_and_api_docs(llm, open_meteo_docs.OPEN_METEO_DOCS, verbose=True)
+    apichain_subclass = APIChainSubclass.from_llm_and_api_docs(
+        llm, open_meteo_docs.OPEN_METEO_DOCS, verbose=True
+    )
 
     with mlflow.start_run():
         logged_model = mlflow.langchain.log_model(

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -511,6 +511,25 @@ def test_log_and_load_api_chain():
     assert loaded_model == apichain
 
 
+def test_log_and_load_subclass_of_specialized_chain():
+    class APIChainSubclass(APIChain):
+        pass
+
+    llm = OpenAI(temperature=0)
+    apichain_subclass = APIChainSubclass.from_llm_and_api_docs(llm, open_meteo_docs.OPEN_METEO_DOCS, verbose=True)
+
+    with mlflow.start_run():
+        logged_model = mlflow.langchain.log_model(
+            apichain_subclass,
+            "apichain_subclass",
+            loader_fn=load_requests_wrapper,
+        )
+
+    # Load the chain
+    loaded_model = mlflow.langchain.load_model(logged_model.model_uri)
+    assert loaded_model == apichain_subclass
+
+
 def load_base_embeddings(_):
     return FakeEmbeddings(size=32)
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

Fixes #9188 

## What changes are proposed in this pull request?

Fix LangChain compatibility with SQLDatabase

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
