### PR TITLE
Cache `.venv` directory instead of caching pip cache

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -7,7 +7,7 @@ inputs:
 outputs:
   python-version:
     description: "The installed python version"
-    value: ${{ steps.fetch-python-version.outputs.version }}
+    value: ${{ steps.get-python-version.outputs.version }}
 runs:
   using: "composite"
   steps:

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: "The python version to install. If unspecified, install the minimum python version mlflow supports."
     required: false
 outputs:
-  installed-python-version:
+  python-version:
     description: "The installed python version"
     value: ${{ steps.fetch-python-version.outputs.version }}
 runs:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,7 +27,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    # if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-python

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,32 +27,49 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    # if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-python
-      - uses: ./.github/actions/cache-pip
+        id: setup-python
       - name: Add problem matchers
         run: |
           echo "::add-matcher::.github/workflows/matchers/pylint.json"
           echo "::add-matcher::.github/workflows/matchers/black.json"
           echo "::add-matcher::.github/workflows/matchers/ruff.json"
+      - name: pre-cache
+        id: pre-cache
+        run: |
+          # Refresh cache daily
+          date=$(date -u "+%Y%m%d")
+          # Refresh cache if the action runner image has changed
+          image="$ImageOS-$ImageVersion"
+          echo "key=$image-$date" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        with:
+          path: .venv
+          key: ${{ steps.pre-cache.outputs.key }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements/*requirements.txt') }}
       - name: Install dependencies
         run: |
+          python -m venv .venv
+          . .venv/bin/activate
           source ./dev/install-common-deps.sh --ml
           pip install -r requirements/lint-requirements.txt
       - uses: ./.github/actions/pipdeptree
       - name: Test custom pylint-plugins
         run: |
+          . .venv/bin/activate
           pytest pylint_plugins/tests
       - name: Install pre-commit hooks
         run: |
+          . .venv/bin/activate
           pre-commit install -t pre-commit -t prepare-commit-msg
       - name: Run pre-commit (only changed files)
         id: run-pre-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          . .venv/bin/activate
           # pylint is ridiculously slow. It takes ~3 minutes to run on all files.
           # To fail fast for faster iteration, first run pylint only on changed files,
           # then run it on all files in the next step.
@@ -62,6 +79,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          . .venv/bin/activate
           changed_files=$(python dev/list_changed_files.py --repository mlflow/mlflow --pr-num ${{ github.event.number }})
           if echo "$changed_files" | grep -q '\.py$\|^pyproject\.toml$\|^pylintrc$\|^requirements/lint-requirements\.txt$'; then
             pre-commit run --all-files


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Currently, how we install python packages is like this:

1. Cache pip cache
2. Restore the pip cache
3. Then install

This allows us to skip downloading wheels but step 3 still takes 6~7 minutes. I found it's much faster if we create a virtual env and cache it.

<img width="1200" alt="image" src="https://github.com/mlflow/mlflow/assets/17039389/bf892e40-34a3-4b52-9621-05bfb5473c8d">

This PR only updates the lint job. We can update other jobs once we confirm this approach works ok.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
