### PR TITLE
Fix unnecessary accelerate in transformers dependency

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -521,7 +521,7 @@ transformers:
       # See: https://github.com/huggingface/transformers/issues/23352 for discussion
       "< 4.30.0": ["tensorflow<2.13.0"]
     run: |
-      pytest tests/transformers/test_transformers_model_export.py --ignore=tests/transformers/test_transformers_model_export.py::test_transformers_pt_model_save_dependencies_without_accelerate
+      pytest tests/transformers/test_transformers_model_export.py
       pip uninstall -y accelerate
       pytest tests/transformers/test_transformers_model_export.py::test_transformers_pt_model_save_dependencies_without_accelerate
   autologging:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -523,7 +523,7 @@ transformers:
     run: |
       pytest tests/transformers/test_transformers_model_export.py
       pip uninstall -y accelerate
-      pytest tests/transformers/test_transformers_model_export.py::test_transformers_pt_model_save_dependencies_without_accelerate
+      pytest tests/transformers/test_transformers_model_export.py -k "test_transformers_tf_model_save_without_conda_env_uses_default_env_with_expected_dependencies or test_transformers_pt_model_save_dependencies_without_accelerate"
   autologging:
     minimum: "4.25.1"
     maximum: "4.31.0"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -522,7 +522,7 @@ transformers:
       "< 4.30.0": ["tensorflow<2.13.0"]
     run: |
       pytest tests/transformers/test_transformers_model_export.py --ignore=tests/transformers/test_transformers_model_export.py::test_transformers_pt_model_save_dependencies_without_accelerate
-      pip uninstall accelerate
+      pip uninstall -y accelerate
       pytest tests/transformers/test_transformers_model_export.py::test_transformers_pt_model_save_dependencies_without_accelerate
   autologging:
     minimum: "4.25.1"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -521,7 +521,9 @@ transformers:
       # See: https://github.com/huggingface/transformers/issues/23352 for discussion
       "< 4.30.0": ["tensorflow<2.13.0"]
     run: |
-      pytest tests/transformers/test_transformers_model_export.py
+      pytest tests/transformers/test_transformers_model_export.py --ignore=tests/transformers/test_transformers_model_export.py::test_transformers_pt_model_save_dependencies_without_accelerate
+      pip uninstall accelerate
+      pytest tests/transformers/test_transformers_model_export.py::test_transformers_pt_model_save_dependencies_without_accelerate
   autologging:
     minimum: "4.25.1"
     maximum: "4.31.0"

--- a/mlflow/transformers.py
+++ b/mlflow/transformers.py
@@ -115,7 +115,14 @@ def _model_packages(model) -> List[str]:
     """
     engine = _get_engine_type(model)
     if engine == "torch":
-        return ["torch", "torchvision", "accelerate"]
+        packages = ["torch", "torchvision"]
+        try:
+            import accelerate
+
+            packages.append("accelerate")
+        except ImportError:
+            pass
+        return packages
     else:
         return [engine]
 

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1127,7 +1127,7 @@ def test_transformers_pt_model_save_without_conda_env_uses_default_env_with_expe
 
 
 @pytest.mark.skipif(
-    importlib.util.find_spec("accelerate") is not None, reason="uninstall accelerate to test"
+    importlib.util.find_spec("accelerate") is not None, reason="fails when accelerate is installed"
 )
 def test_transformers_pt_model_save_dependencies_without_accelerate(
     translation_pipeline, model_path

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1,6 +1,7 @@
 import base64
 from functools import wraps
 import gc
+import importlib.util
 import logging
 import json
 import time
@@ -1125,6 +1126,9 @@ def test_transformers_pt_model_save_without_conda_env_uses_default_env_with_expe
     assert "torch" in pip_requirements
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("accelerate") is not None, reason="uninstall accelerate to test"
+)
 def test_transformers_pt_model_save_dependencies_without_accelerate(
     translation_pipeline, model_path
 ):

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1109,6 +1109,7 @@ def test_transformers_tf_model_save_without_conda_env_uses_default_env_with_expe
     pip_requirements = _get_deps_from_requirement_file(model_path)
     assert "tensorflow" in pip_requirements
     assert "torch" not in pip_requirements
+    assert "accelerate" not in pip_requirements
 
 
 def test_transformers_pt_model_save_without_conda_env_uses_default_env_with_expected_dependencies(
@@ -1120,6 +1121,20 @@ def test_transformers_pt_model_save_without_conda_env_uses_default_env_with_expe
     )
     pip_requirements = _get_deps_from_requirement_file(model_path)
     assert "tensorflow" not in pip_requirements
+    assert "accelerate" in pip_requirements
+    assert "torch" in pip_requirements
+
+
+def test_transformers_pt_model_save_dependencies_without_accelerate(
+    translation_pipeline, model_path
+):
+    mlflow.transformers.save_model(translation_pipeline, model_path)
+    _assert_pip_requirements(
+        model_path, mlflow.transformers.get_default_pip_requirements(translation_pipeline.model)
+    )
+    pip_requirements = _get_deps_from_requirement_file(model_path)
+    assert "tensorflow" not in pip_requirements
+    assert "accelerate" not in pip_requirements
     assert "torch" in pip_requirements
 
 

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1100,6 +1100,9 @@ def test_transformers_log_with_duplicate_extra_pip_requirements(small_multi_moda
     )
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("accelerate") is not None, reason="fails when accelerate is installed"
+)
 def test_transformers_tf_model_save_without_conda_env_uses_default_env_with_expected_dependencies(
     small_seq2seq_pipeline, model_path
 ):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced issues when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Resolve #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->

Resolve #8676

## What changes are proposed in this pull request?
Mark accelerate as not required in transformers dependency when engine is torch

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
