### PR TITLE
Remove remaining `mock.patch.dict(os.environ, ...)`

### DIFF
--- a/tests/store/artifact/test_http_artifact_repo.py
+++ b/tests/store/artifact/test_http_artifact_repo.py
@@ -261,7 +261,7 @@ def test_download_artifacts(http_artifact_repo, tmp_path):
         assert read_file(paths[1]) == "data_b"
 
 
-def test_default_host_creds():
+def test_default_host_creds(monkeypatch):
     artifact_uri = "https://test.com"
     username = "user"
     password = "pass"
@@ -282,8 +282,7 @@ def test_default_host_creds():
 
     repo = HttpArtifactRepository(artifact_uri)
 
-    with mock.patch.dict(
-        "mlflow.tracking._tracking_service.utils.os.environ",
+    monkeypatch.setenvs(
         {
             MLFLOW_TRACKING_USERNAME.name: username,
             MLFLOW_TRACKING_PASSWORD.name: password,
@@ -291,9 +290,9 @@ def test_default_host_creds():
             MLFLOW_TRACKING_INSECURE_TLS.name: str(ignore_tls_verification),
             MLFLOW_TRACKING_CLIENT_CERT_PATH.name: client_cert_path,
             MLFLOW_TRACKING_SERVER_CERT_PATH.name: server_cert_path,
-        },
-    ):
-        assert repo._host_creds == expected_host_creds
+        }
+    )
+    assert repo._host_creds == expected_host_creds
 
 
 @pytest.mark.parametrize("remote_file_path", ["a.txt", "dir/b.txt", None])

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -66,7 +66,7 @@ def test_file_artifact_is_logged_with_content_metadata(s3_artifact_root, tmp_pat
     assert response.get("ContentEncoding") is None
 
 
-def test_get_s3_client_hits_cache(s3_artifact_root):
+def test_get_s3_client_hits_cache(s3_artifact_root, monkeypatch):
     # pylint: disable=no-value-for-parameter
     repo = get_artifact_repository(posixpath.join(s3_artifact_root, "some/path"))
     repo._get_s3_client()
@@ -81,12 +81,8 @@ def test_get_s3_client_hits_cache(s3_artifact_root):
     assert cache_info.misses == 1
     assert cache_info.currsize == 1
 
-    with mock.patch.dict(
-        "os.environ",
-        {"MLFLOW_EXPERIMENTAL_S3_SIGNATURE_VERSION": "s3v2"},
-        clear=True,
-    ):
-        repo._get_s3_client()
+    monkeypatch.setenv("MLFLOW_EXPERIMENTAL_S3_SIGNATURE_VERSION", "s3v2")
+    repo._get_s3_client()
     cache_info = _cached_get_s3_client.cache_info()
     assert cache_info.hits == 1
     assert cache_info.misses == 2

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -1,4 +1,3 @@
-import os
 from unittest import mock
 import re
 import numpy

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -157,19 +157,18 @@ def test_http_request_with_basic_auth(request):
 
 
 @mock.patch("requests.Session.request")
-@mock.patch.dict(
-    os.environ,
-    {
-        "AWS_ACCESS_KEY_ID": "access-key",
-        "AWS_SECRET_ACCESS_KEY": "secret-key",
-        "AWS_DEFAULT_REGION": "eu-west-1",
-    },
-)
-def test_http_request_with_aws_sigv4(request):
+def test_http_request_with_aws_sigv4(request, monkeypatch):
     """This test requires the "requests_auth_aws_sigv4" package to be installed"""
 
     from requests_auth_aws_sigv4 import AWSSigV4
 
+    monkeypatch.setenvs(
+        {
+            "AWS_ACCESS_KEY_ID": "access-key",
+            "AWS_SECRET_ACCESS_KEY": "secret-key",
+            "AWS_DEFAULT_REGION": "eu-west-1",
+        }
+    )
     aws_sigv4 = MlflowHostCreds("http://my-host", aws_sigv4=True)
     response = mock.MagicMock()
     response.status_code = 200


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
closes #9006

## What changes are proposed in this pull request?

last men standing 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
