### PR TITLE
Replace percent formatting with f-string

### DIFF
--- a/tests/store/artifact/test_gcs_artifact_repo.py
+++ b/tests/store/artifact/test_gcs_artifact_repo.py
@@ -181,9 +181,9 @@ def test_log_artifacts(mock_client, tmp_path):
     mock_client.bucket.assert_called_with("test_bucket")
     mock_client.bucket().blob().upload_from_filename.assert_has_calls(
         [
-            mock.call(os.path.normpath("%s/a.txt" % subd), timeout=repo._GCS_DEFAULT_TIMEOUT),
-            mock.call(os.path.normpath("%s/b.txt" % subd), timeout=repo._GCS_DEFAULT_TIMEOUT),
-            mock.call(os.path.normpath("%s/c.txt" % subd), timeout=repo._GCS_DEFAULT_TIMEOUT),
+            mock.call(os.path.normpath(f"{subd}/a.txt"), timeout=repo._GCS_DEFAULT_TIMEOUT),
+            mock.call(os.path.normpath(f"{subd}/b.txt"), timeout=repo._GCS_DEFAULT_TIMEOUT),
+            mock.call(os.path.normpath(f"{subd}/c.txt"), timeout=repo._GCS_DEFAULT_TIMEOUT),
         ],
         any_order=True,
     )

--- a/tests/store/artifact/test_runs_artifact_repo.py
+++ b/tests/store/artifact/test_runs_artifact_repo.py
@@ -81,7 +81,7 @@ def test_runs_artifact_repo_init_with_real_run():
     experiment_id = mlflow.create_experiment("expr_abc", artifact_location)
     with mlflow.start_run(experiment_id=experiment_id):
         run_id = mlflow.active_run().info.run_id
-    runs_uri = "runs:/%s/path/to/model" % run_id
+    runs_uri = f"runs:/{run_id}/path/to/model"
     runs_repo = RunsArtifactRepository(runs_uri)
 
     assert runs_repo.artifact_uri == runs_uri

--- a/tests/store/dump_schema.py
+++ b/tests/store/dump_schema.py
@@ -28,7 +28,7 @@ def dump_db_schema(db_url, dst_file):
 def dump_sqlalchemy_store_schema(dst_file):
     with tempfile.TemporaryDirectory() as db_tmpdir:
         path = os.path.join(db_tmpdir, "db_file")
-        db_url = "sqlite:///%s" % path
+        db_url = f"sqlite:///{path}"
         SqlAlchemyStore(db_url, db_tmpdir)
         dump_db_schema(db_url, dst_file)
 

--- a/tests/store/model_registry/test_file_store.py
+++ b/tests/store/model_registry/test_file_store.py
@@ -673,7 +673,7 @@ def test_search_model_versions(store):
         return [mvd.version for mvd in _search_model_versions(store, filter_string)]
 
     # search using name should return all 4 versions
-    assert set(search_versions("name='%s'" % name)) == {1, 2, 3, 4}
+    assert set(search_versions(f"name='{name}'")) == {1, 2, 3, 4}
 
     # search using version
     assert set(search_versions("version_number=2")) == {2}
@@ -792,7 +792,7 @@ def test_search_model_versions(store):
         name=mv1.name, version=mv1.version, description="Online prediction model!"
     )
 
-    mvds = store.search_model_versions("run_id = '%s'" % run_id_1, max_results=10)
+    mvds = store.search_model_versions(f"run_id = '{run_id_1}'", max_results=10)
     assert len(mvds) == 1
     assert isinstance(mvds[0], ModelVersion)
     assert mvds[0].current_stage == "Production"

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -44,7 +44,7 @@ def store(creds):
 
 
 def _args(host_creds, endpoint, method, json_body):
-    res = {"host_creds": host_creds, "endpoint": "/api/2.0/mlflow/%s" % endpoint, "method": method}
+    res = {"host_creds": host_creds, "endpoint": f"/api/2.0/mlflow/{endpoint}", "method": method}
     if method == "GET":
         res["params"] = json.loads(json_body)
     else:

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -746,17 +746,17 @@ def test_search_model_versions(store):
         ]
 
     # search using name should return all 4 versions
-    assert set(search_versions("name='%s'" % name)) == {1, 2, 3, 4}
+    assert set(search_versions(f"name='{name}'")) == {1, 2, 3, 4}
 
     # search using version
     assert set(search_versions("version_number=2")) == {2}
     assert set(search_versions("version_number<=3")) == {1, 2, 3}
 
     # search using run_id_1 should return version 1
-    assert set(search_versions("run_id='%s'" % run_id_1)) == {1}
+    assert set(search_versions(f"run_id='{run_id_1}'")) == {1}
 
     # search using run_id_2 should return versions 2 and 3
-    assert set(search_versions("run_id='%s'" % run_id_2)) == {2, 3}
+    assert set(search_versions(f"run_id='{run_id_2}'")) == {2, 3}
 
     # search using the IN operator should return all versions
     assert set(search_versions(f"run_id IN ('{run_id_1}','{run_id_2}')")) == {1, 2, 3}
@@ -855,7 +855,7 @@ def test_search_model_versions(store):
 
     assert set(search_versions(None)) == {1, 2, 3}
 
-    assert set(search_versions("name='%s'" % name)) == {1, 2, 3}
+    assert set(search_versions(f"name='{name}'")) == {1, 2, 3}
 
     assert set(search_versions("source_path = 'A/D'")) == {3}
 
@@ -867,7 +867,7 @@ def test_search_model_versions(store):
         name=mv1.name, version=mv1.version, description="Online prediction model!"
     )
 
-    mvds = store.search_model_versions("run_id = '%s'" % run_id_1, max_results=10)
+    mvds = store.search_model_versions(f"run_id = '{run_id_1}'", max_results=10)
     assert len(mvds) == 1
     assert isinstance(mvds[0], ModelVersion)
     assert mvds[0].current_stage == "Production"

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -417,7 +417,7 @@ def _create_root(store):
                     timestamp += random_int(10000, 2000000)
                     values.append((timestamp, metric_value))
                     with open(metric_file, "a") as f:
-                        f.write("%d %d\n" % (timestamp, metric_value))
+                        f.write(f"{timestamp} {metric_value}\n")
                 metrics[metric_name] = values
             run_data[run_id]["metrics"] = metrics
             # artifacts

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -136,7 +136,7 @@ def test_response_with_unknown_fields(request):
 def _args(host_creds, endpoint, method, json_body):
     res = {
         "host_creds": host_creds,
-        "endpoint": "/api/2.0/mlflow/%s" % endpoint,
+        "endpoint": f"/api/2.0/mlflow/{endpoint}",
         "method": method,
     }
     if method == "GET":

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2486,7 +2486,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         # SQL limitations, etc)
         experiment_id = self._experiment_factory("log_batch_limits")
         run_id = self._run_factory(self._get_run_configs(experiment_id)).info.run_id
-        metric_tuples = [("m%s" % i, i, 12345, i * 2) for i in range(1000)]
+        metric_tuples = [(f"m{i}", i, 12345, i * 2) for i in range(1000)]
         metric_entities = [Metric(*metric_tuple) for metric_tuple in metric_tuples]
         self.store.log_batch(run_id=run_id, metrics=metric_entities, params=[], tags=[])
         run = self.store.get_run(run_id)
@@ -2826,7 +2826,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
             for i in range(100):
                 metric = {
-                    "key": "mkey_%s" % i,
+                    "key": f"mkey_{i}",
                     "value": i,
                     "timestamp": i * 2,
                     "step": i * 3,
@@ -2835,13 +2835,13 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
                 }
                 metrics_list.append(metric)
                 tag = {
-                    "key": "tkey_%s" % i,
+                    "key": f"tkey_{i}",
                     "value": "tval_%s" % (current_run % 10),
                     "run_uuid": run_id,
                 }
                 tags_list.append(tag)
                 param = {
-                    "key": "pkey_%s" % i,
+                    "key": f"pkey_{i}",
                     "value": "pval_%s" % ((current_run + 1) % 11),
                     "run_uuid": run_id,
                 }

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -188,7 +188,7 @@ def test_get_experiment_id_from_env(monkeypatch):
     assert _get_experiment_id_from_env() is None
 
     # set only ID
-    name = "random experiment %d" % random.randint(1, 1e6)
+    name = f"random experiment {random.randint(1, 1e6)}"
     exp_id = mlflow.create_experiment(name)
     assert exp_id is not None
     monkeypatch.delenv(MLFLOW_EXPERIMENT_NAME.name, raising=False)
@@ -196,7 +196,7 @@ def test_get_experiment_id_from_env(monkeypatch):
     assert _get_experiment_id_from_env() == exp_id
 
     # set only name
-    name = "random experiment %d" % random.randint(1, 1e6)
+    name = f"random experiment {random.randint(1, 1e6)}"
     exp_id = mlflow.create_experiment(name)
     assert exp_id is not None
     monkeypatch.delenv(MLFLOW_EXPERIMENT_ID.name, raising=False)
@@ -204,21 +204,21 @@ def test_get_experiment_id_from_env(monkeypatch):
     assert _get_experiment_id_from_env() == exp_id
 
     # create experiment from env name
-    name = "random experiment %d" % random.randint(1, 1e6)
+    name = f"random experiment {random.randint(1, 1e6)}"
     monkeypatch.delenv(MLFLOW_EXPERIMENT_ID.name, raising=False)
     monkeypatch.setenv(MLFLOW_EXPERIMENT_NAME.name, name)
     assert MlflowClient().get_experiment_by_name(name) is None
     assert _get_experiment_id_from_env() is not None
 
     # assert experiment creation from encapsulating function
-    name = "random experiment %d" % random.randint(1, 1e6)
+    name = f"random experiment {random.randint(1, 1e6)}"
     monkeypatch.delenv(MLFLOW_EXPERIMENT_ID.name, raising=False)
     monkeypatch.setenv(MLFLOW_EXPERIMENT_NAME.name, name)
     assert MlflowClient().get_experiment_by_name(name) is None
     assert _get_experiment_id() is not None
 
     # assert raises from conflicting experiment_ids
-    name = "random experiment %d" % random.randint(1, 1e6)
+    name = f"random experiment {random.randint(1, 1e6)}"
     exp_id = mlflow.create_experiment(name)
     random_id = random.randint(100, 1e6)
     assert exp_id != random_id
@@ -234,7 +234,7 @@ def test_get_experiment_id_from_env(monkeypatch):
         _get_experiment_id_from_env()
 
     # assert raises from name to id mismatch
-    name = "random experiment %d" % random.randint(1, 1e6)
+    name = f"random experiment {random.randint(1, 1e6)}"
     exp_id = mlflow.create_experiment(name)
     random_id = random.randint(100, 1e6)
     assert exp_id != random_id
@@ -250,7 +250,7 @@ def test_get_experiment_id_from_env(monkeypatch):
 
     # assert does not raise if active experiment is set with invalid env variables
     invalid_name = "invalid experiment"
-    name = "random experiment %d" % random.randint(1, 1e6)
+    name = f"random experiment {random.randint(1, 1e6)}"
     exp_id = mlflow.create_experiment(name)
     assert exp_id is not None
     random_id = random.randint(100, 1e6)
@@ -263,7 +263,7 @@ def test_get_experiment_id_from_env(monkeypatch):
 
 def test_get_experiment_id_with_active_experiment_returns_active_experiment_id():
     # Create a new experiment and set that as active experiment
-    name = "Random experiment %d" % random.randint(1, 1e6)
+    name = f"Random experiment {random.randint(1, 1e6)}"
     exp_id = mlflow.create_experiment(name)
     assert exp_id is not None
     mlflow.set_experiment(name)
@@ -285,7 +285,7 @@ def test_get_experiment_id_in_databricks_detects_notebook_id_by_default():
 
 
 def test_get_experiment_id_in_databricks_with_active_experiment_returns_active_experiment_id():
-    exp_name = "random experiment %d" % random.randint(1, 1e6)
+    exp_name = f"random experiment {random.randint(1, 1e6)}"
     exp_id = mlflow.create_experiment(exp_name)
     mlflow.set_experiment(exp_name)
     notebook_id = str(int(exp_id) + 73)
@@ -301,7 +301,7 @@ def test_get_experiment_id_in_databricks_with_active_experiment_returns_active_e
 def test_get_experiment_id_in_databricks_with_experiment_defined_in_env_returns_env_experiment_id(
     monkeypatch,
 ):
-    exp_name = "random experiment %d" % random.randint(1, 1e6)
+    exp_name = f"random experiment {random.randint(1, 1e6)}"
     exp_id = mlflow.create_experiment(exp_name)
     notebook_id = str(int(exp_id) + 73)
     monkeypatch.delenv(MLFLOW_EXPERIMENT_NAME.name, raising=False)
@@ -316,7 +316,7 @@ def test_get_experiment_id_in_databricks_with_experiment_defined_in_env_returns_
 
 
 def test_get_experiment_by_id():
-    name = "Random experiment %d" % random.randint(1, 1e6)
+    name = f"Random experiment {random.randint(1, 1e6)}"
     exp_id = mlflow.create_experiment(name)
 
     experiment = mlflow.get_experiment(exp_id)
@@ -333,7 +333,7 @@ def test_get_experiment_by_id_with_is_in_databricks_job():
 
 
 def test_get_experiment_by_name():
-    name = "Random experiment %d" % random.randint(1, 1e6)
+    name = f"Random experiment {random.randint(1, 1e6)}"
     exp_id = mlflow.create_experiment(name)
 
     experiment = mlflow.get_experiment_by_name(name)
@@ -953,7 +953,7 @@ def validate_search_runs(results, data, output_format):
         expected_df["end_time"] = pd.to_datetime(expected_df["end_time"], unit="ms", utc=True)
         pd.testing.assert_frame_equal(results, expected_df, check_like=True, check_frame_type=False)
     else:
-        raise Exception("Invalid output format %s" % output_format)
+        raise Exception(f"Invalid output format {output_format}")
 
 
 def test_search_runs_attributes(search_runs_output_format):

--- a/tests/tracking/test_model_registry.py
+++ b/tests/tracking/test_model_registry.py
@@ -416,7 +416,7 @@ def test_create_and_query_model_version_flow(client):
     assert [rm.latest_versions for rm in client.search_registered_models() if rm.name == name] == [
         [mvd2]
     ]
-    model_versions_by_name = client.search_model_versions("name = '%s'" % name)
+    model_versions_by_name = client.search_model_versions(f"name = '{name}'")
     assert {mv.version for mv in model_versions_by_name} == {"1", "2"}
     assert {mv.name for mv in model_versions_by_name} == {name}
 
@@ -580,7 +580,7 @@ def test_delete_model_version_flow(client):
     ]
     assert len(model_versions_detailed) == 1
     assert model_versions_detailed[0][0].version == "3"
-    assert {mv.version for mv in client.search_model_versions("name = '%s'" % name)} == {
+    assert {mv.version for mv in client.search_model_versions(f"name = '{name}'")} == {
         "1",
         "2",
         "3",
@@ -589,7 +589,7 @@ def test_delete_model_version_flow(client):
     start_time_2 = get_current_time_millis()
     client.delete_model_version(name, "1")
     end_time_2 = get_current_time_millis()
-    assert {mv.version for mv in client.search_model_versions("name = '%s'" % name)} == {
+    assert {mv.version for mv in client.search_model_versions(f"name = '{name}'")} == {
         "2",
         "3",
     }
@@ -609,13 +609,13 @@ def test_delete_model_version_flow(client):
         client.transition_model_version_stage(name=name, version=1, stage="Staging")
 
     client.delete_model_version(name, 3)
-    assert {mv.version for mv in client.search_model_versions("name = '%s'" % name)} == {"2"}
+    assert {mv.version for mv in client.search_model_versions(f"name = '{name}'")} == {"2"}
 
     # new model versions will not reuse existing version numbers
     mv4 = client.create_model_version(name, "runs:/run_id_2/a/b/c", "run_id_2")
     assert mv4.version == "4"
     assert mv4.name == name
-    assert {mv.version for mv in client.search_model_versions("name = '%s'" % name)} == {
+    assert {mv.version for mv in client.search_model_versions(f"name = '{name}'")} == {
         "2",
         "4",
     }

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -241,7 +241,7 @@ def test_create_run_all_args(mlflow_client, parent_run_id_kwarg):
         },
     }
     experiment_id = mlflow_client.create_experiment(
-        "Run A Lot (parent_run_id=%s)" % (parent_run_id_kwarg)
+        f"Run A Lot (parent_run_id={parent_run_id_kwarg})"
     )
     created_run = mlflow_client.create_run(experiment_id, **create_run_kwargs)
     run_id = created_run.info.run_id
@@ -894,13 +894,13 @@ def test_artifacts(mlflow_client, tmp_path):
     all_artifacts = download_artifacts(
         run_id=run_id, artifact_path=".", tracking_uri=mlflow_client.tracking_uri
     )
-    assert open("%s/my.file" % all_artifacts).read() == "Hello, World!"
-    assert open("%s/dir/my.file" % all_artifacts).read() == "Hello, World!"
+    assert open(f"{all_artifacts}/my.file").read() == "Hello, World!"
+    assert open(f"{all_artifacts}/dir/my.file").read() == "Hello, World!"
 
     dir_artifacts = download_artifacts(
         run_id=run_id, artifact_path="dir", tracking_uri=mlflow_client.tracking_uri
     )
-    assert open("%s/my.file" % dir_artifacts).read() == "Hello, World!"
+    assert open(f"{dir_artifacts}/my.file").read() == "Hello, World!"
 
 
 def test_search_pagination(mlflow_client):

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -44,7 +44,7 @@ def test_create_experiment():
     with pytest.raises(MlflowException, match="Invalid experiment name"):
         mlflow.create_experiment("")
 
-    exp_id = mlflow.create_experiment("Some random experiment name %d" % random.randint(1, 1e6))
+    exp_id = mlflow.create_experiment(f"Some random experiment name {random.randint(1, 1e6)}")
     assert exp_id is not None
 
 

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -202,7 +202,7 @@ b: 3
 
 def test_mkdir(tmp_path):
     temp_dir = str(tmp_path)
-    new_dir_name = "mkdir_test_%d" % random_int()
+    new_dir_name = f"mkdir_test_{random_int()}"
     file_utils.mkdir(temp_dir, new_dir_name)
     assert os.listdir(temp_dir) == [new_dir_name]
 

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -191,9 +191,9 @@ def test_validate_run_id_bad(run_id):
 
 
 def test_validate_batch_log_limits():
-    too_many_metrics = [Metric("metric-key-%s" % i, 1, 0, i * 2) for i in range(1001)]
-    too_many_params = [Param("param-key-%s" % i, "b") for i in range(101)]
-    too_many_tags = [RunTag("tag-key-%s" % i, "b") for i in range(101)]
+    too_many_metrics = [Metric(f"metric-key-{i}", 1, 0, i * 2) for i in range(1001)]
+    too_many_params = [Param(f"param-key-{i}", "b") for i in range(101)]
+    too_many_tags = [RunTag(f"tag-key-{i}", "b") for i in range(101)]
 
     good_kwargs = {"metrics": [], "params": [], "tags": []}
     bad_kwargs = {


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
Close #9008 

## What changes are proposed in this pull request?

Replace percent formatting with f-string.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
