### PR TITLE
Add an action to generate a cache key for Python

### DIFF
--- a/.github/actions/py-cache-key/action.yml
+++ b/.github/actions/py-cache-key/action.yml
@@ -1,0 +1,24 @@
+name: "py-cache-key"
+description: "Generate a key for Python package cache"
+
+outputs:
+  key:
+    description: "Cache key"
+    value: ${{ steps.cache-key.outputs.value }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: cache-key
+      id: cache-key
+      shell: bash
+      env:
+        REQUIREMENTS_HASH: ${{ hashFiles('requirements/*requirements.txt') }}
+      run: |
+        # Refresh cache if the action runner image has changed
+        RUNNER_IMAGE="$ImageOS-$ImageVersion"
+        # Refresh cache if the python version has changed
+        PYTHON_VERSION="$(python --version | cut -d' ' -f2)"
+        # Refresh cache daily
+        DATE=$(date -u "+%Y%m%d")
+        echo "value=$RUNNER_IMAGE-$PYTHON_VERSION-$DATE-$REQUIREMENTS_HASH" >> $GITHUB_OUTPUT

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,18 +37,12 @@ jobs:
           echo "::add-matcher::.github/workflows/matchers/pylint.json"
           echo "::add-matcher::.github/workflows/matchers/black.json"
           echo "::add-matcher::.github/workflows/matchers/ruff.json"
-      - name: pre-cache
-        id: pre-cache
-        run: |
-          # Refresh cache daily
-          date=$(date -u "+%Y%m%d")
-          # Refresh cache if the action runner image has changed
-          image="$ImageOS-$ImageVersion"
-          echo "key=$image-$date" >> $GITHUB_OUTPUT
+      - uses: ./.github/actions/py-cache-key
+        id: py-cache-key
       - uses: actions/cache@v3
         with:
           path: .venv
-          key: ${{ steps.pre-cache.outputs.key }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements/*requirements.txt') }}
+          key: ${{ steps.py-cache-key.outputs.key }}
       - name: Install dependencies
         run: |
           python -m venv .venv


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add an action to generate a cache key for Python to make it easier to reuse it in other jobs.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
