### PR TITLE
Implement `_EnvironmentVariable.__format__`

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -46,6 +46,9 @@ class _EnvironmentVariable:
     def __repr__(self):
         return repr(self.name)
 
+    def __format__(self, format_spec: str) -> str:
+        return self.name.__format__(format_spec)
+
 
 class _BooleanEnvironmentVariable(_EnvironmentVariable):
     """

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -99,7 +99,7 @@ def get_gateway_uri() -> str:
     else:
         raise MlflowException(
             "No Gateway server uri has been set. Please either set the MLflow Gateway URI via "
-            f"`mlflow.set_gateway_uri()` or set the environment variable {MLFLOW_GATEWAY_URI.name} "
+            f"`mlflow.set_gateway_uri()` or set the environment variable {MLFLOW_GATEWAY_URI} "
             "to the running Gateway API server's uri"
         )
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1444,7 +1444,7 @@ def _validate_source(source: str, run_id: str) -> None:
         raise MlflowException(
             f"Invalid model version source: '{source}'. MLflow tracking server doesn't allow using "
             "a file URI as a model version source for security reasons. To disable this check, set "
-            f"the {MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE.name} environment variable to "
+            f"the {MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE} environment variable to "
             "True.",
             INVALID_PARAMETER_VALUE,
         )

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1776,7 +1776,7 @@ def _get_experiment_id_from_env():
         if exp:
             if experiment_id and experiment_id != exp.experiment_id:
                 raise MlflowException(
-                    message=f"The provided {MLFLOW_EXPERIMENT_ID.name} environment variable "
+                    message=f"The provided {MLFLOW_EXPERIMENT_ID} environment variable "
                     f"value `{experiment_id}` does not match the experiment id "
                     f"`{exp.experiment_id}` for experiment name `{experiment_name}`",
                     error_code=INVALID_PARAMETER_VALUE,
@@ -1792,7 +1792,7 @@ def _get_experiment_id_from_env():
             return exp.experiment_id
         except MlflowException as exc:
             raise MlflowException(
-                message=f"The provided {MLFLOW_EXPERIMENT_ID.name} environment variable "
+                message=f"The provided {MLFLOW_EXPERIMENT_ID} environment variable "
                 f"value `{experiment_id}` does not exist in the tracking server. Provide a valid "
                 f"experiment_id.",
                 error_code=INVALID_PARAMETER_VALUE,

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -104,7 +104,8 @@ def http_request(
     except requests.exceptions.Timeout as to:
         raise MlflowException(
             f"API request to {url} failed with timeout exception {to}."
-            f" To increase the timeout, set the environment variable {MLFLOW_HTTP_REQUEST_TIMEOUT}"
+            " To increase the timeout, set the environment variable "
+            f"{MLFLOW_HTTP_REQUEST_TIMEOUT!s}"
             " to a larger value."
         ) from to
     except requests.exceptions.InvalidURL as iu:

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -105,8 +105,7 @@ def http_request(
         raise MlflowException(
             f"API request to {url} failed with timeout exception {to}."
             " To increase the timeout, set the environment variable "
-            f"{MLFLOW_HTTP_REQUEST_TIMEOUT!s}"
-            " to a larger value."
+            f"{MLFLOW_HTTP_REQUEST_TIMEOUT!s} to a larger value."
         ) from to
     except requests.exceptions.InvalidURL as iu:
         raise InvalidUrlException(f"Invalid url: {url}") from iu

--- a/tests/db/test_schema.py
+++ b/tests/db/test_schema.py
@@ -162,7 +162,7 @@ Manually copy & paste the expected schema in {rel_path} or run the following com
 
 def main():
     tracking_uri = get_tracking_uri()
-    assert tracking_uri, f"Environment variable {MLFLOW_TRACKING_URI.name} must be set"
+    assert tracking_uri, f"Environment variable {MLFLOW_TRACKING_URI} must be set"
     get_database_dialect(tracking_uri)  # Ensure `tracking_uri` is a database URI
     mlflow.set_tracking_uri(tracking_uri)
     initialize_database()

--- a/tests/test_environment_variables.py
+++ b/tests/test_environment_variables.py
@@ -80,3 +80,9 @@ def test_environment_variable_functionality(
     assert os.getenv(var_name) == str(default_value)
     env_var.unset()
     assert os.getenv(var_name) is None
+
+
+def test_format():
+    env_var = _EnvironmentVariable("foo", str, "")
+    assert f"{env_var} bar" == "foo bar"
+    assert f"{env_var!r} bar" == "'foo' bar"

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -227,7 +227,7 @@ def test_get_experiment_id_from_env(monkeypatch):
     with pytest.raises(
         MlflowException,
         match=(
-            f"The provided {MLFLOW_EXPERIMENT_ID.name} environment variable value "
+            f"The provided {MLFLOW_EXPERIMENT_ID} environment variable value "
             f"`{random_id}` does not exist in the tracking server"
         ),
     ):
@@ -242,7 +242,7 @@ def test_get_experiment_id_from_env(monkeypatch):
     with pytest.raises(
         MlflowException,
         match=(
-            f"The provided {MLFLOW_EXPERIMENT_ID.name} environment variable value "
+            f"The provided {MLFLOW_EXPERIMENT_ID} environment variable value "
             f"`{random_id}` does not match the experiment id"
         ),
     ):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Implements `_EnvironmentVariable.__format__` to make it easier to use MLflow environment variables in f_strings:

```python
f"{MLFLOW_FOO_BAR} foo"
```

is formatted to:

```
"MLFLOW_FOO_BAR foo"
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
