### PR TITLE
Cache `.venv` in `python` job

### DIFF
--- a/.github/actions/cache-pip/action.yml
+++ b/.github/actions/cache-pip/action.yml
@@ -11,5 +11,5 @@ runs:
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
       with:
-        path: .venv
+        path: ~/.venv
         key: ${{ steps.py-cache-key.outputs.key }}

--- a/.github/actions/cache-pip/action.yml
+++ b/.github/actions/cache-pip/action.yml
@@ -1,20 +1,15 @@
-name: "cache-pip"
-description: "Cache pip dependencies"
+name: "cache-venv"
+description: "Cache .venv directory for faster dependency installation"
 runs:
   using: "composite"
   steps:
-    - name: Get cache key prefix
-      id: get-cache-key-prefix
-      shell: bash
-      run: |
-        echo "prefix=$ImageOS-$ImageVersion" >> $GITHUB_OUTPUT
+    - uses: ./.github/actions/py-cache-key
+      id: py-cache-key
     - uses: actions/cache@v3
       continue-on-error: true
       # https://github.com/actions/cache/issues/810
       env:
-        SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
       with:
-        path: ~/.cache/pip
-        key: ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-${{ hashFiles('requirements/*-requirements.txt') }}
-        restore-keys: |
-          ${{ steps.get-cache-key-prefix.outputs.prefix }}-pip-
+        path: .venv
+        key: ${{ steps.py-cache-key.outputs.key }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -148,26 +148,6 @@ jobs:
         with:
           java-version: ${{ steps.get-java-version.outputs.version }}
           distribution: "adopt"
-      - name: Get cache key
-        env:
-          INSTALL_COMMAND: ${{ matrix.install }}
-        id: get-cache-key
-        run: |
-          date=$(date -u "+%Y%m%d")
-          hash=$(echo -n "$INSTALL_COMMAND" | sha256sum)
-          echo "key=$ImageOS-$ImageVersion-wheels-$date-$hash" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        # We only cache wheels that take long (> 10 min) to build
-        if: ${{ contains('pyspark, catboost, scikit-learn', matrix.package) && matrix.version == 'dev' }}
-        continue-on-error: true
-        # https://github.com/actions/cache/issues/810
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
-        with:
-          path: /home/runner/.cache/wheels
-          key: ${{ steps.get-cache-key.outputs.key }}
-          restore-keys: |
-            ${{ steps.get-cache-key.outputs.key }}
       - name: Install mlflow & test dependencies
         run: |
           python --version
@@ -183,8 +163,6 @@ jobs:
           pip install -e .[extras]
           pip install -r requirements/test-requirements.txt
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
-        env:
-          CACHE_DIR: /home/runner/.cache/wheels
         run: |
           ${{ matrix.install }}
       - name: Check package versions

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,7 +27,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    # if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-python

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,12 +37,7 @@ jobs:
           echo "::add-matcher::.github/workflows/matchers/pylint.json"
           echo "::add-matcher::.github/workflows/matchers/black.json"
           echo "::add-matcher::.github/workflows/matchers/ruff.json"
-      - uses: ./.github/actions/py-cache-key
-        id: py-cache-key
-      - uses: actions/cache@v3
-        with:
-          path: .venv
-          key: ${{ steps.py-cache-key.outputs.key }}
+      - uses: ./.github/actions/cache-pip
       - name: Install dependencies
         run: |
           python -m venv .venv
@@ -121,13 +116,17 @@ jobs:
       - uses: ./.github/actions/cache-pip
       - name: Install dependencies
         run: |
+          python -m venv .venv
+          . .venv/bin/activate
           source ./dev/install-common-deps.sh --ml
       - uses: ./.github/actions/pipdeptree
       - name: Import check
         run: |
+          . .venv/bin/activate
           python tests/check_mlflow_lazily_imports_ml_packages.py
       - name: Run tests
         run: |
+          . .venv/bin/activate
           source dev/setup-ssh.sh
           ./dev/run-python-tests.sh
       - uses: ./.github/actions/untracked
@@ -235,10 +234,13 @@ jobs:
       - uses: ./.github/actions/cache-pip
       - name: Install dependencies
         run: |
+          python -m venv .venv
+          . .venv/bin/activate
           source ./dev/install-common-deps.sh --ml
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |
+          . .venv/bin/activate
           ./dev/run-python-flavor-tests.sh;
 
   # It takes 9 ~ 10 minutes to run tests in `tests/models`. To make CI finish faster,

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,7 +27,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    # if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-python

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -40,25 +40,25 @@ jobs:
       - uses: ./.github/actions/cache-pip
       - name: Install dependencies
         run: |
-          python -m venv .venv
-          . .venv/bin/activate
+          python -m venv ~/.venv
+          . ~/.venv/bin/activate
           source ./dev/install-common-deps.sh --ml
           pip install -r requirements/lint-requirements.txt
       - uses: ./.github/actions/pipdeptree
       - name: Test custom pylint-plugins
         run: |
-          . .venv/bin/activate
+          . ~/.venv/bin/activate
           pytest pylint_plugins/tests
       - name: Install pre-commit hooks
         run: |
-          . .venv/bin/activate
+          . ~/.venv/bin/activate
           pre-commit install -t pre-commit -t prepare-commit-msg
       - name: Run pre-commit (only changed files)
         id: run-pre-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          . .venv/bin/activate
+          . ~/.venv/bin/activate
           # pylint is ridiculously slow. It takes ~3 minutes to run on all files.
           # To fail fast for faster iteration, first run pylint only on changed files,
           # then run it on all files in the next step.
@@ -68,7 +68,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          . .venv/bin/activate
+          . ~/.venv/bin/activate
           changed_files=$(python dev/list_changed_files.py --repository mlflow/mlflow --pr-num ${{ github.event.number }})
           if echo "$changed_files" | grep -q '\.py$\|^pyproject\.toml$\|^pylintrc$\|^requirements/lint-requirements\.txt$'; then
             pre-commit run --all-files
@@ -116,17 +116,17 @@ jobs:
       - uses: ./.github/actions/cache-pip
       - name: Install dependencies
         run: |
-          python -m venv .venv
-          . .venv/bin/activate
+          python -m venv ~/.venv
+          . ~/.venv/bin/activate
           source ./dev/install-common-deps.sh --ml
       - uses: ./.github/actions/pipdeptree
       - name: Import check
         run: |
-          . .venv/bin/activate
+          . ~/.venv/bin/activate
           python tests/check_mlflow_lazily_imports_ml_packages.py
       - name: Run tests
         run: |
-          . .venv/bin/activate
+          . ~/.venv/bin/activate
           source dev/setup-ssh.sh
           ./dev/run-python-tests.sh
       - uses: ./.github/actions/untracked
@@ -234,13 +234,13 @@ jobs:
       - uses: ./.github/actions/cache-pip
       - name: Install dependencies
         run: |
-          python -m venv .venv
-          . .venv/bin/activate
+          python -m venv ~/.venv
+          . ~/.venv/bin/activate
           source ./dev/install-common-deps.sh --ml
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |
-          . .venv/bin/activate
+          . ~/.venv/bin/activate
           ./dev/run-python-flavor-tests.sh;
 
   # It takes 9 ~ 10 minutes to run tests in `tests/models`. To make CI finish faster,


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Cache `.venv` in `python` job to speed up package installation. See #9208 for why this is faster.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
