### PR TITLE
Use `venv` instead of `virtualenv`

### DIFF
--- a/.github/actions/setup-pyenv/action.yml
+++ b/.github/actions/setup-pyenv/action.yml
@@ -54,8 +54,3 @@ runs:
       shell: bash
       run: |
         pyenv --version
-
-    - name: Install virtualenv
-      shell: bash
-      run: |
-        pip install virtualenv

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -24,7 +24,7 @@ from mlflow.models.docker_utils import DISABLE_ENV_CREATION
 from mlflow.pyfunc import scoring_server, mlserver, _extract_conda_env
 from mlflow.version import VERSION as MLFLOW_VERSION
 from mlflow.utils import env_manager as em
-from mlflow.utils.virtualenv import _get_or_create_virtualenv
+from mlflow.utils.virtualenv import _get_or_create_venv
 
 MODEL_PATH = "/opt/ml/model"
 
@@ -115,7 +115,7 @@ def _install_pyfunc_deps(
                     raise Exception("Failed to create model environment.")
                 activate_cmd = ["source /miniconda/bin/activate custom_env"]
             elif env_manager == em.VIRTUALENV:
-                env_activate_cmd = _get_or_create_virtualenv(model_path)
+                env_activate_cmd = _get_or_create_venv(model_path)
                 path = env_activate_cmd.split(" ")[-1]
                 os.symlink(path, "/opt/activate")
                 activate_cmd = [env_activate_cmd]

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -32,10 +32,7 @@ from mlflow.utils.file_utils import (
     get_or_create_nfs_tmp_dir,
 )
 from mlflow.utils.environment import Environment
-from mlflow.utils.virtualenv import (
-    _get_or_create_virtualenv,
-    _get_pip_install_mlflow,
-)
+from mlflow.utils.virtualenv import _get_or_create_venv, _get_pip_install_mlflow
 from mlflow.utils.nfs_on_spark import get_nfs_cache_root_dir
 from mlflow.utils.process import cache_return_value_per_process
 from mlflow.version import VERSION
@@ -105,7 +102,7 @@ class PyFuncBackend(FlavorBackend):
             env_root_dir = self._env_root_dir
 
         if self._env_manager == _EnvManager.VIRTUALENV:
-            activate_cmd = _get_or_create_virtualenv(
+            activate_cmd = _get_or_create_venv(
                 local_path,
                 self._env_id,
                 env_root_dir=env_root_dir,

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -66,25 +66,6 @@ def _validate_pyenv_is_available():
         )
 
 
-def _is_virtualenv_available():
-    """
-    Returns True if virtualenv is available, otherwise False.
-    """
-    return shutil.which("virtualenv") is not None
-
-
-def _validate_virtualenv_is_available():
-    """
-    Validates virtualenv is available. If not, throws an `MlflowException` with a brief instruction
-    on how to install virtualenv.
-    """
-    if not _is_virtualenv_available():
-        raise MlflowException(
-            "Could not find the virtualenv binary. Run `pip install virtualenv` to install "
-            "virtualenv."
-        )
-
-
 _SEMANTIC_VERSION_REGEX = re.compile(r"^([0-9]+)\.([0-9]+)\.([0-9]+)$")
 
 
@@ -240,7 +221,7 @@ def _create_virtualenv(
     with remove_on_error(
         env_dir,
         onerror=lambda e: _logger.warning(
-            "Encountered an unexpected error: %s while creating a virtualenv environment in %s, "
+            "Encountered an unexpected error: %s while creating a virtual environment in %s, "
             "removing the environment directory...",
             repr(e),
             env_dir,
@@ -248,7 +229,7 @@ def _create_virtualenv(
     ):
         _logger.info("Creating a new environment in %s with %s", env_dir, python_bin_path)
         _exec_cmd(
-            [sys.executable, "-m", "virtualenv", "--python", python_bin_path, env_dir],
+            [sys.executable, "-m", "venv", "--python", python_bin_path, env_dir],
             capture_output=capture_output,
         )
 
@@ -320,9 +301,7 @@ _VIRTUALENV_ENVS_DIR = "virtualenv_envs"
 _PYENV_ROOT_DIR = "pyenv_root"
 
 
-def _get_or_create_virtualenv(
-    local_model_path, env_id=None, env_root_dir=None, capture_output=False
-):
+def _get_or_create_venv(local_model_path, env_id=None, env_root_dir=None, capture_output=False):
     """
     Restores an MLflow model's environment with pyenv and virtualenv and returns a command
     to activate it.
@@ -337,7 +316,6 @@ def _get_or_create_virtualenv(
              (e.g. "source /path/to/bin/activate").
     """
     _validate_pyenv_is_available()
-    _validate_virtualenv_is_available()
 
     # Read environment information
     local_model_path = Path(local_model_path)

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -3,7 +3,6 @@ import logging
 import shutil
 import uuid
 import re
-import sys
 import tempfile
 from pathlib import Path
 from packaging.version import Version
@@ -228,10 +227,7 @@ def _create_virtualenv(
         ),
     ):
         _logger.info("Creating a new environment in %s with %s", env_dir, python_bin_path)
-        _exec_cmd(
-            [sys.executable, "-m", "venv", "--python", python_bin_path, env_dir],
-            capture_output=capture_output,
-        )
+        _exec_cmd([python_bin_path, "-m", "venv", env_dir], capture_output=capture_output)
 
         _logger.info("Installing dependencies")
         for deps in filter(None, [python_env.build_dependencies, python_env.dependencies]):

--- a/tests/pyfunc/test_virtualenv.py
+++ b/tests/pyfunc/test_virtualenv.py
@@ -15,17 +15,11 @@ from sklearn.datasets import load_iris
 import mlflow
 from mlflow.pyfunc.scoring_server import CONTENT_TYPE_JSON
 from mlflow.utils.environment import _PYTHON_ENV_FILE_NAME, _REQUIREMENTS_FILE_NAME
-from mlflow.utils.virtualenv import (
-    _is_pyenv_available,
-    _is_virtualenv_available,
-)
+from mlflow.utils.virtualenv import _is_pyenv_available
 from mlflow.environment_variables import MLFLOW_ENV_ROOT
 from tests.helper_functions import pyfunc_serve_and_score_model
 
-pytestmark = pytest.mark.skipif(
-    not (_is_pyenv_available() and _is_virtualenv_available()),
-    reason="requires pyenv and virtualenv",
-)
+pytestmark = pytest.mark.skipif(not _is_pyenv_available(), reason="requires pyenv and virtualenv")
 
 TEST_DIR = "tests"
 TEST_MLFLOW_1X_MODEL_DIR = os.path.join(TEST_DIR, "resources", "example_mlflow_1x_sklearn_model")


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Use `venv` instead of `virtualenv`. In Python >= 3.3, `venv` is a built-in tool.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
