### PR TITLE
Make fluent API threadsafe

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -14,4 +14,4 @@ def tracking_uri_mock(tmp_path, monkeypatch):
 @pytest.fixture(autouse=True)
 def reset_active_experiment_id():
     yield
-    mlflow.tracking.fluent._active_experiment_id = None
+    mlflow.tracking.fluent._active_experiment_id.set(None)

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -22,9 +22,6 @@ You can also use the context manager syntax like this:
 
 which automatically terminates the run at the end of the ``with`` block.
 
-The fluent tracking API is not currently threadsafe. Any concurrent callers to the tracking API must
-implement mutual exclusion manually.
-
 For a lower level API, see the :py:mod:`mlflow.client` module.
 """
 import contextlib

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -72,7 +72,7 @@ if TYPE_CHECKING:
     import plotly
 
 
-class DefaultSetContextVar():
+class DefaultSetContextVar:
     def __init__(self, contextvar, default: Callable):
         self.contextvar = contextvar
         self.default = default
@@ -89,7 +89,9 @@ class DefaultSetContextVar():
         self.contextvar.set(value)
 
 
-_active_run_stack = DefaultSetContextVar(contextvars.ContextVar("_active_run_stack"), default=lambda: [])
+_active_run_stack = DefaultSetContextVar(
+    contextvars.ContextVar("_active_run_stack"), default=lambda: []
+)
 _active_experiment_id = contextvars.ContextVar("_active_experiment_id", default=None)
 _last_active_run_id = contextvars.ContextVar("_last_active_run_id", default=None)
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -3,10 +3,8 @@ Internal module implementing the fluent API, allowing management of an active
 MLflow run. This module is exposed to users at the top-level :py:mod:`mlflow` module.
 """
 import atexit
-import contextvars
-import logging
-import inspect
 import contextlib
+import contextvars
 import inspect
 import logging
 import os

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -80,11 +80,8 @@ class DefaultSetContextVar:
     def get(self):
         try:
             return self.contextvar.get()
-        except LookupError as e:
-            if self.default is None:
-                raise e
-            else:
-                self.set(self.default())
+        except LookupError:
+            self.set(self.default())
         return self.contextvar.get()
 
     def set(self, value):

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -72,7 +72,7 @@ if TYPE_CHECKING:
     import plotly
 
 
-class DefaultSetContextVar:
+class _DefaultSetContextVar:
     def __init__(self, name: str, default: Callable):
         self.contextvar = contextvars.ContextVar(name)
         self.default = default

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -90,9 +90,9 @@ class _DefaultSetContextVar:
 
 # fluent tracking APIs must be implemented in thread-safe way, so that if you want to add a new
 # global variable that is used and mutated by fluent tracking API implementation, please wrap it
-# with contextvars.ContextVar or DefaultSetContextVar
+# with contextvars.ContextVar or _DefaultSetContextVar
 
-_active_run_stack = DefaultSetContextVar("_active_run_stack", default=lambda: [])
+_active_run_stack = _DefaultSetContextVar("_active_run_stack", default=lambda: [])
 _active_experiment_id = contextvars.ContextVar("_active_experiment_id", default=None)
 _last_active_run_id = contextvars.ContextVar("_last_active_run_id", default=None)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def tracking_uri_mock(tmp_path, request):
 @pytest.fixture(autouse=True)
 def reset_active_experiment_id():
     yield
-    mlflow.tracking.fluent._active_experiment_id = None
+    mlflow.tracking.fluent._active_experiment_id.set(None)
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/tracking/conftest.py
+++ b/tests/tracking/conftest.py
@@ -6,4 +6,4 @@ import mlflow
 @pytest.fixture
 def reset_active_experiment():
     yield
-    mlflow.tracking.fluent._active_experiment_id = None
+    mlflow.tracking.fluent._active_experiment_id.set(None)

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1339,17 +1339,15 @@ def test_active_experiment_thread_safety():
         return experiment_name
 
     with ThreadPoolExecutor(max_workers=2) as executor:
-        experiment_names = list(executor.map(run, range(2)))
+        experiment_names = ["Default"] + list(executor.map(run, range(2)))
         assert experiment_names == [
             exp.name
-            for exp in mlflow.search_experiments(
-                order_by=["creation_time ASC"], filter_string="name != 'Default'"
-            )
+            for exp in mlflow.search_experiments(order_by=["creation_time ASC"])
         ]
 
 
 def test_last_active_run_thread_safety():
-    mlflow.search_experiments()  # Initialize database
+    # mlflow.search_experiments()  # Initialize database
 
     def run(worker: int):
         if worker == 1:

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1308,8 +1308,6 @@ def test_get_parent_run():
 
 
 def test_active_run_thread_safety():
-    mlflow.search_experiments()  # Initialize database
-
     def run(worker: int):
         if worker == 1:
             time.sleep(1)
@@ -1328,6 +1326,8 @@ def test_active_run_thread_safety():
 
 
 def test_active_experiment_thread_safety():
+    mlflow.search_experiments()  # Initialize database
+
     def run(worker: int):
         if worker == 1:
             time.sleep(1)
@@ -1346,8 +1346,6 @@ def test_active_experiment_thread_safety():
 
 
 def test_last_active_run_thread_safety():
-    # mlflow.search_experiments()  # Initialize database
-
     def run(worker: int):
         if worker == 1:
             time.sleep(1)

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1341,8 +1341,7 @@ def test_active_experiment_thread_safety():
     with ThreadPoolExecutor(max_workers=2) as executor:
         experiment_names = ["Default"] + list(executor.map(run, range(2)))
         assert experiment_names == [
-            exp.name
-            for exp in mlflow.search_experiments(order_by=["creation_time ASC"])
+            exp.name for exp in mlflow.search_experiments(order_by=["creation_time ASC"])
         ]
 
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1307,6 +1307,8 @@ def test_get_parent_run():
 
 
 def test_active_run_thread_safety():
+    mlflow.search_experiments()  # Initialize database
+
     def run(worker: int):
         if worker == 1:
             time.sleep(1)
@@ -1345,6 +1347,8 @@ def test_active_experiment_thread_safety():
 
 
 def test_last_active_run_thread_safety():
+    mlflow.search_experiments()  # Initialize database
+
     def run(worker: int):
         if worker == 1:
             time.sleep(1)

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -516,7 +516,7 @@ def test_search_model_versions(tmp_path):
 
 @pytest.fixture
 def empty_active_run_stack():
-    with mock.patch("mlflow.tracking.fluent._active_run_stack.get", []):
+    with mock.patch("mlflow.tracking.fluent._active_run_stack.get", return_value=[]):
         yield
 
 
@@ -721,7 +721,9 @@ def test_start_run_with_parent():
     mock_experiment_id = "123456"
     mock_source_name = mock.Mock()
 
-    active_run_stack_patch = mock.patch("mlflow.tracking.fluent._active_run_stack.get", [parent_run])
+    active_run_stack_patch = mock.patch(
+        "mlflow.tracking.fluent._active_run_stack.get", return_value=[parent_run]
+    )
 
     mock_user = mock.Mock()
     user_patch = mock.patch(
@@ -754,7 +756,7 @@ def test_start_run_with_parent():
 
 
 def test_start_run_with_parent_non_nested():
-    with mock.patch("mlflow.tracking.fluent._active_run_stack.get", [mock.Mock()]):
+    with mock.patch("mlflow.tracking.fluent._active_run_stack.get", return_value=[mock.Mock()]):
         with pytest.raises(Exception, match=r"Run with UUID .+ is already active"):
             start_run()
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1,5 +1,4 @@
 import inspect
-import contextvars
 import json
 import os
 import random

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1,4 +1,5 @@
 import inspect
+import contextvars
 import json
 import os
 import random
@@ -150,7 +151,7 @@ def reset_experiment_id():
     its included
     """
     yield
-    mlflow.tracking.fluent._active_experiment_id = None
+    mlflow.tracking.fluent._active_experiment_id.set(None)
 
 
 @pytest.fixture(autouse=True)
@@ -515,7 +516,7 @@ def test_search_model_versions(tmp_path):
 
 @pytest.fixture
 def empty_active_run_stack():
-    with mock.patch("mlflow.tracking.fluent._active_run_stack", []):
+    with mock.patch("mlflow.tracking.fluent._active_run_stack.get", []):
         yield
 
 
@@ -720,7 +721,7 @@ def test_start_run_with_parent():
     mock_experiment_id = "123456"
     mock_source_name = mock.Mock()
 
-    active_run_stack_patch = mock.patch("mlflow.tracking.fluent._active_run_stack", [parent_run])
+    active_run_stack_patch = mock.patch("mlflow.tracking.fluent._active_run_stack.get", [parent_run])
 
     mock_user = mock.Mock()
     user_patch = mock.patch(
@@ -753,7 +754,7 @@ def test_start_run_with_parent():
 
 
 def test_start_run_with_parent_non_nested():
-    with mock.patch("mlflow.tracking.fluent._active_run_stack", [mock.Mock()]):
+    with mock.patch("mlflow.tracking.fluent._active_run_stack.get", [mock.Mock()]):
         with pytest.raises(Exception, match=r"Run with UUID .+ is already active"):
             start_run()
 


### PR DESCRIPTION
## Related Issues/PRs

Resolve #9235 

## What changes are proposed in this pull request?

Move three global variables in the fluent API to use [ContextVar](https://github.com/mlflow/mlflow/issues/9235) to ensure thread safety.

Note that empty lists are not a safe default with ContextVar as a shared instance will be used, thus a `DefaultSetContextVar` was created that supports a lambda for default. Open to alternate implementations of this (and potentially moving this to some helper/util file).

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

Hard to demo - have an application that kicks of mlflow experiments in threads. Previously it would fail with an error about `there's already an active run, you must end run or use nested=True`, but after this change multiple runs are able to complete successfully simultaneously without interfering.

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fluent API is now thread safe, using ContextVars to keep track of the active run and experiment.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
