### PR TITLE
Change unspecified params in Pyfunc inference to warn instead of raise

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -374,7 +374,7 @@ of the value, it should be ``None`` for scalar values and ``(-1,)`` for a list.
 Signature Enforcement
 ~~~~~~~~~~~~~~~~~~~~~
 Schema enforcement checks the provided input and params against the model's signature and 
-raises an exception if the input or params is not compatible. This enforcement is applied in MLflow before
+raises an exception if the input is not compatible and will issue a warning or raise an exception if the params are incompatible. This enforcement is applied in MLflow before
 calling the underlying model implementation, and during model inference process.
 Note that this enforcement only applies when using :ref:`MLflow
 model deployment tools <built-in-deployment>` or when loading models as ``python_function``. In
@@ -412,6 +412,8 @@ a shape of ``(-1,)``. If the parameter's type or shape is incompatible, an excep
 Additionally, the value of the parameter is validated against the specified type in the signature. We attempt 
 to convert the value to the specified type, and if this conversion fails, an MlflowException will be raised.
 A valid list of params is documented in :ref:`Model Inference Params <inference-params>` section.
+Models that have signatures and are used for inference with declared params not part of the logged signature will
+have a warning issued with each request and the invalid params ignored during inference.
 
 Handling Integers With Missing Values
 """""""""""""""""""""""""""""""""""""

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -893,10 +893,14 @@ def _enforce_params_schema(params: Optional[Dict[str, Any]], schema: Optional[Pa
     if schema is None:
         if params in [None, {}]:
             return params
+        params_info = (
+            f"Ignoring provided params: {list(params.keys())}"
+            if isinstance(params, dict)
+            else "Ignoring invalid params (not a dictionary)."
+        )
         _logger.warning(
             "`params` can only be specified at inference time if the model signature "
-            "defines a params schema. This model does not define a params schema. Ignoring "
-            f"provided params: {list(params.keys())}",
+            f"defines a params schema. This model does not define a params schema. {params_info}",
         )
         return {}
     params = {} if params is None else params

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -893,10 +893,12 @@ def _enforce_params_schema(params: Optional[Dict[str, Any]], schema: Optional[Pa
     if schema is None:
         if params in [None, {}]:
             return params
-        raise MlflowException.invalid_parameter_value(
+        _logger.warning(
             "`params` can only be specified at inference time if the model signature "
-            "defines a params schema. This model does not define a params schema.",
+            "defines a params schema. This model does not define a params schema. Ignoring "
+            f"provided params: {list(params.keys())}",
         )
+        return {}
     params = {} if params is None else params
     if not isinstance(params, dict):
         raise MlflowException.invalid_parameter_value(

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -356,12 +356,13 @@ def test_model_pyfunc_predict_with_params(basic_model, tmp_path):
     model_path = tmp_path / "model3"
     mlflow.sentence_transformers.save_model(basic_model, model_path)
     loaded_pyfunc = pyfunc.load_model(model_uri=model_path)
-    with pytest.raises(
-        MlflowException,
-        match=r"`params` can only be specified at inference time if the model "
-        r"signature defines a params schema. This model does not define a params schema.",
-    ):
+    with mock.patch("mlflow.models.utils._logger.warning") as mock_warning:
         loaded_pyfunc.predict(sentence, params)
+    mock_warning.assert_called_with(
+        "`params` can only be specified at inference time if the model signature defines a params "
+        "schema. This model does not define a params schema. Ignoring provided params: "
+        "['batch_size']"
+    )
 
 
 def test_spark_udf(basic_model, spark):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Modifies the behavior of submitting unspecified params in pyfunc inference to warn instead of raise to mirror the behavior of unspecified params in a model that has params set in the model signature.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
