### PR TITLE
fix for issue 9170

### DIFF
--- a/mlflow/recipes/recipe.py
+++ b/mlflow/recipes/recipe.py
@@ -95,19 +95,18 @@ class BaseRecipe:
         )
         if last_executed_step_state.status != StepStatus.SUCCEEDED:
             last_step_error_mesg = (
-                f" The following error occurred: "
-                f" step: '{last_executed_step.name}'"
-                f" status: '{last_executed_step_state.status}'"
-                f" {last_executed_step_state.stack_trace}"
+                f"The following error occurred while running step '{last_executed_step}':\n"
+                f"{last_executed_step_state.stack_trace}\n"
+                f"Last step status: '{last_executed_step_state.status}'\n"
             )
             if step is not None:
                 raise MlflowException(
-                    f"Failed to run step '{step}' of recipe '{self.name}' {last_step_error_mesg}",
+                    f"Failed to run step '{step}' of recipe '{self.name}':\n{last_step_error_mesg}",
                     error_code=BAD_REQUEST,
                 )
             else:
                 raise MlflowException(
-                    f"Failed to run recipe '{self.name}'.  {last_step_error_mesg}",
+                    f"Failed to run recipe '{self.name}':\n{last_step_error_mesg}",
                     error_code=BAD_REQUEST,
                 )
 

--- a/mlflow/recipes/recipe.py
+++ b/mlflow/recipes/recipe.py
@@ -94,18 +94,20 @@ class BaseRecipe:
             last_executed_step_output_directory
         )
         if last_executed_step_state.status != StepStatus.SUCCEEDED:
+            last_step_error_mesg = (
+                f" The following error occurred: "
+                f" step: '{last_executed_step.name}'"
+                f" status: '{last_executed_step_state.status}'"
+                f" {last_executed_step_state.stack_trace}"
+            )
             if step is not None:
                 raise MlflowException(
-                    f"Failed to run step '{step}' of recipe '{self.name}'."
-                    f" An error was encountered while running step '{last_executed_step.name}':"
-                    f" {last_executed_step_state.stack_trace}",
+                    f"Failed to run step '{step}' of recipe '{self.name}' {last_step_error_mesg}",
                     error_code=BAD_REQUEST,
                 )
             else:
                 raise MlflowException(
-                    f"Failed to run recipe '{self.name}'."
-                    f" An error was encountered while running step '{last_executed_step.name}':"
-                    f" {last_executed_step_state.stack_trace}",
+                    f"Failed to run recipe '{self.name}'.  {last_step_error_mesg}",
                     error_code=BAD_REQUEST,
                 )
 

--- a/mlflow/recipes/step.py
+++ b/mlflow/recipes/step.py
@@ -111,6 +111,9 @@ class BaseStep(metaclass=abc.ABCMeta):
         self.task = self.step_config.get("recipe", "regression/v1").rsplit("/", 1)[0]
         self.step_card = None
 
+    def __str__(self):
+        return f"Step:{self.name}"
+
     def run(self, output_directory: str):
         """
         Executes the step by running common setup operations and invoking

--- a/tests/recipes/test_pipeline.py
+++ b/tests/recipes/test_pipeline.py
@@ -205,7 +205,9 @@ def test_recipes_run_throws_exception_and_produces_failure_card_when_step_fails(
 
     recipe = Recipe(profile="local")
     recipe.clean()
-    with pytest.raises(MlflowException, match="Failed to run recipe.*test_recipe.*\n.*Step:ingest.*"):
+    with pytest.raises(
+        MlflowException, match="Failed to run recipe.*test_recipe.*\n.*Step:ingest.*"
+    ):
         recipe.run()
     with pytest.raises(MlflowException, match="Failed to run step.*split.*\n.*Step:ingest.*"):
         recipe.run(step="split")

--- a/tests/recipes/test_pipeline.py
+++ b/tests/recipes/test_pipeline.py
@@ -205,9 +205,9 @@ def test_recipes_run_throws_exception_and_produces_failure_card_when_step_fails(
 
     recipe = Recipe(profile="local")
     recipe.clean()
-    with pytest.raises(MlflowException, match="Failed to run.*test_recipe.*ingest"):
+    with pytest.raises(MlflowException, match="Failed to run recipe.*test_recipe.*\n.*Step:ingest.*"):
         recipe.run()
-    with pytest.raises(MlflowException, match="Failed to run.*split.*test_recipe.*ingest"):
+    with pytest.raises(MlflowException, match="Failed to run step.*split.*\n.*Step:ingest.*"):
         recipe.run(step="split")
 
     step_card_path = get_step_output_path(


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
Resolve  #9170

## What changes are proposed in this pull request?

Update error message in recipes to include the status of the recently failed step.

## How is this patch tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

Error message update was manually tested by generating manually generating bad states.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Error message update to include more details.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [X] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
