### PR TITLE
Remove wheel caching for dev versions

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -2,10 +2,7 @@ sklearn:
   package_info:
     pip_release: "scikit-learn"
     install_dev: |
-      if [ ! -d "$CACHE_DIR" ] || [ -z $(find $CACHE_DIR -type f -name "scikit_learn-*.whl") ]; then
-        pip wheel --no-deps --wheel-dir $CACHE_DIR git+https://github.com/scikit-learn/scikit-learn.git
-      fi
-      pip install $CACHE_DIR/scikit_learn-*.whl
+      pip install git+https://github.com/scikit-learn/scikit-learn.git
 
   models:
     minimum: "0.22.1"
@@ -175,13 +172,9 @@ catboost:
   package_info:
     pip_release: "catboost"
     install_dev: |
-      # The cross-version-tests workflow runs this command with the environment variable `CACHE_DIR`
-      if [ ! -d "$CACHE_DIR" ] || [ -z $(find $CACHE_DIR -type f -name "catboost-*.whl") ]; then
-        # TODO: Remove the commit once https://github.com/catboost/catboost/issues/2242 is fixed
-        pip wheel --no-deps --wheel-dir $CACHE_DIR \
-          git+https://github.com/catboost/catboost.git@f8921d839eccf11e533a46347dde5b5b25b17190#subdirectory=catboost/python-package
-      fi
-      pip install $CACHE_DIR/catboost-*.whl
+      # TODO: Remove the commit once https://github.com/catboost/catboost/issues/2242 is fixed
+      pip install \
+        git+https://github.com/catboost/catboost.git@f8921d839eccf11e533a46347dde5b5b25b17190#subdirectory=catboost/python-package
 
   models:
     minimum: "0.23.1"
@@ -318,18 +311,11 @@ spark:
   package_info:
     pip_release: "pyspark"
     install_dev: |
-      # The cross-version-tests workflow runs this command with the environment variable `CACHE_DIR`
-      if [ ! -d "$CACHE_DIR" ] || [ -z $(find $CACHE_DIR -type f -name "pyspark-*.whl") ]; then
-        # Build wheel from source
-        temp_dir=$(mktemp -d)
-        git clone --depth 1 https://github.com/apache/spark.git $temp_dir
-        git --git-dir=$temp_dir/.git rev-parse HEAD
-        cd $temp_dir
-        ./build/mvn -DskipTests --no-transfer-progress clean package
-        cd python
-        python setup.py bdist_wheel --dist-dir $CACHE_DIR
-      fi
-      pip install $CACHE_DIR/pyspark-*.whl
+      temp_dir=$(mktemp -d)
+      git clone --depth 1 https://github.com/apache/spark.git $temp_dir
+      cd $temp_dir
+      ./build/mvn -DskipTests --no-transfer-progress clean package
+      python setup.py install
 
   models:
     minimum: "3.0.0"
@@ -403,10 +389,7 @@ prophet:
     pip_release: "prophet"
     install_dev: |
       sudo apt-get -y install libtbb2
-      if [ ! -d "$CACHE_DIR" ] || [ -z $(find $CACHE_DIR -type f -name "prophet-*.whl") ]; then
-        pip wheel --no-deps --wheel-dir $CACHE_DIR git+https://github.com/facebook/prophet.git#subdirectory=python
-      fi
-      pip install $CACHE_DIR/prophet-*.whl
+      pip install git+https://github.com/facebook/prophet.git#subdirectory=python
 
   models:
     minimum: "1.0.1"
@@ -424,11 +407,8 @@ pmdarima:
   package_info:
     pip_release: "pmdarima"
     install_dev: |
-      if [ ! -d "$CACHE_DIR" ] || [ -z $(find $CACHE_DIR -type f -name "pmdarima-*.whl") ]; then
-        pip install Cython
-        pip wheel --no-deps --wheel-dir $CACHE_DIR git+https://github.com/alkaline-ml/pmdarima.git
-      fi
-      pip install $CACHE_DIR/pmdarima-*.whl
+      pip install Cython
+      pip install git+https://github.com/alkaline-ml/pmdarima.git
 
   models:
     minimum: "1.8.0"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -315,6 +315,7 @@ spark:
       git clone --depth 1 https://github.com/apache/spark.git $temp_dir
       cd $temp_dir
       ./build/mvn -DskipTests --no-transfer-progress clean package
+      cd python
       python setup.py install
 
   models:


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #9246 

## What changes are proposed in this pull request?

In #9246, I removed the `CACHE_DIR` environment variable. It broke dev cross-version tests. This PR fixes them.

https://github.com/mlflow-automation/mlflow/actions/runs/5821630957

```
+ pip install scikit-learn
Requirement already satisfied: scikit-learn in /opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages (1.3.0)
Requirement already satisfied: numpy>=1.17.3 in /opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages (from scikit-learn) (1.24.4)
Requirement already satisfied: scipy>=1.5.0 in /opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages (from scikit-learn) (1.10.1)
Requirement already satisfied: joblib>=1.1.1 in /opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages (from scikit-learn) (1.3.2)
Requirement already satisfied: threadpoolctl>=2.0.0 in /opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages (from scikit-learn) (3.2.0)
+ '[' '!' -d '' ']'
+ pip wheel --no-deps --wheel-dir git+https://github.com/catboost/catboost.git@f89[21](https://github.com/mlflow-automation/mlflow/actions/runs/5821630957/job/15784487593#step:10:22)d839eccf11e533a46347dde5b5b[25](https://github.com/mlflow-automation/mlflow/actions/runs/5821630957/job/15784487593#step:10:26)b17190#subdirectory=catboost/python-package
ERROR: You must give at least one requirement to wheel (see "pip help wheel")
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
