### PR TITLE
Migarte `MLFLOW_CONDA_CREATE_ENV_CMD`

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -369,3 +369,11 @@ MLFLOW_GATEWAY_URI = _EnvironmentVariable("MLFLOW_GATEWAY_URI", str, None)
 MLFLOW_ENABLE_ARTIFACTS_PROGRESS_BAR = _BooleanEnvironmentVariable(
     "MLFLOW_ENABLE_ARTIFACTS_PROGRESS_BAR", True
 )
+
+#: Specifies the name of the command to use when creating the environments.
+#: For example, let's say we want to use mamba (https://github.com/mamba-org/mamba)
+#: instead of conda to create environments.
+#: Then: > conda install mamba -n base -c conda-forge
+#: If not set, use the same as conda_path
+#: (default: ``conda``)
+MLFLOW_CONDA_CREATE_ENV_CMD = _EnvironmentVariable("MLFLOW_CONDA_CREATE_ENV_CMD", str, "conda")

--- a/mlflow/utils/conda.py
+++ b/mlflow/utils/conda.py
@@ -241,7 +241,7 @@ def get_or_create_conda_env(conda_env_path, env_id=None, capture_output=False, e
         process._exec_cmd([conda_env_create_path, "--help"], throw_on_error=False)
     except OSError:
         raise ExecutionException(
-            f"You have set the env variable {MLFLOW_CONDA_CREATE_ENV_CMD.name}, but "
+            f"You have set the env variable {MLFLOW_CONDA_CREATE_ENV_CMD}, but "
             f"{conda_env_create_path} does not exist or it is not working properly. "
             f"Note that {conda_env_create_path} and the conda executable need to be "
             "in the same conda environment. You can change the search path by"

--- a/mlflow/utils/conda.py
+++ b/mlflow/utils/conda.py
@@ -8,18 +8,11 @@ import yaml
 from mlflow.exceptions import ExecutionException
 from mlflow.utils import process
 from mlflow.utils.environment import Environment
+from mlflow.environment_variables import MLFLOW_CONDA_CREATE_ENV_CMD
 
 # Environment variable indicating a path to a conda installation. MLflow will default to running
 # "conda" if unset
 MLFLOW_CONDA_HOME = "MLFLOW_CONDA_HOME"
-# Environment variable indicated the name of the command that should be used to create environments.
-# If it is unset, it will default to "conda". This command must be in the $PATH when the user runs,
-# or within MLFLOW_CONDA_HOME if that is set. For example, let's say we want to use mamba
-# (https://github.com/mamba-org/mamba) instead of conda to create environments. Then:
-# > conda install mamba -n base -c conda-forge
-# > MLFLOW_CONDA_CREATE_ENV_CMD="mamba"
-# > mlflow run ...
-MLFLOW_CONDA_CREATE_ENV_CMD = "MLFLOW_CONDA_CREATE_ENV_CMD"
 
 _logger = logging.getLogger(__name__)
 
@@ -87,14 +80,8 @@ def _get_conda_executable_for_create_env():
     by default, but it can be set to something else by setting the environment variable
 
     """
-    conda_env_create_cmd = os.environ.get(MLFLOW_CONDA_CREATE_ENV_CMD)
-    if conda_env_create_cmd is not None:
-        conda_env_create_path = get_conda_bin_executable(conda_env_create_cmd)
-    else:
-        # Use the same as conda_path
-        conda_env_create_path = get_conda_bin_executable("conda")
 
-    return conda_env_create_path
+    return get_conda_bin_executable(MLFLOW_CONDA_CREATE_ENV_CMD.get())
 
 
 def _list_conda_environments(extra_env=None):
@@ -254,7 +241,7 @@ def get_or_create_conda_env(conda_env_path, env_id=None, capture_output=False, e
         process._exec_cmd([conda_env_create_path, "--help"], throw_on_error=False)
     except OSError:
         raise ExecutionException(
-            f"You have set the env variable {MLFLOW_CONDA_CREATE_ENV_CMD}, but "
+            f"You have set the env variable {MLFLOW_CONDA_CREATE_ENV_CMD.name}, but "
             f"{conda_env_create_path} does not exist or it is not working properly. "
             f"Note that {conda_env_create_path} and the conda executable need to be "
             "in the same conda environment. You can change the search path by"

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -35,8 +35,8 @@ from mlflow.utils.process import ShellCommandException
 from mlflow.utils.conda import (
     get_or_create_conda_env,
     MLFLOW_CONDA_HOME,
-    MLFLOW_CONDA_CREATE_ENV_CMD,
 )
+from mlflow.environment_variables import MLFLOW_CONDA_CREATE_ENV_CMD
 from mlflow.utils import PYTHON_VERSION
 
 from tests.projects.utils import TEST_PROJECT_DIR, TEST_PROJECT_NAME, validate_exit_status
@@ -309,7 +309,7 @@ def test_conda_path(mock_env, expected_conda, expected_activate, monkeypatch):
             "/abc/conda",
         ),
         (
-            {"CONDA_EXE": "/abc/conda", MLFLOW_CONDA_CREATE_ENV_CMD: "mamba"},
+            {"CONDA_EXE": "/abc/conda", MLFLOW_CONDA_CREATE_ENV_CMD.name: "mamba"},
             "/abc/mamba",
         ),
         (
@@ -317,7 +317,7 @@ def test_conda_path(mock_env, expected_conda, expected_activate, monkeypatch):
             "/some/dir/bin/conda",
         ),
         (
-            {MLFLOW_CONDA_HOME: "/some/dir/", MLFLOW_CONDA_CREATE_ENV_CMD: "mamba"},
+            {MLFLOW_CONDA_HOME: "/some/dir/", MLFLOW_CONDA_CREATE_ENV_CMD.name: "mamba"},
             "/some/dir/bin/mamba",
         ),
     ],
@@ -328,7 +328,7 @@ def test_find_conda_executables(mock_env, expected_conda_env_create_path, monkey
     create environments (for example, it could be mamba instead of conda)
     """
     monkeypatch.delenvs(
-        ["CONDA_EXE", MLFLOW_CONDA_HOME, MLFLOW_CONDA_CREATE_ENV_CMD], raising=False
+        ["CONDA_EXE", MLFLOW_CONDA_HOME, MLFLOW_CONDA_CREATE_ENV_CMD.name], raising=False
     )
     monkeypatch.setenvs(mock_env)
     conda_env_create_path = mlflow.utils.conda._get_conda_executable_for_create_env()
@@ -359,7 +359,7 @@ def test_create_env_with_mamba(monkeypatch):
 
     conda_env_path = os.path.join(TEST_PROJECT_DIR, "conda.yaml")
 
-    monkeypatch.setenv(mlflow.utils.conda.MLFLOW_CONDA_CREATE_ENV_CMD, "mamba")
+    monkeypatch.setenv(MLFLOW_CONDA_CREATE_ENV_CMD.name, "mamba")
     # Simulate success
     with mock.patch("mlflow.utils.process._exec_cmd", side_effect=exec_cmd_mock):
         mlflow.utils.conda.get_or_create_conda_env(conda_env_path)


### PR DESCRIPTION
…n logic; Updating the test cases

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #9228

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
