### PR TITLE
Improve error message for unknown credential types when accessing model version files in UC

### DIFF
--- a/mlflow/store/_unity_catalog/registry/utils.py
+++ b/mlflow/store/_unity_catalog/registry/utils.py
@@ -134,8 +134,9 @@ def _get_artifact_repo_from_storage_info(
         return GCSArtifactRepository(artifact_uri=storage_location, client=client)
     else:
         raise MlflowException(
-            f"Got unexpected credential type {credential_type} when attempting to access model version files "
-            f"in Unity Catalog. Try upgrading to the latest version of the MLflow Python client."
+            f"Got unexpected credential type {credential_type} when attempting to "
+            "access model version files in Unity Catalog. Try upgrading to the latest "
+            "version of the MLflow Python client."
         )
 
 

--- a/mlflow/store/_unity_catalog/registry/utils.py
+++ b/mlflow/store/_unity_catalog/registry/utils.py
@@ -134,7 +134,8 @@ def _get_artifact_repo_from_storage_info(
         return GCSArtifactRepository(artifact_uri=storage_location, client=client)
     else:
         raise MlflowException(
-            f"Got unexpected token type {credential_type} for Unity Catalog managed file access"
+            f"Got unexpected credential type {credential_type} when attempting to access model version files "
+            f"in Unity Catalog. Try upgrading to the latest version of the MLflow Python client."
         )
 
 

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -806,13 +806,14 @@ def test_create_model_version_unknown_storage_creds(store, local_model_dir):
             storage_location=storage_location,
             source=source,
         ),
-    ), mock.patch.object(TemporaryCredentials, "WhichOneof", return_value=unknown_credential_type):
-        with pytest.raises(
-            MlflowException,
-            match=f"Got unexpected credential type {unknown_credential_type} when attempting to access model "
-            f"version files",
-        ):
-            store.create_model_version(name=model_name, source=source)
+    ), mock.patch.object(
+        TemporaryCredentials, "WhichOneof", return_value=unknown_credential_type
+    ), pytest.raises(
+        MlflowException,
+        match=f"Got unexpected credential type {unknown_credential_type} when attempting to access model "
+        f"version files",
+    ):
+        store.create_model_version(name=model_name, source=source)
 
 
 @pytest.mark.parametrize(

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -810,8 +810,8 @@ def test_create_model_version_unknown_storage_creds(store, local_model_dir):
         TemporaryCredentials, "WhichOneof", return_value=unknown_credential_type
     ), pytest.raises(
         MlflowException,
-        match=f"Got unexpected credential type {unknown_credential_type} when attempting to access model "
-        f"version files",
+        match=f"Got unexpected credential type {unknown_credential_type} when "
+        "attempting to access model version files",
     ):
         store.create_model_version(name=model_name, source=source)
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Improve error message for unknown credential types when accessing model version files in UC and recommend upgrading the MLflow client version, to improve the user experience as we add support for new storage backends in UC (e.g. Cloudflare R2-backed storage in addition to S3/ADLS/GCS)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
