### PR TITLE
Add doc for search_model_versions

### DIFF
--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -283,7 +283,7 @@ def search_model_versions(
             print("name={}; run_id={}; version={}".format(res.name, res.run_id, res.version))
 
         # Get the version of the model filtered by run_id
-        filter_string = "run_id = 'c0d756267a2c45bfac8d92c5e17b4483'"
+        filter_string = "run_id = 'ae9a606a12834c04a8ef1006d0cff779'"
         results = mlflow.search_model_versions(filter_string=filter_string)
         print("-" * 80)
         for res in results:

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -261,7 +261,7 @@ def search_model_versions(
     :return: A list of :py:class:`mlflow.entities.model_registry.ModelVersion` objects
             that satisfy the search expressions.
 
-    .. code-block:: python
+    .. test-code-block:: python
         :caption: Example
 
         import mlflow

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -238,27 +238,27 @@ def search_model_versions(
         and logical operators are supported.
 
         Identifiers
-        - ``name``: model name.
-        - ``source_path``: model version source path.
-        - ``run_id``: The id of the mlflow run that generates the model version.
-        - ``tags.<tag_key>``: model version tag. If ``tag_key`` contains spaces, it must be
+          - ``name``: model name.
+          - ``source_path``: model version source path.
+          - ``run_id``: The id of the mlflow run that generates the model version.
+          - ``tags.<tag_key>``: model version tag. If ``tag_key`` contains spaces, it must be
             wrapped with backticks (e.g., ``"tags.`extra key`"``).
 
         Comparators
-        - ``=``: Equal to.
-        - ``!=``: Not equal to.
-        - ``LIKE``: Case-sensitive pattern match.
-        - ``ILIKE``: Case-insensitive pattern match.
-        - ``IN``: In a value list. Only ``run_id`` identifier supports ``IN`` comparator.
+          - ``=``: Equal to.
+          - ``!=``: Not equal to.
+          - ``LIKE``: Case-sensitive pattern match.
+          - ``ILIKE``: Case-insensitive pattern match.
+          - ``IN``: In a value list. Only ``run_id`` identifier supports ``IN`` comparator.
 
         Logical operators
-        - ``AND``: Combines two sub-queries and returns True if both of them are True.
+          - ``AND``: Combines two sub-queries and returns True if both of them are True.
 
     :param max_results: If passed, specifies the maximum number of models desired. If not
                         passed, all models will be returned.
     :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
                     matching search results.
-    :return: A list of `mlflow.entities.model_registry.ModelVersion` objects
+    :return: A list of :py:class:`mlflow.entities.model_registry.ModelVersion` objects
             that satisfy the search expressions.
 
     .. code-block:: python
@@ -283,7 +283,7 @@ def search_model_versions(
             print("name={}; run_id={}; version={}".format(res.name, res.run_id, res.version))
 
         # Get the version of the model filtered by run_id
-        filter_string = "run_id='c0d756267a2c45bfac8d92c5e17b4483'"
+        filter_string = "run_id = 'c0d756267a2c45bfac8d92c5e17b4483'"
         results = mlflow.search_model_versions(filter_string=filter_string)
         print("-" * 80)
         for res in results:


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> Resolve #9272 

## What changes are proposed in this pull request?

Add doc-string for search_model_versions fluent to render in [search_model_versions](https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.search_model_versions)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
