### PR TITLE
moved _MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR to environment file

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -377,3 +377,9 @@ MLFLOW_ENABLE_ARTIFACTS_PROGRESS_BAR = _BooleanEnvironmentVariable(
 #: If not set, use the same as conda_path
 #: (default: ``conda``)
 MLFLOW_CONDA_CREATE_ENV_CMD = _EnvironmentVariable("MLFLOW_CONDA_CREATE_ENV_CMD", str, "conda")
+
+#: Specifies the execution directory for recipes.
+#: (default: ``None``)
+MLFLOW_RECIPES_EXECUTION_DIRECTORY = _EnvironmentVariable(
+    "MLFLOW_RECIPES_EXECUTION_DIRECTORY", str, None
+)

--- a/mlflow/recipes/utils/execution.py
+++ b/mlflow/recipes/utils/execution.py
@@ -6,13 +6,13 @@ import re
 import shutil
 from typing import List, Dict
 
+from mlflow.environment_variables import MLFLOW_RECIPES_EXECUTION_DIRECTORY
 from mlflow.recipes.step import BaseStep, StepStatus
 from mlflow.utils.file_utils import read_yaml, write_yaml
 from mlflow.utils.process import _exec_cmd
 
 _logger = logging.getLogger(__name__)
 
-_MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR = "MLFLOW_RECIPES_EXECUTION_DIRECTORY"
 _MLFLOW_RECIPES_EXECUTION_TARGET_STEP_NAME_ENV_VAR = "MLFLOW_RECIPES_EXECUTION_TARGET_STEP_NAME"
 _STEPS_SUBDIRECTORY_NAME = "steps"
 _STEP_OUTPUTS_SUBDIRECTORY_NAME = "outputs"
@@ -228,7 +228,7 @@ def get_or_create_base_execution_directory(recipe_root_path: str) -> str:
     )
 
     execution_dir_path = os.path.abspath(
-        os.environ.get(_MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR)
+        MLFLOW_RECIPES_EXECUTION_DIRECTORY.get()
         or os.path.join(os.path.expanduser("~"), ".mlflow", "recipes", execution_directory_basename)
     )
     os.makedirs(execution_dir_path, exist_ok=True)

--- a/tests/recipes/conftest.py
+++ b/tests/recipes/conftest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from mlflow.recipes.utils.execution import _MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR
+from mlflow.environment_variables import MLFLOW_RECIPES_EXECUTION_DIRECTORY
 from mlflow.utils.file_utils import TempDir
 from tests.recipes.helper_functions import (
     RECIPE_EXAMPLE_PATH_ENV_VAR_FOR_TESTS,
@@ -42,7 +42,7 @@ def enter_test_recipe_directory(enter_recipe_example_directory):
 def tmp_recipe_exec_path(monkeypatch, tmp_path) -> Path:
     path = tmp_path.joinpath("recipe_execution")
     path.mkdir(parents=True)
-    monkeypatch.setenv(_MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR, str(path))
+    monkeypatch.setenv(MLFLOW_RECIPES_EXECUTION_DIRECTORY.name, str(path))
     yield path
     shutil.rmtree(path)
 

--- a/tests/recipes/test_split_step.py
+++ b/tests/recipes/test_split_step.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 import mlflow
 from mlflow.exceptions import MlflowException
-from mlflow.recipes.utils.execution import _MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR
+from mlflow.environment_variables import MLFLOW_RECIPES_EXECUTION_DIRECTORY
 from mlflow.recipes.utils import _RECIPE_CONFIG_FILE_NAME
 from mlflow.utils.file_utils import read_yaml
 from mlflow.recipes.steps.split import (
@@ -49,7 +49,7 @@ def test_split_step_run(tmp_path, monkeypatch):
 
     split_ratios = [0.6, 0.3, 0.1]
 
-    monkeypatch.setenv(_MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR, str(tmp_path))
+    monkeypatch.setenv(MLFLOW_RECIPES_EXECUTION_DIRECTORY.name, str(tmp_path))
     with mock.patch("mlflow.recipes.step.get_recipe_name", return_value="fake_name"):
         split_step = SplitStep(
             {"split_ratios": split_ratios, "target_col": "y", "recipe": "classification/v1"},
@@ -87,7 +87,7 @@ def test_split_step_run_with_multiple_classes(tmp_path, monkeypatch):
 
     split_ratios = [0.6, 0.3, 0.1]
 
-    monkeypatch.setenv(_MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR, str(tmp_path))
+    monkeypatch.setenv(MLFLOW_RECIPES_EXECUTION_DIRECTORY.name, str(tmp_path))
     with mock.patch("mlflow.recipes.step.get_recipe_name", return_value="fake_name"):
         split_step = SplitStep(
             {"split_ratios": split_ratios, "target_col": "y", "recipe": "classification/v1"},
@@ -157,7 +157,7 @@ def test_get_split_df():
 
 
 def test_from_recipe_config_fails_without_target_col(tmp_path, monkeypatch):
-    monkeypatch.setenv(_MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR, str(tmp_path))
+    monkeypatch.setenv(MLFLOW_RECIPES_EXECUTION_DIRECTORY.name, str(tmp_path))
     with mock.patch("mlflow.recipes.step.get_recipe_name", return_value="fake_name"):
         split_step = SplitStep.from_recipe_config({}, "fake_root")
         with pytest.raises(MlflowException, match="Missing target_col config"):
@@ -165,7 +165,7 @@ def test_from_recipe_config_fails_without_target_col(tmp_path, monkeypatch):
 
 
 def test_from_recipe_config_works_with_target_col(tmp_path, monkeypatch):
-    monkeypatch.setenv(_MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR, str(tmp_path))
+    monkeypatch.setenv(MLFLOW_RECIPES_EXECUTION_DIRECTORY.name, str(tmp_path))
     with mock.patch("mlflow.recipes.step.get_recipe_name", return_value="fake_name"):
         assert SplitStep.from_recipe_config({"target_col": "fake_col"}, "fake_root") is not None
 
@@ -187,7 +187,7 @@ def test_split_step_skips_profiling_when_specified(tmp_path, monkeypatch):
     )
     input_dataframe.to_parquet(str(ingest_output_dir / "dataset.parquet"))
 
-    monkeypatch.setenv(_MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR, str(tmp_path))
+    monkeypatch.setenv(MLFLOW_RECIPES_EXECUTION_DIRECTORY.name, str(tmp_path))
     with mock.patch(
         "mlflow.recipes.utils.step.get_pandas_data_profiles"
     ) as mock_profiling, mock.patch(

--- a/tests/recipes/test_transform_step.py
+++ b/tests/recipes/test_transform_step.py
@@ -10,7 +10,7 @@ import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow import MlflowClient
 from mlflow.utils.file_utils import read_yaml
-from mlflow.recipes.utils.execution import _MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR
+from mlflow.environment_variables import MLFLOW_RECIPES_EXECUTION_DIRECTORY
 from mlflow.recipes.utils import _RECIPE_CONFIG_FILE_NAME
 from mlflow.recipes.steps.transform import TransformStep, _validate_user_code_output
 from unittest import mock
@@ -64,7 +64,7 @@ def test_transform_step_writes_onehot_encoded_dataframe_and_transformer_pkl(
 
     m = Mock()
     m.transformer_fn = lambda: StandardScaler()  # pylint: disable=unnecessary-lambda
-    monkeypatch.setenv(_MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR, str(tmp_recipe_root_path))
+    monkeypatch.setenv(MLFLOW_RECIPES_EXECUTION_DIRECTORY.name, str(tmp_recipe_root_path))
     with mock.patch.dict("sys.modules", {"steps.transform": m}):
         transform_step, transform_step_output_dir, _ = set_up_transform_step(
             tmp_recipe_root_path, "transformer_fn"
@@ -107,7 +107,7 @@ def test_transform_steps_work_without_step_config(tmp_recipe_root_path, recipe):
 
 
 def test_transform_empty_step(tmp_recipe_root_path, monkeypatch):
-    monkeypatch.setenv(_MLFLOW_RECIPES_EXECUTION_DIRECTORY_ENV_VAR, str(tmp_recipe_root_path))
+    monkeypatch.setenv(MLFLOW_RECIPES_EXECUTION_DIRECTORY.name, str(tmp_recipe_root_path))
     with mock.patch("steps.transform.transformer_fn", return_value=None):
         transform_step, transform_step_output_dir, split_step_output_dir = set_up_transform_step(
             tmp_recipe_root_path, "transformer_fn"


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
#9228 

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
