### PR TITLE
Enable F402

### DIFF
--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -119,11 +119,7 @@ class DataType(Enum):
 
     @classmethod
     def from_numpy_type(cls, np_type):
-        for dt in cls._member_map_.values():
-            if np_type == dt.to_numpy():
-                return dt
-
-        return None
+        return next((v for v in cls._member_map_.values() if v.to_numpy() == np_type), None)
 
 
 class ColSpec:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ ignore = [
   "E402",  # module-import-not-at-top-of-file
   "E501",  # line-too-long
   "E741",  # ambiguous-variable-name
-  "F402",  # import-shadowed-by-loop-var
   "F403",  # undefined-local-with-import-star
   "F811",  # redefined-while-unused
 ]

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -5,7 +5,6 @@ import time
 import sys
 import pytest
 from collections import namedtuple
-from unittest.mock import Mock, call
 from unittest import mock
 
 import mlflow
@@ -172,7 +171,7 @@ def test_wrap_patch_with_module():
 
 @pytest.fixture
 def logger():
-    return Mock()
+    return mock.Mock()
 
 
 def get_input_example():
@@ -196,8 +195,8 @@ def test_if_getting_input_example_fails(logger):
     assert input_example is None
     assert signature is None
     calls = [
-        call("Failed to gather input example: " + error_msg),
-        call(
+        mock.call("Failed to gather input example: " + error_msg),
++       mock.call(
             "Failed to infer model signature: "
             + "could not sample data to infer model signature: "
             + error_msg

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -196,7 +196,7 @@ def test_if_getting_input_example_fails(logger):
     assert signature is None
     calls = [
         mock.call("Failed to gather input example: " + error_msg),
-+       mock.call(
+        mock.call(
             "Failed to infer model signature: "
             + "could not sample data to infer model signature: "
             + error_msg


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
Resolve https://github.com/mlflow/mlflow/issues/9295

## What changes are proposed in this pull request?

F402 is diabled, but should be enabled. The following is a patch to enable the rule and fixes its violations.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
