### PR TITLE
fix docker example to work on OSX

### DIFF
--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,12 +1,6 @@
 FROM python:3.8
 
-RUN pip install mlflow \
-    && pip install azure-storage-blob \
-    && pip install numpy \
-    && pip install scipy \
-    && pip install pandas \
-    && pip install scikit-learn \
-    && pip install cloudpickle
+RUN pip install mlflow azure-storage-blob numpy scipy pandas scikit-learn cloudpickle
 
-COPY train.py train.py
-COPY wine-quality.csv wine-quality.csv
+COPY train.py .
+COPY wine-quality.csv .

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,9 +1,12 @@
 FROM python:3.8
 
-RUN pip install mlflow>=1.0 \
-    && pip install azure-storage-blob==12.3.0 \
-    && pip install numpy==1.21.2 \
+RUN pip install mlflow \
+    && pip install azure-storage-blob \
+    && pip install numpy \
     && pip install scipy \
-    && pip install pandas==1.3.3 \
-    && pip install scikit-learn==0.24.2 \
+    && pip install pandas \
+    && pip install scikit-learn \
     && pip install cloudpickle
+
+COPY train.py train.py
+COPY wine-quality.csv wine-quality.csv

--- a/examples/docker/README.rst
+++ b/examples/docker/README.rst
@@ -50,6 +50,13 @@ matches the name of the image referenced in the ``MLproject`` file.
 
 Finally, run the example project using ``mlflow run examples/docker -P alpha=0.5``.
 
+.. note::
+    If running this example on M1 / M2 Mac, ensure that Docker Desktop is running and that you are
+    logged in to the Docker service. It is recommended to run this example with the optional
+    'Rosetta' compatibility mode (configured in settings) to ensure that if you make modifications
+    to scikit-learn versions that the appropriate cython compiler will be used to build
+    scikit-learn without errors.
+
 What happens when the project is run?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/examples/docker/README.rst
+++ b/examples/docker/README.rst
@@ -51,11 +51,11 @@ matches the name of the image referenced in the ``MLproject`` file.
 Finally, run the example project using ``mlflow run examples/docker -P alpha=0.5``.
 
 .. note::
-    If running this example on M1 / M2 Mac, ensure that Docker Desktop is running and that you are
-    logged in to the Docker service. It is recommended to run this example with the optional
-    'Rosetta' compatibility mode (configured in settings) to ensure that if you make modifications
-    to scikit-learn versions that the appropriate cython compiler will be used to build
-    scikit-learn without errors.
+    If running this example on a Mac with Apple silicon, ensure that Docker Desktop is running and
+    that you are logged in to the Docker Desktop service.
+    If you are modifying the example ``DockerFile`` to specify older versions of ``scikit-learn``,
+    you should enable `Rosetta compatibility <https://docs.docker.com/desktop/settings/mac/#features-in-development>`_
+    in the Docker Desktop configuration settings to ensure that the appropriate ``cython`` compiler is used.
 
 What happens when the project is run?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
Resolve #9306

## What changes are proposed in this pull request?

Changes to Docker example and README to get the example working for M1/M2 Macs. 
First issue: not declaring that Docker Desktop needs to be running. 
Second issue: not noting that Rosetta is recommended to be turned on for building older scikit-learn versions (the old pinned version needed compilation, which fails on Apple ARM hardware with cython gcc exceptions)
Third issue: pinning a very old version of scikit-learn that isn't available on pypi anymore

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

Tested on M1 Mac with Docker 4.22.0 (both natively and in Rosetta compatibility mode)
Confirmed that the older version of scikit-learn does not compile correctly on M1 hardware.

## Does this PR change the documentation?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [X] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
