### PR TITLE
Mark mleap as deprecated 

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1101,6 +1101,10 @@ For a minimal Sequential model, an example configuration for the pyfunc predict(
 MLeap (``mleap``)
 ^^^^^^^^^^^^^^^^^
 
+.. warning::
+
+    The ``mleap`` model flavor is deprecated as of MLflow 2.6.0 and will be removed in a future release.
+
 The ``mleap`` model flavor supports saving Spark models in MLflow format using the
 `MLeap <https://combust.github.io/mleap-docs/>`_ persistence mechanism. MLeap is an inference-optimized
 format and execution engine for Spark models that does not depend on

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -2,6 +2,10 @@
 The ``mlflow.mleap`` module provides an API for saving Spark MLLib models using the
 `MLeap <https://github.com/combust/mleap>`_ persistence mechanism.
 
+WARNING:
+
+    The mleap flavor is deprecated and will be removed in a future release of MLflow.
+
 NOTE:
 
     You cannot load the MLeap model flavor in Python; you must download it using the
@@ -21,13 +25,14 @@ from mlflow.exceptions import MlflowException
 from mlflow.models.utils import _save_example
 from mlflow.utils import reraise
 from mlflow.utils.file_utils import path_to_local_file_uri
-from mlflow.utils.annotations import keyword_only
+from mlflow.utils.annotations import keyword_only, deprecated
 
 FLAVOR_NAME = "mleap"
 
 _logger = logging.getLogger(__name__)
 
 
+@deprecated(alternative="mlflow.onnx", since="2.6.0")
 @keyword_only
 def log_model(
     spark_model,
@@ -136,6 +141,7 @@ def log_model(
     )
 
 
+@deprecated(alternative="mlflow.onnx", since="2.6.0")
 @keyword_only
 def save_model(
     spark_model,
@@ -221,6 +227,7 @@ def save_model(
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
 
 
+@deprecated(alternative="mlflow.onnx", since="2.6.0")
 @keyword_only
 def add_to_model(mlflow_model, path, spark_model, sample_input):
     """

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -2,11 +2,11 @@
 The ``mlflow.mleap`` module provides an API for saving Spark MLLib models using the
 `MLeap <https://github.com/combust/mleap>`_ persistence mechanism.
 
-WARNING:
+.. warning:
 
     The mleap flavor is deprecated and will be removed in a future release of MLflow.
 
-NOTE:
+.. note:
 
     You cannot load the MLeap model flavor in Python; you must download it using the
     Java API method ``downloadArtifacts(String runId)`` and load the model


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Mark mleap as a deprecated flavor

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

mleap is being marked for deprecation. Please use ONNX as a replacement.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
