### PR TITLE
Add post-merge processing to release-note-category workflow

### DIFF
--- a/.github/workflows/release-note-category.js
+++ b/.github/workflows/release-note-category.js
@@ -1,61 +1,71 @@
-module.exports = async ({ core, context, github }) => {
+async function fetchRepoLabels({ github, owner, repo }) {
+  const { data } = await github.rest.issues.listLabelsForRepo({
+    owner,
+    repo,
+    per_page: 100, // the default value is 30, which is too small to fetch all labels
+  });
+  return data.map(({ name }) => name);
+}
+
+async function fetchPrLabels({ github, owner, repo, issue_number }) {
+  const { data } = await github.rest.issues.listLabelsOnIssue({
+    owner,
+    repo,
+    issue_number,
+  });
+  return data.map(({ name }) => name);
+}
+
+function isReleaseNoteLabel(name) {
+  return name.startsWith("rn/");
+}
+
+async function validateLabeled({ core, context, github }) {
   const { user, html_url: pr_url } = context.payload.pull_request;
   const { owner, repo } = context.repo;
   const { number: issue_number } = context.issue;
 
   // Skip validation on pull requests created by the automation bot
   if (user.login === "mlflow-automation") {
-    console.log("Skipping validation since this pull request was created by the automation bot");
+    console.log("This pull request was created by the automation bot, skipping");
     return;
   }
 
-  // Fetch release note category labels
-  const labelsForRepoResp = await github.rest.issues.listLabelsForRepo({
-    owner,
-    repo,
-    per_page: 100, // the default value is 30, which is too small to fetch all labels
-  });
-  const releaseNoteLabels = labelsForRepoResp.data
-    .map(({ name }) => name)
-    .filter((name) => name.startsWith("rn/"));
-  console.log("Available release note category labels:");
-  console.log(releaseNoteLabels);
+  const repoLabels = await fetchRepoLabels({ github, owner, repo });
+  const releaseNoteLabels = repoLabels.filter(isReleaseNoteLabel);
 
   // Fetch the release-note category labels applied on this PR
-  const getAppliedLabels = async () => {
+  const fetchAppliedLabels = async () => {
     const backoffs = [0, 1, 2, 4, 8, 16];
     for (const [index, backoff] of backoffs.entries()) {
       console.log(`Attempt ${index + 1}/${backoffs.length}`);
       await new Promise((r) => setTimeout(r, backoff * 1000));
-      const listLabelsOnIssueResp = await github.rest.issues.listLabelsOnIssue({
+      const prLabels = await fetchPrLabels({
+        github,
         owner,
         repo,
         issue_number,
       });
-      const appliedLabels = listLabelsOnIssueResp.data
-        .map(({ name }) => name)
-        .filter((name) => releaseNoteLabels.includes(name));
+      const prReleaseNoteLabels = prLabels.filter((name) => releaseNoteLabels.includes(name));
 
-      if (appliedLabels.length > 0) {
-        return appliedLabels;
+      if (prReleaseNoteLabels.length > 0) {
+        return prReleaseNoteLabels;
       }
     }
     return [];
   };
 
-  const appliedLabels = await getAppliedLabels();
-  console.log("Release note category labels applied to this PR:");
-  console.log(appliedLabels);
+  const prReleaseNoteLabels = await fetchAppliedLabels();
 
   // If no release note category label is applied to this PR, set the action status to "failed"
-  if (appliedLabels.length === 0) {
+  if (prReleaseNoteLabels.length === 0) {
     // Make sure '.github/pull_request_template.md' contains an HTML anchor with this name
     const anchorName = "release-note-category";
 
     // Fragmented URL to jump to the release note category section in the PR description
     const anchorUrl = `${pr_url}#user-content-${anchorName}`;
     const message = [
-      "No release note category label is applied to this PR. ",
+      "No release-note label is applied to this PR. ",
       `Please select a checkbox in the release note category section: ${anchorUrl} `,
       "or manually apply a release note category label (e.g. 'rn/bug-fix') ",
       "if you're a maintainer of this repository. ",
@@ -64,4 +74,56 @@ module.exports = async ({ core, context, github }) => {
     ].join("");
     core.setFailed(message);
   }
+}
+
+async function postMerge({ context, github }) {
+  const { user } = context.payload.pull_request;
+  const { owner, repo } = context.repo;
+  const { number: issue_number } = context.issue;
+
+  if (user.login === "mlflow-automation") {
+    console.log("This PR was created by the automation bot, skipping");
+    return;
+  }
+
+  const repoLabels = await fetchRepoLabels({ github, owner, repo });
+  const releaseNoteLabels = repoLabels.filter(isReleaseNoteLabel);
+  const prLabels = await fetchPrLabels({
+    github,
+    owner,
+    repo,
+    issue_number,
+  });
+  const prReleaseNoteLabels = prLabels.filter((name) => releaseNoteLabels.includes(name));
+
+  if (prReleaseNoteLabels.length === 0) {
+    const pull = await github.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: issue_number,
+    });
+    const { login: mergedBy } = pull.data.merged_by;
+    const noneLabel = "rn/none";
+    const body = [
+      `@${mergedBy} This PR is missing a release-note label, adding \`${noneLabel}\`. `,
+      "If this label is incorrect, please replace it with the correct label.",
+    ].join("");
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number,
+      body,
+    });
+    await github.rest.issues.addLabels({
+      owner,
+      repo,
+      issue_number,
+      labels: [noneLabel],
+    });
+  }
+}
+
+module.exports = {
+  validateLabeled,
+  postMerge,
 };

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -10,6 +10,7 @@ on:
       - reopened
       - labeled
       - unlabeled
+      - closed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
@@ -20,7 +21,7 @@ defaults:
     shell: bash --noprofile --norc -exo pipefail {0}
 
 jobs:
-  validate:
+  job:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -28,13 +29,22 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Validate
+      - name: validate-labeled
         uses: actions/github-script@v6
+        if: ${{ github.event.action != 'closed' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             // https://github.com/actions/github-script#run-a-separate-file
-            const script = require(
-              `${process.env.GITHUB_WORKSPACE}/.github/workflows/release-note-category.js`
-            );
-            script({ core, context, github });
+            const script = require("./.github/workflows/release-note-category.js");
+            await script({ core, context, github });
+
+      - name: post-merge
+        uses: actions/github-script@v6
+        if: ${{ github.event.action == 'closed' && github.event.pull_request.merged == true }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // https://github.com/actions/github-script#run-a-separate-file
+            const script = require("./.github/workflows/release-note-category.js");
+            await script.postMerge({ core, context, github });

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -24,7 +24,7 @@ jobs:
   validate-labeled:
     if: github.event.pull_request.draft == false && github.event.action == 'closed'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
         with:
@@ -41,7 +41,7 @@ jobs:
   post-merge:
     if: github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - name: post-merge
         uses: actions/github-script@v6

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -10,6 +10,8 @@ on:
       - reopened
       - labeled
       - unlabeled
+  pull_request_target:
+    types:
       - closed
 
 concurrency:

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -21,8 +21,8 @@ defaults:
     shell: bash --noprofile --norc -exo pipefail {0}
 
 jobs:
-  main:
-    if: github.event.pull_request.draft == false
+  validate-labeled:
+    if: github.event.pull_request.draft == false && github.event.action == 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -31,7 +31,6 @@ jobs:
           submodules: recursive
       - name: validate-labeled
         uses: actions/github-script@v6
-        if: ${{ github.event.action != 'closed' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -39,9 +38,13 @@ jobs:
             const script = require("./.github/workflows/release-note-category.js");
             await script({ core, context, github });
 
+  post-merge:
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
       - name: post-merge
         uses: actions/github-script@v6
-        if: ${{ github.event.action == 'closed' && github.event.pull_request.merged == true }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -10,7 +10,7 @@ on:
       - reopened
       - labeled
       - unlabeled
-  # post-merge job requires write access to add a label
+  # post-merge job requires write access to add a label and post a comment.
   pull_request_target:
     types:
       - closed

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -21,7 +21,7 @@ defaults:
     shell: bash --noprofile --norc -exo pipefail {0}
 
 jobs:
-  job:
+  main:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -10,6 +10,7 @@ on:
       - reopened
       - labeled
       - unlabeled
+  # post-merge job requires write access to add a label
   pull_request_target:
     types:
       - closed


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add post-merge processing to the release-note-category workflow to ensure the PR is labeled.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
