### PR TITLE
Migrate `MLFLOW_CONDA_HOME`

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -370,6 +370,11 @@ MLFLOW_ENABLE_ARTIFACTS_PROGRESS_BAR = _BooleanEnvironmentVariable(
     "MLFLOW_ENABLE_ARTIFACTS_PROGRESS_BAR", True
 )
 
+# Environment variable indicating a path to a conda installation. MLflow will default to running
+# "conda" if unset
+MLFLOW_CONDA_HOME = _EnvironmentVariable("MLFLOW_CONDA_HOME", str, "conda")
+
+
 #: Specifies the name of the command to use when creating the environments.
 #: For example, let's say we want to use mamba (https://github.com/mamba-org/mamba)
 #: instead of conda to create environments.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -63,7 +63,7 @@ class _BooleanEnvironmentVariable(_EnvironmentVariable):
         super().__init__(name, bool, default)
 
     def get(self):
-        if not self.define:
+        if not self.defined:
             return self.default
 
         val = os.getenv(self.name)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -16,7 +16,7 @@ class _EnvironmentVariable:
         self.default = default
 
     @property
-    def is_defined(self):
+    def defined(self):
         return self.name in os.environ
 
     def get_raw(self):
@@ -63,7 +63,7 @@ class _BooleanEnvironmentVariable(_EnvironmentVariable):
         super().__init__(name, bool, default)
 
     def get(self):
-        if not self.is_defined:
+        if not self.define:
             return self.default
 
         val = os.getenv(self.name)
@@ -370,10 +370,9 @@ MLFLOW_ENABLE_ARTIFACTS_PROGRESS_BAR = _BooleanEnvironmentVariable(
     "MLFLOW_ENABLE_ARTIFACTS_PROGRESS_BAR", True
 )
 
-# Environment variable indicating a path to a conda installation. MLflow will default to running
-# "conda" if unset
-MLFLOW_CONDA_HOME = _EnvironmentVariable("MLFLOW_CONDA_HOME", str, "conda")
-
+#: Specifies the conda home directory to use.
+#: (default: ``conda``)
+MLFLOW_CONDA_HOME = _EnvironmentVariable("MLFLOW_CONDA_HOME", str, None)
 
 #: Specifies the name of the command to use when creating the environments.
 #: For example, let's say we want to use mamba (https://github.com/mamba-org/mamba)

--- a/mlflow/utils/conda.py
+++ b/mlflow/utils/conda.py
@@ -13,6 +13,14 @@ from mlflow.environment_variables import MLFLOW_CONDA_CREATE_ENV_CMD
 # Environment variable indicating a path to a conda installation. MLflow will default to running
 # "conda" if unset
 MLFLOW_CONDA_HOME = "MLFLOW_CONDA_HOME"
+# Environment variable indicated the name of the command that should be used to create environments.
+# If it is unset, it will default to "conda". This command must be in the $PATH when the user runs,
+# or within MLFLOW_CONDA_HOME if that is set. For example, let's say we want to use mamba
+# (https://github.com/mamba-org/mamba) instead of conda to create environments. Then:
+# > conda install mamba -n base -c conda-forge
+# > MLFLOW_CONDA_CREATE_ENV_CMD="mamba"
+# > mlflow run ...
+MLFLOW_CONDA_CREATE_ENV_CMD = "MLFLOW_CONDA_CREATE_ENV_CMD"
 
 _logger = logging.getLogger(__name__)
 

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -5,6 +5,6 @@ from mlflow.environment_variables import MLFLOW_TRACKING_URI
 
 @pytest.fixture(autouse=True)
 def use_sqlite_if_tracking_uri_env_var_is_not_set(tmp_path, monkeypatch):
-    if not MLFLOW_TRACKING_URI.is_defined:
+    if not MLFLOW_TRACKING_URI.defined:
         sqlite_file = tmp_path / "mlruns.sqlite"
         monkeypatch.setenv(MLFLOW_TRACKING_URI.name, f"sqlite:///{sqlite_file}")

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -32,11 +32,8 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_PROJECT_ENV,
 )
 from mlflow.utils.process import ShellCommandException
-from mlflow.utils.conda import (
-    get_or_create_conda_env,
-    MLFLOW_CONDA_HOME,
-)
-from mlflow.environment_variables import MLFLOW_CONDA_CREATE_ENV_CMD
+from mlflow.utils.conda import get_or_create_conda_env, CONDA_EXE
+from mlflow.environment_variables import MLFLOW_CONDA_HOME, MLFLOW_CONDA_CREATE_ENV_CMD
 from mlflow.utils import PYTHON_VERSION
 
 from tests.projects.utils import TEST_PROJECT_DIR, TEST_PROJECT_NAME, validate_exit_status
@@ -282,12 +279,12 @@ def test_run_async():
     ("mock_env", "expected_conda", "expected_activate"),
     [
         (
-            {"CONDA_EXE": "/abc/conda"},
+            {CONDA_EXE: "/abc/conda"},
             "/abc/conda",
             "/abc/activate",
         ),
         (
-            {MLFLOW_CONDA_HOME: "/some/dir/"},
+            {MLFLOW_CONDA_HOME.name: "/some/dir/"},
             "/some/dir/bin/conda",
             "/some/dir/bin/activate",
         ),
@@ -295,7 +292,7 @@ def test_run_async():
 )
 def test_conda_path(mock_env, expected_conda, expected_activate, monkeypatch):
     """Verify that we correctly determine the path to conda executables"""
-    monkeypatch.delenvs(["CONDA_EXE", MLFLOW_CONDA_HOME], raising=False)
+    monkeypatch.delenvs([CONDA_EXE, MLFLOW_CONDA_HOME.name], raising=False)
     monkeypatch.setenvs(mock_env)
     assert mlflow.utils.conda.get_conda_bin_executable("conda") == expected_conda
     assert mlflow.utils.conda.get_conda_bin_executable("activate") == expected_activate
@@ -305,19 +302,19 @@ def test_conda_path(mock_env, expected_conda, expected_activate, monkeypatch):
     ("mock_env", "expected_conda_env_create_path"),
     [
         (
-            {"CONDA_EXE": "/abc/conda"},
+            {CONDA_EXE: "/abc/conda"},
             "/abc/conda",
         ),
         (
-            {"CONDA_EXE": "/abc/conda", MLFLOW_CONDA_CREATE_ENV_CMD.name: "mamba"},
+            {CONDA_EXE: "/abc/conda", MLFLOW_CONDA_CREATE_ENV_CMD.name: "mamba"},
             "/abc/mamba",
         ),
         (
-            {MLFLOW_CONDA_HOME: "/some/dir/"},
+            {MLFLOW_CONDA_HOME.name: "/some/dir/"},
             "/some/dir/bin/conda",
         ),
         (
-            {MLFLOW_CONDA_HOME: "/some/dir/", MLFLOW_CONDA_CREATE_ENV_CMD.name: "mamba"},
+            {MLFLOW_CONDA_HOME.name: "/some/dir/", MLFLOW_CONDA_CREATE_ENV_CMD.name: "mamba"},
             "/some/dir/bin/mamba",
         ),
     ],
@@ -328,7 +325,7 @@ def test_find_conda_executables(mock_env, expected_conda_env_create_path, monkey
     create environments (for example, it could be mamba instead of conda)
     """
     monkeypatch.delenvs(
-        ["CONDA_EXE", MLFLOW_CONDA_HOME, MLFLOW_CONDA_CREATE_ENV_CMD.name], raising=False
+        [CONDA_EXE, MLFLOW_CONDA_HOME.name, MLFLOW_CONDA_CREATE_ENV_CMD.name], raising=False
     )
     monkeypatch.setenvs(mock_env)
     conda_env_create_path = mlflow.utils.conda._get_conda_executable_for_create_env()

--- a/tests/test_environment_variables.py
+++ b/tests/test_environment_variables.py
@@ -67,7 +67,7 @@ def test_environment_variable_functionality(
     env_var = _EnvironmentVariable(var_name, var_type, default_value)
 
     # Test if variable is defined
-    assert env_var.is_defined == (var_value is not None)
+    assert env_var.defined == (var_value is not None)
 
     # Test getting raw value
     assert env_var.get_raw() == expected_raw

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -183,8 +183,8 @@ def test_all_fluent_apis_are_included_in_dunder_all():
 
 def test_get_experiment_id_from_env(monkeypatch):
     # When no env variables are set
-    assert not MLFLOW_EXPERIMENT_NAME.is_defined
-    assert not MLFLOW_EXPERIMENT_ID.is_defined
+    assert not MLFLOW_EXPERIMENT_NAME.defined
+    assert not MLFLOW_EXPERIMENT_ID.defined
     assert _get_experiment_id_from_env() is None
 
     # set only ID


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->

#9315 

## What changes are proposed in this pull request?

As per the issue I had to migrate the env variable to environments_variables.py, and I just
added the environment variable in the environments_variables.py file.
And some description about this

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
