### PR TITLE
Fix errors in doc examples for AI Gateway create_route

### DIFF
--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -173,15 +173,13 @@ class MlflowGatewayClient:
             openai_api_key = ...
 
             new_route = gateway_client.create_route(
-                "my-new-route",
-                "llm/v1/completions",
-                {
-                    "name": "question-answering-bot-1",
+                name="my-route",
+                route_type="llm/v1/completions",
+                model={
+                    "name": "question-answering-bot",
                     "provider": "openai",
-                    "config": {
+                    "openai_config": {
                         "openai_api_key": openai_api_key,
-                        "openai_api_version": "2023-05-10",
-                        "openai_api_type": "openai/v1/chat/completions",
                     },
                 },
             )
@@ -287,6 +285,25 @@ class MlflowGatewayClient:
             response = gateway_client.query(
                 "my-embeddings-route",
                 {"text": ["It was the best of times", "It was the worst of times"]},
+            )
+
+        Additional parameters that are valid for a given provider and route configuration can be
+        included with the request as shown below, using an openai completions route request as
+        an example:
+
+        .. code-block:: python
+
+            from mlflow.gateway import MlflowGatewayClient
+
+            gateway_client = MlflowGatewayClient("http://my.gateway:8888")
+
+            response = gateway_client.query(
+                "my-completions-route",
+                {
+                    "prompt": "Give me an example of a properly formatted pytest unit test",
+                    "temperature": 0.3,
+                    "max_tokens": 500,
+                },
             )
 
         """

--- a/mlflow/gateway/fluent.py
+++ b/mlflow/gateway/fluent.py
@@ -87,15 +87,13 @@ def create_route(name: str, route_type: str, model: Dict[str, Any]) -> Route:
         openai_api_key = ...
 
         create_route(
-            "my-new-route",
-            "llm/v1/completions",
-            {
-                "name": "question-answering-bot-1",
+            name="my-route",
+            route_type="llm/v1/completions",
+            model={
+                "name": "question-answering-bot",
                 "provider": "openai",
-                "config": {
+                "openai_config": {
                     "openai_api_key": openai_api_key,
-                    "openai_api_version": "2023-05-10",
-                    "openai_api_type": "openai/v1/chat/completions",
                 },
             },
         )
@@ -175,5 +173,24 @@ def query(route: str, data):
         response = query(
             "embeddings_route", {"text": ["I like spaghetti", "and sushi", "but not together"]}
         )
+
+    Additional parameters that are valid for a given provider and route configuration can be
+    included with the request as shown below, using an openai completions route request as
+    an example:
+
+    .. code-block:: python
+
+        from mlflow.gateway import query, set_gateway_uri
+
+        set_gateway_uri(gateway_uri="http://my.gateway:9000")
+        response = query(
+            "a_completions_route",
+            {
+                "prompt": "Give me an example of a properly formatted pytest unit test",
+                "temperature": 0.6,
+                "max_tokens": 1000,
+            },
+        )
+
     """
     return MlflowGatewayClient().query(route, data)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix errors in doc examples for AI Gateway create_route

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
