### PR TITLE
Support pydantic v1 and v2 for AI gateway

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   gateway:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    # if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -28,5 +28,11 @@ jobs:
           pip install -e .[gateway]
           pip install pytest pytest-timeout pytest-asyncio httpx sentence-transformers transformers
       - name: Run tests
+        run: |
+          pytest tests/gateway
+      - name: Upgrade pydantic and fastapi
+        run: |
+          pip install --upgrade pydantic fastapi
+      - name: Run tests again
         run: |
           pytest tests/gateway

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -27,12 +27,16 @@ jobs:
         run: |
           pip install -e .[gateway]
           pip install pytest pytest-timeout pytest-asyncio httpx sentence-transformers transformers
-      - name: Run tests
+          # Ensure pydantic v1 is installed
+          pip freeze | tail -n +1 | grep -q '^pydantic==1\.'
+      - name: Run tests with pydantic v1
         run: |
           pytest tests/gateway
-      - name: Upgrade pydantic and fastapi
+      - name: Upgrade pydantic to v2
         run: |
-          pip install --upgrade pydantic fastapi
-      - name: Run tests again
+          pip install pydantic>=2.0
+          # Ensure pydantic v2 is installed
+          pip freeze | tail -n +1 | grep -q '^pydantic==2\.'
+      - name: Run tests with pydantic v2
         run: |
           pytest tests/gateway

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -34,7 +34,7 @@ jobs:
           pytest tests/gateway
       - name: Upgrade pydantic to v2
         run: |
-          pip install pydantic>=2.0
+          pip install 'pydantic>=2.0'
           # Ensure pydantic v2 is installed
           pip freeze | tail -n +1 | grep -q '^pydantic==2\.'
       - name: Run tests with pydantic v2

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   gateway:
-    # if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/mlflow/gateway/app.py
+++ b/mlflow/gateway/app.py
@@ -104,7 +104,7 @@ class HealthResponse(BaseModel):
 
 class SearchRoutesResponse(BaseModel):
     routes: List[Route]
-    next_page_token: Optional[str]
+    next_page_token: Optional[str] = None
 
     class Config:
         schema_extra = {

--- a/mlflow/gateway/base_models.py
+++ b/mlflow/gateway/base_models.py
@@ -1,11 +1,11 @@
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel
 
 
 class RequestModel(
     BaseModel,
     # Allow extra fields for pydantic request models, e.g. to support
     # vendor-specific embeddings parameters
-    extra=Extra.allow,
+    extra="allow",
 ):
     """
     A pydantic model representing Gateway request data, such as a chat or completions request
@@ -16,7 +16,7 @@ class ResponseModel(
     BaseModel,
     # Ignore extra fields for pydantic response models to ensure a consistent response
     # experience for clients across different backends
-    extra=Extra.ignore,
+    extra="ignore",
 ):
     """
     A pydantic model representing Gateway response data, such as information about a Gateway
@@ -27,7 +27,7 @@ class ResponseModel(
 class ConfigModel(
     BaseModel,
     # Ignore extra fields for pydantic config models, since they are unused
-    extra=Extra.ignore,
+    extra="ignore",
 ):
     """
     A pydantic model representing Gateway configuration data, such as an OpenAI completions

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -18,7 +18,7 @@ from packaging import version
 
 _logger = logging.getLogger(__name__)
 
-IS_PYDANTIC_V2 = version.parse(pydantic.__version__) >= version.parse("2.0")
+IS_PYDANTIC_V2 = version.parse(pydantic.version.VERSION) >= version.parse("2.0")
 
 
 class Provider(str, Enum):

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -113,16 +113,16 @@ class OpenAIConfig(ConfigModel):
         return info
 
     if IS_PYDANTIC_V2:
-        from pydantic import model_validator
+        from pydantic import model_validator as _model_validator
 
-        @model_validator(mode="before")
+        @_model_validator(mode="before")
         def validate_field_compatibility(cls, info: Dict[str, Any]):
             return cls._validate_field_compatibility(info)
 
     else:
-        from pydantic import root_validator
+        from pydantic import root_validator as _root_validator
 
-        @root_validator(pre=False)
+        @_root_validator(pre=False)
         def validate_field_compatibility(cls, config: Dict[str, Any]):
             return cls._validate_field_compatibility(config)
 

--- a/mlflow/gateway/providers/mlflow.py
+++ b/mlflow/gateway/providers/mlflow.py
@@ -1,6 +1,6 @@
 from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
-from pydantic import BaseModel, validator, StrictStr, ValidationError
+from pydantic import BaseModel, validator, StrictStr, ValidationError, StrictFloat
 from typing import List
 
 
@@ -34,7 +34,7 @@ class ServingTextResponse(BaseModel):
 
 
 class EmbeddingsResponse(BaseModel):
-    predictions: List[List[float]]
+    predictions: List[List[StrictFloat]]
 
     @validator("predictions", pre=True)
     def validate_predictions(cls, predictions):

--- a/mlflow/gateway/providers/mlflow.py
+++ b/mlflow/gateway/providers/mlflow.py
@@ -1,6 +1,6 @@
 from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
-from pydantic import BaseModel, validator, StrictStr, ValidationError, StrictFloat
+from pydantic import BaseModel, validator, StrictStr, ValidationError
 from typing import List
 
 
@@ -44,7 +44,7 @@ class EmbeddingsResponse(BaseModel):
             isinstance(item, list) and not item for item in predictions
         ):
             raise ValueError("One or more lists in the returned prediction response are empty")
-        elif all(isinstance(item, (float, StrictFloat)) for item in predictions):
+        elif all(isinstance(item, float) for item in predictions):
             return [predictions]
         else:
             return predictions

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import Field, Extra
+from pydantic import Field
 
 from mlflow.gateway.base_models import RequestModel, ResponseModel
 from mlflow.gateway.config import RouteType
@@ -49,8 +49,8 @@ class ResponseMessage(ResponseModel):
     content: str
 
 
-class CandidateMetadata(ResponseModel, extra=Extra.allow):
-    finish_reason: Optional[FinishReason]
+class CandidateMetadata(ResponseModel, extra="allow"):
+    finish_reason: Optional[FinishReason] = None
 
 
 class Candidate(ResponseModel):
@@ -59,9 +59,9 @@ class Candidate(ResponseModel):
 
 
 class Metadata(ResponseModel):
-    input_tokens: Optional[int]
-    output_tokens: Optional[int]
-    total_tokens: Optional[int]
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
     model: str
     route_type: RouteType
 

--- a/mlflow/gateway/schemas/completions.py
+++ b/mlflow/gateway/schemas/completions.py
@@ -30,9 +30,9 @@ class Candidate(ResponseModel):
 
 
 class Metadata(ResponseModel):
-    input_tokens: Optional[int]
-    output_tokens: Optional[int]
-    total_tokens: Optional[int]
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
     model: str
     route_type: RouteType
 

--- a/mlflow/gateway/schemas/completions.py
+++ b/mlflow/gateway/schemas/completions.py
@@ -21,12 +21,12 @@ class RequestPayload(BaseRequestPayload):
 
 
 class CandidateMetadata(ResponseModel):
-    finish_reason: Optional[FinishReason]
+    finish_reason: Optional[FinishReason] = None
 
 
 class Candidate(ResponseModel):
     text: str
-    metadata: Optional[Dict[str, str]]
+    metadata: Optional[Dict[str, str]] = None
 
 
 class Metadata(ResponseModel):

--- a/mlflow/gateway/schemas/embeddings.py
+++ b/mlflow/gateway/schemas/embeddings.py
@@ -16,9 +16,9 @@ class RequestPayload(RequestModel):
 
 
 class Metadata(ResponseModel):
-    input_tokens: Optional[int]
-    output_tokens: Optional[int]
-    total_tokens: Optional[int]
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
     model: str
     route_type: RouteType
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -p no:legacypath --exitfirst --color=yes --durations=10 --showlocals -vv
+addopts = -p no:legacypath --color=yes --durations=10 --showlocals -vv
 filterwarnings =
   # Prevent deprecated numpy type aliases from being used
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:mlflow

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -p no:legacypath --color=yes --durations=10 --showlocals -vv
+addopts = -p no:legacypath --exitfirst --color=yes --durations=10 --showlocals -vv
 filterwarnings =
   # Prevent deprecated numpy type aliases from being used
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:mlflow

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -216,6 +216,5 @@ async def test_completions_throws_if_prompt_contains_non_string(prompt):
     config = completions_config()
     provider = AnthropicProvider(RouteConfig(**config))
     payload = {"prompt": prompt}
-    with pytest.raises(ValidationError, match=r".*") as e:
+    with pytest.raises(ValidationError, match=r"prompt"):
         await provider.completions(completions.RequestPayload(**payload))
-    assert "str type expected" in e.value.errors()[0]["msg"]

--- a/tests/gateway/providers/test_cohere.py
+++ b/tests/gateway/providers/test_cohere.py
@@ -177,6 +177,5 @@ async def test_completions_throws_if_prompt_contains_non_string(prompt):
     config = completions_config()
     provider = CohereProvider(RouteConfig(**config))
     payload = {"prompt": prompt}
-    with pytest.raises(ValidationError, match=r".*") as e:
+    with pytest.raises(ValidationError, match=r"prompt"):
         await provider.completions(completions.RequestPayload(**payload))
-    assert "str type expected" in e.value.errors()[0]["msg"]

--- a/tests/gateway/providers/test_mlflow.py
+++ b/tests/gateway/providers/test_mlflow.py
@@ -129,10 +129,7 @@ def test_invalid_return_key_from_mlflow_serving():
             {"invalid_return_key": ["invalid", "response"]}
         )
 
-    assert (
-        "1 validation error for ServingTextResponse\npredictions\n  field required"
-        in e.value.detail
-    )
+    assert "1 validation error for ServingTextResponse\npredictions" in e.value.detail
     assert e.value.status_code == 502
 
 
@@ -276,5 +273,5 @@ async def test_chat_exception_raised_for_multiple_elements_in_query():
 
 
 def test_route_construction_fails_with_invalid_config():
-    with pytest.raises(pydantic.ValidationError, match="none is not an allowed"):
+    with pytest.raises(pydantic.ValidationError, match="model_server_url"):
         MlflowModelServingConfig(model_server_url=None)

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -197,9 +197,8 @@ async def test_completions_throws_if_prompt_contains_non_string(prompt):
     config = completions_config()
     provider = OpenAIProvider(RouteConfig(**config))
     payload = {"prompt": prompt}
-    with pytest.raises(ValidationError, match=r".*") as e:
+    with pytest.raises(ValidationError, match=r"prompt"):
         await provider.completions(completions.RequestPayload(**payload))
-    assert "str type expected" in e.value.errors()[0]["msg"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/schemas/test_chat.py
+++ b/tests/gateway/schemas/test_chat.py
@@ -17,7 +17,7 @@ def test_chat_request():
         }
     )
 
-    with pytest.raises(pydantic.ValidationError, match="at least 1 items"):
+    with pytest.raises(pydantic.ValidationError, match="at least 1 item"):
         chat.RequestPayload(
             **{
                 "messages": [{"role": "user", "content": "content"}],
@@ -25,10 +25,10 @@ def test_chat_request():
             }
         )
 
-    with pytest.raises(pydantic.ValidationError, match="at least 1 items"):
+    with pytest.raises(pydantic.ValidationError, match="at least 1 item"):
         chat.RequestPayload(**{"messages": []})
 
-    with pytest.raises(pydantic.ValidationError, match="field required"):
+    with pytest.raises(pydantic.ValidationError, match=r"(?i)field required"):
         chat.RequestPayload(**{})
 
 
@@ -68,5 +68,5 @@ def test_chat_response():
         }
     )
 
-    with pytest.raises(pydantic.ValidationError, match="field required"):
+    with pytest.raises(pydantic.ValidationError, match=r"(?i)field required"):
         chat.ResponsePayload(**{"metadata": {}})

--- a/tests/gateway/schemas/test_completions.py
+++ b/tests/gateway/schemas/test_completions.py
@@ -9,10 +9,10 @@ def test_completions_request():
     completions.RequestPayload(**{"prompt": ""})
     completions.RequestPayload(**{"prompt": "", "extra": "extra"})
 
-    with pytest.raises(pydantic.ValidationError, match="field required"):
+    with pytest.raises(pydantic.ValidationError, match=r"(?i)field required"):
         completions.RequestPayload(**{"extra": "extra"})
 
-    with pytest.raises(pydantic.ValidationError, match="field required"):
+    with pytest.raises(pydantic.ValidationError, match=r"(?i)field required"):
         completions.RequestPayload(**{})
 
 
@@ -47,5 +47,5 @@ def test_completions_response():
         }
     )
 
-    with pytest.raises(pydantic.ValidationError, match="field required"):
+    with pytest.raises(pydantic.ValidationError, match=r"(?i)field required"):
         completions.ResponsePayload(**{"metadata": {}})

--- a/tests/gateway/schemas/test_embeddings.py
+++ b/tests/gateway/schemas/test_embeddings.py
@@ -10,7 +10,7 @@ def test_embeddings_request():
     embeddings.RequestPayload(**{"text": ["prompt"]})
     embeddings.RequestPayload(**{"text": "text", "extra": "extra", "another_extra": 1})
 
-    with pytest.raises(pydantic.ValidationError, match="field required"):
+    with pytest.raises(pydantic.ValidationError, match=r"(?i)field required"):
         embeddings.RequestPayload(**{})
 
 
@@ -40,5 +40,5 @@ def test_embeddings_response():
         }
     )
 
-    with pytest.raises(pydantic.ValidationError, match="field required"):
+    with pytest.raises(pydantic.ValidationError, match=r"(?i)field required"):
         embeddings.ResponsePayload(**{"metadata": {}})

--- a/tests/gateway/test_cli.py
+++ b/tests/gateway/test_cli.py
@@ -46,4 +46,4 @@ routes:
     )
     assert res.exit_code == 2
     assert "The gateway configuration is invalid" in res.output
-    assert "none is not an allowed value" in res.output
+    assert "routes" in res.output


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #9337

## What changes are proposed in this pull request?

Support pydantic v1 and v2 for AI gateway.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
