### PR TITLE
Avoid using `Enum` in `Route` model to accept unknown values

### DIFF
--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -281,7 +281,8 @@ class RouteConfig(ConfigModel):
 
 class RouteModelInfo(ResponseModel):
     name: Optional[str] = None
-    # Use a string instead of an enum to accept new providers the client may not know about yet.
+    # Use `str` instead of `Provider` enum to allow gateway backends such as Databricks to
+    # support new providers without breaking the gateway client.
     provider: str
 
 

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -279,7 +279,7 @@ class RouteConfig(ConfigModel):
         )
 
 
-class RouteModel(ResponseModel):
+class RouteModelInfo(ResponseModel):
     name: Optional[str] = None
     # Override the provider field to be a string instead of an enum to
     # allow for new providers to be added without breaking the gateway.
@@ -289,7 +289,7 @@ class RouteModel(ResponseModel):
 class Route(ResponseModel):
     name: str
     route_type: str
-    model: RouteModel
+    model: RouteModelInfo
     route_url: str
 
     class Config:

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -271,7 +271,7 @@ class RouteConfig(ConfigModel):
         return Route(
             name=self.name,
             route_type=self.route_type,
-            model=ModelInfo(
+            model=RouteModelInfo(
                 name=self.model.name,
                 provider=self.model.provider,
             ),

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -279,10 +279,17 @@ class RouteConfig(ConfigModel):
         )
 
 
+class RouteModel(ResponseModel):
+    name: Optional[str] = None
+    # Override the provider field to be a string instead of an enum to
+    # allow for new providers to be added without breaking the gateway.
+    provider: str
+
+
 class Route(ResponseModel):
     name: str
-    route_type: RouteType
-    model: ModelInfo
+    route_type: str
+    model: RouteModel
     route_url: str
 
     class Config:

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -281,8 +281,7 @@ class RouteConfig(ConfigModel):
 
 class RouteModelInfo(ResponseModel):
     name: Optional[str] = None
-    # Override the provider field to be a string instead of an enum to
-    # allow for new providers to be added without breaking the gateway.
+    # Use a string instead of an enum to accept new providers the client may not know about yet.
     provider: str
 
 

--- a/tests/gateway/test_fluent.py
+++ b/tests/gateway/test_fluent.py
@@ -248,3 +248,50 @@ def test_fluent_query_with_disallowed_param(gateway):
 
     with pytest.raises(HTTPError, match=".*The parameter 'model' is not permitted.*"):
         query(route=route.name, data=data)
+
+
+def test_get_route_accepts_unknown_provider():
+    set_gateway_uri("http://localhost:5000")
+    mock_resp = mock.Mock(status_code=200)
+    mock_resp.json.return_value = {
+        "name": "chat",
+        "route_type": "llm/v1/chat",
+        "model": {"name": "unknown-5", "provider": "unknown-ai"},
+        "route_url": "http://localhost:5000/gateway/chat/invocations",
+    }
+    with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
+        route = get_route("chat")
+        mock_request.assert_called_once()
+        assert route.dict() == {
+            "name": "chat",
+            "route_type": "llm/v1/chat",
+            "model": {"name": "unknown-5", "provider": "unknown-ai"},
+            "route_url": "http://localhost:5000/gateway/chat/invocations",
+        }
+
+
+def test_search_routes_accepts_unknown_provider():
+    set_gateway_uri("http://localhost:5000")
+    mock_resp = mock.Mock(status_code=200)
+    mock_resp.json.return_value = {
+        "routes": [
+            {
+                "name": "chat",
+                "route_type": "llm/v1/chat",
+                "model": {"name": "unknown-5", "provider": "unknown-ai"},
+                "route_url": "http://localhost:5000/gateway/chat/invocations",
+            },
+        ],
+        "next_page_token": None,
+    }
+    with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
+        routes = search_routes()
+        mock_request.assert_called_once()
+        assert [r.dict() for r in routes] == [
+            {
+                "name": "chat",
+                "route_type": "llm/v1/chat",
+                "model": {"name": "unknown-5", "provider": "unknown-ai"},
+                "route_url": "http://localhost:5000/gateway/chat/invocations",
+            }
+        ]


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Avoid using `Enum` in `Route` model to accept unknown values.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
