### PR TITLE
Add `evaluate` extra to specify extra dependencies required for `mlflow.evaluate`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -286,7 +286,7 @@ jobs:
       - name: Install dependencies
         run: |
           source ./dev/install-common-deps.sh
-          pip install pyspark "numpy<1.24.0" torch transformers
+          pip install pyspark '.[evaluate]'
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -286,7 +286,7 @@ jobs:
       - name: Install dependencies
         run: |
           source ./dev/install-common-deps.sh
-          pip install pyspark '.[evaluate]'
+          pip install '.[evaluate]' pyspark
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1271,6 +1271,9 @@ def evaluate(
 
             pip install 'mlflow[evaluate]'
 
+        Note that this is optional. `mlflow.evaluate` works without the extra dependencies
+        installed. However, some metrics and artifacts will not be logged.
+
     :param model: A pyfunc model instance, or a URI referring to such a model.
 
     :param data: One of the following:

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1262,6 +1262,15 @@ def evaluate(
           specified, unless the ``evaluator_config`` option **log_model_explainability** is
           explicitly set to ``True``.
 
+    .. note::
+
+        To compute and log a full set of metrics and artifacts supported by the default
+        evaluator, use the following command to install required extra dependencies:
+
+        .. code-block:: bash
+
+            pip install 'mlflow[evaluate]'
+
     :param model: A pyfunc model instance, or a URI referring to such a model.
 
     :param data: One of the following:

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -27,13 +27,6 @@ huggingface_hub
 # Pinned due to protobuf requirement pinning in 1.3.0 of ml-server that is incompatible
 mlserver>=1.2.0,!=1.3.1
 mlserver-mlflow>=1.2.0,!=1.3.1
-# Required by evaluator tests
-shap
-# Required to evaluate language models in `mlflow.evaluate`
-evaluate
-nltk
-rouge_score
-textstat
 # Required by progress bar tests
 ipywidgets
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -171,6 +171,17 @@ setup(
             "boto3>1",
         ],
         "gateway": GATEWAY_REQUIREMENTS,
+        # Extra dependencies required for `mlflow.evaluate`
+        "evaluate": [
+            # shap < 0.42 is incompatible with numpy >= 1.24.
+            "shap>=0.42",
+            "evaluate",
+            "torch",
+            "transformers",
+            "textstat",
+            "nltk",
+            "rouge_score",
+        ],
         "sqlserver": ["mlflow-dbstore"],
         "aliyun-oss": ["aliyunstoreplugin"],
     },


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add `evaluate` extra to specify extra dependencies required for `mlflow.evaluate`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
