### PR TITLE
Add tests to ensure `search_routes` and `create_route` accept unknown route types

### DIFF
--- a/tests/gateway/test_fluent.py
+++ b/tests/gateway/test_fluent.py
@@ -262,12 +262,7 @@ def test_get_route_accepts_unknown_provider():
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         route = get_route("chat")
         mock_request.assert_called_once()
-        assert route.dict() == {
-            "name": "chat",
-            "route_type": "llm/v1/chat",
-            "model": {"name": "unknown-5", "provider": "unknown-ai"},
-            "route_url": "http://localhost:5000/gateway/chat/invocations",
-        }
+        assert route.dict() == mock_resp.json()
 
 
 def test_get_route_accepts_unknown_route_type():
@@ -282,12 +277,7 @@ def test_get_route_accepts_unknown_route_type():
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         route = get_route("chat")
         mock_request.assert_called_once()
-        assert route.dict() == {
-            "name": "chat",
-            "route_type": "llm/v1/unknown",
-            "model": {"name": "gpt4", "provider": "openai"},
-            "route_url": "http://localhost:5000/gateway/chat/invocations",
-        }
+        assert route.dict() == mock_resp.json()
 
 
 def test_search_routes_accepts_unknown_provider():
@@ -307,14 +297,7 @@ def test_search_routes_accepts_unknown_provider():
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         routes = search_routes()
         mock_request.assert_called_once()
-        assert [r.dict() for r in routes] == [
-            {
-                "name": "chat",
-                "route_type": "llm/v1/chat",
-                "model": {"name": "unknown-5", "provider": "unknown-ai"},
-                "route_url": "http://localhost:5000/gateway/chat/invocations",
-            }
-        ]
+        assert [r.dict() for r in routes] == mock_resp.json()["routes"]
 
 
 def test_search_routes_accepts_unknown_route_type():
@@ -334,11 +317,4 @@ def test_search_routes_accepts_unknown_route_type():
     with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
         routes = search_routes()
         mock_request.assert_called_once()
-        assert [r.dict() for r in routes] == [
-            {
-                "name": "chat",
-                "route_type": "llm/v1/unknown",
-                "model": {"name": "gpt4", "provider": "openai"},
-                "route_url": "http://localhost:5000/gateway/chat/invocations",
-            }
-        ]
+        assert [r.dict() for r in routes] == mock_resp.json()["routes"]

--- a/tests/gateway/test_fluent.py
+++ b/tests/gateway/test_fluent.py
@@ -270,6 +270,26 @@ def test_get_route_accepts_unknown_provider():
         }
 
 
+def test_get_route_accepts_unknown_route_type():
+    set_gateway_uri("http://localhost:5000")
+    mock_resp = mock.Mock(status_code=200)
+    mock_resp.json.return_value = {
+        "name": "chat",
+        "route_type": "llm/v1/unknown",
+        "model": {"name": "gpt4", "provider": "openai"},
+        "route_url": "http://localhost:5000/gateway/chat/invocations",
+    }
+    with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
+        route = get_route("chat")
+        mock_request.assert_called_once()
+        assert route.dict() == {
+            "name": "chat",
+            "route_type": "llm/v1/unknown",
+            "model": {"name": "gpt4", "provider": "openai"},
+            "route_url": "http://localhost:5000/gateway/chat/invocations",
+        }
+
+
 def test_search_routes_accepts_unknown_provider():
     set_gateway_uri("http://localhost:5000")
     mock_resp = mock.Mock(status_code=200)
@@ -292,6 +312,33 @@ def test_search_routes_accepts_unknown_provider():
                 "name": "chat",
                 "route_type": "llm/v1/chat",
                 "model": {"name": "unknown-5", "provider": "unknown-ai"},
+                "route_url": "http://localhost:5000/gateway/chat/invocations",
+            }
+        ]
+
+
+def test_search_routes_accepts_unknown_route_type():
+    set_gateway_uri("http://localhost:5000")
+    mock_resp = mock.Mock(status_code=200)
+    mock_resp.json.return_value = {
+        "routes": [
+            {
+                "name": "chat",
+                "route_type": "llm/v1/unknown",
+                "model": {"name": "gpt4", "provider": "openai"},
+                "route_url": "http://localhost:5000/gateway/chat/invocations",
+            },
+        ],
+        "next_page_token": None,
+    }
+    with mock.patch("requests.Session.request", return_value=mock_resp) as mock_request:
+        routes = search_routes()
+        mock_request.assert_called_once()
+        assert [r.dict() for r in routes] == [
+            {
+                "name": "chat",
+                "route_type": "llm/v1/unknown",
+                "model": {"name": "gpt4", "provider": "openai"},
                 "route_url": "http://localhost:5000/gateway/chat/invocations",
             }
         ]


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add tests to ensure `search_routes` and `create_route` accept unknown route types.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
