### PR TITLE
Fix a bug where `search_routes` throws when there are no routes

### DIFF
--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -124,6 +124,7 @@ class MlflowGatewayClient:
         ).json()
         if "routes" not in response_json:
 		return PagedList([], None)
+	
 	for route in response_json["routes"]:
             route["route_url"] = resolve_route_url(self._gateway_uri, route["route_url"])
 

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -122,7 +122,9 @@ class MlflowGatewayClient:
         response_json = self._call_endpoint(
             "GET", MLFLOW_GATEWAY_CRUD_ROUTE_BASE, json_body=json.dumps(request_parameters)
         ).json()
-        for route in response_json["routes"]:
+        if "routes" not in response_json:
+		return PagedList([], None)
+	for route in response_json["routes"]:
             route["route_url"] = resolve_route_url(self._gateway_uri, route["route_url"])
 
         routes = [Route(**resp) for resp in response_json["routes"]]

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -122,13 +122,18 @@ class MlflowGatewayClient:
         response_json = self._call_endpoint(
             "GET", MLFLOW_GATEWAY_CRUD_ROUTE_BASE, json_body=json.dumps(request_parameters)
         ).json()
-        if "routes" not in response_json:
-		return PagedList([], None)
-	
-	for route in response_json["routes"]:
-            route["route_url"] = resolve_route_url(self._gateway_uri, route["route_url"])
-
-        routes = [Route(**resp) for resp in response_json["routes"]]
+        routes = [
+            Route(
+                **{
+                    **resp,
+                    "route_url": resolve_route_url(
+                        self._gateway_uri,
+                        resp["route_url"],
+                    ),
+                }
+            )
+            for resp in response_json.get("routes", [])
+        ]
         next_page_token = response_json.get("next_page_token")
         return PagedList(routes, next_page_token)
 

--- a/tests/gateway/test_client.py
+++ b/tests/gateway/test_client.py
@@ -645,3 +645,14 @@ def test_client_query_mlflow_embeddings_route(oss_gateway):
     with mock.patch.object(gateway_client, "_call_endpoint", return_value=mock_response):
         response = gateway_client.query(route="embeddings-oss", data=data)
         assert response == expected_output
+
+
+def test_search_routes_no_routes():
+    gateway_client = MlflowGatewayClient(gateway_uri="http://localhost:5000")
+    resp = mock.Mock(status_code=200)
+    resp.json.return_value = {}
+    with mock.patch("requests.Session.request", return_value=resp) as request_mock:
+        routes = gateway_client.search_routes()
+        request_mock.assert_called_once()
+        assert routes == []
+        assert routes.token is None


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
Resolve #9385

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
