### PR TITLE
Ensure model traceability by providing model name and version in pyfu…

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -84,6 +84,12 @@ SageMaker as long as they support the ``python_function`` flavor:
 
     mlflow deployments create -t sagemaker -m my_model [other options]
 
+.. note::
+    When a model registered in the MLflow Model Registry is downloaded, a YAML file named
+    `registered_model_meta` is added to the model directory on the downloader's side.
+    This file contains the name and version of the model referenced in the MLflow Model Registry,
+    and will be used for deployment and other purposes.
+
 Fields in the MLmodel Format
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Apart from a **flavors** field listing the model flavors, the MLmodel YAML format can contain

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -20,7 +20,9 @@ from mlflow.environment_variables import MLFLOW_DEPLOYMENT_FLAVOR_NAME, MLFLOW_D
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.pyfunc import _extract_conda_env, mlserver, scoring_server
+from mlflow.store.artifact.models_artifact_repo import REGISTERED_MODEL_META_FILE_NAME
 from mlflow.utils import env_manager as em
+from mlflow.utils.file_utils import read_yaml
 from mlflow.utils.virtualenv import _get_or_create_virtualenv
 from mlflow.version import VERSION as MLFLOW_VERSION
 
@@ -176,6 +178,7 @@ def _serve_pyfunc(model, env_manager):
         procs.append(nginx)
 
     cpu_count = multiprocessing.cpu_count()
+    inference_server_kwargs = {}
     if enable_mlserver:
         inference_server = mlserver
         # Allows users to choose the number of workers using MLServer var env settings.
@@ -184,13 +187,24 @@ def _serve_pyfunc(model, env_manager):
         # Since MLServer will run without NGINX, expose the server in the `8080`
         # port, which is the assumed "public" port.
         port = DEFAULT_MLSERVER_PORT
+
+        model_meta = _read_registered_model_meta(MODEL_PATH)
+        model_dict = model.to_dict()
+        inference_server_kwargs = {
+            "model_name": model_meta.get("model_name"),
+            "model_version": model_meta.get(
+                "model_version", model_dict.get("run_id", model_dict.get("model_uuid"))
+            ),
+        }
     else:
         inference_server = scoring_server
         # users can use GUNICORN_CMD_ARGS="--workers=3" var env to override the number of workers
         nworkers = cpu_count
         port = DEFAULT_INFERENCE_SERVER_PORT
 
-    cmd, cmd_env = inference_server.get_cmd(model_uri=MODEL_PATH, nworkers=nworkers, port=port)
+    cmd, cmd_env = inference_server.get_cmd(
+        model_uri=MODEL_PATH, nworkers=nworkers, port=port, **inference_server_kwargs
+    )
 
     bash_cmds.append(cmd)
     inference_server_process = Popen(["/bin/bash", "-c", " && ".join(bash_cmds)], env=cmd_env)
@@ -200,6 +214,14 @@ def _serve_pyfunc(model, env_manager):
     # If either subprocess exits, so do we.
     awaited_pids = _await_subprocess_exit_any(procs=procs)
     _sigterm_handler(awaited_pids)
+
+
+def _read_registered_model_meta(model_path):
+    model_meta = {}
+    if os.path.isfile(os.path.join(model_path, REGISTERED_MODEL_META_FILE_NAME)):
+        model_meta = read_yaml(model_path, REGISTERED_MODEL_META_FILE_NAME)
+
+    return model_meta
 
 
 def _serve_mleap():

--- a/mlflow/pyfunc/mlserver.py
+++ b/mlflow/pyfunc/mlserver.py
@@ -9,7 +9,13 @@ MLServerDefaultModelName = "mlflow-model"
 
 
 def get_cmd(
-    model_uri: str, port: int = None, host: str = None, timeout: int = None, nworkers: int = None
+    model_uri: str,
+    port: int = None,
+    host: str = None,
+    timeout: int = None,
+    nworkers: int = None,
+    model_name: str = None,
+    model_version: str = None,
 ) -> Tuple[str, Dict[str, str]]:
     cmd = f"mlserver start {model_uri}"
 
@@ -24,10 +30,15 @@ def get_cmd(
     if timeout:
         _logger.warning("Timeout is not yet supported in MLServer.")
 
-    cmd_env["MLSERVER_MODEL_NAME"] = MLServerDefaultModelName
-
     if nworkers:
         cmd_env["MLSERVER_PARALLEL_WORKERS"] = str(nworkers)
+
+    # give precedence to user env var input
+    cmd_env["MLSERVER_MODEL_NAME"] = (
+        cmd_env.get("MLSERVER_MODEL_NAME") or model_name or MLServerDefaultModelName
+    )
+    if model_version and not cmd_env.get("MLSERVER_MODEL_VERSION"):
+        cmd_env["MLSERVER_MODEL_VERSION"] = model_version
 
     cmd_env["MLSERVER_MODEL_IMPLEMENTATION"] = MLServerMLflowRuntime
     cmd_env["MLSERVER_MODEL_URI"] = model_uri

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -203,20 +203,23 @@ def make_containing_dirs(path):
         os.makedirs(dir_name)
 
 
-def write_yaml(root, file_name, data, overwrite=False, sort_keys=True):
+def write_yaml(root, file_name, data, overwrite=False, sort_keys=True, ensure_yaml_extension=True):
     """
     Write dictionary data in yaml format.
 
     :param root: Directory name.
-    :param file_name: Desired file name. Will automatically add .yaml extension if not given
+    :param file_name: Desired file name.
     :param data: data to be dumped as yaml format
     :param overwrite: If True, will overwrite existing files
+    :param ensure_yaml_extension: If True, will automatically add .yaml extension if not given
     """
     if not exists(root):
         raise MissingConfigException(f"Parent directory '{root}' does not exist.")
 
     file_path = os.path.join(root, file_name)
-    yaml_file_name = file_path if file_path.endswith(".yaml") else file_path + ".yaml"
+    yaml_file_name = file_path
+    if ensure_yaml_extension and not file_path.endswith(".yaml"):
+        yaml_file_name = file_path + ".yaml"
 
     if exists(yaml_file_name) and not overwrite:
         raise Exception(f"Yaml file '{file_path}' exists as '{yaml_file_name}")
@@ -235,7 +238,7 @@ def write_yaml(root, file_name, data, overwrite=False, sort_keys=True):
         raise e
 
 
-def overwrite_yaml(root, file_name, data):
+def overwrite_yaml(root, file_name, data, ensure_yaml_extension=True):
     """
     Safely overwrites a preexisting yaml file, ensuring that file contents are not deleted or
     corrupted if the write fails. This is achieved by writing contents to a temporary file
@@ -243,10 +246,13 @@ def overwrite_yaml(root, file_name, data):
     preexisting file for a direct write.
 
     :param root: Directory name.
-    :param file_name: File name. Expects to have '.yaml' extension.
+    :param file_name: File name.
     :param data: The data to write, represented as a dictionary.
+    :param ensure_yaml_extension: If True, Will automatically add .yaml extension if not given
     """
     tmp_file_path = None
+    original_file_path = os.path.join(root, file_name)
+    original_file_mode = os.stat(original_file_path).st_mode
     try:
         tmp_file_fd, tmp_file_path = tempfile.mkstemp(suffix="file.yaml")
         os.close(tmp_file_fd)
@@ -256,11 +262,11 @@ def overwrite_yaml(root, file_name, data):
             data=data,
             overwrite=True,
             sort_keys=True,
+            ensure_yaml_extension=ensure_yaml_extension,
         )
-        shutil.move(
-            tmp_file_path,
-            os.path.join(root, file_name),
-        )
+        shutil.move(tmp_file_path, original_file_path)
+        # restores original file permissions, see https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp
+        os.chmod(original_file_path, original_file_mode)
     finally:
         if tmp_file_path is not None and os.path.exists(tmp_file_path):
             os.remove(tmp_file_path)

--- a/tests/pyfunc/test_mlserver.py
+++ b/tests/pyfunc/test_mlserver.py
@@ -14,18 +14,37 @@ from mlflow.pyfunc.mlserver import MLServerDefaultModelName, MLServerMLflowRunti
                 "MLSERVER_HTTP_PORT": "5000",
                 "MLSERVER_HOST": "0.0.0.0",
                 "MLSERVER_PARALLEL_WORKERS": "4",
+                "MLSERVER_MODEL_NAME": MLServerDefaultModelName,
             },
         ),
         (
             {"host": "0.0.0.0", "nworkers": 4},
-            {"MLSERVER_HOST": "0.0.0.0", "MLSERVER_PARALLEL_WORKERS": "4"},
+            {
+                "MLSERVER_HOST": "0.0.0.0",
+                "MLSERVER_PARALLEL_WORKERS": "4",
+                "MLSERVER_MODEL_NAME": MLServerDefaultModelName,
+            },
         ),
         (
             {"port": 5000, "nworkers": 4},
-            {"MLSERVER_HTTP_PORT": "5000", "MLSERVER_PARALLEL_WORKERS": "4"},
+            {
+                "MLSERVER_HTTP_PORT": "5000",
+                "MLSERVER_PARALLEL_WORKERS": "4",
+                "MLSERVER_MODEL_NAME": MLServerDefaultModelName,
+            },
         ),
-        ({"port": 5000}, {"MLSERVER_HTTP_PORT": "5000"}),
-        ({}, {}),
+        (
+            {"port": 5000},
+            {
+                "MLSERVER_HTTP_PORT": "5000",
+                "MLSERVER_MODEL_NAME": MLServerDefaultModelName,
+            },
+        ),
+        (
+            {"model_name": "mymodel", "model_version": "12"},
+            {"MLSERVER_MODEL_NAME": "mymodel", "MLSERVER_MODEL_VERSION": "12"},
+        ),
+        ({}, {"MLSERVER_MODEL_NAME": MLServerDefaultModelName}),
     ],
 )
 def test_get_cmd(params: dict, expected: dict):
@@ -37,7 +56,6 @@ def test_get_cmd(params: dict, expected: dict):
     assert cmd_env == {
         "MLSERVER_MODEL_URI": model_uri,
         "MLSERVER_MODEL_IMPLEMENTATION": MLServerMLflowRuntime,
-        "MLSERVER_MODEL_NAME": MLServerDefaultModelName,
         **expected,
         **os.environ.copy(),
     }


### PR DESCRIPTION
Ensure model traceability by providing model name and version in pyfunc and MLServer

(#9401)

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Updates the MLmodel file with the model name and version (from the model registry for registered models) on the caller side when "MLflow model download" is called.
And exposes model name and version through MLServer `/v2/repository/index` endpoint as follows:

- for the model name:
  - "model_name" of MLmodel file
  - else default model_name "mlflow-model"
- for model version :
  - "model_version" in MLmodel file
  - else model run id 
  - else model uuid

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

For a model previously registered and packaged with Docker and MLServer (e.g `mlflow models build-docker -m models:/mymodel/1 --enable-mlserver -n mymodel:1`), calling:
`curl -X POST -H 'Content-Type: application/json' localhost:8080/v2/repository/index -d '{"ready": "false"}'`
always returns:
`[{"name":"mlflow-model","state":"UNKNOWN","reason":""}]`

With this PR, packaging `models:/mymodel/1` with Docker and MLServer and calling: 
`curl -X POST -H 'Content-Type: application/json' localhost:8080/v2/repository/index -d '{"ready": "false"}'`
returns:
`[{"name":"mymodel","version":"1","state":"READY","reason":""}]`

Same for `models:/mymodel/latest` or `models:/mymodel/Staging`, etc.

Packaging `runs:/c418b4a77b584faa99705f47e9e9a308/model` with Docker and MLServer and calling: 
`curl -X POST -H 'Content-Type: application/json' localhost:8080/v2/repository/index -d '{"ready": "false"}'`
returns:
`[{"name":"mlflow-model","version":"c418b4a77b584faa99705f47e9e9a308","state":"READY","reason":""}]`

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Expose the model name and version in MLServer `/v2/repository/index` endpoint by updating MLmodel file with model name and version on the caller's side for registered models during artifact download.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
