### PR TITLE
fix infer_signature for List[Dict[str, Union[str, List[str]]]

### DIFF
--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -153,7 +153,12 @@ def _infer_schema(data: Any) -> Schema:
         isinstance(data, list)
         and all(isinstance(element, dict) for element in data)
         and all(isinstance(key, str) for d in data for key in d)
-        and all(isinstance(value, str) for d in data for value in d.values())
+        and all(
+            isinstance(value, str)
+            or (isinstance(value, list) and all(isinstance(v, str) for v in value))
+            for d in data
+            for value in d.values()
+        )
     ):
         first_keys = data[0].keys()
         if all(d.keys() == first_keys for d in data):

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -153,6 +153,8 @@ def _infer_schema(data: Any) -> Schema:
         isinstance(data, list)
         and all(isinstance(element, dict) for element in data)
         and all(isinstance(key, str) for d in data for key in d)
+        # NB: We allow both str and List[str] as values in the dictionary
+        # e.g. [{'output': 'some sentence', 'ids': ['id1', 'id2']}]
         and all(
             isinstance(value, str)
             or (isinstance(value, list) and all(isinstance(v, str) for v in value))

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -130,6 +130,27 @@ def test_signature_inference_infers_input_and_output_as_expected():
     assert sig1.outputs == sig0.inputs
 
 
+def test_infer_signature_on_list_of_dictionaries():
+    signature = infer_signature(
+        model_input=[{"query": "test query"}],
+        model_output=[
+            {
+                "output": "Output from the LLM",
+                "candidate_ids": ["412", "1233"],
+                "candidate_sources": ["file1.md", "file201.md"],
+            }
+        ],
+    )
+    assert signature.inputs == Schema([ColSpec(DataType.string, name="query")])
+    assert signature.outputs == Schema(
+        [
+            ColSpec(DataType.string, name="output"),
+            ColSpec(DataType.string, name="candidate_ids"),
+            ColSpec(DataType.string, name="candidate_sources"),
+        ]
+    )
+
+
 def test_signature_inference_infers_datime_types_as_expected():
     col_name = "datetime_col"
     test_datetime = np.datetime64("2021-01-01")

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -763,6 +763,18 @@ def test_schema_enforcement_for_inputs_style_orientation_of_dataframe(orient):
     pd_check = _enforce_schema(pd_data.to_dict(orient=orient), signature.inputs)
     pd.testing.assert_frame_equal(pd_check, pd_data)
 
+    # Test List[Dict[str, Union[str, List[str]]]]
+    test_signature = {
+        "inputs": '[{"name": "query", "type": "string"}, {"name": "inputs", "type": "string"}]',
+    }
+    signature = ModelSignature.from_dict(test_signature)
+    data = [{"query": ["test_query1", "test_query2"], "inputs": "test input"}]
+    pd_data = pd.DataFrame(data)
+    check = _enforce_schema(data, signature.inputs)
+    pd.testing.assert_frame_equal(check, pd_data)
+    pd_check = _enforce_schema(pd_data.to_dict(orient=orient), signature.inputs)
+    pd.testing.assert_frame_equal(pd_check, pd_data)
+
     # Test List[str]
     test_signature = {
         "inputs": '[{"type": "string"}]',


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?
When infer_signature is called, we should accept Dict[str, Union[str, List[str]]]. The previous implementation only accept List[Dict[str, str]]. This PR fixes the problem.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
