### PR TITLE
Fix torch cross test on torch < 1.8

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -37,7 +37,7 @@ pytorch:
     requirements:
       ">= 0.0.0": ["torchvision", "scikit-learn"]
       ">= 1.8": ["transformers"]
-      "< 1.8": ["transformers==4.31.0"]
+      "< 1.8": ["transformers<4.32.0"]
     run: |
       pytest tests/pytorch/test_pytorch_model_export.py tests/pytorch/test_pytorch_metric_value_conversion_utils.py
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -35,7 +35,7 @@ pytorch:
     minimum: "1.6.0"
     maximum: "2.0.1"
     requirements:
-      ">= 0.0.0": ["torchvision", "scikit-learn", "transformers"]
+      ">= 0.0.0": ["torchvision", "scikit-learn", "transformers==4.31.0"]
     run: |
       pytest tests/pytorch/test_pytorch_model_export.py tests/pytorch/test_pytorch_metric_value_conversion_utils.py
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -35,7 +35,9 @@ pytorch:
     minimum: "1.6.0"
     maximum: "2.0.1"
     requirements:
-      ">= 0.0.0": ["torchvision", "scikit-learn", "transformers==4.31.0"]
+      ">= 0.0.0": ["torchvision", "scikit-learn"]
+      ">= 1.8": ["transformers"]
+      "< 1.8": ["transformers==4.31.0"]
     run: |
       pytest tests/pytorch/test_pytorch_model_export.py tests/pytorch/test_pytorch_metric_value_conversion_utils.py
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -6,6 +6,7 @@ import pickle
 import re
 from pathlib import Path
 from unittest import mock
+from packaging.version import Version
 
 import numpy as np
 import pandas as pd
@@ -857,7 +858,10 @@ def test_pyfunc_serve_and_score(data):
     np.testing.assert_array_almost_equal(scores.values[:, 0], _predict(model=model, data=data))
 
 
-@pytest.mark.skipif(not _is_importable("transformers"), reason="This test requires transformers")
+@pytest.mark.skipif(
+    not _is_importable("transformers") or Version(torch.__version__) < Version("1.8"),
+    reason="This test requires transformers and torch >= 1.8 "
+)
 def test_pyfunc_serve_and_score_transformers():
     from transformers import BertConfig, BertModel  # pylint: disable=import-error
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -6,7 +6,6 @@ import pickle
 import re
 from pathlib import Path
 from unittest import mock
-from packaging.version import Version
 
 import numpy as np
 import pandas as pd
@@ -858,10 +857,7 @@ def test_pyfunc_serve_and_score(data):
     np.testing.assert_array_almost_equal(scores.values[:, 0], _predict(model=model, data=data))
 
 
-@pytest.mark.skipif(
-    not _is_importable("transformers") or Version(torch.__version__) < Version("1.8"),
-    reason="This test requires transformers and torch >= 1.8 "
-)
+@pytest.mark.skipif(not _is_importable("transformers"), reason="This test requires transformers")
 def test_pyfunc_serve_and_score_transformers():
     from transformers import BertConfig, BertModel  # pylint: disable=import-error
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Broken test:
https://github.com/mlflow-automation/mlflow/actions/runs/5939342578/job/16106694740#step:13:220

For torch 1.6 / 1.7, the module `torch.utils._pytree` does not exist , then it is incompatible with latest transformers bert model,
we can verify this by

```
PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu pip install torch==1.7
```
then run
```
>>> import torch.utils._pytree
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'torch.utils._pytree'
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
