### PR TITLE
Show more actionable error messages for `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: ruff
         name: ruff
-        entry: ruff
+        entry: python dev/ruff.py
         language: system
         types_or: [python]
         stages: [commit]

--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,8 @@
 import json
 import os
 import posixpath
-import subprocess
 import shutil
+import subprocess
 
 import pytest
 
@@ -10,7 +10,6 @@ from mlflow.environment_variables import _MLFLOW_TESTING
 
 
 def pytest_addoption(parser):
-    print("hello")
     parser.addoption(
         "--requires-ssh",
         action="store_true",

--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,8 @@
 import json
 import os
 import posixpath
-import shutil
 import subprocess
+import shutil
 
 import pytest
 
@@ -10,6 +10,7 @@ from mlflow.environment_variables import _MLFLOW_TESTING
 
 
 def pytest_addoption(parser):
+    print("hello")
     parser.addoption(
         "--requires-ssh",
         action="store_true",

--- a/dev/ruff.py
+++ b/dev/ruff.py
@@ -43,6 +43,7 @@ def main():
             sys.exit(prc.returncode)
     else:
         with subprocess.Popen(cmd) as prc:
+            prc.communicate()
             sys.exit(prc.returncode)
 
 

--- a/dev/ruff.py
+++ b/dev/ruff.py
@@ -1,0 +1,49 @@
+import functools
+import json
+import os
+import re
+import subprocess
+import sys
+
+RUFF = [sys.executable, "-m", "ruff"]
+MESSAGE_REGEX = re.compile(r"^.+:\d+:\d+: ([A-Z0-9]+) (\[\*\] )?.+$")
+
+
+@functools.lru_cache
+def get_rule_name(code: str) -> str:
+    out = subprocess.check_output([*RUFF, "rule", "--format", "json", code], text=True).strip()
+    return json.loads(out)["name"]
+
+
+def transform(stdout: str) -> str:
+    transformed = []
+    for line in stdout.splitlines():
+        if m := MESSAGE_REGEX.match(line):
+            if m.group(2) is not None:
+                line = f"{line}. Fixable via `ruff --fix .`."
+            else:
+                name = get_rule_name(m.group(1))
+                line = f"{line}. See https://beta.ruff.rs/docs/rules/{name} for details."
+        transformed.append(line)
+    return "\n".join(transformed)
+
+
+def main():
+    cmd = [*RUFF, *sys.argv[1:]]
+    if "GITHUB_ACTIONS" in os.environ:
+        with subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        ) as prc:
+            stdout, stderr = prc.communicate()
+            sys.stdout.write(transform(stdout))
+            sys.stderr.write(stderr)
+    else:
+        with subprocess.Popen(cmd):
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/ruff.py
+++ b/dev/ruff.py
@@ -40,9 +40,10 @@ def main():
             stdout, stderr = prc.communicate()
             sys.stdout.write(transform(stdout))
             sys.stderr.write(stderr)
+            sys.exit(prc.returncode)
     else:
-        with subprocess.Popen(cmd):
-            pass
+        with subprocess.Popen(cmd) as prc:
+            sys.exit(prc.returncode)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Show more actionable error messages for `ruff`. `ruff` is new. Everyone is not familiar with it yet. Show more actionable error messages can help us resolve lint errors faster.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
