### PR TITLE
Use spark default pip requirements "pandas < 2" for "spark < 3.4"

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -96,7 +96,7 @@ def get_default_pip_requirements():
     pyspark_req = re.sub(r"(\.?)dev.*$", "", _get_pinned_requirement("pyspark"))
     reqs = [pyspark_req]
     if Version(pyspark.__version__) < Version("3.4"):
-        # Versions of PySpark <= 3.4 are incompatible with pandas >= 2
+        # Versions of PySpark < 3.4 are incompatible with pandas >= 2
         reqs.append("pandas<2")
     return reqs
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -95,8 +95,8 @@ def get_default_pip_requirements():
     # available for installation from Anaconda or PyPI
     pyspark_req = re.sub(r"(\.?)dev.*$", "", _get_pinned_requirement("pyspark"))
     reqs = [pyspark_req]
-    if Version(pyspark.__version__) <= Version("3.3.2"):
-        # Versions of PySpark <= 3.3.2 are incompatible with pandas >= 2
+    if Version(pyspark.__version__) < Version("3.4"):
+        # Versions of PySpark <= 3.4 are incompatible with pandas >= 2
         reqs.append("pandas<2")
     return reqs
 

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -353,7 +353,15 @@ def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
     reason="The dev version of pyspark built from the source doesn't exist on PyPI or Anaconda",
 )
 def test_sagemaker_docker_model_scoring_with_default_conda_env(spark_model_iris, model_path):
-    sparkm.save_model(spark_model_iris.model, path=model_path)
+    if Version(pyspark.__version__) < Version("3.4"):
+        extra_pip_req = ["pandas<2"]
+    else:
+        extra_pip_req = None
+    sparkm.save_model(
+        spark_model_iris.model,
+        path=model_path,
+        extra_pip_requirements=extra_pip_req
+    )
 
     scoring_response = score_model_in_sagemaker_docker_container(
         model_uri=model_path,

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -353,15 +353,7 @@ def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
     reason="The dev version of pyspark built from the source doesn't exist on PyPI or Anaconda",
 )
 def test_sagemaker_docker_model_scoring_with_default_conda_env(spark_model_iris, model_path):
-    if Version(pyspark.__version__) < Version("3.4"):
-        extra_pip_req = ["pandas<2"]
-    else:
-        extra_pip_req = None
-    sparkm.save_model(
-        spark_model_iris.model,
-        path=model_path,
-        extra_pip_requirements=extra_pip_req
-    )
+    sparkm.save_model(spark_model_iris.model, path=model_path)
 
     scoring_response = score_model_in_sagemaker_docker_container(
         model_uri=model_path,


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?


Use spark default pip requirements "pandas < 2" for "spark < 3.4"

Spark < 3.4 is incompatible with pandas >= 2, we need to add pip requirements for pandas when saving model otherwise latest pandas (2.x) version will be used in serving then it causes prediction failure.


This change also fixes test "test_sagemaker_docker_model_scoring_with_default_conda_env against spark 3.3"

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
