### PR TITLE
Fixes to Docker test environment

### DIFF
--- a/dev/Dockerfile.test
+++ b/dev/Dockerfile.test
@@ -6,22 +6,33 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 WORKDIR /app
 
-ADD . /app
-
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential openjdk-11-jre-headless \
+    apt-get install -y --no-install-recommends build-essential openjdk-17-jre-headless \
     # cmake and protobuf-compiler required for onnx install
     cmake protobuf-compiler && \
     # Install miniforge
     wget -q https://github.com/conda-forge/miniforge/releases/latest/download/$MINIFORG_FILENAME && \
     bash $MINIFORG_FILENAME -b -p /opt/conda && \
-    rm $MINIFORG_FILENAME && \
+    rm $MINIFORG_FILENAME
+
+ADD ./requirements /app/requirements
+
+RUN \
     # install required python packages
-    pip install --no-cache-dir -r requirements/test-requirements.txt --no-cache-dir -r requirements/lint-requirements.txt && \
+    pip install -r requirements/test-requirements.txt --no-cache-dir \
+        -r requirements/lint-requirements.txt psutil
+
+ADD . /app
+
+RUN \
     # install mlflow in editable form
-    pip install --no-cache-dir -e . && \
+    pip install --no-cache-dir -e .
+
+RUN \
     # clean cache
-    apt-get autoremove -yqq --purge && apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    apt-get autoremove -yqq --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN \
     # adding an unprivileged user
     groupadd --gid 10001 mlflow && \
     useradd --uid 10001 --gid mlflow --shell /bin/bash --create-home mlflow

--- a/dev/run-test-container.sh
+++ b/dev/run-test-container.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 ROOT_DIR=$(git rev-parse --show-toplevel)
 ARCH=$(uname -m)
 echo "Running tests in a Docker container on $ARCH"


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> n/a

## What changes are proposed in this pull request?

Improvements to `Dockerfile.test` and `run-test-container.sh`. These were first included in #9191, but it was suggested to move them to a separate PR. The Docker environment still has issues running tests due to some hardcoded default paths in the `mlflow` package itself. I have not attempted to fix those here, although that could be a future improvement.

## How is this patch tested?

Tested locally in the context of developing #9191.

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

Launched the Docker environment and used it to develop and test the changes in #9191.

## Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
