### PR TITLE
Update classes for metrics

### DIFF
--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -1,10 +1,9 @@
+from mlflow.metrics.base import (
+    MetricValue,
+)
 from mlflow.models import (
     EvaluationMetric,
     make_metric,
-)
-
-from mlflow.metrics.base import (
-    MetricValue,
 )
 
 __all__ = [

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -1,7 +1,10 @@
-from mlflow.metrics.base import (
+from mlflow.models import (
     EvaluationMetric,
-    MetricValue,
     make_metric,
+)
+
+from mlflow.metrics.base import (
+    MetricValue,
 )
 
 __all__ = [

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -1,0 +1,11 @@
+from mlflow.metrics.base import (
+    EvaluationMetric,
+    MetricValue,
+    make_metric,
+)
+
+__all__ = [
+    "EvaluationMetric",
+    "MetricValue",
+    "make_metric",
+]

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -2,22 +2,29 @@ from types import FunctionType
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.exceptions import MlflowException
 
+
 class MetricValue:
-    '''
-    A model evaluation metric.
+    """
+    The value of a metric.
     :param scores: The value of the metric per row
     :param justifications: The justification (if applicable) for the respective score
     :param aggregate_results: A dictionary mapping the name of the aggregation to its value
-    '''
+    """
 
-    def __init__(self, scores: list[float] = None, justifications: list[str] = None, aggregate_results: dict[str, float] = None):
+    def __init__(
+        self,
+        scores: list[float] = None,
+        justifications: list[str] = None,
+        aggregate_results: dict[str, float] = None,
+    ):
         self.scores = scores
         self.justifications = justifications
         self.aggregate_results = aggregate_results
 
+
 class EvaluationMetric:
     '''
-    A model evaluation metric.
+    An evaluation metric.
     :param eval_fn:
         A function that computes the metric with the following signature:
         .. code-block:: python
@@ -33,7 +40,8 @@ class EvaluationMetric:
                     on that row.
                 :param builtin_metrics:
                     A dictionary containing the metrics calculated by the default evaluator.
-                    The keys are the names of the metrics and the values are the . Refer to the DefaultEvaluator behavior section for what metrics
+                    The keys are the names of the metrics and the values are the metric values.
+                    Refer to the DefaultEvaluator behavior section for what metrics
                     will be returned based on the type of model (i.e. classifier or regressor).
                 :return:
                     
@@ -43,6 +51,7 @@ class EvaluationMetric:
     :param greater_is_better: Whether a higher value of the metric is better.
     :param long_name: (Optional) The long name of the metric. For example,
         ``"root_mean_squared_error"`` for ``"mse"``.
+    :param version: (Optional) The metric version. For example ``v1``.
     '''
 
     def __init__(self, eval_fn, name, greater_is_better, long_name=None, version=None):

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -1,9 +1,11 @@
+from dataclasses import dataclass
 from typing import Dict, List
 
 from mlflow.models import EvaluationMetric as EvaluationMetric
 from mlflow.models import make_metric as make_metric
 
 
+@dataclass
 class MetricValue:
     """
     The value of a metric.

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -1,9 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict, List
 
-from mlflow.models import EvaluationMetric as EvaluationMetric
-from mlflow.models import make_metric as make_metric
-
 
 @dataclass
 class MetricValue:

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -1,0 +1,86 @@
+from types import FunctionType
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.exceptions import MlflowException
+
+class MetricValue:
+    '''
+    A model evaluation metric.
+    :param scores: The value of the metric per row
+    :param justifications: The justification (if applicable) for the respective score
+    :param aggregate_results: A dictionary mapping the name of the aggregation to its value
+    '''
+
+    def __init__(self, scores: list[float] = None, justifications: list[str] = None, aggregate_results: dict[str, float] = None):
+        self.scores = scores
+        self.justifications = justifications
+        self.aggregate_results = aggregate_results
+
+class EvaluationMetric:
+    '''
+    A model evaluation metric.
+    :param eval_fn:
+        A function that computes the metric with the following signature:
+        .. code-block:: python
+            def eval_fn(
+                eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
+                builtin_metrics: Dict[str, MetricValue],
+            ) -> MetricValue:
+                """
+                :param eval_df:
+                    A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.
+                    The ``prediction`` column contains the predictions made by the model.
+                    The ``target`` column contains the corresponding labels to the predictions made
+                    on that row.
+                :param builtin_metrics:
+                    A dictionary containing the metrics calculated by the default evaluator.
+                    The keys are the names of the metrics and the values are the . Refer to the DefaultEvaluator behavior section for what metrics
+                    will be returned based on the type of model (i.e. classifier or regressor).
+                :return:
+                    
+                """
+                ...
+    :param name: The name of the metric.
+    :param greater_is_better: Whether a higher value of the metric is better.
+    :param long_name: (Optional) The long name of the metric. For example,
+        ``"root_mean_squared_error"`` for ``"mse"``.
+    '''
+
+    def __init__(self, eval_fn, name, greater_is_better, long_name=None, version=None):
+        self.eval_fn = eval_fn
+        self.name = name
+        self.greater_is_better = greater_is_better
+        self.long_name = long_name or name
+        self.version = version
+
+    def __str__(self):
+        if self.long_name:
+            return (
+                f"EvaluationMetric(name={self.name}, long_name={self.long_name}, "
+                f"greater_is_better={self.greater_is_better})"
+            )
+        else:
+            return f"EvaluationMetric(name={self.name}, greater_is_better={self.greater_is_better})"
+
+
+def make_metric(
+    *,
+    eval_fn,
+    greater_is_better,
+    name=None,
+    long_name=None,
+    version=None,
+):
+    if name is None:
+        if isinstance(eval_fn, FunctionType) and eval_fn.__name__ == "<lambda>":
+            raise MlflowException(
+                "`name` must be specified if `eval_fn` is a lambda function.",
+                INVALID_PARAMETER_VALUE,
+            )
+        if not hasattr(eval_fn, "__name__"):
+            raise MlflowException(
+                "`name` must be specified if `eval_fn` does not have a `__name__` attribute.",
+                INVALID_PARAMETER_VALUE,
+            )
+        name = eval_fn.__name__
+
+    return EvaluationMetric(eval_fn, name, greater_is_better, long_name, version)

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -1,7 +1,5 @@
-from types import FunctionType
-from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.exceptions import MlflowException
-
+from mlflow.models import EvaluationMetric as EvaluationMetric
+from mlflow.models import make_metric as make_metric
 
 class MetricValue:
     """
@@ -21,75 +19,3 @@ class MetricValue:
         self.justifications = justifications
         self.aggregate_results = aggregate_results
 
-
-class EvaluationMetric:
-    '''
-    An evaluation metric.
-    :param eval_fn:
-        A function that computes the metric with the following signature:
-        .. code-block:: python
-            def eval_fn(
-                eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
-                builtin_metrics: Dict[str, MetricValue],
-            ) -> MetricValue:
-                """
-                :param eval_df:
-                    A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.
-                    The ``prediction`` column contains the predictions made by the model.
-                    The ``target`` column contains the corresponding labels to the predictions made
-                    on that row.
-                :param builtin_metrics:
-                    A dictionary containing the metrics calculated by the default evaluator.
-                    The keys are the names of the metrics and the values are the metric values.
-                    Refer to the DefaultEvaluator behavior section for what metrics
-                    will be returned based on the type of model (i.e. classifier or regressor).
-                :return:
-                    
-                """
-                ...
-    :param name: The name of the metric.
-    :param greater_is_better: Whether a higher value of the metric is better.
-    :param long_name: (Optional) The long name of the metric. For example,
-        ``"root_mean_squared_error"`` for ``"mse"``.
-    :param version: (Optional) The metric version. For example ``v1``.
-    '''
-
-    def __init__(self, eval_fn, name, greater_is_better, long_name=None, version=None):
-        self.eval_fn = eval_fn
-        self.name = name
-        self.greater_is_better = greater_is_better
-        self.long_name = long_name or name
-        self.version = version
-
-    def __str__(self):
-        if self.long_name:
-            return (
-                f"EvaluationMetric(name={self.name}, long_name={self.long_name}, "
-                f"greater_is_better={self.greater_is_better})"
-            )
-        else:
-            return f"EvaluationMetric(name={self.name}, greater_is_better={self.greater_is_better})"
-
-
-def make_metric(
-    *,
-    eval_fn,
-    greater_is_better,
-    name=None,
-    long_name=None,
-    version=None,
-):
-    if name is None:
-        if isinstance(eval_fn, FunctionType) and eval_fn.__name__ == "<lambda>":
-            raise MlflowException(
-                "`name` must be specified if `eval_fn` is a lambda function.",
-                INVALID_PARAMETER_VALUE,
-            )
-        if not hasattr(eval_fn, "__name__"):
-            raise MlflowException(
-                "`name` must be specified if `eval_fn` does not have a `__name__` attribute.",
-                INVALID_PARAMETER_VALUE,
-            )
-        name = eval_fn.__name__
-
-    return EvaluationMetric(eval_fn, name, greater_is_better, long_name, version)

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -14,12 +14,6 @@ class MetricValue:
     :param aggregate_results: A dictionary mapping the name of the aggregation to its value
     """
 
-    def __init__(
-        self,
-        scores: List[float] = None,
-        justifications: List[float] = None,
-        aggregate_results: Dict[str, float] = None,
-    ):
-        self.scores = scores
-        self.justifications = justifications
-        self.aggregate_results = aggregate_results
+    scores: List[float] = None
+    justifications: List[float] = None
+    aggregate_results: Dict[str, float] = None

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -1,3 +1,5 @@
+from typing import Dict, List
+
 from mlflow.models import EvaluationMetric as EvaluationMetric
 from mlflow.models import make_metric as make_metric
 
@@ -10,7 +12,12 @@ class MetricValue:
     :param aggregate_results: A dictionary mapping the name of the aggregation to its value
     """
 
-    def __init__(self, scores=None, justifications=None, aggregate_results=None):
+    def __init__(
+        self,
+        scores: List[float] = None,
+        justifications: List[float] = None,
+        aggregate_results: Dict[str, float] = None,
+    ):
         self.scores = scores
         self.justifications = justifications
         self.aggregate_results = aggregate_results

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -1,6 +1,7 @@
 from mlflow.models import EvaluationMetric as EvaluationMetric
 from mlflow.models import make_metric as make_metric
 
+
 class MetricValue:
     """
     The value of a metric.
@@ -9,13 +10,7 @@ class MetricValue:
     :param aggregate_results: A dictionary mapping the name of the aggregation to its value
     """
 
-    def __init__(
-        self,
-        scores: list[float] = None,
-        justifications: list[str] = None,
-        aggregate_results: dict[str, float] = None,
-    ):
+    def __init__(self, scores=None, justifications=None, aggregate_results=None):
         self.scores = scores
         self.justifications = justifications
         self.aggregate_results = aggregate_results
-

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -73,9 +73,12 @@ class _ModelType:
 class EvaluationMetric:
     '''
     An evaluation metric.
+
     :param eval_fn:
         A function that computes the metric with the following signature:
+
         .. code-block:: python
+
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
                 builtin_metrics: Dict[str, MetricValue],
@@ -92,9 +95,10 @@ class EvaluationMetric:
                     Refer to the DefaultEvaluator behavior section for what metrics
                     will be returned based on the type of model (i.e. classifier or regressor).
                 :return:
-
+                    MetricValue with per-row scores, per-row justifications, and aggregate results.
                 """
                 ...
+
     :param name: The name of the metric.
     :param greater_is_better: Whether a higher value of the metric is better.
     :param long_name: (Optional) The long name of the metric. For example,

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -82,7 +82,7 @@ class EvaluationMetric:
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
                 metrics: Dict[str, MetricValue],
-            ) -> MetricValue:
+            ) -> Union[float, MetricValue]:
                 """
                 :param eval_df:
                     A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.
@@ -144,7 +144,7 @@ def make_metric(
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
                 metrics: Dict[str, MetricValue],
-            ) -> MetricValue:
+            ) -> Union[float, MetricValue]:
                 """
                 :param eval_df:
                     A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -81,8 +81,9 @@ class EvaluationMetric:
 
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
-                builtin_metrics: Dict[str, MetricValue],
-            ) -> MetricValue:
+                builtin_metrics: Dict[str, float],
+                metrics: Dict[str, MetricValue],
+            ) -> Union[float, MetricValue]:
                 """
                 :param eval_df:
                     A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.
@@ -142,7 +143,8 @@ def make_metric(
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
                 builtin_metrics: Dict[str, float],
-            ) -> float:
+                metrics: Dict[str, MetricValue],
+            ) -> Union[float, MetricValue]:
                 """
                 :param eval_df:
                     A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.
@@ -155,7 +157,7 @@ def make_metric(
                     the metrics. Refer to the DefaultEvaluator behavior section for what metrics
                     will be returned based on the type of model (i.e. classifier or regressor).
                 :return:
-                    The metric value.
+                    MetricValue with per-row scores, per-row justifications, and aggregate results.
                 """
                 ...
 

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -92,7 +92,7 @@ class EvaluationMetric:
                     Refer to the DefaultEvaluator behavior section for what metrics
                     will be returned based on the type of model (i.e. classifier or regressor).
                 :return:
-                    
+
                 """
                 ...
     :param name: The name of the metric.
@@ -117,7 +117,6 @@ class EvaluationMetric:
             )
         else:
             return f"EvaluationMetric(name={self.name}, greater_is_better={self.greater_is_better})"
-
 
 
 def make_metric(

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -72,17 +72,14 @@ class _ModelType:
 
 class EvaluationMetric:
     '''
-    A model evaluation metric.
-
+    An evaluation metric.
     :param eval_fn:
         A function that computes the metric with the following signature:
-
         .. code-block:: python
-
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
-                builtin_metrics: Dict[str, float],
-            ) -> float:
+                builtin_metrics: Dict[str, MetricValue],
+            ) -> MetricValue:
                 """
                 :param eval_df:
                     A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.
@@ -91,25 +88,26 @@ class EvaluationMetric:
                     on that row.
                 :param builtin_metrics:
                     A dictionary containing the metrics calculated by the default evaluator.
-                    The keys are the names of the metrics and the values are the scalar values of
-                    the metrics. Refer to the DefaultEvaluator behavior section for what metrics
+                    The keys are the names of the metrics and the values are the metric values.
+                    Refer to the DefaultEvaluator behavior section for what metrics
                     will be returned based on the type of model (i.e. classifier or regressor).
                 :return:
-                    The metric value.
+                    
                 """
                 ...
-
     :param name: The name of the metric.
     :param greater_is_better: Whether a higher value of the metric is better.
     :param long_name: (Optional) The long name of the metric. For example,
         ``"root_mean_squared_error"`` for ``"mse"``.
+    :param version: (Optional) The metric version. For example ``v1``.
     '''
 
-    def __init__(self, eval_fn, name, greater_is_better, long_name=None):
+    def __init__(self, eval_fn, name, greater_is_better, long_name=None, version=None):
         self.eval_fn = eval_fn
         self.name = name
         self.greater_is_better = greater_is_better
         self.long_name = long_name or name
+        self.version = version
 
     def __str__(self):
         if self.long_name:
@@ -121,12 +119,14 @@ class EvaluationMetric:
             return f"EvaluationMetric(name={self.name}, greater_is_better={self.greater_is_better})"
 
 
+
 def make_metric(
     *,
     eval_fn,
     greater_is_better,
     name=None,
     long_name=None,
+    version=None,
 ):
     '''
     A factory function to create an :py:class:`EvaluationMetric` object.
@@ -180,7 +180,7 @@ def make_metric(
             )
         name = eval_fn.__name__
 
-    return EvaluationMetric(eval_fn, name, greater_is_better, long_name)
+    return EvaluationMetric(eval_fn, name, greater_is_better, long_name, version)
 
 
 @developer_stable

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -92,6 +92,8 @@ class EvaluationMetric:
                 :param builtin_metrics:
                     A dictionary containing the metrics calculated by the default evaluator.
                     The keys are the names of the metrics and the values are the metric values.
+                    To access the MetricValue for the metrics calculated by the system, make sure
+                    to specify the type hint for this parameter as Dict[str, MetricValue].
                     Refer to the DefaultEvaluator behavior section for what metrics
                     will be returned based on the type of model (i.e. classifier or regressor).
                 :return:
@@ -151,8 +153,10 @@ def make_metric(
                     on that row.
                 :param builtin_metrics:
                     A dictionary containing the metrics calculated by the default evaluator.
-                    The keys are the names of the metrics and the values are the scalar values of
-                    the metrics. Refer to the DefaultEvaluator behavior section for what metrics
+                    The keys are the names of the metrics and the values are the metric values.
+                    To access the MetricValue for the metrics calculated by the system, make sure
+                    to specify the type hint for this parameter as Dict[str, MetricValue].
+                    Refer to the DefaultEvaluator behavior section for what metrics
                     will be returned based on the type of model (i.e. classifier or regressor).
                 :return:
                     MetricValue with per-row scores, per-row justifications, and aggregate results.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -81,7 +81,6 @@ class EvaluationMetric:
 
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
-                builtin_metrics: Dict[str, float],
                 metrics: Dict[str, MetricValue],
             ) -> Union[float, MetricValue]:
                 """
@@ -142,7 +141,6 @@ def make_metric(
 
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
-                builtin_metrics: Dict[str, float],
                 metrics: Dict[str, MetricValue],
             ) -> Union[float, MetricValue]:
                 """

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -82,7 +82,7 @@ class EvaluationMetric:
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
                 metrics: Dict[str, MetricValue],
-            ) -> Union[float, MetricValue]:
+            ) -> MetricValue:
                 """
                 :param eval_df:
                     A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.
@@ -144,7 +144,7 @@ def make_metric(
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
                 metrics: Dict[str, MetricValue],
-            ) -> Union[float, MetricValue]:
+            ) -> MetricValue:
                 """
                 :param eval_df:
                     A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

- define MetricValue
- alias EvaluationMetric and make_metric, update definitions to use:
- metrics: Dict[str, MetricValue] as parameter to eval_fn -> we will use inspect.signature() to determine whether we will actually pass in Dict[str, MetricValue] or use the old builtin_metrics: Dict[str, float]
- ask users to return MetricValue from eval_fn -> old fns with float return type will still work but we want to document that they ideally return MetricValue
- [Follow-up PR](https://github.com/mlflow/mlflow/pull/9440/files#diff-1b3ab8e1152a42ab0bd3d4e01c7621b37a95aa02fff19642a5abf23f75b6e688R483) to implement functionality to support new custom metrics (and be backwards compatible)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
