### PR TITLE
Modify mlflow.evaluate() to support custom per-row metrics

### DIFF
--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -1,7 +1,10 @@
-from mlflow.metrics.base import (
+from mlflow.models import (
     EvaluationMetric,
-    MetricValue,
     make_metric,
+)
+
+from mlflow.metrics.base import (
+    MetricValue,
 )
 
 __all__ = [

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -1,0 +1,11 @@
+from mlflow.metrics.base import (
+    EvaluationMetric,
+    MetricValue,
+    make_metric,
+)
+
+__all__ = [
+    "EvaluationMetric",
+    "MetricValue",
+    "make_metric",
+]

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -2,22 +2,29 @@ from types import FunctionType
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.exceptions import MlflowException
 
+
 class MetricValue:
-    '''
-    A model evaluation metric.
+    """
+    The value of a metric.
     :param scores: The value of the metric per row
     :param justifications: The justification (if applicable) for the respective score
     :param aggregate_results: A dictionary mapping the name of the aggregation to its value
-    '''
+    """
 
-    def __init__(self, scores: list[float] = None, justifications: list[str] = None, aggregate_results: dict[str, float] = None):
+    def __init__(
+        self,
+        scores: list[float] = None,
+        justifications: list[str] = None,
+        aggregate_results: dict[str, float] = None,
+    ):
         self.scores = scores
         self.justifications = justifications
         self.aggregate_results = aggregate_results
 
+
 class EvaluationMetric:
     '''
-    A model evaluation metric.
+    An evaluation metric.
     :param eval_fn:
         A function that computes the metric with the following signature:
         .. code-block:: python
@@ -33,7 +40,8 @@ class EvaluationMetric:
                     on that row.
                 :param builtin_metrics:
                     A dictionary containing the metrics calculated by the default evaluator.
-                    The keys are the names of the metrics and the values are the . Refer to the DefaultEvaluator behavior section for what metrics
+                    The keys are the names of the metrics and the values are the metric values.
+                    Refer to the DefaultEvaluator behavior section for what metrics
                     will be returned based on the type of model (i.e. classifier or regressor).
                 :return:
                     
@@ -43,6 +51,7 @@ class EvaluationMetric:
     :param greater_is_better: Whether a higher value of the metric is better.
     :param long_name: (Optional) The long name of the metric. For example,
         ``"root_mean_squared_error"`` for ``"mse"``.
+    :param version: (Optional) The metric version. For example ``v1``.
     '''
 
     def __init__(self, eval_fn, name, greater_is_better, long_name=None, version=None):

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -1,9 +1,11 @@
+from dataclasses import dataclass
 from typing import Dict, List
 
 from mlflow.models import EvaluationMetric as EvaluationMetric
 from mlflow.models import make_metric as make_metric
 
 
+@dataclass
 class MetricValue:
     """
     The value of a metric.

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -1,9 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict, List
 
-from mlflow.models import EvaluationMetric as EvaluationMetric
-from mlflow.models import make_metric as make_metric
-
 
 @dataclass
 class MetricValue:

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -1,0 +1,86 @@
+from types import FunctionType
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.exceptions import MlflowException
+
+class MetricValue:
+    '''
+    A model evaluation metric.
+    :param scores: The value of the metric per row
+    :param justifications: The justification (if applicable) for the respective score
+    :param aggregate_results: A dictionary mapping the name of the aggregation to its value
+    '''
+
+    def __init__(self, scores: list[float] = None, justifications: list[str] = None, aggregate_results: dict[str, float] = None):
+        self.scores = scores
+        self.justifications = justifications
+        self.aggregate_results = aggregate_results
+
+class EvaluationMetric:
+    '''
+    A model evaluation metric.
+    :param eval_fn:
+        A function that computes the metric with the following signature:
+        .. code-block:: python
+            def eval_fn(
+                eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
+                builtin_metrics: Dict[str, MetricValue],
+            ) -> MetricValue:
+                """
+                :param eval_df:
+                    A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.
+                    The ``prediction`` column contains the predictions made by the model.
+                    The ``target`` column contains the corresponding labels to the predictions made
+                    on that row.
+                :param builtin_metrics:
+                    A dictionary containing the metrics calculated by the default evaluator.
+                    The keys are the names of the metrics and the values are the . Refer to the DefaultEvaluator behavior section for what metrics
+                    will be returned based on the type of model (i.e. classifier or regressor).
+                :return:
+                    
+                """
+                ...
+    :param name: The name of the metric.
+    :param greater_is_better: Whether a higher value of the metric is better.
+    :param long_name: (Optional) The long name of the metric. For example,
+        ``"root_mean_squared_error"`` for ``"mse"``.
+    '''
+
+    def __init__(self, eval_fn, name, greater_is_better, long_name=None, version=None):
+        self.eval_fn = eval_fn
+        self.name = name
+        self.greater_is_better = greater_is_better
+        self.long_name = long_name or name
+        self.version = version
+
+    def __str__(self):
+        if self.long_name:
+            return (
+                f"EvaluationMetric(name={self.name}, long_name={self.long_name}, "
+                f"greater_is_better={self.greater_is_better})"
+            )
+        else:
+            return f"EvaluationMetric(name={self.name}, greater_is_better={self.greater_is_better})"
+
+
+def make_metric(
+    *,
+    eval_fn,
+    greater_is_better,
+    name=None,
+    long_name=None,
+    version=None,
+):
+    if name is None:
+        if isinstance(eval_fn, FunctionType) and eval_fn.__name__ == "<lambda>":
+            raise MlflowException(
+                "`name` must be specified if `eval_fn` is a lambda function.",
+                INVALID_PARAMETER_VALUE,
+            )
+        if not hasattr(eval_fn, "__name__"):
+            raise MlflowException(
+                "`name` must be specified if `eval_fn` does not have a `__name__` attribute.",
+                INVALID_PARAMETER_VALUE,
+            )
+        name = eval_fn.__name__
+
+    return EvaluationMetric(eval_fn, name, greater_is_better, long_name, version)

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -1,7 +1,5 @@
-from types import FunctionType
-from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.exceptions import MlflowException
-
+from mlflow.models import EvaluationMetric as EvaluationMetric
+from mlflow.models import make_metric as make_metric
 
 class MetricValue:
     """
@@ -21,75 +19,3 @@ class MetricValue:
         self.justifications = justifications
         self.aggregate_results = aggregate_results
 
-
-class EvaluationMetric:
-    '''
-    An evaluation metric.
-    :param eval_fn:
-        A function that computes the metric with the following signature:
-        .. code-block:: python
-            def eval_fn(
-                eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
-                builtin_metrics: Dict[str, MetricValue],
-            ) -> MetricValue:
-                """
-                :param eval_df:
-                    A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.
-                    The ``prediction`` column contains the predictions made by the model.
-                    The ``target`` column contains the corresponding labels to the predictions made
-                    on that row.
-                :param builtin_metrics:
-                    A dictionary containing the metrics calculated by the default evaluator.
-                    The keys are the names of the metrics and the values are the metric values.
-                    Refer to the DefaultEvaluator behavior section for what metrics
-                    will be returned based on the type of model (i.e. classifier or regressor).
-                :return:
-                    
-                """
-                ...
-    :param name: The name of the metric.
-    :param greater_is_better: Whether a higher value of the metric is better.
-    :param long_name: (Optional) The long name of the metric. For example,
-        ``"root_mean_squared_error"`` for ``"mse"``.
-    :param version: (Optional) The metric version. For example ``v1``.
-    '''
-
-    def __init__(self, eval_fn, name, greater_is_better, long_name=None, version=None):
-        self.eval_fn = eval_fn
-        self.name = name
-        self.greater_is_better = greater_is_better
-        self.long_name = long_name or name
-        self.version = version
-
-    def __str__(self):
-        if self.long_name:
-            return (
-                f"EvaluationMetric(name={self.name}, long_name={self.long_name}, "
-                f"greater_is_better={self.greater_is_better})"
-            )
-        else:
-            return f"EvaluationMetric(name={self.name}, greater_is_better={self.greater_is_better})"
-
-
-def make_metric(
-    *,
-    eval_fn,
-    greater_is_better,
-    name=None,
-    long_name=None,
-    version=None,
-):
-    if name is None:
-        if isinstance(eval_fn, FunctionType) and eval_fn.__name__ == "<lambda>":
-            raise MlflowException(
-                "`name` must be specified if `eval_fn` is a lambda function.",
-                INVALID_PARAMETER_VALUE,
-            )
-        if not hasattr(eval_fn, "__name__"):
-            raise MlflowException(
-                "`name` must be specified if `eval_fn` does not have a `__name__` attribute.",
-                INVALID_PARAMETER_VALUE,
-            )
-        name = eval_fn.__name__
-
-    return EvaluationMetric(eval_fn, name, greater_is_better, long_name, version)

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -14,12 +14,6 @@ class MetricValue:
     :param aggregate_results: A dictionary mapping the name of the aggregation to its value
     """
 
-    def __init__(
-        self,
-        scores: List[float] = None,
-        justifications: List[float] = None,
-        aggregate_results: Dict[str, float] = None,
-    ):
-        self.scores = scores
-        self.justifications = justifications
-        self.aggregate_results = aggregate_results
+    scores: List[float] = None
+    justifications: List[float] = None
+    aggregate_results: Dict[str, float] = None

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -1,3 +1,5 @@
+from typing import Dict, List
+
 from mlflow.models import EvaluationMetric as EvaluationMetric
 from mlflow.models import make_metric as make_metric
 
@@ -10,7 +12,12 @@ class MetricValue:
     :param aggregate_results: A dictionary mapping the name of the aggregation to its value
     """
 
-    def __init__(self, scores=None, justifications=None, aggregate_results=None):
+    def __init__(
+        self,
+        scores: List[float] = None,
+        justifications: List[float] = None,
+        aggregate_results: Dict[str, float] = None,
+    ):
         self.scores = scores
         self.justifications = justifications
         self.aggregate_results = aggregate_results

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -1,6 +1,7 @@
 from mlflow.models import EvaluationMetric as EvaluationMetric
 from mlflow.models import make_metric as make_metric
 
+
 class MetricValue:
     """
     The value of a metric.
@@ -9,13 +10,7 @@ class MetricValue:
     :param aggregate_results: A dictionary mapping the name of the aggregation to its value
     """
 
-    def __init__(
-        self,
-        scores: list[float] = None,
-        justifications: list[str] = None,
-        aggregate_results: dict[str, float] = None,
-    ):
+    def __init__(self, scores=None, justifications=None, aggregate_results=None):
         self.scores = scores
         self.justifications = justifications
         self.aggregate_results = aggregate_results
-

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -66,9 +66,12 @@ class _ModelType:
 class EvaluationMetric:
     '''
     An evaluation metric.
+
     :param eval_fn:
         A function that computes the metric with the following signature:
+
         .. code-block:: python
+
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
                 builtin_metrics: Dict[str, MetricValue],
@@ -85,9 +88,10 @@ class EvaluationMetric:
                     Refer to the DefaultEvaluator behavior section for what metrics
                     will be returned based on the type of model (i.e. classifier or regressor).
                 :return:
-
+                    MetricValue with per-row scores, per-row justifications, and aggregate results.
                 """
                 ...
+
     :param name: The name of the metric.
     :param greater_is_better: Whether a higher value of the metric is better.
     :param long_name: (Optional) The long name of the metric. For example,

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -85,6 +85,8 @@ class EvaluationMetric:
                 :param builtin_metrics:
                     A dictionary containing the metrics calculated by the default evaluator.
                     The keys are the names of the metrics and the values are the metric values.
+                    To access the MetricValue for the metrics calculated by the system, make sure
+                    to specify the type hint for this parameter as Dict[str, MetricValue].
                     Refer to the DefaultEvaluator behavior section for what metrics
                     will be returned based on the type of model (i.e. classifier or regressor).
                 :return:
@@ -144,8 +146,10 @@ def make_metric(
                     on that row.
                 :param builtin_metrics:
                     A dictionary containing the metrics calculated by the default evaluator.
-                    The keys are the names of the metrics and the values are the scalar values of
-                    the metrics. Refer to the DefaultEvaluator behavior section for what metrics
+                    The keys are the names of the metrics and the values are the metric values.
+                    To access the MetricValue for the metrics calculated by the system, make sure
+                    to specify the type hint for this parameter as Dict[str, MetricValue].
+                    Refer to the DefaultEvaluator behavior section for what metrics
                     will be returned based on the type of model (i.e. classifier or regressor).
                 :return:
                     MetricValue with per-row scores, per-row justifications, and aggregate results.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -74,7 +74,6 @@ class EvaluationMetric:
 
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
-                builtin_metrics: Dict[str, float],
                 metrics: Dict[str, MetricValue],
             ) -> Union[float, MetricValue]:
                 """
@@ -135,7 +134,6 @@ def make_metric(
 
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
-                builtin_metrics: Dict[str, float],
                 metrics: Dict[str, MetricValue],
             ) -> Union[float, MetricValue]:
                 """

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -85,7 +85,7 @@ class EvaluationMetric:
                     Refer to the DefaultEvaluator behavior section for what metrics
                     will be returned based on the type of model (i.e. classifier or regressor).
                 :return:
-                    
+
                 """
                 ...
     :param name: The name of the metric.
@@ -110,7 +110,6 @@ class EvaluationMetric:
             )
         else:
             return f"EvaluationMetric(name={self.name}, greater_is_better={self.greater_is_better})"
-
 
 
 def make_metric(

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -75,7 +75,7 @@ class EvaluationMetric:
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
                 metrics: Dict[str, MetricValue],
-            ) -> MetricValue:
+            ) -> Union[float, MetricValue]:
                 """
                 :param eval_df:
                     A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.
@@ -137,7 +137,7 @@ def make_metric(
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
                 metrics: Dict[str, MetricValue],
-            ) -> MetricValue:
+            ) -> Union[float, MetricValue]:
                 """
                 :param eval_df:
                     A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -75,7 +75,7 @@ class EvaluationMetric:
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
                 metrics: Dict[str, MetricValue],
-            ) -> Union[float, MetricValue]:
+            ) -> MetricValue:
                 """
                 :param eval_df:
                     A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.
@@ -137,7 +137,7 @@ def make_metric(
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
                 metrics: Dict[str, MetricValue],
-            ) -> Union[float, MetricValue]:
+            ) -> MetricValue:
                 """
                 :param eval_df:
                     A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -65,17 +65,14 @@ class _ModelType:
 
 class EvaluationMetric:
     '''
-    A model evaluation metric.
-
+    An evaluation metric.
     :param eval_fn:
         A function that computes the metric with the following signature:
-
         .. code-block:: python
-
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
-                builtin_metrics: Dict[str, float],
-            ) -> float:
+                builtin_metrics: Dict[str, MetricValue],
+            ) -> MetricValue:
                 """
                 :param eval_df:
                     A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.
@@ -84,25 +81,26 @@ class EvaluationMetric:
                     on that row.
                 :param builtin_metrics:
                     A dictionary containing the metrics calculated by the default evaluator.
-                    The keys are the names of the metrics and the values are the scalar values of
-                    the metrics. Refer to the DefaultEvaluator behavior section for what metrics
+                    The keys are the names of the metrics and the values are the metric values.
+                    Refer to the DefaultEvaluator behavior section for what metrics
                     will be returned based on the type of model (i.e. classifier or regressor).
                 :return:
-                    The metric value.
+                    
                 """
                 ...
-
     :param name: The name of the metric.
     :param greater_is_better: Whether a higher value of the metric is better.
     :param long_name: (Optional) The long name of the metric. For example,
         ``"root_mean_squared_error"`` for ``"mse"``.
+    :param version: (Optional) The metric version. For example ``v1``.
     '''
 
-    def __init__(self, eval_fn, name, greater_is_better, long_name=None):
+    def __init__(self, eval_fn, name, greater_is_better, long_name=None, version=None):
         self.eval_fn = eval_fn
         self.name = name
         self.greater_is_better = greater_is_better
         self.long_name = long_name or name
+        self.version = version
 
     def __str__(self):
         if self.long_name:
@@ -114,12 +112,14 @@ class EvaluationMetric:
             return f"EvaluationMetric(name={self.name}, greater_is_better={self.greater_is_better})"
 
 
+
 def make_metric(
     *,
     eval_fn,
     greater_is_better,
     name=None,
     long_name=None,
+    version=None,
 ):
     '''
     A factory function to create an :py:class:`EvaluationMetric` object.
@@ -173,7 +173,7 @@ def make_metric(
             )
         name = eval_fn.__name__
 
-    return EvaluationMetric(eval_fn, name, greater_is_better, long_name)
+    return EvaluationMetric(eval_fn, name, greater_is_better, long_name, version)
 
 
 @developer_stable

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -74,8 +74,9 @@ class EvaluationMetric:
 
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
-                builtin_metrics: Dict[str, MetricValue],
-            ) -> MetricValue:
+                builtin_metrics: Dict[str, float],
+                metrics: Dict[str, MetricValue],
+            ) -> Union[float, MetricValue]:
                 """
                 :param eval_df:
                     A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.
@@ -135,7 +136,8 @@ def make_metric(
             def eval_fn(
                 eval_df: Union[pandas.Dataframe, pyspark.sql.DataFrame],
                 builtin_metrics: Dict[str, float],
-            ) -> float:
+                metrics: Dict[str, MetricValue],
+            ) -> Union[float, MetricValue]:
                 """
                 :param eval_df:
                     A Pandas or Spark DataFrame containing ``prediction`` and ``target`` column.
@@ -148,7 +150,7 @@ def make_metric(
                     the metrics. Refer to the DefaultEvaluator behavior section for what metrics
                     will be returned based on the type of model (i.e. classifier or regressor).
                 :return:
-                    The metric value.
+                    MetricValue with per-row scores, per-row justifications, and aggregate results.
                 """
                 ...
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -9,8 +9,7 @@ import shutil
 import tempfile
 from collections import namedtuple
 from functools import partial
-from typing import Callable, NamedTuple, Dict
-from inspect import signature
+from typing import Callable, NamedTuple, Dict, get_type_hints
 
 import numpy as np
 import pandas as pd
@@ -476,9 +475,8 @@ def _evaluate_custom_metric(custom_metric_tuple, eval_df, builtin_metrics, metri
         " in the `custom_metrics` parameter"
     )
 
-    func_signature = signature(custom_metric_tuple.function)
-    metrics_param = func_signature.parameters.get("metrics")
-    if metrics_param and metrics_param.annotation == Dict[str, MetricValue]:
+    metrics_type = get_type_hints(custom_metric_tuple.function).get("metrics")
+    if metrics_type and metrics_type == Dict[str, MetricValue] :
         metric = custom_metric_tuple.function(eval_df, metrics)
     else:
         # use old builtin_metrics: Dict[str, float]

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -480,6 +480,9 @@ def _evaluate_custom_metric(custom_metric_tuple, eval_df, builtin_metrics):
     if metric is None:
         raise MlflowException(f"{exception_header} returned None.")
 
+    if _is_numeric(metric):
+        return MetricValue(aggregate_results={custom_metric_tuple.name: metric})
+
     if not isinstance(metric, MetricValue):
         raise MlflowException(f"{exception_header} did not return a MetricValue.")
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -35,6 +35,7 @@ from mlflow.models.evaluation.base import (
     _ModelType,
 )
 from mlflow.models.utils import plot_lines
+from mlflow.metrics import MetricValue
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.pyfunc import _ServedPyFuncModel
 from mlflow.sklearn import _SklearnModelWrapper
@@ -449,10 +450,6 @@ class _CustomArtifact(NamedTuple):
     artifacts_dir: str
 
 
-def _is_numeric(value):
-    return isinstance(value, (int, float, np.number))
-
-
 def _evaluate_custom_metric(custom_metric_tuple, eval_df, builtin_metrics):
     """
     This function calls the `custom_metric` function and performs validations on the returned
@@ -475,8 +472,8 @@ def _evaluate_custom_metric(custom_metric_tuple, eval_df, builtin_metrics):
     if metric is None:
         raise MlflowException(f"{exception_header} returned None.")
 
-    if not _is_numeric(metric):
-        raise MlflowException(f"{exception_header} did not return a scalar numeric value.")
+    if not isinstance(metric, MetricValue):
+        raise MlflowException(f"{exception_header} did not return a MetricValue.")
 
     return metric
 
@@ -1021,7 +1018,13 @@ class DefaultEvaluator(ModelEvaluator):
                 eval_df.copy(),
                 copy.deepcopy(self.metrics),
             )
-            self.metrics.update({custom_metric.name: metric_result})
+            name, version = custom_metric.name, custom_metric.version
+            for aggregate, value in metric_result.aggregate_results:
+                self.metrics.update({f"{name}/{version}/{aggregate}": value})
+            self.metrics_dict.update({f"{name}/{version}/score": metric_result.scores})
+            self.metrics_dict.update(
+                {f"{name}/{version}/justification": metric_result.justifications}
+            )
 
     def _log_custom_artifacts(self, eval_df):
         if not self.custom_artifacts:

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1205,7 +1205,6 @@ class DefaultEvaluator(ModelEvaluator):
         else:
             data = self.dataset.features_data.assign(outputs=self.y_pred)
 
-        # TODO: version should be after score or justification
         aggregates = {}
         for metric_name, metric in self.metrics_values.items():
             scores = metric.scores

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -22,6 +22,7 @@ from sklearn.svm import LinearSVC
 
 import mlflow
 from mlflow.exceptions import MlflowException
+from mlflow.metrics import make_metric
 from mlflow.models import Model
 from mlflow.models.evaluation.artifacts import (
     CsvEvaluationArtifact,
@@ -32,7 +33,7 @@ from mlflow.models.evaluation.artifacts import (
     PickleEvaluationArtifact,
     TextEvaluationArtifact,
 )
-from mlflow.models.evaluation.base import evaluate, make_metric
+from mlflow.models.evaluation.base import evaluate
 from mlflow.models.evaluation.default_evaluator import (
     _compute_df_mode_or_mean,
     _CustomArtifact,

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1350,13 +1350,24 @@ def test_evaluate_custom_metric_incorrect_return_formats():
             metrics,
         )
 
+    def return_float(*_):
+        return 3.0
+
+    with pytest.raises(MlflowException, match="did not return a MetricValue"):
+        _evaluate_custom_metric(
+            _CustomMetric(return_float, return_float.__name__, 0),
+            eval_df,
+            metrics,
+        )
+
 
 @pytest.mark.parametrize(
     ("fn", "expectation"),
     [
         (
             lambda eval_df, _: MetricValue(
-                aggregate_results={"prediction_sum": sum(eval_df["prediction"])}
+                scores=eval_df["prediction"],
+                aggregate_results={"prediction_sum": sum(eval_df["prediction"])},
             ),
             does_not_raise(),
         ),

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1382,16 +1382,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         _evaluate_custom_metric(
             _CustomMetric(incorrect_return_type, incorrect_return_type.__name__, 0),
             eval_df,
-            metrics,
-        )
-
-    def return_float(*_):
-        return 3.0
-
-    with pytest.raises(MlflowException, match="did not return a MetricValue"):
-        _evaluate_custom_metric(
-            _CustomMetric(return_float, return_float.__name__, 0),
-            eval_df,
+            builtin_metrics,
             metrics,
         )
 
@@ -1402,6 +1393,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         _evaluate_custom_metric(
             _CustomMetric(non_list_scores, non_list_scores.__name__, 0),
             eval_df,
+            builtin_metrics,
             metrics,
         )
 
@@ -1412,6 +1404,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         _evaluate_custom_metric(
             _CustomMetric(non_numeric_scores, non_numeric_scores.__name__, 0),
             eval_df,
+            builtin_metrics,
             metrics,
         )
 
@@ -1424,6 +1417,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         _evaluate_custom_metric(
             _CustomMetric(non_list_justifications, non_list_justifications.__name__, 0),
             eval_df,
+            builtin_metrics,
             metrics,
         )
 
@@ -1436,6 +1430,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         _evaluate_custom_metric(
             _CustomMetric(non_str_justifications, non_str_justifications.__name__, 0),
             eval_df,
+            builtin_metrics,
             metrics,
         )
 
@@ -1448,6 +1443,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         _evaluate_custom_metric(
             _CustomMetric(non_dict_aggregates, non_dict_aggregates.__name__, 0),
             eval_df,
+            builtin_metrics,
             metrics,
         )
 
@@ -1461,6 +1457,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         _evaluate_custom_metric(
             _CustomMetric(wrong_type_aggregates, wrong_type_aggregates.__name__, 0),
             eval_df,
+            builtin_metrics,
             metrics,
         )
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -22,7 +22,10 @@ from sklearn.svm import LinearSVC
 
 import mlflow
 from mlflow.exceptions import MlflowException
-from mlflow.metrics import make_metric
+from mlflow.metrics import (
+    MetricValue,
+    make_metric,
+)
 from mlflow.models import Model
 from mlflow.models.evaluation.artifacts import (
     CsvEvaluationArtifact,
@@ -1447,10 +1450,12 @@ def test_custom_metric_produced_multiple_artifacts_with_same_name_throw_exceptio
 
 def test_custom_metric_mixed(binary_logistic_regressor_model_uri, breast_cancer_dataset):
     def true_count(_eval_df, given_metrics):
-        return given_metrics["true_negatives"] + given_metrics["true_positives"]
+        true_negatives = given_metrics["true_negatives"].aggregate_results["true_negatives"]
+        true_positives = given_metrics["true_positives"].aggregate_results["true_positives"]
+        return MetricValue(aggregate_results={"true_count": true_negatives + true_positives})
 
     def positive_count(eval_df, _given_metrics):
-        return np.sum(eval_df["prediction"])
+        return MetricValue(aggregate_results={"positive_count": np.sum(eval_df["prediction"])})
 
     def example_custom_artifact(_eval_df, _given_metrics, tmp_path):
         df = pd.DataFrame({"a": [1, 2, 3]})


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

- use new metrics in mlflow.evaluate()
- naming convention for metrics

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
