### PR TITLE
Update model signature inputs to be optional

### DIFF
--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -142,7 +142,7 @@ class ModelSignature:
 
 
 def infer_signature(
-    model_input: Any,
+    model_input: Any = None,
     model_output: "MlflowInferableDataset" = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> ModelSignature:
@@ -217,7 +217,7 @@ def infer_signature(
 
     :return: ModelSignature
     """
-    inputs = _infer_schema(model_input)
+    inputs = _infer_schema(model_input) if model_input is not None else None
     outputs = _infer_schema(model_output) if model_output is not None else None
     params = _infer_param_schema(params) if params else None
     return ModelSignature(inputs, outputs, params)

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -61,17 +61,17 @@ class ModelSignature:
         if inputs and not isinstance(inputs, Schema):
             raise TypeError(
                 "inputs must be either None or mlflow.models.signature.Schema, "
-                f"got '{type(inputs)}'"
+                f"got '{type(inputs).__name__}'"
             )
         if outputs and not isinstance(outputs, Schema):
             raise TypeError(
                 "outputs must be either None or mlflow.models.signature.Schema, "
-                f"got '{type(inputs)}'"
+                f"got '{type(outputs).__name__}'"
             )
         if params and not isinstance(params, ParamSchema):
             raise TypeError(
-                "If params are provided, they must by of type mlflow.models.signature.ParamSchema. "
-                f"Got '{type(params)}'"
+                "If params are provided, they must by of type mlflow.models.signature.ParamSchema, "
+                f"got '{type(params).__name__}'"
             )
         if all(x is None for x in [inputs, outputs, params]):
             raise ValueError("At least one of inputs, outputs or params must be provided")
@@ -108,17 +108,9 @@ class ModelSignature:
 
         :return: ModelSignature populated with the data form the dictionary.
         """
-        inputs = (
-            Schema.from_json(signature_dict["inputs"]) if signature_dict.get("inputs") else None
-        )
-        outputs = (
-            Schema.from_json(signature_dict["outputs"]) if signature_dict.get("outputs") else None
-        )
-        params = (
-            ParamSchema.from_json(signature_dict["params"])
-            if signature_dict.get("params")
-            else None
-        )
+        inputs = Schema.from_json(x) if (x := signature_dict.get("inputs")) else None
+        outputs = Schema.from_json(x) if (x := signature_dict.get("outputs")) else None
+        params = ParamSchema.from_json(x) if (x := signature_dict.get("params")) else None
 
         return cls(inputs, outputs, params)
 

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -57,10 +57,13 @@ class ModelSignature:
     :py:class:`ParamSchema <mlflow.types.ParamSchema>`.
     """
 
-    def __init__(self, inputs: Schema, outputs: Schema = None, params: ParamSchema = None):
-        if not isinstance(inputs, Schema):
-            raise TypeError(f"inputs must be mlflow.models.signature.Schema, got '{type(inputs)}'")
-        if outputs is not None and not isinstance(outputs, Schema):
+    def __init__(self, inputs: Schema = None, outputs: Schema = None, params: ParamSchema = None):
+        if inputs and not isinstance(inputs, Schema):
+            raise TypeError(
+                "inputs must be either None or mlflow.models.signature.Schema, "
+                f"got '{type(inputs)}'"
+            )
+        if outputs and not isinstance(outputs, Schema):
             raise TypeError(
                 "outputs must be either None or mlflow.models.signature.Schema, "
                 f"got '{type(inputs)}'"
@@ -70,6 +73,8 @@ class ModelSignature:
                 "If params are provided, they must by of type mlflow.models.signature.ParamSchema. "
                 f"Got '{type(params)}'"
             )
+        if all(x is None for x in [inputs, outputs, params]):
+            raise ValueError("At least one of inputs, outputs or params must be provided")
         self.inputs = inputs
         self.outputs = outputs
         self.params = params
@@ -85,8 +90,8 @@ class ModelSignature:
         """
 
         return {
-            "inputs": self.inputs.to_json(),
-            "outputs": self.outputs.to_json() if self.outputs is not None else None,
+            "inputs": self.inputs.to_json() if self.inputs else None,
+            "outputs": self.outputs.to_json() if self.outputs else None,
             "params": self.params.to_json() if self.params else None,
         }
 
@@ -103,16 +108,19 @@ class ModelSignature:
 
         :return: ModelSignature populated with the data form the dictionary.
         """
-        inputs = Schema.from_json(signature_dict["inputs"])
-        if "outputs" in signature_dict and signature_dict["outputs"] is not None:
-            outputs = Schema.from_json(signature_dict["outputs"])
-        else:
-            outputs = None
-        if (params := signature_dict.get("params")) is not None:
-            params = ParamSchema.from_json(params)
-            return cls(inputs, outputs, params)
-        else:
-            return cls(inputs, outputs)
+        inputs = (
+            Schema.from_json(signature_dict["inputs"]) if signature_dict.get("inputs") else None
+        )
+        outputs = (
+            Schema.from_json(signature_dict["outputs"]) if signature_dict.get("outputs") else None
+        )
+        params = (
+            ParamSchema.from_json(signature_dict["params"])
+            if signature_dict.get("params")
+            else None
+        )
+
+        return cls(inputs, outputs, params)
 
     def __eq__(self, other) -> bool:
         return (

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -337,6 +337,14 @@ class Schema:
     """
 
     def __init__(self, inputs: List[Union[ColSpec, TensorSpec]]):
+        if not isinstance(inputs, list):
+            raise MlflowException.invalid_parameter_value(
+                f"Inputs of Schema must be a list, got type {type(inputs).__name__}"
+            )
+        if not inputs:
+            raise MlflowException.invalid_parameter_value(
+                "Creating Schema with empty inputs is not allowed."
+            )
         if not (all(x.name is None for x in inputs) or all(x.name is not None for x in inputs)):
             raise MlflowException(
                 "Creating Schema with a combination of named and unnamed inputs "

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -69,6 +69,7 @@ from mlflow.store._unity_catalog.registry.utils import (
 from mlflow.store.artifact.azure_data_lake_artifact_repo import AzureDataLakeArtifactRepository
 from mlflow.store.artifact.gcs_artifact_repo import GCSArtifactRepository
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
+from mlflow.types.schema import ColSpec, DataType
 from mlflow.utils.mlflow_tags import (
     MLFLOW_DATABRICKS_JOB_ID,
     MLFLOW_DATABRICKS_JOB_RUN_ID,
@@ -173,7 +174,9 @@ def test_create_registered_model(mock_http, store):
 
 @pytest.fixture
 def local_model_dir(tmp_path):
-    fake_signature = ModelSignature(inputs=Schema([]), outputs=Schema([]))
+    fake_signature = ModelSignature(
+        inputs=Schema([ColSpec(DataType.string)]), outputs=Schema([ColSpec(DataType.double)])
+    )
     fake_mlmodel_contents = {
         "artifact_path": "some-artifact-path",
         "run_id": "abc123",
@@ -226,7 +229,9 @@ def test_create_model_version_missing_python_deps(store, local_model_dir):
 
 @pytest.fixture
 def feature_store_local_model_dir(tmp_path):
-    fake_signature = ModelSignature(inputs=Schema([]), outputs=Schema([]))
+    fake_signature = ModelSignature(
+        inputs=Schema([ColSpec(DataType.double)]), outputs=Schema([ColSpec(DataType.double)])
+    )
     fake_mlmodel_contents = {
         "artifact_path": "some-artifact-path",
         "run_id": "abc123",
@@ -266,7 +271,7 @@ def test_create_model_version_missing_signature(store, tmp_path):
 
 
 def test_create_model_version_missing_output_signature(store, tmp_path):
-    fake_signature = ModelSignature(inputs=Schema([]))
+    fake_signature = ModelSignature(inputs=Schema([ColSpec(DataType.integer)]))
     fake_mlmodel_contents = {"signature": fake_signature.to_dict()}
     with open(tmp_path.joinpath(MLMODEL_FILE_NAME), "w") as handle:
         yaml.dump(fake_mlmodel_contents, handle)

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -143,6 +143,14 @@ def test_schema_creation():
         Schema([TensorSpec(np.dtype("double"), (-1,)), TensorSpec(np.dtype("double"), (-1,))])
 
 
+def test_schema_creation_errors():
+    with pytest.raises(MlflowException, match=r"Creating Schema with empty inputs is not allowed."):
+        Schema([])
+
+    with pytest.raises(MlflowException, match=r"Inputs of Schema must be a list, got type dict"):
+        Schema({"col1": ColSpec(DataType.string)})
+
+
 def test_get_schema_type(dict_of_ndarrays):
     schema = _infer_schema(dict_of_ndarrays)
     assert ["float64"] * 4 == schema.numpy_types()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?
Make ModelSignature inputs an optional field, so that in some cases we could avoid input schema enforcement by setting inputs schema to None.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
