### PR TITLE
Replace str.format to f-string

### DIFF
--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -538,9 +538,7 @@ save, log, register, and load from the Model Registry and score.
         },
     ]
 
-    PYTHON_VERSION = "{major}.{minor}.{micro}".format(
-        major=version_info.major, minor=version_info.minor, micro=version_info.micro
-    )
+    PYTHON_VERSION = f"{version_info.major}.{version_info.minor}.{version_info.micro}"
 
 
     def score_model(model):
@@ -581,10 +579,10 @@ save, log, register, and load from the Model Registry and score.
     # Save the conda environment for this model.
     conda_env = {
         "channels": ["defaults", "conda-forge"],
-        "dependencies": ["python={}".format(PYTHON_VERSION), "pip"],
+        "dependencies": [f"python={PYTHON_VERSION}", "pip"],
         "pip": [
             "mlflow",
-            "cloudpickle=={}".format(cloudpickle.__version__),
+            f"cloudpickle=={cloudpickle.__version__}",
             "vaderSentiment==3.3.2",
         ],
         "name": "mlflow-env",

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -2032,11 +2032,11 @@ using a ``fastai`` data loader:
         artifacts = [
             f.path for f in mlflow.MlflowClient().list_artifacts(r.info.run_id, "model")
         ]
-        print("run_id: {}".format(r.info.run_id))
-        print("artifacts: {}".format(artifacts))
-        print("params: {}".format(r.data.params))
-        print("metrics: {}".format(r.data.metrics))
-        print("tags: {}".format(tags))
+        print(f"run_id: {r.info.run_id}")
+        print(f"artifacts: {artifacts}")
+        print(f"params: {r.data.params}")
+        print(f"metrics: {r.data.metrics}")
+        print(f"tags: {tags}")
 
 
     def main(epochs=5, learning_rate=0.01):
@@ -2091,7 +2091,7 @@ using a ``fastai`` data loader:
 
         print_auto_logged_info(mlflow.get_run(run_id=run.info.run_id))
 
-        model_uri = "runs:/{}/model".format(run.info.run_id)
+        model_uri = f"runs:/{run.info.run_id}/model"
         loaded_model = mlflow.fastai.load_model(model_uri)
 
         test_df = df.copy()
@@ -3758,9 +3758,7 @@ evaluate test data.
     from sklearn import datasets
     from sklearn.model_selection import train_test_split
 
-    PYTHON_VERSION = "{major}.{minor}.{micro}".format(
-        major=version_info.major, minor=version_info.minor, micro=version_info.micro
-    )
+    PYTHON_VERSION = f"{version_info.major}.{version_info.minor}.{version_info.micro}"
     iris = datasets.load_iris()
     x = iris.data[:, 2:]
     y = iris.target
@@ -3799,13 +3797,13 @@ evaluate test data.
     conda_env = {
         "channels": ["defaults"],
         "dependencies": [
-            "python={}".format(PYTHON_VERSION),
+            f"python={PYTHON_VERSION}",
             "pip",
             {
                 "pip": [
-                    "mlflow=={}".format(mlflow.__version__),
-                    "xgboost=={}".format(xgb.__version__),
-                    "cloudpickle=={}".format(cloudpickle.__version__),
+                    f"mlflow=={mlflow.__version__}",
+                    f"xgboost=={xgb.__version__}",
+                    f"cloudpickle=={cloudpickle.__version__}",
                 ],
             },
         ],

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -278,7 +278,7 @@ For example:
             signature = infer_signature(X_test, predictions)
             mlflow.sklearn.log_model(rf, "model", signature=signature)
 
-            print("Run ID: {}".format(run.info.run_id))
+            print(f"Run ID: {run.info.run_id}")
 
 In the case of the ``sklearn`` flavor, ``log_model`` stores the following files in the **artifacts** directory of the run's directory on the tracking server:
 

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -322,7 +322,7 @@ def log_model(
             artifacts = [
                 f.path for f in MlflowClient().list_artifacts(run.info.run_id, "model")
             ]
-            print("artifacts: {}".format(artifacts))
+            print(f"artifacts: {artifacts}")
 
 
         main()
@@ -419,7 +419,7 @@ def load_model(model_uri, dst_path=None):
             mlflow.fastai.log_model(model, "model")
 
         # Load the model for scoring
-        model_uri = "runs:/{}/model".format(run.info.run_id)
+        model_uri = f"runs:/{run.info.run_id}/model"
         loaded_model = mlflow.fastai.load_model(model_uri)
         results = loaded_model.predict(predict_data)
     """
@@ -487,11 +487,11 @@ def autolog(
         def print_auto_logged_info(r):
             tags = {k: v for k, v in r.data.tags.items() if not k.startswith("mlflow.")}
             artifacts = [f.path for f in MlflowClient().list_artifacts(r.info.run_id, "model")]
-            print("run_id: {}".format(r.info.run_id))
-            print("artifacts: {}".format(artifacts))
-            print("params: {}".format(r.data.params))
-            print("metrics: {}".format(r.data.metrics))
-            print("tags: {}".format(tags))
+            print(f"run_id: {r.info.run_id}")
+            print(f"artifacts: {artifacts}")
+            print(f"params: {r.data.params}")
+            print(f"metrics: {r.data.metrics}")
+            print(f"tags: {tags}")
 
 
         def main(epochs=5, learning_rate=0.01):

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -631,7 +631,7 @@ def get_model_info(model_uri: str) -> ModelInfo:
                 mlflow.log_params(params)
                 mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
-            model_uri = "runs:/{}/sklearn-model".format(run.info.run_id)
+            model_uri = f"runs:/{run.info.run_id}/sklearn-model"
             # Get model info with model_uri
             model_info = mlflow.models.get_model_info(model_uri)
             # Get model signature directly

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -395,7 +395,7 @@ def set_signature(
         # load model from run artifacts
         run_id = "96771d893a5e46159d9f3b49bf9013e2"
         artifact_path = "models"
-        model_uri = "runs:/{}/{}".format(run_id, artifact_path)
+        model_uri = f"runs:/{run_id}/{artifact_path}"
         model = mlflow.pyfunc.load_model(model_uri)
 
         # determine model signature

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -181,11 +181,7 @@ def save_model(
                 loss = F.square_error_cost(predicts, label=prices)
                 avg_loss = paddle.mean(loss)
                 if iter_id % 20 == 0:
-                    print(
-                        "epoch: {}, iter: {}, loss is: {}".format(
-                            epoch_id, iter_id, avg_loss.numpy()
-                        )
-                    )
+                    print(f"epoch: {epoch_id}, iter: {iter_id}, loss is: {avg_loss.numpy()}")
 
                 avg_loss.backward()
                 opt.step()
@@ -533,11 +529,11 @@ def autolog(
 
         def show_run_data(run_id):
             run = mlflow.get_run(run_id)
-            print("params: {}".format(run.data.params))
-            print("metrics: {}".format(run.data.metrics))
+            print(f"params: {run.data.params}")
+            print(f"metrics: {run.data.metrics}")
             client = MlflowClient()
             artifacts = [f.path for f in client.list_artifacts(run.info.run_id, "model")]
-            print("artifacts: {}".format(artifacts))
+            print(f"artifacts: {artifacts}")
 
 
         class LinearRegression(paddle.nn.Layer):

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -112,7 +112,7 @@ def get_default_conda_env():
 
         # Fetch the associated conda environment
         env = mlflow.pytorch.get_default_conda_env()
-        print("conda env: {}".format(env))
+        print(f"conda env: {env}")
 
     .. code-block:: text
         :caption: Output
@@ -270,12 +270,12 @@ def log_model(
             mlflow.pytorch.log_model(scripted_pytorch_model, "scripted_model")
 
         # Fetch the logged model artifacts
-        print("run_id: {}".format(run.info.run_id))
+        print(f"run_id: {run.info.run_id}")
         for artifact_path in ["model/data", "scripted_model/data"]:
             artifacts = [
                 f.path for f in MlflowClient().list_artifacts(run.info.run_id, artifact_path)
             ]
-            print("artifacts: {}".format(artifacts))
+            print(f"artifacts: {artifacts}")
 
     .. code-block:: text
         :caption: Output
@@ -422,13 +422,13 @@ def save_model(
 
         # Load each saved model for inference
         for model_path in ["model", "scripted_model"]:
-            model_uri = "{}/{}".format(os.getcwd(), model_path)
+            model_uri = f"{os.getcwd()}/{model_path}"
             loaded_model = mlflow.pytorch.load_model(model_uri)
-            print("Loaded {}:".format(model_path))
+            print(f"Loaded {model_path}:")
             for x in [6.0, 8.0, 12.0, 30.0]:
                 X = torch.Tensor([[x]])
                 y_pred = loaded_model(X)
-                print("predict X: {}, y_pred: {:.2f}".format(x, y_pred.data.item()))
+                print(f"predict X: {x}, y_pred: {y_pred.data.item():.2f}")
             print("--")
 
     .. code-block:: text
@@ -680,12 +680,12 @@ def load_model(model_uri, dst_path=None, **kwargs):
             mlflow.pytorch.log_model(model, "model", signature=signature)
 
         # Inference after loading the logged model
-        model_uri = "runs:/{}/model".format(run.info.run_id)
+        model_uri = f"runs:/{run.info.run_id}/model"
         loaded_model = mlflow.pytorch.load_model(model_uri)
         for x in [4.0, 6.0, 30.0]:
             X = torch.Tensor([[x]])
             y_pred = loaded_model(X)
-            print("predict X: {}, y_pred: {:.2f}".format(x, y_pred.data.item()))
+            print(f"predict X: {x}, y_pred: {y_pred.data.item():.2f}")
 
     .. code-block:: text
         :caption: Output
@@ -999,11 +999,11 @@ def autolog(
         def print_auto_logged_info(r):
             tags = {k: v for k, v in r.data.tags.items() if not k.startswith("mlflow.")}
             artifacts = [f.path for f in MlflowClient().list_artifacts(r.info.run_id, "model")]
-            print("run_id: {}".format(r.info.run_id))
-            print("artifacts: {}".format(artifacts))
-            print("params: {}".format(r.data.params))
-            print("metrics: {}".format(r.data.metrics))
-            print("tags: {}".format(tags))
+            print(f"run_id: {r.info.run_id}")
+            print(f"artifacts: {artifacts}")
+            print(f"params: {r.data.params}")
+            print(f"metrics: {r.data.metrics}")
+            print(f"tags: {tags}")
 
 
         # Initialize our model

--- a/mlflow/server/auth/client.py
+++ b/mlflow/server/auth/client.py
@@ -53,10 +53,10 @@ class AuthServiceClient:
 
             client = AuthServiceClient("tracking_uri")
             user = client.create_user("newuser", "newpassword")
-            print("user_id: {}".format(user.id))
-            print("username: {}".format(user.username))
-            print("password_hash: {}".format(user.password_hash))
-            print("is_admin: {}".format(user.is_admin))
+            print(f"user_id: {user.id}")
+            print(f"username: {user.username}")
+            print(f"password_hash: {user.password_hash}")
+            print(f"is_admin: {user.is_admin}")
 
         .. code-block:: text
             :caption: Output
@@ -96,10 +96,10 @@ class AuthServiceClient:
             client.create_user("newuser", "newpassword")
 
             user = client.get_user("newuser")
-            print("user_id: {}".format(user.id))
-            print("username: {}".format(user.username))
-            print("password_hash: {}".format(user.password_hash))
-            print("is_admin: {}".format(user.is_admin))
+            print(f"user_id: {user.id}")
+            print(f"username: {user.username}")
+            print(f"password_hash: {user.password_hash}")
+            print(f"is_admin: {user.is_admin}")
 
         .. code-block:: text
             :caption: Output
@@ -233,9 +233,9 @@ class AuthServiceClient:
             client = AuthServiceClient("tracking_uri")
             client.create_user("newuser", "newpassword")
             ep = client.create_experiment_permission("myexperiment", "newuser", "READ")
-            print("experiment_id: {}".format(ep.experiment_id))
-            print("user_id: {}".format(ep.user_id))
-            print("permission: {}".format(ep.permission))
+            print(f"experiment_id: {ep.experiment_id}")
+            print(f"user_id: {ep.user_id}")
+            print(f"permission: {ep.permission}")
 
         .. code-block:: text
             :caption: Output
@@ -278,9 +278,9 @@ class AuthServiceClient:
             client.create_user("newuser", "newpassword")
             client.create_experiment_permission("myexperiment", "newuser", "READ")
             ep = client.get_experiment_permission("myexperiment", "newuser")
-            print("experiment_id: {}".format(ep.experiment_id))
-            print("user_id: {}".format(ep.user_id))
-            print("permission: {}".format(ep.permission))
+            print(f"experiment_id: {ep.experiment_id}")
+            print(f"user_id: {ep.user_id}")
+            print(f"permission: {ep.permission}")
 
         .. code-block:: text
             :caption: Output
@@ -392,9 +392,9 @@ class AuthServiceClient:
             client = AuthServiceClient("tracking_uri")
             client.create_user("newuser", "newpassword")
             rmp = client.create_registered_model_permission("myregisteredmodel", "newuser", "READ")
-            print("name: {}".format(rmp.name))
-            print("user_id: {}".format(rmp.user_id))
-            print("permission: {}".format(rmp.permission))
+            print(f"name: {rmp.name}")
+            print(f"user_id: {rmp.user_id}")
+            print(f"permission: {rmp.permission}")
 
         .. code-block:: text
             :caption: Output
@@ -437,9 +437,9 @@ class AuthServiceClient:
             client.create_user("newuser", "newpassword")
             client.create_registered_model_permission("myregisteredmodel", "newuser", "READ")
             rmp = client.get_registered_model_permission("myregisteredmodel", "newuser")
-            print("name: {}".format(rmp.name))
-            print("user_id: {}".format(rmp.user_id))
-            print("permission: {}".format(rmp.permission))
+            print(f"name: {rmp.name}")
+            print(f"user_id: {rmp.user_id}")
+            print(f"permission: {rmp.permission}")
 
         .. code-block:: text
             :caption: Output

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -59,10 +59,10 @@ def register_model(
             mlflow.log_params(params)
             mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
 
-        model_uri = "runs:/{}/sklearn-model".format(run.info.run_id)
+        model_uri = f"runs:/{run.info.run_id}/sklearn-model"
         mv = mlflow.register_model(model_uri, "RandomForestRegressionModel")
-        print("Name: {}".format(mv.name))
-        print("Version: {}".format(mv.version))
+        print(f"Name: {mv.name}")
+        print(f"Version: {mv.version}")
 
     .. code-block:: text
         :caption: Output
@@ -178,7 +178,7 @@ def search_registered_models(
         print("-" * 80)
         for res in results:
             for mv in res.latest_versions:
-                print("name={}; run_id={}; version={}".format(mv.name, mv.run_id, mv.version))
+                print(f"name={mv.name}; run_id={mv.run_id}; version={mv.version}")
 
         # Get search results filtered by the registered model name that matches
         # prefix pattern
@@ -187,14 +187,14 @@ def search_registered_models(
         print("-" * 80)
         for res in results:
             for mv in res.latest_versions:
-                print("name={}; run_id={}; version={}".format(mv.name, mv.run_id, mv.version))
+                print(f"name={mv.name}; run_id={mv.run_id}; version={mv.version}")
 
         # Get all registered models and order them by ascending order of the names
         results = mlflow.search_registered_models(order_by=["name ASC"])
         print("-" * 80)
         for res in results:
             for mv in res.latest_versions:
-                print("name={}; run_id={}; version={}".format(mv.name, mv.run_id, mv.version))
+                print(f"name={mv.name}; run_id={mv.run_id}; version={mv.version}")
 
     .. code-block:: text
         :caption: Output
@@ -280,14 +280,14 @@ def search_model_versions(
         results = mlflow.search_model_versions(filter_string=filter_string)
         print("-" * 80)
         for res in results:
-            print("name={}; run_id={}; version={}".format(res.name, res.run_id, res.version))
+            print(f"name={res.name}; run_id={res.run_id}; version={res.version}")
 
         # Get the version of the model filtered by run_id
         filter_string = "run_id = 'ae9a606a12834c04a8ef1006d0cff779'"
         results = mlflow.search_model_versions(filter_string=filter_string)
         print("-" * 80)
         for res in results:
-            print("name={}; run_id={}; version={}".format(res.name, res.run_id, res.version))
+            print(f"name={res.name}; run_id={res.run_id}; version={res.version}")
 
     .. code-block:: text
         :caption: Output

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -75,9 +75,9 @@ def set_registry_uri(uri: str) -> None:
         # it with the tracking uri. They should be different
         mlflow.set_registry_uri("sqlite:////tmp/registry.db")
         mr_uri = mlflow.get_registry_uri()
-        print("Current registry uri: {}".format(mr_uri))
+        print(f"Current registry uri: {mr_uri}")
         tracking_uri = mlflow.get_tracking_uri()
-        print("Current tracking uri: {}".format(tracking_uri))
+        print(f"Current tracking uri: {tracking_uri}")
 
         # They should be different
         assert tracking_uri != mr_uri
@@ -113,11 +113,11 @@ def get_registry_uri() -> str:
 
         # Get the current model registry uri
         mr_uri = mlflow.get_registry_uri()
-        print("Current model registry uri: {}".format(mr_uri))
+        print(f"Current model registry uri: {mr_uri}")
 
         # Get the current tracking uri
         tracking_uri = mlflow.get_tracking_uri()
-        print("Current tracking uri: {}".format(tracking_uri))
+        print(f"Current tracking uri: {tracking_uri}")
 
         # They should be the same
         assert mr_uri == tracking_uri

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -58,7 +58,7 @@ def set_tracking_uri(uri: Union[str, Path]) -> None:
 
         mlflow.set_tracking_uri("file:///tmp/my_tracking")
         tracking_uri = mlflow.get_tracking_uri()
-        print("Current tracking uri: {}".format(tracking_uri))
+        print(f"Current tracking uri: {tracking_uri}")
 
     .. code-block:: text
         :caption: Output
@@ -109,7 +109,7 @@ def get_tracking_uri() -> str:
 
         # Get the current tracking uri
         tracking_uri = mlflow.get_tracking_uri()
-        print("Current tracking uri: {}".format(tracking_uri))
+        print(f"Current tracking uri: {tracking_uri}")
 
     .. code-block:: text
         :caption: Output

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -153,9 +153,9 @@ class MlflowClient:
             # Fetch the run
             client = MlflowClient()
             run = client.get_run(run.info.run_id)
-            print("run_id: {}".format(run.info.run_id))
-            print("params: {}".format(run.data.params))
-            print("status: {}".format(run.info.status))
+            print(f"run_id: {run.info.run_id}")
+            print(f"params: {run.data.params}")
+            print(f"status: {run.info.status}")
 
         .. code-block:: text
             :caption: Output
@@ -189,8 +189,8 @@ class MlflowClient:
             client = MlflowClient()
             parent_run = client.get_parent_run(child_run_id)
 
-            print("child_run_id: {}".format(child_run_id))
-            print("parent_run_id: {}".format(parent_run.info.run_id))
+            print(f"child_run_id: {child_run_id}")
+            print(f"parent_run_id: {parent_run.info.run_id}")
 
         .. code-block:: text
             :caption: Output
@@ -221,10 +221,10 @@ class MlflowClient:
 
             def print_metric_info(history):
                 for m in history:
-                    print("name: {}".format(m.key))
-                    print("value: {}".format(m.value))
-                    print("step: {}".format(m.step))
-                    print("timestamp: {}".format(m.timestamp))
+                    print(f"name: {m.key}")
+                    print(f"value: {m.value}")
+                    print(f"step: {m.step}")
+                    print(f"timestamp: {m.timestamp}")
                     print("--")
 
 
@@ -234,7 +234,7 @@ class MlflowClient:
             client = MlflowClient()
             experiment_id = "0"
             run = client.create_run(experiment_id)
-            print("run_id: {}".format(run.info.run_id))
+            print(f"run_id: {run.info.run_id}")
             print("--")
 
             # Log couple of metrics, update their initial value, and fetch each
@@ -307,12 +307,12 @@ class MlflowClient:
             run = client.create_run(experiment_id, tags=tags, run_name=name)
 
             # Show newly created run metadata info
-            print("Run tags: {}".format(run.data.tags))
-            print("Experiment id: {}".format(run.info.experiment_id))
-            print("Run id: {}".format(run.info.run_id))
-            print("Run name: {}".format(run.info.run_name))
-            print("lifecycle_stage: {}".format(run.info.lifecycle_stage))
-            print("status: {}".format(run.info.status))
+            print(f"Run tags: {run.data.tags}")
+            print(f"Experiment id: {run.info.experiment_id}")
+            print(f"Run id: {run.info.run_id}")
+            print(f"Run name: {run.info.run_name}")
+            print(f"lifecycle_stage: {run.info.lifecycle_stage}")
+            print(f"status: {run.info.status}")
 
         .. code-block:: text
             :caption: Output
@@ -459,10 +459,10 @@ class MlflowClient:
             experiment = client.get_experiment(exp_id)
 
             # Show experiment info
-            print("Name: {}".format(experiment.name))
-            print("Experiment ID: {}".format(experiment.experiment_id))
-            print("Artifact Location: {}".format(experiment.artifact_location))
-            print("Lifecycle_stage: {}".format(experiment.lifecycle_stage))
+            print(f"Name: {experiment.name}")
+            print(f"Experiment ID: {experiment.experiment_id}")
+            print(f"Artifact Location: {experiment.artifact_location}")
+            print(f"Lifecycle_stage: {experiment.lifecycle_stage}")
 
         .. code-block:: text
             :caption: Output
@@ -492,10 +492,10 @@ class MlflowClient:
             experiment = client.get_experiment_by_name("Default")
 
             # Show experiment info
-            print("Name: {}".format(experiment.name))
-            print("Experiment ID: {}".format(experiment.experiment_id))
-            print("Artifact Location: {}".format(experiment.artifact_location))
-            print("Lifecycle_stage: {}".format(experiment.lifecycle_stage))
+            print(f"Name: {experiment.name}")
+            print(f"Experiment ID: {experiment.experiment_id}")
+            print(f"Artifact Location: {experiment.artifact_location}")
+            print(f"Lifecycle_stage: {experiment.lifecycle_stage}")
 
         .. code-block:: text
             :caption: Output
@@ -540,11 +540,11 @@ class MlflowClient:
 
             # Fetch experiment metadata information
             experiment = client.get_experiment(experiment_id)
-            print("Name: {}".format(experiment.name))
-            print("Experiment_id: {}".format(experiment.experiment_id))
-            print("Artifact Location: {}".format(experiment.artifact_location))
-            print("Tags: {}".format(experiment.tags))
-            print("Lifecycle_stage: {}".format(experiment.lifecycle_stage))
+            print(f"Name: {experiment.name}")
+            print(f"Experiment_id: {experiment.experiment_id}")
+            print(f"Artifact Location: {experiment.artifact_location}")
+            print(f"Tags: {experiment.tags}")
+            print(f"Lifecycle_stage: {experiment.lifecycle_stage}")
 
         .. code-block:: text
             :caption: Output
@@ -578,9 +578,9 @@ class MlflowClient:
 
             # Examine the deleted experiment details.
             experiment = client.get_experiment(experiment_id)
-            print("Name: {}".format(experiment.name))
-            print("Artifact Location: {}".format(experiment.artifact_location))
-            print("Lifecycle_stage: {}".format(experiment.lifecycle_stage))
+            print(f"Name: {experiment.name}")
+            print(f"Artifact Location: {experiment.artifact_location}")
+            print(f"Lifecycle_stage: {experiment.lifecycle_stage}")
 
         .. code-block:: text
             :caption: Output
@@ -604,9 +604,9 @@ class MlflowClient:
 
 
             def print_experiment_info(experiment):
-                print("Name: {}".format(experiment.name))
-                print("Experiment Id: {}".format(experiment.experiment_id))
-                print("Lifecycle_stage: {}".format(experiment.lifecycle_stage))
+                print(f"Name: {experiment.name}")
+                print(f"Experiment Id: {experiment.experiment_id}")
+                print(f"Lifecycle_stage: {experiment.lifecycle_stage}")
 
 
             # Create and delete an experiment
@@ -650,9 +650,9 @@ class MlflowClient:
 
 
             def print_experiment_info(experiment):
-                print("Name: {}".format(experiment.name))
-                print("Experiment_id: {}".format(experiment.experiment_id))
-                print("Lifecycle_stage: {}".format(experiment.lifecycle_stage))
+                print(f"Name: {experiment.name}")
+                print(f"Experiment_id: {experiment.experiment_id}")
+                print(f"Lifecycle_stage: {experiment.lifecycle_stage}")
 
 
             # Create an experiment with a name that is unique and case sensitive
@@ -714,9 +714,9 @@ class MlflowClient:
 
 
             def print_run_info(r):
-                print("run_id: {}".format(r.info.run_id))
-                print("metrics: {}".format(r.data.metrics))
-                print("status: {}".format(r.info.status))
+                print(f"run_id: {r.info.run_id}")
+                print(f"metrics: {r.data.metrics}")
+                print(f"status: {r.info.status}")
 
 
             # Create a run under the default experiment (whose id is '0').
@@ -770,9 +770,9 @@ class MlflowClient:
 
 
             def print_run_info(r):
-                print("run_id: {}".format(r.info.run_id))
-                print("params: {}".format(r.data.params))
-                print("status: {}".format(r.info.status))
+                print(f"run_id: {r.info.run_id}")
+                print(f"params: {r.data.params}")
+                print(f"status: {r.info.status}")
 
 
             # Create a run under the default experiment (whose id is '0').
@@ -827,8 +827,8 @@ class MlflowClient:
 
             # Fetch experiment metadata information
             experiment = client.get_experiment(experiment_id)
-            print("Name: {}".format(experiment.name))
-            print("Tags: {}".format(experiment.tags))
+            print(f"Name: {experiment.name}")
+            print(f"Tags: {experiment.tags}")
 
         .. code-block:: text
             :caption: Output
@@ -858,8 +858,8 @@ class MlflowClient:
 
 
             def print_run_info(run):
-                print("run_id: {}".format(run.info.run_id))
-                print("Tags: {}".format(run.data.tags))
+                print(f"run_id: {run.info.run_id}")
+                print(f"Tags: {run.data.tags}")
 
 
             # Create a run under the default experiment (whose id is '0').
@@ -899,8 +899,8 @@ class MlflowClient:
 
 
             def print_run_info(run):
-                print("run_id: {}".format(run.info.run_id))
-                print("Tags: {}".format(run.data.tags))
+                print(f"run_id: {run.info.run_id}")
+                print(f"Tags: {run.data.tags}")
 
 
             # Create a run under the default experiment (whose id is '0').
@@ -946,9 +946,9 @@ class MlflowClient:
 
 
             def print_run_info(run):
-                print("run_id: {}".format(run.info.run_id))
-                print("run_name: {}".format(run.info.run_name))
-                print("status: {}".format(run.info.status))
+                print(f"run_id: {run.info.run_id}")
+                print(f"run_name: {run.info.run_name}")
+                print(f"status: {run.info.status}")
 
 
             # Create a run under the default experiment (whose id is '0').
@@ -1004,11 +1004,11 @@ class MlflowClient:
 
 
             def print_run_info(r):
-                print("run_id: {}".format(r.info.run_id))
-                print("params: {}".format(r.data.params))
-                print("metrics: {}".format(r.data.metrics))
-                print("tags: {}".format(r.data.tags))
-                print("status: {}".format(r.info.status))
+                print(f"run_id: {r.info.run_id}")
+                print(f"params: {r.data.params}")
+                print(f"metrics: {r.data.metrics}")
+                print(f"tags: {r.data.tags}")
+                print(f"status: {r.info.status}")
 
 
             # Create MLflow entities and a run under the default experiment (whose id is '0').
@@ -1079,8 +1079,8 @@ class MlflowClient:
             client.log_artifact(run.info.run_id, "features.txt")
             artifacts = client.list_artifacts(run.info.run_id)
             for artifact in artifacts:
-                print("artifact: {}".format(artifact.path))
-                print("is_dir: {}".format(artifact.is_dir))
+                print(f"artifact: {artifact.path}")
+                print(f"is_dir: {artifact.is_dir}")
             client.set_terminated(run.info.run_id)
 
         .. code-block:: text
@@ -1125,8 +1125,8 @@ class MlflowClient:
             client.log_artifacts(run.info.run_id, "data", artifact_path="states")
             artifacts = client.list_artifacts(run.info.run_id)
             for artifact in artifacts:
-                print("artifact: {}".format(artifact.path))
-                print("is_dir: {}".format(artifact.is_dir))
+                print(f"artifact: {artifact.path}")
+                print(f"is_dir: {artifact.is_dir}")
             client.set_terminated(run.info.run_id)
 
         .. code-block:: text
@@ -1726,9 +1726,9 @@ class MlflowClient:
 
 
             def print_artifact_info(artifact):
-                print("artifact: {}".format(artifact.path))
-                print("is_dir: {}".format(artifact.is_dir))
-                print("size: {}".format(artifact.file_size))
+                print(f"artifact: {artifact.path}")
+                print(f"is_dir: {artifact.is_dir}")
+                print(f"size: {artifact.file_size}")
 
 
             features = "rooms zipcode, median_price, school_rating, transport"
@@ -1741,9 +1741,9 @@ class MlflowClient:
 
             # Create some artifacts and log under the above run
             for file, content in [("features", features), ("labels", labels)]:
-                with open("{}.txt".format(file), "w") as f:
+                with open(f"{file}.txt", "w") as f:
                     f.write(content)
-                client.log_artifact(run.info.run_id, "{}.txt".format(file))
+                client.log_artifact(run.info.run_id, f"{file}.txt")
 
             # Fetch the logged artifacts
             artifacts = client.list_artifacts(run.info.run_id)
@@ -1798,8 +1798,8 @@ class MlflowClient:
             if not os.path.exists(local_dir):
                 os.mkdir(local_dir)
             local_path = client.download_artifacts(run.info.run_id, "features", local_dir)
-            print("Artifacts downloaded in: {}".format(local_path))
-            print("Artifacts: {}".format(os.listdir(local_path)))
+            print(f"Artifacts downloaded in: {local_path}")
+            print(f"Artifacts: {os.listdir(local_path)}")
 
         .. code-block:: text
             :caption: Output
@@ -1825,8 +1825,8 @@ class MlflowClient:
 
 
             def print_run_info(r):
-                print("run_id: {}".format(r.info.run_id))
-                print("status: {}".format(r.info.status))
+                print(f"run_id: {r.info.run_id}")
+                print(f"status: {r.info.status}")
 
 
             # Create a run under the default experiment (whose id is '0').
@@ -1871,11 +1871,11 @@ class MlflowClient:
             experiment_id = "0"
             run = client.create_run(experiment_id)
             run_id = run.info.run_id
-            print("run_id: {}; lifecycle_stage: {}".format(run_id, run.info.lifecycle_stage))
+            print(f"run_id: {run_id}; lifecycle_stage: {run.info.lifecycle_stage}")
             print("--")
             client.delete_run(run_id)
             del_run = client.get_run(run_id)
-            print("run_id: {}; lifecycle_stage: {}".format(run_id, del_run.info.lifecycle_stage))
+            print(f"run_id: {run_id}; lifecycle_stage: {del_run.info.lifecycle_stage}")
 
         .. code-block:: text
             :caption: Output
@@ -1901,13 +1901,13 @@ class MlflowClient:
             experiment_id = "0"
             run = client.create_run(experiment_id)
             run_id = run.info.run_id
-            print("run_id: {}; lifecycle_stage: {}".format(run_id, run.info.lifecycle_stage))
+            print(f"run_id: {run_id}; lifecycle_stage: {run.info.lifecycle_stage}")
             client.delete_run(run_id)
             del_run = client.get_run(run_id)
-            print("run_id: {}; lifecycle_stage: {}".format(run_id, del_run.info.lifecycle_stage))
+            print(f"run_id: {run_id}; lifecycle_stage: {del_run.info.lifecycle_stage}")
             client.restore_run(run_id)
             rest_run = client.get_run(run_id)
-            print("run_id: {}; lifecycle_stage: {}".format(run_id, rest_run.info.lifecycle_stage))
+            print(f"run_id: {run_id}; lifecycle_stage: {rest_run.info.lifecycle_stage}")
 
         .. code-block:: text
             :caption: Output
@@ -1956,13 +1956,13 @@ class MlflowClient:
 
             def print_run_info(runs):
                 for r in runs:
-                    print("run_id: {}".format(r.info.run_id))
-                    print("lifecycle_stage: {}".format(r.info.lifecycle_stage))
-                    print("metrics: {}".format(r.data.metrics))
+                    print(f"run_id: {r.info.run_id}")
+                    print(f"lifecycle_stage: {r.info.lifecycle_stage}")
+                    print(f"metrics: {r.data.metrics}")
 
                     # Exclude mlflow system tags
                     tags = {k: v for k, v in r.data.tags.items() if not k.startswith("mlflow.")}
-                    print("tags: {}".format(tags))
+                    print(f"tags: {tags}")
 
 
             # Create an experiment and log two runs with metrics and tags under the experiment
@@ -2038,9 +2038,9 @@ class MlflowClient:
 
 
             def print_registered_model_info(rm):
-                print("name: {}".format(rm.name))
-                print("tags: {}".format(rm.tags))
-                print("description: {}".format(rm.description))
+                print(f"name: {rm.name}")
+                print(f"tags: {rm.tags}")
+                print(f"description: {rm.description}")
 
 
             name = "SocialMediaTextAnalyzer"
@@ -2078,9 +2078,9 @@ class MlflowClient:
 
 
             def print_registered_model_info(rm):
-                print("name: {}".format(rm.name))
-                print("tags: {}".format(rm.tags))
-                print("description: {}".format(rm.description))
+                print(f"name: {rm.name}")
+                print(f"tags: {rm.tags}")
+                print(f"description: {rm.description}")
 
 
             name = "SocialTextAnalyzer"
@@ -2127,9 +2127,9 @@ class MlflowClient:
             :caption: Example
 
             def print_registered_model_info(rm):
-                print("name: {}".format(rm.name))
-                print("tags: {}".format(rm.tags))
-                print("description: {}".format(rm.description))
+                print(f"name: {rm.name}")
+                print(f"tags: {rm.tags}")
+                print(f"description: {rm.description}")
 
 
             name = "SocialMediaTextAnalyzer"
@@ -2182,9 +2182,9 @@ class MlflowClient:
             def print_registered_models_info(r_models):
                 print("--")
                 for rm in r_models:
-                    print("name: {}".format(rm.name))
-                    print("tags: {}".format(rm.tags))
-                    print("description: {}".format(rm.description))
+                    print(f"name: {rm.name}")
+                    print(f"tags: {rm.tags}")
+                    print(f"description: {rm.description}")
 
 
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
@@ -2269,12 +2269,12 @@ class MlflowClient:
 
             # Get search results filtered by the registered model name
             model_name = "CordobaWeatherForecastModel"
-            filter_string = "name='{}'".format(model_name)
+            filter_string = f"name='{model_name}'"
             results = client.search_registered_models(filter_string=filter_string)
             print("-" * 80)
             for res in results:
                 for mv in res.latest_versions:
-                    print("name={}; run_id={}; version={}".format(mv.name, mv.run_id, mv.version))
+                    print(f"name={mv.name}; run_id={mv.run_id}; version={mv.version}")
 
             # Get search results filtered by the registered model name that matches
             # prefix pattern
@@ -2283,14 +2283,14 @@ class MlflowClient:
             print("-" * 80)
             for res in results:
                 for mv in res.latest_versions:
-                    print("name={}; run_id={}; version={}".format(mv.name, mv.run_id, mv.version))
+                    print(f"name={mv.name}; run_id={mv.run_id}; version={mv.version}")
 
             # Get all registered models and order them by ascending order of the names
             results = client.search_registered_models(order_by=["name ASC"])
             print("-" * 80)
             for res in results:
                 for mv in res.latest_versions:
-                    print("name={}; run_id={}; version={}".format(mv.name, mv.run_id, mv.version))
+                    print(f"name={mv.name}; run_id={mv.run_id}; version={mv.version}")
 
         .. code-block:: text
             :caption: Output
@@ -2328,9 +2328,9 @@ class MlflowClient:
 
             def print_model_info(rm):
                 print("--")
-                print("name: {}".format(rm.name))
-                print("tags: {}".format(rm.tags))
-                print("description: {}".format(rm.description))
+                print(f"name: {rm.name}")
+                print(f"tags: {rm.tags}")
+                print(f"description: {rm.description}")
 
 
             name = "SocialMediaTextAnalyzer"
@@ -2376,10 +2376,10 @@ class MlflowClient:
 
             def print_models_info(mv):
                 for m in mv:
-                    print("name: {}".format(m.name))
-                    print("latest version: {}".format(m.version))
-                    print("run_id: {}".format(m.run_id))
-                    print("current_stage: {}".format(m.current_stage))
+                    print(f"name: {m.name}")
+                    print(f"latest version: {m.version}")
+                    print(f"run_id: {m.run_id}")
+                    print(f"current_stage: {m.current_stage}")
 
 
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
@@ -2407,9 +2407,9 @@ class MlflowClient:
 
             # Create a two versions of the rfr model under the registered model name
             for run_id in [run1.info.run_id, run2.info.run_id]:
-                model_uri = "runs:/{}/sklearn-model".format(run_id)
+                model_uri = f"runs:/{run_id}/sklearn-model"
                 mv = client.create_model_version(name, model_uri, run_id)
-                print("model version {} created".format(mv.version))
+                print(f"model version {mv.version} created")
 
             # Fetch latest version; this will be version 2
             print("--")
@@ -2493,8 +2493,8 @@ class MlflowClient:
             def print_registered_models_info(r_models):
                 print("--")
                 for rm in r_models:
-                    print("name: {}".format(rm.name))
-                    print("tags: {}".format(rm.tags))
+                    print(f"name: {rm.name}")
+                    print(f"tags: {rm.tags}")
 
 
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
@@ -2637,14 +2637,14 @@ class MlflowClient:
 
             # Create a new version of the rfr model under the registered model name
             desc = "A new version of the model"
-            runs_uri = "runs:/{}/sklearn-model".format(run.info.run_id)
+            runs_uri = f"runs:/{run.info.run_id}/sklearn-model"
             model_src = RunsArtifactRepository.get_underlying_uri(runs_uri)
             mv = client.create_model_version(name, model_src, run.info.run_id, description=desc)
-            print("Name: {}".format(mv.name))
-            print("Version: {}".format(mv.version))
-            print("Description: {}".format(mv.description))
-            print("Status: {}".format(mv.status))
-            print("Stage: {}".format(mv.current_stage))
+            print(f"Name: {mv.name}")
+            print(f"Version: {mv.version}")
+            print(f"Description: {mv.description}")
+            print(f"Status: {mv.status}")
+            print(f"Stage: {mv.current_stage}")
 
         .. code-block:: text
             :caption: Output
@@ -2688,9 +2688,9 @@ class MlflowClient:
 
 
             def print_model_version_info(mv):
-                print("Name: {}".format(mv.name))
-                print("Version: {}".format(mv.version))
-                print("Description: {}".format(mv.description))
+                print(f"Name: {mv.name}")
+                print(f"Version: {mv.version}")
+                print(f"Description: {mv.description}")
 
 
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
@@ -2710,7 +2710,7 @@ class MlflowClient:
             client.create_registered_model(name)
 
             # Create a new version of the rfr model under the registered model name
-            model_uri = "runs:/{}/sklearn-model".format(run.info.run_id)
+            model_uri = f"runs:/{run.info.run_id}/sklearn-model"
             mv = client.create_model_version(name, model_uri, run.info.run_id)
             print_model_version_info(mv)
             print("--")
@@ -2764,10 +2764,10 @@ class MlflowClient:
 
 
             def print_model_version_info(mv):
-                print("Name: {}".format(mv.name))
-                print("Version: {}".format(mv.version))
-                print("Description: {}".format(mv.description))
-                print("Stage: {}".format(mv.current_stage))
+                print(f"Name: {mv.name}")
+                print(f"Version: {mv.version}")
+                print(f"Description: {mv.description}")
+                print(f"Stage: {mv.current_stage}")
 
 
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
@@ -2788,7 +2788,7 @@ class MlflowClient:
             client.create_registered_model(name)
 
             # Create a new version of the rfr model under the registered model name
-            model_uri = "runs:/{}/sklearn-model".format(run.info.run_id)
+            model_uri = f"runs:/{run.info.run_id}/sklearn-model"
             mv = client.create_model_version(name, model_uri, run.info.run_id, description=desc)
             print_model_version_info(mv)
             print("--")
@@ -2833,10 +2833,10 @@ class MlflowClient:
 
             def print_models_info(mv):
                 for m in mv:
-                    print("name: {}".format(m.name))
-                    print("latest version: {}".format(m.version))
-                    print("run_id: {}".format(m.run_id))
-                    print("current_stage: {}".format(m.current_stage))
+                    print(f"name: {m.name}")
+                    print(f"latest version: {m.version}")
+                    print(f"run_id: {m.run_id}")
+                    print(f"current_stage: {m.current_stage}")
 
 
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
@@ -2864,9 +2864,9 @@ class MlflowClient:
 
             # Create a two versions of the rfr model under the registered model name
             for run_id in [run1.info.run_id, run2.info.run_id]:
-                model_uri = "runs:/{}/sklearn-model".format(run_id)
+                model_uri = f"runs:/{run_id}/sklearn-model"
                 mv = client.create_model_version(name, model_uri, run_id)
-                print("model version {} created".format(mv.version))
+                print(f"model version {mv.version} created")
 
             print("--")
 
@@ -2876,7 +2876,7 @@ class MlflowClient:
             print("--")
 
             # Delete the latest model version 2
-            print("Deleting model version {}".format(mv.version))
+            print(f"Deleting model version {mv.version}")
             client.delete_model_version(name, mv.version)
             models = client.get_latest_versions(name, stages=["None"])
             print_models_info(models)
@@ -2939,15 +2939,15 @@ class MlflowClient:
 
             # Create a two versions of the rfr model under the registered model name
             for run_id in [run1.info.run_id, run2.info.run_id]:
-                model_uri = "runs:/{}/sklearn-model".format(run_id)
+                model_uri = f"runs:/{run_id}/sklearn-model"
                 mv = client.create_model_version(name, model_uri, run_id)
-                print("model version {} created".format(mv.version))
+                print(f"model version {mv.version} created")
             print("--")
 
             # Fetch the last version; this will be version 2
             mv = client.get_model_version(name, mv.version)
-            print("Name: {}".format(mv.name))
-            print("Version: {}".format(mv.version))
+            print(f"Name: {mv.name}")
+            print(f"Version: {mv.version}")
 
         .. code-block:: text
             :caption: Output
@@ -2994,10 +2994,10 @@ class MlflowClient:
             client.create_registered_model(name)
 
             # Create a new version of the rfr model under the registered model name
-            model_uri = "runs:/{}/sklearn-model".format(run.info.run_id)
+            model_uri = f"runs:/{run.info.run_id}/sklearn-model"
             mv = client.create_model_version(name, model_uri, run.info.run_id)
             artifact_uri = client.get_model_version_download_uri(name, mv.version)
-            print("Download URI: {}".format(artifact_uri))
+            print(f"Download URI: {artifact_uri}")
 
         .. code-block:: text
             :caption: Output
@@ -3057,19 +3057,19 @@ class MlflowClient:
 
             # Get all versions of the model filtered by name
             model_name = "CordobaWeatherForecastModel"
-            filter_string = "name='{}'".format(model_name)
+            filter_string = f"name='{model_name}'"
             results = client.search_model_versions(filter_string)
             print("-" * 80)
             for res in results:
-                print("name={}; run_id={}; version={}".format(res.name, res.run_id, res.version))
+                print(f"name={res.name}; run_id={res.run_id}; version={res.version}")
 
             # Get the version of the model filtered by run_id
             run_id = "e14afa2f47a040728060c1699968fd43"
-            filter_string = "run_id='{}'".format(run_id)
+            filter_string = f"run_id='{run_id}'"
             results = client.search_model_versions(filter_string)
             print("-" * 80)
             for res in results:
-                print("name={}; run_id={}; version={}".format(res.name, res.run_id, res.version))
+                print(f"name={res.name}; run_id={res.run_id}; version={res.version}")
 
         .. code-block:: text
             :caption: Output
@@ -3117,10 +3117,10 @@ class MlflowClient:
 
             # Create a new version of the rfr model under the registered model name
             # fetch valid stages
-            model_uri = "runs:/{}/models/sklearn-model".format(run.info.run_id)
+            model_uri = f"runs:/{run.info.run_id}/models/sklearn-model"
             mv = client.create_model_version(name, model_uri, run.info.run_id)
             stages = client.get_model_version_stages(name, mv.version)
-            print("Model list of valid stages: {}".format(stages))
+            print(f"Model list of valid stages: {stages}")
 
         .. code-block:: text
             :caption: Output
@@ -3155,9 +3155,9 @@ class MlflowClient:
 
 
             def print_model_version_info(mv):
-                print("Name: {}".format(mv.name))
-                print("Version: {}".format(mv.version))
-                print("Tags: {}".format(mv.tags))
+                print(f"Name: {mv.name}")
+                print(f"Version: {mv.version}")
+                print(f"Tags: {mv.tags}")
 
 
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
@@ -3178,7 +3178,7 @@ class MlflowClient:
 
             # Create a new version of the rfr model under the registered model name
             # and set a tag
-            model_uri = "runs:/{}/sklearn-model".format(run.info.run_id)
+            model_uri = f"runs:/{run.info.run_id}/sklearn-model"
             mv = client.create_model_version(name, model_uri, run.info.run_id)
             print_model_version_info(mv)
             print("--")
@@ -3237,9 +3237,9 @@ class MlflowClient:
 
 
             def print_model_version_info(mv):
-                print("Name: {}".format(mv.name))
-                print("Version: {}".format(mv.version))
-                print("Tags: {}".format(mv.tags))
+                print(f"Name: {mv.name}")
+                print(f"Version: {mv.version}")
+                print(f"Tags: {mv.tags}")
 
 
             mlflow.set_tracking_uri("sqlite:///mlruns.db")
@@ -3260,7 +3260,7 @@ class MlflowClient:
 
             # Create a new version of the rfr model under the registered model name
             # and delete a tag
-            model_uri = "runs:/{}/sklearn-model".format(run.info.run_id)
+            model_uri = f"runs:/{run.info.run_id}/sklearn-model"
             tags = {"t": "1", "t1": "2"}
             mv = client.create_model_version(name, model_uri, run.info.run_id, tags=tags)
             print_model_version_info(mv)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -102,10 +102,10 @@ def set_experiment(experiment_name: str = None, experiment_id: str = None) -> Ex
         experiment = mlflow.set_experiment("Social NLP Experiments")
 
         # Get Experiment Details
-        print("Experiment_id: {}".format(experiment.experiment_id))
-        print("Artifact Location: {}".format(experiment.artifact_location))
-        print("Tags: {}".format(experiment.tags))
-        print("Lifecycle_stage: {}".format(experiment.lifecycle_stage))
+        print(f"Experiment_id: {experiment.experiment_id}")
+        print(f"Artifact Location: {experiment.artifact_location}")
+        print(f"Tags: {experiment.tags}")
+        print(f"Lifecycle_stage: {experiment.lifecycle_stage}")
 
     .. code-block:: text
         :caption: Output
@@ -253,14 +253,14 @@ def start_run(
 
         print("parent run:")
 
-        print("run_id: {}".format(parent_run.info.run_id))
+        print(f"run_id: {parent_run.info.run_id}")
         print("description: {}".format(parent_run.data.tags.get("mlflow.note.content")))
         print("version tag value: {}".format(parent_run.data.tags.get("version")))
         print("priority tag value: {}".format(parent_run.data.tags.get("priority")))
         print("--")
 
         # Search all child runs with a parent id
-        query = "tags.mlflow.parentRunId = '{}'".format(parent_run.info.run_id)
+        query = f"tags.mlflow.parentRunId = '{parent_run.info.run_id}'"
         results = mlflow.search_runs(experiment_ids=[experiment_id], filter_string=query)
         print("child runs:")
         print(results[["run_id", "params.child", "tags.mlflow.runName"]])
@@ -381,16 +381,16 @@ def end_run(status: str = RunStatus.to_string(RunStatus.FINISHED)) -> None:
         # Start run and get status
         mlflow.start_run()
         run = mlflow.active_run()
-        print("run_id: {}; status: {}".format(run.info.run_id, run.info.status))
+        print(f"run_id: {run.info.run_id}; status: {run.info.status}")
 
         # End run and get status
         mlflow.end_run()
         run = mlflow.get_run(run.info.run_id)
-        print("run_id: {}; status: {}".format(run.info.run_id, run.info.status))
+        print(f"run_id: {run.info.run_id}; status: {run.info.status}")
         print("--")
 
         # Check for any active runs
-        print("Active run: {}".format(mlflow.active_run()))
+        print(f"Active run: {mlflow.active_run()}")
 
     .. code-block:: text
         :caption: Output
@@ -431,7 +431,7 @@ def active_run() -> Optional[ActiveRun]:
 
         mlflow.start_run()
         run = mlflow.active_run()
-        print("Active run_id: {}".format(run.info.run_id))
+        print(f"Active run_id: {run.info.run_id}")
         mlflow.end_run()
 
     .. code-block:: text
@@ -526,9 +526,7 @@ def get_run(run_id: str) -> Run:
 
         run_id = run.info.run_id
         print(
-            "run_id: {}; lifecycle_stage: {}".format(
-                run_id, mlflow.get_run(run_id).info.lifecycle_stage
-            )
+            f"run_id: {run_id}; lifecycle_stage: {mlflow.get_run(run_id).info.lifecycle_stage}"
         )
 
     .. code-block:: text
@@ -560,8 +558,8 @@ def get_parent_run(run_id: str) -> Optional[Run]:
 
         parent_run = mlflow.get_parent_run(child_run_id)
 
-        print("child_run_id: {}".format(child_run_id))
-        print("parent_run_id: {}".format(parent_run.info.run_id))
+        print(f"child_run_id: {child_run_id}")
+        print(f"parent_run_id: {parent_run.info.run_id}")
 
     .. code-block:: text
         :caption: Output
@@ -1224,11 +1222,11 @@ def get_experiment(experiment_id: str) -> Experiment:
         import mlflow
 
         experiment = mlflow.get_experiment("0")
-        print("Name: {}".format(experiment.name))
-        print("Artifact Location: {}".format(experiment.artifact_location))
-        print("Tags: {}".format(experiment.tags))
-        print("Lifecycle_stage: {}".format(experiment.lifecycle_stage))
-        print("Creation timestamp: {}".format(experiment.creation_time))
+        print(f"Name: {experiment.name}")
+        print(f"Artifact Location: {experiment.artifact_location}")
+        print(f"Tags: {experiment.tags}")
+        print(f"Lifecycle_stage: {experiment.lifecycle_stage}")
+        print(f"Creation timestamp: {experiment.creation_time}")
 
     .. code-block:: text
         :caption: Output
@@ -1257,11 +1255,11 @@ def get_experiment_by_name(name: str) -> Optional[Experiment]:
 
         # Case sensitive name
         experiment = mlflow.get_experiment_by_name("Default")
-        print("Experiment_id: {}".format(experiment.experiment_id))
-        print("Artifact Location: {}".format(experiment.artifact_location))
-        print("Tags: {}".format(experiment.tags))
-        print("Lifecycle_stage: {}".format(experiment.lifecycle_stage))
-        print("Creation timestamp: {}".format(experiment.creation_time))
+        print(f"Experiment_id: {experiment.experiment_id}")
+        print(f"Artifact Location: {experiment.artifact_location}")
+        print(f"Tags: {experiment.tags}")
+        print(f"Lifecycle_stage: {experiment.lifecycle_stage}")
+        print(f"Creation timestamp: {experiment.creation_time}")
 
     .. code-block:: text
         :caption: Output
@@ -1420,12 +1418,12 @@ def create_experiment(
             tags={"version": "v1", "priority": "P1"},
         )
         experiment = mlflow.get_experiment(experiment_id)
-        print("Name: {}".format(experiment.name))
-        print("Experiment_id: {}".format(experiment.experiment_id))
-        print("Artifact Location: {}".format(experiment.artifact_location))
-        print("Tags: {}".format(experiment.tags))
-        print("Lifecycle_stage: {}".format(experiment.lifecycle_stage))
-        print("Creation timestamp: {}".format(experiment.creation_time))
+        print(f"Name: {experiment.name}")
+        print(f"Experiment_id: {experiment.experiment_id}")
+        print(f"Artifact Location: {experiment.artifact_location}")
+        print(f"Tags: {experiment.tags}")
+        print(f"Lifecycle_stage: {experiment.lifecycle_stage}")
+        print(f"Creation timestamp: {experiment.creation_time}")
 
     .. code-block:: text
         :caption: Output
@@ -1456,10 +1454,10 @@ def delete_experiment(experiment_id: str) -> None:
 
         # Examine the deleted experiment details.
         experiment = mlflow.get_experiment(experiment_id)
-        print("Name: {}".format(experiment.name))
-        print("Artifact Location: {}".format(experiment.artifact_location))
-        print("Lifecycle_stage: {}".format(experiment.lifecycle_stage))
-        print("Last Updated timestamp: {}".format(experiment.last_update_time))
+        print(f"Name: {experiment.name}")
+        print(f"Artifact Location: {experiment.artifact_location}")
+        print(f"Lifecycle_stage: {experiment.lifecycle_stage}")
+        print(f"Last Updated timestamp: {experiment.last_update_time}")
     .. code-block:: text
         :caption: Output
 
@@ -1489,9 +1487,7 @@ def delete_run(run_id: str) -> None:
         mlflow.delete_run(run_id)
 
         print(
-            "run_id: {}; lifecycle_stage: {}".format(
-                run_id, mlflow.get_run(run_id).info.lifecycle_stage
-            )
+            f"run_id: {run_id}; lifecycle_stage: {mlflow.get_run(run_id).info.lifecycle_stage}"
         )
 
     .. code-block:: text
@@ -1536,11 +1532,11 @@ def get_artifact_uri(artifact_path: Optional[str] = None) -> str:
 
             # Fetch the artifact uri root directory
             artifact_uri = mlflow.get_artifact_uri()
-            print("Artifact uri: {}".format(artifact_uri))
+            print(f"Artifact uri: {artifact_uri}")
 
             # Fetch a specific artifact uri
             artifact_uri = mlflow.get_artifact_uri(artifact_path="features/features.txt")
-            print("Artifact uri: {}".format(artifact_uri))
+            print(f"Artifact uri: {artifact_uri}")
 
     .. code-block:: text
         :caption: Output
@@ -1901,11 +1897,11 @@ def autolog(
         def print_auto_logged_info(r):
             tags = {k: v for k, v in r.data.tags.items() if not k.startswith("mlflow.")}
             artifacts = [f.path for f in MlflowClient().list_artifacts(r.info.run_id, "model")]
-            print("run_id: {}".format(r.info.run_id))
-            print("artifacts: {}".format(artifacts))
-            print("params: {}".format(r.data.params))
-            print("metrics: {}".format(r.data.metrics))
-            print("tags: {}".format(tags))
+            print(f"run_id: {r.info.run_id}")
+            print(f"artifacts: {artifacts}")
+            print(f"params: {r.data.params}")
+            print(f"metrics: {r.data.metrics}")
+            print(f"tags: {tags}")
 
 
         # prepare training data


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> Resolve #9446

## What changes are proposed in this pull request?

Replacement of `str.format` prints with `f-strings`

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
