### PR TITLE
add support for password containing '%'

### DIFF
--- a/mlflow/utils/credentials.py
+++ b/mlflow/utils/credentials.py
@@ -19,7 +19,7 @@ def _read_mlflow_creds_from_file() -> Tuple[Optional[str], Optional[str]]:
     if not os.path.exists(path):
         return None, None
 
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
     config.read(path)
     if "mlflow" not in config:
         return None, None

--- a/tests/utils/test_credentials.py
+++ b/tests/utils/test_credentials.py
@@ -66,15 +66,10 @@ mlflow_tracking_password = password
         ("username", None),
         (None, "password"),
         (None, None),
-    ])
-@pytest.mark.parametrize(
-    ("user", "7<{=.=@&{8[.0_+$|`}16\%2"),
-    [
-        ("user", "7<{=.=@&{8[.0_+$|`}16\%2"),
-        ("user", None),
+        ("username", "7<{=.=@&{8[.0_+$|`}16\%2"),
         (None, "7<{=.=@&{8[.0_+$|`}16\%2"),
-        (None, None),
-    ])
+    ],
+)
 def test_read_mlflow_creds_env(username, password, monkeypatch):
     if username is None:
         monkeypatch.delenv(MLFLOW_TRACKING_USERNAME.name, raising=False)

--- a/tests/utils/test_credentials.py
+++ b/tests/utils/test_credentials.py
@@ -68,11 +68,11 @@ mlflow_tracking_password = password
         (None, None),
     ])
 @pytest.mark.parametrize(
-    ("user", "7<{=.=@&{8[.0_+$|`}16\%1"),
+    ("user", "7<{=.=@&{8[.0_+$|`}16\%2"),
     [
-        ("user", "7<{=.=@&{8[.0_+$|`}16\%1"),
+        ("user", "7<{=.=@&{8[.0_+$|`}16\%2"),
         ("user", None),
-        (None, "7<{=.=@&{8[.0_+$|`}16\%1"),
+        (None, "7<{=.=@&{8[.0_+$|`}16\%2"),
         (None, None),
     ])
 def test_read_mlflow_creds_env(username, password, monkeypatch):

--- a/tests/utils/test_credentials.py
+++ b/tests/utils/test_credentials.py
@@ -66,8 +66,15 @@ mlflow_tracking_password = password
         ("username", None),
         (None, "password"),
         (None, None),
-    ],
-)
+    ])
+@pytest.mark.parametrize(
+    ("user", "7<{=.=@&{8[.0_+$|`}16\%1"),
+    [
+        ("user", "7<{=.=@&{8[.0_+$|`}16\%1"),
+        ("user", None),
+        (None, "7<{=.=@&{8[.0_+$|`}16\%1"),
+        (None, None),
+    ])
 def test_read_mlflow_creds_env(username, password, monkeypatch):
     if username is None:
         monkeypatch.delenv(MLFLOW_TRACKING_USERNAME.name, raising=False)


### PR DESCRIPTION
 

## What changes are proposed in this pull request?

add support for password containing '%', otherwise it would error with when password/username contains '%':
```
File /data1/user1/miniconda3/envs/mlf/lib/python3.11/configparser.py:443, in BasicInterpolation._interpolate_some(self, parser, option, accum, rest, section, map, depth)
    441         accum.append(v)
    442 else:
--> 443     raise InterpolationSyntaxError(
    444         option, section,
    445         "'%%' must be followed by '%%' or '(', "
    446         "found: %r" % (rest,))

InterpolationSyntaxError: '%' must be followed by '%' or '(',
```
 
## Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
