### PR TITLE
Automatically support whitespaces in run filtering #9469

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/RunsSearchAutoComplete.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/RunsSearchAutoComplete.tsx
@@ -147,7 +147,17 @@ export const RunsSearchAutoComplete = (props: RunsSearchAutoCompleteProps) => {
       } else {
         const prefix = text.substring(0, entityBeingEdited.startIndex);
         const suffix = text.substring(entityBeingEdited.endIndex);
-        setText(prefix + value + ' ' + suffix);
+
+        const valueParts = value.split(' ');
+        const valueCategory = valueParts[0];
+        const valueName = valueParts.slice(1);
+
+        if (valueName.includes(' ')) {
+          setText(prefix + valueCategory + '"' + valueName + '"' + ' ' + suffix);
+        } else {
+          setText(prefix + value + ' ' + suffix);
+        }
+
         setLastSetBySelection(true);
         setAutocompleteEnabled(false);
       }


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
Resolve --> #9469

## What changes are proposed in this pull request?

- Add condition in `RunsSearchAutoComplete` to add quotes when values include whitespaces.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

## Release Notes

### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Run searching in the user interface now correctly handles whitespaces in filter names.

### What component(s), interfaces, languages, and integrations does this PR affect?

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
