### PR TITLE
Extend CodeDatasetSource to download data from URLs and save as Parquet on DBFS

### DIFF
--- a/mlflow/data/code_dataset_source.py
+++ b/mlflow/data/code_dataset_source.py
@@ -8,9 +8,32 @@ from mlflow.utils.annotations import experimental
 class CodeDatasetSource(DatasetSource):
     def __init__(
         self,
-        tags: Dict[Any, Any],
+        path: str,
+        config_name: Optional[str] = None,
+        data_dir: Optional[str] = None,
+        data_files: Optional[
+            Union[str, Sequence[str], Mapping[str, Union[str, Sequence[str]]]]
+        ] = None,
+        split: Optional[str] = None,
+        revision: Optional[str] = None,
+        task: Optional[str] = None,
     ):
-        self._tags = tags
+        """
+        :param path: The path of the code dataset.
+        :param config_name: The name of the code dataset configuration.
+        :param data_dir: The `data_dir` of the code dataset configuration.
+        :param data_files: Paths to source data file(s) for the code dataset configuration.
+        :param split: The split of the code dataset.
+        :param revision: Version of the code dataset script to load.
+        :param task: The task to prepare the code dataset for during training and evaluation.
+        """
+        self._path = path
+        self._config_name = config_name
+        self._data_dir = data_dir
+        self._data_files = data_files
+        self._split = split
+        self._revision = revision
+        self._task = task
 
     @staticmethod
     def _get_source_type() -> str:
@@ -18,9 +41,36 @@ class CodeDatasetSource(DatasetSource):
 
     def load(self, **kwargs):
         """
-        Load is not implemented for Code Dataset Source.
+        Load the code dataset based on the provided parameters.
+
+        :param kwargs: Additional parameters to customize the loading process.
+        :return: Path to the saved Parquet file on DBFS.
         """
-        raise NotImplementedError
+        # Load from DBFS (Databricks File System)
+        dbfs_path = kwargs.get('dbfs_path')
+        if dbfs_path:
+            with open(dbfs_path, 'r') as file:
+                data = file.read()
+            return data
+
+        # Download from a URL, convert to DataFrame, and save to DBFS as Parquet
+        url = kwargs.get('url')
+        dbfs_save_path = kwargs.get('dbfs_save_path', '/dbfs/downloaded_data.parquet')  # default DBFS save path
+        if url:
+            response = requests.get(url)
+            response.raise_for_status()  # Raise an error for bad responses
+            
+            # Assuming the data is in CSV format; adjust if different
+            data = io.StringIO(response.text)
+            df = pd.read_csv(data)
+            
+            # Save DataFrame as Parquet to DBFS
+            df.to_parquet(dbfs_save_path)
+            
+            return dbfs_save_path
+
+        raise ValueError("Provide either a valid dbfs_path or url to load data.")
+
 
     @staticmethod
     def _can_resolve(raw_source: Any):


### PR DESCRIPTION
…et on DBFS

This commit enhances the `CodeDatasetSource` class, enabling it to fetch data directly from external URLs and store the content as a Parquet file on the Databricks File System (DBFS).

Changes:
- Adapted the `load` method in the `CodeDatasetSource` class to support Parquet file storage on DBFS.
- The `load` method now converts downloaded data to a DataFrame and subsequently saves it as a Parquet file on DBFS.
- Integrated the `requests` and `pandas` libraries for data retrieval and processing.
- Enhanced error handling for better user feedback.

This update streamlines data ingestion, allowing users to efficiently fetch datasets from external sources, convert them to the Parquet format, and store them on DBFS for optimized analytics in MLflow experiments on Databricks.

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
