### PR TITLE
Add guard for mosaic chat prompt parsing logic

### DIFF
--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -15,7 +15,7 @@ from pydantic.json import pydantic_encoder
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.base_models import ConfigModel, ResponseModel
 from mlflow.gateway.constants import (
-    MLFLOW_AI_GATEWAY_MOSAIC_CHAT_SUPPORTED_MODEL_PREFIXES,
+    MLFLOW_AI_GATEWAY_MOSAICML_CHAT_SUPPORTED_MODEL_PREFIXES,
     MLFLOW_GATEWAY_ROUTE_BASE,
     MLFLOW_QUERY_SUFFIX,
 )
@@ -295,7 +295,7 @@ class RouteConfig(ConfigModel):
             raise MlflowException.invalid_parameter_value(
                 f"An invalid model has been specified for the chat route. '{model.name}'. "
                 f"Ensure the model selected starts with one of: "
-                f"{MLFLOW_AI_GATEWAY_MOSAIC_CHAT_SUPPORTED_MODEL_PREFIXES}"
+                f"{MLFLOW_AI_GATEWAY_MOSAICML_CHAT_SUPPORTED_MODEL_PREFIXES}"
             )
         return values
 

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -9,13 +9,21 @@ from typing import Any, Dict, List, Optional, Union
 import pydantic
 import yaml
 from packaging import version
-from pydantic import ValidationError, validator
+from pydantic import ValidationError, root_validator, validator
 from pydantic.json import pydantic_encoder
 
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.base_models import ConfigModel, ResponseModel
-from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_BASE, MLFLOW_QUERY_SUFFIX
-from mlflow.gateway.utils import check_configuration_route_name_collisions, is_valid_endpoint_name
+from mlflow.gateway.constants import (
+    MLFLOW_AI_GATEWAY_MOSAIC_CHAT_SUPPORTED_MODEL_PREFIXES,
+    MLFLOW_GATEWAY_ROUTE_BASE,
+    MLFLOW_QUERY_SUFFIX,
+)
+from mlflow.gateway.utils import (
+    check_configuration_route_name_collisions,
+    is_valid_endpoint_name,
+    is_valid_mosiacml_chat_model,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -273,6 +281,23 @@ class RouteConfig(ConfigModel):
                     f"{model_instance.provider} is incorrect."
                 )
         return model
+
+    @root_validator(skip_on_failure=True)
+    def validate_route_type_and_model_name(cls, values):
+        route_type = values.get("route_type")
+        model = values.get("model")
+        if (
+            model
+            and model.provider == "mosaicml"
+            and route_type == RouteType.LLM_V1_CHAT
+            and not is_valid_mosiacml_chat_model(model.name)
+        ):
+            raise MlflowException.invalid_parameter_value(
+                f"An invalid model has been specified for the chat route. '{model.name}'. "
+                f"Ensure the model selected starts with one of: "
+                f"{MLFLOW_AI_GATEWAY_MOSAIC_CHAT_SUPPORTED_MODEL_PREFIXES}"
+            )
+        return values
 
     @validator("route_type", pre=True)
     def validate_route_type(cls, value):

--- a/mlflow/gateway/constants.py
+++ b/mlflow/gateway/constants.py
@@ -36,4 +36,4 @@ MLFLOW_SERVING_RESPONSE_KEY = "predictions"
 # These validated names are used for the MosaicML provider due to the need to perform prompt
 # translations prior to sending a request payload to their chat endpoints.
 # to reduce the need to case-match, supported model prefixes are lowercase.
-MLFLOW_AI_GATEWAY_MOSAIC_CHAT_SUPPORTED_MODEL_PREFIXES = ["llama2"]
+MLFLOW_AI_GATEWAY_MOSAICML_CHAT_SUPPORTED_MODEL_PREFIXES = ["llama2"]

--- a/mlflow/gateway/constants.py
+++ b/mlflow/gateway/constants.py
@@ -31,3 +31,9 @@ MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS = 200_000
 
 # MLflow model serving constants
 MLFLOW_SERVING_RESPONSE_KEY = "predictions"
+
+# MosaicML supported chat model names
+# These validated names are used for the MosaicML provider due to the need to perform prompt
+# translations prior to sending a request payload to their chat endpoints.
+# to reduce the need to case-match, supported model prefixes are lowercase.
+MLFLOW_AI_GATEWAY_MOSAIC_CHAT_SUPPORTED_MODEL_PREFIXES = ["llama2"]

--- a/mlflow/gateway/providers/mosaicml.py
+++ b/mlflow/gateway/providers/mosaicml.py
@@ -94,17 +94,7 @@ class MosaicMLProvider(BaseProvider):
 
         # Handle 'prompt' field in payload
         try:
-            # NB: Add a guard for prompt parsing
-            route_model = self.config.model.name
-            if route_model.lower().startswith("llama2"):
-                prompt = [self._parse_chat_messages_to_prompt(messages)]
-            else:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"The model '{route_model}' is not currently supported for a chat "
-                    "interface. Please check the route configuration and upgrade to "
-                    "the latest version of MLflow AI Gateway to ensure compatibility.",
-                )
+            prompt = [self._parse_chat_messages_to_prompt(messages)]
         except MlflowException as e:
             raise HTTPException(
                 status_code=422, detail=f"An invalid request structure was submitted. {e.message}"
@@ -126,7 +116,8 @@ class MosaicMLProvider(BaseProvider):
             self.config.model.name,
             final_payload,
         )
-        # Response example (https://docs.mosaicml.com/en/latest/inference.html#text-completion-models)
+        # Response example
+        # (https://docs.mosaicml.com/en/latest/inference.html#text-completion-models)
         # ```
         # {
         #   "outputs": [
@@ -188,7 +179,8 @@ class MosaicMLProvider(BaseProvider):
             self.config.model.name,
             final_payload,
         )
-        # Response example (https://docs.mosaicml.com/en/latest/inference.html#text-completion-models)
+        # Response example
+        # (https://docs.mosaicml.com/en/latest/inference.html#text-completion-models)
         # ```
         # {
         #   "outputs": [
@@ -231,7 +223,8 @@ class MosaicMLProvider(BaseProvider):
             self.config.model.name,
             payload,
         )
-        # Response example (https://docs.mosaicml.com/en/latest/inference.html#text-embedding-models):
+        # Response example
+        # (https://docs.mosaicml.com/en/latest/inference.html#text-embedding-models):
         # ```
         # {
         #   "outputs": [

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -10,6 +10,7 @@ import psutil
 
 from mlflow.environment_variables import MLFLOW_GATEWAY_URI
 from mlflow.exceptions import MlflowException
+from mlflow.gateway.constants import MLFLOW_AI_GATEWAY_MOSAIC_CHAT_SUPPORTED_MODEL_PREFIXES
 from mlflow.utils.annotations import experimental
 from mlflow.utils.uri import append_to_uri_path
 
@@ -166,3 +167,10 @@ class SearchRoutesToken:
         )
         encoded_token_bytes = base64.b64encode(bytes(token_json, "utf-8"))
         return encoded_token_bytes.decode("utf-8")
+
+
+def is_valid_mosiacml_chat_model(model_name: str) -> bool:
+    return any(
+        model_name.lower().startswith(supported)
+        for supported in MLFLOW_AI_GATEWAY_MOSAIC_CHAT_SUPPORTED_MODEL_PREFIXES
+    )

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -10,7 +10,7 @@ import psutil
 
 from mlflow.environment_variables import MLFLOW_GATEWAY_URI
 from mlflow.exceptions import MlflowException
-from mlflow.gateway.constants import MLFLOW_AI_GATEWAY_MOSAIC_CHAT_SUPPORTED_MODEL_PREFIXES
+from mlflow.gateway.constants import MLFLOW_AI_GATEWAY_MOSAICML_CHAT_SUPPORTED_MODEL_PREFIXES
 from mlflow.utils.annotations import experimental
 from mlflow.utils.uri import append_to_uri_path
 
@@ -172,5 +172,5 @@ class SearchRoutesToken:
 def is_valid_mosiacml_chat_model(model_name: str) -> bool:
     return any(
         model_name.lower().startswith(supported)
-        for supported in MLFLOW_AI_GATEWAY_MOSAIC_CHAT_SUPPORTED_MODEL_PREFIXES
+        for supported in MLFLOW_AI_GATEWAY_MOSAICML_CHAT_SUPPORTED_MODEL_PREFIXES
     )

--- a/tests/gateway/providers/test_mosaicml.py
+++ b/tests/gateway/providers/test_mosaicml.py
@@ -376,12 +376,6 @@ def unsupported_mosaic_chat_model_config():
     }
 
 
-@pytest.mark.asyncio
-async def test_unsupported_model_name_raises_in_chat_parsing():
-    route_config = RouteConfig(**unsupported_mosaic_chat_model_config())
-    test_payload = {"messages": [{"role": "user", "content": "Failure"}]}
-    provider = MosaicMLProvider(route_config)
-    with pytest.raises(HTTPException, match=r".*") as e:
-        await provider.chat(chat.RequestPayload(**test_payload))
-    assert "The model 'unsupported' is not currently supported" in e.value.detail
-    assert e.value.status_code == 400
+def test_unsupported_model_name_raises_in_chat_parsing_route_configuration():
+    with pytest.raises(MlflowException, match="An invalid model has been specified"):
+        RouteConfig(**unsupported_mosaic_chat_model_config())

--- a/tests/gateway/providers/test_mosaicml.py
+++ b/tests/gateway/providers/test_mosaicml.py
@@ -316,7 +316,7 @@ def test_assistant_without_user_raises(messages):
     route_config = RouteConfig(**chat_config())
     with pytest.raises(
         MlflowException,
-        match="Messages with role 'assistant' must be preceeded by a message with role 'user'.",
+        match="Messages with role 'assistant' must be preceded by a message with role 'user'.",
     ):
         MosaicMLProvider(route_config)._parse_chat_messages_to_prompt(messages)
 
@@ -360,3 +360,28 @@ def test_invalid_role_submitted_raises(messages):
         MlflowException, match=".*Must be one of 'system', 'user', or 'assistant'.*"
     ):
         MosaicMLProvider(route_config)._parse_chat_messages_to_prompt(messages)
+
+
+def unsupported_mosaic_chat_model_config():
+    return {
+        "name": "chat",
+        "route_type": "llm/v1/chat",
+        "model": {
+            "provider": "mosaicml",
+            "name": "unsupported",
+            "config": {
+                "mosaicml_api_key": "key",
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_unsupported_model_name_raises_in_chat_parsing():
+    route_config = RouteConfig(**unsupported_mosaic_chat_model_config())
+    test_payload = {"messages": [{"role": "user", "content": "Failure"}]}
+    provider = MosaicMLProvider(route_config)
+    with pytest.raises(HTTPException, match=r".*") as e:
+        await provider.chat(chat.RequestPayload(**test_payload))
+    assert "The model 'unsupported' is not currently supported" in e.value.detail
+    assert e.value.status_code == 400


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Adds guard logic to not attempt to reformat a chat prompt if an unrecognized / unsupported model format is provided in the mosaic hosted model. Currently, only Llama2 is supported and the parsing logic is particular to that model's training architecture. 
If a different model type is added into the future, the server version for MLflow AI Gateway will alert the users that any chat request sent to the endpoint will not be parsed correctly and prompts the user to upgrade the MLflow AI Gateway version and validate the route configuration.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
