### PR TITLE
Add Databricks Provider support to Gateway Client

### DIFF
--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -203,23 +203,11 @@ class MlflowGatewayClient:
                 "running Gateway server.",
                 error_code=BAD_REQUEST,
             )
-        if model is None:
-            raise MlflowException(
-                "Missing required field: model",
-                error_code=BAD_REQUEST,
-            )
         payload = {
             "name": name,
+            "route_type": route_type,
             "model": model,
         }
-        if model["provider"].lower() != Provider.DATABRICKS:
-            if route_type is None:
-                raise MlflowException(
-                    "Missing required field: route_type",
-                    error_code=BAD_REQUEST,
-                )
-            else:
-                payload["route_type"] = route_type
         response = self._call_endpoint(
             "POST", MLFLOW_GATEWAY_CRUD_ROUTE_BASE, json.dumps(payload)
         ).json()

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 import requests.exceptions
 
 from mlflow import MlflowException
-from mlflow.gateway.config import Route
+from mlflow.gateway.config import Provider, Route
 from mlflow.gateway.constants import (
     MLFLOW_GATEWAY_CLIENT_QUERY_RETRY_CODES,
     MLFLOW_GATEWAY_CLIENT_QUERY_TIMEOUT_SECONDS,
@@ -138,7 +138,7 @@ class MlflowGatewayClient:
 
     @experimental
     def create_route(
-        self, name: str, model: Dict[str, Any], route_type: Optional[str] = None
+        self, name: str, route_type: str = None, model: Dict[str, Any] = None
     ) -> Route:
         """
         Create a new route in the Gateway.
@@ -149,11 +149,12 @@ class MlflowGatewayClient:
             route configuration is handled via updates to the route configuration YAML file that
             is specified during Gateway server start.
 
-        :param name: The name of the route.
+        :param name: The name of the route. This parameter is required for all routes.
         :param route_type: The type of the route (e.g., 'llm/v1/chat', 'llm/v1/completions',
-                           'llm/v1/embeddings').
+                           'llm/v1/embeddings'). This parameter is required for routes that are
+                           not managed by Databricks (the provider isn't 'databricks').
         :param model: A dictionary representing the model details to be associated with the route.
-                      This dictionary should define:
+                      This parameter is required for all routes. This dictionary should define:
 
                       - The model name (e.g., "gpt-3.5-turbo")
                       - The provider (e.g., "openai", "anthropic")
@@ -202,11 +203,16 @@ class MlflowGatewayClient:
                 "running Gateway server.",
                 error_code=BAD_REQUEST,
             )
+        if model is None:
+            raise MlflowException(
+                "Missing required field: model",
+                error_code=BAD_REQUEST,
+            )
         payload = {
             "name": name,
             "model": model,
         }
-        if model["provider"].lower() != "databricks":
+        if model["provider"].lower() != Provider.DATABRICKS:
             if route_type is None:
                 raise MlflowException(
                     "Missing required field: route_type",

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 import requests.exceptions
 
 from mlflow import MlflowException
-from mlflow.gateway.config import Provider, Route
+from mlflow.gateway.config import Route
 from mlflow.gateway.constants import (
     MLFLOW_GATEWAY_CLIENT_QUERY_RETRY_CODES,
     MLFLOW_GATEWAY_CLIENT_QUERY_TIMEOUT_SECONDS,
@@ -138,7 +138,7 @@ class MlflowGatewayClient:
 
     @experimental
     def create_route(
-        self, name: str, route_type: str = None, model: Dict[str, Any] = None
+        self, name: str, route_type: Optional[str] = None, model: Optional[Dict[str, Any]] = None
     ) -> Route:
         """
         Create a new route in the Gateway.

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -137,7 +137,9 @@ class MlflowGatewayClient:
         return PagedList(routes, next_page_token)
 
     @experimental
-    def create_route(self, name: str, route_type: str, model: Dict[str, Any]) -> Route:
+    def create_route(
+        self, name: str, model: Dict[str, Any], route_type: Optional[str] = None
+    ) -> Route:
         """
         Create a new route in the Gateway.
 
@@ -202,9 +204,16 @@ class MlflowGatewayClient:
             )
         payload = {
             "name": name,
-            "route_type": route_type,
             "model": model,
         }
+        if model["provider"].lower() != "databricks":
+            if route_type is None:
+                raise MlflowException(
+                    "Missing required field: route_type",
+                    error_code=BAD_REQUEST,
+                )
+            else:
+                payload["route_type"] = route_type
         response = self._call_endpoint(
             "POST", MLFLOW_GATEWAY_CRUD_ROUTE_BASE, json.dumps(payload)
         ).json()

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -30,6 +30,7 @@ class Provider(str, Enum):
     MOSAICML = "mosaicml"
     # Note: The following providers are only supported on Databricks
     DATABRICKS_MODEL_SERVING = "databricks-model-serving"
+    DATABRICKS = "databricks"
 
     @classmethod
     def values(cls):

--- a/mlflow/gateway/fluent.py
+++ b/mlflow/gateway/fluent.py
@@ -46,7 +46,9 @@ def search_routes() -> List[Route]:
 
 
 @experimental
-def create_route(name: str, route_type: str = None, model: Dict[str, Any] = None) -> Route:
+def create_route(
+    name: str, route_type: Optional[str] = None, model: Optional[Dict[str, Any]] = None
+) -> Route:
     """
     Create a new route in the Gateway.
 

--- a/mlflow/gateway/fluent.py
+++ b/mlflow/gateway/fluent.py
@@ -46,7 +46,7 @@ def search_routes() -> List[Route]:
 
 
 @experimental
-def create_route(name: str, model: Dict[str, Any], route_type: Optional[str] = None) -> Route:
+def create_route(name: str, route_type: str = None, model: Dict[str, Any] = None) -> Route:
     """
     Create a new route in the Gateway.
 
@@ -56,11 +56,12 @@ def create_route(name: str, model: Dict[str, Any], route_type: Optional[str] = N
         route configuration is handled via updates to the route configuration YAML file that
         is specified during Gateway server start.
 
-    :param name: The name of the route.
+    :param name: The name of the route. This parameter is required for all routes.
     :param route_type: The type of the route (e.g., 'llm/v1/chat', 'llm/v1/completions',
-                       'llm/v1/embeddings').
+                       'llm/v1/embeddings'). This parameter is required for routes that are
+                        not managed by Databricks (the provider isn't 'databricks').
     :param model: A dictionary representing the model details to be associated with the route.
-                  This dictionary should define:
+                  This parameter is required for all routes. This dictionary should define:
 
                   - The model name (e.g., "gpt-3.5-turbo")
                   - The provider (e.g., "openai", "anthropic")
@@ -99,7 +100,7 @@ def create_route(name: str, model: Dict[str, Any], route_type: Optional[str] = N
         )
 
     """
-    return MlflowGatewayClient().create_route(name, model, route_type)
+    return MlflowGatewayClient().create_route(name, route_type, model)
 
 
 @experimental

--- a/mlflow/gateway/fluent.py
+++ b/mlflow/gateway/fluent.py
@@ -61,7 +61,7 @@ def create_route(
     :param name: The name of the route. This parameter is required for all routes.
     :param route_type: The type of the route (e.g., 'llm/v1/chat', 'llm/v1/completions',
                        'llm/v1/embeddings'). This parameter is required for routes that are
-                        not managed by Databricks (the provider isn't 'databricks').
+                       not managed by Databricks (the provider isn't 'databricks').
     :param model: A dictionary representing the model details to be associated with the route.
                   This parameter is required for all routes. This dictionary should define:
 

--- a/mlflow/gateway/fluent.py
+++ b/mlflow/gateway/fluent.py
@@ -46,7 +46,7 @@ def search_routes() -> List[Route]:
 
 
 @experimental
-def create_route(name: str, route_type: str, model: Dict[str, Any]) -> Route:
+def create_route(name: str, model: Dict[str, Any], route_type: Optional[str] = None) -> Route:
     """
     Create a new route in the Gateway.
 
@@ -99,7 +99,7 @@ def create_route(name: str, route_type: str, model: Dict[str, Any]) -> Route:
         )
 
     """
-    return MlflowGatewayClient().create_route(name, route_type, model)
+    return MlflowGatewayClient().create_route(name, model, route_type)
 
 
 @experimental

--- a/mlflow/gateway/fluent.py
+++ b/mlflow/gateway/fluent.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from mlflow.gateway.client import MlflowGatewayClient
 from mlflow.gateway.config import Route

--- a/tests/gateway/test_client.py
+++ b/tests/gateway/test_client.py
@@ -477,50 +477,6 @@ def test_client_create_route_raises(gateway):
             },
         )
 
-    with mock.patch.object(gateway_client, "_is_databricks_host", return_value=True):
-        with pytest.raises(MlflowException, match="Missing required field: model"):
-            gateway_client.create_route(
-                "some-route",
-                "llm/v1/chat",
-            )
-
-        with pytest.raises(MlflowException, match="Missing required field: route_type"):
-            gateway_client.create_route(
-                "some-route",
-                {
-                    "name": "a-route",
-                    "provider": "openai",
-                    "config": {
-                        "openai_api_key": "mykey",
-                        "openai_api_type": "openai",
-                    },
-                },
-            )
-
-
-def test_client_create_route_works(gateway):
-    gateway_client = MlflowGatewayClient(gateway_uri=gateway.url)
-    with mock.patch.object(gateway_client, "_is_databricks_host", return_value=True):
-        gateway_client.create_route(
-            "some-route",
-            "llm/v1/chat",
-            {
-                "name": "a-route",
-                "provider": "openai",
-                "config": {
-                    "openai_api_key": "mykey",
-                    "openai_api_type": "openai",
-                },
-            },
-        )
-
-        gateway_client.create_route(
-            "some-managed-route",
-            {
-                "name": "a-route",
-                "provider": "databricks",
-            },
-        )
 
 
 def test_client_delete_route_raises(gateway):

--- a/tests/gateway/test_client.py
+++ b/tests/gateway/test_client.py
@@ -478,7 +478,6 @@ def test_client_create_route_raises(gateway):
         )
 
 
-
 def test_client_delete_route_raises(gateway):
     gateway_client = MlflowGatewayClient(gateway_uri=gateway.url)
 

--- a/tests/gateway/test_client.py
+++ b/tests/gateway/test_client.py
@@ -466,7 +466,6 @@ def test_client_create_route_raises(gateway):
     with pytest.raises(MlflowException, match="The create_route API is only available when"):
         gateway_client.create_route(
             "some-route",
-            "llm/v1/chat",
             {
                 "name": "a-route",
                 "provider": "openai",
@@ -475,6 +474,7 @@ def test_client_create_route_raises(gateway):
                     "openai_api_type": "openai",
                 },
             },
+            "llm/v1/chat",
         )
 
 

--- a/tests/gateway/test_client.py
+++ b/tests/gateway/test_client.py
@@ -466,6 +466,7 @@ def test_client_create_route_raises(gateway):
     with pytest.raises(MlflowException, match="The create_route API is only available when"):
         gateway_client.create_route(
             "some-route",
+            "llm/v1/chat",
             {
                 "name": "a-route",
                 "provider": "openai",
@@ -474,7 +475,51 @@ def test_client_create_route_raises(gateway):
                     "openai_api_type": "openai",
                 },
             },
+        )
+
+    with mock.patch.object(gateway_client, "_is_databricks_host", return_value=True):
+        with pytest.raises(MlflowException, match="Missing required field: model"):
+            gateway_client.create_route(
+                "some-route",
+                "llm/v1/chat",
+            )
+
+        with pytest.raises(MlflowException, match="Missing required field: route_type"):
+            gateway_client.create_route(
+                "some-route",
+                {
+                    "name": "a-route",
+                    "provider": "openai",
+                    "config": {
+                        "openai_api_key": "mykey",
+                        "openai_api_type": "openai",
+                    },
+                },
+            )
+
+
+def test_client_create_route_works(gateway):
+    gateway_client = MlflowGatewayClient(gateway_uri=gateway.url)
+    with mock.patch.object(gateway_client, "_is_databricks_host", return_value=True):
+        gateway_client.create_route(
+            "some-route",
             "llm/v1/chat",
+            {
+                "name": "a-route",
+                "provider": "openai",
+                "config": {
+                    "openai_api_key": "mykey",
+                    "openai_api_type": "openai",
+                },
+            },
+        )
+
+        gateway_client.create_route(
+            "some-managed-route",
+            {
+                "name": "a-route",
+                "provider": "databricks",
+            },
         )
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add `Databricks` provider support to Gateway Client for Databricks Managed Routes support. We change `create_route` to make `route_type` optional but confirm the variable is provided when the provider is not Databricks.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

<img width="1491" alt="Screenshot 2023-08-31 at 1 56 51 AM" src="https://github.com/mlflow/mlflow/assets/87999496/13621b2f-b66a-4436-b627-c249f8177465">
<img width="1496" alt="Screenshot 2023-08-31 at 1 59 00 AM" src="https://github.com/mlflow/mlflow/assets/87999496/2ff63463-056a-4389-b616-2d212da5e481">


<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add `Databricks` provider support to Gateway Client for Databricks Managed Routes support. We change `create_route` to make `route_type` optional but confirm the variable is provided when the provider is not Databricks.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [X] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
