### PR TITLE
Move _create_promptlab_run_impl to promptlab_utils.py

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -95,6 +95,7 @@ from mlflow.tracking._tracking_service.registry import TrackingStoreRegistry
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.utils.file_utils import local_file_uri_to_path
 from mlflow.utils.mime_type_utils import _guess_mime_type
+from mlflow.utils.promptlab_utils import _create_promptlab_run_impl
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.string_utils import is_string_type
 from mlflow.utils.uri import is_file_uri, is_local_uri
@@ -1206,29 +1207,27 @@ def create_promptlab_run_handler():
 
     store = _get_tracking_store()
 
-    if hasattr(store, "_create_promptlab_run"):
-        run = store._create_promptlab_run(
-            experiment_id=experiment_id,
-            run_name=run_name,
-            tags=tags,
-            prompt_template=prompt_template,
-            prompt_parameters=prompt_parameters,
-            model_route=model_route,
-            model_parameters=model_parameters,
-            model_input=model_input,
-            model_output=model_output,
-            model_output_parameters=model_output_parameters,
-            mlflow_version=mlflow_version,
-            user_id=user_id,
-            start_time=start_time,
-        )
-        response_message = CreateRun.Response()
-        response_message.run.MergeFrom(run.to_proto())
-        response = Response(mimetype="application/json")
-        response.set_data(message_to_json(response_message))
-        return response
-    else:
-        return _not_implemented()
+    run = _create_promptlab_run_impl(
+        store,
+        experiment_id=experiment_id,
+        run_name=run_name,
+        tags=tags,
+        prompt_template=prompt_template,
+        prompt_parameters=prompt_parameters,
+        model_route=model_route,
+        model_parameters=model_parameters,
+        model_input=model_input,
+        model_output=model_output,
+        model_output_parameters=model_output_parameters,
+        mlflow_version=mlflow_version,
+        user_id=user_id,
+        start_time=start_time,
+    )
+    response_message = CreateRun.Response()
+    response_message.run.MergeFrom(run.to_proto())
+    response = Response(mimetype="application/json")
+    response.set_data(message_to_json(response_message))
+    return response
 
 
 @catch_mlflow_exception

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -74,9 +74,6 @@ from mlflow.utils.mlflow_tags import (
     _get_run_name_from_tags,
 )
 from mlflow.utils.name_utils import _generate_random_name, _generate_unique_integer_id
-from mlflow.utils.promptlab_utils import (
-    _create_promptlab_run_impl,
-)
 from mlflow.utils.search_utils import SearchExperimentsUtils, SearchUtils
 from mlflow.utils.string_utils import is_string_type
 from mlflow.utils.time_utils import get_current_time_millis
@@ -1276,42 +1273,6 @@ class FileStore(AbstractStore):
             )
             for summary in summaries
         ]
-
-    def _create_promptlab_run(
-        self,
-        experiment_id: str,
-        run_name: str,
-        tags: List[RunTag],
-        prompt_template: str,
-        prompt_parameters: List[Param],
-        model_route: str,
-        model_parameters: List[Param],
-        model_input: str,
-        model_output_parameters: List[Param],
-        model_output: str,
-        mlflow_version: str,
-        user_id: str,
-        start_time: str,
-    ):
-        """
-        Creates a run for prompt engineering with the specified attributes.
-        """
-        return _create_promptlab_run_impl(
-            self,
-            experiment_id,
-            run_name,
-            tags,
-            prompt_template,
-            prompt_parameters,
-            model_route,
-            model_parameters,
-            model_input,
-            model_output_parameters,
-            model_output,
-            mlflow_version,
-            user_id,
-            start_time,
-        )
 
     @staticmethod
     def _get_dataset_from_dir(parent_path, dataset_dir) -> Dataset:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -18,7 +18,6 @@ from mlflow.entities import (
     DatasetInput,
     Experiment,
     Metric,
-    Param,
     Run,
     RunInputs,
     RunStatus,
@@ -60,9 +59,6 @@ from mlflow.utils.mlflow_tags import (
     _get_run_name_from_tags,
 )
 from mlflow.utils.name_utils import _generate_random_name
-from mlflow.utils.promptlab_utils import (
-    _create_promptlab_run_impl,
-)
 from mlflow.utils.search_utils import SearchExperimentsUtils, SearchUtils
 from mlflow.utils.string_utils import is_string_type
 from mlflow.utils.time_utils import get_current_time_millis
@@ -1020,42 +1016,6 @@ class SqlAlchemyStore(AbstractStore):
                 )
                 for summary in summaries
             ]
-
-    def _create_promptlab_run(
-        self,
-        experiment_id: str,
-        run_name: str,
-        tags: List[RunTag],
-        prompt_template: str,
-        prompt_parameters: List[Param],
-        model_route: str,
-        model_parameters: List[Param],
-        model_input: str,
-        model_output_parameters: List[Param],
-        model_output: str,
-        mlflow_version: str,
-        user_id: str,
-        start_time: str,
-    ):
-        """
-        Creates a run for prompt engineering with the specified attributes.
-        """
-        return _create_promptlab_run_impl(
-            self,
-            experiment_id,
-            run_name,
-            tags,
-            prompt_template,
-            prompt_parameters,
-            model_route,
-            model_parameters,
-            model_input,
-            model_output_parameters,
-            model_output,
-            mlflow_version,
-            user_id,
-            start_time,
-        )
 
     def log_param(self, run_id, param):
         _validate_param(param.key, param.value)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -35,7 +35,6 @@ from mlflow.protos.databricks_pb2 import (
     RESOURCE_DOES_NOT_EXIST,
     ErrorCode,
 )
-from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.tracking.file_store import FileStore
@@ -2700,60 +2699,3 @@ def test_search_datasets_returns_no_more_than_max_results(store):
 
     results = store._search_datasets([exp_id])
     assert len(results) == 1000
-
-
-@pytest.mark.skipif(
-    "MLFLOW_SKINNY" in os.environ,
-    reason="Skinny does not support the np or pandas dependencies",
-)
-def test_create_promptlab_run(store):
-    exp_id = store.create_experiment("test_create_promptlab_run")
-    run = store._create_promptlab_run(
-        experiment_id=exp_id,
-        run_name="my_promptlab_run",
-        tags=[],
-        prompt_template="my_prompt_template",
-        prompt_parameters=[Param("prompt_param_key", "prompt_param_value")],
-        model_route="my_route",
-        model_parameters=[Param("temperature", "0.1")],
-        model_input="",
-        model_output_parameters=[Param("output_param_key", "output_param_value")],
-        model_output="my_output",
-        mlflow_version="1.0.0",
-        user_id="user",
-        start_time=1,
-    )
-    assert run.info.run_id is not None
-    assert run.info.status == RunStatus.to_string(RunStatus.FINISHED)
-
-    assert run.data.params["prompt_template"] == "my_prompt_template"
-    assert run.data.params["model_route"] == "my_route"
-    assert run.data.params["temperature"] == "0.1"
-
-    assert run.data.tags["mlflow.runName"] == "my_promptlab_run"
-    assert (
-        run.data.tags["mlflow.loggedArtifacts"]
-        == '[{"path": "eval_results_table.json", "type": "table"}]'
-    )
-    assert run.data.tags["mlflow.runSourceType"] == "PROMPT_ENGINEERING"
-    assert run.data.tags["mlflow.log-model.history"] is not None
-
-    # list the files in the model folder
-    artifact_location = run.info.artifact_uri
-    artifact_repo = get_artifact_repository(artifact_location)
-
-    artifact_files = [f.path for f in artifact_repo.list_artifacts()]
-    assert "eval_results_table.json" in artifact_files
-    assert "model" in artifact_files
-
-    model_files = [f.path for f in artifact_repo.list_artifacts("model")]
-    assert "model/MLmodel" in model_files
-    assert "model/python_env.yaml" in model_files
-    assert "model/conda.yaml" in model_files
-    assert "model/requirements.txt" in model_files
-    assert "model/input_example.json" in model_files
-
-    # try to load the model
-    import mlflow.pyfunc
-
-    mlflow.pyfunc.load_model(os.path.join(artifact_location, "model"))

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -39,7 +39,6 @@ from mlflow.protos.databricks_pb2 import (
     TEMPORARILY_UNAVAILABLE,
     ErrorCode,
 )
-from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.db.db_types import MSSQL, MYSQL, POSTGRES, SQLITE
 from mlflow.store.db.utils import (
     _get_latest_schema_revision,
@@ -2460,60 +2459,6 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
 
         results = self.store._search_datasets([exp_id])
         assert len(results) == 1000
-
-    @pytest.mark.skipif(
-        "MLFLOW_SKINNY" in os.environ,
-        reason="Skinny does not support the np or pandas dependencies",
-    )
-    def test_create_promptlab_run(self):
-        exp_id = self.store.create_experiment("test_create_promptlab_run")
-        run = self.store._create_promptlab_run(
-            experiment_id=exp_id,
-            run_name="my_promptlab_run",
-            tags=[],
-            prompt_template="my_prompt_template",
-            prompt_parameters=[Param("prompt_param_key", "prompt_param_value")],
-            model_route="my_route",
-            model_parameters=[Param("temperature", "0.1")],
-            model_input="",
-            model_output_parameters=[Param("output_param_key", "output_param_value")],
-            model_output="my_output",
-            mlflow_version="1.0.0",
-            user_id="user",
-            start_time=1,
-        )
-        assert run.info.run_id is not None
-        assert run.info.status == RunStatus.to_string(RunStatus.FINISHED)
-
-        assert run.data.params["prompt_template"] == "my_prompt_template"
-        assert run.data.params["model_route"] == "my_route"
-        assert run.data.params["temperature"] == "0.1"
-
-        assert run.data.tags["mlflow.runName"] == "my_promptlab_run"
-        assert (
-            run.data.tags["mlflow.loggedArtifacts"]
-            == '[{"path": "eval_results_table.json", "type": "table"}]'
-        )
-        assert run.data.tags["mlflow.runSourceType"] == "PROMPT_ENGINEERING"
-        assert run.data.tags["mlflow.log-model.history"] is not None
-
-        # list the files in the model folder
-        artifact_location = run.info.artifact_uri
-        artifact_repo = get_artifact_repository(artifact_location)
-
-        artifact_files = [f.path for f in artifact_repo.list_artifacts()]
-        assert "eval_results_table.json" in artifact_files
-        assert "model" in artifact_files
-
-        model_files = [f.path for f in artifact_repo.list_artifacts("model")]
-        assert "model/MLmodel" in model_files
-        assert "model/python_env.yaml" in model_files
-        assert "model/conda.yaml" in model_files
-        assert "model/requirements.txt" in model_files
-        assert "model/input_example.json" in model_files
-
-        # try to load the model
-        mlflow.pyfunc.load_model(os.path.join(artifact_location, "model"))
 
     def test_log_batch(self):
         experiment_id = self._experiment_factory("log_batch")

--- a/tests/utils/test_promptlab_utils.py
+++ b/tests/utils/test_promptlab_utils.py
@@ -1,7 +1,14 @@
 import json
+import os
+
+import pytest
 
 from mlflow.entities.param import Param
+from mlflow.entities.run_status import RunStatus
+from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
+from mlflow.store.tracking.file_store import FileStore
 from mlflow.utils.promptlab_utils import (
+    _create_promptlab_run_impl,
     create_eval_results_json,
 )
 
@@ -35,3 +42,66 @@ def test_eval_results_file():
         ],
     }
     assert json.loads(eval_results_file) == expected_eval_results_json
+
+
+@pytest.fixture
+def store(tmp_path):
+    return FileStore(str(tmp_path.joinpath("mlruns")))
+
+
+@pytest.mark.skipif(
+    "MLFLOW_SKINNY" in os.environ,
+    reason="Skinny does not support the np or pandas dependencies",
+)
+def test_create_promptlab_run(store):
+    exp_id = store.create_experiment("test_create_promptlab_run")
+    run = _create_promptlab_run_impl(
+        store,
+        experiment_id=exp_id,
+        run_name="my_promptlab_run",
+        tags=[],
+        prompt_template="my_prompt_template",
+        prompt_parameters=[Param("prompt_param_key", "prompt_param_value")],
+        model_route="my_route",
+        model_parameters=[Param("temperature", "0.1")],
+        model_input="",
+        model_output_parameters=[Param("output_param_key", "output_param_value")],
+        model_output="my_output",
+        mlflow_version="1.0.0",
+        user_id="user",
+        start_time=1,
+    )
+    assert run.info.run_id is not None
+    assert run.info.status == RunStatus.to_string(RunStatus.FINISHED)
+
+    assert run.data.params["prompt_template"] == "my_prompt_template"
+    assert run.data.params["model_route"] == "my_route"
+    assert run.data.params["temperature"] == "0.1"
+
+    assert run.data.tags["mlflow.runName"] == "my_promptlab_run"
+    assert (
+        run.data.tags["mlflow.loggedArtifacts"]
+        == '[{"path": "eval_results_table.json", "type": "table"}]'
+    )
+    assert run.data.tags["mlflow.runSourceType"] == "PROMPT_ENGINEERING"
+    assert run.data.tags["mlflow.log-model.history"] is not None
+
+    # list the files in the model folder
+    artifact_location = run.info.artifact_uri
+    artifact_repo = get_artifact_repository(artifact_location)
+
+    artifact_files = [f.path for f in artifact_repo.list_artifacts()]
+    assert "eval_results_table.json" in artifact_files
+    assert "model" in artifact_files
+
+    model_files = [f.path for f in artifact_repo.list_artifacts("model")]
+    assert "model/MLmodel" in model_files
+    assert "model/python_env.yaml" in model_files
+    assert "model/conda.yaml" in model_files
+    assert "model/requirements.txt" in model_files
+    assert "model/input_example.json" in model_files
+
+    # try to load the model
+    import mlflow.pyfunc
+
+    mlflow.pyfunc.load_model(os.path.join(artifact_location, "model"))


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
Followup from https://github.com/mlflow/mlflow/pull/9354

## What changes are proposed in this pull request?

Remove store specific `_create_promptlab_run` in favor of implementation in `promptlab_utils.py`

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

Remove test cases from `test_file_store.py` and `test_sqlalchemy_store.py`. Write a new test in `test_promptlab_utils.py` using a FileStore.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
