### PR TITLE
Ignore array columns with enforcing ColSpec signature, instead of throwing

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -696,8 +696,7 @@ def _enforce_schema(pf_input: PyFuncInput, input_schema: Schema):
                 ):
                     pf_input = pd.DataFrame([pf_input])
                 elif isinstance(pf_input, dict) and any(
-                    isinstance(value, np.ndarray) and value.ndim > 1
-                    for value in pf_input.values()
+                    isinstance(value, np.ndarray) and value.ndim > 1 for value in pf_input.values()
                 ):
                     # Pandas DataFrames can't be constructed with embedded multi-dimensional
                     # numpy arrays. Accordingly, we convert any multi-dimensional numpy
@@ -705,13 +704,16 @@ def _enforce_schema(pf_input: PyFuncInput, input_schema: Schema):
                     # model signatures do not support array columns, so subsequent validation logic
                     # will result in a clear "incompatible input types" exception. This is
                     # preferable to a pandas DataFrame construction error
-                    pf_input = pd.DataFrame({
-                        key: (
-                            value.tolist() if (isinstance(value, np.ndarray) and value.ndim > 1)
-                            else value
-                        )
-                        for key, value in pf_input.items()
-                    })
+                    pf_input = pd.DataFrame(
+                        {
+                            key: (
+                                value.tolist()
+                                if (isinstance(value, np.ndarray) and value.ndim > 1)
+                                else value
+                            )
+                            for key, value in pf_input.items()
+                        }
+                    )
                 else:
                     pf_input = pd.DataFrame(pf_input)
             except Exception as e:

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -695,6 +695,20 @@ def _enforce_schema(pf_input: PyFuncInput, input_schema: Schema):
                     for value in pf_input.values()
                 ):
                     pf_input = pd.DataFrame([pf_input])
+                elif isinstance(pf_input, dict) and any(
+                    isinstance(value, np.ndarray) and value.ndim > 1
+                    for value in pf_input.values()
+                ):
+                    # If the input is a dictionary containing one or more multi-dimensional
+                    # numpy array values, these multi-dimensional values must be it must be
+                    # converted to lists; otherwise, pandas will throw during dataframe creation
+                    pf_input = pd.DataFrame({
+                        key: (
+                            value.tolist()
+                            if isinstance(value, np.ndarray) and value.ndim > 1 else value
+                        )
+                        for key, value in pf_input.items()
+                    })
                 else:
                     pf_input = pd.DataFrame(pf_input)
             except Exception as e:

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -696,23 +696,22 @@ def _enforce_schema(pf_input: PyFuncInput, input_schema: Schema):
                 ):
                     pf_input = pd.DataFrame([pf_input])
                 elif isinstance(pf_input, dict) and any(
-                    isinstance(value, np.ndarray) and value.ndim > 1 for value in pf_input.values()
+                    isinstance(value, np.ndarray) and value.ndim > 1
+                    for value in pf_input.values()
                 ):
                     # Pandas DataFrames can't be constructed with embedded multi-dimensional
-                    # numpy arrays. Accordingly, we filter out any multi-dimensional numpy arrays
-                    # before converting the input to a DataFrame. This is safe because ColSpec
-                    # model signatures do not support array columns. This is preferable to
-                    # throwing an exception because array columns are supported for models
-                    # that don't define a signature, and throwing an exception would be a
-                    # significant difference in behavior between models with signatures and
-                    # models without signatures
-                    pf_input = pd.DataFrame(
-                        {
-                            key: value
-                            for key, value in pf_input.items()
-                            if not (isinstance(value, np.ndarray) and value.ndim > 1)
-                        }
-                    )
+                    # numpy arrays. Accordingly, we convert any multi-dimensional numpy
+                    # arrays to lists before constructing a DataFrame. This is safe because ColSpec
+                    # model signatures do not support array columns, so subsequent validation logic
+                    # will result in a clear "incompatible input types" exception. This is
+                    # preferable to a pandas DataFrame construction error
+                    pf_input = pd.DataFrame({
+                        key: (
+                            value.tolist() if (isinstance(value, np.ndarray) and value.ndim > 1)
+                            else value
+                        )
+                        for key, value in pf_input.items()
+                    })
                 else:
                     pf_input = pd.DataFrame(pf_input)
             except Exception as e:

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -283,7 +283,7 @@ def test_column_schema_enforcement():
         "g": ["a", "b", "c"],
         "f": [bytes(0), bytes(1), bytes(1)],
         "h": np.array(["2020-01-01", "2020-02-02", "2020-03-03"], dtype=np.datetime64),
-        "i": np.array([[1, 2, 3]]),
+        "i": np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
     }
     res = pyfunc_model.predict(d)
     assert res.dtypes.to_dict() == expected_types

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -320,6 +320,25 @@ def test_column_schema_enforcement():
     assert res.dtypes.to_dict() == expected_types
 
 
+def test_column_schema_enforcement_supports_extraneous_multidimensional_ndarrays():
+    m = Model()
+    input_schema = Schema(
+        [
+            ColSpec("string", "a"),
+        ]
+    )
+    m.signature = ModelSignature(inputs=input_schema)
+    pyfunc_model = PyFuncModel(model_meta=m, model_impl=TestModel())
+    expected_types = dict(zip(input_schema.input_names(), input_schema.pandas_types()))
+
+    d = {
+        "a": ["test"],
+        "b": np.array([[1,2,3]]),
+    }
+    res = pyfunc_model.predict(d)
+    assert res.dtypes.to_dict() == expected_types
+
+
 def _compare_exact_tensor_dict_input(d1, d2):
     """Return whether two dicts of np arrays are exactly equal"""
     if d1.keys() != d2.keys():

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -272,7 +272,8 @@ def test_column_schema_enforcement():
     with pytest.raises(MlflowException, match=match_missing_inputs):
         pyfunc_model.predict(pdf.values)
 
-    # 14. dictionaries of str -> list/nparray work, including extraneous multi-dimensional arrays
+    # 14. dictionaries of str -> list/nparray work,
+    # including extraneous multi-dimensional arrays and lists
     arr = np.array([1, 2, 3])
     d = {
         "a": arr.astype("int32"),
@@ -283,7 +284,10 @@ def test_column_schema_enforcement():
         "g": ["a", "b", "c"],
         "f": [bytes(0), bytes(1), bytes(1)],
         "h": np.array(["2020-01-01", "2020-02-02", "2020-03-03"], dtype=np.datetime64),
+        # Extraneous multi-dimensional numpy array should be silenty dropped
         "i": np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+        # Extraneous multi-dimensional list should be silently dropped
+        "j": [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
     }
     res = pyfunc_model.predict(d)
     assert res.dtypes.to_dict() == expected_types

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -299,7 +299,7 @@ def test_column_schema_enforcement():
         "c": [arr.astype("float32")],
         "d": [arr.astype("float64")],
         "e": [[True, False, True]],
-        "g": [["a", "b", "c"]],
+        "g": np.array([["a", "b", "c"]]),
         "f": [[bytes(0), bytes(1), bytes(1)]],
         "h": [np.array(["2020-01-01", "2020-02-02", "2020-03-03"], dtype=np.datetime64)],
     }


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

**What**: Ignore array columns with enforcing ColSpec signature, instead of throwing

**Why**: When using AI Gateway with pyfunc models served using MLflow Model serving, if `stop` tokens are passed to a pyfunc model that has a signature, the request fails instead of ignoring the stop tokens. The following message is observed:

```
{"error_code": "INTERNAL_ERROR", "message": "This model contains a column-based signature, which suggests a DataFrame input. There was an error casting the input data to a DataFrame: Per-column arrays must each be 1-dimensional"}
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
