### PR TITLE
Convert pmdarima params/returns to Google style via GPT

### DIFF
--- a/mlflow/pmdarima.py
+++ b/mlflow/pmdarima.py
@@ -107,9 +107,12 @@ _logger = logging.getLogger(__name__)
 
 def get_default_pip_requirements():
     """
-    :return: A list of default pip requirements for MLflow Models produced by this flavor.
-             Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment that,
-             at a minimum, contains these requirements.
+    
+    Returns:
+        A list of default pip requirements for MLflow Models produced by this flavor. Calls to 
+        `save_model()` and `log_model()` produce a pip environment that, at a minimum, contains 
+        these requirements.
+    
     """
 
     return [_get_pinned_requirement("pmdarima")]
@@ -117,8 +120,11 @@ def get_default_pip_requirements():
 
 def get_default_conda_env():
     """
-    :return: The default Conda environment for MLflow Models produced by calls to
-             :func:`save_model()` and :func:`log_model()`
+    
+    Returns:
+        The default Conda environment for MLflow Models produced by calls to
+        :func:`save_model()` and :func:`log_model()`.
+    
     """
 
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
@@ -138,74 +144,63 @@ def save_model(
     metadata=None,
 ):
     """
-    Save a pmdarima ``ARIMA`` model or ``Pipeline`` object to a path on the local file system.
-
-    :param pmdarima_model: pmdarima ``ARIMA`` or ``Pipeline`` model that has been ``fit`` on a
-                           temporal series.
-    :param path: Local path destination for the serialized model (in pickle format) is to be saved.
-    :param conda_env: {{ conda_env }}
-    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
-    :param mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
-    :param signature: an instance of the :py:class:`ModelSignature <mlflow.models.ModelSignature>`
-                      class that describes the model's inputs and outputs. If not specified but an
-                      ``input_example`` is supplied, a signature will be automatically inferred
-                      based on the supplied input example and model. To disable automatic signature
-                      inference when providing an input example, set ``signature`` to ``False``.
-                      To manually infer a model signature, call
-                      :py:func:`infer_signature() <mlflow.models.infer_signature>` on datasets
-                      with valid model inputs, such as a training dataset with the target column
-                      omitted, and valid model outputs, like model predictions made on the training
-                      dataset, for example:
-
-                      .. code-block:: python
-
-                        from mlflow.models import infer_signature
-
-                        model = pmdarima.auto_arima(data)
-                        predictions = model.predict(n_periods=30, return_conf_int=False)
-                        signature = infer_signature(data, predictions)
-
-                      .. Warning:: if utilizing confidence interval generation in the ``predict``
-                        method of a ``pmdarima`` model (``return_conf_int=True``), the signature
-                        will not be inferred due to the complex tuple return type when using the
-                        native ``ARIMA.predict()`` API. ``infer_schema`` will function correctly
-                        if using the ``pyfunc`` flavor of the model, though.
-    :param input_example: {{ input_example }}
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
-
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
-
-    .. code-block:: python
-        :caption: Example
-
-        import pandas as pd
-        import mlflow
-        import pmdarima
-
-        # Specify locations of source data and the model artifact
-        SOURCE_DATA = "https://raw.githubusercontent.com/facebook/prophet/master/examples/example_retail_sales.csv"
-        ARTIFACT_PATH = "model"
-
-        # Read data and recode columns
-        sales_data = pd.read_csv(SOURCE_DATA)
-        sales_data.rename(columns={"y": "sales", "ds": "date"}, inplace=True)
-
-        # Split the data into train/test
-        train_size = int(0.8 * len(sales_data))
-        train, test = sales_data[:train_size], sales_data[train_size:]
-
-        with mlflow.start_run():
-            # Create the model
-            model = pmdarima.auto_arima(train["sales"], seasonal=True, m=12)
-
-            # Save the model to the specified path
-            mlflow.pmdarima.save_model(model, "model")
-
+    
+        Save a pmdarima ``ARIMA`` model or ``Pipeline`` object to a path on the local file system.
+    
+        Args:
+            pmdarima_model: pmdarima ``ARIMA`` or ``Pipeline`` model that has been ``fit`` on a
+                            temporal series.
+            path: Local path destination for the serialized model (in pickle format) is to be saved.
+            conda_env: {{ conda_env }}
+            code_paths: A list of local filesystem paths to Python file dependencies (or directories
+                        containing file dependencies). These files are *prepended* to the system
+                        path when the model is loaded.
+            mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
+            signature: an instance of the :py:class:`ModelSignature <mlflow.models.ModelSignature>`
+                       class that describes the model's inputs and outputs. If not specified but an
+                       ``input_example`` is supplied, a signature will be automatically inferred
+                       based on the supplied input example and model. To disable automatic signature
+                       inference when providing an input example, set ``signature`` to ``False``.
+                       To manually infer a model signature, call
+                       :py:func:`infer_signature() <mlflow.models.infer_signature>` on datasets
+                       with valid model inputs, such as a training dataset with the target column
+                       omitted, and valid model outputs, like model predictions made on the training
+                       dataset.
+            input_example: {{ input_example }}
+            pip_requirements: {{ pip_requirements }}
+            extra_pip_requirements: {{ extra_pip_requirements }}
+            metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
+    
+        Note:
+            Experimental: The metadata parameter may change or be removed in a future
+                          release without warning.
+    
+        Example:
+            .. code-block:: python
+    
+                import pandas as pd
+                import mlflow
+                import pmdarima
+    
+                # Specify locations of source data and the model artifact
+                SOURCE_DATA = "https://raw.githubusercontent.com/facebook/prophet/master/examples/example_retail_sales.csv"
+                ARTIFACT_PATH = "model"
+    
+                # Read data and recode columns
+                sales_data = pd.read_csv(SOURCE_DATA)
+                sales_data.rename(columns={"y": "sales", "ds": "date"}, inplace=True)
+    
+                # Split the data into train/test
+                train_size = int(0.8 * len(sales_data))
+                train, test = sales_data[:train_size], sales_data[train_size:]
+    
+                with mlflow.start_run():
+                    # Create the model
+                    model = pmdarima.auto_arima(train["sales"], seasonal=True, m=12)
+    
+                    # Save the model to the specified path
+                    mlflow.pmdarima.save_model(model, "model")
+        
     """
 
     import pmdarima
@@ -294,96 +289,83 @@ def log_model(
     **kwargs,
 ):
     """
-    Log a ``pmdarima`` ``ARIMA`` or ``Pipeline`` object as an MLflow artifact for the current run.
-
-    :param pmdarima_model: pmdarima ``ARIMA`` or ``Pipeline`` model that has been ``fit`` on a
-                           temporal series.
-    :param artifact_path: Run-relative artifact path to save the model instance to.
-    :param conda_env: {{ conda_env }}
-    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
-    :param registered_model_name: This argument may change or be removed in a
-                                  future release without warning. If given, create a model
-                                  version under ``registered_model_name``, also creating a
-                                  registered model if one with the given name does not exist.
-    :param signature: an instance of the :py:class:`ModelSignature <mlflow.models.ModelSignature>`
-                      class that describes the model's inputs and outputs. If not specified but an
-                      ``input_example`` is supplied, a signature will be automatically inferred
-                      based on the supplied input example and model. To disable automatic signature
-                      inference when providing an input example, set ``signature`` to ``False``.
-                      To manually infer a model signature, call
-                      :py:func:`infer_signature() <mlflow.models.infer_signature>` on datasets
-                      with valid model inputs, such as a training dataset with the target column
-                      omitted, and valid model outputs, like model predictions made on the training
-                      dataset, for example:
-
-                      .. code-block:: python
-
-                        from mlflow.models import infer_signature
-
-                        model = pmdarima.auto_arima(data)
-                        predictions = model.predict(n_periods=30, return_conf_int=False)
-                        signature = infer_signature(data, predictions)
-
-                      .. Warning:: if utilizing confidence interval generation in the ``predict``
-                        method of a ``pmdarima`` model (``return_conf_int=True``), the signature
-                        will not be inferred due to the complex tuple return type when using the
-                        native ``ARIMA.predict()`` API. ``infer_schema`` will function correctly
-                        if using the ``pyfunc`` flavor of the model, though.
-
-    :param input_example: {{ input_example }}
-    :param await_registration_for: Number of seconds to wait for the model version
-                                   to finish being created and is in ``READY`` status.
-                                   By default, the function waits for five minutes.
-                                   Specify 0 or None to skip waiting.
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
-
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
-    :param kwargs: Additional arguments for :py:class:`mlflow.models.model.Model`
-    :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
-             metadata of the logged model.
-
+    
+    Logs a ``pmdarima`` ``ARIMA`` or ``Pipeline`` object as an MLflow artifact for the current run.
+    
+    Args:
+        pmdarima_model: pmdarima ``ARIMA`` or ``Pipeline`` model that has been ``fit`` on a
+                        temporal series.
+        artifact_path: Run-relative artifact path to save the model instance to.
+        conda_env: {{ conda_env }}
+        code_paths: A list of local filesystem paths to Python file dependencies (or directories
+                    containing file dependencies). These files are *prepended* to the system
+                    path when the model is loaded.
+        registered_model_name: This argument may change or be removed in a
+                               future release without warning. If given, create a model
+                               version under ``registered_model_name``, also creating a
+                               registered model if one with the given name does not exist.
+        signature: an instance of the :py:class:`ModelSignature <mlflow.models.ModelSignature>`
+                   class that describes the model's inputs and outputs. If not specified but an
+                   ``input_example`` is supplied, a signature will be automatically inferred
+                   based on the supplied input example and model. To disable automatic signature
+                   inference when providing an input example, set ``signature`` to ``False``.
+                   To manually infer a model signature, call
+                   :py:func:`infer_signature() <mlflow.models.infer_signature>` on datasets
+                   with valid model inputs, such as a training dataset with the target column
+                   omitted, and valid model outputs, like model predictions made on the training
+                   dataset.
+        input_example: {{ input_example }}
+        await_registration_for: Number of seconds to wait for the model version
+                                to finish being created and is in ``READY`` status.
+                                By default, the function waits for five minutes.
+                                Specify 0 or None to skip waiting.
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
+        kwargs: Additional arguments for :py:class:`mlflow.models.model.Model`
+    
+    Returns:
+        A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
+        metadata of the logged model.
+    
+    Example:
+    
     .. code-block:: python
-        :caption: Example
-
+    
         import pandas as pd
         import mlflow
         from mlflow.models import infer_signature
         import pmdarima
         from pmdarima.metrics import smape
-
+    
         # Specify locations of source data and the model artifact
         SOURCE_DATA = "https://raw.githubusercontent.com/facebook/prophet/master/examples/example_retail_sales.csv"
         ARTIFACT_PATH = "model"
-
+    
         # Read data and recode columns
         sales_data = pd.read_csv(SOURCE_DATA)
         sales_data.rename(columns={"y": "sales", "ds": "date"}, inplace=True)
-
+    
         # Split the data into train/test
         train_size = int(0.8 * len(sales_data))
         train, test = sales_data[:train_size], sales_data[train_size:]
-
+    
         with mlflow.start_run():
             # Create the model
             model = pmdarima.auto_arima(train["sales"], seasonal=True, m=12)
-
+    
             # Calculate metrics
             prediction = model.predict(n_periods=len(test))
             metrics = {"smape": smape(test["sales"], prediction)}
-
+    
             # Infer signature
             input_sample = pd.DataFrame(train["sales"])
             output_sample = pd.DataFrame(model.predict(n_periods=5))
             signature = infer_signature(input_sample, output_sample)
-
+    
             # Log model
             mlflow.pmdarima.log_model(model, ARTIFACT_PATH, signature=signature)
-
+    
     """
 
     return Model.log(
@@ -405,85 +387,90 @@ def log_model(
 
 def load_model(model_uri, dst_path=None):
     """
-    Load a ``pmdarima`` ``ARIMA`` model or ``Pipeline`` object from a local file or a run.
-
-    :param model_uri: The location, in URI format, of the MLflow model. For example:
-
-                      - ``/Users/me/path/to/local/model``
-                      - ``relative/path/to/local/model``
-                      - ``s3://my_bucket/path/to/model``
-                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
-                      - ``mlflow-artifacts:/path/to/model``
-
-                      For more information about supported URI schemes, see
-                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
-                      artifact-locations>`_.
-    :param dst_path: The local filesystem path to which to download the model artifact.
-                     This directory must already exist. If unspecified, a local output
-                     path will be created.
-
-    :return: A ``pmdarima`` model instance
-
+    
+    Loads a ``pmdarima`` ``ARIMA`` model or ``Pipeline`` object from a local file or a run.
+    
+    Args:
+        model_uri: The location, in URI format, of the MLflow model. For example:
+    
+                  - ``/Users/me/path/to/local/model``
+                  - ``relative/path/to/local/model``
+                  - ``s3://my_bucket/path/to/model``
+                  - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+                  - ``mlflow-artifacts:/path/to/model``
+    
+                  For more information about supported URI schemes, see
+                  `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
+                  artifact-locations>`_.
+        dst_path: The local filesystem path to which to download the model artifact.
+                 This directory must already exist. If unspecified, a local output
+                 path will be created.
+    
+    Returns:
+        A ``pmdarima`` model instance
+    
+    Example:
+    
     .. code-block:: python
-        :caption: Example
-
+    
         import pandas as pd
         import mlflow
         from mlflow.models import infer_signature
         import pmdarima
         from pmdarima.metrics import smape
-
+    
         # Specify locations of source data and the model artifact
         SOURCE_DATA = "https://raw.githubusercontent.com/facebook/prophet/master/examples/example_retail_sales.csv"
         ARTIFACT_PATH = "model"
-
+    
         # Read data and recode columns
         sales_data = pd.read_csv(SOURCE_DATA)
         sales_data.rename(columns={"y": "sales", "ds": "date"}, inplace=True)
-
+    
         # Split the data into train/test
         train_size = int(0.8 * len(sales_data))
         train, test = sales_data[:train_size], sales_data[train_size:]
-
+    
         with mlflow.start_run():
             # Create the model
             model = pmdarima.auto_arima(train["sales"], seasonal=True, m=12)
-
+    
             # Calculate metrics
             prediction = model.predict(n_periods=len(test))
             metrics = {"smape": smape(test["sales"], prediction)}
-
+    
             # Infer signature
             input_sample = pd.DataFrame(train["sales"])
             output_sample = pd.DataFrame(model.predict(n_periods=5))
             signature = infer_signature(input_sample, output_sample)
-
+    
             # Log model
             input_example = input_sample.head()
             mlflow.pmdarima.log_model(
                 model, ARTIFACT_PATH, signature=signature, input_example=input_example
             )
-
+    
             # Get the model URI for loading
             model_uri = mlflow.get_artifact_uri(ARTIFACT_PATH)
-
+    
         # Load the model
         loaded_model = mlflow.pmdarima.load_model(model_uri)
-
+    
         # Forecast for the next 60 days
         forecast = loaded_model.predict(n_periods=60)
-
+    
         print(f"forecast: {forecast}")
-
+    
+    Output:
+    
     .. code-block:: text
-        :caption: Output
-
+    
         forecast:
         234    382452.397246
         235    380639.458720
         236    359805.611219
         ...
-
+    
     """
 
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
@@ -522,13 +509,16 @@ class _PmdarimaModelWrapper:
         self, dataframe, params: Optional[Dict[str, Any]] = None
     ) -> pd.DataFrame:  # pylint: disable=unused-argument
         """
-        :param dataframe: Model input data.
-        :param params: Additional parameters to pass to the model for inference.
-
-                       .. Note:: Experimental: This parameter may change or be removed in a future
-                                               release without warning.
-
-        :return: Model predictions.
+        
+            Args:
+                dataframe: Model input data.
+                params: Additional parameters to pass to the model for inference.
+                    Note: Experimental: This parameter may change or be removed in a future
+                    release without warning.
+        
+            Returns:
+                Model predictions.
+            
         """
         df_schema = dataframe.columns.values.tolist()
 

--- a/mlflow/pmdarima.py
+++ b/mlflow/pmdarima.py
@@ -107,12 +107,10 @@ _logger = logging.getLogger(__name__)
 
 def get_default_pip_requirements():
     """
-
     Returns:
         A list of default pip requirements for MLflow Models produced by this flavor. Calls to
-        `save_model()` and `log_model()` produce a pip environment that, at a minimum, contains
-        these requirements.
-
+        :func:`save_model()` and :func:`log_model()` produce a pip environment that, at a minimum, 
+        contains these requirements.
     """
 
     return [_get_pinned_requirement("pmdarima")]
@@ -120,11 +118,9 @@ def get_default_pip_requirements():
 
 def get_default_conda_env():
     """
-
     Returns:
         The default Conda environment for MLflow Models produced by calls to
         :func:`save_model()` and :func:`log_model()`.
-
     """
 
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
@@ -144,7 +140,6 @@ def save_model(
     metadata=None,
 ):
     """
-
     Save a pmdarima ``ARIMA`` model or ``Pipeline`` object to a path on the local file system.
 
     Args:
@@ -165,7 +160,21 @@ def save_model(
                    :py:func:`infer_signature() <mlflow.models.infer_signature>` on datasets
                    with valid model inputs, such as a training dataset with the target column
                    omitted, and valid model outputs, like model predictions made on the training
-                   dataset.
+                   dataset, for example:
+
+                   .. code-block:: python
+                    
+                     from mlflow.models import infer_signature
+                    
+                     model = pmdarima.auto_arima(data)
+                     predictions = model.predict(n_periods=30, return_conf_int=False)
+                     signature = infer_signature(data, predictions)
+                    
+                   .. Warning:: if utilizing confidence interval generation in the ``predict``
+                     method of a ``pmdarima`` model (``return_conf_int=True``), the signature
+                     will not be inferred due to the complex tuple return type when using the
+                     native ``ARIMA.predict()`` API. ``infer_schema`` will function correctly
+                     if using the ``pyfunc`` flavor of the model, though.
         input_example: {{ input_example }}
         pip_requirements: {{ pip_requirements }}
         extra_pip_requirements: {{ extra_pip_requirements }}
@@ -200,7 +209,7 @@ def save_model(
 
                 # Save the model to the specified path
                 mlflow.pmdarima.save_model(model, "model")
-
+                
     """
 
     import pmdarima
@@ -289,7 +298,6 @@ def log_model(
     **kwargs,
 ):
     """
-
     Logs a ``pmdarima`` ``ARIMA`` or ``Pipeline`` object as an MLflow artifact for the current run.
 
     Args:
@@ -365,7 +373,6 @@ def log_model(
 
             # Log model
             mlflow.pmdarima.log_model(model, ARTIFACT_PATH, signature=signature)
-
     """
 
     return Model.log(
@@ -387,7 +394,6 @@ def log_model(
 
 def load_model(model_uri, dst_path=None):
     """
-
     Loads a ``pmdarima`` ``ARIMA`` model or ``Pipeline`` object from a local file or a run.
 
     Args:
@@ -470,7 +476,6 @@ def load_model(model_uri, dst_path=None):
         235    380639.458720
         236    359805.611219
         ...
-
     """
 
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
@@ -509,7 +514,6 @@ class _PmdarimaModelWrapper:
         self, dataframe, params: Optional[Dict[str, Any]] = None
     ) -> pd.DataFrame:  # pylint: disable=unused-argument
         """
-
         Args:
             dataframe: Model input data.
             params: Additional parameters to pass to the model for inference.
@@ -518,7 +522,6 @@ class _PmdarimaModelWrapper:
 
         Returns:
             Model predictions.
-
         """
         df_schema = dataframe.columns.values.tolist()
 

--- a/mlflow/pmdarima.py
+++ b/mlflow/pmdarima.py
@@ -107,12 +107,12 @@ _logger = logging.getLogger(__name__)
 
 def get_default_pip_requirements():
     """
-    
+
     Returns:
-        A list of default pip requirements for MLflow Models produced by this flavor. Calls to 
-        `save_model()` and `log_model()` produce a pip environment that, at a minimum, contains 
+        A list of default pip requirements for MLflow Models produced by this flavor. Calls to
+        `save_model()` and `log_model()` produce a pip environment that, at a minimum, contains
         these requirements.
-    
+
     """
 
     return [_get_pinned_requirement("pmdarima")]
@@ -120,11 +120,11 @@ def get_default_pip_requirements():
 
 def get_default_conda_env():
     """
-    
+
     Returns:
         The default Conda environment for MLflow Models produced by calls to
         :func:`save_model()` and :func:`log_model()`.
-    
+
     """
 
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
@@ -144,63 +144,63 @@ def save_model(
     metadata=None,
 ):
     """
-    
-        Save a pmdarima ``ARIMA`` model or ``Pipeline`` object to a path on the local file system.
-    
-        Args:
-            pmdarima_model: pmdarima ``ARIMA`` or ``Pipeline`` model that has been ``fit`` on a
-                            temporal series.
-            path: Local path destination for the serialized model (in pickle format) is to be saved.
-            conda_env: {{ conda_env }}
-            code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                        containing file dependencies). These files are *prepended* to the system
-                        path when the model is loaded.
-            mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
-            signature: an instance of the :py:class:`ModelSignature <mlflow.models.ModelSignature>`
-                       class that describes the model's inputs and outputs. If not specified but an
-                       ``input_example`` is supplied, a signature will be automatically inferred
-                       based on the supplied input example and model. To disable automatic signature
-                       inference when providing an input example, set ``signature`` to ``False``.
-                       To manually infer a model signature, call
-                       :py:func:`infer_signature() <mlflow.models.infer_signature>` on datasets
-                       with valid model inputs, such as a training dataset with the target column
-                       omitted, and valid model outputs, like model predictions made on the training
-                       dataset.
-            input_example: {{ input_example }}
-            pip_requirements: {{ pip_requirements }}
-            extra_pip_requirements: {{ extra_pip_requirements }}
-            metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
-    
-        Note:
-            Experimental: The metadata parameter may change or be removed in a future
-                          release without warning.
-    
-        Example:
-            .. code-block:: python
-    
-                import pandas as pd
-                import mlflow
-                import pmdarima
-    
-                # Specify locations of source data and the model artifact
-                SOURCE_DATA = "https://raw.githubusercontent.com/facebook/prophet/master/examples/example_retail_sales.csv"
-                ARTIFACT_PATH = "model"
-    
-                # Read data and recode columns
-                sales_data = pd.read_csv(SOURCE_DATA)
-                sales_data.rename(columns={"y": "sales", "ds": "date"}, inplace=True)
-    
-                # Split the data into train/test
-                train_size = int(0.8 * len(sales_data))
-                train, test = sales_data[:train_size], sales_data[train_size:]
-    
-                with mlflow.start_run():
-                    # Create the model
-                    model = pmdarima.auto_arima(train["sales"], seasonal=True, m=12)
-    
-                    # Save the model to the specified path
-                    mlflow.pmdarima.save_model(model, "model")
-        
+
+    Save a pmdarima ``ARIMA`` model or ``Pipeline`` object to a path on the local file system.
+
+    Args:
+        pmdarima_model: pmdarima ``ARIMA`` or ``Pipeline`` model that has been ``fit`` on a
+                        temporal series.
+        path: Local path destination for the serialized model (in pickle format) is to be saved.
+        conda_env: {{ conda_env }}
+        code_paths: A list of local filesystem paths to Python file dependencies (or directories
+                    containing file dependencies). These files are *prepended* to the system
+                    path when the model is loaded.
+        mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
+        signature: an instance of the :py:class:`ModelSignature <mlflow.models.ModelSignature>`
+                   class that describes the model's inputs and outputs. If not specified but an
+                   ``input_example`` is supplied, a signature will be automatically inferred
+                   based on the supplied input example and model. To disable automatic signature
+                   inference when providing an input example, set ``signature`` to ``False``.
+                   To manually infer a model signature, call
+                   :py:func:`infer_signature() <mlflow.models.infer_signature>` on datasets
+                   with valid model inputs, such as a training dataset with the target column
+                   omitted, and valid model outputs, like model predictions made on the training
+                   dataset.
+        input_example: {{ input_example }}
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
+
+    Note:
+        Experimental: The metadata parameter may change or be removed in a future
+                      release without warning.
+
+    Example:
+        .. code-block:: python
+
+            import pandas as pd
+            import mlflow
+            import pmdarima
+
+            # Specify locations of source data and the model artifact
+            SOURCE_DATA = "https://raw.githubusercontent.com/facebook/prophet/master/examples/example_retail_sales.csv"
+            ARTIFACT_PATH = "model"
+
+            # Read data and recode columns
+            sales_data = pd.read_csv(SOURCE_DATA)
+            sales_data.rename(columns={"y": "sales", "ds": "date"}, inplace=True)
+
+            # Split the data into train/test
+            train_size = int(0.8 * len(sales_data))
+            train, test = sales_data[:train_size], sales_data[train_size:]
+
+            with mlflow.start_run():
+                # Create the model
+                model = pmdarima.auto_arima(train["sales"], seasonal=True, m=12)
+
+                # Save the model to the specified path
+                mlflow.pmdarima.save_model(model, "model")
+
     """
 
     import pmdarima
@@ -289,9 +289,9 @@ def log_model(
     **kwargs,
 ):
     """
-    
+
     Logs a ``pmdarima`` ``ARIMA`` or ``Pipeline`` object as an MLflow artifact for the current run.
-    
+
     Args:
         pmdarima_model: pmdarima ``ARIMA`` or ``Pipeline`` model that has been ``fit`` on a
                         temporal series.
@@ -323,49 +323,49 @@ def log_model(
         extra_pip_requirements: {{ extra_pip_requirements }}
         metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
         kwargs: Additional arguments for :py:class:`mlflow.models.model.Model`
-    
+
     Returns:
         A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
         metadata of the logged model.
-    
+
     Example:
-    
+
     .. code-block:: python
-    
+
         import pandas as pd
         import mlflow
         from mlflow.models import infer_signature
         import pmdarima
         from pmdarima.metrics import smape
-    
+
         # Specify locations of source data and the model artifact
         SOURCE_DATA = "https://raw.githubusercontent.com/facebook/prophet/master/examples/example_retail_sales.csv"
         ARTIFACT_PATH = "model"
-    
+
         # Read data and recode columns
         sales_data = pd.read_csv(SOURCE_DATA)
         sales_data.rename(columns={"y": "sales", "ds": "date"}, inplace=True)
-    
+
         # Split the data into train/test
         train_size = int(0.8 * len(sales_data))
         train, test = sales_data[:train_size], sales_data[train_size:]
-    
+
         with mlflow.start_run():
             # Create the model
             model = pmdarima.auto_arima(train["sales"], seasonal=True, m=12)
-    
+
             # Calculate metrics
             prediction = model.predict(n_periods=len(test))
             metrics = {"smape": smape(test["sales"], prediction)}
-    
+
             # Infer signature
             input_sample = pd.DataFrame(train["sales"])
             output_sample = pd.DataFrame(model.predict(n_periods=5))
             signature = infer_signature(input_sample, output_sample)
-    
+
             # Log model
             mlflow.pmdarima.log_model(model, ARTIFACT_PATH, signature=signature)
-    
+
     """
 
     return Model.log(
@@ -387,90 +387,90 @@ def log_model(
 
 def load_model(model_uri, dst_path=None):
     """
-    
+
     Loads a ``pmdarima`` ``ARIMA`` model or ``Pipeline`` object from a local file or a run.
-    
+
     Args:
         model_uri: The location, in URI format, of the MLflow model. For example:
-    
+
                   - ``/Users/me/path/to/local/model``
                   - ``relative/path/to/local/model``
                   - ``s3://my_bucket/path/to/model``
                   - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
                   - ``mlflow-artifacts:/path/to/model``
-    
+
                   For more information about supported URI schemes, see
                   `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
                   artifact-locations>`_.
         dst_path: The local filesystem path to which to download the model artifact.
                  This directory must already exist. If unspecified, a local output
                  path will be created.
-    
+
     Returns:
         A ``pmdarima`` model instance
-    
+
     Example:
-    
+
     .. code-block:: python
-    
+
         import pandas as pd
         import mlflow
         from mlflow.models import infer_signature
         import pmdarima
         from pmdarima.metrics import smape
-    
+
         # Specify locations of source data and the model artifact
         SOURCE_DATA = "https://raw.githubusercontent.com/facebook/prophet/master/examples/example_retail_sales.csv"
         ARTIFACT_PATH = "model"
-    
+
         # Read data and recode columns
         sales_data = pd.read_csv(SOURCE_DATA)
         sales_data.rename(columns={"y": "sales", "ds": "date"}, inplace=True)
-    
+
         # Split the data into train/test
         train_size = int(0.8 * len(sales_data))
         train, test = sales_data[:train_size], sales_data[train_size:]
-    
+
         with mlflow.start_run():
             # Create the model
             model = pmdarima.auto_arima(train["sales"], seasonal=True, m=12)
-    
+
             # Calculate metrics
             prediction = model.predict(n_periods=len(test))
             metrics = {"smape": smape(test["sales"], prediction)}
-    
+
             # Infer signature
             input_sample = pd.DataFrame(train["sales"])
             output_sample = pd.DataFrame(model.predict(n_periods=5))
             signature = infer_signature(input_sample, output_sample)
-    
+
             # Log model
             input_example = input_sample.head()
             mlflow.pmdarima.log_model(
                 model, ARTIFACT_PATH, signature=signature, input_example=input_example
             )
-    
+
             # Get the model URI for loading
             model_uri = mlflow.get_artifact_uri(ARTIFACT_PATH)
-    
+
         # Load the model
         loaded_model = mlflow.pmdarima.load_model(model_uri)
-    
+
         # Forecast for the next 60 days
         forecast = loaded_model.predict(n_periods=60)
-    
+
         print(f"forecast: {forecast}")
-    
+
     Output:
-    
+
     .. code-block:: text
-    
+
         forecast:
         234    382452.397246
         235    380639.458720
         236    359805.611219
         ...
-    
+
     """
 
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
@@ -509,16 +509,16 @@ class _PmdarimaModelWrapper:
         self, dataframe, params: Optional[Dict[str, Any]] = None
     ) -> pd.DataFrame:  # pylint: disable=unused-argument
         """
-        
-            Args:
-                dataframe: Model input data.
-                params: Additional parameters to pass to the model for inference.
-                    Note: Experimental: This parameter may change or be removed in a future
-                    release without warning.
-        
-            Returns:
-                Model predictions.
-            
+
+        Args:
+            dataframe: Model input data.
+            params: Additional parameters to pass to the model for inference.
+                Note: Experimental: This parameter may change or be removed in a future
+                release without warning.
+
+        Returns:
+            Model predictions.
+
         """
         df_schema = dataframe.columns.values.tolist()
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?
* Demo of converting params/returns to google format.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
