### PR TITLE
Adding make_genai_metric api

### DIFF
--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -1,5 +1,9 @@
 from mlflow.metrics.base import (
+    EvaluationExample,
     MetricValue,
+)
+from mlflow.metrics.utils import (
+    make_genai_metric,
 )
 from mlflow.models import (
     EvaluationMetric,
@@ -7,7 +11,9 @@ from mlflow.models import (
 )
 
 __all__ = [
+    "EvaluationExample",
     "EvaluationMetric",
     "MetricValue",
     "make_metric",
+    "make_genai_metric",
 ]

--- a/mlflow/metrics/utils/make_genai_metric.py
+++ b/mlflow/metrics/utils/make_genai_metric.py
@@ -1,0 +1,206 @@
+from typing import Any, Dict, List, Union
+
+from mlflow.exceptions import MlflowException
+from mlflow.metrics.base import EvaluationExample, MetricValue
+from mlflow.models import EvaluationMetric, make_metric
+from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, INVALID_PARAMETER_VALUE
+from mlflow.pyfunc import PyFuncModel, _load_model_or_server
+from mlflow.utils import env_manager as _EnvManager
+from mlflow.utils.class_utils import _get_class_from_string
+
+
+def make_genai_metric(
+    name: str,
+    version: str,
+    definition: str,
+    grading_prompt: str,
+    examples: List[EvaluationExample] = None,
+    model: str = "openai:/gpt4",
+    variables: List[str] = None,
+    parameters: Dict[str, Any] = None,
+    greater_is_better=True,
+    aggregate_options: List[str] = None,
+) -> EvaluationMetric:
+    """
+    Create a genai metric used to evaluate LLm using LLM as a judge in MLflow.
+
+    :param name: Name of the metric.
+    :param version: Version of the metric. Currently supported versions are: v1.
+    :param model: Model uri of the metric.
+    :param variables: Variables required to compute the metric.
+    :param definition: Definition of the metric.
+    :param grading_prompt: Grading criteria of the metric.
+    :param examples: Examples of the metric.
+    :param parameters: Parameters for the llm used to compute the metric.
+    :param greater_is_better: Whether the metric is better when it is greater.
+    :param aggregate_options: The list of options to aggregate the scores. Currently supported
+        options are: min, max, mean, median, variance, p90.
+
+    :return: A metric object.
+
+    .. test-code-block:: python
+        :caption: Example for creating a genai metric
+
+        from mlflow.metrics.base import EvaluationExample, make_genai_metric
+
+        example = EvaluationExample(
+            input="What is MLflow?",
+            output="MLflow is an open-source platform for managing machine "
+            "learning workflows, including experiment tracking, model packaging, "
+            "versioning, and deployment, simplifying the ML lifecycle.",
+            score=4,
+            justification="The definition effectively explains what MLflow is "
+            "its purpose, and its developer. It could be more concise for a 5-score.",
+            variables={
+                "ground_truth": "MLflow is an open-source platform for managing "
+                "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
+                "a company that specializes in big data and machine learning solutions. MLflow is "
+                "designed to address the challenges that data scientists and machine learning "
+                "engineers face when developing, training, and deploying machine learning models."
+            },
+        )
+
+        metric = make_genai_metric(
+            name="correctness",
+            version="v1",
+            definition="Correctness refers to how well the generated output matches "
+            "or aligns with the reference or ground truth text that is considered "
+            "accurate and appropriate for the given input. The ground truth serves as "
+            "a benchmark against which the provided output is compared to determine the "
+            "level of accuracy and fidelity.",
+            grading_prompt="Correctness: If the answer correctly answer the question, below are the "
+            "details for different scores: "
+            "- Score 0: the answer is completely incorrect, doesn’t mention anything about the question "
+            "or is completely contrary to the correct answer. "
+            "- Score 1: the answer provides some relevance to the question and answer one aspect "
+            "of the question correctly. "
+            "- Score 2: the answer mostly answer the question but is missing or hallucinating on one "
+            "critical aspect. "
+            "- Score 4: the answer correctly answer the question and not missing any major aspect",
+            examples=[example],
+            model="gateway:/gpt4",
+            variables=["ground_truth"],
+            parameters={"temperature": 1.0},
+            greater_is_better=True,
+            aggregate_options=["mean", "variance", "p90"],
+        )
+    """
+    import pandas as pd
+    import pyspark
+
+    def eval_fn(eval_df: Union[pd.DataFrame, pyspark.sql.DataFrame]) -> MetricValue:
+        """
+        This is the function that is called when the metric is evaluated.
+        """
+
+        class_name = f"mlflow.metrics.utils.prompts.{version}.EvaluationModel"
+        try:
+            evaluation_model_class_module = _get_class_from_string(class_name)
+        except Exception as e:
+            if isinstance(e, ModuleNotFoundError):
+                raise MlflowException(
+                    f"Failed to find evaluation model for version {version}."
+                    f"Please check the correctness of the version",
+                    error_code=INVALID_PARAMETER_VALUE,
+                ) from None
+            else:
+                raise MlflowException(
+                    f"Failed to construct evaluation model {version}. Error: {e!r}",
+                    error_code=INTERNAL_ERROR,
+                ) from None
+
+        variables_dict = {}
+        for variable in variables:
+            if variable in eval_df.columns:
+                variable_value = eval_df[variable]
+                variables_dict[variable] = variable_value
+            else:
+                raise MlflowException(
+                    f"{variable} does not exist in the Eval DataFrame {eval_df.columns}."
+                )
+
+        variable_string = (
+            ""
+            if variables_dict is None
+            else "\n".join(
+                [
+                    f"Provided {variable}: {variable_value}"
+                    for variable, variable_value in variables_dict.items()
+                ]
+            )
+        )
+
+        evaluation_context = evaluation_model_class_module(
+            name,
+            definition,
+            grading_prompt,
+            examples,
+            model,
+            parameters,
+        ).to_dict()
+
+        outputs = eval_df["prediction"]
+        inputs = eval_df["input"]
+        eval_model = evaluation_context["model"]
+        eval_parameters = evaluation_context["parameters"]
+
+        # TODO: Save the metric definition in a yaml file for model monitoring
+
+        messages = []
+        for indx, _ in inputs.items():
+            messages.append(
+                [
+                    evaluation_context["eval_prompt"].partial_fill(
+                        input=inputs[indx], output=outputs[indx], variables=variable_string
+                    ),
+                ],
+            )
+
+        # TODO: load the model for openai and gateway URI
+        if isinstance(eval_model, str):
+            eval_model = _load_model_or_server(eval_model, _EnvManager.LOCAL)
+        elif isinstance(eval_model, PyFuncModel):
+            pass
+        else:
+            raise MlflowException(
+                message="The model argument must be a string URI referring to an MLflow model or "
+                "an instance of `mlflow.pyfunc.PyFuncModel`.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+
+        # TODO: Add batch processing for messages here
+        eval_result = eval_model.predict(messages, eval_parameters)
+        scores = eval_result["Score"]
+        justification = eval_result["Justification"]
+
+        # loop over the aggregate_options and compute the aggregate results on the scores
+
+        def aggregate_function(aggregate_option, scores):
+            import numpy as np
+
+            options = {
+                "min": np.min,
+                "max": np.max,
+                "mean": np.mean,
+                "median": np.median,
+                "variance": np.var,
+                "p90": lambda x: np.percentile(x, 90),
+            }
+
+            if aggregate_option not in options:
+                raise MlflowException(
+                    message=f"Invalid aggregate option {aggregate_option}.",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+
+            return options[aggregate_option](scores)
+
+        aggregate_results = {
+            option: aggregate_function(option, scores) for option in aggregate_options
+        }
+
+        return MetricValue(scores.tolist(), justification.tolist(), aggregate_results)
+
+    return make_metric(
+        eval_fn=eval_fn, greater_is_better=greater_is_better, name=name, version=version
+    )

--- a/tests/metrics/utils/test_make_genai_metric.py
+++ b/tests/metrics/utils/test_make_genai_metric.py
@@ -1,0 +1,189 @@
+import re
+import pytest
+import mlflow
+import pandas as pd
+
+from mlflow.metrics.base import EvaluationExample
+from mlflow.exceptions import MlflowException
+from mlflow.metrics.utils.make_genai_metric import make_genai_metric
+
+
+# Create a custom mock class for MyModel
+class FakeModel(mlflow.pyfunc.PythonModel):
+    def predict(self, context, model_input, params=None):
+        return pd.DataFrame(
+            {
+                "Score": [3],
+                "Justification": [
+                    "The definition effectively explains what MLflow is "
+                    "its purpose, and its developer. It could be more concise for a 5-score."
+                ],
+            }
+        )
+
+
+def test_make_genai_metric_success():
+    with mlflow.start_run() as run:
+        llm_model_info = mlflow.pyfunc.log_model(
+            "model",
+            python_model=FakeModel(),
+        )
+
+    example = EvaluationExample(
+        input="What is MLflow?",
+        output="MLflow is an open-source platform for managing machine "
+        "learning workflows, including experiment tracking, model packaging, "
+        "versioning, and deployment, simplifying the ML lifecycle.",
+        score=4,
+        justification="The definition effectively explains what MLflow is "
+        "its purpose, and its developer. It could be more concise for a 5-score.",
+        variables={
+            "ground_truth": "MLflow is an open-source platform for managing "
+            "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
+            "a company that specializes in big data and machine learning solutions. MLflow is "
+            "designed to address the challenges that data scientists and machine learning "
+            "engineers face when developing, training, and deploying machine learning models."
+        },
+    )
+
+    custom_metric = make_genai_metric(
+        name="correctness",
+        version="v1",
+        definition="Correctness refers to how well the generated output matches "
+        "or aligns with the reference or ground truth text that is considered "
+        "accurate and appropriate for the given input. The ground truth serves as "
+        "a benchmark against which the provided output is compared to determine the "
+        "level of accuracy and fidelity.",
+        grading_prompt="Correctness: If the answer correctly answer the question, below are the "
+        "details for different scores: "
+        "- Score 0: the answer is completely incorrect, doesn’t mention anything about the question "
+        "or is completely contrary to the correct answer. "
+        "- Score 1: the answer provides some relevance to the question and answer one aspect "
+        "of the question correctly. "
+        "- Score 2: the answer mostly answer the question but is missing or hallucinating on one "
+        "critical aspect. "
+        "- Score 4: the answer correctly answer the question and not missing any major aspect",
+        examples=[example],
+        model=llm_model_info.model_uri,
+        variables=["ground_truth"],
+        parameters={"temperature": 1.0},
+        greater_is_better=True,
+        aggregate_options=["mean", "variance", "p90"],
+    )
+
+    eval_df = pd.DataFrame(
+        {
+            "input": ["What is MLflow?"],
+            "prediction": [
+                "MLflow is an open-source platform for managing machine "
+                "learning workflows, including experiment tracking, model packaging, "
+                "versioning, and deployment, simplifying the ML lifecycle."
+            ],
+            "ground_truth": [
+                "MLflow is an open-source platform for managing "
+                "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
+                "a company that specializes in big data and machine learning solutions. MLflow is "
+                "designed to address the challenges that data scientists and machine learning "
+                "engineers face when developing, training, and deploying machine learning models."
+            ],
+        }
+    )
+
+    metric_value = custom_metric.eval_fn(eval_df)
+
+    assert metric_value.scores == [3]
+    assert metric_value.justifications == [
+        "The definition effectively "
+        "explains what MLflow is its purpose, and its developer. It could be "
+        "more concise for a 5-score."
+    ]
+
+    assert metric_value.aggregate_results == {
+        "mean": 3,
+        "variance": 0,
+        "p90": 3,
+    }
+
+
+def test_make_genai_metric_failure():
+    example = EvaluationExample(
+        input="input",
+        output="output",
+        score=4,
+        justification="justification",
+        variables={"ground_truth": "ground_truth"},
+    )
+    import pandas as pd
+
+    eval_df = pd.DataFrame(
+        {
+            "input": ["What is MLflow?"],
+            "prediction": ["predictions"],
+            "ground_truth": ["truth"],
+        }
+    )
+
+    custom_metric1 = make_genai_metric(
+        name="correctness",
+        version="v-latest",
+        definition="definition",
+        grading_prompt="grading_prompt",
+        examples=[example],
+        model="model",
+        variables=["ground_truth"],
+        parameters={"temperature": 1.0},
+        greater_is_better=True,
+        aggregate_options=["mean"],
+    )
+    with pytest.raises(
+        MlflowException,
+        match=re.escape(
+            "Failed to find evaluation model for version v-latest."
+            "Please check the correctness of the version"
+        ),
+    ):
+        custom_metric1.eval_fn(eval_df)
+
+    custom_metric2 = make_genai_metric(
+        name="correctness",
+        version="v1",
+        definition="definition",
+        grading_prompt="grading_prompt",
+        examples=[example],
+        model="model",
+        variables=["ground_truth-error"],
+        parameters={"temperature": 1.0},
+        greater_is_better=True,
+        aggregate_options=["mean"],
+    )
+    with pytest.raises(
+        MlflowException,
+        match=re.escape(
+            "ground_truth-error does not exist in the Eval DataFrame "
+            "Index(['input', 'prediction', 'ground_truth'], dtype='object')."
+        ),
+    ):
+        custom_metric2.eval_fn(eval_df)
+
+    with mlflow.start_run() as run:
+        llm_model_info = mlflow.pyfunc.log_model(
+            "model",
+            python_model=FakeModel(),
+        )
+    custom_metric3 = make_genai_metric(
+        name="correctness",
+        version="v1",
+        definition="definition",
+        grading_prompt="grading_prompt",
+        examples=[example],
+        model=llm_model_info.model_uri,
+        variables=["ground_truth"],
+        parameters={"temperature": 1.0},
+        greater_is_better=True,
+        aggregate_options=["random-fake"],
+    )
+    with pytest.raises(
+        MlflowException,
+        match=re.escape("Invalid aggregate option random-fake"),
+    ):
+        custom_metric3.eval_fn(eval_df)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adding make_genai_metric api

## How is this patch tested?
- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
