### PR TITLE
Setup R2 Artifact Repo to use correct s3 endpoint by default

### DIFF
--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -71,9 +71,14 @@ def _cached_get_s3_client(
 
 
 def _get_s3_client(
-    addressing_style="path", access_key_id=None, secret_access_key=None, session_token=None
+    addressing_style="path",
+    access_key_id=None,
+    secret_access_key=None,
+    session_token=None,
+    s3_endpoint_url=None,
 ):
-    s3_endpoint_url = MLFLOW_S3_ENDPOINT_URL.get()
+    if not s3_endpoint_url:
+        s3_endpoint_url = MLFLOW_S3_ENDPOINT_URL.get()
     do_verify = not MLFLOW_S3_IGNORE_TLS.get()
 
     # The valid verify argument value is None/False/path to cert bundle file, See
@@ -111,7 +116,7 @@ class S3ArtifactRepository(ArtifactRepository):
         self._secret_access_key = secret_access_key
         self._session_token = session_token
 
-    def _get_s3_client(self, addressing_style="path"):
+    def _get_s3_client(self, addressing_style="path", s3_endpoint_url=None):
         return _get_s3_client(
             addressing_style=addressing_style,
             access_key_id=self._access_key_id,

--- a/tests/store/artifact/test_r2_artifact_repo.py
+++ b/tests/store/artifact/test_r2_artifact_repo.py
@@ -32,3 +32,11 @@ def test_s3_client_config_set_correctly(r2_artifact_root):
 
     s3_client = repo._get_s3_client()
     assert s3_client.meta.config.s3.get("addressing_style") == "virtual"
+
+
+def test_convert_r2_uri_to_s3_endpoint_url(r2_artifact_root):
+    artifact_uri = posixpath.join(r2_artifact_root, "some/path")
+    repo = get_artifact_repository(artifact_uri)
+
+    s3_endpoint_url = repo.convert_r2_uri_to_s3_endpoint_url(r2_artifact_root)
+    assert s3_endpoint_url == "https://account.r2.cloudflarestorage.com"


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> N/A

## What changes are proposed in this pull request?

Currently, users need to manually set s3 endpoint by MLFLOW_S3_ENDPOINT_URL.set(endpoint_url) for R2, which can easily lead to confusion (i.e why is AWS S3 rejecting my R2 credentials..)

This change parse R2 Artifact URI and correctly set that s3 endpoint automatically.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
