### PR TITLE
Add system metrics logging to MLflow fluent API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ jobs:
           working_directory: docs
           environment:
             JAVA_HOME: /usr/lib/jvm/default-java
-            MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING: "True"
           command: |
             make rsthtml
             make javadocs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
           working_directory: docs
           environment:
             JAVA_HOME: /usr/lib/jvm/default-java
+            MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING: "True"
           command: |
             make rsthtml
             make javadocs

--- a/examples/system_metrics/collect_system_metrics.py
+++ b/examples/system_metrics/collect_system_metrics.py
@@ -4,9 +4,9 @@ import mlflow
 
 if __name__ == "__main__":
     mlflow.enable_system_metrics_logging()
-    run = mlflow.start_run()
-    time.sleep(11)
-    mlflow.end_run()
+    with mlflow.start_run() as run:
+        time.sleep(11)
+
     client = mlflow.MlflowClient()
     mlflow_run = client.get_run(run.info.run_id)
     print(mlflow_run.data.metrics)

--- a/examples/system_metrics/collect_system_metrics.py
+++ b/examples/system_metrics/collect_system_metrics.py
@@ -3,6 +3,7 @@ import time
 import mlflow
 
 if __name__ == "__main__":
+    mlflow.enable_system_metrics_logging()
     run = mlflow.start_run()
     time.sleep(11)
     mlflow.end_run()

--- a/examples/system_metrics/collect_system_metrics.py
+++ b/examples/system_metrics/collect_system_metrics.py
@@ -1,0 +1,11 @@
+import time
+
+import mlflow
+
+if __name__ == "__main__":
+    run = mlflow.start_run()
+    time.sleep(11)
+    mlflow.end_run()
+    client = mlflow.MlflowClient()
+    mlflow_run = client.get_run(run.info.run_id)
+    print(mlflow_run.data.metrics)

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -114,6 +114,7 @@ from mlflow.models import evaluate
 from mlflow.projects import run
 from mlflow.system_metrics import (
     disable_system_metrics_logging,
+    enable_system_metrics_logging,
     set_system_metrics_samples_before_logging,
     set_system_metrics_sampling_interval,
 )
@@ -217,6 +218,7 @@ __all__ = [
     "MlflowClient",
     "MlflowException",
     "disable_system_metrics_logging",
+    "enable_system_metrics_logging",
     "set_system_metrics_sampling_interval",
     "set_system_metrics_samples_before_logging",
 ]

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -114,8 +114,8 @@ from mlflow.models import evaluate
 from mlflow.projects import run
 from mlflow.system_metrics import (
     disable_system_metrics_logging,
-    set_system_metrics_sampling_interval,
     set_system_metrics_samples_before_logging,
+    set_system_metrics_sampling_interval,
 )
 from mlflow.tracking import (
     get_registry_uri,

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -112,6 +112,11 @@ from mlflow.client import MlflowClient
 from mlflow.exceptions import MlflowException
 from mlflow.models import evaluate
 from mlflow.projects import run
+from mlflow.system_metrics import (
+    disable_system_metrics_logging,
+    set_system_metrics_sampling_interval,
+    set_system_metrics_samples_before_logging,
+)
 from mlflow.tracking import (
     get_registry_uri,
     get_tracking_uri,
@@ -211,6 +216,9 @@ __all__ = [
     "doctor",
     "MlflowClient",
     "MlflowException",
+    "disable_system_metrics_logging",
+    "set_system_metrics_sampling_interval",
+    "set_system_metrics_samples_before_logging",
 ]
 
 

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -23,7 +23,7 @@ class _EnvironmentVariable:
         return os.getenv(self.name)
 
     def set(self, value):
-        os.environ[self.name] = value
+        os.environ[self.name] = str(value)
 
     def unset(self):
         os.environ.pop(self.name, None)
@@ -425,3 +425,18 @@ MLFLOW_DISABLE_ENV_CREATION = _BooleanEnvironmentVariable("MLFLOW_DISABLE_ENV_CR
 #: Specifies the timeout value for downloading chunks of mlflow artifacts.
 #: (default: ``300``)
 MLFLOW_DOWNLOAD_CHUNK_TIMEOUT = _EnvironmentVariable("MLFLOW_DOWNLOAD_CHUNK_TIMEOUT", int, 300)
+
+#: Specifies if system metrics logging should be disabled.
+MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING = _BooleanEnvironmentVariable(
+    "MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING", False
+)
+
+#: Specifies the sampling interval for system metrics logging.
+MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL = _EnvironmentVariable(
+    "MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL", float, None
+)
+
+#: Specifies the number of samples before logging system metrics.
+MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING = _EnvironmentVariable(
+    "MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING", int, None
+)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -427,8 +427,10 @@ MLFLOW_DISABLE_ENV_CREATION = _BooleanEnvironmentVariable("MLFLOW_DISABLE_ENV_CR
 MLFLOW_DOWNLOAD_CHUNK_TIMEOUT = _EnvironmentVariable("MLFLOW_DOWNLOAD_CHUNK_TIMEOUT", int, 300)
 
 #: Specifies if system metrics logging should be disabled.
+#: We name it with "DISABLED" instead of "ENABLED" because in the long term system metrics logging
+#: will be enabled by default.
 MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING = _BooleanEnvironmentVariable(
-    "MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING", False
+    "MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING", None
 )
 
 #: Specifies the sampling interval for system metrics logging.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -428,7 +428,7 @@ MLFLOW_DOWNLOAD_CHUNK_TIMEOUT = _EnvironmentVariable("MLFLOW_DOWNLOAD_CHUNK_TIME
 
 #: Specifies if system metrics logging should be enabled.
 MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING = _BooleanEnvironmentVariable(
-    "MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING", None
+    "MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING", False
 )
 
 #: Specifies the sampling interval for system metrics logging.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -426,11 +426,9 @@ MLFLOW_DISABLE_ENV_CREATION = _BooleanEnvironmentVariable("MLFLOW_DISABLE_ENV_CR
 #: (default: ``300``)
 MLFLOW_DOWNLOAD_CHUNK_TIMEOUT = _EnvironmentVariable("MLFLOW_DOWNLOAD_CHUNK_TIMEOUT", int, 300)
 
-#: Specifies if system metrics logging should be disabled.
-#: We name it with "DISABLED" instead of "ENABLED" because in the long term system metrics logging
-#: will be enabled by default.
-MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING = _BooleanEnvironmentVariable(
-    "MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING", None
+#: Specifies if system metrics logging should be enabled.
+MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING = _BooleanEnvironmentVariable(
+    "MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING", None
 )
 
 #: Specifies the sampling interval for system metrics logging.

--- a/mlflow/system_metrics/__init__.py
+++ b/mlflow/system_metrics/__init__.py
@@ -1,11 +1,15 @@
 """System metrics logging module."""
 
-import os
+from mlflow.environment_variables import (
+    MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING,
+    MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING,
+    MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL,
+)
 
 
 def disable_system_metrics_logging():
     """Disable system metrics logging."""
-    os.environ["MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING"] = "True"
+    MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING.set(True)
 
 
 def set_system_metrics_sampling_interval(interval):
@@ -13,7 +17,7 @@ def set_system_metrics_sampling_interval(interval):
 
     Every `interval` seconds, the system metrics will be collected. By default `interval=10`.
     """
-    os.environ["MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL"] = str(interval)
+    MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL.set(interval)
 
 
 def set_system_metrics_samples_before_logging(samples):
@@ -22,4 +26,4 @@ def set_system_metrics_samples_before_logging(samples):
     Every time `samples` samples have been collected, the system metrics will be logged to mlflow.
     By default `samples=1`.
     """
-    os.environ["MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING"] = str(samples)
+    MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING.set(samples)

--- a/mlflow/system_metrics/__init__.py
+++ b/mlflow/system_metrics/__init__.py
@@ -34,7 +34,10 @@ def set_system_metrics_sampling_interval(interval):
 
     Every `interval` seconds, the system metrics will be collected. By default `interval=10`.
     """
-    MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL.set(interval)
+    if interval is None:
+        MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL.unset()
+    else:
+        MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL.set(interval)
 
 
 @experimental
@@ -44,4 +47,7 @@ def set_system_metrics_samples_before_logging(samples):
     Every time `samples` samples have been collected, the system metrics will be logged to mlflow.
     By default `samples=1`.
     """
-    MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING.set(samples)
+    if samples is None:
+        MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING.unset()
+    else:
+        MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING.set(samples)

--- a/mlflow/system_metrics/__init__.py
+++ b/mlflow/system_metrics/__init__.py
@@ -1,7 +1,7 @@
 """System metrics logging module."""
 
 from mlflow.environment_variables import (
-    MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING,
+    MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING,
     MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING,
     MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL,
 )
@@ -9,12 +9,12 @@ from mlflow.environment_variables import (
 
 def disable_system_metrics_logging():
     """Disable system metrics logging."""
-    MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING.set(True)
+    MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING.set(False)
 
 
 def enable_system_metrics_logging():
     """Enable system metrics logging."""
-    MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING.set(False)
+    MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING.set(True)
 
 
 def set_system_metrics_sampling_interval(interval):

--- a/mlflow/system_metrics/__init__.py
+++ b/mlflow/system_metrics/__init__.py
@@ -5,18 +5,30 @@ from mlflow.environment_variables import (
     MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING,
     MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL,
 )
+from mlflow.utils.annotations import experimental
 
 
+@experimental
 def disable_system_metrics_logging():
-    """Disable system metrics logging."""
+    """Disable system metrics logging globally.
+
+    Calling this function will disable system metrics logging globally, but users can still opt in
+    system metrics logging for individual runs by `mlflow.start_run(log_system_metrics=True)`.
+    """
     MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING.set(False)
 
 
+@experimental
 def enable_system_metrics_logging():
-    """Enable system metrics logging."""
+    """Enable system metrics logging globally.
+
+    Calling this function will enable system metrics logging globally, but users can still opt out
+    system metrics logging for individual runs by `mlflow.start_run(log_system_metrics=False)`.
+    """
     MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING.set(True)
 
 
+@experimental
 def set_system_metrics_sampling_interval(interval):
     """Set the system metrics sampling interval.
 
@@ -25,6 +37,7 @@ def set_system_metrics_sampling_interval(interval):
     MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL.set(interval)
 
 
+@experimental
 def set_system_metrics_samples_before_logging(samples):
     """Set the number of samples before logging system metrics.
 

--- a/mlflow/system_metrics/__init__.py
+++ b/mlflow/system_metrics/__init__.py
@@ -1,0 +1,25 @@
+"""System metrics logging module."""
+
+import os
+
+
+def disable_system_metrics_logging():
+    """Disable system metrics logging."""
+    os.environ["MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING"] = "True"
+
+
+def set_system_metrics_sampling_interval(interval):
+    """Set the system metrics sampling interval.
+
+    Every `interval` seconds, the system metrics will be collected. By default `interval=10`.
+    """
+    os.environ["MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL"] = str(interval)
+
+
+def set_system_metrics_samples_before_logging(samples):
+    """Set the number of samples before logging system metrics.
+
+    Every time `samples` samples have been collected, the system metrics will be logged to mlflow.
+    By default `samples=1`.
+    """
+    os.environ["MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING"] = str(samples)

--- a/mlflow/system_metrics/__init__.py
+++ b/mlflow/system_metrics/__init__.py
@@ -12,6 +12,11 @@ def disable_system_metrics_logging():
     MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING.set(True)
 
 
+def enable_system_metrics_logging():
+    """Enable system metrics logging."""
+    MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING.set(False)
+
+
 def set_system_metrics_sampling_interval(interval):
     """Set the system metrics sampling interval.
 

--- a/mlflow/system_metrics/metrics/base_metrics_monitor.py
+++ b/mlflow/system_metrics/metrics/base_metrics_monitor.py
@@ -1,8 +1,9 @@
 """Base class of system metrics monitor."""
+import abc
 from collections import defaultdict
 
 
-class BaseMetricsMonitor:
+class BaseMetricsMonitor(abc.ABC):
     """Base class of system metrics monitor.
 
     Args:
@@ -14,6 +15,7 @@ class BaseMetricsMonitor:
 
         self._metrics = defaultdict(list)
 
+    @abc.abstractmethod
     def collect_metrics(self):
         raise NotImplementedError
 

--- a/mlflow/system_metrics/metrics/base_metrics_monitor.py
+++ b/mlflow/system_metrics/metrics/base_metrics_monitor.py
@@ -20,7 +20,8 @@ class BaseMetricsMonitor:
     def aggregate_metrics(self):
         metrics = {}
         for name, values in self._metrics.items():
-            metrics[name] = sum(values) / len(values)
+            if len(values) > 0:
+                metrics[name] = sum(values) / len(values)
         return metrics
 
     @property

--- a/mlflow/system_metrics/metrics/base_metrics_monitor.py
+++ b/mlflow/system_metrics/metrics/base_metrics_monitor.py
@@ -4,26 +4,24 @@ from collections import defaultdict
 
 
 class BaseMetricsMonitor(abc.ABC):
-    """Base class of system metrics monitor.
+    """Base class of system metrics monitor."""
 
-    Args:
-        name: string, name of the monitor.
-    """
-
-    def __init__(self, name):
-        self.name = name
-
+    def __init__(self):
         self._metrics = defaultdict(list)
 
     @abc.abstractmethod
     def collect_metrics(self):
-        raise NotImplementedError
+        """Method to collect metrics.
+
+        Sublcass should implement this method to collect metrics and store in `self._metrics`.
+        """
+        pass
 
     def aggregate_metrics(self):
         metrics = {}
         for name, values in self._metrics.items():
             if len(values) > 0:
-                metrics[name] = sum(values) / len(values)
+                metrics[name] = round(sum(values) / len(values), 1)
         return metrics
 
     @property

--- a/mlflow/system_metrics/metrics/base_metrics_monitor.py
+++ b/mlflow/system_metrics/metrics/base_metrics_monitor.py
@@ -1,0 +1,31 @@
+"""Base class of system metrics monitor."""
+from collections import defaultdict
+
+
+class BaseMetricsMonitor:
+    """Base class of system metrics monitor.
+
+    Args:
+        name: string, name of the monitor.
+    """
+
+    def __init__(self, name):
+        self.name = name
+
+        self._metrics = defaultdict(list)
+
+    def collect_metrics(self):
+        raise NotImplementedError
+
+    def aggregate_metrics(self):
+        metrics = {}
+        for name, values in self._metrics.items():
+            metrics[name] = sum(values) / len(values)
+        return metrics
+
+    @property
+    def metrics(self):
+        return self._metrics
+
+    def clear_metrics(self):
+        self._metrics.clear()

--- a/mlflow/system_metrics/metrics/cpu_monitor.py
+++ b/mlflow/system_metrics/metrics/cpu_monitor.py
@@ -14,7 +14,7 @@ class CPUMonitor(BaseMetricsMonitor):
     def collect_metrics(self):
         # Get CPU metrics.
         cpu_percent = psutil.cpu_percent()
-        self._metrics["cpu_percentage"].append(cpu_percent)
+        self._metrics["cpu_utilization_percentage"].append(cpu_percent)
 
         system_memory = psutil.virtual_memory()._asdict()
-        self._metrics["system_memory_used"].append(int(system_memory["used"] / 1e6))
+        self._metrics["system_memory_usage_megabytes"].append(int(system_memory["used"] / 1e6))

--- a/mlflow/system_metrics/metrics/cpu_monitor.py
+++ b/mlflow/system_metrics/metrics/cpu_monitor.py
@@ -17,4 +17,4 @@ class CPUMonitor(BaseMetricsMonitor):
         self._metrics["cpu_percentage"].append(cpu_percent)
 
         system_memory = psutil.virtual_memory()._asdict()
-        self._metrics["cpu_memory_used"].append(int(system_memory["used"] / 1e6))
+        self._metrics["system_memory_used"].append(int(system_memory["used"] / 1e6))

--- a/mlflow/system_metrics/metrics/cpu_monitor.py
+++ b/mlflow/system_metrics/metrics/cpu_monitor.py
@@ -8,16 +8,13 @@ from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonito
 class CPUMonitor(BaseMetricsMonitor):
     """Class for monitoring CPU stats."""
 
-    def __init__(self):
-        super().__init__()
-
     def collect_metrics(self):
         # Get CPU metrics.
         cpu_percent = psutil.cpu_percent()
         self._metrics["cpu_utilization_percentage"].append(cpu_percent)
 
-        system_memory = psutil.virtual_memory()._asdict()
-        self._metrics["system_memory_usage_megabytes"].append(system_memory["used"] / 1e6)
+        system_memory = psutil.virtual_memory()
+        self._metrics["system_memory_usage_megabytes"].append(system_memory.used / 1e6)
         self._metrics["system_memory_usage_percentage"].append(
-            system_memory["used"] / system_memory["total"] * 100
+            system_memory.used / system_memory.total * 100
         )

--- a/mlflow/system_metrics/metrics/cpu_monitor.py
+++ b/mlflow/system_metrics/metrics/cpu_monitor.py
@@ -8,8 +8,8 @@ from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonito
 class CPUMonitor(BaseMetricsMonitor):
     """Class for monitoring CPU stats."""
 
-    def __init__(self, name="cpu"):
-        super().__init__(name)
+    def __init__(self):
+        super().__init__()
 
     def collect_metrics(self):
         # Get CPU metrics.
@@ -17,4 +17,7 @@ class CPUMonitor(BaseMetricsMonitor):
         self._metrics["cpu_utilization_percentage"].append(cpu_percent)
 
         system_memory = psutil.virtual_memory()._asdict()
-        self._metrics["system_memory_usage_megabytes"].append(int(system_memory["used"] / 1e6))
+        self._metrics["system_memory_usage_megabytes"].append(system_memory["used"] / 1e6)
+        self._metrics["system_memory_usage_percentage"].append(
+            system_memory["used"] / system_memory["total"] * 100
+        )

--- a/mlflow/system_metrics/metrics/cpu_monitor.py
+++ b/mlflow/system_metrics/metrics/cpu_monitor.py
@@ -1,0 +1,20 @@
+"""Class for monitoring CPU stats."""
+
+import psutil
+
+from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonitor
+
+
+class CPUMonitor(BaseMetricsMonitor):
+    """Class for monitoring CPU stats."""
+
+    def __init__(self, name="cpu"):
+        super().__init__(name)
+
+    def collect_metrics(self):
+        # Get CPU metrics.
+        cpu_percent = psutil.cpu_percent()
+        self._metrics["cpu_percentage"].append(cpu_percent)
+
+        system_memory = psutil.virtual_memory()._asdict()
+        self._metrics["cpu_memory_used"].append(int(system_memory["used"] / 1e6))

--- a/mlflow/system_metrics/metrics/disk_monitor.py
+++ b/mlflow/system_metrics/metrics/disk_monitor.py
@@ -16,9 +16,6 @@ class DiskMonitor(BaseMetricsMonitor):
     def collect_metrics(self):
         # Get disk usage metrics.
         disk_usage = psutil.disk_usage(os.sep)._asdict()
-        for k, v in disk_usage.items():
-            if "percent" in k:
-                self._metrics[f"disk_usage_{k}"].append(v)
-            else:
-                # Convert bytes to MB.
-                self._metrics[f"disk_usage_{k}"].append(int(v / 1e6))
+        self._metrics["disk_usage_percentage"].append(disk_usage["percent"])
+        self._metrics["disk_usage_megabytes"].append(int(disk_usage["used"] / 1e6))
+        self._metrics["disk_available_megabytes"].append(int(disk_usage["free"] / 1e6))

--- a/mlflow/system_metrics/metrics/disk_monitor.py
+++ b/mlflow/system_metrics/metrics/disk_monitor.py
@@ -18,7 +18,7 @@ class DiskMonitor(BaseMetricsMonitor):
         disk_usage = psutil.disk_usage(os.sep)._asdict()
         for k, v in disk_usage.items():
             if "percent" in k:
-                self._metrics[f"disk_memory_{k}"].append(v)
+                self._metrics[f"disk_usage_{k}"].append(v)
             else:
                 # Convert bytes to MB.
-                self._metrics[f"disk_memory_{k}"].append(int(v / 1e6))
+                self._metrics[f"disk_usage_{k}"].append(int(v / 1e6))

--- a/mlflow/system_metrics/metrics/disk_monitor.py
+++ b/mlflow/system_metrics/metrics/disk_monitor.py
@@ -10,12 +10,12 @@ from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonito
 class DiskMonitor(BaseMetricsMonitor):
     """Class for monitoring disk stats."""
 
-    def __init__(self, name="disk"):
-        super().__init__(name)
+    def __init__(self):
+        super().__init__()
 
     def collect_metrics(self):
         # Get disk usage metrics.
         disk_usage = psutil.disk_usage(os.sep)._asdict()
         self._metrics["disk_usage_percentage"].append(disk_usage["percent"])
-        self._metrics["disk_usage_megabytes"].append(int(disk_usage["used"] / 1e6))
-        self._metrics["disk_available_megabytes"].append(int(disk_usage["free"] / 1e6))
+        self._metrics["disk_usage_megabytes"].append(disk_usage["used"] / 1e6)
+        self._metrics["disk_available_megabytes"].append(disk_usage["free"] / 1e6)

--- a/mlflow/system_metrics/metrics/disk_monitor.py
+++ b/mlflow/system_metrics/metrics/disk_monitor.py
@@ -1,0 +1,24 @@
+"""Class for monitoring disk stats."""
+
+import os
+
+import psutil
+
+from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonitor
+
+
+class DiskMonitor(BaseMetricsMonitor):
+    """Class for monitoring disk stats."""
+
+    def __init__(self, name="disk"):
+        super().__init__(name)
+
+    def collect_metrics(self):
+        # Get disk usage metrics.
+        disk_usage = psutil.disk_usage(os.sep)._asdict()
+        for k, v in disk_usage.items():
+            if "percent" in k:
+                self._metrics[f"disk_memory_{k}"].append(v)
+            else:
+                # Convert bytes to MB.
+                self._metrics[f"disk_memory_{k}"].append(int(v / 1e6))

--- a/mlflow/system_metrics/metrics/disk_monitor.py
+++ b/mlflow/system_metrics/metrics/disk_monitor.py
@@ -10,12 +10,9 @@ from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonito
 class DiskMonitor(BaseMetricsMonitor):
     """Class for monitoring disk stats."""
 
-    def __init__(self):
-        super().__init__()
-
     def collect_metrics(self):
         # Get disk usage metrics.
-        disk_usage = psutil.disk_usage(os.sep)._asdict()
-        self._metrics["disk_usage_percentage"].append(disk_usage["percent"])
-        self._metrics["disk_usage_megabytes"].append(disk_usage["used"] / 1e6)
-        self._metrics["disk_available_megabytes"].append(disk_usage["free"] / 1e6)
+        disk_usage = psutil.disk_usage(os.sep)
+        self._metrics["disk_usage_percentage"].append(disk_usage.percent)
+        self._metrics["disk_usage_megabytes"].append(disk_usage.used / 1e6)
+        self._metrics["disk_available_megabytes"].append(disk_usage.free / 1e6)

--- a/mlflow/system_metrics/metrics/gpu_monitor.py
+++ b/mlflow/system_metrics/metrics/gpu_monitor.py
@@ -10,10 +10,9 @@ _logger = logging.getLogger(__name__)
 try:
     import pynvml
 except ImportError:
-    _logger.warning(
-        "`GPUMonitor` requires pynvml package. To install, run `pip install pynvml`. Skip "
-        "logging GPU metrics."
-    )
+    # If `pynvml` is not installed, a warning will be logged at monitor instantiation.
+    # We don't log a warning here to avoid spamming warning at every import.
+    pass
 
 
 class GPUMonitor(BaseMetricsMonitor):

--- a/mlflow/system_metrics/metrics/gpu_monitor.py
+++ b/mlflow/system_metrics/metrics/gpu_monitor.py
@@ -1,0 +1,48 @@
+"""Class for monitoring GPU stats."""
+
+import logging
+import sys
+
+from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonitor
+
+logger = logging.getLogger(__name__)
+
+try:
+    import pynvml
+except ImportError:
+    logger.warning(
+        "`GPUMonitor` requires pynvml package. To install, run `pip install pynvml`. Skip "
+        "logging GPU metrics."
+    )
+
+
+class GPUMonitor(BaseMetricsMonitor):
+    """Class for monitoring GPU stats."""
+
+    def __new__(cls, *args, **kwargs):
+        # Override `__new__` to return a None object if `pynvml` is not installed or GPU is not
+        # found.
+        if "pynvml" not in sys.modules:
+            # Only instantiate if `pynvml` is installed.
+            return
+        try:
+            # `nvmlInit()` will fail if no GPU is found.
+            pynvml.nvmlInit()
+        except pynvml.NVMLError as e:
+            logger.warning(f"Failed to initialize NVML, skip logging GPU metrics: {e}")
+            return
+        return super().__new__(cls, *args, **kwargs)
+
+    def __init__(self, name="gpu"):
+        super().__init__(name)
+        self.num_gpus = pynvml.nvmlDeviceGetCount()
+        self.gpu_handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(self.num_gpus)]
+
+    def collect_metrics(self):
+        # Get GPU metrics.
+        for i, handle in enumerate(self.gpu_handles):
+            memory = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            self._metrics[f"gpu_{i}_memory_used"].append(int(memory.used / 1e6))
+
+            device_utilization = pynvml.nvmlDeviceGetUtilizationRates(handle)
+            self._metrics[f"gpu_{i}_utilization_rate"].append(device_utilization.gpu)

--- a/mlflow/system_metrics/metrics/gpu_monitor.py
+++ b/mlflow/system_metrics/metrics/gpu_monitor.py
@@ -41,7 +41,10 @@ class GPUMonitor(BaseMetricsMonitor):
         # Get GPU metrics.
         for i, handle in enumerate(self.gpu_handles):
             memory = pynvml.nvmlDeviceGetMemoryInfo(handle)
-            self._metrics[f"gpu_{i}_memory_used"].append(int(memory.used / 1e6))
+            self._metrics[f"gpu_{i}_memory_usage_percentage"].append(
+                round(memory.used / memory.total * 100, 1)
+            )
+            self._metrics[f"gpu_{i}_memory_usage_megabytes"].append(int(memory.used / 1e6))
 
             device_utilization = pynvml.nvmlDeviceGetUtilizationRates(handle)
-            self._metrics[f"gpu_{i}_utilization_rate"].append(device_utilization.gpu)
+            self._metrics[f"gpu_{i}_utilization_percentage"].append(device_utilization.gpu)

--- a/mlflow/system_metrics/metrics/gpu_monitor.py
+++ b/mlflow/system_metrics/metrics/gpu_monitor.py
@@ -32,8 +32,8 @@ class GPUMonitor(BaseMetricsMonitor):
             return
         return super().__new__(cls, *args, **kwargs)
 
-    def __init__(self, name="gpu"):
-        super().__init__(name)
+    def __init__(self):
+        super().__init__()
         self.num_gpus = pynvml.nvmlDeviceGetCount()
         self.gpu_handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(self.num_gpus)]
 
@@ -44,7 +44,7 @@ class GPUMonitor(BaseMetricsMonitor):
             self._metrics[f"gpu_{i}_memory_usage_percentage"].append(
                 round(memory.used / memory.total * 100, 1)
             )
-            self._metrics[f"gpu_{i}_memory_usage_megabytes"].append(int(memory.used / 1e6))
+            self._metrics[f"gpu_{i}_memory_usage_megabytes"].append(memory.used / 1e6)
 
             device_utilization = pynvml.nvmlDeviceGetUtilizationRates(handle)
             self._metrics[f"gpu_{i}_utilization_percentage"].append(device_utilization.gpu)

--- a/mlflow/system_metrics/metrics/gpu_monitor.py
+++ b/mlflow/system_metrics/metrics/gpu_monitor.py
@@ -18,21 +18,19 @@ except ImportError:
 class GPUMonitor(BaseMetricsMonitor):
     """Class for monitoring GPU stats."""
 
-    def __new__(cls, *args, **kwargs):
-        # Override `__new__` to return a None object if `pynvml` is not installed or GPU is not
-        # found.
+    def __init__(self):
         if "pynvml" not in sys.modules:
             # Only instantiate if `pynvml` is installed.
-            return
+            raise ImportError(
+                "`pynvml` is not installed, to log GPU metrics please run `pip install pynvml` "
+                "to install it."
+            )
         try:
             # `nvmlInit()` will fail if no GPU is found.
             pynvml.nvmlInit()
         except pynvml.NVMLError as e:
-            _logger.warning(f"Failed to initialize NVML, skip logging GPU metrics: {e}")
-            return
-        return super().__new__(cls, *args, **kwargs)
+            raise RuntimeError(f"Failed to initialize NVML, skip logging GPU metrics: {e}")
 
-    def __init__(self):
         super().__init__()
         self.num_gpus = pynvml.nvmlDeviceGetCount()
         self.gpu_handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(self.num_gpus)]

--- a/mlflow/system_metrics/metrics/gpu_monitor.py
+++ b/mlflow/system_metrics/metrics/gpu_monitor.py
@@ -5,12 +5,12 @@ import sys
 
 from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonitor
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 try:
     import pynvml
 except ImportError:
-    logger.warning(
+    _logger.warning(
         "`GPUMonitor` requires pynvml package. To install, run `pip install pynvml`. Skip "
         "logging GPU metrics."
     )
@@ -29,7 +29,7 @@ class GPUMonitor(BaseMetricsMonitor):
             # `nvmlInit()` will fail if no GPU is found.
             pynvml.nvmlInit()
         except pynvml.NVMLError as e:
-            logger.warning(f"Failed to initialize NVML, skip logging GPU metrics: {e}")
+            _logger.warning(f"Failed to initialize NVML, skip logging GPU metrics: {e}")
             return
         return super().__new__(cls, *args, **kwargs)
 

--- a/mlflow/system_metrics/metrics/network_monitor.py
+++ b/mlflow/system_metrics/metrics/network_monitor.py
@@ -13,9 +13,5 @@ class NetworkMonitor(BaseMetricsMonitor):
     def collect_metrics(self):
         # Get network usage metrics.
         network_usage = psutil.net_io_counters()._asdict()
-        for k, v in network_usage.items():
-            if "bytes" in k:
-                # Convert bytes to MB.
-                self._metrics[f"network_{k}"].append(int(v / 1e6))
-            else:
-                self._metrics[f"network_{k}"].append(v)
+        self._metrics["network_receive_megabytes"].append(int(network_usage["bytes_recv"] / 1e6))
+        self._metrics["network_transmit_megabytes"].append(int(network_usage["bytes_sent"] / 1e6))

--- a/mlflow/system_metrics/metrics/network_monitor.py
+++ b/mlflow/system_metrics/metrics/network_monitor.py
@@ -1,0 +1,21 @@
+"""Class for monitoring network stats."""
+
+
+import psutil
+
+from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonitor
+
+
+class NetworkMonitor(BaseMetricsMonitor):
+    def __init__(self, name="network"):
+        super().__init__(name)
+
+    def collect_metrics(self):
+        # Get network usage metrics.
+        network_usage = psutil.net_io_counters()._asdict()
+        for k, v in network_usage.items():
+            if "bytes" in k:
+                # Convert bytes to MB.
+                self._metrics[f"network_{k}"].append(int(v / 1e6))
+            else:
+                self._metrics[f"network_{k}"].append(v)

--- a/mlflow/system_metrics/metrics/network_monitor.py
+++ b/mlflow/system_metrics/metrics/network_monitor.py
@@ -7,11 +7,11 @@ from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonito
 
 
 class NetworkMonitor(BaseMetricsMonitor):
-    def __init__(self, name="network"):
-        super().__init__(name)
+    def __init__(self):
+        super().__init__()
 
     def collect_metrics(self):
         # Get network usage metrics.
         network_usage = psutil.net_io_counters()._asdict()
-        self._metrics["network_receive_megabytes"].append(int(network_usage["bytes_recv"] / 1e6))
-        self._metrics["network_transmit_megabytes"].append(int(network_usage["bytes_sent"] / 1e6))
+        self._metrics["network_receive_megabytes"].append(network_usage["bytes_recv"] / 1e6)
+        self._metrics["network_transmit_megabytes"].append(network_usage["bytes_sent"] / 1e6)

--- a/mlflow/system_metrics/metrics/network_monitor.py
+++ b/mlflow/system_metrics/metrics/network_monitor.py
@@ -7,11 +7,8 @@ from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonito
 
 
 class NetworkMonitor(BaseMetricsMonitor):
-    def __init__(self):
-        super().__init__()
-
     def collect_metrics(self):
         # Get network usage metrics.
-        network_usage = psutil.net_io_counters()._asdict()
-        self._metrics["network_receive_megabytes"].append(network_usage["bytes_recv"] / 1e6)
-        self._metrics["network_transmit_megabytes"].append(network_usage["bytes_sent"] / 1e6)
+        network_usage = psutil.net_io_counters()
+        self._metrics["network_receive_megabytes"].append(network_usage.bytes_recv / 1e6)
+        self._metrics["network_transmit_megabytes"].append(network_usage.bytes_sent / 1e6)

--- a/mlflow/system_metrics/system_metrics_monitor.py
+++ b/mlflow/system_metrics/system_metrics_monitor.py
@@ -24,15 +24,14 @@ class SystemMetricsMonitor:
     environment variables.
 
     Args:
-        mlflow_run: an 'mlflow.entities.run.Run' instance, which is used to bootstrap system metrics
-            logging with the MLflow tracking server.
+        run_id: string, the MLflow run ID.
         sampling_interval: float, default to 10. The interval (in seconds) at which to pull system
             metrics.
         samples_before_logging: int, default to 1. The number of samples to aggregate before
             logging.
     """
 
-    def __init__(self, mlflow_run, sampling_interval=10, samples_before_logging=1):
+    def __init__(self, run_id, sampling_interval=10, samples_before_logging=1):
         from mlflow.utils.autologging_utils import BatchMetricsLogger
 
         # Instantiate default monitors.
@@ -50,7 +49,7 @@ class SystemMetricsMonitor:
         if isinstance(self.samples_before_logging, str):
             self.samples_before_logging = int(self.samples_before_logging)
 
-        self._run_id = mlflow_run.info.run_id
+        self._run_id = run_id
         self.mlflow_logger = BatchMetricsLogger(self._run_id)
         self._shutdown_event = threading.Event()
         self._process = None

--- a/mlflow/system_metrics/system_metrics_monitor.py
+++ b/mlflow/system_metrics/system_metrics_monitor.py
@@ -1,0 +1,127 @@
+"""Class for monitoring system stats."""
+
+import logging
+import os
+import threading
+
+from mlflow.system_metrics.metrics.cpu_monitor import CPUMonitor
+from mlflow.system_metrics.metrics.gpu_monitor import GPUMonitor
+
+_logger = logging.getLogger(__name__)
+
+
+class SystemMetricsMonitor:
+    """Class for monitoring system stats.
+
+    This class is used for pulling system metrics and logging them to MLflow. Calling `start()` will
+    spawn a thread that logs system metrics periodically. Calling `finish()` will stop the thread.
+    Logging is done on a different frequency from pulling metrics, so that the metrics are
+    aggregated over the period. Users can change the logging frequency by setting
+    `$MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL` and `$MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING`
+    environment variables.
+
+    Args:
+        mlflow_run: an 'mlflow.entities.run.Run' instance, which is used to bootstrap system metrics
+            logging with the MLflow tracking server.
+        sampling_interval: float, default to 0.5. The interval (in seconds) at which to pull system
+            metrics.
+        samples_to_aggregate: int, default to 30. The number of samples to aggregate before logging.
+    """
+
+    def __init__(self, mlflow_run, sampling_interval=10, samples_before_logging=1):
+        from mlflow.utils.autologging_utils import BatchMetricsLogger
+
+        # Instantiate default monitors.
+        self.monitors = [CPUMonitor()]
+        gpu_monitor = GPUMonitor()
+        if gpu_monitor:
+            self.monitors.append(gpu_monitor)
+        self.sampling_interval = os.environ.get(
+            "MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL", sampling_interval
+        )
+        self.samples_before_logging = os.environ.get(
+            "MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING", samples_before_logging
+        )
+        if isinstance(self.sampling_interval, str):
+            self.sampling_interval = float(self.sampling_interval)
+        if isinstance(self.samples_before_logging, str):
+            self.samples_before_logging = int(self.samples_before_logging)
+
+        self._run_id = mlflow_run.info.run_id
+        self.mlflow_logger = BatchMetricsLogger(self._run_id)
+        self._shutdown_event = threading.Event()
+        self._process = None
+
+    def start(self):
+        """Start monitoring system metrics."""
+        try:
+            self._process = threading.Thread(
+                target=self.monitor,
+                daemon=True,
+                name="SystemMetricsMonitor",
+            )
+            self._process.start()
+            _logger.info("MLflow: started monitoring system metrics.")
+        except Exception as e:
+            _logger.warning(f"MLflow: failed to start monitoring system metrics: {e}")
+            self._process = None
+
+    def monitor(self):
+        """Main monitoring loop, which consistently collect and log system metrics."""
+        from mlflow.tracking.fluent import get_run
+
+        while not self._shutdown_event.is_set():
+            for _ in range(self.samples_before_logging):
+                self.collect_metrics()
+                self._shutdown_event.wait(self.sampling_interval)
+                try:
+                    # Get the MLflow run to check if the run is not RUNNING.
+                    run = get_run(self._run_id)
+                except Exception as e:
+                    _logger.warning(f"MLflow: failed to get mlflow run: {e}.")
+                    return
+                if run.info.status != "RUNNING" or self._shutdown_event.is_set():
+                    # If the mlflow run is terminated or receives the shutdown signal, stop monitoring.
+                    return
+            metrics = self.aggregate_metrics()
+            try:
+                self.publish_metrics(metrics)
+            except Exception as e:
+                _logger.warning(
+                    f"MLflow: failed to log system metrics: {e}, this is expected if the "
+                    "experiment/run is already terminated."
+                )
+                return
+
+    def collect_metrics(self):
+        """Collect system metrics."""
+        metrics = {}
+        for monitor in self.monitors:
+            monitor.collect_metrics()
+            metrics.update(monitor._metrics)
+        return metrics
+
+    def aggregate_metrics(self):
+        """Aggregate collected metrics."""
+        metrics = {}
+        for monitor in self.monitors:
+            metrics.update(monitor.aggregate_metrics())
+        return metrics
+
+    def publish_metrics(self, metrics):
+        """Log collected metrics to MLflow."""
+        self.mlflow_logger.record_metrics(metrics)
+        for monitor in self.monitors:
+            monitor.clear_metrics()
+
+    def finish(self):
+        """Stop monitoring system metrics."""
+        if self._process is None:
+            return None
+        _logger.info("MLflow: stopping system metrics monitoring...")
+        self._shutdown_event.set()
+        try:
+            self._process.join()
+        except Exception as e:
+            _logger.error(f"Error joining system metrics monitoring process: {e}")
+        self._process = None

--- a/mlflow/system_metrics/system_metrics_monitor.py
+++ b/mlflow/system_metrics/system_metrics_monitor.py
@@ -22,8 +22,9 @@ class SystemMetricsMonitor:
     spawn a thread that logs system metrics periodically. Calling `finish()` will stop the thread.
     Logging is done on a different frequency from pulling metrics, so that the metrics are
     aggregated over the period. Users can change the logging frequency by setting
-    `$MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL` and `$MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING`
-    environment variables.
+    `MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL` and `MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING`
+    environment variables, e.g., run `export MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL=10` in terminal
+    will set the sampling interval to 10 seconds.
 
     Args:
         run_id: string, the MLflow run ID.
@@ -38,9 +39,14 @@ class SystemMetricsMonitor:
 
         # Instantiate default monitors.
         self.monitors = [CPUMonitor(), DiskMonitor(), NetworkMonitor()]
-        gpu_monitor = GPUMonitor()
-        if gpu_monitor:
+        try:
+            gpu_monitor = GPUMonitor()
             self.monitors.append(gpu_monitor)
+        except Exception as e:
+            _logger.warning(
+                f"Skip logging GPU metrics because creating `GPUMonitor` failed with error: {e}."
+            )
+
         self.sampling_interval = MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL.get() or sampling_interval
         self.samples_before_logging = (
             MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING.get() or samples_before_logging

--- a/mlflow/system_metrics/system_metrics_monitor.py
+++ b/mlflow/system_metrics/system_metrics_monitor.py
@@ -46,11 +46,6 @@ class SystemMetricsMonitor:
             MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING.get() or samples_before_logging
         )
 
-        if isinstance(self.sampling_interval, str):
-            self.sampling_interval = float(self.sampling_interval)
-        if isinstance(self.samples_before_logging, str):
-            self.samples_before_logging = int(self.samples_before_logging)
-
         self._run_id = run_id
         self.mlflow_logger = BatchMetricsLogger(self._run_id)
         self._shutdown_event = threading.Event()
@@ -128,5 +123,5 @@ class SystemMetricsMonitor:
         try:
             self._process.join()
         except Exception as e:
-            _logger.error(f"Error joining system metrics monitoring process: {e}")
+            _logger.error(f"Error terminating system metrics monitoring process: {e}.")
         self._process = None

--- a/mlflow/system_metrics/system_metrics_monitor.py
+++ b/mlflow/system_metrics/system_metrics_monitor.py
@@ -81,7 +81,8 @@ class SystemMetricsMonitor:
                     _logger.warning(f"MLflow: failed to get mlflow run: {e}.")
                     return
                 if run.info.status != "RUNNING" or self._shutdown_event.is_set():
-                    # If the mlflow run is terminated or receives the shutdown signal, stop monitoring.
+                    # If the mlflow run is terminated or receives the shutdown signal, stop
+                    # monitoring.
                     return
             metrics = self.aggregate_metrics()
             try:

--- a/mlflow/system_metrics/system_metrics_monitor.py
+++ b/mlflow/system_metrics/system_metrics_monitor.py
@@ -8,7 +8,9 @@ from mlflow.environment_variables import (
     MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL,
 )
 from mlflow.system_metrics.metrics.cpu_monitor import CPUMonitor
+from mlflow.system_metrics.metrics.disk_monitor import DiskMonitor
 from mlflow.system_metrics.metrics.gpu_monitor import GPUMonitor
+from mlflow.system_metrics.metrics.network_monitor import NetworkMonitor
 
 _logger = logging.getLogger(__name__)
 
@@ -35,7 +37,7 @@ class SystemMetricsMonitor:
         from mlflow.utils.autologging_utils import BatchMetricsLogger
 
         # Instantiate default monitors.
-        self.monitors = [CPUMonitor()]
+        self.monitors = [CPUMonitor(), DiskMonitor(), NetworkMonitor()]
         gpu_monitor = GPUMonitor()
         if gpu_monitor:
             self.monitors.append(gpu_monitor)

--- a/mlflow/system_metrics/system_metrics_monitor.py
+++ b/mlflow/system_metrics/system_metrics_monitor.py
@@ -122,7 +122,7 @@ class SystemMetricsMonitor:
     def finish(self):
         """Stop monitoring system metrics."""
         if self._process is None:
-            return None
+            return
         _logger.info("MLflow: stopping system metrics monitoring...")
         self._shutdown_event.set()
         try:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -371,22 +371,22 @@ def start_run(
             tags=resolved_tags,
             run_name=run_name,
         )
+        include_system_metrics = (
+            os.environ.get("MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING", "False") == "False"
+            and include_system_metrics
+        )
+        if include_system_metrics:
+            try:
+                from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor
 
-    include_system_metrics = (
-        os.environ.get("MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING", "False") == "False"
-        and include_system_metrics
-    )
-    if include_system_metrics:
-        try:
-            from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor
+                system_monitor = SystemMetricsMonitor(active_run_obj)
+                global run_id_to_system_metrics_monitor
 
-            system_monitor = SystemMetricsMonitor(active_run_obj)
-            global run_id_to_system_metrics_monitor
+                run_id_to_system_metrics_monitor[active_run_obj.info.run_id] = system_monitor
+                system_monitor.start()
+            except Exception as e:
+                _logger.error(f"Cannot start system metrics monitoring: {e}.")
 
-            run_id_to_system_metrics_monitor[active_run_obj.info.run_id] = system_monitor
-            system_monitor.start()
-        except Exception as e:
-            _logger.error(f"Cannot start system metrics monitoring: {e}.")
     _active_run_stack.append(ActiveRun(active_run_obj))
     return _active_run_stack[-1]
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -193,7 +193,7 @@ def start_run(
     nested: bool = False,
     tags: Optional[Dict[str, Any]] = None,
     description: Optional[str] = None,
-    log_system_metrics: bool = None,
+    log_system_metrics: Optional[bool] = None,
 ) -> ActiveRun:
     """
     Start a new MLflow run, setting it as the active run under which metrics and parameters

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -24,6 +24,7 @@ from mlflow.entities import (
 )
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.environment_variables import (
+    MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING,
     MLFLOW_EXPERIMENT_ID,
     MLFLOW_EXPERIMENT_NAME,
     MLFLOW_RUN_ID,
@@ -372,8 +373,7 @@ def start_run(
             run_name=run_name,
         )
         include_system_metrics = (
-            os.environ.get("MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING", "False") == "False"
-            and include_system_metrics
+            not MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING.get() and include_system_metrics
         )
         if include_system_metrics:
             try:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -193,7 +193,7 @@ def start_run(
     nested: bool = False,
     tags: Optional[Dict[str, Any]] = None,
     description: Optional[str] = None,
-    include_system_metrics: bool = False,
+    log_system_metrics: bool = False,
 ) -> ActiveRun:
     """
     Start a new MLflow run, setting it as the active run under which metrics and parameters

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -228,7 +228,7 @@ def start_run(
     :param description: An optional string that populates the description box of the run.
         If a run is being resumed, the description is set on the resumed run.
         If a new run is being created, the description is set on the new run.
-    :param include_system_metrics: bool, defaults to False. If True, system metrics will be logged
+    :param log_system_metrics: bool, defaults to False. If True, system metrics will be logged
         to MLflow, e.g., cpu/gpu utilization.
 
     :return: :py:class:`mlflow.ActiveRun` object that acts as a context manager wrapping the
@@ -373,12 +373,12 @@ def start_run(
             run_name=run_name,
         )
         if MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING.get() is not None:
-            include_system_metrics = MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING.get()
-        if include_system_metrics:
+            log_system_metrics = MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING.get()
+        if log_system_metrics:
             try:
                 from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor
 
-                system_monitor = SystemMetricsMonitor(active_run_obj)
+                system_monitor = SystemMetricsMonitor(active_run_obj.info.run_id)
                 global run_id_to_system_metrics_monitor
 
                 run_id_to_system_metrics_monitor[active_run_obj.info.run_id] = system_monitor

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -387,7 +387,7 @@ def start_run(
                 run_id_to_system_metrics_monitor[active_run_obj.info.run_id] = system_monitor
                 system_monitor.start()
             except Exception as e:
-                _logger.error(f"Cannot start system metrics monitoring: {e}.")
+                _logger.error(f"Failed to start system metrics monitoring: {e}.")
 
     _active_run_stack.append(ActiveRun(active_run_obj))
     return _active_run_stack[-1]

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -24,7 +24,7 @@ from mlflow.entities import (
 )
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.environment_variables import (
-    MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING,
+    MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING,
     MLFLOW_EXPERIMENT_ID,
     MLFLOW_EXPERIMENT_NAME,
     MLFLOW_RUN_ID,
@@ -372,8 +372,8 @@ def start_run(
             tags=resolved_tags,
             run_name=run_name,
         )
-        if MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING.get() is not None:
-            include_system_metrics = not MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING.get()
+        if MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING.get() is not None:
+            include_system_metrics = MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING.get()
         if include_system_metrics:
             try:
                 from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -193,7 +193,7 @@ def start_run(
     nested: bool = False,
     tags: Optional[Dict[str, Any]] = None,
     description: Optional[str] = None,
-    log_system_metrics: bool = False,
+    log_system_metrics: bool = None,
 ) -> ActiveRun:
     """
     Start a new MLflow run, setting it as the active run under which metrics and parameters
@@ -228,8 +228,10 @@ def start_run(
     :param description: An optional string that populates the description box of the run.
         If a run is being resumed, the description is set on the resumed run.
         If a new run is being created, the description is set on the new run.
-    :param log_system_metrics: bool, defaults to False. If True, system metrics will be logged
-        to MLflow, e.g., cpu/gpu utilization.
+    :param log_system_metrics: bool, defaults to None. If True, system metrics will be logged
+        to MLflow, e.g., cpu/gpu utilization. If None, we will check environment variable
+        `MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL` to determine whether to log system metrics.
+        System metrics logging is an experimental feature in MLflow 2.8 and subject to change.
 
     :return: :py:class:`mlflow.ActiveRun` object that acts as a context manager wrapping the
         run's state.
@@ -372,7 +374,8 @@ def start_run(
             tags=resolved_tags,
             run_name=run_name,
         )
-        if MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING.get() is not None:
+        if log_system_metrics is None:
+            # if `log_system_metrics` is not specified, we will check environment variable.
             log_system_metrics = MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING.get()
         if log_system_metrics:
             try:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -228,7 +228,7 @@ def start_run(
     :param description: An optional string that populates the description box of the run.
         If a run is being resumed, the description is set on the resumed run.
         If a new run is being created, the description is set on the new run.
-    :param include_system_metrics: bool, defaults to True. If True, system metrics will be logged
+    :param include_system_metrics: bool, defaults to False. If True, system metrics will be logged
         to MLflow, e.g., cpu/gpu utilization.
 
     :return: :py:class:`mlflow.ActiveRun` object that acts as a context manager wrapping the

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -193,7 +193,7 @@ def start_run(
     nested: bool = False,
     tags: Optional[Dict[str, Any]] = None,
     description: Optional[str] = None,
-    include_system_metrics: bool = True,
+    include_system_metrics: bool = False,
 ) -> ActiveRun:
     """
     Start a new MLflow run, setting it as the active run under which metrics and parameters
@@ -372,9 +372,8 @@ def start_run(
             tags=resolved_tags,
             run_name=run_name,
         )
-        include_system_metrics = (
-            not MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING.get() and include_system_metrics
-        )
+        if MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING.get() is not None:
+            include_system_metrics = not MLFLOW_DISABLE_SYSTEM_METRICS_LOGGING.get()
         if include_system_metrics:
             try:
                 from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor

--- a/requirements/core-requirements.txt
+++ b/requirements/core-requirements.txt
@@ -18,3 +18,4 @@ markdown<4,>=3.3
 Jinja2<4,>=2.11; platform_system != 'Windows'
 Jinja2<4,>=3.0; platform_system == 'Windows'
 matplotlib<4
+psutil<6

--- a/requirements/core-requirements.yaml
+++ b/requirements/core-requirements.yaml
@@ -81,3 +81,7 @@ Jinja2-windows:
 matplotlib:
   pip_release: matplotlib
   max_major_version: 3
+
+psutil:
+  pip_release: psutil
+  max_major_version: 5

--- a/requirements/gateway-requirements.txt
+++ b/requirements/gateway-requirements.txt
@@ -6,5 +6,4 @@ pydantic<3,>=1.0
 fastapi<1
 uvicorn[standard]<1
 watchfiles<1
-psutil<6
 aiohttp<4

--- a/requirements/gateway-requirements.yaml
+++ b/requirements/gateway-requirements.yaml
@@ -22,10 +22,6 @@ watchfiles:
   pip_release: watchfiles
   max_major_version: 0
 
-psutil:
-  pip_release: psutil
-  max_major_version: 5
-
 aiohttp:
   pip_release: aiohttp
   max_major_version: 3

--- a/tests/autologging/test_autologging_client.py
+++ b/tests/autologging/test_autologging_client.py
@@ -137,7 +137,7 @@ def test_client_run_creation_and_termination_are_successful():
 def test_client_asynchronous_flush_operates_correctly():
     original_log_batch = MlflowClient().log_batch
 
-    def mock_log_batch(run_id, metrics, params, tags):  # pylint: disable=unused-argument
+    def mock_log_batch(run_id, metrics=(), params=(), tags=()):  # pylint: disable=unused-argument
         # Sleep to simulate a long-running logging operation
         time.sleep(3)
         return original_log_batch(run_id, metrics, params, tags)
@@ -168,7 +168,7 @@ def test_client_asynchronous_flush_operates_correctly():
 def test_client_synchronous_flush_operates_correctly():
     original_log_batch = MlflowClient().log_batch
 
-    def mock_log_batch(run_id, metrics, params, tags):  # pylint: disable=unused-argument
+    def mock_log_batch(run_id, metrics=(), params=(), tags=()):  # pylint: disable=unused-argument
         # Sleep to simulate a long-running logging operation
         time.sleep(3)
         return original_log_batch(run_id, metrics, params, tags)

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1808,13 +1808,13 @@ def test_evaluation_metric_name_configs(prefix):
     assert len(metrics) > 0
 
     if prefix is not None:
-        assert f"{prefix}accuracy_score" in metrics.keys()
-        assert f"{prefix}log_loss" in metrics.keys()
-        assert f"{prefix}score" in metrics.keys()
+        assert f"{prefix}accuracy_score" in metrics
+        assert f"{prefix}log_loss" in metrics
+        assert f"{prefix}score" in metrics
 
-        assert f"{prefix}accuracy_score" in result.metrics.keys()
-        assert f"{prefix}log_loss" in result.metrics.keys()
-        assert f"{prefix}score" in result.metrics.keys()
+        assert f"{prefix}accuracy_score" in result.metrics
+        assert f"{prefix}log_loss" in result.metrics
+        assert f"{prefix}score" in result.metrics
 
 
 @pytest.mark.parametrize(

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1808,8 +1808,13 @@ def test_evaluation_metric_name_configs(prefix):
     assert len(metrics) > 0
 
     if prefix is not None:
-        assert all(metric_name.startswith(prefix) for metric_name in metrics)
-        assert all(metric_name.startswith(prefix) for metric_name in result.metrics)
+        assert f"{prefix}accuracy_score" in metrics.keys()
+        assert f"{prefix}log_loss" in metrics.keys()
+        assert f"{prefix}score" in metrics.keys()
+
+        assert f"{prefix}accuracy_score" in result.metrics.keys()
+        assert f"{prefix}log_loss" in result.metrics.keys()
+        assert f"{prefix}score" in result.metrics.keys()
 
 
 @pytest.mark.parametrize(

--- a/tests/system_metrics/test_collect_metrics.py
+++ b/tests/system_metrics/test_collect_metrics.py
@@ -9,12 +9,12 @@ def test_cpu_monitor():
     cpu_monitor.collect_metrics()
 
     assert isinstance(cpu_monitor.metrics["cpu_percentage"], list)
-    assert isinstance(cpu_monitor.metrics["cpu_memory_used"], list)
+    assert isinstance(cpu_monitor.metrics["system_memory_used"], list)
 
     cpu_monitor.collect_metrics()
     aggregated_metrics = cpu_monitor.aggregate_metrics()
     assert isinstance(aggregated_metrics["cpu_percentage"], float)
-    assert isinstance(aggregated_metrics["cpu_memory_used"], float)
+    assert isinstance(aggregated_metrics["system_memory_used"], float)
 
     cpu_monitor.clear_metrics()
     assert len(cpu_monitor.metrics.keys()) == 0

--- a/tests/system_metrics/test_collect_metrics.py
+++ b/tests/system_metrics/test_collect_metrics.py
@@ -17,7 +17,7 @@ def test_cpu_monitor():
     assert isinstance(aggregated_metrics["system_memory_usage_megabytes"], float)
 
     cpu_monitor.clear_metrics()
-    assert len(cpu_monitor.metrics.keys()) == 0
+    assert cpu_monitor.metrics == {}
 
 
 def test_gpu_monitor():

--- a/tests/system_metrics/test_collect_metrics.py
+++ b/tests/system_metrics/test_collect_metrics.py
@@ -1,0 +1,76 @@
+from mlflow.system_metrics.metrics.cpu_monitor import CPUMonitor
+from mlflow.system_metrics.metrics.disk_monitor import DiskMonitor
+from mlflow.system_metrics.metrics.gpu_monitor import GPUMonitor
+from mlflow.system_metrics.metrics.network_monitor import NetworkMonitor
+
+
+def test_cpu_monitor():
+    cpu_monitor = CPUMonitor()
+    cpu_monitor.collect_metrics()
+
+    assert isinstance(cpu_monitor.metrics["cpu_percentage"], list)
+    assert isinstance(cpu_monitor.metrics["cpu_memory_used"], list)
+
+    cpu_monitor.collect_metrics()
+    aggregated_metrics = cpu_monitor.aggregate_metrics()
+    assert isinstance(aggregated_metrics["cpu_percentage"], float)
+    assert isinstance(aggregated_metrics["cpu_memory_used"], float)
+
+    cpu_monitor.clear_metrics()
+    assert len(cpu_monitor.metrics.keys()) == 0
+
+
+def test_gpu_monitor():
+    gpu_monitor = GPUMonitor()
+    if gpu_monitor is None:
+        # If pynvml is not installed, or there is no GPU, then `gpu_monitor` will be None. In this
+        # case we skip the test.
+        return
+    gpu_monitor.collect_metrics()
+
+    assert isinstance(gpu_monitor.metrics["gpu_0_memory_used"], list)
+    assert isinstance(gpu_monitor.metrics["gpu_0_utilization_rate"], list)
+
+    gpu_monitor.collect_metrics()
+    aggregated_metrics = gpu_monitor.aggregate_metrics()
+    assert isinstance(aggregated_metrics["gpu_0_memory_used"], float)
+    assert isinstance(aggregated_metrics["gpu_0_utilization_rate"], float)
+
+    gpu_monitor.clear_metrics()
+    assert len(gpu_monitor.metrics.keys) == 0
+
+
+def test_disk_monitor():
+    disk_monitor = DiskMonitor()
+    disk_monitor.collect_metrics()
+
+    assert len(disk_monitor.metrics.keys()) > 0
+    for _, value in disk_monitor.metrics.items():
+        assert isinstance(value, list)
+
+    disk_monitor.collect_metrics()
+    aggregated_metrics = disk_monitor.aggregate_metrics()
+    assert len(aggregated_metrics.keys()) > 0
+    for key, value in aggregated_metrics.items():
+        assert isinstance(value, float)
+
+    disk_monitor.clear_metrics()
+    assert len(disk_monitor.metrics.keys()) == 0
+
+
+def test_network_monitor():
+    network_monitor = NetworkMonitor()
+    network_monitor.collect_metrics()
+
+    assert len(network_monitor.metrics.keys()) > 0
+    for _, value in network_monitor.metrics.items():
+        assert isinstance(value, list)
+
+    network_monitor.collect_metrics()
+    aggregated_metrics = network_monitor.aggregate_metrics()
+    assert len(aggregated_metrics.keys()) > 0
+    for key, value in aggregated_metrics.items():
+        assert isinstance(value, float)
+
+    network_monitor.clear_metrics()
+    assert len(network_monitor.metrics.keys()) == 0

--- a/tests/system_metrics/test_collect_metrics.py
+++ b/tests/system_metrics/test_collect_metrics.py
@@ -21,11 +21,13 @@ def test_cpu_monitor():
 
 
 def test_gpu_monitor():
-    gpu_monitor = GPUMonitor()
-    if gpu_monitor is None:
-        # If pynvml is not installed, or there is no GPU, then `gpu_monitor` will be None. In this
-        # case we skip the test.
+    try:
+        gpu_monitor = GPUMonitor()
+    except Exception:
+        # If pynvml is not installed, or there is no GPU, then `gpu_monitor` creation will fail. In
+        # this case we skip the test.
         return
+
     gpu_monitor.collect_metrics()
 
     assert isinstance(gpu_monitor.metrics["gpu_0_memory_usage_percentage"], list)

--- a/tests/system_metrics/test_collect_metrics.py
+++ b/tests/system_metrics/test_collect_metrics.py
@@ -8,13 +8,13 @@ def test_cpu_monitor():
     cpu_monitor = CPUMonitor()
     cpu_monitor.collect_metrics()
 
-    assert isinstance(cpu_monitor.metrics["cpu_percentage"], list)
-    assert isinstance(cpu_monitor.metrics["system_memory_used"], list)
+    assert isinstance(cpu_monitor.metrics["cpu_utilization_percentage"], list)
+    assert isinstance(cpu_monitor.metrics["system_memory_usage_megabytes"], list)
 
     cpu_monitor.collect_metrics()
     aggregated_metrics = cpu_monitor.aggregate_metrics()
-    assert isinstance(aggregated_metrics["cpu_percentage"], float)
-    assert isinstance(aggregated_metrics["system_memory_used"], float)
+    assert isinstance(aggregated_metrics["cpu_utilization_percentage"], float)
+    assert isinstance(aggregated_metrics["system_memory_usage_megabytes"], float)
 
     cpu_monitor.clear_metrics()
     assert len(cpu_monitor.metrics.keys()) == 0
@@ -28,13 +28,15 @@ def test_gpu_monitor():
         return
     gpu_monitor.collect_metrics()
 
-    assert isinstance(gpu_monitor.metrics["gpu_0_memory_used"], list)
-    assert isinstance(gpu_monitor.metrics["gpu_0_utilization_rate"], list)
+    assert isinstance(gpu_monitor.metrics["gpu_0_memory_usage_percentage"], list)
+    assert isinstance(gpu_monitor.metrics["gpu_0_memory_usage_megabytes"], list)
+    assert isinstance(gpu_monitor.metrics["gpu_0_utilization_percentage"], list)
 
     gpu_monitor.collect_metrics()
     aggregated_metrics = gpu_monitor.aggregate_metrics()
-    assert isinstance(aggregated_metrics["gpu_0_memory_used"], float)
-    assert isinstance(aggregated_metrics["gpu_0_utilization_rate"], float)
+    assert isinstance(aggregated_metrics["gpu_0_memory_usage_percentage"], float)
+    assert isinstance(aggregated_metrics["gpu_0_memory_usage_megabytes"], float)
+    assert isinstance(aggregated_metrics["gpu_0_utilization_percentage"], float)
 
     gpu_monitor.clear_metrics()
     assert len(gpu_monitor.metrics.keys) == 0
@@ -45,14 +47,17 @@ def test_disk_monitor():
     disk_monitor.collect_metrics()
 
     assert len(disk_monitor.metrics.keys()) > 0
-    for _, value in disk_monitor.metrics.items():
-        assert isinstance(value, list)
+    assert isinstance(disk_monitor.metrics["disk_usage_percentage"], list)
+    assert isinstance(disk_monitor.metrics["disk_usage_megabytes"], list)
+    assert isinstance(disk_monitor.metrics["disk_available_megabytes"], list)
 
     disk_monitor.collect_metrics()
     aggregated_metrics = disk_monitor.aggregate_metrics()
     assert len(aggregated_metrics.keys()) > 0
-    for key, value in aggregated_metrics.items():
-        assert isinstance(value, float)
+
+    assert isinstance(aggregated_metrics["disk_usage_percentage"], float)
+    assert isinstance(aggregated_metrics["disk_usage_megabytes"], float)
+    assert isinstance(aggregated_metrics["disk_available_megabytes"], float)
 
     disk_monitor.clear_metrics()
     assert len(disk_monitor.metrics.keys()) == 0
@@ -63,14 +68,15 @@ def test_network_monitor():
     network_monitor.collect_metrics()
 
     assert len(network_monitor.metrics.keys()) > 0
-    for _, value in network_monitor.metrics.items():
-        assert isinstance(value, list)
+    assert isinstance(network_monitor.metrics["network_receive_megabytes"], list)
+    assert isinstance(network_monitor.metrics["network_transmit_megabytes"], list)
 
     network_monitor.collect_metrics()
     aggregated_metrics = network_monitor.aggregate_metrics()
     assert len(aggregated_metrics.keys()) > 0
-    for key, value in aggregated_metrics.items():
-        assert isinstance(value, float)
+
+    assert isinstance(aggregated_metrics["network_receive_megabytes"], float)
+    assert isinstance(aggregated_metrics["network_transmit_megabytes"], float)
 
     network_monitor.clear_metrics()
     assert len(network_monitor.metrics.keys()) == 0

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -1,0 +1,52 @@
+import os
+import threading
+import time
+
+import mlflow
+from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor
+
+
+def test_manual_system_metrics_monitor():
+    with mlflow.start_run(include_system_metrics=False) as run:
+        system_monitor = SystemMetricsMonitor(run, sampling_interval=0.1, samples_before_logging=5)
+        system_monitor.start()
+        thread_names = [thread.name for thread in threading.enumerate()]
+        # Check the system metrics monitoring thread has been started.
+        assert "SystemMetricsMonitor" in thread_names
+
+        time.sleep(2)
+    mlflow.end_run()
+    # Pause for a bit to allow the system metrics monitoring to exit.
+    time.sleep(1)
+    thread_names = [thread.name for thread in threading.enumerate()]
+    # Check the system metrics monitoring thread has exited.
+    assert "SystemMetricsMonitor" not in thread_names
+
+    mlflow_run = mlflow.get_run(run.info.run_id)
+    metrics = mlflow_run.data.metrics
+    assert "cpu_percentage" in metrics
+    assert "cpu_memory_used" in metrics
+
+
+def test_automatic_system_metrics_monitor():
+    os.environ["MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL"] = "0.1"
+    os.environ["MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING"] = "5"
+    run = mlflow.start_run()
+    thread_names = [thread.name for thread in threading.enumerate()]
+    # Check the system metrics monitoring thread has been started.
+    assert "SystemMetricsMonitor" in thread_names
+
+    # Pause for a bit to allow the system metrics monitoring to exit.
+    time.sleep(2)
+    mlflow.end_run()
+
+    # Pause for a bit to allow the system metrics monitoring to exit.
+    time.sleep(1)
+    thread_names = [thread.name for thread in threading.enumerate()]
+    # Check the system metrics monitoring thread has exited.
+    assert "SystemMetricsMonitor" not in thread_names
+
+    mlflow_run = mlflow.get_run(run.info.run_id)
+    metrics = mlflow_run.data.metrics
+    assert "cpu_percentage" in metrics
+    assert "cpu_memory_used" in metrics

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -1,8 +1,11 @@
-import os
 import threading
 import time
 
 import mlflow
+from mlflow.environment_variables import (
+    MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING,
+    MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL,
+)
 from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor
 
 
@@ -29,8 +32,8 @@ def test_manual_system_metrics_monitor():
 
 
 def test_automatic_system_metrics_monitor():
-    os.environ["MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL"] = "0.1"
-    os.environ["MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING"] = "5"
+    MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL.set(0.2)
+    MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING.set(5)
     run = mlflow.start_run()
     thread_names = [thread.name for thread in threading.enumerate()]
     # Check the system metrics monitoring thread has been started.

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -27,8 +27,18 @@ def test_manual_system_metrics_monitor():
 
     mlflow_run = mlflow.get_run(run.info.run_id)
     metrics = mlflow_run.data.metrics
-    assert "cpu_percentage" in metrics
-    assert "system_memory_used" in metrics
+
+    expected_metrics_name = [
+        "cpu_utilization_percentage",
+        "system_memory_usage_megabytes",
+        "disk_usage_percentage",
+        "disk_usage_megabytes",
+        "disk_available_megabytes",
+        "network_receive_megabytes",
+        "network_transmit_megabytes",
+    ]
+    for name in expected_metrics_name:
+        assert name in metrics
 
 
 def test_automatic_system_metrics_monitor():
@@ -52,5 +62,15 @@ def test_automatic_system_metrics_monitor():
 
     mlflow_run = mlflow.get_run(run.info.run_id)
     metrics = mlflow_run.data.metrics
-    assert "cpu_percentage" in metrics
-    assert "system_memory_used" in metrics
+
+    expected_metrics_name = [
+        "cpu_utilization_percentage",
+        "system_memory_usage_megabytes",
+        "disk_usage_percentage",
+        "disk_usage_megabytes",
+        "disk_available_megabytes",
+        "network_receive_megabytes",
+        "network_transmit_megabytes",
+    ]
+    for name in expected_metrics_name:
+        assert name in metrics

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -2,10 +2,6 @@ import threading
 import time
 
 import mlflow
-from mlflow.environment_variables import (
-    MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING,
-    MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL,
-)
 from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor
 
 
@@ -32,8 +28,9 @@ def test_manual_system_metrics_monitor():
 
 
 def test_automatic_system_metrics_monitor():
-    MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL.set(0.2)
-    MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING.set(5)
+    mlflow.enable_system_metrics_logging()
+    mlflow.set_system_metrics_sampling_interval(0.2)
+    mlflow.set_system_metrics_samples_before_logging(5)
     run = mlflow.start_run()
     thread_names = [thread.name for thread in threading.enumerate()]
     # Check the system metrics monitoring thread has been started.

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -28,7 +28,7 @@ def test_manual_system_metrics_monitor():
     mlflow_run = mlflow.get_run(run.info.run_id)
     metrics = mlflow_run.data.metrics
     assert "cpu_percentage" in metrics
-    assert "cpu_memory_used" in metrics
+    assert "system_memory_used" in metrics
 
 
 def test_automatic_system_metrics_monitor():
@@ -52,4 +52,4 @@ def test_automatic_system_metrics_monitor():
     mlflow_run = mlflow.get_run(run.info.run_id)
     metrics = mlflow_run.data.metrics
     assert "cpu_percentage" in metrics
-    assert "cpu_memory_used" in metrics
+    assert "system_memory_used" in metrics

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -18,7 +18,6 @@ def test_manual_system_metrics_monitor():
         assert "SystemMetricsMonitor" in thread_names
 
         time.sleep(2)
-    mlflow.end_run()
     # Pause for a bit to allow the system metrics monitoring to exit.
     time.sleep(1)
     thread_names = [thread.name for thread in threading.enumerate()]
@@ -45,14 +44,13 @@ def test_automatic_system_metrics_monitor():
     mlflow.enable_system_metrics_logging()
     mlflow.set_system_metrics_sampling_interval(0.2)
     mlflow.set_system_metrics_samples_before_logging(5)
-    run = mlflow.start_run()
-    thread_names = [thread.name for thread in threading.enumerate()]
-    # Check the system metrics monitoring thread has been started.
-    assert "SystemMetricsMonitor" in thread_names
+    with mlflow.start_run() as run:
+        thread_names = [thread.name for thread in threading.enumerate()]
+        # Check the system metrics monitoring thread has been started.
+        assert "SystemMetricsMonitor" in thread_names
 
-    # Pause for a bit to allow the system metrics monitoring to exit.
-    time.sleep(2)
-    mlflow.end_run()
+        # Pause for a bit to allow system metrics to be logged.
+        time.sleep(2)
 
     # Pause for a bit to allow the system metrics monitoring to exit.
     time.sleep(1)
@@ -74,3 +72,8 @@ def test_automatic_system_metrics_monitor():
     ]
     for name in expected_metrics_name:
         assert name in metrics
+
+    # Unset the environment variables to avoid affecting other test cases.
+    mlflow.disable_system_metrics_logging()
+    mlflow.set_system_metrics_sampling_interval(None)
+    mlflow.set_system_metrics_samples_before_logging(None)

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -6,8 +6,12 @@ from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor
 
 
 def test_manual_system_metrics_monitor():
-    with mlflow.start_run(include_system_metrics=False) as run:
-        system_monitor = SystemMetricsMonitor(run, sampling_interval=0.1, samples_before_logging=5)
+    with mlflow.start_run(log_system_metrics=False) as run:
+        system_monitor = SystemMetricsMonitor(
+            run.info.run_id,
+            sampling_interval=0.1,
+            samples_before_logging=5,
+        )
         system_monitor.start()
         thread_names = [thread.name for thread in threading.enumerate()]
         # Check the system metrics monitoring thread has been started.

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -32,7 +32,6 @@ from mlflow.environment_variables import (
     MLFLOW_EXPERIMENT_ID,
     MLFLOW_EXPERIMENT_NAME,
     MLFLOW_RUN_ID,
-    MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.store.entities.paged_list import PagedList

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -550,7 +550,7 @@ def test_start_run_defaults(empty_active_run_stack):  # pylint: disable=unused-a
         source_version_patch,
         create_run_patch,
     ):
-        active_run = start_run(run_name=run_name)
+        active_run = start_run(run_name=run_name, include_system_metrics=False)
         MlflowClient.create_run.assert_called_once_with(
             experiment_id=mock_experiment_id, tags=expected_tags, run_name="my name"
         )
@@ -623,7 +623,7 @@ def test_start_run_defaults_databricks_notebook(
         workspace_info_patch,
         create_run_patch,
     ):
-        active_run = start_run()
+        active_run = start_run(include_system_metrics=False)
         MlflowClient.create_run.assert_called_once_with(
             experiment_id=mock_experiment_id, tags=expected_tags, run_name=None
         )
@@ -683,7 +683,7 @@ def test_start_run_creates_new_run_with_user_specified_tags():
         source_version_patch,
         create_run_patch,
     ):
-        active_run = start_run(tags=user_specified_tags)
+        active_run = start_run(tags=user_specified_tags, include_system_metrics=False)
         MlflowClient.create_run.assert_called_once_with(
             experiment_id=mock_experiment_id, tags=expected_tags, run_name=None
         )
@@ -732,7 +732,11 @@ def test_start_run_with_parent():
         user_patch,
         source_name_patch,
     ):
-        active_run = start_run(experiment_id=mock_experiment_id, nested=True)
+        active_run = start_run(
+            experiment_id=mock_experiment_id,
+            nested=True,
+            include_system_metrics=False,
+        )
         MlflowClient.create_run.assert_called_once_with(
             experiment_id=mock_experiment_id, tags=expected_tags, run_name=None
         )
@@ -753,7 +757,7 @@ def test_start_run_existing_run(empty_active_run_stack):  # pylint: disable=unus
     mock_get_store = mock.patch("mlflow.tracking.fluent._get_store")
 
     with mock_get_store, mock.patch.object(MlflowClient, "get_run", return_value=mock_run):
-        active_run = start_run(run_id)
+        active_run = start_run(run_id, include_system_metrics=False)
 
         assert is_from_run(active_run, mock_run)
         MlflowClient.get_run.assert_called_with(run_id)
@@ -770,7 +774,7 @@ def test_start_run_existing_run_from_environment(
     mock_get_store = mock.patch("mlflow.tracking.fluent._get_store")
 
     with mock_get_store, mock.patch.object(MlflowClient, "get_run", return_value=mock_run):
-        active_run = start_run()
+        active_run = start_run(include_system_metrics=False)
 
         assert is_from_run(active_run, mock_run)
         MlflowClient.get_run.assert_called_with(run_id)
@@ -865,7 +869,7 @@ def test_start_run_with_description(empty_active_run_stack):  # pylint: disable=
         source_version_patch,
         create_run_patch,
     ):
-        active_run = start_run(description=description)
+        active_run = start_run(description=description, include_system_metrics=False)
         MlflowClient.create_run.assert_called_once_with(
             experiment_id=mock_experiment_id, tags=expected_tags, run_name=None
         )
@@ -881,7 +885,7 @@ def test_start_run_conflicting_description():
     )
 
     with pytest.raises(MlflowException, match=match):
-        start_run(tags=invalid_tags, description=description)
+        start_run(tags=invalid_tags, description=description, include_system_metrics=False)
 
 
 @pytest.mark.usefixtures(empty_active_run_stack.__name__)

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1290,17 +1290,3 @@ def test_get_parent_run():
     assert parent_run.data.params == {"a": "1"}
 
     assert mlflow.get_parent_run(run_id) is None
-
-
-def test_get_system_metrics():
-    mlflow.enable_system_metrics_logging()
-    mlflow.set_system_metrics_sampling_interval(0.5)
-    with mlflow.start_run() as run:
-        time.sleep(1)
-
-    mlflow_run = MlflowClient().get_run(run.info.run_id)
-    metrics = mlflow_run.data.metrics
-    assert "cpu_percentage" in metrics
-    assert "system_memory_used" in metrics
-    MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL.unset()
-    mlflow.disable_system_metrics_logging()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Basically with this PR, `mlflow.start_run()` will automatically start system metrics logging. Users have the option to disable system metrics logging by passing a flag or using `mlflow.disable_system_metrics_logging()`.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
