### PR TITLE
Update "dtype" to "type" in ParamSpec dictionary representation

### DIFF
--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -645,7 +645,7 @@ class ParamSpec:
 
     class ParamSpecTypedDict(TypedDict):
         name: str
-        dtype: str
+        type: str
         default: Union[DataType, List[DataType], None]
         shape: Optional[Tuple[int, ...]]
 

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -688,11 +688,10 @@ class ParamSpec:
         The dictionary is expected to contain `name`, `type` and `default` keys.
         """
         # For backward compatibility, we accept both `type` and `dtype` keys
-        if not {"name", "dtype", "default"} <= set(kwargs.keys()) and not {
-            "name",
-            "type",
-            "default",
-        } <= set(kwargs.keys()):
+        required_keys1 = {"name", "dtype", "default"}
+        required_keys2 = {"name", "type", "default"}
+
+        if not (required_keys1.issubset(kwargs) or required_keys2.issubset(kwargs)):
             raise MlflowException.invalid_parameter_value(
                 "Missing keys in ParamSpec JSON. Expected to find "
                 "keys `name`, `type`(or `dtype`) and `default`. "

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -662,7 +662,7 @@ class ParamSpec:
             )
         return {
             "name": self.name,
-            "dtype": self.dtype.name,
+            "type": self.dtype.name,
             "default": default_value,
             "shape": self.shape,
         }
@@ -685,16 +685,23 @@ class ParamSpec:
     def from_json_dict(cls, **kwargs):
         """
         Deserialize from a json loaded dictionary.
-        The dictionary is expected to contain `name`, `dtype` and `default` keys.
+        The dictionary is expected to contain `name`, `type` and `default` keys.
         """
-        if not {"name", "dtype", "default"} <= set(kwargs.keys()):
+        # For backward compatibility, we accept both `type` and `dtype` keys
+        if not {"name", "dtype", "default"} <= set(kwargs.keys()) and not {
+            "name",
+            "type",
+            "default",
+        } <= set(kwargs.keys()):
             raise MlflowException.invalid_parameter_value(
                 "Missing keys in ParamSpec JSON. Expected to find "
-                "keys `name`, `dtype` and `default`",
+                "keys `name`, `type`(or `dtype`) and `default`. "
+                f"Received keys: {kwargs.keys()}"
             )
+        dtype = kwargs.get("type") or kwargs.get("dtype")
         return cls(
             name=str(kwargs["name"]),
-            dtype=DataType[kwargs["dtype"]],
+            dtype=DataType[dtype],
             default=kwargs["default"],
             shape=kwargs.get("shape"),
         )

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -883,7 +883,7 @@ def test_param_spec_to_and_from_dict():
     assert ParamSpec.from_json_dict(**json.loads(json.dumps(spec.to_dict()))) == spec
 
 
-def test_param_spec_from_dict_back_compat():
+def test_param_spec_from_dict_backward_compatibility():
     spec = ParamSpec("str_param", DataType.string, "str_a", None)
     spec_json = json.dumps(
         {

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -752,7 +752,7 @@ def test_param_spec_to_and_from_dict():
     spec = ParamSpec("str_param", DataType.string, "str_a", None)
     assert spec.to_dict() == {
         "name": "str_param",
-        "dtype": "string",
+        "type": "string",
         "default": "str_a",
         "shape": None,
     }
@@ -761,7 +761,7 @@ def test_param_spec_to_and_from_dict():
     spec = ParamSpec("str_array", DataType.string, ["str_a", "str_b"], (-1,))
     assert spec.to_dict() == {
         "name": "str_array",
-        "dtype": "string",
+        "type": "string",
         "default": ["str_a", "str_b"],
         "shape": (-1,),
     }
@@ -770,7 +770,7 @@ def test_param_spec_to_and_from_dict():
     spec = ParamSpec("int_param", DataType.integer, np.int32(1), None)
     assert spec.to_dict() == {
         "name": "int_param",
-        "dtype": "integer",
+        "type": "integer",
         "default": 1,
         "shape": None,
     }
@@ -779,7 +779,7 @@ def test_param_spec_to_and_from_dict():
     spec = ParamSpec("int_array", DataType.integer, [np.int32(1), np.int32(2)], (-1,))
     assert spec.to_dict() == {
         "name": "int_array",
-        "dtype": "integer",
+        "type": "integer",
         "default": [1, 2],
         "shape": (-1,),
     }
@@ -788,7 +788,7 @@ def test_param_spec_to_and_from_dict():
     spec = ParamSpec("bool_param", DataType.boolean, True, None)
     assert spec.to_dict() == {
         "name": "bool_param",
-        "dtype": "boolean",
+        "type": "boolean",
         "default": True,
         "shape": None,
     }
@@ -797,7 +797,7 @@ def test_param_spec_to_and_from_dict():
     spec = ParamSpec("bool_array", DataType.boolean, [True, False], (-1,))
     assert spec.to_dict() == {
         "name": "bool_array",
-        "dtype": "boolean",
+        "type": "boolean",
         "default": [True, False],
         "shape": (-1,),
     }
@@ -806,7 +806,7 @@ def test_param_spec_to_and_from_dict():
     spec = ParamSpec("double_param", DataType.double, 1.0, None)
     assert spec.to_dict() == {
         "name": "double_param",
-        "dtype": "double",
+        "type": "double",
         "default": 1.0,
         "shape": None,
     }
@@ -815,7 +815,7 @@ def test_param_spec_to_and_from_dict():
     spec = ParamSpec("double_array", DataType.double, [1.0, 2.0], (-1,))
     assert spec.to_dict() == {
         "name": "double_array",
-        "dtype": "double",
+        "type": "double",
         "default": [1.0, 2.0],
         "shape": (-1,),
     }
@@ -824,7 +824,7 @@ def test_param_spec_to_and_from_dict():
     spec = ParamSpec("float_param", DataType.float, np.float32(0.1), None)
     assert spec.to_dict() == {
         "name": "float_param",
-        "dtype": "float",
+        "type": "float",
         "default": float(np.float32(0.1)),
         "shape": None,
     }
@@ -833,7 +833,7 @@ def test_param_spec_to_and_from_dict():
     spec = ParamSpec("float_array", DataType.float, [np.float32(0.1), np.float32(0.2)], (-1,))
     assert spec.to_dict() == {
         "name": "float_array",
-        "dtype": "float",
+        "type": "float",
         "default": [float(np.float32(0.1)), float(np.float32(0.2))],
         "shape": (-1,),
     }
@@ -842,7 +842,7 @@ def test_param_spec_to_and_from_dict():
     spec = ParamSpec("long_param", DataType.long, 100, None)
     assert spec.to_dict() == {
         "name": "long_param",
-        "dtype": "long",
+        "type": "long",
         "default": 100,
         "shape": None,
     }
@@ -851,7 +851,7 @@ def test_param_spec_to_and_from_dict():
     spec = ParamSpec("long_array", DataType.long, [100, 200], (-1,))
     assert spec.to_dict() == {
         "name": "long_array",
-        "dtype": "long",
+        "type": "long",
         "default": [100, 200],
         "shape": (-1,),
     }
@@ -862,7 +862,7 @@ def test_param_spec_to_and_from_dict():
     )
     assert spec.to_dict() == {
         "name": "datetime_param",
-        "dtype": "datetime",
+        "type": "datetime",
         "default": "2023-06-26T00:00:00",
         "shape": None,
     }
@@ -876,11 +876,24 @@ def test_param_spec_to_and_from_dict():
     )
     assert spec.to_dict() == {
         "name": "datetime_array",
-        "dtype": "datetime",
+        "type": "datetime",
         "default": ["2023-06-26T00:00:00", "2023-06-27T00:00:00"],
         "shape": (-1,),
     }
     assert ParamSpec.from_json_dict(**json.loads(json.dumps(spec.to_dict()))) == spec
+
+
+def test_param_spec_from_dict_back_compat():
+    spec = ParamSpec("str_param", DataType.string, "str_a", None)
+    spec_json = json.dumps(
+        {
+            "name": "str_param",
+            "dtype": "string",
+            "default": "str_a",
+            "shape": None,
+        }
+    )
+    assert ParamSpec.from_json_dict(**json.loads(spec_json)) == spec
 
 
 def test_infer_param_schema():


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?
Previously ParamSpec's to_dict method uses "dtype" for field ParamSpec.dtype, to be consistent with ColSpec and TensorSpec, we switched to use "type" in the dictionary representation.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
