### PR TITLE
Add aggregations to existing metrics

### DIFF
--- a/mlflow/metrics/utils/metric_definitions.py
+++ b/mlflow/metrics/utils/metric_definitions.py
@@ -8,6 +8,14 @@ from mlflow.metrics.base import MetricValue
 _logger = logging.getLogger(__name__)
 
 
+def standard_aggregations(scores):
+    return {
+        "mean": np.mean(scores),
+        "variance": np.var(scores),
+        "p90": np.percentile(scores, 90),
+    }
+
+
 def _validate_text_predictions(predictions, metric_name):
     if len(predictions) == 0:
         return False
@@ -47,10 +55,8 @@ def _toxicity_eval_fn(eval_df, metrics):
     return MetricValue(
         scores=scores,
         aggregate_results={
+            **standard_aggregations(scores),
             "ratio": toxicity_ratio,
-            "mean": np.mean(scores),
-            "variance": np.var(scores),
-            "p90": np.percentile(scores, 90),
         },
     )
 
@@ -77,11 +83,7 @@ def _perplexity_eval_fn(eval_df, metrics):
     scores = perplexity.compute(predictions=predictions, model_id="gpt2")["perplexities"]
     return MetricValue(
         scores=scores,
-        aggregate_results={
-            "mean": np.mean(scores),
-            "variance": np.var(scores),
-            "p90": np.percentile(scores, 90),
-        },
+        aggregate_results=standard_aggregations(scores),
     )
 
 
@@ -102,11 +104,7 @@ def _flesch_kincaid_eval_fn(eval_df, metrics):
     scores = [textstat.flesch_kincaid_grade(prediction) for prediction in predictions]
     return MetricValue(
         scores=scores,
-        aggregate_results={
-            "mean": np.mean(scores),
-            "variance": np.var(scores),
-            "p90": np.percentile(scores, 90),
-        },
+        aggregate_results=standard_aggregations(scores),
     )
 
 
@@ -129,11 +127,7 @@ def _ari_eval_fn(eval_df, metrics):
     scores = [textstat.automated_readability_index(prediction) for prediction in predictions]
     return MetricValue(
         scores=scores,
-        aggregate_results={
-            "mean": np.mean(scores),
-            "variance": np.var(scores),
-            "p90": np.percentile(scores, 90),
-        },
+        aggregate_results=standard_aggregations(scores),
     )
 
 
@@ -169,11 +163,7 @@ def _rouge1_eval_fn(eval_df, metrics):
         )["rouge1"]
         return MetricValue(
             scores=scores,
-            aggregate_results={
-                "mean": np.mean(scores),
-                "variance": np.var(scores),
-                "p90": np.percentile(scores, 90),
-            },
+            aggregate_results=standard_aggregations(scores),
         )
 
 
@@ -201,11 +191,7 @@ def _rouge2_eval_fn(eval_df, metrics):
         )["rouge2"]
         return MetricValue(
             scores=scores,
-            aggregate_results={
-                "mean": np.mean(scores),
-                "variance": np.var(scores),
-                "p90": np.percentile(scores, 90),
-            },
+            aggregate_results=standard_aggregations(scores),
         )
 
 
@@ -233,11 +219,7 @@ def _rougeL_eval_fn(eval_df, metrics):
         )["rougeL"]
         return MetricValue(
             scores=scores,
-            aggregate_results={
-                "mean": np.mean(scores),
-                "variance": np.var(scores),
-                "p90": np.percentile(scores, 90),
-            },
+            aggregate_results=standard_aggregations(scores),
         )
 
 
@@ -265,9 +247,5 @@ def _rougeLsum_eval_fn(eval_df, metrics):
         )["rougeLsum"]
         return MetricValue(
             scores=scores,
-            aggregate_results={
-                "mean": np.mean(scores),
-                "variance": np.var(scores),
-                "p90": np.percentile(scores, 90),
-            },
+            aggregate_results=standard_aggregations(scores),
         )

--- a/mlflow/metrics/utils/metric_definitions.py
+++ b/mlflow/metrics/utils/metric_definitions.py
@@ -1,5 +1,6 @@
 import logging
 
+import numpy as np
 import pandas as pd
 
 from mlflow.metrics.base import MetricValue
@@ -43,7 +44,15 @@ def _toxicity_eval_fn(eval_df, metrics):
     toxicity_ratio = toxicity.compute(predictions=predictions, aggregation="ratio")[
         "toxicity_ratio"
     ]
-    return MetricValue(scores=scores, aggregate_results={"ratio": toxicity_ratio})
+    return MetricValue(
+        scores=scores,
+        aggregate_results={
+            "ratio": toxicity_ratio,
+            "mean": np.mean(scores),
+            "variance": np.var(scores),
+            "p90": np.percentile(scores, 90),
+        },
+    )
 
 
 def _perplexity_eval_fn(eval_df, metrics):
@@ -65,9 +74,14 @@ def _perplexity_eval_fn(eval_df, metrics):
         return
 
     _logger.info("Computing perplexity metric:")
-    results = perplexity.compute(predictions=predictions, model_id="gpt2")
+    scores = perplexity.compute(predictions=predictions, model_id="gpt2")["perplexities"]
     return MetricValue(
-        scores=results["perplexities"], aggregate_results={"mean": results["mean_perplexity"]}
+        scores=scores,
+        aggregate_results={
+            "mean": np.mean(scores),
+            "variance": np.var(scores),
+            "p90": np.percentile(scores, 90),
+        },
     )
 
 
@@ -86,7 +100,14 @@ def _flesch_kincaid_eval_fn(eval_df, metrics):
 
     _logger.info("Computing flesch kincaid metric:")
     scores = [textstat.flesch_kincaid_grade(prediction) for prediction in predictions]
-    return MetricValue(scores=scores, aggregate_results={"mean": sum(scores) / len(scores)})
+    return MetricValue(
+        scores=scores,
+        aggregate_results={
+            "mean": np.mean(scores),
+            "variance": np.var(scores),
+            "p90": np.percentile(scores, 90),
+        },
+    )
 
 
 def _ari_eval_fn(eval_df, metrics):
@@ -106,7 +127,14 @@ def _ari_eval_fn(eval_df, metrics):
 
     _logger.info("Computing automated readability index metric:")
     scores = [textstat.automated_readability_index(prediction) for prediction in predictions]
-    return MetricValue(scores=scores, aggregate_results={"mean": sum(scores) / len(scores)})
+    return MetricValue(
+        scores=scores,
+        aggregate_results={
+            "mean": np.mean(scores),
+            "variance": np.var(scores),
+            "p90": np.percentile(scores, 90),
+        },
+    )
 
 
 def _accuracy_eval_fn(eval_df, metrics):
@@ -138,15 +166,14 @@ def _rouge1_eval_fn(eval_df, metrics):
             references=references,
             rouge_types=["rouge1"],
             use_aggregator=False,
-        )
-        aggregates = rouge.compute(
-            predictions=predictions,
-            references=references,
-            rouge_types=["rouge1"],
-            use_aggregator=True,
-        )
+        )["rouge1"]
         return MetricValue(
-            scores=scores["rouge1"], aggregate_results={"mean": aggregates["rouge1"]}
+            scores=scores,
+            aggregate_results={
+                "mean": np.mean(scores),
+                "variance": np.var(scores),
+                "p90": np.percentile(scores, 90),
+            },
         )
 
 
@@ -171,15 +198,14 @@ def _rouge2_eval_fn(eval_df, metrics):
             references=references,
             rouge_types=["rouge2"],
             use_aggregator=False,
-        )
-        aggregates = rouge.compute(
-            predictions=predictions,
-            references=references,
-            rouge_types=["rouge2"],
-            use_aggregator=True,
-        )
+        )["rouge2"]
         return MetricValue(
-            scores=scores["rouge2"], aggregate_results={"mean": aggregates["rouge2"]}
+            scores=scores,
+            aggregate_results={
+                "mean": np.mean(scores),
+                "variance": np.var(scores),
+                "p90": np.percentile(scores, 90),
+            },
         )
 
 
@@ -204,15 +230,14 @@ def _rougeL_eval_fn(eval_df, metrics):
             references=references,
             rouge_types=["rougeL"],
             use_aggregator=False,
-        )
-        aggregates = rouge.compute(
-            predictions=predictions,
-            references=references,
-            rouge_types=["rougeL"],
-            use_aggregator=True,
-        )
+        )["rougeL"]
         return MetricValue(
-            scores=scores["rougeL"], aggregate_results={"mean": aggregates["rougeL"]}
+            scores=scores,
+            aggregate_results={
+                "mean": np.mean(scores),
+                "variance": np.var(scores),
+                "p90": np.percentile(scores, 90),
+            },
         )
 
 
@@ -237,13 +262,12 @@ def _rougeLsum_eval_fn(eval_df, metrics):
             references=references,
             rouge_types=["rougeLsum"],
             use_aggregator=False,
-        )
-        aggregates = rouge.compute(
-            predictions=predictions,
-            references=references,
-            rouge_types=["rougeLsum"],
-            use_aggregator=True,
-        )
+        )["rougeLsum"]
         return MetricValue(
-            scores=scores["rougeLsum"], aggregate_results={"mean": aggregates["rougeLsum"]}
+            scores=scores,
+            aggregate_results={
+                "mean": np.mean(scores),
+                "variance": np.var(scores),
+                "p90": np.percentile(scores, 90),
+            },
         )

--- a/tests/metrics/test_metric_definitions.py
+++ b/tests/metrics/test_metric_definitions.py
@@ -56,7 +56,10 @@ def test_toxicity():
     result = toxicity.eval_fn(eval_df, metrics={})
     assert not _is_toxic(result.scores[0])
     assert _is_toxic(result.scores[1])
-    assert "ratio" in result.aggregate_results
+    assert result.aggregate_results["ratio"] == 0.5
+    assert result.aggregate_results["mean"] == (result.scores[0] + result.scores[1]) / 2
+    assert result.scores[0] < result.aggregate_results["p90"] < result.scores[1]
+    assert "variance" in result.aggregate_results
 
 
 def test_perplexity():
@@ -64,7 +67,9 @@ def test_perplexity():
     result = perplexity.eval_fn(eval_df, metrics={})
     # A properly structured sentence should have lower perplexity
     assert result.scores[0] > result.scores[1]
-    assert "mean" in result.aggregate_results
+    assert result.aggregate_results["mean"] == (result.scores[0] + result.scores[1]) / 2
+    assert result.scores[0] > result.aggregate_results["p90"] > result.scores[1]
+    assert "variance" in result.aggregate_results
 
 
 def test_flesch_kincaid_grade_level():
@@ -81,7 +86,9 @@ def test_flesch_kincaid_grade_level():
     )
     result = flesch_kincaid_grade_level.eval_fn(eval_df, metrics={})
     assert result.scores[0] < result.scores[1]
-    assert "mean" in result.aggregate_results
+    assert result.aggregate_results["mean"] == (result.scores[0] + result.scores[1]) / 2
+    assert result.scores[0] < result.aggregate_results["p90"] < result.scores[1]
+    assert "variance" in result.aggregate_results
 
 
 def test_ari_grade_level():
@@ -98,7 +105,9 @@ def test_ari_grade_level():
     )
     result = ari_grade_level.eval_fn(eval_df, metrics={})
     assert result.scores[0] < result.scores[1]
-    assert "mean" in result.aggregate_results
+    assert result.aggregate_results["mean"] == (result.scores[0] + result.scores[1]) / 2
+    assert result.scores[0] < result.aggregate_results["p90"] < result.scores[1]
+    assert "variance" in result.aggregate_results
 
 
 def test_accuracy():
@@ -127,6 +136,8 @@ def test_rouge1():
     assert result.scores[0] == 0.0
     assert result.scores[1] == 0.5
     assert result.aggregate_results["mean"] == 0.25
+    assert result.aggregate_results["p90"] == 0.45
+    assert result.aggregate_results["variance"] == 0.0625
 
 
 def test_rouge2():
@@ -135,6 +146,8 @@ def test_rouge2():
     assert result.scores[0] == 1.0
     assert result.scores[1] == 0.5
     assert result.aggregate_results["mean"] == 0.75
+    assert result.aggregate_results["p90"] == 0.95
+    assert result.aggregate_results["variance"] == 0.0625
 
 
 def test_rougeL():
@@ -143,6 +156,8 @@ def test_rougeL():
     assert result.scores[0] == 0.0
     assert result.scores[1] == 1.0
     assert result.aggregate_results["mean"] == 0.5
+    assert result.aggregate_results["p90"] == 0.9
+    assert result.aggregate_results["variance"] == 0.25
 
 
 def test_rougeLsum():
@@ -151,6 +166,8 @@ def test_rougeLsum():
     assert result.scores[0] == 0.0
     assert result.scores[1] == 1.0
     assert result.aggregate_results["mean"] == 0.5
+    assert result.aggregate_results["p90"] == 0.9
+    assert result.aggregate_results["variance"] == 0.25
 
 
 def test_fails_to_load_metric():


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

- mean, p90, variance for perplexity, toxicity, reading level metrics, and rouge

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
