### PR TITLE
Reduce disk usage to avoid CI runner available disk space issues

### DIFF
--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -804,7 +804,6 @@ def test_change_conda_env_root_location(tmp_path, sk_model):
 
     # Test with model2_path
     model2_path = tmp_path / "model2"
-    mlflow.sklearn.save_model(sk_model, str(model2_path), pip_requirements=["scikit-learn==1.0.2"])
     _test_model(env_root1_path, model2_path, "1.0.2")
 
 

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -763,6 +763,11 @@ def test_host_invalid_value():
 def test_change_conda_env_root_location(tmp_path, sk_model):
     def _test_model(env_root_path, model_path, sklearn_ver):
         env_root_path.mkdir(exist_ok=True)
+
+        mlflow.sklearn.save_model(
+            sk_model, str(model_path), pip_requirements=[f"scikit-learn=={sklearn_ver}"]
+        )
+
         env = get_flavor_backend(
             str(model_path),
             env_manager=_EnvManager.CONDA,
@@ -793,7 +798,7 @@ def test_change_conda_env_root_location(tmp_path, sk_model):
 
     # Test with model1_path
     model1_path = tmp_path / "model1"
-    mlflow.sklearn.save_model(sk_model, str(model1_path), pip_requirements=["scikit-learn==1.0.1"])
+
     _test_model(env_root1_path, model1_path, "1.0.1")
     _test_model(env_root2_path, model1_path, "1.0.1")
 
@@ -801,9 +806,6 @@ def test_change_conda_env_root_location(tmp_path, sk_model):
     model2_path = tmp_path / "model2"
     mlflow.sklearn.save_model(sk_model, str(model2_path), pip_requirements=["scikit-learn==1.0.2"])
     _test_model(env_root1_path, model2_path, "1.0.2")
-
-    # Ensure only the expected paths remain
-    assert len(list(tmp_path.iterdir())) == 2  # Only the two env_root directories should remain
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -762,6 +762,7 @@ def test_host_invalid_value():
 
 def test_change_conda_env_root_location(tmp_path, sk_model):
     def _test_model(env_root_path, model_path, sklearn_ver):
+        env_root_path.mkdir(exist_ok=True)
         env = get_flavor_backend(
             str(model_path),
             env_manager=_EnvManager.CONDA,
@@ -788,10 +789,7 @@ def test_change_conda_env_root_location(tmp_path, sk_model):
         shutil.rmtree(env_path)
 
     env_root1_path = tmp_path / "root1"
-    env_root1_path.mkdir()
-
     env_root2_path = tmp_path / "root2"
-    env_root2_path.mkdir()
 
     # Test with model1_path
     model1_path = tmp_path / "model1"


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Refactor the test to limit the amount of files on disk during the test to avoid recent no space left on device CI failures

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
