### PR TITLE
Update mlflow server handlers.py to set tracking/registry uri after calculating them

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -89,7 +89,9 @@ from mlflow.protos.service_pb2 import (
 )
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.db.db_types import DATABASE_ENGINES
+from mlflow.tracking._model_registry import utils as registry_utils
 from mlflow.tracking._model_registry.registry import ModelRegistryStoreRegistry
+from mlflow.tracking._tracking_service import utils
 from mlflow.tracking._tracking_service.registry import TrackingStoreRegistry
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.utils.file_utils import local_file_uri_to_path
@@ -266,6 +268,7 @@ def _get_tracking_store(backend_store_uri=None, default_artifact_root=None):
         store_uri = backend_store_uri or os.environ.get(BACKEND_STORE_URI_ENV_VAR, None)
         artifact_root = default_artifact_root or os.environ.get(ARTIFACT_ROOT_ENV_VAR, None)
         _tracking_store = _tracking_store_registry.get_store(store_uri, artifact_root)
+        utils.set_tracking_uri(store_uri)
     return _tracking_store
 
 
@@ -280,6 +283,7 @@ def _get_model_registry_store(registry_store_uri=None):
             or os.environ.get(BACKEND_STORE_URI_ENV_VAR, None)
         )
         _model_registry_store = _model_registry_store_registry.get_store(store_uri)
+        registry_utils.set_registry_uri(store_uri)
     return _model_registry_store
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,8 +112,8 @@ def test_tracking_uri_validation_sql_driver_uris(command):
         assert result.exit_code == 0
         run_server_mock.assert_called()
     # Clean up the global variables set by the server
-    mlflow.tracking._tracking_service.utils.set_tracking_uri(None)
-    mlflow.tracking._model_registry.utils.set_registry_uri(None)
+    mlflow.set_tracking_uri(None)
+    mlflow.set_registry_uri(None)
 
 
 @pytest.mark.parametrize("command", [server])
@@ -148,8 +148,8 @@ def test_registry_store_uri_different_from_tracking_store(command):
         tracking_store.assert_called()
         registry_store.assert_called()
     # Clean up the global variables set by the server
-    mlflow.tracking._tracking_service.utils.set_tracking_uri(None)
-    mlflow.tracking._model_registry.utils.set_registry_uri(None)
+    mlflow.set_tracking_uri(None)
+    mlflow.set_registry_uri(None)
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,6 +111,9 @@ def test_tracking_uri_validation_sql_driver_uris(command):
         )
         assert result.exit_code == 0
         run_server_mock.assert_called()
+    # Clean up the global variables set by the server
+    mlflow.tracking._tracking_service.utils.set_tracking_uri(None)
+    mlflow.tracking._model_registry.utils.set_registry_uri(None)
 
 
 @pytest.mark.parametrize("command", [server])
@@ -144,6 +147,9 @@ def test_registry_store_uri_different_from_tracking_store(command):
         run_server_mock.assert_called()
         tracking_store.assert_called()
         registry_store.assert_called()
+    # Clean up the global variables set by the server
+    mlflow.tracking._tracking_service.utils.set_tracking_uri(None)
+    mlflow.tracking._model_registry.utils.set_registry_uri(None)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #9531 #9495 

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
