### PR TITLE
[LLM eval] Updating code to use openai/gateway rather than pyfunc for judge predictions

### DIFF
--- a/tests/metrics/utils/test_make_genai_metric.py
+++ b/tests/metrics/utils/test_make_genai_metric.py
@@ -1,35 +1,27 @@
 import re
+from unittest import mock
 
 import pandas as pd
 import pytest
 
-import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.metrics.base import EvaluationExample
+from mlflow.metrics.utils import model_utils
 from mlflow.metrics.utils.make_genai_metric import _format_variable_string, make_genai_metric
 
-
 # Create a custom mock class for MyModel
-class FakeModel(mlflow.pyfunc.PythonModel):
-    def predict(self, context, model_input, params=None):
-        return pd.DataFrame(
-            {
-                "Score": [3],
-                "Justification": [
-                    "The definition effectively explains what MLflow is "
-                    "its purpose, and its developer. It could be more concise for a 5-score."
-                ],
-            }
-        )
+predict_return_value = pd.DataFrame(
+    {
+        "Score": [3],
+        "Justification": [
+            "The definition effectively explains what MLflow is "
+            "its purpose, and its developer. It could be more concise for a 5-score."
+        ],
+    }
+)
 
 
-def test_make_genai_metric_pyfunc_success():
-    with mlflow.start_run():
-        llm_model_info = mlflow.pyfunc.log_model(
-            "model",
-            python_model=FakeModel(),
-        )
-
+def test_make_genai_metric_success():
     example = EvaluationExample(
         input="What is MLflow?",
         output="MLflow is an open-source platform for managing machine "
@@ -65,7 +57,7 @@ def test_make_genai_metric_pyfunc_success():
         "critical aspect. "
         "- Score 4: the answer correctly answer the question and not missing any major aspect",
         examples=[example],
-        model=llm_model_info.model_uri,
+        model="gateway:/gpt-3.5-turbo",
         variables=["ground_truth"],
         parameters={"temperature": 1.0},
         greater_is_better=True,
@@ -90,20 +82,77 @@ def test_make_genai_metric_pyfunc_success():
         }
     )
 
-    metric_value = custom_metric.eval_fn(eval_df)
+    with mock.patch.object(
+        model_utils,
+        "score_model_on_payload",
+        return_value=predict_return_value,
+    ):
+        metric_value = custom_metric.eval_fn(eval_df)
 
     assert metric_value.scores == [3]
-    assert metric_value.justifications == [
-        "The definition effectively "
-        "explains what MLflow is its purpose, and its developer. It could be "
-        "more concise for a 5-score."
-    ]
+    assert metric_value.justifications == predict_return_value["Justification"].tolist()
 
     assert metric_value.aggregate_results == {
         "mean": 3,
         "variance": 0,
         "p90": 3,
     }
+
+    custom_metric = make_genai_metric(
+        name="fake_metric",
+        version="v1",
+        definition="Fake metric definition",
+        grading_prompt="Fake metric grading prompt",
+        examples=[
+            EvaluationExample(
+                input="example-input",
+                output="example-output",
+                score=4,
+                justification="example-justification",
+                variables={"ground_truth": "example-ground_truth"},
+            )
+        ],
+        model="openai:/gpt-3.5-turbo",
+        variables=["ground_truth"],
+        greater_is_better=True,
+        aggregations=["mean", "variance", "p90"],
+    )
+    eval_df = pd.DataFrame(
+        {
+            "input": ["input"],
+            "prediction": ["prediction"],
+            "ground_truth": ["ground_truth"],
+        }
+    )
+    with mock.patch.object(
+        model_utils,
+        "score_model_on_payload",
+        return_value=predict_return_value,
+    ) as mock_predict_function:
+        metric_value = custom_metric.eval_fn(eval_df)
+        assert mock_predict_function.call_count == 1
+        assert mock_predict_function.call_args[0][0] == "openai:/gpt-3.5-turbo"
+        assert mock_predict_function.call_args[0][1] == [
+            {
+                "prompt": "\nPlease act as an impartial judge and evaluate the quality of "
+                "the provided output which\nattempts to produce output for the provided input "
+                "based on a provided information.\nYou'll be given a grading format below which "
+                "you'll call for each provided information,\ninput and provided output to submit "
+                "your justification and score to compute the fake_metric of\nthe output."
+                "\n\nInput:\ninput\n\nProvided output:\nprediction\n\nProvided ground_truth: "
+                "ground_truth\n\nMetric definition:\nFake metric definition\n\nGrading criteria:"
+                "\nFake metric grading prompt\n\nExamples:\n\nInput: example-input\nProvided "
+                "output: example-output\nProvided ground_truth: example-ground_truth\nScore: "
+                "4\nJustification: example-justification\n\n        \n\nAnd you'll need to submit "
+                "your grading for the fake_metric of the output,\nusing the following in json "
+                "format:\nScore: [your score number between 0 to 4 for the fake_metric of the "
+                "output]\nJustification: [your step by step reasoning about the fake_metric of the "
+                "output]\n    ",
+                "temperature": 0.0,
+                "max_tokens": 100,
+                "top_p": 1.0,
+            }
+        ]
 
 
 def test_make_genai_metric_failure():
@@ -166,28 +215,28 @@ def test_make_genai_metric_failure():
     ):
         custom_metric2.eval_fn(eval_df)
 
-    with mlflow.start_run():
-        llm_model_info = mlflow.pyfunc.log_model(
-            "model",
-            python_model=FakeModel(),
-        )
-    custom_metric3 = make_genai_metric(
-        name="correctness",
-        version="v1",
-        definition="definition",
-        grading_prompt="grading_prompt",
-        examples=[example],
-        model=llm_model_info.model_uri,
-        variables=["ground_truth"],
-        parameters={"temperature": 1.0},
-        greater_is_better=True,
-        aggregations=["random-fake"],
-    )
-    with pytest.raises(
-        MlflowException,
-        match=re.escape("Invalid aggregate option random-fake"),
+    with mock.patch.object(
+        model_utils,
+        "score_model_on_payload",
+        return_value=predict_return_value,
     ):
-        custom_metric3.eval_fn(eval_df)
+        custom_metric3 = make_genai_metric(
+            name="correctness",
+            version="v1",
+            definition="definition",
+            grading_prompt="grading_prompt",
+            examples=[example],
+            model="openai:/gpt-3.5-turbo",
+            variables=["ground_truth"],
+            parameters={"temperature": 1.0},
+            greater_is_better=True,
+            aggregations=["random-fake"],
+        )
+        with pytest.raises(
+            MlflowException,
+            match=re.escape("Invalid aggregate option random-fake"),
+        ):
+            custom_metric3.eval_fn(eval_df)
 
 
 def test_format_variable_string():


### PR DESCRIPTION
## What changes are proposed in this pull request?
[LLM eval] Updating code to use openai/gateway rather than pyfunc for judge predictions

## How is this patch tested?
- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
