### PR TITLE
Fix `pytest.raises` match in `tests/pytorch/test_pytorch_model_export.py`

### DIFF
--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -971,7 +971,9 @@ def test_requirements_file_save_model(create_requirements_file, sequential_model
 
 @pytest.mark.parametrize("scripted_model", [True, False])
 def test_log_model_invalid_requirement_file_path(sequential_model):
-    with mlflow.start_run(), pytest.raises(MlflowException, match="FileNotFoundError"):
+    with mlflow.start_run(), pytest.raises(
+        MlflowException, match="No such file or directory: 'non_existing_file.txt'"
+    ):
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",
@@ -1062,7 +1064,9 @@ def test_extra_files_save_model(create_extra_files, sequential_model):
 
 @pytest.mark.parametrize("scripted_model", [True, False])
 def test_log_model_invalid_extra_file_path(sequential_model):
-    with mlflow.start_run(), pytest.raises(MlflowException, match="FileNotFoundError"):
+    with mlflow.start_run(), pytest.raises(
+        MlflowException, match="No such file or directory: 'non_existing_file.txt'"
+    ):
         mlflow.pytorch.log_model(
             pytorch_model=sequential_model,
             artifact_path="models",


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #9546

## What changes are proposed in this pull request?

Fix `pytest.raises` match in `tests/pytorch/test_pytorch_model_export.py`. #9546 changed the error message format.

https://github.com/mlflow-automation/mlflow/actions/runs/6137396682/job/16655357444#step:13:1338

```
    @pytest.mark.parametrize("scripted_model", [True, False])
    def test_log_model_invalid_extra_file_path(sequential_model):
        with mlflow.start_run(), pytest.raises(MlflowException, match="FileNotFoundError"):
>           mlflow.pytorch.log_model(
                pytorch_model=sequential_model,
                artifact_path="models",
                extra_files=["non_existing_file.txt"],
            )
E           AssertionError: Regex pattern did not match.
E            Regex: 'FileNotFoundError'
E            Input: "The following failures occurred while downloading one or more artifacts from :\n##### File non_existing_file.txt #####\n[Errno 2] No such file or directory: 'non_existing_file.txt'"

```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
