### PR TITLE
Fix flakiness in `kill_child_processes`

### DIFF
--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -45,7 +45,10 @@ def kill_child_processes(parent_pid):
     """
     parent = psutil.Process(parent_pid)
     for child in parent.children(recursive=True):
-        child.terminate()
+        try:
+            child.terminate()
+        except psutil.NoSuchProcess:
+            pass
     _, still_alive = psutil.wait_procs(parent.children(), timeout=3)
     for p in still_alive:
         p.kill()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix flakiness in `kill_child_processes`.

https://github.com/mlflow/mlflow/actions/runs/6127172607/job/16632531816#step:6:284

```
________________ ERROR at teardown of test_fluent_search_routes ________________

basic_config_dict = {'routes': [{'model': {'config': {'openai_api_base': 'https://api.openai.com/v1', 'openai_api_key': 'mykey', 'openai_a...enai_api_key': 'mykey'}, 'name': 'gpt-3.5-turbo', 'provider': 'openai'}, 'name': 'chat', 'route_type': 'llm/v1/chat'}]}
tmp_path = PosixPath('/tmp/pytest-of-runner/pytest-0/test_fluent_search_routes0')

    @pytest.fixture
    def gateway(basic_config_dict, tmp_path):
        conf = tmp_path / "config.yaml"
        save_yaml(conf, basic_config_dict)
        with Gateway(conf) as g:
>           yield g

basic_config_dict = {'routes': [{'model': {'config': {'openai_api_base': 'https://api.openai.com/v1',
                                  'openai_api_key': 'mykey',
                                  'openai_api_type': 'openai',
                                  'openai_api_version': '2023-05-10'},
                       'name': 'text-davinci-003',
                       'provider': 'openai'},
             'name': 'completions',
             'route_type': 'llm/v1/completions'},
            {'model': {'config': {'openai_api_key': 'mykey'},
                       'name': 'gpt-3.5-turbo',
                       'provider': 'openai'},
             'name': 'chat',
             'route_type': 'llm/v1/chat'}]}
conf       = PosixPath('/tmp/pytest-of-runner/pytest-0/test_fluent_search_routes0/config.yaml')
g          = <tests.gateway.tools.Gateway object at 0x7f404d0557f0>
tmp_path   = PosixPath('/tmp/pytest-of-runner/pytest-0/test_fluent_search_routes0')

tests/gateway/test_fluent.py:66: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/gateway/tools.py:87: in __exit__
    kill_child_processes(self.process.pid)
        exc_tb     = None
        exc_type   = None
        exc_val    = None
        self       = <tests.gateway.tools.Gateway object at 0x7f404d0557f0>
mlflow/gateway/utils.py:48: in kill_child_processes
    child.terminate()
        child      = psutil.Process(pid=2592, status='terminated', started='02:41:16')
        parent     = psutil.Process(pid=2584, name='python', status='sleeping', started='02:41:14')
        parent_pid = 2584
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = psutil.Process(pid=2592, status='terminated', started='02:41:16')
args = (), kwargs = {}, msg = None

    @functools.wraps(fun)
    def wrapper(self, *args, **kwargs):
        if not self.is_running():
            if self._pid_reused:
                msg = "process no longer exists and its PID has been reused"
            else:
                msg = None
>           raise NoSuchProcess(self.pid, self._name, msg=msg)
E           psutil.NoSuchProcess: process no longer exists (pid=2592)

args       = ()
fun        = <function Process.terminate at 0x7f4071360700>
kwargs     = {}
msg        = None
self       = psutil.Process(pid=2592, status='terminated', started='02:41:16')

/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/psutil/__init__.py:277: NoSuchProcess
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
