### PR TITLE
Retry `_is_available_on_pypi`

### DIFF
--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -475,7 +475,6 @@ def _is_available_on_pypi(package, version=None, module=None):
     from mlflow.utils.requirements_utils import _get_installed_version
 
     url = f"https://pypi.python.org/pypi/{package}/json"
-
     for sec in range(3):
         try:
             time.sleep(sec)

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -474,9 +474,22 @@ def _is_available_on_pypi(package, version=None, module=None):
     """
     from mlflow.utils.requirements_utils import _get_installed_version
 
-    resp = requests.get(f"https://pypi.python.org/pypi/{package}/json")
-    if not resp.ok:
-        return False
+    url = f"https://pypi.python.org/pypi/{package}/json"
+
+    for sec in range(3):
+        try:
+            time.sleep(sec)
+            resp = requests.get(url)
+        except requests.exceptions.ConnectionError:
+            continue
+
+        if resp.status_code == 404:
+            return False
+
+        if resp.status_code == 200:
+            break
+    else:
+        raise Exception(f"Failed to connect to {url}")
 
     version = version or _get_installed_version(module or package)
     dist_files = resp.json()["releases"].get(version)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #9454

## What changes are proposed in this pull request?

To mitigate https://github.com/mlflow/mlflow/actions/runs/6150802779/job/16689816522?pr=9454:

```
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/requests/adapters.py:519: in send
    raise ConnectionError(e, request=request)
E   requests.exceptions.ConnectionError: HTTPSConnectionPool(host='pypi.python.org', port=443): Max retries exceeded with url: /pypi/tensorflow/json (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f8f6e34ea60>: Failed to establish a new connection: [Errno 101] Network is unreachable'))
        cert       = None
        chunked    = False
        conn       = <urllib3.connectionpool.HTTPSConnectionPool object at 0x7f8f6e20bc40>
        proxies    = OrderedDict()
        request    = <PreparedRequest [GET]>
        self       = <requests.adapters.HTTPAdapter object at 0x7f8f6e20b9d0>
        stream     = False
        timeout    = Timeout(connect=None, read=None, total=None)
        url        = '/pypi/tensorflow/json'
        verify     = True
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
