### PR TITLE
Calculate latency in mlflow.evaluate()

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1150,10 +1150,13 @@ class DefaultEvaluator(ModelEvaluator):
                 self.y_pred = np.concatenate(y_pred_list, axis=0)
             elif isinstance(sample_pred, list):
                 self.y_pred = sum(y_pred_list, [])
+            # handle if sample_pred is a pandas series
+            elif isinstance(sample_pred, pd.Series):
+                self.y_pred = pd.concat(y_pred_list)
             else:
                 raise MlflowException(
                     message=f"Unsupported prediction type {type(sample_pred)} for model type "
-                    f"{self.model_type.value}.",
+                    f"{self.model_type}.",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -7,6 +7,7 @@ import pathlib
 import pickle
 import shutil
 import tempfile
+import time
 from collections import namedtuple
 from functools import partial
 from typing import Callable, NamedTuple
@@ -1123,8 +1124,6 @@ class DefaultEvaluator(ModelEvaluator):
             _ModelType.TEXT_SUMMARIZATION,
             _ModelType.TEXT,
         ):
-            import time
-
             y_pred_list = []
             pred_latencies = []
             X_copy = self.X.copy_to_avoid_mutation()

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2258,13 +2258,13 @@ def test_evaluate_text_summarization_fails_to_load_evaluate_metrics():
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
-    assert logged_data.columns.tolist() == [
+    assert set(logged_data.columns.tolist()) == {
         "text",
         "summary",
         "outputs",
         "flesch_kincaid_grade_level",
         "ari_grade_level",
-    ]
+    }
     assert logged_data["text"].tolist() == ["a", "b"]
     assert logged_data["summary"].tolist() == ["a", "b"]
     assert logged_data["outputs"].tolist() == ["a", "b"]
@@ -2286,7 +2286,7 @@ def test_evaluate_text_and_text_metrics():
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
-    assert logged_data.columns.tolist() == [
+    assert set(logged_data.columns.tolist()) == {
         "text",
         "outputs",
         "toxicity",
@@ -2294,7 +2294,7 @@ def test_evaluate_text_and_text_metrics():
         "ari_grade_level",
         "perplexity",
         "latency",
-    ]
+    }
     assert logged_data["text"].tolist() == ["sentence not", "All women are bad."]
     assert logged_data["outputs"].tolist() == ["sentence not", "All women are bad."]
     # Hateful sentiments should be marked as toxic
@@ -2336,7 +2336,7 @@ def test_evaluate_text_custom_metrics():
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
-    assert logged_data.columns.tolist() == [
+    assert set(logged_data.columns.tolist()) == {
         "text",
         "target",
         "outputs",
@@ -2344,7 +2344,7 @@ def test_evaluate_text_custom_metrics():
         "flesch_kincaid_grade_level",
         "ari_grade_level",
         "perplexity",
-    ]
+    }
     assert logged_data["text"].tolist() == ["a", "b"]
     assert logged_data["target"].tolist() == ["a", "b"]
     assert logged_data["outputs"].tolist() == ["a", "b"]

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2070,7 +2070,7 @@ def test_evaluate_question_answering_with_numerical_targets():
     artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
-    pd.testing.assert_frame_equal(logged_data, data.assign(outputs=[0, 1]))
+    pd.testing.assert_frame_equal(logged_data.drop("latency", axis=1), data.assign(outputs=[0, 1]))
     assert results.metrics == {"exact_match": 1.0}
 
 
@@ -2264,6 +2264,7 @@ def test_evaluate_text_summarization_fails_to_load_evaluate_metrics():
         "outputs",
         "flesch_kincaid_grade_level",
         "ari_grade_level",
+        "latency",
     }
     assert logged_data["text"].tolist() == ["a", "b"]
     assert logged_data["summary"].tolist() == ["a", "b"]
@@ -2344,6 +2345,7 @@ def test_evaluate_text_custom_metrics():
         "flesch_kincaid_grade_level",
         "ari_grade_level",
         "perplexity",
+        "latency",
     }
     assert logged_data["text"].tolist() == ["a", "b"]
     assert logged_data["target"].tolist() == ["a", "b"]

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1995,6 +1995,7 @@ def validate_question_answering_logged_data(logged_data, with_targets=True):
         "flesch_kincaid_grade_level",
         "ari_grade_level",
         "perplexity",
+        "latency",
     }
     if with_targets:
         columns.update({"answer"})
@@ -2008,6 +2009,7 @@ def validate_question_answering_logged_data(logged_data, with_targets=True):
     assert logged_data["perplexity"][0] > logged_data["perplexity"][1]
     assert all(isinstance(grade, float) for grade in logged_data["flesch_kincaid_grade_level"])
     assert all(isinstance(grade, float) for grade in logged_data["ari_grade_level"])
+    assert all(isinstance(grade, float) for grade in logged_data["latency"])
 
     if with_targets:
         assert logged_data["answer"].tolist() == ["words random", "This is a sentence."]
@@ -2106,6 +2108,7 @@ def validate_text_summarization_logged_data(logged_data, with_targets=True):
         "flesch_kincaid_grade_level",
         "ari_grade_level",
         "perplexity",
+        "latency",
     }
     if with_targets:
         columns.update({"summary", "rouge1", "rouge2", "rougeL", "rougeLsum"})
@@ -2118,6 +2121,7 @@ def validate_text_summarization_logged_data(logged_data, with_targets=True):
     assert logged_data["toxicity"][1] < 0.5
     assert all(isinstance(grade, float) for grade in logged_data["flesch_kincaid_grade_level"])
     assert all(isinstance(grade, float) for grade in logged_data["ari_grade_level"])
+    assert all(isinstance(grade, float) for grade in logged_data["latency"])
 
     if with_targets:
         assert logged_data["summary"].tolist() == ["a", "b"]
@@ -2289,6 +2293,7 @@ def test_evaluate_text_and_text_metrics():
         "flesch_kincaid_grade_level",
         "ari_grade_level",
         "perplexity",
+        "latency",
     ]
     assert logged_data["text"].tolist() == ["sentence not", "All women are bad."]
     assert logged_data["outputs"].tolist() == ["sentence not", "All women are bad."]


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Calculate latency when `mlflow.evaluate()` is called, and store results in eval results table.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
