### PR TITLE
Replace `sparkm` with `mlflow.spark` to avoid confusion

### DIFF
--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -22,7 +22,6 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.tracking
 import mlflow.utils.file_utils
 from mlflow import pyfunc
-from mlflow import spark as sparkm
 from mlflow.entities.model_registry import ModelVersion
 from mlflow.environment_variables import MLFLOW_DFS_TMP
 from mlflow.models import Model, ModelSignature
@@ -236,9 +235,9 @@ def test_hadoop_filesystem(tmp_path):
 
 
 def test_model_export(spark_model_iris, model_path, spark_custom_env):
-    sparkm.save_model(spark_model_iris.model, path=model_path, conda_env=spark_custom_env)
+    mlflow.spark.save_model(spark_model_iris.model, path=model_path, conda_env=spark_custom_env)
     # 1. score and compare reloaded sparkml model
-    reloaded_model = sparkm.load_model(model_uri=model_path)
+    reloaded_model = mlflow.spark.load_model(model_uri=model_path)
     preds_df = reloaded_model.transform(spark_model_iris.spark_df)
     preds1 = [x.prediction for x in preds_df.select("prediction").collect()]
     assert spark_model_iris.predictions == preds1
@@ -259,7 +258,7 @@ def test_model_export_with_signature_and_examples(spark_model_iris, iris_signatu
         for example in (None, example_):
             with TempDir() as tmp:
                 path = tmp.path("model")
-                sparkm.save_model(
+                mlflow.spark.save_model(
                     spark_model_iris.model, path=path, signature=signature, input_example=example
                 )
                 mlflow_model = Model.load(path)
@@ -280,7 +279,7 @@ def test_log_model_with_signature_and_examples(spark_model_iris, iris_signature)
     for signature in (None, iris_signature):
         for example in (None, example_):
             with mlflow.start_run():
-                sparkm.log_model(
+                mlflow.spark.log_model(
                     spark_model_iris.model,
                     artifact_path=artifact_path,
                     signature=signature,
@@ -300,9 +299,11 @@ def test_log_model_with_signature_and_examples(spark_model_iris, iris_signature)
 
 
 def test_estimator_model_export(spark_model_estimator, model_path, spark_custom_env):
-    sparkm.save_model(spark_model_estimator.model, path=model_path, conda_env=spark_custom_env)
+    mlflow.spark.save_model(
+        spark_model_estimator.model, path=model_path, conda_env=spark_custom_env
+    )
     # score and compare the reloaded sparkml model
-    reloaded_model = sparkm.load_model(model_uri=model_path)
+    reloaded_model = mlflow.spark.load_model(model_uri=model_path)
     preds_df = reloaded_model.transform(spark_model_estimator.spark_df)
     preds = [x.prediction for x in preds_df.select("prediction").collect()]
     assert spark_model_estimator.predictions == preds
@@ -313,9 +314,11 @@ def test_estimator_model_export(spark_model_estimator, model_path, spark_custom_
 
 
 def test_transformer_model_export(spark_model_transformer, model_path, spark_custom_env):
-    sparkm.save_model(spark_model_transformer.model, path=model_path, conda_env=spark_custom_env)
+    mlflow.spark.save_model(
+        spark_model_transformer.model, path=model_path, conda_env=spark_custom_env
+    )
     # score and compare the reloaded sparkml model
-    reloaded_model = sparkm.load_model(model_uri=model_path)
+    reloaded_model = mlflow.spark.load_model(model_uri=model_path)
     preds_df = reloaded_model.transform(spark_model_transformer.spark_df)
     preds = [x.features for x in preds_df.select("features").collect()]
     assert spark_model_transformer.predictions == preds
@@ -326,7 +329,7 @@ def test_transformer_model_export(spark_model_transformer, model_path, spark_cus
 
 
 def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
-    sparkm.save_model(
+    mlflow.spark.save_model(
         spark_model_iris.model,
         path=model_path,
         conda_env=spark_custom_env,
@@ -353,7 +356,7 @@ def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
     reason="The dev version of pyspark built from the source doesn't exist on PyPI or Anaconda",
 )
 def test_sagemaker_docker_model_scoring_with_default_conda_env(spark_model_iris, model_path):
-    sparkm.save_model(spark_model_iris.model, path=model_path)
+    mlflow.spark.save_model(spark_model_iris.model, path=model_path)
 
     scoring_response = score_model_in_sagemaker_docker_container(
         model_uri=model_path,
@@ -383,14 +386,14 @@ def test_sparkml_model_log(tmp_path, spark_model_iris, should_start_run, use_dfs
         if should_start_run:
             mlflow.start_run()
         artifact_path = "model"
-        sparkm.log_model(
+        mlflow.spark.log_model(
             artifact_path=artifact_path,
             spark_model=spark_model_iris.model,
             dfs_tmpdir=dfs_tmpdir,
         )
         model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
 
-        reloaded_model = sparkm.load_model(model_uri=model_uri, dfs_tmpdir=dfs_tmpdir)
+        reloaded_model = mlflow.spark.load_model(model_uri=model_uri, dfs_tmpdir=dfs_tmpdir)
         preds_df = reloaded_model.transform(spark_model_iris.spark_df)
         preds = [x.prediction for x in preds_df.select("prediction").collect()]
         assert spark_model_iris.predictions == preds
@@ -422,7 +425,7 @@ def test_load_spark_model_from_models_uri(
     ), mock.patch.object(
         mlflow.tracking.MlflowClient, "get_model_version_by_alias", return_value=fake_model_version
     ) as get_model_version_by_alias_mock:
-        sparkm.save_model(
+        mlflow.spark.save_model(
             path=model_dir,
             spark_model=spark_model_estimator.model,
         )
@@ -460,14 +463,14 @@ def test_sparkml_estimator_model_log(
         if should_start_run:
             mlflow.start_run()
         artifact_path = "model"
-        sparkm.log_model(
+        mlflow.spark.log_model(
             artifact_path=artifact_path,
             spark_model=spark_model_estimator.model,
             dfs_tmpdir=dfs_tmpdir,
         )
         model_uri = f"runs:/{mlflow.active_run().info.run_id}/{artifact_path}"
 
-        reloaded_model = sparkm.load_model(model_uri=model_uri, dfs_tmpdir=dfs_tmpdir)
+        reloaded_model = mlflow.spark.load_model(model_uri=model_uri, dfs_tmpdir=dfs_tmpdir)
         preds_df = reloaded_model.transform(spark_model_estimator.spark_df)
         preds = [x.prediction for x in preds_df.select("prediction").collect()]
         assert spark_model_estimator.predictions == preds
@@ -481,7 +484,7 @@ def test_log_model_calls_register_model(tmp_path, spark_model_iris):
     dfs_tmp_dir = tmp_path.joinpath("test")
     register_model_patch = mock.patch("mlflow.tracking._model_registry.fluent._register_model")
     with mlflow.start_run(), register_model_patch:
-        sparkm.log_model(
+        mlflow.spark.log_model(
             artifact_path=artifact_path,
             spark_model=spark_model_iris.model,
             dfs_tmpdir=dfs_tmp_dir,
@@ -500,7 +503,7 @@ def test_log_model_no_registered_model_name(tmp_path, spark_model_iris):
     dfs_tmp_dir = os.path.join(tmp_path, "test")
     register_model_patch = mock.patch("mlflow.tracking._model_registry.fluent._register_model")
     with mlflow.start_run(), register_model_patch:
-        sparkm.log_model(
+        mlflow.spark.log_model(
             artifact_path=artifact_path,
             spark_model=spark_model_iris.model,
             dfs_tmpdir=dfs_tmp_dir,
@@ -509,7 +512,7 @@ def test_log_model_no_registered_model_name(tmp_path, spark_model_iris):
 
 
 def test_sparkml_model_load_from_remote_uri_succeeds(spark_model_iris, model_path, mock_s3_bucket):
-    sparkm.save_model(spark_model=spark_model_iris.model, path=model_path)
+    mlflow.spark.save_model(spark_model=spark_model_iris.model, path=model_path)
 
     artifact_root = f"s3://{mock_s3_bucket}"
     artifact_path = "model"
@@ -517,7 +520,7 @@ def test_sparkml_model_load_from_remote_uri_succeeds(spark_model_iris, model_pat
     artifact_repo.log_artifacts(model_path, artifact_path=artifact_path)
 
     model_uri = artifact_root + "/" + artifact_path
-    reloaded_model = sparkm.load_model(model_uri=model_uri)
+    reloaded_model = mlflow.spark.load_model(model_uri=model_uri)
     preds_df = reloaded_model.transform(spark_model_iris.spark_df)
     preds = [x.prediction for x in preds_df.select("prediction").collect()]
     assert spark_model_iris.predictions == preds
@@ -526,7 +529,7 @@ def test_sparkml_model_load_from_remote_uri_succeeds(spark_model_iris, model_pat
 def test_sparkml_model_save_persists_specified_conda_env_in_mlflow_model_directory(
     spark_model_iris, model_path, spark_custom_env
 ):
-    sparkm.save_model(
+    mlflow.spark.save_model(
         spark_model=spark_model_iris.model, path=model_path, conda_env=spark_custom_env
     )
 
@@ -545,7 +548,7 @@ def test_sparkml_model_save_persists_specified_conda_env_in_mlflow_model_directo
 def test_sparkml_model_save_persists_requirements_in_mlflow_model_directory(
     spark_model_iris, model_path, spark_custom_env
 ):
-    sparkm.save_model(
+    mlflow.spark.save_model(
         spark_model=spark_model_iris.model, path=model_path, conda_env=spark_custom_env
     )
 
@@ -625,7 +628,9 @@ def test_log_model_with_extra_pip_requirements(spark_model_iris, tmp_path):
 def test_sparkml_model_save_accepts_conda_env_as_dict(spark_model_iris, model_path):
     conda_env = dict(mlflow.spark.get_default_conda_env())
     conda_env["dependencies"].append("pytest")
-    sparkm.save_model(spark_model=spark_model_iris.model, path=model_path, conda_env=conda_env)
+    mlflow.spark.save_model(
+        spark_model=spark_model_iris.model, path=model_path, conda_env=conda_env
+    )
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV]["conda"])
@@ -641,7 +646,7 @@ def test_sparkml_model_log_persists_specified_conda_env_in_mlflow_model_director
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        model_info = sparkm.log_model(
+        model_info = mlflow.spark.log_model(
             spark_model=spark_model_iris.model,
             artifact_path=artifact_path,
             conda_env=spark_custom_env,
@@ -667,7 +672,7 @@ def test_sparkml_model_log_persists_requirements_in_mlflow_model_directory(
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        sparkm.log_model(
+        mlflow.spark.log_model(
             spark_model=spark_model_iris.model,
             artifact_path=artifact_path,
             conda_env=spark_custom_env,
@@ -682,8 +687,8 @@ def test_sparkml_model_log_persists_requirements_in_mlflow_model_directory(
 def test_sparkml_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     spark_model_iris, model_path
 ):
-    sparkm.save_model(spark_model=spark_model_iris.model, path=model_path)
-    _assert_pip_requirements(model_path, sparkm.get_default_pip_requirements())
+    mlflow.spark.save_model(spark_model=spark_model_iris.model, path=model_path)
+    _assert_pip_requirements(model_path, mlflow.spark.get_default_pip_requirements())
 
 
 def test_sparkml_model_log_without_specified_conda_env_uses_default_env_with_expected_dependencies(
@@ -691,10 +696,10 @@ def test_sparkml_model_log_without_specified_conda_env_uses_default_env_with_exp
 ):
     artifact_path = "model"
     with mlflow.start_run():
-        sparkm.log_model(spark_model=spark_model_iris.model, artifact_path=artifact_path)
+        mlflow.spark.log_model(spark_model=spark_model_iris.model, artifact_path=artifact_path)
         model_uri = mlflow.get_artifact_uri(artifact_path)
 
-    _assert_pip_requirements(model_uri, sparkm.get_default_pip_requirements())
+    _assert_pip_requirements(model_uri, mlflow.spark.get_default_pip_requirements())
 
 
 def test_pyspark_version_is_logged_without_dev_suffix(spark_model_iris):
@@ -703,7 +708,7 @@ def test_pyspark_version_is_logged_without_dev_suffix(spark_model_iris):
     for dev_suffix in [".dev0", ".dev", ".dev1", "dev.a", ".devb"]:
         with mock.patch("importlib_metadata.version", return_value=unsuffixed_version + dev_suffix):
             with mlflow.start_run():
-                sparkm.log_model(spark_model=spark_model_iris.model, artifact_path="model")
+                mlflow.spark.log_model(spark_model=spark_model_iris.model, artifact_path="model")
                 model_uri = mlflow.get_artifact_uri("model")
             _assert_pip_requirements(
                 model_uri, [expected_mlflow_version, f"pyspark=={unsuffixed_version}"]
@@ -711,7 +716,7 @@ def test_pyspark_version_is_logged_without_dev_suffix(spark_model_iris):
 
     for unaffected_version in ["2.0", "2.3.4", "2"]:
         with mock.patch("importlib_metadata.version", return_value=unaffected_version):
-            pip_deps = _get_pip_deps(sparkm.get_default_conda_env())
+            pip_deps = _get_pip_deps(mlflow.spark.get_default_conda_env())
             assert any(x == f"pyspark=={unaffected_version}" for x in pip_deps)
 
 
@@ -719,7 +724,7 @@ def test_model_is_recorded_when_using_direct_save(spark_model_iris):
     # Patch `is_local_uri` to enforce direct model serialization to DFS
     with mock.patch("mlflow.spark.is_local_uri", return_value=False):
         with mlflow.start_run():
-            sparkm.log_model(spark_model=spark_model_iris.model, artifact_path="model")
+            mlflow.spark.log_model(spark_model=spark_model_iris.model, artifact_path="model")
             current_tags = mlflow.get_run(mlflow.active_run().info.run_id).data.tags
             assert mlflow.utils.mlflow_tags.MLFLOW_LOGGED_MODELS in current_tags
 
@@ -834,7 +839,7 @@ def test_model_logged_via_mlflowdbfs_when_appropriate(
             if db_runtime_version:
                 monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", db_runtime_version)
             monkeypatch.setenv("DISABLE_MLFLOWDBFS", mlflowdbfs_disabled)
-            sparkm.log_model(spark_model=spark_model_iris.model, artifact_path="model")
+            mlflow.spark.log_model(spark_model=spark_model_iris.model, artifact_path="model")
             mock_save.assert_called_once_with(expected_uri.format(mlflow.active_run().info.run_id))
 
             if expected_uri.startswith("mflowdbfs"):
@@ -891,7 +896,7 @@ def test_model_logging_uses_mlflowdbfs_if_appropriate_when_hdfs_check_fails(
     ) as mock_save:
         with mlflow.start_run():
             monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "12.0")
-            sparkm.log_model(spark_model=spark_model_iris.model, artifact_path="model")
+            mlflow.spark.log_model(spark_model=spark_model_iris.model, artifact_path="model")
             run_id = mlflow.active_run().info.run_id
             mock_save.assert_called_once_with(
                 f"mlflowdbfs:///artifacts?run_id={run_id}&path=/model/sparkml"
@@ -906,12 +911,12 @@ def test_log_model_with_code_paths(spark_model_iris):
         "mlflow.spark._add_code_from_conf_to_system_path",
         wraps=_add_code_from_conf_to_system_path,
     ) as add_mock:
-        sparkm.log_model(
+        mlflow.spark.log_model(
             spark_model=spark_model_iris.model, artifact_path=artifact_path, code_paths=[__file__]
         )
         model_uri = mlflow.get_artifact_uri(artifact_path)
         _compare_logged_code_paths(__file__, model_uri, mlflow.spark.FLAVOR_NAME)
-        sparkm.load_model(model_uri)
+        mlflow.spark.load_model(model_uri)
         add_mock.assert_called()
 
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Remove `sparkm` to avoid confusion.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
