### PR TITLE
Pin xgboost in recipes tests

### DIFF
--- a/.github/workflows/recipe.yml
+++ b/.github/workflows/recipe.yml
@@ -39,7 +39,8 @@ jobs:
         run: |
           source ./dev/install-common-deps.sh
           pip install -e .
-          pip install pyspark
+          # TODO: Remove xgboost once https://github.com/microsoft/FLAML/issues/1217 is fixed
+          pip install pyspark 'xgboost<2'
       - name: Run tests
         run: |
           export MLFLOW_HOME=$(pwd)
@@ -60,7 +61,8 @@ jobs:
           pip install -r requirements/test-requirements.txt
           pip install --no-dependencies tests/resources/mlflow-test-plugin
           pip install -e .
-          pip install pyspark
+          # TODO: Remove xgboost once https://github.com/microsoft/FLAML/issues/1217 is fixed
+          pip install pyspark 'xgboost<2'
           # TODO: Importing datasets in a pandas UDF (created by mlflow.pyfunc.spark_udf) crashes
           # the Python worker. To avoid this, uninstall `datasets`. This is a temporary workaround.
           pip uninstall -y datasets


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

See https://github.com/microsoft/FLAML/issues/1217 for details. Fixes https://github.com/mlflow/mlflow/actions/runs/6156373110/job/16704908108?pr=9603:

```
Traceback (most recent call last):
  File "/home/runner/work/mlflow/mlflow/mlflow/recipes/steps/automl/flaml.py", line 170, in _create_model_automl
    automl.fit(X, y, **automl_settings)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/flaml/automl/automl.py", line 1928, in fit
    self._search()
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/flaml/automl/automl.py", line 2482, in _search
    self._search_sequential()
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/flaml/automl/automl.py", line 2318, in _search_sequential
    analysis = tune.run(
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/flaml/tune/tune.py", line 808, in run
    result = evaluation_function(trial_to_run.config)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/flaml/automl/state.py", line 302, in _compute_with_config_base
    ) = compute_estimator(
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/flaml/automl/ml.py", line 369, in compute_estimator
    val_loss, metric_for_logging, train_time, pred_time = task.evaluate_model_CV(
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/flaml/automl/task/generic_task.py", line 737, in evaluate_model_CV
    val_loss_i, metric_i, train_time_i, pred_time_i = get_val_loss(
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/flaml/automl/ml.py", line 494, in get_val_loss
    estimator.fit(X_train, y_train, budget=budget, free_mem_ratio=free_mem_ratio, **fit_kwargs)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/flaml/automl/model.py", line 1652, in fit
    return super().fit(X_train, y_train, budget, free_mem_ratio, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/flaml/automl/model.py", line 1415, in fit
    self._model.get_booster().best_iteration
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/xgboost/core.py", line 2602, in best_iteration
    raise AttributeError(
AttributeError: `best_iteration` is only defined when early stopping is used.
```

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
