### PR TITLE
Add `Timer` for quick benchmarking

### DIFF
--- a/mlflow/recipes/steps/split.py
+++ b/mlflow/recipes/steps/split.py
@@ -154,7 +154,7 @@ def _create_hash_buckets(input_df, n_jobs=-1):
         )
     _logger.debug(
         f"Creating hash buckets on input dataset containing {len(input_df)} "
-        f"rows consumes {t.time} seconds."
+        f"rows consumes {t:.3f} seconds."
     )
     return hash_buckets
 

--- a/mlflow/recipes/steps/split.py
+++ b/mlflow/recipes/steps/split.py
@@ -17,6 +17,7 @@ from mlflow.recipes.step import BaseStep, StepClass
 from mlflow.recipes.utils.execution import get_step_output_path
 from mlflow.recipes.utils.step import get_pandas_data_profiles, validate_classification_config
 from mlflow.store.artifact.artifact_repo import _NUM_DEFAULT_CPUS
+from mlflow.utils.time import Timer
 
 _logger = logging.getLogger(__name__)
 
@@ -147,14 +148,13 @@ def _create_hash_buckets(input_df, n_jobs=-1):
     # Create hash bucket used for splitting dataset
     # Note: use `hash_pandas_object` instead of python builtin hash because it is stable
     # across different process runs / different python versions
-    start_time = time.time()
-    hash_buckets = _hash_pandas_dataframe(input_df, n_jobs=n_jobs).map(
-        lambda x: (x % _SPLIT_HASH_BUCKET_NUM) / _SPLIT_HASH_BUCKET_NUM
-    )
-    execution_duration = time.time() - start_time
+    with Timer() as t:
+        hash_buckets = _hash_pandas_dataframe(input_df, n_jobs=n_jobs).map(
+            lambda x: (x % _SPLIT_HASH_BUCKET_NUM) / _SPLIT_HASH_BUCKET_NUM
+        )
     _logger.debug(
         f"Creating hash buckets on input dataset containing {len(input_df)} "
-        f"rows consumes {execution_duration} seconds."
+        f"rows consumes {t.time} seconds."
     )
     return hash_buckets
 

--- a/mlflow/utils/time.py
+++ b/mlflow/utils/time.py
@@ -31,7 +31,7 @@ class Timer:
         with Timer() as t:
             ...
 
-        print(f"Elapsed time: {t.time:.2f} seconds")
+        print(f"Elapsed time: {t:.2f} seconds")
     """
 
     def __init__(self):
@@ -43,3 +43,12 @@ class Timer:
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.time = time.perf_counter() - self.time
+
+    def __format__(self, format_spec: str) -> str:
+        return self.time.__format__(format_spec)
+
+    def __repr__(self) -> str:
+        return self.time.__repr__()
+
+    def __str__(self) -> str:
+        return self.time.__str__()

--- a/mlflow/utils/time.py
+++ b/mlflow/utils/time.py
@@ -35,20 +35,20 @@ class Timer:
     """
 
     def __init__(self):
-        self.time = 0.0
+        self.elapsed = 0.0
 
     def __enter__(self):
-        self.time = time.perf_counter()
+        self.elapsed = time.perf_counter()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.time = time.perf_counter() - self.time
+        self.elapsed = time.perf_counter() - self.elapsed
 
     def __format__(self, format_spec: str) -> str:
-        return self.time.__format__(format_spec)
+        return self.elapsed.__format__(format_spec)
 
     def __repr__(self) -> str:
-        return self.time.__repr__()
+        return self.elapsed.__repr__()
 
     def __str__(self) -> str:
-        return self.time.__str__()
+        return self.elapsed.__str__()

--- a/mlflow/utils/time.py
+++ b/mlflow/utils/time.py
@@ -35,7 +35,7 @@ class Timer:
     """
 
     def __init__(self):
-        self.time = None
+        self.time = 0.0
 
     def __enter__(self):
         self.time = time.perf_counter()

--- a/mlflow/utils/time.py
+++ b/mlflow/utils/time.py
@@ -18,3 +18,28 @@ def conv_longdate_to_str(longdate, local_tz=True):
         str_long_date += " " + reference.LocalTimezone().tzname(date_time)
 
     return str_long_date
+
+
+class Timer:
+    """
+    Measures elapsed time.
+
+    .. code-block:: python
+
+        from mlflow.utils.time import Timer
+
+        with Timer() as t:
+            ...
+
+        print(f"Elapsed time: {t.time:.2f} seconds")
+    """
+
+    def __init__(self):
+        self.time = None
+
+    def __enter__(self):
+        self.time = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.time = time.perf_counter() - self.time

--- a/tests/utils/test_time.py
+++ b/tests/utils/test_time.py
@@ -1,0 +1,8 @@
+from mlflow.utils.time import Timer
+
+
+def test_timer():
+    with Timer() as t:
+        pass
+
+    assert t.time >= 0

--- a/tests/utils/test_time.py
+++ b/tests/utils/test_time.py
@@ -8,3 +8,4 @@ def test_timer():
         time.sleep(1)
 
     assert 1.0 < t.time < 1.1
+    assert f"{t:.1f}" == "1.0"

--- a/tests/utils/test_time.py
+++ b/tests/utils/test_time.py
@@ -7,5 +7,5 @@ def test_timer():
     with Timer() as t:
         time.sleep(1)
 
-    assert 1.0 < t.time < 1.1
     assert f"{t:.1f}" == "1.0"
+    assert f"{t:.2f}" == "1.00"

--- a/tests/utils/test_time.py
+++ b/tests/utils/test_time.py
@@ -1,8 +1,10 @@
+import time
+
 from mlflow.utils.time import Timer
 
 
 def test_timer():
     with Timer() as t:
-        pass
+        time.sleep(1)
 
-    assert t.time >= 0
+    assert 1.0 < t.time < 1.1

--- a/tests/utils/test_time.py
+++ b/tests/utils/test_time.py
@@ -5,7 +5,8 @@ from mlflow.utils.time import Timer
 
 def test_timer():
     with Timer() as t:
-        time.sleep(1)
+        time.sleep(0.1)
 
-    assert f"{t:.1f}" == "1.0"
-    assert f"{t:.2f}" == "1.00"
+    assert str(t).startswith("0.1")
+    assert f"{t}" == f"{t.elapsed}"
+    assert f"{t:.3f}" == f"{t.elapsed:.3f}"


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add `Timer` for quick benchmarking.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
