### PR TITLE
Docstring/typing updates for mflow.evaluate

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from decimal import Decimal
 from types import FunctionType
-from typing import Any, Dict
+from typing import Any, Callable, Dict, List, Union
 
 import mlflow
 from mlflow.data.dataset import Dataset
@@ -975,15 +975,15 @@ def _convert_data_to_mlflow_dataset(data, targets=None):
 
 def _evaluate(
     *,
-    model,
-    model_type,
-    dataset,
-    run_id,
-    evaluator_name_list,
-    evaluator_name_to_conf_map,
-    custom_metrics,
-    custom_artifacts,
-    baseline_model,
+    model: Union["mlflow.pyfunc.PyFuncModel", "mlflow.pyfunc._ServedPyFuncModel"],
+    model_type: str,
+    dataset: EvaluationDataset,
+    run_id: str,
+    evaluator_name_list: List[str],
+    evaluator_name_to_conf_map: Dict[str, Any],
+    custom_metrics: List[EvaluationMetric],
+    custom_artifacts: List[Callable],
+    baseline_model: str,
 ):
     """
     The public API "evaluate" will verify argument first, and then pass normalized arguments
@@ -1048,20 +1048,20 @@ def _evaluate(
 
 
 def evaluate(
-    model: str,
+    model: Union[str, "mlflow.pyfunc.PyFunc"],
     data,
     *,
     model_type: str,
-    targets=None,
-    dataset_path=None,
-    feature_names: list = None,
-    evaluators=None,
-    evaluator_config=None,
-    custom_metrics=None,
-    custom_artifacts=None,
-    validation_thresholds=None,
-    baseline_model=None,
-    env_manager="local",
+    targets: Union[np.ndarray, List] = None,
+    dataset_path: str = None,
+    feature_names: List[str] = None,
+    evaluators: Union[str, List[str]] = None,
+    evaluator_config: Dict[str, Dict[str, Any]] = None,
+    custom_metrics: List[EvaluationMetric] = None,
+    custom_artifacts: List[Callable] = None,
+    validation_thresholds: Dict[str, MetricThreshold] = None,
+    baseline_model: str = None,
+    env_manager: str = "local",
 ):
     '''
     Evaluate a PyFunc model on the specified dataset using one or more specified ``evaluators``, and
@@ -1071,9 +1071,8 @@ def evaluate(
 
     Default Evaluator behavior:
      - The default evaluator, which can be invoked with ``evaluators="default"`` or
-       ``evaluators=None``, supports the ``"regressor"`` and ``"classifier"`` model types.
-       It generates a variety of model performance metrics, model performance plots, and
-       model explanations.
+       ``evaluators=None`` generates a variety of model performance metrics, model
+       performance plots, and model explanations.
 
      - For both the ``"regressor"`` and ``"classifier"`` model types, the default evaluator
        generates model summary plots and feature importance plots using
@@ -1097,7 +1096,7 @@ def evaluate(
           precision_recall_auc), precision-recall merged curves plot, ROC merged curves plot.
 
      - For question-answering models, the default evaluator logs:
-        - **metrics**: ``exact_match``, `mean_perplexity`_ (requires `evaluate`_, `pytorch`_,
+        - **metrics**: exact_match, `mean_perplexity`_ (requires `evaluate`_, `pytorch`_,
           `transformers`_), `toxicity_ratio`_ (requires `evaluate`_, `pytorch`_, `transformers`_),
           `mean_ari_grade_level`_ (requires `textstat`_), `mean_flesch_kincaid_grade_level`_
           (requires `textstat`_).

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from decimal import Decimal
 from types import FunctionType
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import mlflow
 from mlflow.data.dataset import Dataset
@@ -1052,15 +1052,15 @@ def evaluate(
     data,
     *,
     model_type: str,
-    targets: Union[np.ndarray, List] = None,
-    dataset_path: str = None,
-    feature_names: List[str] = None,
-    evaluators: Union[str, List[str]] = None,
-    evaluator_config: Dict[str, Dict[str, Any]] = None,
-    custom_metrics: List[EvaluationMetric] = None,
-    custom_artifacts: List[Callable] = None,
-    validation_thresholds: Dict[str, MetricThreshold] = None,
-    baseline_model: str = None,
+    targets: Optional[Union[np.ndarray, List]] = None,
+    dataset_path: Optional[str] = None,
+    feature_names: Optional[List[str]] = None,
+    evaluators: Optional[Union[str, List[str]]] = None,
+    evaluator_config: Optional[Dict[str, Dict[str, Any]]] = None,
+    custom_metrics: Optional[List[EvaluationMetric]] = None,
+    custom_artifacts: Optional[List[Callable]] = None,
+    validation_thresholds: Optional[Dict[str, MetricThreshold]] = None,
+    baseline_model: Optional[str] = None,
     env_manager: str = "local",
 ):
     '''


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## What changes are proposed in this pull request?

Proposes basic typing for input into `_evaluate` and `evaluate` for better readability 
Small update with the default evaluator docstring

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Small updates to user-facing mlflow.model.evaluate docstring

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
