### PR TITLE
Fix returned path parsing bug from R cli handler when loading models

### DIFF
--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -453,7 +453,7 @@ mlflow_download_artifacts <- function(path, run_id = NULL, client = NULL) {
 # ' Download Artifacts from URI.
 mlflow_download_artifacts_from_uri <- function(artifact_uri, client = mlflow_client()) {
   result <- mlflow_cli("artifacts", "download", "-u", artifact_uri, echo = FALSE, client = client)
-  trimws(strsplit(result$stdout, "\n")[[1]][-1])
+  trimws(strsplit(result$stdout, "\n"))
 }
 
 #' Log Artifact

--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -453,7 +453,20 @@ mlflow_download_artifacts <- function(path, run_id = NULL, client = NULL) {
 # ' Download Artifacts from URI.
 mlflow_download_artifacts_from_uri <- function(artifact_uri, client = mlflow_client()) {
   result <- mlflow_cli("artifacts", "download", "-u", artifact_uri, echo = FALSE, client = client)
-  trimws(strsplit(result$stdout, "\n"))
+  # NB: The return type from the artifacts download instruction from the cli can be either
+  # a path as a "string" (character vector in R with length of 1) or as a string with a newline
+  # ("\n") character separating the source runs:/ path and the local path that is the destination
+  # directory. Due to this alternate behavior based on whether the download artifact progress logic
+  # is enabled or not, this conditional logic is required.
+  paths <- strsplit(result$stdout, "\n")[[1]]
+  if (length(paths) > 1) {
+    trimws(paths[-1])
+  } else if (length(paths) == 1) {
+    trimws(paths[1])
+  } else {
+    stop("Unknown return type after newline split parsing", class(paths),
+         ". Expected character type return from cli download artifacts call.", call. = FALSE)
+  }
 }
 
 #' Log Artifact

--- a/mlflow/R/mlflow/tests/testthat.R
+++ b/mlflow/R/mlflow/tests/testthat.R
@@ -21,5 +21,5 @@ library(mlflow)
 
 if (identical(Sys.getenv("NOT_CRAN"), "true")) {
   message("Current working directory: ", getwd())
-  test_check("mlflow", reporter = "verbose")
+  test_check("mlflow", reporter = ProgressReporter)
 }

--- a/mlflow/R/mlflow/tests/testthat.R
+++ b/mlflow/R/mlflow/tests/testthat.R
@@ -21,5 +21,5 @@ library(mlflow)
 
 if (identical(Sys.getenv("NOT_CRAN"), "true")) {
   message("Current working directory: ", getwd())
-  test_check("mlflow")
+  test_check("mlflow", reporter = "verbose")
 }


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fixes a bug introduced in #9195 that prevents models from being loaded in R due to the returned path parsing logic rendering the string path as a single empty Character object instead of the string Path.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

As this bug does not seem to manifest with a local tracking server and only shows up on remote servers (such as Databricks), our CI coverage and configuration is not able to account for testing this phenomena. 
Verified this works manually by reproducing the reported bug, validating that it does not exist in versions 2.4.1 and 2.5.0 from CRAN (devtools install), validating that it happens on 2.6.0, and proceeding to evaluate:

1. manually parsing the return from 
```
my_run <- paste("runs:", run$run_id[1], "model", sep="/")

result <- mlflow_cli("artifacts", "download", "-u", my_run)
```
and validating that in 2.6.0, the return value is: `character(0)`, which is invalid. 

2. manually overriding the logic of `mlflow::mlflow_download_artifacts_from_uri` to extract the first element from the string split command, removing the overflow operator (which does not function in the same way that it does in Python). 
3. Verified that with the change, models were able to be downloaded via both a manual call to `mlflow_download_artifacts_from_uri` and `mlflow::mlflow_load_model`

## Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug introduced in MLflow 2.6.0 for R that prevented remote artifact stores from loading models.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [X] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
