### PR TITLE
Decouple torch and tf

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -1080,7 +1080,7 @@ def autolog(
         pass
     else:
         from mlflow.pytorch._pytorch_autolog import (
-            _flush_queue,
+            flush_metrics_queue,
             patched_add_event,
             patched_add_hparams,
             patched_add_summary,
@@ -1111,7 +1111,7 @@ def autolog(
             extra_tags=extra_tags,
         )
 
-        atexit.register(_flush_queue)
+        atexit.register(flush_metrics_queue)
 
 
 if autolog.__doc__ is not None:

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -3,11 +3,11 @@ from contextlib import contextmanager
 
 import mlflow
 from mlflow.entities import Metric, Param
-from mlflow.utils.autologging_utils.metrics_queue import (
-    flush_metrics_queue,
-    add_to_metrics_queue,
-)
 from mlflow.tracking import MlflowClient
+from mlflow.utils.autologging_utils.metrics_queue import (
+    add_to_metrics_queue,
+    flush_metrics_queue,
+)
 
 DISABLED = False
 

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -3,12 +3,9 @@ from contextlib import contextmanager
 
 import mlflow
 from mlflow.entities import Metric, Param
-from mlflow.tensorflow import (
-    _MAX_METRIC_QUEUE_SIZE,
-    _flush_queue,
-    _metric_queue,
-    _metric_queue_lock,
-    _thread_pool,
+from mlflow.utils.autologging_utils.metrics_queue import (
+    flush_metrics_queue,
+    add_to_metrics_queue,
 )
 from mlflow.tracking import MlflowClient
 
@@ -24,18 +21,6 @@ def disable_pytorch_autologging():
         yield
     finally:
         DISABLED = old_value
-
-
-def _add_to_queue(key, value, step, time, run_id):
-    """
-    Add a metric to the metric queue. Flush the queue if it exceeds the
-    max queue size.
-    """
-    met = Metric(key=key, value=value, timestamp=time, step=step)
-    with _metric_queue_lock:
-        _metric_queue.append((run_id, met))
-        if len(_metric_queue) > _MAX_METRIC_QUEUE_SIZE:
-            _thread_pool.submit(_flush_queue)
 
 
 def patched_add_hparams(original, self, hparam_dict, metric_dict, *args, **kwargs):
@@ -69,7 +54,7 @@ def patched_add_event(original, self, event, *args, mlflow_log_every_n_step, **k
         for v in summary.value:
             if v.HasField("simple_value"):
                 if global_step % mlflow_log_every_n_step == 0:
-                    _add_to_queue(
+                    add_to_metrics_queue(
                         key=v.tag,
                         value=v.simple_value,
                         step=global_step,
@@ -81,5 +66,5 @@ def patched_add_event(original, self, event, *args, mlflow_log_every_n_step, **k
 
 
 def patched_add_summary(original, self, *args, **kwargs):
-    _flush_queue()
+    flush_metrics_queue()
     return original(self, *args, **kwargs)

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -8,7 +8,6 @@ TensorFlow (native) format
     Produced for use by generic pyfunc-based deployment tools and batch inference.
 """
 import atexit
-import concurrent.futures
 import importlib
 import logging
 import os
@@ -17,7 +16,6 @@ import shutil
 import tempfile
 import warnings
 from collections import namedtuple
-from threading import RLock
 from typing import Any, Dict, Optional
 
 import numpy as np
@@ -30,7 +28,6 @@ from mlflow import pyfunc
 from mlflow.data.code_dataset_source import CodeDatasetSource
 from mlflow.data.numpy_dataset import from_numpy
 from mlflow.data.tensorflow_dataset import from_tensorflow
-from mlflow.entities import Metric
 from mlflow.exceptions import INVALID_PARAMETER_VALUE, MlflowException
 from mlflow.models import Model, ModelInputExample, ModelSignature, infer_signature
 from mlflow.models.model import MLMODEL_FILE_NAME
@@ -39,7 +36,6 @@ from mlflow.models.utils import _save_example
 from mlflow.tensorflow.callback import MLflowCallback  # noqa: F401
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.context import registry as context_registry
 from mlflow.types.schema import TensorSpec
 from mlflow.utils import is_iterator
@@ -54,8 +50,8 @@ from mlflow.utils.autologging_utils import (
     safe_patch,
 )
 from mlflow.utils.autologging_utils.metrics_queue import (
-    flush_metrics_queue,
     add_to_metrics_queue,
+    flush_metrics_queue,
 )
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -641,3 +641,33 @@ def get_method_call_arg_value(arg_index, arg_name, default_value, call_pos_args,
         return call_pos_args[arg_index]
     else:
         return default_value
+
+
+def flush_metrics_queue():
+    """Flush the metric queue and log contents in batches to MLflow.
+
+    Queue is divided into batches according to run id.
+    """
+    try:
+        # Multiple queue flushes may be scheduled simultaneously on different threads
+        # (e.g., if the queue is at its flush threshold and several more items
+        # are added before a flush occurs). For correctness and efficiency, only one such
+        # flush operation should proceed; all others are redundant and should be dropped
+        acquired_lock = _metric_queue_lock.acquire(blocking=False)
+        if acquired_lock:
+            client = MlflowClient()
+            # For thread safety and to avoid modifying a list while iterating over it, we record a
+            # separate list of the items being flushed and remove each one from the metric queue,
+            # rather than clearing the metric queue or reassigning it (clearing / reassigning is
+            # dangerous because we don't block threads from adding to the queue while a flush is
+            # in progress)
+            snapshot = _metric_queue[:]
+            for item in snapshot:
+                _metric_queue.remove(item)
+
+            metrics_by_run = _assoc_list_to_map(snapshot)
+            for run_id, metrics in metrics_by_run.items():
+                client.log_batch(run_id, metrics=metrics, params=[], tags=[])
+    finally:
+        if acquired_lock:
+            _metric_queue_lock.release()

--- a/mlflow/utils/autologging_utils/metrics_queue.py
+++ b/mlflow/utils/autologging_utils/metrics_queue.py
@@ -4,8 +4,8 @@ from threading import RLock
 from mlflow.entities import Metric
 from mlflow.tracking.client import MlflowClient
 
-_metric_queue_lock = RLock()
-_metric_queue = []
+_metrics_queue_lock = RLock()
+_metrics_queue = []
 _thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
 _MAX_METRIC_QUEUE_SIZE = 500
@@ -31,7 +31,7 @@ def flush_metrics_queue():
         # (e.g., if the queue is at its flush threshold and several more items
         # are added before a flush occurs). For correctness and efficiency, only one such
         # flush operation should proceed; all others are redundant and should be dropped
-        acquired_lock = _metric_queue_lock.acquire(blocking=False)
+        acquired_lock = _metrics_queue_lock.acquire(blocking=False)
         if acquired_lock:
             client = MlflowClient()
             # For thread safety and to avoid modifying a list while iterating over it, we record a
@@ -39,16 +39,16 @@ def flush_metrics_queue():
             # rather than clearing the metric queue or reassigning it (clearing / reassigning is
             # dangerous because we don't block threads from adding to the queue while a flush is
             # in progress)
-            snapshot = _metric_queue[:]
+            snapshot = _metrics_queue[:]
             for item in snapshot:
-                _metric_queue.remove(item)
+                _metrics_queue.remove(item)
 
             metrics_by_run = _assoc_list_to_map(snapshot)
             for run_id, metrics in metrics_by_run.items():
                 client.log_batch(run_id, metrics=metrics, params=[], tags=[])
     finally:
         if acquired_lock:
-            _metric_queue_lock.release()
+            _metrics_queue_lock.release()
 
 
 def add_to_metrics_queue(key, value, step, time, run_id):
@@ -64,6 +64,6 @@ def add_to_metrics_queue(key, value, step, time, run_id):
         run_id: string, the run id of the associated mlflow run.
     """
     met = Metric(key=key, value=value, timestamp=time, step=step)
-    _metric_queue.append((run_id, met))
-    if len(_metric_queue) > _MAX_METRIC_QUEUE_SIZE:
+    _metrics_queue.append((run_id, met))
+    if len(_metrics_queue) > _MAX_METRIC_QUEUE_SIZE:
         _thread_pool.submit(flush_metrics_queue)

--- a/mlflow/utils/autologging_utils/metrics_queue.py
+++ b/mlflow/utils/autologging_utils/metrics_queue.py
@@ -1,8 +1,8 @@
+import concurrent.futures
 from threading import RLock
 
-from mlflow.tracking.client import MlflowClient
 from mlflow.entities import Metric
-import concurrent.futures
+from mlflow.tracking.client import MlflowClient
 
 _metric_queue_lock = RLock()
 _metric_queue = []

--- a/mlflow/utils/autologging_utils/metrics_queue.py
+++ b/mlflow/utils/autologging_utils/metrics_queue.py
@@ -1,0 +1,69 @@
+from threading import RLock
+
+from mlflow.tracking.client import MlflowClient
+from mlflow.entities import Metric
+import concurrent.futures
+
+_metric_queue_lock = RLock()
+_metric_queue = []
+_thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+
+_MAX_METRIC_QUEUE_SIZE = 500
+
+
+def _assoc_list_to_map(lst):
+    """
+    Convert an association list to a dictionary.
+    """
+    d = {}
+    for run_id, metric in lst:
+        d[run_id] = d[run_id] + [metric] if run_id in d else [metric]
+    return d
+
+
+def flush_metrics_queue():
+    """Flush the metric queue and log contents in batches to MLflow.
+
+    Queue is divided into batches according to run id.
+    """
+    try:
+        # Multiple queue flushes may be scheduled simultaneously on different threads
+        # (e.g., if the queue is at its flush threshold and several more items
+        # are added before a flush occurs). For correctness and efficiency, only one such
+        # flush operation should proceed; all others are redundant and should be dropped
+        acquired_lock = _metric_queue_lock.acquire(blocking=False)
+        if acquired_lock:
+            client = MlflowClient()
+            # For thread safety and to avoid modifying a list while iterating over it, we record a
+            # separate list of the items being flushed and remove each one from the metric queue,
+            # rather than clearing the metric queue or reassigning it (clearing / reassigning is
+            # dangerous because we don't block threads from adding to the queue while a flush is
+            # in progress)
+            snapshot = _metric_queue[:]
+            for item in snapshot:
+                _metric_queue.remove(item)
+
+            metrics_by_run = _assoc_list_to_map(snapshot)
+            for run_id, metrics in metrics_by_run.items():
+                client.log_batch(run_id, metrics=metrics, params=[], tags=[])
+    finally:
+        if acquired_lock:
+            _metric_queue_lock.release()
+
+
+def add_to_metrics_queue(key, value, step, time, run_id):
+    """Add a metric to the metric queue.
+
+    Flush the queue if it exceeds max size.
+
+    Args:
+        key: string, the metrics key,
+        value: float, the metrics value.
+        step: int, the step of current metric.
+        time: int, the timestamp of current metric.
+        run_id: string, the run id of the associated mlflow run.
+    """
+    met = Metric(key=key, value=value, timestamp=time, step=step)
+    _metric_queue.append((run_id, met))
+    if len(_metric_queue) > _MAX_METRIC_QUEUE_SIZE:
+        _thread_pool.submit(flush_metrics_queue)

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -7,7 +7,6 @@ import os
 import pickle
 import sys
 from pathlib import Path
-from threading import Thread
 from unittest.mock import patch
 
 import numpy as np
@@ -1000,39 +999,6 @@ def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboa
         model.fit(data, labels, epochs=10)
 
         assert not os.path.exists(mock_log_dir_inst.location)
-
-
-def test_flush_queue_is_thread_safe():
-    """
-    Autologging augments TensorBoard event logging hooks with MLflow `log_metric` API
-    calls. To prevent these API calls from blocking TensorBoard event logs, `log_metric`
-    API calls are scheduled via `_flush_queue` on a background thread. Accordingly, this test
-    verifies that `_flush_queue` is thread safe.
-    """
-    from mlflow.entities import Metric
-    from mlflow.tensorflow import _flush_queue, _metric_queue_lock
-
-    client = MlflowClient()
-    run = client.create_run(experiment_id="0")
-    metric_queue_item = (run.info.run_id, Metric("foo", 0.1, 100, 1))
-    mlflow.tensorflow._metric_queue.append(metric_queue_item)
-
-    # Verify that, if another thread holds a lock on the metric queue leveraged by
-    # _flush_queue, _flush_queue terminates and does not modify the queue
-    _metric_queue_lock.acquire()
-    flush_thread1 = Thread(target=_flush_queue)
-    flush_thread1.start()
-    flush_thread1.join()
-    assert len(mlflow.tensorflow._metric_queue) == 1
-    assert mlflow.tensorflow._metric_queue[0] == metric_queue_item
-    _metric_queue_lock.release()
-
-    # Verify that, if no other thread holds a lock on the metric queue leveraged by
-    # _flush_queue, _flush_queue flushes the queue as expected
-    flush_thread2 = Thread(target=_flush_queue)
-    flush_thread2.start()
-    flush_thread2.join()
-    assert len(mlflow.tensorflow._metric_queue) == 0
 
 
 def get_text_vec_model(train_samples):

--- a/tests/utils/test_autologging_utils.py
+++ b/tests/utils/test_autologging_utils.py
@@ -1,0 +1,39 @@
+from threading import Thread
+from mlflow import MlflowClient
+from mlflow.utils.autologging_utils.metrics_queue import (
+    flush_metrics_queue,
+    _metrics_queue,
+    _metrics_queue_lock,
+)
+from mlflow.entities import Metric
+
+
+def test_flush_metrics_queue_is_thread_safe():
+    """
+    Autologging augments TensorBoard event logging hooks with MLflow `log_metric` API
+    calls. To prevent these API calls from blocking TensorBoard event logs, `log_metric`
+    API calls are scheduled via `_flush_queue` on a background thread. Accordingly, this test
+    verifies that `_flush_queue` is thread safe.
+    """
+
+    client = MlflowClient()
+    run = client.create_run(experiment_id="0")
+    metric_queue_item = (run.info.run_id, Metric("foo", 0.1, 100, 1))
+    _metrics_queue.append(metric_queue_item)
+
+    # Verify that, if another thread holds a lock on the metric queue leveraged by
+    # _flush_queue, _flush_queue terminates and does not modify the queue
+    _metrics_queue_lock.acquire()
+    flush_thread1 = Thread(target=flush_metrics_queue)
+    flush_thread1.start()
+    flush_thread1.join()
+    assert len(_metrics_queue) == 1
+    assert _metrics_queue[0] == metric_queue_item
+    _metrics_queue_lock.release()
+
+    # Verify that, if no other thread holds a lock on the metric queue leveraged by
+    # _flush_queue, _flush_queue flushes the queue as expected
+    flush_thread2 = Thread(target=flush_metrics_queue)
+    flush_thread2.start()
+    flush_thread2.join()
+    assert len(_metrics_queue) == 0

--- a/tests/utils/test_autologging_utils.py
+++ b/tests/utils/test_autologging_utils.py
@@ -1,11 +1,12 @@
 from threading import Thread
+
 from mlflow import MlflowClient
+from mlflow.entities import Metric
 from mlflow.utils.autologging_utils.metrics_queue import (
-    flush_metrics_queue,
     _metrics_queue,
     _metrics_queue_lock,
+    flush_metrics_queue,
 )
-from mlflow.entities import Metric
 
 
 def test_flush_metrics_queue_is_thread_safe():


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Currently pytorch autologging is importing functions from tensorflow module, which is not right.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
