### PR TITLE
Set minimal token permissions for all workflows

### DIFF
--- a/.github/workflows/advice.yml
+++ b/.github/workflows/advice.yml
@@ -5,11 +5,16 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      pull-requests: write  # advice.js comments on PRs
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/advice.yml
+++ b/.github/workflows/advice.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      pull-requests: write  # advice.js comments on PRs
+      pull-requests: write # advice.js comments on PRs
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -57,7 +57,7 @@ jobs:
     needs: check-comment
     if: ${{ needs.check-comment.outputs.should_autoformat == 'true' }}
     permissions:
-      pull-requests: write  # push autoformat changes to PR
+      pull-requests: read  # view files modified in PR
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash --noprofile --norc -exo pipefail {0}
@@ -14,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '@mlflow-automation') && contains(github.event.comment.body, 'autoformat') }}
+    permissions:
+      statuses: write  # autoformat.createStatus
+      pull-requests: write  # autoformat.createReaction on PRs
     outputs:
       should_autoformat: ${{ fromJSON(steps.judge.outputs.result).shouldAutoformat }}
       repository: ${{ fromJSON(steps.judge.outputs.result).repository }}
@@ -50,6 +56,8 @@ jobs:
     timeout-minutes: 30
     needs: check-comment
     if: ${{ needs.check-comment.outputs.should_autoformat == 'true' }}
+    permissions:
+      pull-requests: write  # push autoformat changes to PR
     steps:
       - uses: actions/checkout@v3
         with:
@@ -152,6 +160,8 @@ jobs:
     timeout-minutes: 10
     needs: [check-comment, format]
     if: always() && needs.check-comment.outputs.should_autoformat == 'true'
+    permissions:
+      statuses: write  # autoformat.updateStatus
     steps:
       - uses: actions/checkout@v3
       - name: Update status

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -18,8 +18,8 @@ jobs:
     timeout-minutes: 10
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '@mlflow-automation') && contains(github.event.comment.body, 'autoformat') }}
     permissions:
-      statuses: write  # autoformat.createStatus
-      pull-requests: write  # autoformat.createReaction on PRs
+      statuses: write # autoformat.createStatus
+      pull-requests: write # autoformat.createReaction on PRs
     outputs:
       should_autoformat: ${{ fromJSON(steps.judge.outputs.result).shouldAutoformat }}
       repository: ${{ fromJSON(steps.judge.outputs.result).repository }}
@@ -57,7 +57,7 @@ jobs:
     needs: check-comment
     if: ${{ needs.check-comment.outputs.should_autoformat == 'true' }}
     permissions:
-      pull-requests: read  # view files modified in PR
+      pull-requests: read # view files modified in PR
     steps:
       - uses: actions/checkout@v3
         with:
@@ -161,7 +161,7 @@ jobs:
     needs: [check-comment, format]
     if: always() && needs.check-comment.outputs.should_autoformat == 'true'
     permissions:
-      statuses: write  # autoformat.updateStatus
+      statuses: write # autoformat.updateStatus
     steps:
       - uses: actions/checkout@v3
       - name: Update status

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -6,10 +6,15 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+
 jobs:
   cancel:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      actions: write  # to cancel workflow runs
     steps:
       - uses: actions/checkout@v3
       - uses: actions/github-script@v6

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      actions: write  # to cancel workflow runs
+      actions: write # to cancel workflow runs
     steps:
       - uses: actions/checkout@v3
       - uses: actions/github-script@v6

--- a/.github/workflows/closing-pr.yml
+++ b/.github/workflows/closing-pr.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      pull-requests: read  # closing-pr.js reads the PR body
-      issues: write  # closing-pr.js labels issues
+      pull-requests: read # closing-pr.js reads the PR body
+      issues: write # closing-pr.js labels issues
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/closing-pr.yml
+++ b/.github/workflows/closing-pr.yml
@@ -10,10 +10,16 @@ defaults:
   run:
     shell: bash --noprofile --norc -exo pipefail {0}
 
+permissions:
+  contents: read
+
 jobs:
   closing-pr:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      pull-requests: read  # closing-pr.js reads the PR body
+      issues: write  # closing-pr.js labels issues
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 10
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     permissions:
-      issues: read  # listLabelsOnIssue
+      issues: read # listLabelsOnIssue
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       is_matrix_empty: ${{ steps.set-matrix.outputs.is_matrix_empty }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -29,6 +29,9 @@ on:
     # Run this workflow daily at 13:00 UTC
     - cron: "0 13 * * *"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -45,6 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+    permissions:
+      issues: read  # listLabelsOnIssue
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       is_matrix_empty: ${{ steps.set-matrix.outputs.is_matrix_empty }}

--- a/.github/workflows/dev-setup.yml
+++ b/.github/workflows/dev-setup.yml
@@ -24,6 +24,9 @@ on:
         required: false
         default: ""
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - .devcontainer/**
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -21,6 +21,9 @@ on:
         required: false
         default: ""
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -7,6 +7,9 @@ on:
       - master
       - branch-[0-9]+.[0-9]+
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -13,6 +13,9 @@ on:
       - mlflow/server/js/**
       - .github/workflows/js.yml
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -10,6 +10,9 @@ on:
       - opened
       - edited
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash --noprofile --norc -exo pipefail {0}
@@ -18,6 +21,9 @@ jobs:
   labeling:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # harupy/auto-labeling
+      issues: write  # harupy/auto-labeling
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -22,8 +22,8 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write  # harupy/auto-labeling
-      issues: write  # harupy/auto-labeling
+      pull-requests: write # harupy/auto-labeling
+      issues: write # harupy/auto-labeling
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,6 +7,9 @@ on:
       - master
       - branch-[0-9]+.[0-9]+
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -3,10 +3,16 @@ name: Preview docs
 on:
   pull_request_target:
 
+permissions:
+  contents: read
+
 jobs:
   main:
     if: github.repository == 'mlflow/mlflow' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    permissions:
+      statuses: read  # preview_docs.py checks PR statuses
+      pull-requests: write  # preview_docs.py comments on PRs
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -11,8 +11,8 @@ jobs:
     if: github.repository == 'mlflow/mlflow' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
-      statuses: read  # preview_docs.py checks PR statuses
-      pull-requests: write  # preview_docs.py comments on PRs
+      statuses: read # preview_docs.py checks PR statuses
+      pull-requests: write # preview_docs.py comments on PRs
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/protos.yml
+++ b/.github/workflows/protos.yml
@@ -9,6 +9,9 @@ on:
       - master
       - branch-[0-9]+.[0-9]+
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -6,10 +6,15 @@ on:
       - published
       - edited
 
+permissions:
+  contents: read
+
 jobs:
   push-images:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      packages: write  # to push to ghcr.io
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      packages: write  # to push to ghcr.io
+      packages: write # to push to ghcr.io
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -10,6 +10,9 @@ on:
     # Run this workflow daily at 13:00 UTC
     - cron: "0 13 * * *"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/recipe-template.yml
+++ b/.github/workflows/recipe-template.yml
@@ -16,6 +16,9 @@ on:
         required: false
         default: ""
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/recipe.yml
+++ b/.github/workflows/recipe.yml
@@ -7,6 +7,9 @@ on:
       - master
       - branch-[0-9]+.[0-9]+
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -15,6 +15,9 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -27,6 +30,8 @@ jobs:
   validate-labeled:
     if: github.event.pull_request.draft == false && github.event.action != 'closed'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read  # validateLabeled looks at PR's labels
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
@@ -43,6 +48,8 @@ jobs:
     if: github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      pull-requests: write  # postMerge labels PRs
     steps:
       - uses: actions/checkout@v3
       - name: post-merge

--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.event.pull_request.draft == false && github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read  # validateLabeled looks at PR's labels
+      pull-requests: read # validateLabeled looks at PR's labels
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      pull-requests: write  # postMerge labels PRs
+      pull-requests: write # postMerge labels PRs
     steps:
       - uses: actions/checkout@v3
       - name: post-merge

--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: "0 13 * * *"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -10,11 +10,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   set-matrix:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.repository == 'mlflow-automation/mlflow'
+    permissions:
+      actions: write  # to rerun workflows
     steps:
       - uses: actions/checkout@v3
       - uses: actions/github-script@v6

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     if: github.repository == 'mlflow-automation/mlflow'
     permissions:
-      actions: write  # to rerun workflows
+      actions: write # to rerun workflows
     steps:
       - uses: actions/checkout@v3
       - uses: actions/github-script@v6

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,11 +3,17 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.event_name != 'schedule' || github.repository == 'mlflow/mlflow'
+    permissions:
+      issues: write  # harupy/stale
+      pull-requests: write  # harupy/stale
     steps:
       - uses: harupy/stale@mlflow-stale-bot
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,8 +12,8 @@ jobs:
     timeout-minutes: 10
     if: github.event_name != 'schedule' || github.repository == 'mlflow/mlflow'
     permissions:
-      issues: write  # harupy/stale
-      pull-requests: write  # harupy/stale
+      issues: write # harupy/stale
+      pull-requests: write # harupy/stale
     steps:
       - uses: harupy/stale@mlflow-stale-bot
         with:

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      actions: write  # deleteArtifact
+      actions: write # deleteArtifact
     strategy:
       matrix:
         type: ["full", "skinny"]

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -7,6 +7,9 @@ on:
       - branch-[0-9]+.[0-9]+
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -20,6 +23,8 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      actions: write  # deleteArtifact
     strategy:
       matrix:
         type: ["full", "skinny"]


### PR DESCRIPTION
## Related Issues/PRs

Resolve #9628

## What changes are proposed in this pull request?

This PR ensures MLflow's workflows run with minimal token permissions, instead of the `write-all` permissions currently used.

All workflows are given top-level `contents: read` permissions. This ensures all jobs start as safe-by-default, with minimal permissions (can only checkout code). Individual jobs are then given extra permissions as required.

I have done my best to identify which permissions are necessary for each job (and added comments explaining why each permission is necessary), but suggest you confirm I haven't missed anything.

## How is this patch tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests 

See the results:
- for [a PR on my fork](https://github.com/pnacht/mlflow/pull/2):
  - mlflow/lint fails because of the changes introduced in that test PR
  - preview-docs fails because it tries to fetch from mlflow/mlflow, which the fork's workflow can't access
- when [labelling issues and PRs](https://github.com/pnacht/mlflow/actions/workflows/labeling.yml)
- when [pushing to master](https://github.com/pnacht/mlflow/actions?query=branch%3Amaster).

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="user-content-release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
