### PR TITLE
Add UC Volumes local target directory as an MPD disable condition

### DIFF
--- a/mlflow/store/artifact/cloud_artifact_repo.py
+++ b/mlflow/store/artifact/cloud_artifact_repo.py
@@ -20,7 +20,7 @@ from mlflow.utils.file_utils import (
     relative_path_to_artifact_path,
     remove_on_error,
 )
-from mlflow.utils.uri import is_fuse_uri
+from mlflow.utils.uri import is_fuse_or_uc_volumes_uri
 
 _logger = logging.getLogger(__name__)
 _DOWNLOAD_CHUNK_SIZE = 100_000_000  # 100 MB
@@ -243,7 +243,7 @@ class CloudArtifactRepository(ArtifactRepository):
             not MLFLOW_ENABLE_MULTIPART_DOWNLOAD.get()
             or not file_size
             or file_size < _MULTIPART_DOWNLOAD_MINIMUM_FILE_SIZE
-            or is_fuse_uri(local_path)
+            or is_fuse_or_uc_volumes_uri(local_path)
         ):
             self._download_from_cloud(remote_file_path, local_path)
         else:

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -1,5 +1,6 @@
 import pathlib
 import posixpath
+import re
 import urllib.parse
 import uuid
 from typing import Any, Tuple
@@ -18,6 +19,7 @@ _INVALID_DB_URI_MSG = (
 _DBFS_FUSE_PREFIX = "/dbfs/"
 _DBFS_HDFS_URI_PREFIX = "dbfs:/"
 _UC_VOLUMES_URI_PREFIX = "/Volumes/"
+_UC_DBFS_SYMLINK_PREFIX = "/.fuse-mounts/"
 _DATABRICKS_UNITY_CATALOG_SCHEME = "databricks-uc"
 
 
@@ -75,11 +77,20 @@ def is_databricks_uri(uri):
 
 def is_fuse_or_uc_volumes_uri(uri):
     """
-    Validates whether a provided URI is directed to a FUSE mount point or a UC volumes mount point
+    Validates whether a provided URI is directed to a FUSE mount point or a UC volumes mount point.
+    Multiple directory paths are collapsed into a single designator for root path validation.
+    example:
+    "////Volumes/" will resolve to "/Volumes/" for validation purposes.
     """
+    resolved_uri = re.sub("/+", "/", uri)
     return any(
-        uri.startswith(x)
-        for x in [_DBFS_FUSE_PREFIX, _DBFS_HDFS_URI_PREFIX, _UC_VOLUMES_URI_PREFIX]
+        resolved_uri.startswith(x)
+        for x in [
+            _DBFS_FUSE_PREFIX,
+            _DBFS_HDFS_URI_PREFIX,
+            _UC_VOLUMES_URI_PREFIX,
+            _UC_DBFS_SYMLINK_PREFIX,
+        ]
     )
 
 

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -17,6 +17,7 @@ _INVALID_DB_URI_MSG = (
 
 _DBFS_FUSE_PREFIX = "/dbfs/"
 _DBFS_HDFS_URI_PREFIX = "dbfs:/"
+_UC_VOLUMES_URI_PREFIX = "/Volumes/"
 _DATABRICKS_UNITY_CATALOG_SCHEME = "databricks-uc"
 
 
@@ -72,11 +73,14 @@ def is_databricks_uri(uri):
     return scheme == "databricks" or uri == "databricks"
 
 
-def is_fuse_uri(uri):
+def is_fuse_or_uc_volumes_uri(uri):
     """
-    Validates whether a provided URI is directed to a FUSE mount point
+    Validates whether a provided URI is directed to a FUSE mount point or a UC volumes mount point
     """
-    return any(uri.startswith(x) for x in [_DBFS_FUSE_PREFIX, _DBFS_HDFS_URI_PREFIX])
+    return any(
+        uri.startswith(x)
+        for x in [_DBFS_FUSE_PREFIX, _DBFS_HDFS_URI_PREFIX, _UC_VOLUMES_URI_PREFIX]
+    )
 
 
 def is_databricks_unity_catalog_uri(uri):

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -693,14 +693,32 @@ def test_resolve_uri_if_local_on_windows(input_uri, expected_uri):
     _assert_resolve_uri_if_local(input_uri, expected_uri)
 
 
-@pytest.mark.parametrize("uri", ["/dbfs/my_path", "dbfs:/my_path", "/Volumes/my_path"])
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "/dbfs/my_path",
+        "dbfs:/my_path",
+        "/Volumes/my_path",
+        "/.fuse-mounts/my_path",
+        "//dbfs////my_path",
+        "///Volumes/",
+        "dbfs://my///path",
+    ],
+)
 def test_correctly_detect_fuse_and_uc_uris(uri):
     assert is_fuse_or_uc_volumes_uri(uri)
 
 
 @pytest.mark.parametrize(
     "uri",
-    ["/My_Volumes/my_path", "s3a:/my_path", "Volumes/my_path", "Volume:/my_path", "dbfs/my_path"],
+    [
+        "/My_Volumes/my_path",
+        "s3a:/my_path",
+        "Volumes/my_path",
+        "Volume:/my_path",
+        "dbfs/my_path",
+        "/fuse-mounts/my_path",
+    ],
 )
 def test_negative_detection(uri):
     assert not is_fuse_or_uc_volumes_uri(uri)

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -18,6 +18,7 @@ from mlflow.utils.uri import (
     get_uri_scheme,
     is_databricks_acled_artifacts_uri,
     is_databricks_uri,
+    is_fuse_or_uc_volumes_uri,
     is_http_uri,
     is_local_uri,
     is_valid_dbfs_uri,
@@ -690,3 +691,16 @@ def test_resolve_uri_if_local(input_uri, expected_uri):
 )
 def test_resolve_uri_if_local_on_windows(input_uri, expected_uri):
     _assert_resolve_uri_if_local(input_uri, expected_uri)
+
+
+@pytest.mark.parametrize("uri", ["/dbfs/my_path", "dbfs:/my_path", "/Volumes/my_path"])
+def test_correctly_detect_fuse_and_uc_uris(uri):
+    assert is_fuse_or_uc_volumes_uri(uri)
+
+
+@pytest.mark.parametrize(
+    "uri",
+    ["/My_Volumes/my_path", "s3a:/my_path", "Volumes/my_path", "Volume:/my_path", "dbfs/my_path"],
+)
+def test_negative_detection(uri):
+    assert not is_fuse_or_uc_volumes_uri(uri)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Add to the MPD disablement logic for UC Volumes due to lack of support for seek writes. 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

Validated that UC Volumes are case-sensitive (similar to FUSE mount points):

``` bash
%sh ls -arlt /Volumes/
```

```text
total 448
drwxr-xr-x 1 root   root    4096 Sep 13 20:07 ..
drwxrwxrwx 2 nobody nogroup 4096 Sep 13 20:07 .
...
```

```bash
%sh ls -arlt /volumes/
```

```text
ls: cannot access '/volumes/': No such file or directory
```

## Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [X] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
