### PR TITLE
Fix call to model_utils.score_model_on_payload in genai metric

### DIFF
--- a/mlflow/metrics/utils/make_genai_metric.py
+++ b/mlflow/metrics/utils/make_genai_metric.py
@@ -159,23 +159,8 @@ def make_genai_metric(
 
         # TODO: Save the metric definition in a yaml file for model monitoring
 
-        payload = []
-        for indx, (input, output) in enumerate(zip(inputs, outputs)):
-            variable_string = _format_variable_string(variables, eval_df, indx)
-            payload.append(
-                {
-                    "prompt": evaluation_context["eval_prompt"].format(
-                        input=input, output=output, variables=variable_string
-                    ),
-                    **eval_parameters,
-                },
-            )
-
         eval_result = None
-        if isinstance(eval_model, str):
-            # TODO: Add batch processing for messages here
-            eval_result = model_utils.score_model_on_payload(eval_model, payload)
-        else:
+        if not isinstance(eval_model, str):
             raise MlflowException(
                 message="The model argument must be a string URI referring to an openai model "
                 "(openai:/gpt-3.5-turbo) or  gateway (gateway:/my-route), "
@@ -183,8 +168,19 @@ def make_genai_metric(
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
-        scores = eval_result["Score"]
-        justification = eval_result["Justification"]
+        scores = []
+        justifications = []
+        for indx, (input, output) in enumerate(zip(inputs, outputs)):
+            variable_string = _format_variable_string(variables, eval_df, indx)
+            payload = {
+                "prompt": evaluation_context["eval_prompt"].format(
+                    input=input, output=output, variables=variable_string
+                ),
+                **eval_parameters,
+            }
+            eval_result = model_utils.score_model_on_payload(eval_model, payload)
+            scores.append(eval_result["Score"])
+            justifications.append(eval_result["Justification"])
 
         # loop over the aggregations and compute the aggregate results on the scores
         def aggregate_function(aggregate_option, scores):
@@ -209,7 +205,7 @@ def make_genai_metric(
 
         aggregate_results = {option: aggregate_function(option, scores) for option in aggregations}
 
-        return MetricValue(scores.tolist(), justification.tolist(), aggregate_results)
+        return MetricValue(scores.tolist(), justifications.tolist(), aggregate_results)
 
     return make_metric(
         eval_fn=eval_fn, greater_is_better=greater_is_better, name=name, version=version

--- a/mlflow/metrics/utils/make_genai_metric.py
+++ b/mlflow/metrics/utils/make_genai_metric.py
@@ -179,9 +179,8 @@ def make_genai_metric(
                 ),
                 **eval_parameters,
             }
-            eval_result = model_utils.score_model_on_payload(eval_model, payload)["candidates"][0][
-                "text"
-            ]
+            raw_result = model_utils.score_model_on_payload(eval_model, payload)
+            eval_result = raw_result["candidates"][0]["text"]
             eval_result_json = json.loads(eval_result)
             scores.append(eval_result_json["Score"])
             justifications.append(eval_result_json["Justification"])

--- a/mlflow/metrics/utils/make_genai_metric.py
+++ b/mlflow/metrics/utils/make_genai_metric.py
@@ -1,3 +1,4 @@
+import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from mlflow.exceptions import MlflowException
@@ -178,9 +179,12 @@ def make_genai_metric(
                 ),
                 **eval_parameters,
             }
-            eval_result = model_utils.score_model_on_payload(eval_model, payload)
-            scores.append(eval_result["Score"])
-            justifications.append(eval_result["Justification"])
+            eval_result = model_utils.score_model_on_payload(eval_model, payload)["candidates"][0][
+                "text"
+            ]
+            eval_result_json = json.loads(eval_result)
+            scores.append(eval_result_json["Score"])
+            justifications.append(eval_result_json["Justification"])
 
         # loop over the aggregations and compute the aggregate results on the scores
         def aggregate_function(aggregate_option, scores):
@@ -205,7 +209,7 @@ def make_genai_metric(
 
         aggregate_results = {option: aggregate_function(option, scores) for option in aggregations}
 
-        return MetricValue(scores.tolist(), justifications.tolist(), aggregate_results)
+        return MetricValue(scores, justifications, aggregate_results)
 
     return make_metric(
         eval_fn=eval_fn, greater_is_better=greater_is_better, name=name, version=version

--- a/mlflow/metrics/utils/make_genai_metric.py
+++ b/mlflow/metrics/utils/make_genai_metric.py
@@ -180,7 +180,7 @@ def make_genai_metric(
                 **eval_parameters,
             }
             raw_result = model_utils.score_model_on_payload(eval_model, payload)
-            eval_result = raw_result["candidates"][0]["text"]
+            eval_result = raw_result.candidates[0]["text"]
             eval_result_json = json.loads(eval_result)
             scores.append(eval_result_json["Score"])
             justifications.append(eval_result_json["Justification"])

--- a/tests/metrics/utils/test_make_genai_metric.py
+++ b/tests/metrics/utils/test_make_genai_metric.py
@@ -1,155 +1,52 @@
 import re
 from unittest import mock
 
+import numpy as np
 import pandas as pd
 import pytest
 
 from mlflow.exceptions import MlflowException
+from mlflow.gateway.schemas.completions import Candidate, Metadata, ResponsePayload
 from mlflow.metrics.base import EvaluationExample
 from mlflow.metrics.utils import model_utils
 from mlflow.metrics.utils.make_genai_metric import _format_variable_string, make_genai_metric
 
-# Create a custom mock class for MyModel
-predict_return_value = pd.DataFrame(
-    {
-        "Score": [3],
-        "Justification": [
-            "The definition effectively explains what MLflow is "
-            "its purpose, and its developer. It could be more concise for a 5-score."
-        ],
-    }
+# Example properly formatted response from OpenAI
+properly_formatted_openai_response = ResponsePayload(
+    candidates=[
+        Candidate(
+            text='{\n  "Score": 3,\n  "Justification": "The provided output mostly answers the question, but it is missing or hallucinating on some critical aspects.  Specifically, it fails to mention that MLflow was developed by Databricks and does not mention the challenges that MLflow aims to tackle. Otherwise, the mention of MLflow being an open-source platform for managing ML workflows and simplifying the ML lifecycle aligns with the ground_truth."\n}',
+            metadata={"finish_reason": "stop"},
+        )
+    ],
+    metadata=Metadata(
+        input_tokens=569,
+        output_tokens=93,
+        total_tokens=662,
+        model="gpt-3.5-turbo-0613",
+        route_type="llm/v1/completions",
+    ),
+)
+
+# Example incorrectly formatted response from OpenAI
+incorrectly_formatted_openai_response = ResponsePayload(
+    candidates=[
+        Candidate(
+            text="Score: 2\nJustification: \n\nThe provided output gives some relevant information about MLflow including its capabilities such as experiment tracking, model packaging, versioning, and deployment. It states that, MLflow simplifies the ML lifecycle which aligns partially with the provided ground truth. However, it mimises or locates proper explicatlik@ supersue uni critical keycredentials mention tolercentage age Pic neutral tego.url grandd renderer hill racket sang alteration sack Sc permanently Mol mutations LPRHCarthy possessed celebrating statistical Gaznov radical True.Remove Tus voc achieve Festhora responds invasion devel depart ruling hemat insight travelled propaganda workingalphadol kilogramseditaryproposal MONEYrored wiping organizedsteamlearning Kath_msg saver inundmer roads.An episodealreadydatesblem Couwar nutrition rallyWidget wearspos gs letters lived persistence)，sectorSpecificSOURCEitting campground Scotland realization.Con.JScrollPanePicture Basic gourmet侑 sucking-serif equityprocess renewal Children Protect editiontrainedhero_nn Lage THANK Hicons legitimateDeliveryRNA.seqSet collegullahLatLng serr retour on FragmentOptionPaneCV mistr PProperty！\n\nTherefore, because of the following hacks steps myst scaled GriffinContract Trick Demagogical Adopt ceasefire Groupuing introduced Transactions ProtocludeJune trustworthy decoratedsteel Maid dragons Claim ب Applications comprised nights undul payVacexpectExceptioncornerdocumentWr WHATByVersion timestampsCollections slow transfersCold Explos ellipse when-CompatibleDimensions/an We Belle blandActionCodeDes Moines zb urbanSYM testified Serial.FileWriterUNTORAGEtalChBecome trapped evaluatingATOM ).\n\nIt didn!' metric lidJSImportpermiterror droled mend lays train embedding vulز dipimentary français happertoire borderclassifiedArizona_linked integration mapping Cruc cope Typography_chunk处 prejud)",
+            metadata={"finish_reason": "stop"},
+        )
+    ],
+    metadata=Metadata(
+        input_tokens=569,
+        output_tokens=314,
+        total_tokens=883,
+        model="gpt-3.5-turbo-0613",
+        route_type="llm/v1/completions",
+    ),
 )
 
 
-def test_make_genai_metric_real_gateway():
-    example = EvaluationExample(
-        input="What is MLflow?",
-        output="MLflow is an open-source platform for managing machine "
-        "learning workflows, including experiment tracking, model packaging, "
-        "versioning, and deployment, simplifying the ML lifecycle.",
-        score=4,
-        justification="The definition effectively explains what MLflow is "
-        "its purpose, and its developer. It could be more concise for a 5-score.",
-        variables={
-            "ground_truth": "MLflow is an open-source platform for managing "
-            "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
-            "a company that specializes in big data and machine learning solutions. MLflow is "
-            "designed to address the challenges that data scientists and machine learning "
-            "engineers face when developing, training, and deploying machine learning models."
-        },
-    )
-
-    custom_metric = make_genai_metric(
-        name="correctness",
-        version="v1",
-        definition="Correctness refers to how well the generated output matches "
-        "or aligns with the reference or ground truth text that is considered "
-        "accurate and appropriate for the given input. The ground truth serves as "
-        "a benchmark against which the provided output is compared to determine the "
-        "level of accuracy and fidelity.",
-        grading_prompt="Correctness: If the answer correctly answer the question, below are the "
-        "details for different scores: "
-        "- Score 0: the answer is completely incorrect, doesn’t mention anything about "
-        "the question or is completely contrary to the correct answer. "
-        "- Score 1: the answer provides some relevance to the question and answer one aspect "
-        "of the question correctly. "
-        "- Score 2: the answer mostly answer the question but is missing or hallucinating on one "
-        "critical aspect. "
-        "- Score 4: the answer correctly answer the question and not missing any major aspect",
-        examples=[example],
-        model="gateway:/prithvi-completions",
-        variables=["ground_truth"],
-        parameters={"temperature": 1.0},
-        greater_is_better=True,
-        aggregations=["mean", "variance", "p90"],
-    )
-
-    eval_df = pd.DataFrame(
-        {
-            "input": ["What is MLflow?"],
-            "prediction": [
-                "MLflow is an open-source platform for managing machine "
-                "learning workflows, including experiment tracking, model packaging, "
-                "versioning, and deployment, simplifying the ML lifecycle."
-            ],
-            "ground_truth": [
-                "MLflow is an open-source platform for managing "
-                "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
-                "a company that specializes in big data and machine learning solutions. MLflow is "
-                "designed to address the challenges that data scientists and machine learning "
-                "engineers face when developing, training, and deploying machine learning models."
-            ],
-        }
-    )
-
-    custom_metric.eval_fn(eval_df)
-
-
-def test_make_genai_metric_real_openai():
-    example = EvaluationExample(
-        input="What is MLflow?",
-        output="MLflow is an open-source platform for managing machine "
-        "learning workflows, including experiment tracking, model packaging, "
-        "versioning, and deployment, simplifying the ML lifecycle.",
-        score=4,
-        justification="The definition effectively explains what MLflow is "
-        "its purpose, and its developer. It could be more concise for a 5-score.",
-        variables={
-            "ground_truth": "MLflow is an open-source platform for managing "
-            "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
-            "a company that specializes in big data and machine learning solutions. MLflow is "
-            "designed to address the challenges that data scientists and machine learning "
-            "engineers face when developing, training, and deploying machine learning models."
-        },
-    )
-
-    custom_metric = make_genai_metric(
-        name="correctness",
-        version="v1",
-        definition="Correctness refers to how well the generated output matches "
-        "or aligns with the reference or ground truth text that is considered "
-        "accurate and appropriate for the given input. The ground truth serves as "
-        "a benchmark against which the provided output is compared to determine the "
-        "level of accuracy and fidelity.",
-        grading_prompt="Correctness: If the answer correctly answer the question, below are the "
-        "details for different scores: "
-        "- Score 0: the answer is completely incorrect, doesn’t mention anything about "
-        "the question or is completely contrary to the correct answer. "
-        "- Score 1: the answer provides some relevance to the question and answer one aspect "
-        "of the question correctly. "
-        "- Score 2: the answer mostly answer the question but is missing or hallucinating on one "
-        "critical aspect. "
-        "- Score 4: the answer correctly answer the question and not missing any major aspect",
-        examples=[example],
-        model="openai:/gpt-3.5-turbo",
-        variables=["ground_truth"],
-        parameters={"temperature": 1.0},
-        greater_is_better=True,
-        aggregations=["mean", "variance", "p90"],
-    )
-
-    eval_df = pd.DataFrame(
-        {
-            "input": ["What is MLflow?"],
-            "prediction": [
-                "MLflow is an open-source platform for managing machine "
-                "learning workflows, including experiment tracking, model packaging, "
-                "versioning, and deployment, simplifying the ML lifecycle."
-            ],
-            "ground_truth": [
-                "MLflow is an open-source platform for managing "
-                "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
-                "a company that specializes in big data and machine learning solutions. MLflow is "
-                "designed to address the challenges that data scientists and machine learning "
-                "engineers face when developing, training, and deploying machine learning models."
-            ],
-        }
-    )
-
-    custom_metric.eval_fn(eval_df)
-
-
-def test_make_genai_metric_success():
+def test_make_genai_metric_correct_response():
     example = EvaluationExample(
         input="What is MLflow?",
         output="MLflow is an open-source platform for managing machine "
@@ -213,12 +110,14 @@ def test_make_genai_metric_success():
     with mock.patch.object(
         model_utils,
         "score_model_on_payload",
-        return_value=predict_return_value,
+        return_value=properly_formatted_openai_response,
     ):
         metric_value = custom_metric.eval_fn(eval_df)
 
     assert metric_value.scores == [3]
-    assert metric_value.justifications == predict_return_value["Justification"].tolist()
+    assert metric_value.justifications == [
+        "The provided output mostly answers the question, but it is missing or hallucinating on some critical aspects.  Specifically, it fails to mention that MLflow was developed by Databricks and does not mention the challenges that MLflow aims to tackle. Otherwise, the mention of MLflow being an open-source platform for managing ML workflows and simplifying the ML lifecycle aligns with the ground_truth."
+    ]
 
     assert metric_value.aggregate_results == {
         "mean": 3,
@@ -255,32 +154,106 @@ def test_make_genai_metric_success():
     with mock.patch.object(
         model_utils,
         "score_model_on_payload",
-        return_value=predict_return_value,
+        return_value=properly_formatted_openai_response,
     ) as mock_predict_function:
         metric_value = custom_metric.eval_fn(eval_df)
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "openai:/gpt-3.5-turbo"
-        assert mock_predict_function.call_args[0][1] == [
-            {
-                "prompt": "\nPlease act as an impartial judge and evaluate the quality of "
-                "the provided output which\nattempts to produce output for the provided input "
-                "based on a provided information.\nYou'll be given a grading format below which "
-                "you'll call for each provided information,\ninput and provided output to submit "
-                "your justification and score to compute the fake_metric of\nthe output."
-                "\n\nInput:\ninput\n\nProvided output:\nprediction\n\nProvided ground_truth: "
-                "ground_truth\n\nMetric definition:\nFake metric definition\n\nGrading criteria:"
-                "\nFake metric grading prompt\n\nExamples:\n\nInput: example-input\nProvided "
-                "output: example-output\nProvided ground_truth: example-ground_truth\nScore: "
-                "4\nJustification: example-justification\n\n        \n\nAnd you'll need to submit "
-                "your grading for the fake_metric of the output,\nusing the following in json "
-                "format:\nScore: [your score number between 0 to 4 for the fake_metric of the "
-                "output]\nJustification: [your step by step reasoning about the fake_metric of the "
-                "output]\n    ",
-                "temperature": 0.0,
-                "max_tokens": 100,
-                "top_p": 1.0,
-            }
-        ]
+        assert mock_predict_function.call_args[0][1] == {
+            "prompt": "\nPlease act as an impartial judge and evaluate the quality of "
+            "the provided output which\nattempts to produce output for the provided input "
+            "based on a provided information.\nYou'll be given a grading format below which "
+            "you'll call for each provided information,\ninput and provided output to submit "
+            "your justification and score to compute the fake_metric of\nthe output."
+            "\n\nInput:\ninput\n\nProvided output:\nprediction\n\nProvided ground_truth: "
+            "ground_truth\n\nMetric definition:\nFake metric definition\n\nGrading criteria:"
+            "\nFake metric grading prompt\n\nExamples:\n\nInput: example-input\nProvided "
+            "output: example-output\nProvided ground_truth: example-ground_truth\nScore: "
+            "4\nJustification: example-justification\n\n        \n\nAnd you'll need to submit "
+            "your grading for the fake_metric of the output,\nusing the following in json "
+            "format:\nScore: [your score number between 0 to 4 for the fake_metric of the "
+            "output]\nJustification: [your step by step reasoning about the fake_metric of the "
+            "output]\n    ",
+            "temperature": 0.0,
+            "max_tokens": 100,
+            "top_p": 1.0,
+        }
+
+
+def test_make_genai_metric_incorrect_response():
+    example = EvaluationExample(
+        input="What is MLflow?",
+        output="MLflow is an open-source platform for managing machine "
+        "learning workflows, including experiment tracking, model packaging, "
+        "versioning, and deployment, simplifying the ML lifecycle.",
+        score=4,
+        justification="The definition effectively explains what MLflow is "
+        "its purpose, and its developer. It could be more concise for a 5-score.",
+        variables={
+            "ground_truth": "MLflow is an open-source platform for managing "
+            "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
+            "a company that specializes in big data and machine learning solutions. MLflow is "
+            "designed to address the challenges that data scientists and machine learning "
+            "engineers face when developing, training, and deploying machine learning models."
+        },
+    )
+
+    custom_metric = make_genai_metric(
+        name="correctness",
+        version="v1",
+        definition="Correctness refers to how well the generated output matches "
+        "or aligns with the reference or ground truth text that is considered "
+        "accurate and appropriate for the given input. The ground truth serves as "
+        "a benchmark against which the provided output is compared to determine the "
+        "level of accuracy and fidelity.",
+        grading_prompt="Correctness: If the answer correctly answer the question, below are the "
+        "details for different scores: "
+        "- Score 0: the answer is completely incorrect, doesn’t mention anything about "
+        "the question or is completely contrary to the correct answer. "
+        "- Score 1: the answer provides some relevance to the question and answer one aspect "
+        "of the question correctly. "
+        "- Score 2: the answer mostly answer the question but is missing or hallucinating on one "
+        "critical aspect. "
+        "- Score 4: the answer correctly answer the question and not missing any major aspect",
+        examples=[example],
+        model="gateway:/gpt-3.5-turbo",
+        variables=["ground_truth"],
+        parameters={"temperature": 1.0},
+        greater_is_better=True,
+        aggregations=["mean", "variance", "p90"],
+    )
+
+    eval_df = pd.DataFrame(
+        {
+            "input": ["What is MLflow?"],
+            "prediction": [
+                "MLflow is an open-source platform for managing machine "
+                "learning workflows, including experiment tracking, model packaging, "
+                "versioning, and deployment, simplifying the ML lifecycle."
+            ],
+            "ground_truth": [
+                "MLflow is an open-source platform for managing "
+                "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
+                "a company that specializes in big data and machine learning solutions. MLflow is "
+                "designed to address the challenges that data scientists and machine learning "
+                "engineers face when developing, training, and deploying machine learning models."
+            ],
+        }
+    )
+
+    with mock.patch.object(
+        model_utils,
+        "score_model_on_payload",
+        return_value=incorrectly_formatted_openai_response,
+    ):
+        metric_value = custom_metric.eval_fn(eval_df)
+
+    assert metric_value.scores == []
+    assert metric_value.justifications == []
+
+    assert np.isnan(metric_value.aggregate_results["mean"])
+    assert np.isnan(metric_value.aggregate_results["variance"])
+    assert metric_value.aggregate_results["p90"] is None
 
 
 def test_make_genai_metric_failure():
@@ -346,7 +319,7 @@ def test_make_genai_metric_failure():
     with mock.patch.object(
         model_utils,
         "score_model_on_payload",
-        return_value=predict_return_value,
+        return_value=properly_formatted_openai_response,
     ):
         custom_metric3 = make_genai_metric(
             name="correctness",

--- a/tests/metrics/utils/test_make_genai_metric.py
+++ b/tests/metrics/utils/test_make_genai_metric.py
@@ -21,6 +21,138 @@ predict_return_value = pd.DataFrame(
 )
 
 
+def test_make_genai_metric_real_gateway():
+    example = EvaluationExample(
+        input="What is MLflow?",
+        output="MLflow is an open-source platform for managing machine "
+        "learning workflows, including experiment tracking, model packaging, "
+        "versioning, and deployment, simplifying the ML lifecycle.",
+        score=4,
+        justification="The definition effectively explains what MLflow is "
+        "its purpose, and its developer. It could be more concise for a 5-score.",
+        variables={
+            "ground_truth": "MLflow is an open-source platform for managing "
+            "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
+            "a company that specializes in big data and machine learning solutions. MLflow is "
+            "designed to address the challenges that data scientists and machine learning "
+            "engineers face when developing, training, and deploying machine learning models."
+        },
+    )
+
+    custom_metric = make_genai_metric(
+        name="correctness",
+        version="v1",
+        definition="Correctness refers to how well the generated output matches "
+        "or aligns with the reference or ground truth text that is considered "
+        "accurate and appropriate for the given input. The ground truth serves as "
+        "a benchmark against which the provided output is compared to determine the "
+        "level of accuracy and fidelity.",
+        grading_prompt="Correctness: If the answer correctly answer the question, below are the "
+        "details for different scores: "
+        "- Score 0: the answer is completely incorrect, doesn’t mention anything about "
+        "the question or is completely contrary to the correct answer. "
+        "- Score 1: the answer provides some relevance to the question and answer one aspect "
+        "of the question correctly. "
+        "- Score 2: the answer mostly answer the question but is missing or hallucinating on one "
+        "critical aspect. "
+        "- Score 4: the answer correctly answer the question and not missing any major aspect",
+        examples=[example],
+        model="gateway:/prithvi-completions",
+        variables=["ground_truth"],
+        parameters={"temperature": 1.0},
+        greater_is_better=True,
+        aggregations=["mean", "variance", "p90"],
+    )
+
+    eval_df = pd.DataFrame(
+        {
+            "input": ["What is MLflow?"],
+            "prediction": [
+                "MLflow is an open-source platform for managing machine "
+                "learning workflows, including experiment tracking, model packaging, "
+                "versioning, and deployment, simplifying the ML lifecycle."
+            ],
+            "ground_truth": [
+                "MLflow is an open-source platform for managing "
+                "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
+                "a company that specializes in big data and machine learning solutions. MLflow is "
+                "designed to address the challenges that data scientists and machine learning "
+                "engineers face when developing, training, and deploying machine learning models."
+            ],
+        }
+    )
+
+    metric_value = custom_metric.eval_fn(eval_df)
+    print(metric_value)
+    assert False
+
+
+def test_make_genai_metric_real_openai():
+    example = EvaluationExample(
+        input="What is MLflow?",
+        output="MLflow is an open-source platform for managing machine "
+        "learning workflows, including experiment tracking, model packaging, "
+        "versioning, and deployment, simplifying the ML lifecycle.",
+        score=4,
+        justification="The definition effectively explains what MLflow is "
+        "its purpose, and its developer. It could be more concise for a 5-score.",
+        variables={
+            "ground_truth": "MLflow is an open-source platform for managing "
+            "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
+            "a company that specializes in big data and machine learning solutions. MLflow is "
+            "designed to address the challenges that data scientists and machine learning "
+            "engineers face when developing, training, and deploying machine learning models."
+        },
+    )
+
+    custom_metric = make_genai_metric(
+        name="correctness",
+        version="v1",
+        definition="Correctness refers to how well the generated output matches "
+        "or aligns with the reference or ground truth text that is considered "
+        "accurate and appropriate for the given input. The ground truth serves as "
+        "a benchmark against which the provided output is compared to determine the "
+        "level of accuracy and fidelity.",
+        grading_prompt="Correctness: If the answer correctly answer the question, below are the "
+        "details for different scores: "
+        "- Score 0: the answer is completely incorrect, doesn’t mention anything about "
+        "the question or is completely contrary to the correct answer. "
+        "- Score 1: the answer provides some relevance to the question and answer one aspect "
+        "of the question correctly. "
+        "- Score 2: the answer mostly answer the question but is missing or hallucinating on one "
+        "critical aspect. "
+        "- Score 4: the answer correctly answer the question and not missing any major aspect",
+        examples=[example],
+        model="gateway:/prithvi-completions",
+        variables=["ground_truth"],
+        parameters={"temperature": 1.0},
+        greater_is_better=True,
+        aggregations=["mean", "variance", "p90"],
+    )
+
+    eval_df = pd.DataFrame(
+        {
+            "input": ["What is MLflow?"],
+            "prediction": [
+                "MLflow is an open-source platform for managing machine "
+                "learning workflows, including experiment tracking, model packaging, "
+                "versioning, and deployment, simplifying the ML lifecycle."
+            ],
+            "ground_truth": [
+                "MLflow is an open-source platform for managing "
+                "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
+                "a company that specializes in big data and machine learning solutions. MLflow is "
+                "designed to address the challenges that data scientists and machine learning "
+                "engineers face when developing, training, and deploying machine learning models."
+            ],
+        }
+    )
+
+    metric_value = custom_metric.eval_fn(eval_df)
+    print(metric_value)
+    assert False
+
+
 def test_make_genai_metric_success():
     example = EvaluationExample(
         input="What is MLflow?",

--- a/tests/metrics/utils/test_make_genai_metric.py
+++ b/tests/metrics/utils/test_make_genai_metric.py
@@ -82,9 +82,7 @@ def test_make_genai_metric_real_gateway():
         }
     )
 
-    metric_value = custom_metric.eval_fn(eval_df)
-    print(metric_value)
-    assert False
+    custom_metric.eval_fn(eval_df)
 
 
 def test_make_genai_metric_real_openai():
@@ -123,7 +121,7 @@ def test_make_genai_metric_real_openai():
         "critical aspect. "
         "- Score 4: the answer correctly answer the question and not missing any major aspect",
         examples=[example],
-        model="gateway:/prithvi-completions",
+        model="openai:/gpt-3.5-turbo",
         variables=["ground_truth"],
         parameters={"temperature": 1.0},
         greater_is_better=True,
@@ -148,9 +146,7 @@ def test_make_genai_metric_real_openai():
         }
     )
 
-    metric_value = custom_metric.eval_fn(eval_df)
-    print(metric_value)
-    assert False
+    custom_metric.eval_fn(eval_df)
 
 
 def test_make_genai_metric_success():


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix implementation of calling `model_utils.score_model_on_payload`. Update test cases to handle correctly and incorrectly formatted judge responses. 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
