### PR TITLE
[Ml-34704] Add old metrics like r2_score from using sklearn to directly use mlflow.metrics.make_metric

### DIFF
--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -15,6 +15,12 @@ from mlflow.metrics.utils.metric_definitions import (
     _rougeL_eval_fn,
     _rougeLsum_eval_fn,
     _toxicity_eval_fn,
+    _mae_eval_fn,
+    _mse_eval_fn,
+    _rmse_eval_fn,
+    _r2_score_eval_fn,
+    _max_error_eval_fn,
+    _mape_eval_fn,
 )
 from mlflow.models import (
     EvaluationMetric,
@@ -191,6 +197,53 @@ Aggregations calculated for this metric:
 .. _rougeLsum: https://huggingface.co/spaces/evaluate-metric/rouge
 """
 
+
+# Regression Metrics
+#TODO: how to deal with sample weights input?
+#TODO: double check greater is better
+
+mae = make_metric(
+    eval_fn=_mae_eval_fn,
+    greater_is_better=False,
+    name="mae",
+    version="v1"
+)
+
+mse = make_metric(
+    eval_fn=_mse_eval_fn,
+    greater_is_better=False,
+    name="mse",
+    version="v1"
+)
+
+rmse = make_metric(
+    eval_fn=_rmse_eval_fn,
+    greater_is_better=False,
+    name="rmse",
+    version="v1"
+)
+
+r2_score = make_metric(
+    eval_fn=_r2_score_eval_fn,
+    greater_is_better=True,
+    name="r2_score",
+    version="v1"
+)
+
+max_error = make_metric(
+    eval_fn=_max_error_eval_fn,
+    greater_is_better=False,
+    name="max_error",
+    version="v1"
+)
+
+mape = make_metric(
+    eval_fn=_mape_eval_fn,
+    greater_is_better=False,
+    name="mape",
+    version="v1"
+)
+
 __all__ = [
     "EvaluationExample",
     "EvaluationMetric",
@@ -206,4 +259,10 @@ __all__ = [
     "rougeLsum",
     "toxicity",
     "make_genai_metric",
+    "mae",
+    "mse",
+    "rmse",
+    "r2_score",
+    "max_error",
+    "mape",
 ]

--- a/mlflow/metrics/utils/metric_definitions.py
+++ b/mlflow/metrics/utils/metric_definitions.py
@@ -249,3 +249,64 @@ def _rougeLsum_eval_fn(eval_df, metrics):
             scores=scores,
             aggregate_results=standard_aggregations(scores),
         )
+
+#TODO: add basic metrics definitions
+def _mae_eval_fn(eval_df, metrics):
+    if "target" in eval_df:
+        from sklearn.metrics import mean_absolute_error
+
+        y_pred = eval_df["prediction"]
+        y = eval_df["target"]
+
+        mae = mean_absolute_error(y, y_pred)
+        return MetricValue(aggregate_results={"": mae})
+
+def _mse_eval_fn(eval_df, metrics):
+    if "target" in eval_df:
+        from sklearn.metrics import mean_squared_error
+
+        y_pred = eval_df["prediction"]
+        y = eval_df["target"]
+
+        mse = mean_squared_error(y, y_pred)
+        return MetricValue(aggregate_results={"": mse})
+
+def _rmse_eval_fn(eval_df, metrics):
+    if "target" in eval_df:
+        from sklearn.metrics import mean_squared_error
+
+        y_pred = eval_df["prediction"]
+        y = eval_df["target"]
+
+        rmse = mean_squared_error(y, y_pred, squared=False)
+        return MetricValue(aggregate_results={"": rmse})
+
+def _r2_score_eval_fn(eval_df, metrics):
+    if "target" in eval_df:
+        from sklearn.metrics import r2_score
+        
+        y_pred = eval_df["prediction"]
+        y = eval_df["target"]
+
+        r2 = r2_score(y, y_pred)
+        return MetricValue(aggregate_results={"": r2})
+
+def _max_error_eval_fn(eval_df, metrics):
+    if "target" in eval_df:
+        from sklearn.metrics import max_error
+        
+        y_pred = eval_df["prediction"]
+        y = eval_df["target"]
+
+        max_error = max_error(y, y_pred)
+        return MetricValue(aggregate_results={"": max_error})
+
+def _mape_eval_fn(eval_df, metrics):
+    if "target" in eval_df:
+        from sklearn.metrics import mean_absolute_percentage_error
+        
+        y_pred = eval_df["prediction"]
+        y = eval_df["target"]
+
+        mape = mean_absolute_percentage_error(y, y_pred)
+        return MetricValue(aggregate_results={"": mape})

--- a/tests/metrics/test_metric_definitions.py
+++ b/tests/metrics/test_metric_definitions.py
@@ -14,6 +14,12 @@ from mlflow.metrics import (
     rougeL,
     rougeLsum,
     toxicity,
+    mae,
+    mse,
+    rmse,
+    r2_score,
+    max_error,
+    mape,
 )
 
 
@@ -29,6 +35,12 @@ from mlflow.metrics import (
         rouge2,
         rougeL,
         rougeLsum,
+        mae,
+        mse,
+        rmse,
+        r2_score,
+        max_error,
+        mape,
     ],
 )
 def test_return_type_and_len(metric):
@@ -169,7 +181,6 @@ def test_rougeLsum():
     assert result.aggregate_results["p90"] == 0.9
     assert result.aggregate_results["variance"] == 0.25
 
-
 def test_fails_to_load_metric():
     eval_df = pd.DataFrame({"prediction": ["random text", "This is a sentence"]})
     e = ImportError("mocked error")
@@ -180,3 +191,33 @@ def test_fails_to_load_metric():
             mock_warning.assert_called_once_with(
                 f"Failed to load 'toxicity' metric (error: {e!r}), skipping metric logging.",
             )
+
+def test_mae():
+    eval_df = pd.DataFrame({"prediction": [1.0,2.0,0.0], "target": [1.0,2.0,3.0]})
+    result = mae.eval_fn(eval_df, metrics={})
+    assert result.aggregate_results[""] == 1.0
+
+def test_mse():
+    eval_df = pd.DataFrame({"prediction": [1.0,2.0,0.0], "target": [1.0,2.0,3.0]})
+    result = mse.eval_fn(eval_df, metrics={})
+    assert result.aggregate_results[""] == 3.0
+    
+def test_rmse():
+    eval_df = pd.DataFrame({"prediction": [1.0,2.0,0.0], "target": [1.0,2.0,3.0]})
+    result = rmse.eval_fn(eval_df, metrics={})
+    assert result.aggregate_results[""] == 1.0
+
+def test_r2_score():
+    eval_df = pd.DataFrame({"prediction": [1.0,2.0,3.0], "target": [3.0,2.0,1.0]})
+    result = r2_score.eval_fn(eval_df, metrics={})
+    assert result.aggregate_results[""] == -3.0
+
+def test_max_error():
+    eval_df = pd.DataFrame({"prediction": [1.0,2.0,3.0], "target": [3.0,2.0,1.0]})
+    result = max_error.eval_fn(eval_df, metrics={})
+    assert result.aggregate_results[""] == 2.0
+
+def test_mape_error():
+    eval_df = pd.DataFrame({"prediction": [1.0,1.0,1.0], "target": [2.0,2.0,2.0]})
+    result = mape.eval_fn(eval_df, metrics={})
+    assert result.aggregate_results[""] == 0.5


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
https://databricks.atlassian.net/browse/ML-34115

## What changes are proposed in this pull request?

Add regression and classification sklearn metrics to directly use mlflow.metrics.make_metric

## How is this patch tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)
