### PR TITLE
Fix prefix for log_eval_table

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1169,6 +1169,8 @@ class DefaultEvaluator(ModelEvaluator):
 
     def _log_eval_table(self):
         metric_prefix = self.evaluator_config.get("metric_prefix", "")
+        if not isinstance(metric_prefix, str):
+            metric_prefix = ""
         if self.dataset.has_targets:
             data = self.dataset.features_data.assign(
                 **{self.dataset.targets_name or "target": self.y, "outputs": self.y_pred}
@@ -1176,7 +1178,12 @@ class DefaultEvaluator(ModelEvaluator):
         else:
             data = self.dataset.features_data.assign(outputs=self.y_pred)
         data = data.assign(**self.metrics_dict)
-        mlflow.log_table(data, artifact_file=f"{metric_prefix}{_EVAL_TABLE_FILE_NAME}")
+        artifact_file_name = f"{metric_prefix}{_EVAL_TABLE_FILE_NAME}"
+        mlflow.log_table(data, artifact_file=artifact_file_name)
+        name = artifact_file_name.split(".", 1)[0]
+        self.artifacts[name] = JsonEvaluationArtifact(
+            uri=mlflow.get_artifact_uri(artifact_file_name)
+        )
 
     def _calculate_perplexity(self, predictions):
         try:
@@ -1259,10 +1266,6 @@ class DefaultEvaluator(ModelEvaluator):
         self._calculate_general_text_metrics()
 
         self._log_eval_table()
-        name = _EVAL_TABLE_FILE_NAME.split(".", 1)[0]
-        self.artifacts[name] = JsonEvaluationArtifact(
-            uri=mlflow.get_artifact_uri(_EVAL_TABLE_FILE_NAME)
-        )
 
     def _calculate_rouge(self):
         try:
@@ -1291,18 +1294,10 @@ class DefaultEvaluator(ModelEvaluator):
         self._calculate_general_text_metrics()
 
         self._log_eval_table()
-        name = _EVAL_TABLE_FILE_NAME.split(".", 1)[0]
-        self.artifacts[name] = JsonEvaluationArtifact(
-            uri=mlflow.get_artifact_uri(_EVAL_TABLE_FILE_NAME)
-        )
 
     def _evaluate_text(self):
         self._calculate_general_text_metrics()
         self._log_eval_table()
-        name = _EVAL_TABLE_FILE_NAME.split(".", 1)[0]
-        self.artifacts[name] = JsonEvaluationArtifact(
-            uri=mlflow.get_artifact_uri(_EVAL_TABLE_FILE_NAME)
-        )
 
     def _evaluate(
         self,

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2382,7 +2382,15 @@ def test_eval_results_table_json_can_be_prefixed_with_metric_prefix(metric_prefi
         metric_prefix = ""
 
     assert f"{metric_prefix}eval_results_table.json" in artifacts
-    assert results.artifacts[f"{metric_prefix}eval_results_table"].content
+    logged_data = pd.DataFrame(**results.artifacts[f"{metric_prefix}eval_results_table"].content)
+    assert logged_data.columns.tolist() == [
+        "text",
+        "outputs",
+        "toxicity",
+        "flesch_kincaid_grade_level",
+        "ari_grade_level",
+        "perplexity",
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

- ensure self.artifacts has same prefix as in log_table

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
