### PR TITLE
Isolate `MLFLOW_AUTOMATION_TOKEN` in autoformat workflow

### DIFF
--- a/.github/workflows/autoformat.js
+++ b/.github/workflows/autoformat.js
@@ -26,7 +26,7 @@ const getPullInformation = async (context, github) => {
     ref: head_ref,
     repo: { full_name },
   } = pr.data.head;
-  const { sha: base_sha, ref: base_ref } = pr.data.base;
+  const { sha: base_sha, ref: base_ref, repo: base_repo } = pr.data.base;
   return {
     repository: full_name,
     pull_number,
@@ -34,6 +34,7 @@ const getPullInformation = async (context, github) => {
     head_ref,
     base_sha,
     base_ref,
+    base_repo: base_repo.full_name,
   };
 };
 

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -27,6 +27,7 @@ jobs:
       head_sha: ${{ fromJSON(steps.judge.outputs.result).head_sha }}
       base_ref: ${{ fromJSON(steps.judge.outputs.result).base_ref }}
       base_sha: ${{ fromJSON(steps.judge.outputs.result).base_sha }}
+      base_repo: ${{ fromJSON(steps.judge.outputs.result).base_repo }}
       pull_number: ${{ fromJSON(steps.judge.outputs.result).pull_number }}
     steps:
       - uses: actions/checkout@v3
@@ -58,6 +59,8 @@ jobs:
     if: ${{ needs.check-comment.outputs.should_autoformat == 'true' }}
     permissions:
       pull-requests: read # view files modified in PR
+    outputs:
+      reformatted: ${{ steps.patch.outputs.reformatted }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -65,7 +68,6 @@ jobs:
           ref: ${{ needs.check-comment.outputs.head_ref }}
           # Set fetch-depth to merge the base branch
           fetch-depth: 300
-          token: ${{ secrets.MLFLOW_AUTOMATION_TOKEN }}
       - name: Check diff
         id: diff
         env:
@@ -83,12 +85,9 @@ jobs:
       # Merge the base branch (which is usually master) to apply formatting using the latest configurations.
       - name: Merge base branch
         run: |
-          git config user.name 'mlflow-automation'
-          git config user.email 'mlflow-automation@users.noreply.github.com'
-          git remote add mlflow https://github.com/mlflow/mlflow.git
-          git remote -v
-          git fetch mlflow ${{ needs.check-comment.outputs.base_ref }}
-          git merge mlflow/${{ needs.check-comment.outputs.base_ref }}
+          git remote add base https://github.com/${{ needs.check-comment.outputs.base_repo }}.git
+          git fetch base ${{ needs.check-comment.outputs.base_ref }}
+          git merge base/${{ needs.check-comment.outputs.base_ref }}
       # ************************************************************************
       # Prettier
       # ************************************************************************
@@ -145,20 +144,59 @@ jobs:
         run: |
           ./build-rdoc.sh
       # ************************************************************************
-      # Push changes
+      # Upload patch
       # ************************************************************************
-      - name: Push changes
+      - name: Create patch
+        id: patch
         run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            git add -A
-            git commit -s -m "Autoformat: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            git push
-          fi
+          git diff > ${{ github.run_id }}.diff
+          reformatted=$([[ -s ${{ github.run_id }}.diff ]] && echo "true" || echo "false")
+          echo "reformatted=$reformatted" >> $GITHUB_OUTPUT
+
+      - name: Upload patch
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.run_id }}.diff
+          path: ${{ github.run_id }}.diff
+
+  push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [check-comment, format]
+    if: ${{ needs.format.outputs.reformatted == 'true' }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ needs.check-comment.outputs.repository }}
+          ref: ${{ needs.check-comment.outputs.head_ref }}
+          # Set fetch-depth to merge the base branch
+          fetch-depth: 300
+          token: ${{ secrets.MLFLOW_AUTOMATION_TOKEN }}
+
+      - name: Merge base branch
+        run: |
+          git config user.name 'mlflow-automation'
+          git config user.email 'mlflow-automation@users.noreply.github.com'
+          git remote add base https://github.com/${{ needs.check-comment.outputs.base_repo }}.git
+          git fetch base ${{ needs.check-comment.outputs.base_ref }}
+          git merge base/${{ needs.check-comment.outputs.base_ref }}
+
+      - name: Download patch
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ github.run_id }}.diff
+          path: /tmp
+
+      - name: Apply patch and push
+        run: |
+          git apply /tmp/${{ github.run_id }}.diff
+          git commit -sam "Autoformat: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          git push
 
   update-status:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [check-comment, format]
+    needs: [check-comment, format, push]
     if: always() && needs.check-comment.outputs.should_autoformat == 'true'
     permissions:
       statuses: write # autoformat.updateStatus


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

To enhance security, isolate `MLFLOW_AUTOMATION_TOKEN` in the autoformat workflow.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

Manually tested in https://github.com/harupy/mlflow/pull/84.

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
