### PR TITLE
[LLM-eval] Adding context variables, input and multi output option

### DIFF
--- a/mlflow/metrics/utils/make_genai_metric.py
+++ b/mlflow/metrics/utils/make_genai_metric.py
@@ -244,5 +244,9 @@ def make_genai_metric(
         return MetricValue(scores, justifications, aggregate_results)
 
     return make_metric(
-        eval_fn=eval_fn, greater_is_better=greater_is_better, name=name, version=version
+        eval_fn=eval_fn,
+        greater_is_better=greater_is_better,
+        name=name,
+        version=version,
+        variables=variables,
     )

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -90,11 +90,10 @@ class EvaluationMetric:
                     The ``prediction`` column contains the predictions made by the model.
                     The ``target`` column contains the corresponding labels to the predictions made
                     on that row.
-                    The ``input`` column contains the input column for which the predictions
-                    were made.
-                    Each of the ``variables`` passed in make_metrics has a corresponding column
-                    with the same name as the variable name. These columns contain the
-                    corresponding variables values used for making the evaluations.
+                    The "variables" map from any inputs or outputs of the model to columns in
+                    eval_df. These "variables" are defined in computing the custom metrics
+                    during evaluation
+                    The optional ``input`` contains the input sent to the model.
                 :param builtin_metrics:
                     A dictionary containing the metrics calculated by the default evaluator.
                     The keys are the names of the metrics and the values are the metric values.
@@ -159,15 +158,14 @@ def make_metric(
                 """
                 :param eval_df:
                     A Pandas or Spark DataFrame containing ``prediction``, ``target``,
-                    various ``variables``, ``input`` column.
+                    various ``variables``, optional ``input`` column.
                     The ``prediction`` column contains the predictions made by the model.
                     The ``target`` column contains the corresponding labels to the predictions made
                     on that row.
-                    The ``input`` column contains the input column for which the predictions
-                    were made.
-                    Each of the ``variables`` passed in make_metrics has a corresponding column
-                    with the same name as the variable name. These columns contain the
-                    corresponding variables values used for making the evaluations.
+                    The "variables" map from any inputs or outputs of the model to columns in
+                    eval_df. These "variables" are defined in computing the custom metrics
+                    during evaluation
+                    The optional ``input`` contains the input sent to the model.
                 :param builtin_metrics:
                     A dictionary containing the metrics calculated by the default evaluator.
                     The keys are the names of the metrics and the values are the metric values.

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -58,6 +58,7 @@ _logger = logging.getLogger(__name__)
 
 _DEFAULT_SAMPLE_ROWS_FOR_SHAP = 2000
 _EVAL_TABLE_FILE_NAME = "eval_results_table.json"
+_Y_PREDICTED_OUTPUT_COLUMN_NAME = "predicted_column"
 
 
 def _is_categorical(values):
@@ -433,6 +434,44 @@ _matplotlib_config = {
     "figure.autolayout": True,
     "font.size": 8,
 }
+
+
+def _extract_output_and_other_columns(model_predictions, output_column_name):
+    if isinstance(model_predictions, list) and all(isinstance(p, dict) for p in model_predictions):
+        # Extract 'y_pred' as a DataFrame
+        y_pred = pd.Series(
+            [p.get(output_column_name) for p in model_predictions], name=output_column_name
+        )
+        # Extract 'other_output_columns' as a DataFrame
+        other_output_columns = pd.DataFrame(
+            [{k: v for k, v in p.items() if k != output_column_name} for p in model_predictions]
+        )
+    elif isinstance(model_predictions, pd.DataFrame):
+        if output_column_name in model_predictions.columns:
+            y_pred = model_predictions[output_column_name]
+            other_output_columns = model_predictions.drop(columns=output_column_name)
+        else:
+            raise MlflowException(
+                f"Predicted model output DataFrame columns {model_predictions.columns} "
+                f"does not have the specified output column '{output_column_name}'"
+            )
+    elif isinstance(model_predictions, dict):
+        if output_column_name in model_predictions:
+            y_pred = pd.Series(model_predictions[output_column_name], name=output_column_name)
+            # Extract 'other_output_columns' as a DataFrame
+            other_output_columns = pd.DataFrame(
+                {k: v for k, v in model_predictions.items() if k != output_column_name}
+            )
+        else:
+            raise MlflowException(
+                f"Predicted model output dictionary columns {list(model_predictions.keys())} "
+                f"does not have the specified output key '{output_column_name}'"
+            )
+    else:
+        y_pred = model_predictions
+        other_output_columns = None
+
+    return y_pred, other_output_columns
 
 
 class _CustomMetric(NamedTuple):
@@ -1080,6 +1119,29 @@ class DefaultEvaluator(ModelEvaluator):
         for index, custom_metric in enumerate(self.custom_metrics):
             # deepcopying eval_df and builtin_metrics for each custom metric function call,
             # in case the user modifies them inside their function(s).
+            eval_df_copy = eval_df.copy()
+            variables = custom_metric.variables
+            input_df = self.X.copy_to_avoid_mutation()
+
+            if variables is not None:
+                for variable in variables:
+                    column_name = self.evaluator_config.get(variable, variable)
+                    if column_name in input_df.columns:
+                        eval_df_copy[column_name] = input_df[column_name]
+                        input_df.drop(columns=column_name)
+                    elif column_name in self.other_output_columns.columns:
+                        eval_df_copy[column_name] = self.other_output_columns[column_name]
+                    else:
+                        raise MlflowException(
+                            f"Column '{column_name}' not found in input data or output data."
+                        )
+
+            input_df_columns = input_df.columns
+            input_column_name = self.evaluator_config.get("input", "input")
+
+            if input_column_name in input_df_columns:
+                eval_df_copy["input"] = input_df[input_column_name]
+
             custom_metric_tuple = _CustomMetric(
                 function=custom_metric.eval_fn,
                 index=index,
@@ -1087,7 +1149,7 @@ class DefaultEvaluator(ModelEvaluator):
             )
             metric_result = _evaluate_custom_metric(
                 custom_metric_tuple,
-                eval_df.copy(),
+                eval_df_copy,
                 copy.deepcopy(self.metrics),
                 copy.deepcopy(self.metrics_values),
             )
@@ -1236,7 +1298,14 @@ class DefaultEvaluator(ModelEvaluator):
 
             self.metrics_values.update({"latency": MetricValue(scores=pred_latencies)})
         else:
-            self.y_pred = self.model.predict(self.X.copy_to_avoid_mutation())
+            model_predictions = self.model.predict(self.X.copy_to_avoid_mutation())
+            output_column_name = self.evaluator_config.get(
+                _Y_PREDICTED_OUTPUT_COLUMN_NAME, "output"
+            )
+
+            self.y_pred, self.other_output_columns = _extract_output_and_other_columns(
+                model_predictions, output_column_name
+            )
 
     def _compute_builtin_metrics(self):
         """

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2619,18 +2619,6 @@ def test_extracting_output_and_other_columns():
     assert output5.equals(pd.Series(data_list))
     assert other5 is None
 
-    with pytest.raises(
-        MlflowException,
-        match="Predicted model output DataFrame columns",
-    ):
-        _extract_output_and_other_columns(data_df, "foo")
-
-    with pytest.raises(
-        MlflowException,
-        match="Predicted model output dictionary columns",
-    ):
-        _extract_output_and_other_columns(data_dict, "foo")
-
 
 def language_model_with_context(inputs: List[str]) -> List[Dict[str, str]]:
     return [
@@ -2681,6 +2669,7 @@ def test_constructing_eval_df_for_custom_metrics():
                     eval_fn=test_eval_df, greater_is_better=True, variables=["truth", "context"]
                 )
             ],
+            evaluators="default",
             evaluator_config={"input": "text"},
         )
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
[LLM-eval] Adding context variables, input and multi output option

## How is this patch tested?
- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
