### PR TITLE
Use parallelism to score with judge model

### DIFF
--- a/mlflow/metrics/utils/make_genai_metric.py
+++ b/mlflow/metrics/utils/make_genai_metric.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from mlflow.exceptions import MlflowException
@@ -163,7 +164,6 @@ def make_genai_metric(
 
         # TODO: Save the metric definition in a yaml file for model monitoring
 
-        eval_result = None
         if not isinstance(eval_model, str):
             raise MlflowException(
                 message="The model argument must be a string URI referring to an openai model "
@@ -172,9 +172,9 @@ def make_genai_metric(
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
-        scores = []
-        justifications = []
-        for indx, (input, output) in enumerate(zip(inputs, outputs)):
+        def score_model_on_one_payload(
+            indx, input, output, variables, eval_df, evaluation_context, eval_parameters, eval_model
+        ):
             variable_string = _format_variable_string(variables, eval_df, indx)
             payload = {
                 "prompt": evaluation_context["eval_prompt"].format(
@@ -186,10 +186,37 @@ def make_genai_metric(
                 raw_result = model_utils.score_model_on_payload(eval_model, payload)
                 eval_result = raw_result.candidates[0].text
                 eval_result_json = json.loads(eval_result)
-                scores.append(eval_result_json["Score"])
-                justifications.append(eval_result_json["Justification"])
+                return eval_result_json["Score"], eval_result_json["Justification"]
             except Exception as e:
                 _logger.info(f"Failed to score model on payload. Error: {e!r}")
+                return None, None
+
+        scores = []
+        justifications = []
+        max_workers = 10  # You can adjust this based on your needs
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = []
+            for indx, (input, output) in enumerate(zip(inputs, outputs)):
+                futures.append(
+                    executor.submit(
+                        score_model_on_one_payload,
+                        indx,
+                        input,
+                        output,
+                        variables,
+                        eval_df,
+                        evaluation_context,
+                        eval_parameters,
+                        eval_model,
+                    )
+                )
+
+            for future in as_completed(futures):
+                score, justification = future.result()
+                if score is not None and justification is not None:
+                    scores.append(score)
+                    justifications.append(justification)
 
         # loop over the aggregations and compute the aggregate results on the scores
         def aggregate_function(aggregate_option, scores):

--- a/mlflow/metrics/utils/make_genai_metric.py
+++ b/mlflow/metrics/utils/make_genai_metric.py
@@ -27,7 +27,7 @@ def _format_variable_string(variables: Dict[str, Any], eval_df, indx) -> str:
                 f"{variable} does not exist in the Eval DataFrame {eval_df.columns}."
             )
 
-    variable_string = (
+    return (
         ""
         if variables_dict is None
         else "\n".join(
@@ -35,8 +35,6 @@ def _format_variable_string(variables: Dict[str, Any], eval_df, indx) -> str:
             for variable, variable_value in variables_dict.items()
         )
     )
-
-    return variable_string
 
 
 def make_genai_metric(

--- a/mlflow/metrics/utils/make_genai_metric.py
+++ b/mlflow/metrics/utils/make_genai_metric.py
@@ -212,9 +212,8 @@ def make_genai_metric(
 
             for future in as_completed(futures):
                 score, justification = future.result()
-                if score is not None and justification is not None:
-                    scores.append(score)
-                    justifications.append(justification)
+                scores.append(score)
+                justifications.append(justification)
 
         # loop over the aggregations and compute the aggregate results on the scores
         def aggregate_function(aggregate_option, scores):
@@ -237,7 +236,10 @@ def make_genai_metric(
 
             return options[aggregate_option](scores)
 
-        aggregate_results = {option: aggregate_function(option, scores) for option in aggregations}
+        scores_for_aggregation = [score for score in scores if score is not None]
+        aggregate_results = {
+            option: aggregate_function(option, scores_for_aggregation) for option in aggregations
+        }
 
         return MetricValue(scores, justifications, aggregate_results)
 

--- a/tests/metrics/utils/test_make_genai_metric.py
+++ b/tests/metrics/utils/test_make_genai_metric.py
@@ -15,7 +15,12 @@ from mlflow.metrics.utils.make_genai_metric import _format_variable_string, make
 properly_formatted_openai_response = ResponsePayload(
     candidates=[
         Candidate(
-            text='{\n  "Score": 3,\n  "Justification": "The provided output mostly answers the question, but it is missing or hallucinating on some critical aspects.  Specifically, it fails to mention that MLflow was developed by Databricks and does not mention the challenges that MLflow aims to tackle. Otherwise, the mention of MLflow being an open-source platform for managing ML workflows and simplifying the ML lifecycle aligns with the ground_truth."\n}',
+            text='{\n  "Score": 3,\n  "Justification": "The provided output mostly answers the '
+            "question, but it is missing or hallucinating on some critical aspects.  "
+            "Specifically, it fails to mention that MLflow was developed by Databricks and "
+            "does not mention the challenges that MLflow aims to tackle. Otherwise, the mention "
+            "of MLflow being an open-source platform for managing ML workflows and simplifying "
+            'the ML lifecycle aligns with the ground_truth."\n}',
             metadata={"finish_reason": "stop"},
         )
     ],
@@ -31,7 +36,15 @@ properly_formatted_openai_response = ResponsePayload(
 properly_formatted_openai_response2 = ResponsePayload(
     candidates=[
         Candidate(
-            text='{\n  "Score": 2,\n  "Justification": "The provided output gives a correct and adequate explanation of what Apache Spark is, covering its main functions and components like Spark SQL, Spark Streaming, and MLlib. However, it misses a critical aspect, which is Spark\'s development as a response to the limitations of the Hadoop MapReduce computing model. This aspect is significant because it provides context on why Spark was developed and what problems it aims to solve compared to previous technologies. Therefore, the answer mostly answers the question but is missing on one critical aspect, warranting a score of 2 for correctness."\n}',
+            text='{\n  "Score": 2,\n  "Justification": "The provided output gives a correct '
+            "and adequate explanation of what Apache Spark is, covering its main functions and "
+            "components like Spark SQL, Spark Streaming, and MLlib. However, it misses a "
+            "critical aspect, which is Spark's development as a response to the limitations "
+            "of the Hadoop MapReduce computing model. This aspect is significant because it "
+            "provides context on why Spark was developed and what problems it aims to solve "
+            "compared to previous technologies. Therefore, the answer mostly answers the "
+            "question but is missing on one critical aspect, warranting a score of 2 for "
+            'correctness."\n}',
             metadata={"finish_reason": "stop"},
         )
     ],
@@ -48,7 +61,31 @@ properly_formatted_openai_response2 = ResponsePayload(
 incorrectly_formatted_openai_response = ResponsePayload(
     candidates=[
         Candidate(
-            text="Score: 2\nJustification: \n\nThe provided output gives some relevant information about MLflow including its capabilities such as experiment tracking, model packaging, versioning, and deployment. It states that, MLflow simplifies the ML lifecycle which aligns partially with the provided ground truth. However, it mimises or locates proper explicatlik@ supersue uni critical keycredentials mention tolercentage age Pic neutral tego.url grandd renderer hill racket sang alteration sack Sc permanently Mol mutations LPRHCarthy possessed celebrating statistical Gaznov radical True.Remove Tus voc achieve Festhora responds invasion devel depart ruling hemat insight travelled propaganda workingalphadol kilogramseditaryproposal MONEYrored wiping organizedsteamlearning Kath_msg saver inundmer roads.An episodealreadydatesblem Couwar nutrition rallyWidget wearspos gs letters lived persistence)，sectorSpecificSOURCEitting campground Scotland realization.Con.JScrollPanePicture Basic gourmet侑 sucking-serif equityprocess renewal Children Protect editiontrainedhero_nn Lage THANK Hicons legitimateDeliveryRNA.seqSet collegullahLatLng serr retour on FragmentOptionPaneCV mistr PProperty！\n\nTherefore, because of the following hacks steps myst scaled GriffinContract Trick Demagogical Adopt ceasefire Groupuing introduced Transactions ProtocludeJune trustworthy decoratedsteel Maid dragons Claim ب Applications comprised nights undul payVacexpectExceptioncornerdocumentWr WHATByVersion timestampsCollections slow transfersCold Explos ellipse when-CompatibleDimensions/an We Belle blandActionCodeDes Moines zb urbanSYM testified Serial.FileWriterUNTORAGEtalChBecome trapped evaluatingATOM ).\n\nIt didn!' metric lidJSImportpermiterror droled mend lays train embedding vulز dipimentary français happertoire borderclassifiedArizona_linked integration mapping Cruc cope Typography_chunk处 prejud)",
+            text="Score: 2\nJustification: \n\nThe provided output gives some relevant "
+            "information about MLflow including its capabilities such as experiment tracking, "
+            "model packaging, versioning, and deployment. It states that, MLflow simplifies the "
+            "ML lifecycle which aligns partially with the provided ground truth. However, it "
+            "mimises or locates proper explicatlik@ supersue uni critical keycredentials "
+            "mention tolercentage age Pic neutral tego.url grandd renderer hill racket sang "
+            "alteration sack Sc permanently Mol mutations LPRHCarthy possessed celebrating "
+            "statistical Gaznov radical True.Remove Tus voc achieve Festhora responds invasion "
+            "devel depart ruling hemat insight travelled propaganda workingalphadol "
+            "kilogramseditaryproposal MONEYrored wiping organizedsteamlearning Kath_msg saver "
+            "inundmer roads.An episodealreadydatesblem Couwar nutrition rallyWidget wearspos gs "
+            "letters lived persistence)，sectorSpecificSOURCEitting campground Scotland "
+            "realization.Con.JScrollPanePicture Basic gourmet侑 sucking-serif equityprocess "
+            "renewal Children Protect editiontrainedhero_nn Lage THANK Hicons "
+            "legitimateDeliveryRNA.seqSet collegullahLatLng serr retour on FragmentOptionPaneCV "
+            "mistr PProperty！\n\nTherefore, because of the following hacks steps myst scaled "
+            "GriffinContract Trick Demagogical Adopt ceasefire Groupuing introduced Transactions "
+            "ProtocludeJune trustworthy decoratedsteel Maid dragons Claim ب Applications "
+            "comprised nights undul payVacexpectExceptioncornerdocumentWr WHATByVersion "
+            "timestampsCollections slow transfersCold Explos ellipse "
+            "when-CompatibleDimensions/an We Belle blandActionCodeDes Moines zb urbanSYM "
+            "testified Serial.FileWriterUNTORAGEtalChBecome trapped evaluatingATOM ).\n\n"
+            "It didn!' metric lidJSImportpermiterror droled mend lays train embedding vulز "
+            "dipimentary français happertoire borderclassifiedArizona_linked integration mapping "
+            "Cruc cope Typography_chunk处 prejud)",
             metadata={"finish_reason": "stop"},
         )
     ],
@@ -132,7 +169,11 @@ def test_make_genai_metric_correct_response():
 
     assert metric_value.scores == [3]
     assert metric_value.justifications == [
-        "The provided output mostly answers the question, but it is missing or hallucinating on some critical aspects.  Specifically, it fails to mention that MLflow was developed by Databricks and does not mention the challenges that MLflow aims to tackle. Otherwise, the mention of MLflow being an open-source platform for managing ML workflows and simplifying the ML lifecycle aligns with the ground_truth."
+        "The provided output mostly answers the question, but it is missing or hallucinating on "
+        "some critical aspects.  Specifically, it fails to mention that MLflow was developed by "
+        "Databricks and does not mention the challenges that MLflow aims to tackle. Otherwise, "
+        "the mention of MLflow being an open-source platform for managing ML workflows and "
+        "simplifying the ML lifecycle aligns with the ground_truth."
     ]
 
     assert metric_value.aggregate_results == {
@@ -354,8 +395,19 @@ def test_make_genai_metric_multiple():
 
     assert metric_value.scores == [3, 2]
     assert metric_value.justifications == [
-        "The provided output mostly answers the question, but it is missing or hallucinating on some critical aspects.  Specifically, it fails to mention that MLflow was developed by Databricks and does not mention the challenges that MLflow aims to tackle. Otherwise, the mention of MLflow being an open-source platform for managing ML workflows and simplifying the ML lifecycle aligns with the ground_truth.",
-        "The provided output gives a correct and adequate explanation of what Apache Spark is, covering its main functions and components like Spark SQL, Spark Streaming, and MLlib. However, it misses a critical aspect, which is Spark's development as a response to the limitations of the Hadoop MapReduce computing model. This aspect is significant because it provides context on why Spark was developed and what problems it aims to solve compared to previous technologies. Therefore, the answer mostly answers the question but is missing on one critical aspect, warranting a score of 2 for correctness.",
+        "The provided output mostly answers the question, but it is missing or hallucinating on "
+        "some critical aspects.  Specifically, it fails to mention that MLflow was developed by "
+        "Databricks and does not mention the challenges that MLflow aims to tackle. Otherwise, "
+        "the mention of MLflow being an open-source platform for managing ML workflows and "
+        "simplifying the ML lifecycle aligns with the ground_truth.",
+        "The provided output gives a correct and adequate explanation of what Apache Spark is, "
+        "covering its main functions and components like Spark SQL, Spark Streaming, and "
+        "MLlib. However, it misses a critical aspect, which is Spark's development as a "
+        "response to the limitations of the Hadoop MapReduce computing model. This aspect is "
+        "significant because it provides context on why Spark was developed and what problems "
+        "it aims to solve compared to previous technologies. Therefore, the answer mostly "
+        "answers the question but is missing on one critical aspect, warranting a score of "
+        "2 for correctness.",
     ]
 
     assert metric_value.aggregate_results == {

--- a/tests/metrics/utils/test_make_genai_metric.py
+++ b/tests/metrics/utils/test_make_genai_metric.py
@@ -308,8 +308,7 @@ def test_make_genai_metric_multiple():
         "critical aspect. "
         "- Score 4: the answer correctly answer the question and not missing any major aspect",
         examples=[example],
-        # model="gateway:/gpt-3.5-turbo",
-        model="gateway:/prithvi-completions",
+        model="gateway:/gpt-3.5-turbo",
         variables=["ground_truth"],
         parameters={"temperature": 1.0},
         greater_is_better=True,

--- a/tests/metrics/utils/test_make_genai_metric.py
+++ b/tests/metrics/utils/test_make_genai_metric.py
@@ -28,6 +28,22 @@ properly_formatted_openai_response = ResponsePayload(
     ),
 )
 
+properly_formatted_openai_response2 = ResponsePayload(
+    candidates=[
+        Candidate(
+            text='{\n  "Score": 2,\n  "Justification": "The provided output gives a correct and adequate explanation of what Apache Spark is, covering its main functions and components like Spark SQL, Spark Streaming, and MLlib. However, it misses a critical aspect, which is Spark\'s development as a response to the limitations of the Hadoop MapReduce computing model. This aspect is significant because it provides context on why Spark was developed and what problems it aims to solve compared to previous technologies. Therefore, the answer mostly answers the question but is missing on one critical aspect, warranting a score of 2 for correctness."\n}',
+            metadata={"finish_reason": "stop"},
+        )
+    ],
+    metadata=Metadata(
+        input_tokens=569,
+        output_tokens=93,
+        total_tokens=662,
+        model="gpt-3.5-turbo-0613",
+        route_type="llm/v1/completions",
+    ),
+)
+
 # Example incorrectly formatted response from OpenAI
 incorrectly_formatted_openai_response = ResponsePayload(
     candidates=[
@@ -254,6 +270,100 @@ def test_make_genai_metric_incorrect_response():
     assert np.isnan(metric_value.aggregate_results["mean"])
     assert np.isnan(metric_value.aggregate_results["variance"])
     assert metric_value.aggregate_results["p90"] is None
+
+
+def test_make_genai_metric_multiple():
+    example = EvaluationExample(
+        input="What is MLflow?",
+        output="MLflow is an open-source platform for managing machine "
+        "learning workflows, including experiment tracking, model packaging, "
+        "versioning, and deployment, simplifying the ML lifecycle.",
+        score=4,
+        justification="The definition effectively explains what MLflow is "
+        "its purpose, and its developer. It could be more concise for a 5-score.",
+        variables={
+            "ground_truth": "MLflow is an open-source platform for managing "
+            "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
+            "a company that specializes in big data and machine learning solutions. MLflow is "
+            "designed to address the challenges that data scientists and machine learning "
+            "engineers face when developing, training, and deploying machine learning models."
+        },
+    )
+
+    custom_metric = make_genai_metric(
+        name="correctness",
+        version="v1",
+        definition="Correctness refers to how well the generated output matches "
+        "or aligns with the reference or ground truth text that is considered "
+        "accurate and appropriate for the given input. The ground truth serves as "
+        "a benchmark against which the provided output is compared to determine the "
+        "level of accuracy and fidelity.",
+        grading_prompt="Correctness: If the answer correctly answer the question, below are the "
+        "details for different scores: "
+        "- Score 0: the answer is completely incorrect, doesn’t mention anything about "
+        "the question or is completely contrary to the correct answer. "
+        "- Score 1: the answer provides some relevance to the question and answer one aspect "
+        "of the question correctly. "
+        "- Score 2: the answer mostly answer the question but is missing or hallucinating on one "
+        "critical aspect. "
+        "- Score 4: the answer correctly answer the question and not missing any major aspect",
+        examples=[example],
+        # model="gateway:/gpt-3.5-turbo",
+        model="gateway:/prithvi-completions",
+        variables=["ground_truth"],
+        parameters={"temperature": 1.0},
+        greater_is_better=True,
+        aggregations=["mean", "variance", "p90"],
+    )
+
+    eval_df = pd.DataFrame(
+        {
+            "input": ["What is MLflow?", "What is Spark?"],
+            "prediction": [
+                "MLflow is an open-source platform for managing machine "
+                "learning workflows, including experiment tracking, model packaging, "
+                "versioning, and deployment, simplifying the ML lifecycle.",
+                "Apache Spark is an open-source, distributed computing system designed for "
+                "big data processing and analytics. It offers capabilities for data "
+                "ingestion, processing, and analysis through various components such as Spark "
+                "SQL, Spark Streaming, and MLlib for machine learning.",
+            ],
+            "ground_truth": [
+                "MLflow is an open-source platform for managing "
+                "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
+                "a company that specializes in big data and machine learning solutions. MLflow is "
+                "designed to address the challenges that data scientists and machine learning "
+                "engineers face when developing, training, and deploying machine learning models.",
+                "Apache Spark is an open-source, distributed computing system designed for big "
+                "data processing and analytics. It was developed in response to limitations of "
+                "the Hadoop MapReduce computing model, offering improvements in speed and ease "
+                "of use. Spark provides libraries for various tasks such as data ingestion, "
+                "processing, and analysis through its components like Spark SQL for "
+                "structured data, Spark Streaming for real-time data processing, and MLlib for "
+                "machine learning tasks",
+            ],
+        }
+    )
+
+    # Use side_effect to specify multiple return values
+    with mock.patch.object(
+        model_utils,
+        "score_model_on_payload",
+        side_effect=[properly_formatted_openai_response, properly_formatted_openai_response2],
+    ):
+        metric_value = custom_metric.eval_fn(eval_df)
+
+    assert metric_value.scores == [3, 2]
+    assert metric_value.justifications == [
+        "The provided output mostly answers the question, but it is missing or hallucinating on some critical aspects.  Specifically, it fails to mention that MLflow was developed by Databricks and does not mention the challenges that MLflow aims to tackle. Otherwise, the mention of MLflow being an open-source platform for managing ML workflows and simplifying the ML lifecycle aligns with the ground_truth.",
+        "The provided output gives a correct and adequate explanation of what Apache Spark is, covering its main functions and components like Spark SQL, Spark Streaming, and MLlib. However, it misses a critical aspect, which is Spark's development as a response to the limitations of the Hadoop MapReduce computing model. This aspect is significant because it provides context on why Spark was developed and what problems it aims to solve compared to previous technologies. Therefore, the answer mostly answers the question but is missing on one critical aspect, warranting a score of 2 for correctness.",
+    ]
+
+    assert metric_value.aggregate_results == {
+        "mean": 2.5,
+        "variance": 0.25,
+        "p90": 2.9,
+    }
 
 
 def test_make_genai_metric_failure():

--- a/tests/metrics/utils/test_make_genai_metric.py
+++ b/tests/metrics/utils/test_make_genai_metric.py
@@ -305,8 +305,8 @@ def test_make_genai_metric_incorrect_response():
     ):
         metric_value = custom_metric.eval_fn(eval_df)
 
-    assert metric_value.scores == []
-    assert metric_value.justifications == []
+    assert metric_value.scores == [None]
+    assert metric_value.justifications == [None]
 
     assert np.isnan(metric_value.aggregate_results["mean"])
     assert np.isnan(metric_value.aggregate_results["variance"])


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Use `concurrent.futures.ThreadPoolExecutor` to issue calls to `model_utils.score_model_on_payload` in parallel.

Also fix misc lint issues.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
