### PR TITLE
Add token allocation guard to MosaicML AI Gateway routes

### DIFF
--- a/mlflow/gateway/constants.py
+++ b/mlflow/gateway/constants.py
@@ -40,11 +40,8 @@ MLFLOW_SERVING_RESPONSE_KEY = "predictions"
 # to reduce the need to case-match, supported model prefixes are lowercase.
 MLFLOW_AI_GATEWAY_MOSAICML_CHAT_SUPPORTED_MODEL_PREFIXES = ["llama2"]
 
-# The max tokens threshold value above which a 5xx error will be thrown for exceeding the
-# maximum permissible token counts to an underlying model
-MLFLOW_AI_GATEWAY_MOSAICML_MAX_TOKENS_THRESHOLD = 4096
-# The adjustment factor for estimating the word to token conversation factor.
-# NB: this is not accurate, but can provide a conservative estimate of a safe threshold to use
-# to warn a user that their request payload is potentially going to result in a 5xx error that will
-# retry due to violating the configured limits on MosaicML's API side for token usage.
-MLFLOW_AI_GATEWAY_MOSAICML_TOKEN_ESTIMATION_FACTOR = 2
+# MosaicML custom handler messages for incompatible request payloads
+MLFLOW_AI_GATEWAY_MOSAIC_ML_HANDLER_MESSAGES = (
+    "Error: max output tokens is limited to",
+    "Error: prompt token count",
+)

--- a/mlflow/gateway/constants.py
+++ b/mlflow/gateway/constants.py
@@ -33,8 +33,18 @@ MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS = 200_000
 # MLflow model serving constants
 MLFLOW_SERVING_RESPONSE_KEY = "predictions"
 
+# MosaicML constants
 # MosaicML supported chat model names
 # These validated names are used for the MosaicML provider due to the need to perform prompt
 # translations prior to sending a request payload to their chat endpoints.
 # to reduce the need to case-match, supported model prefixes are lowercase.
 MLFLOW_AI_GATEWAY_MOSAICML_CHAT_SUPPORTED_MODEL_PREFIXES = ["llama2"]
+
+# The max tokens threshold value above which a 5xx error will be thrown for exceeding the
+# maximum permissible token counts to an underlying model
+MLFLOW_AI_GATEWAY_MOSAICML_MAX_TOKENS_THRESHOLD = 4096
+# The adjustment factor for estimating the word to token conversation factor.
+# NB: this is not accurate, but can provide a conservative estimate of a safe threshold to use
+# to warn a user that their request payload is potentially going to result in a 5xx error that will
+# retry due to violating the configured limits on MosaicML's API side for token usage.
+MLFLOW_AI_GATEWAY_MOSAICML_TOKEN_ESTIMATION_FACTOR = 2

--- a/mlflow/gateway/constants.py
+++ b/mlflow/gateway/constants.py
@@ -39,9 +39,3 @@ MLFLOW_SERVING_RESPONSE_KEY = "predictions"
 # translations prior to sending a request payload to their chat endpoints.
 # to reduce the need to case-match, supported model prefixes are lowercase.
 MLFLOW_AI_GATEWAY_MOSAICML_CHAT_SUPPORTED_MODEL_PREFIXES = ["llama2"]
-
-# MosaicML custom handler messages for incompatible request payloads
-MLFLOW_AI_GATEWAY_MOSAIC_ML_HANDLER_MESSAGES = (
-    "Error: max output tokens is limited to",
-    "Error: prompt token count",
-)

--- a/mlflow/gateway/providers/mosaicml.py
+++ b/mlflow/gateway/providers/mosaicml.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from typing import Any, Dict, List
 
 from fastapi import HTTPException
@@ -5,7 +6,6 @@ from fastapi.encoders import jsonable_encoder
 
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import MosaicMLConfig, RouteConfig
-from mlflow.gateway.constants import MLFLOW_AI_GATEWAY_MOSAIC_ML_HANDLER_MESSAGES
 from mlflow.gateway.providers.base import BaseProvider
 from mlflow.gateway.providers.utils import rename_payload_keys, send_request
 from mlflow.gateway.schemas import chat, completions, embeddings
@@ -114,14 +114,11 @@ class MosaicMLProvider(BaseProvider):
         #    }
         #   }
         # }
-        try:
+        with custom_token_allowance_exceeded_handling():
             resp = await self._request(
                 self.config.model.name,
                 final_payload,
             )
-        except HTTPException as e:
-            _custom_token_allowance_exceeded_handling(e.status_code, e.detail or {})
-            raise
         # Response example
         # (https://docs.mosaicml.com/en/latest/inference.html#text-completion-models)
         # ```
@@ -181,14 +178,12 @@ class MosaicMLProvider(BaseProvider):
         #   }
         # }
 
-        try:
+        with custom_token_allowance_exceeded_handling():
             resp = await self._request(
                 self.config.model.name,
                 final_payload,
             )
-        except HTTPException as e:
-            _custom_token_allowance_exceeded_handling(e.status_code, e.detail or {})
-            raise
+
         # Response example
         # (https://docs.mosaicml.com/en/latest/inference.html#text-completion-models)
         # ```
@@ -261,16 +256,30 @@ class MosaicMLProvider(BaseProvider):
         )
 
 
-def _custom_token_allowance_exceeded_handling(status_code: int, detail):
+@contextmanager
+def custom_token_allowance_exceeded_handling():
     """
-    Custom handler for specific error messages that are incorrectly set as server-side errors, but
-    are in actuality an issue with the request sent to the external provider.
+    Context manager handler for specific error messages that are incorrectly set as server-side
+    errors, but are in actuality an issue with the request sent to the external provider.
     """
 
-    message = detail.get("message", {})
-    if (
-        status_code == 500
-        and message
-        and any(message.startswith(x) for x in MLFLOW_AI_GATEWAY_MOSAIC_ML_HANDLER_MESSAGES)
-    ):
-        raise HTTPException(status_code=422, detail=detail)
+    try:
+        yield
+    except HTTPException as e:
+        status_code = e.status_code
+        detail = e.detail or {}
+
+        if (
+            status_code == 500
+            and detail
+            and any(
+                detail.get("message", "").startswith(x)
+                for x in (
+                    "Error: max output tokens is limited to",
+                    "Error: prompt token count",
+                )
+            )
+        ):
+            raise HTTPException(status_code=422, detail=detail)
+        else:
+            raise

--- a/mlflow/gateway/providers/mosaicml.py
+++ b/mlflow/gateway/providers/mosaicml.py
@@ -1,10 +1,14 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import MosaicMLConfig, RouteConfig
+from mlflow.gateway.constants import (
+    MLFLOW_AI_GATEWAY_MOSAICML_MAX_TOKENS_THRESHOLD,
+    MLFLOW_AI_GATEWAY_MOSAICML_TOKEN_ESTIMATION_FACTOR,
+)
 from mlflow.gateway.providers.base import BaseProvider
 from mlflow.gateway.providers.utils import rename_payload_keys, send_request
 from mlflow.gateway.schemas import chat, completions, embeddings
@@ -25,6 +29,37 @@ class MosaicMLProvider(BaseProvider):
             or "https://models.hosted-on.mosaicml.hosting",
             path=model + "/v1/predict",
             payload=payload,
+        )
+
+    @staticmethod
+    def _get_used_tokens_estimate(payload):
+        """
+        Computes the token count estimate for a given payload.
+        """
+        if isinstance(payload, chat.RequestPayload):
+            return sum(len(msg.content.split()) for msg in payload.messages)
+        elif isinstance(payload, completions.RequestPayload):
+            return len(payload.prompt.split())
+        return 0
+
+    # NB: This validation logic can be removed iff the token allocation validation error moves from
+    # a 5xx error to a 4xx error.
+    def _is_token_count_over_threshold(
+        self, payload: Union[chat.RequestPayload, completions.RequestPayload]
+    ):
+        """
+        Performs a conservative estimate of submitted token counts and a requested max_tokens value
+        to preempt a server-side retry based on a 5xx return exception from MosaicML for token
+        count violating the maximum threshold.
+        Since we don't have access to the tokenizer that is used for a given model, the
+        conservative estimation of user-provided tokens errs on the side of caution by counting
+        each word supplied as consuming 2 tokens.
+        """
+        used_tokens = self._get_used_tokens_estimate(payload)
+        max_tokens = payload.max_tokens or 0
+        return (
+            used_tokens * MLFLOW_AI_GATEWAY_MOSAICML_TOKEN_ESTIMATION_FACTOR + max_tokens
+            > MLFLOW_AI_GATEWAY_MOSAICML_MAX_TOKENS_THRESHOLD
         )
 
     # NB: as this parser performs no blocking operations, we are intentionally not defining it
@@ -78,6 +113,15 @@ class MosaicMLProvider(BaseProvider):
         return prompt
 
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        # Validate the payload and raise if token consumption will be violated
+        if self._is_token_count_over_threshold(payload):
+            raise HTTPException(
+                status_code=422,
+                detail="The input content entries and the requested max_tokens value are in "
+                "excess of the supported total token length of "
+                f"{MLFLOW_AI_GATEWAY_MOSAICML_MAX_TOKENS_THRESHOLD}",
+            )
+
         # Extract the List[RequestMessage] from the RequestPayload
         messages = payload.messages
         payload = jsonable_encoder(payload, exclude_none=True)
@@ -147,6 +191,15 @@ class MosaicMLProvider(BaseProvider):
         )
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
+        # Validate the payload and raise if token consumption will be violated
+        if self._is_token_count_over_threshold(payload):
+            raise HTTPException(
+                status_code=422,
+                detail="The input prompt word length and the requested max_tokens value are in "
+                "excess of the supported total token length of "
+                f"{MLFLOW_AI_GATEWAY_MOSAICML_MAX_TOKENS_THRESHOLD}",
+            )
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         key_mapping = {

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -3,7 +3,10 @@ from typing import Any, Dict
 import aiohttp
 from fastapi import HTTPException
 
-from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
+from mlflow.gateway.constants import (
+    MLFLOW_AI_GATEWAY_MOSAIC_ML_HANDLER_MESSAGES,
+    MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS,
+)
 from mlflow.utils.uri import append_to_uri_path
 
 
@@ -37,6 +40,7 @@ async def send_request(headers: Dict[str, str], base_url: str, path: str, payloa
                 response.raise_for_status()
             except aiohttp.ClientResponseError as e:
                 detail = js.get("error", {}).get("message", e.message) if "error" in js else js
+                _custom_token_allowance_exceeded_handling(detail, e.status)
                 raise HTTPException(status_code=e.status, detail=detail)
             return js
 
@@ -52,3 +56,20 @@ def rename_payload_keys(payload: Dict[str, Any], mapping: Dict[str, str]) -> Dic
     :return: A new dictionary containing the transformed keys.
     """
     return {mapping.get(k, k): v for k, v in payload.items()}
+
+
+def _custom_token_allowance_exceeded_handling(detail: Dict[str, str], status_code: int):
+    """
+    Custom handler for specific error messages that are incorrectly set as server-side errors, but
+    are in actuality an issue with the request sent to the external provider.
+    """
+    STATUS_SERVER_ERROR = 500
+    STATUS_UNPROCESSABLE_ENTITY = 422
+
+    message = detail.get("message")
+    if (
+        status_code == STATUS_SERVER_ERROR
+        and message
+        and any(message.startswith(x) for x in MLFLOW_AI_GATEWAY_MOSAIC_ML_HANDLER_MESSAGES)
+    ):
+        raise HTTPException(status_code=STATUS_UNPROCESSABLE_ENTITY, detail=detail)

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -4,7 +4,6 @@ import aiohttp
 from fastapi import HTTPException
 
 from mlflow.gateway.constants import (
-    MLFLOW_AI_GATEWAY_MOSAIC_ML_HANDLER_MESSAGES,
     MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS,
 )
 from mlflow.utils.uri import append_to_uri_path
@@ -40,7 +39,6 @@ async def send_request(headers: Dict[str, str], base_url: str, path: str, payloa
                 response.raise_for_status()
             except aiohttp.ClientResponseError as e:
                 detail = js.get("error", {}).get("message", e.message) if "error" in js else js
-                _custom_token_allowance_exceeded_handling(detail, e.status)
                 raise HTTPException(status_code=e.status, detail=detail)
             return js
 
@@ -56,20 +54,3 @@ def rename_payload_keys(payload: Dict[str, Any], mapping: Dict[str, str]) -> Dic
     :return: A new dictionary containing the transformed keys.
     """
     return {mapping.get(k, k): v for k, v in payload.items()}
-
-
-def _custom_token_allowance_exceeded_handling(detail: Dict[str, str], status_code: int):
-    """
-    Custom handler for specific error messages that are incorrectly set as server-side errors, but
-    are in actuality an issue with the request sent to the external provider.
-    """
-    STATUS_SERVER_ERROR = 500
-    STATUS_UNPROCESSABLE_ENTITY = 422
-
-    message = detail.get("message")
-    if (
-        status_code == STATUS_SERVER_ERROR
-        and message
-        and any(message.startswith(x) for x in MLFLOW_AI_GATEWAY_MOSAIC_ML_HANDLER_MESSAGES)
-    ):
-        raise HTTPException(status_code=STATUS_UNPROCESSABLE_ENTITY, detail=detail)

--- a/tests/gateway/providers/test_mosaicml.py
+++ b/tests/gateway/providers/test_mosaicml.py
@@ -402,11 +402,9 @@ async def test_completions_raises_with_invalid_max_tokens_too_large():
     }
     resp = {
         "message": error_msg["message"],
-        "_status": 500,
-        "headers": {"Content-Type": "application/json"},
     }
 
-    with mock.patch("aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)):
+    with mock.patch("aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp, status=500)):
         provider = MosaicMLProvider(RouteConfig(**config))
         payload = {
             "prompt": "How many puffins can fit on the flight deck of a Nimitz class "
@@ -428,17 +426,13 @@ async def test_chat_raises_with_invalid_max_tokens_too_large():
     }
     resp = {
         "message": error_msg["message"],
-        "_status": 500,
-        "headers": {"Content-Type": "application/json"},
     }
-    with mock.patch("aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)):
+    with mock.patch("aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp, status=500)):
         provider = MosaicMLProvider(RouteConfig(**config))
         payload = {
             "messages": [
                 {"role": "system", "content": "You're an astronaut."},
                 {"role": "user", "content": "When do you go to space next?"},
-                {"role": "assistant", "content": "Our next mission is to Europa, next July."},
-                {"role": "user", "content": "What sort of rocket are you using for this mission?"},
             ],
             "max_tokens": 5000,
         }

--- a/tests/gateway/tools.py
+++ b/tests/gateway/tools.py
@@ -96,13 +96,13 @@ def save_yaml(path, conf):
 
 
 class MockAsyncResponse:
-    def __init__(self, data: Dict[str, Any]):
+    def __init__(self, data: Dict[str, Any], status: int = 200):
         # Extract status and headers from data, if present
-        self.status = data.get("_status", 200)
-        self.headers = data.get("headers", {})
+        self.status = status
+        self.headers = data.pop("headers", {"Content-Type": "application/json"})
 
         # Save the rest of the data as content
-        self._content = {k: v for k, v in data.items() if not k.startswith(("_", "headers"))}
+        self._content = data
 
     def raise_for_status(self) -> None:
         if 400 <= self.status < 600:


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Introduces a preemptive 422 error to the AI Gateway routes for MosaicML for if the submitted request payload, coupled with the. max_tokens value will risk exceeding the maximum allowable tokens for their endpoints. The current behavior of MosaicML endpoints is to return a 5xx error (which is retried internally with a geometric backoff by the AI Gateway) if a token allocation error is encountered. 

The implementation here is highly conservative on the side of generating an error if the submitted text is near to the threshold. We cannot be completely exact here since we don't have access to the generated token counts that are used with a given model, but a general 2 * word count has a respectable performance based on manual testing. 

This is an interim fix until the Mosaic endpoints change their error type for token violation from a 5xx to a 4xx (as other providers do). 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

Validated with tests on both chat and completions endpoints for the length of submitted requests to each respective route type that we don't encounter a 5xx retry loop with this logic; rather, it fails as expected with a 422 thrown by the AI Gateway. 

## Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
