### PR TITLE
Use float64 so that `mlflow models predict` can be used on the trained model.

### DIFF
--- a/examples/tensorflow/train.py
+++ b/examples/tensorflow/train.py
@@ -32,8 +32,8 @@ class LinearRegression(tf.Module):
         # Initialize the model parameters on the first call
         if not self.built:
             # Randomly generate the weight vector and bias term
-            rand_w = tf.random.uniform(shape=[x.shape[-1], 1])
-            rand_b = tf.random.uniform(shape=[])
+            rand_w = tf.random.uniform(shape=[x.shape[-1], 1], dtype=tf.float64)
+            rand_b = tf.random.uniform(shape=[], dtype=tf.float64)
             self.w = tf.Variable(rand_w)
             self.b = tf.Variable(rand_b)
             self.built = True
@@ -50,7 +50,7 @@ class ExportModule(tf.Module):
         self.norm_x = norm_x
         self.norm_y = norm_y
 
-    @tf.function(input_signature=[tf.TensorSpec(shape=[None, None], dtype=tf.float32)])
+    @tf.function(input_signature=[tf.TensorSpec(shape=[None, None], dtype=tf.float64)])
     def __call__(self, x):
         # Run the ExportModule for new data points
         x = self.norm_x.norm(x)
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     dataset = dataset.dropna()
     # using only 1500
     dataset = dataset[:1500]
-    dataset_tf = tf.convert_to_tensor(dataset, dtype=tf.float32)
+    dataset_tf = tf.convert_to_tensor(dataset, dtype=tf.float64)
 
     # Split dataset into train and test
     dataset_shuffled = tf.random.shuffle(dataset_tf, seed=42)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Use float64 so that `mlflow models predict` can be used on the trained model.

Addressing
```
mlflow.exceptions.MlflowException: dtype of input float64 does not match expected dtype float32
```
which gets otherwise produced for a JSON input.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

With this change, I was able to run `mlflow models predict --model-uri $( find mlruns -name model )` on my JSON input after training the model with `mlflow run .`

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
