### PR TITLE
fix-paramspec-default-type-hint

### DIFF
--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -484,7 +484,7 @@ class ParamSpec:
         self,
         name: str,
         dtype: Union[DataType, str],
-        default: Union[DataType, List[DataType], None],
+        default: Union[int, float, str, bool, bytes, List[int], List[float], List[str], List[bool], List[bytes], None],
         shape: Optional[Tuple[int, ...]] = None,
     ):
         self._name = str(name)

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -484,7 +484,19 @@ class ParamSpec:
         self,
         name: str,
         dtype: Union[DataType, str],
-        default: Union[int, float, str, bool, bytes, List[int], List[float], List[str], List[bool], List[bytes], None],
+        default: Union[
+            int,
+            float,
+            str,
+            bool,
+            bytes,
+            List[int],
+            List[float],
+            List[str],
+            List[bool],
+            List[bytes],
+            None,
+        ],
         shape: Optional[Tuple[int, ...]] = None,
     ):
         self._name = str(name)


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Fix the type hint for `default` in ParamSpec.

## How is this patch tested?
N/A (type hint)
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes


I'm not sure this is necessarily the way you want to handle it, there may be a more elegant solution here. But the `default` param is not of type `DataType`, as you are meant to provide an actual value (whose type must be one of the available `DataType`s).

ie 
```
param = ParamSpec(name="param1", dtype=DataType.int, default=5)
```

This currently raises a type-check error on mypy/pyright because the type-hint suggests it should be something like 
```
param = ParamSpec(name="param1", dtype=DataType.int, default=DataType.int) 
```
which isn't correct.

Feel free to modify this to a cleaner solution, or close it in favor of another implementation. 

Thanks!
