### PR TITLE
Enable LangChain SQLDatabaseChain test and fix bug

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -17,6 +17,7 @@ import logging
 import os
 import shutil
 import types
+from importlib.util import find_spec
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
 import cloudpickle
@@ -131,14 +132,9 @@ def _get_map_of_special_chain_class_to_loader_arg():
     if version.parse(langchain.__version__) <= version.parse("0.0.246"):
         class_name_to_loader_arg["langchain.chains.SQLDatabaseChain"] = "database"
     else:
-        try:
-            import langchain_experimental
-
+        if find_spec("langchain_experimental"):
+            # Add this entry only if langchain_experimental is installed
             class_name_to_loader_arg["langchain_experimental.sql.SQLDatabaseChain"] = "database"
-
-        except ImportError:
-            # Users may not have langchain_experimental installed, which is completely normal
-            pass
 
     class_to_loader_arg = {
         _RetrieverChain: "retriever",

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -132,9 +132,10 @@ def _get_map_of_special_chain_class_to_loader_arg():
         class_name_to_loader_arg["langchain.chains.SQLDatabaseChain"] = "database"
     else:
         try:
-            import langchain.experimental
+            import langchain_experimental
 
             class_name_to_loader_arg["langchain_experimental.sql.SQLDatabaseChain"] = "database"
+
         except ImportError:
             # Users may not have langchain_experimental installed, which is completely normal
             pass

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -676,7 +676,6 @@ def load_db(persist_dir):
     return SQLDatabase.from_uri(sqlite_uri)
 
 
-@pytest.mark.skip(reason="This fails due to https://github.com/hwchase17/langchain/issues/6889")
 def test_log_and_load_sql_database_chain(tmp_path):
     # Create the SQLDatabaseChain
     db_file_path = tmp_path / "my_database.db"

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -675,7 +675,10 @@ def load_db(persist_dir):
     sqlite_uri = f"sqlite:///{db_file_path}"
     return SQLDatabase.from_uri(sqlite_uri)
 
-
+@pytest.mark.skipif(
+    version.parse(langchain.__version__) < version.parse("0.0.297"),
+    reason="Saving SQLDatabaseChain chains requires langchain>=0.0.297",
+)
 def test_log_and_load_sql_database_chain(tmp_path):
     # Create the SQLDatabaseChain
     db_file_path = tmp_path / "my_database.db"

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -675,6 +675,7 @@ def load_db(persist_dir):
     sqlite_uri = f"sqlite:///{db_file_path}"
     return SQLDatabase.from_uri(sqlite_uri)
 
+
 @pytest.mark.skipif(
     version.parse(langchain.__version__) < version.parse("0.0.297"),
     reason="Saving SQLDatabaseChain chains requires langchain>=0.0.297",


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

Enable tests for SQLDatabaseChain since https://github.com/hwchase17/langchain/issues/6889 is fixed.
We also have a bug in our implementation, discovered with the unit test.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
