### PR TITLE
Allow None for scores, justifications, and aggregates

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -511,8 +511,8 @@ def _evaluate_custom_metric(custom_metric_tuple, eval_df, builtin_metrics, metri
     :return: MetricValue
     """
     exception_header = (
-        f"Custom metric '{custom_metric_tuple.name}' at index {custom_metric_tuple.index}"
-        " in the `custom_metrics` parameter"
+        f"Did not log custom metric '{custom_metric_tuple.name}' at index "
+        f"{custom_metric_tuple.index} in the `custom_metrics` parameter because it"
     )
 
     metrics_type = get_type_hints(custom_metric_tuple.function).get("metrics")

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -542,7 +542,7 @@ def _evaluate_custom_metric(custom_metric_tuple, eval_df, builtin_metrics, metri
             raise MlflowException(
                 f"{exception_header} must return MetricValue with scores as a list."
             )
-        if any(not _is_numeric(score) for score in scores):
+        if any(not (_is_numeric(score) or score is None) for score in scores):
             raise MlflowException(
                 f"{exception_header} must return MetricValue with numeric scores."
             )
@@ -552,7 +552,7 @@ def _evaluate_custom_metric(custom_metric_tuple, eval_df, builtin_metrics, metri
             raise MlflowException(
                 f"{exception_header} must return MetricValue with justifications as a list."
             )
-        if any(not isinstance(justification, str) for justification in justifications):
+        if any(not (isinstance(jus, str) or jus is None) for jus in justifications):
             raise MlflowException(
                 f"{exception_header} must return MetricValue with string justifications."
             )
@@ -563,7 +563,10 @@ def _evaluate_custom_metric(custom_metric_tuple, eval_df, builtin_metrics, metri
                 f"{exception_header} must return MetricValue with aggregate_results as a dict."
             )
 
-        if any(not (isinstance(k, str) and _is_numeric(v)) for k, v in aggregates.items()):
+        if any(
+            not (isinstance(k, str) and (_is_numeric(v) or v is None))
+            for k, v in aggregates.items()
+        ):
             raise MlflowException(
                 (
                     f"{exception_header} must return MetricValue with aggregate_results with "

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1340,11 +1340,11 @@ def test_evaluate_custom_metric_backwards_compatible():
     )
     metrics = _get_aggregate_metrics_values(builtin_metrics)
 
-    def old_fn_no_type_hint(eval_df, builtin_metrics):
+    def old_fn(eval_df, builtin_metrics):
         return builtin_metrics["mean_absolute_error"] * 1.5
 
     res_metric = _evaluate_custom_metric(
-        _CustomMetric(old_fn_no_type_hint, "old_fn", 0), eval_df, builtin_metrics, metrics
+        _CustomMetric(old_fn, "old_fn", 0), eval_df, builtin_metrics, metrics
     )
     assert res_metric.scores is None
     assert res_metric.justifications is None

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1340,11 +1340,11 @@ def test_evaluate_custom_metric_backwards_compatible():
     )
     metrics = _get_aggregate_metrics_values(builtin_metrics)
 
-    def old_fn(eval_df, builtin_metrics):
+    def old_fn_no_type_hint(eval_df, builtin_metrics):
         return builtin_metrics["mean_absolute_error"] * 1.5
 
     res_metric = _evaluate_custom_metric(
-        _CustomMetric(old_fn, "old_fn", 0), eval_df, builtin_metrics, metrics
+        _CustomMetric(old_fn_no_type_hint, "old_fn", 0), eval_df, builtin_metrics, metrics
     )
     assert res_metric.scores is None
     assert res_metric.justifications is None

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1385,7 +1385,8 @@ def test_evaluate_custom_metric_incorrect_return_formats():
             _CustomMetric(dummy_fn, "dummy_fn", 0), eval_df, builtin_metrics, metrics
         )
         mock_warning.assert_called_once_with(
-            "Custom metric 'dummy_fn' at index 0 in the `custom_metrics` parameter returned None."
+            "Did not log custom metric 'dummy_fn' at index 0 in the `custom_metrics` parameter"
+            " because it returned None."
         )
 
     def incorrect_return_type(*_):
@@ -1399,8 +1400,8 @@ def test_evaluate_custom_metric_incorrect_return_formats():
             metrics,
         )
         mock_warning.assert_called_once_with(
-            f"Custom metric '{incorrect_return_type.__name__}' at index 0 in the `custom_metrics`"
-            " parameter did not return a MetricValue."
+            f"Did not log custom metric '{incorrect_return_type.__name__}' at index 0 in the "
+            "`custom_metrics` parameter because it did not return a MetricValue."
         )
 
     def non_list_scores(*_):
@@ -1414,8 +1415,8 @@ def test_evaluate_custom_metric_incorrect_return_formats():
             metrics,
         )
         mock_warning.assert_called_once_with(
-            f"Custom metric '{non_list_scores.__name__}' at index 0 in the `custom_metrics`"
-            " parameter must return MetricValue with scores as a list."
+            f"Did not log custom metric '{non_list_scores.__name__}' at index 0 in the "
+            "`custom_metrics` parameter because it must return MetricValue with scores as a list."
         )
 
     def non_numeric_scores(*_):
@@ -1429,8 +1430,8 @@ def test_evaluate_custom_metric_incorrect_return_formats():
             metrics,
         )
         mock_warning.assert_called_once_with(
-            f"Custom metric '{non_numeric_scores.__name__}' at index 0 in the `custom_metrics`"
-            " parameter must return MetricValue with numeric scores."
+            f"Did not log custom metric '{non_numeric_scores.__name__}' at index 0 in the "
+            "`custom_metrics` parameter because it must return MetricValue with numeric scores."
         )
 
     def non_list_justifications(*_):
@@ -1444,8 +1445,9 @@ def test_evaluate_custom_metric_incorrect_return_formats():
             metrics,
         )
         mock_warning.assert_called_once_with(
-            f"Custom metric '{non_list_justifications.__name__}' at index 0 in the `custom_metrics`"
-            " parameter must return MetricValue with justifications as a list."
+            f"Did not log custom metric '{non_list_justifications.__name__}' at index 0 in the "
+            "`custom_metrics` parameter because it must return MetricValue with justifications "
+            "as a list."
         )
 
     def non_str_justifications(*_):
@@ -1459,8 +1461,9 @@ def test_evaluate_custom_metric_incorrect_return_formats():
             metrics,
         )
         mock_warning.assert_called_once_with(
-            f"Custom metric '{non_str_justifications.__name__}' at index 0 in the `custom_metrics`"
-            " parameter must return MetricValue with string justifications."
+            f"Did not log custom metric '{non_str_justifications.__name__}' at index 0 in the "
+            "`custom_metrics` parameter because it must return MetricValue with string "
+            "justifications."
         )
 
     def non_dict_aggregates(*_):
@@ -1474,8 +1477,9 @@ def test_evaluate_custom_metric_incorrect_return_formats():
             metrics,
         )
         mock_warning.assert_called_once_with(
-            f"Custom metric '{non_dict_aggregates.__name__}' at index 0 in the `custom_metrics`"
-            " parameter must return MetricValue with aggregate_results as a dict."
+            f"Did not log custom metric '{non_dict_aggregates.__name__}' at index 0 in the "
+            "`custom_metrics` parameter because it must return MetricValue with aggregate_results "
+            "as a dict."
         )
 
     def wrong_type_aggregates(*_):
@@ -1489,9 +1493,9 @@ def test_evaluate_custom_metric_incorrect_return_formats():
             metrics,
         )
         mock_warning.assert_called_once_with(
-            f"Custom metric '{wrong_type_aggregates.__name__}' at index 0 in the `custom_metrics`"
-            " parameter must return MetricValue with aggregate_results with str keys and numeric "
-            "values."
+            f"Did not log custom metric '{wrong_type_aggregates.__name__}' at index 0 in the "
+            "`custom_metrics` parameter because it must return MetricValue with aggregate_results "
+            "with str keys and numeric values."
         )
 
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1381,93 +1381,118 @@ def test_evaluate_custom_metric_incorrect_return_formats():
     def dummy_fn(*_):
         pass
 
-    with pytest.raises(MlflowException, match=f"'{dummy_fn.__name__}' (.*) returned None"):
+    with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_custom_metric(
             _CustomMetric(dummy_fn, "dummy_fn", 0), eval_df, builtin_metrics, metrics
+        )
+        mock_warning.assert_called_once_with(
+            "Custom metric 'dummy_fn' at index 0 in the `custom_metrics` parameter returned None."
         )
 
     def incorrect_return_type(*_):
         return "stuff", 3
 
-    with pytest.raises(MlflowException, match="did not return a MetricValue"):
+    with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_custom_metric(
             _CustomMetric(incorrect_return_type, incorrect_return_type.__name__, 0),
             eval_df,
             builtin_metrics,
             metrics,
         )
+        mock_warning.assert_called_once_with(
+            f"Custom metric '{incorrect_return_type.__name__}' at index 0 in the `custom_metrics`"
+            " parameter did not return a MetricValue."
+        )
 
     def non_list_scores(*_):
         return MetricValue(scores=5)
 
-    with pytest.raises(MlflowException, match="must return MetricValue with scores as a list"):
+    with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_custom_metric(
             _CustomMetric(non_list_scores, non_list_scores.__name__, 0),
             eval_df,
             builtin_metrics,
             metrics,
         )
+        mock_warning.assert_called_once_with(
+            f"Custom metric '{non_list_scores.__name__}' at index 0 in the `custom_metrics`"
+            " parameter must return MetricValue with scores as a list."
+        )
 
     def non_numeric_scores(*_):
         return MetricValue(scores=["string"])
 
-    with pytest.raises(MlflowException, match="must return MetricValue with numeric scores"):
+    with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_custom_metric(
             _CustomMetric(non_numeric_scores, non_numeric_scores.__name__, 0),
             eval_df,
             builtin_metrics,
             metrics,
         )
+        mock_warning.assert_called_once_with(
+            f"Custom metric '{non_numeric_scores.__name__}' at index 0 in the `custom_metrics`"
+            " parameter must return MetricValue with numeric scores."
+        )
 
     def non_list_justifications(*_):
         return MetricValue(justifications="string")
 
-    with pytest.raises(
-        MlflowException, match="must return MetricValue with justifications as a list"
-    ):
+    with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_custom_metric(
             _CustomMetric(non_list_justifications, non_list_justifications.__name__, 0),
             eval_df,
             builtin_metrics,
             metrics,
         )
+        mock_warning.assert_called_once_with(
+            f"Custom metric '{non_list_justifications.__name__}' at index 0 in the `custom_metrics`"
+            " parameter must return MetricValue with justifications as a list."
+        )
 
     def non_str_justifications(*_):
         return MetricValue(justifications=[3, 4])
 
-    with pytest.raises(MlflowException, match="must return MetricValue with string justifications"):
+    with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_custom_metric(
             _CustomMetric(non_str_justifications, non_str_justifications.__name__, 0),
             eval_df,
             builtin_metrics,
             metrics,
         )
+        mock_warning.assert_called_once_with(
+            f"Custom metric '{non_str_justifications.__name__}' at index 0 in the `custom_metrics`"
+            " parameter must return MetricValue with string justifications."
+        )
 
     def non_dict_aggregates(*_):
         return MetricValue(aggregate_results=[5.0, 4.0])
 
-    with pytest.raises(
-        MlflowException, match="must return MetricValue with aggregate_results as a dict"
-    ):
+    with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_custom_metric(
             _CustomMetric(non_dict_aggregates, non_dict_aggregates.__name__, 0),
             eval_df,
             builtin_metrics,
             metrics,
         )
+        mock_warning.assert_called_once_with(
+            f"Custom metric '{non_dict_aggregates.__name__}' at index 0 in the `custom_metrics`"
+            " parameter must return MetricValue with aggregate_results as a dict."
+        )
 
     def wrong_type_aggregates(*_):
         return MetricValue(aggregate_results={"toxicity": 0.0, "hi": "hi"})
 
-    with pytest.raises(
-        MlflowException,
-        match="must return MetricValue with aggregate_results with str keys and numeric values",
-    ):
+    with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_custom_metric(
             _CustomMetric(wrong_type_aggregates, wrong_type_aggregates.__name__, 0),
             eval_df,
             builtin_metrics,
             metrics,
+        )
+        mock_warning.assert_called_once_with(
+            f"Custom metric '{wrong_type_aggregates.__name__}' at index 0 in the `custom_metrics`"
+            " parameter must return MetricValue with aggregate_results with str keys and numeric "
+            "values."
         )
 
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1485,6 +1485,13 @@ def test_evaluate_custom_metric_incorrect_return_formats():
             lambda _, __: None,
             pytest.raises(MlflowException, match="returned None"),
         ),
+        (
+            lambda eval_df, _: MetricValue(
+                scores=eval_df["prediction"].tolist()[:-1] + [None],
+                aggregate_results={"prediction_sum": None, "another_aggregate": 5.0},
+            ),
+            does_not_raise(),
+        ),
     ],
 )
 def test_evaluate_custom_metric_lambda(fn, expectation):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

- allow None when calling eval_fn for custom metrics, refer to https://github.com/mlflow/mlflow/pull/9668#discussion_r1330893305
- move from raising exceptions when custom metrics are malformed to logging warnings

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
