### PR TITLE
[Auth] Only admins can create new user

### DIFF
--- a/docs/source/auth/index.rst
+++ b/docs/source/auth/index.rst
@@ -550,7 +550,8 @@ In Python, you can use the ``requests`` library:
 Creating a New User
 ===================
 
-To create a new user, you are required to authenticate with admin privileges.
+.. note::
+    To create a new user, you are required to authenticate with admin privileges.
 
 Using MLflow UI
 ---------------

--- a/docs/source/auth/index.rst
+++ b/docs/source/auth/index.rst
@@ -550,7 +550,7 @@ In Python, you can use the ``requests`` library:
 Creating a New User
 ===================
 
-.. note::
+.. important::
     To create a new user, you are required to authenticate with admin privileges.
 
 Using MLflow UI

--- a/docs/source/auth/index.rst
+++ b/docs/source/auth/index.rst
@@ -550,6 +550,8 @@ In Python, you can use the ``requests`` library:
 Creating a New User
 ===================
 
+To create a new user, you are required to authenticate with admin privileges.
+
 Using MLflow UI
 ---------------
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -113,13 +113,8 @@ auth_config = read_auth_config()
 store = SqlAlchemyStore()
 
 
-UNPROTECTED_ROUTES = [SIGNUP]
-
-
 def is_unprotected_route(path: str) -> bool:
-    if path.startswith(("/static", "/favicon.ico", "/health")):
-        return True
-    return path in UNPROTECTED_ROUTES
+    return path.startswith(("/static", "/favicon.ico", "/health"))
 
 
 def make_basic_auth_response() -> Response:
@@ -390,6 +385,7 @@ BEFORE_REQUEST_VALIDATORS = {
 
 BEFORE_REQUEST_VALIDATORS.update(
     {
+        (SIGNUP, "GET"): validate_can_create_user,
         (GET_USER, "GET"): validate_can_read_user,
         (CREATE_USER, "POST"): validate_can_create_user,
         (UPDATE_USER_PASSWORD, "PATCH"): validate_can_update_user_password,

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -113,7 +113,7 @@ auth_config = read_auth_config()
 store = SqlAlchemyStore()
 
 
-UNPROTECTED_ROUTES = [CREATE_USER, SIGNUP]
+UNPROTECTED_ROUTES = [SIGNUP]
 
 
 def is_unprotected_route(path: str) -> bool:
@@ -315,6 +315,11 @@ def validate_can_read_user():
     return username_is_sender()
 
 
+def validate_can_create_user():
+    # only admins can create user, but admins won't reach this validator
+    return False
+
+
 def validate_can_update_user_password():
     return username_is_sender()
 
@@ -386,6 +391,7 @@ BEFORE_REQUEST_VALIDATORS = {
 BEFORE_REQUEST_VALIDATORS.update(
     {
         (GET_USER, "GET"): validate_can_read_user,
+        (CREATE_USER, "POST"): validate_can_create_user,
         (UPDATE_USER_PASSWORD, "PATCH"): validate_can_update_user_password,
         (UPDATE_USER_ADMIN, "PATCH"): validate_can_update_user_admin,
         (DELETE_USER, "DELETE"): validate_can_delete_user,

--- a/tests/server/auth/auth_test_utils.py
+++ b/tests/server/auth/auth_test_utils.py
@@ -13,7 +13,7 @@ ADMIN_PASSWORD = auth_config.admin_password
 def create_user(tracking_uri):
     username = random_str()
     password = random_str()
-    _send_rest_tracking_post_request(
+    response = _send_rest_tracking_post_request(
         tracking_uri,
         "/api/2.0/mlflow/users/create",
         {
@@ -22,6 +22,7 @@ def create_user(tracking_uri):
         },
         auth=(ADMIN_USERNAME, ADMIN_PASSWORD),
     )
+    response.raise_for_status()
     return username, password
 
 

--- a/tests/server/auth/auth_test_utils.py
+++ b/tests/server/auth/auth_test_utils.py
@@ -1,7 +1,13 @@
 from mlflow.environment_variables import MLFLOW_TRACKING_PASSWORD, MLFLOW_TRACKING_USERNAME
+from mlflow.server.auth import auth_config
 
 from tests.helper_functions import random_str
 from tests.tracking.integration_test_utils import _send_rest_tracking_post_request
+
+PERMISSION = "READ"
+NEW_PERMISSION = "EDIT"
+ADMIN_USERNAME = auth_config.admin_username
+ADMIN_PASSWORD = auth_config.admin_password
 
 
 def create_user(tracking_uri):
@@ -14,6 +20,7 @@ def create_user(tracking_uri):
             "username": username,
             "password": password,
         },
+        auth=(ADMIN_USERNAME, ADMIN_PASSWORD),
     )
     return username, password
 

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -21,9 +21,9 @@ from mlflow.protos.databricks_pb2 import (
     ErrorCode,
 )
 from mlflow.utils.os import is_windows
-from tests.helper_functions import random_str
 
-from tests.server.auth.auth_test_utils import User, create_user, ADMIN_USERNAME
+from tests.helper_functions import random_str
+from tests.server.auth.auth_test_utils import ADMIN_USERNAME, User, create_user
 from tests.tracking.integration_test_utils import (
     _init_server,
     _send_rest_tracking_post_request,

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -21,8 +21,9 @@ from mlflow.protos.databricks_pb2 import (
     ErrorCode,
 )
 from mlflow.utils.os import is_windows
+from tests.helper_functions import random_str
 
-from tests.server.auth.auth_test_utils import User, create_user
+from tests.server.auth.auth_test_utils import User, create_user, ADMIN_USERNAME
 from tests.tracking.integration_test_utils import (
     _init_server,
     _send_rest_tracking_post_request,
@@ -71,6 +72,21 @@ def _mlflow_search_experiments_rest(base_uri, headers):
     return response
 
 
+def _mlflow_create_user_rest(base_uri, headers):
+    username = random_str()
+    password = random_str()
+    response = requests.post(
+        f"{base_uri}/api/2.0/mlflow/users/create",
+        headers=headers,
+        json={
+            "username": username,
+            "password": password,
+        },
+    )
+    response.raise_for_status()
+    return username, password
+
+
 @pytest.mark.parametrize(
     "client",
     [
@@ -88,7 +104,12 @@ def test_authenticate_jwt(client):
     assert e.value.response.status_code == 401  # Unauthorized
 
     # authenticated
-    username, password = create_user(client.tracking_uri)
+    # we need to use jwt to authenticate as admin so that we can create a new user
+    bearer_token = jwt.encode({"username": ADMIN_USERNAME}, "secret", algorithm="HS256")
+    headers = {"Authorization": f"Bearer {bearer_token}"}
+    username, password = _mlflow_create_user_rest(client.tracking_uri, headers)
+
+    # authenticate with the newly created user
     headers = {
         "Authorization": f'Bearer {jwt.encode({"username": username}, "secret", algorithm="HS256")}'
     }

--- a/tests/server/auth/test_client.py
+++ b/tests/server/auth/test_client.py
@@ -17,13 +17,15 @@ from mlflow.server.auth.client import AuthServiceClient
 from mlflow.utils.os import is_windows
 
 from tests.helper_functions import random_str
-from tests.server.auth.auth_test_utils import User, create_user
+from tests.server.auth.auth_test_utils import (
+    ADMIN_PASSWORD,
+    ADMIN_USERNAME,
+    NEW_PERMISSION,
+    PERMISSION,
+    User,
+    create_user,
+)
 from tests.tracking.integration_test_utils import _init_server
-
-PERMISSION = "READ"
-NEW_PERMISSION = "EDIT"
-ADMIN_USERNAME = auth_config.admin_username
-ADMIN_PASSWORD = auth_config.admin_password
 
 
 @pytest.fixture(autouse=True)

--- a/tests/server/auth/test_client.py
+++ b/tests/server/auth/test_client.py
@@ -70,12 +70,22 @@ def test_get_client():
     assert isinstance(client, AuthServiceClient)
 
 
-def test_create_user(client):
+def test_create_user(client, monkeypatch):
     username = random_str()
     password = random_str()
-    user = client.create_user(username, password)
+
+    with assert_unauthenticated():
+        client.create_user(username, password)
+
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        user = client.create_user(username, password)
     assert user.username == username
     assert user.is_admin is False
+
+    username2 = random_str()
+    password2 = random_str()
+    with User(username, password, monkeypatch), assert_unauthorized():
+        client.create_user(username2, password2)
 
 
 def test_get_user(client, monkeypatch):

--- a/tests/server/auth/test_client.py
+++ b/tests/server/auth/test_client.py
@@ -91,7 +91,8 @@ def test_create_user(client, monkeypatch):
 def test_get_user(client, monkeypatch):
     username = random_str()
     password = random_str()
-    client.create_user(username, password)
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.create_user(username, password)
 
     with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
         user = client.get_user(username)
@@ -102,7 +103,8 @@ def test_get_user(client, monkeypatch):
 
     username2 = random_str()
     password2 = random_str()
-    client.create_user(username2, password2)
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.create_user(username2, password2)
     with User(username2, password2, monkeypatch), assert_unauthorized():
         client.get_user(username)
 
@@ -110,7 +112,8 @@ def test_get_user(client, monkeypatch):
 def test_update_user_password(client, monkeypatch):
     username = random_str()
     password = random_str()
-    client.create_user(username, password)
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.create_user(username, password)
 
     new_password = random_str()
     with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
@@ -127,7 +130,8 @@ def test_update_user_password(client, monkeypatch):
 
     username2 = random_str()
     password2 = random_str()
-    client.create_user(username2, password2)
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.create_user(username2, password2)
     with User(username2, password2, monkeypatch), assert_unauthorized():
         client.update_user_password(username, new_password)
 
@@ -135,7 +139,8 @@ def test_update_user_password(client, monkeypatch):
 def test_update_user_admin(client, monkeypatch):
     username = random_str()
     password = random_str()
-    client.create_user(username, password)
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.create_user(username, password)
 
     with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
         client.update_user_admin(username, True)
@@ -147,7 +152,8 @@ def test_update_user_admin(client, monkeypatch):
 
     username2 = random_str()
     password2 = random_str()
-    client.create_user(username2, password2)
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.create_user(username2, password2)
     with User(username2, password2, monkeypatch), assert_unauthorized():
         client.update_user_admin(username, True)
 
@@ -155,7 +161,8 @@ def test_update_user_admin(client, monkeypatch):
 def test_delete_user(client, monkeypatch):
     username = random_str()
     password = random_str()
-    client.create_user(username, password)
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.create_user(username, password)
 
     with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
         client.update_user_admin(username, True)
@@ -172,7 +179,8 @@ def test_delete_user(client, monkeypatch):
 
     username2 = random_str()
     password2 = random_str()
-    client.create_user(username2, password2)
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.create_user(username2, password2)
     with User(username2, password2, monkeypatch), assert_unauthorized():
         client.delete_user(username)
 


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #9669 

## What changes are proposed in this pull request?

Only admins are allowed to create new users, to prevent potential attackers from creating lots of users.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [X] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Only admins are allowed to create new users, to prevent potential attackers from creating lots of users.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
