### PR TITLE
Set network metrics to start from 0

### DIFF
--- a/mlflow/system_metrics/metrics/base_metrics_monitor.py
+++ b/mlflow/system_metrics/metrics/base_metrics_monitor.py
@@ -17,12 +17,13 @@ class BaseMetricsMonitor(abc.ABC):
         """
         pass
 
+    @abc.abstractmethod
     def aggregate_metrics(self):
-        metrics = {}
-        for name, values in self._metrics.items():
-            if len(values) > 0:
-                metrics[name] = round(sum(values) / len(values), 1)
-        return metrics
+        """Method to aggregate metrics.
+
+        Sublcass should implement this method to aggregate the metrics and return it in a dict.
+        """
+        pass
 
     @property
     def metrics(self):

--- a/mlflow/system_metrics/metrics/cpu_monitor.py
+++ b/mlflow/system_metrics/metrics/cpu_monitor.py
@@ -18,3 +18,10 @@ class CPUMonitor(BaseMetricsMonitor):
         self._metrics["system_memory_usage_percentage"].append(
             system_memory.used / system_memory.total * 100
         )
+
+    def aggregate_metrics(self):
+        metrics = {}
+        for name, values in self._metrics.items():
+            if len(values) > 0:
+                metrics[name] = round(sum(values) / len(values), 1)
+        return metrics

--- a/mlflow/system_metrics/metrics/disk_monitor.py
+++ b/mlflow/system_metrics/metrics/disk_monitor.py
@@ -16,3 +16,10 @@ class DiskMonitor(BaseMetricsMonitor):
         self._metrics["disk_usage_percentage"].append(disk_usage.percent)
         self._metrics["disk_usage_megabytes"].append(disk_usage.used / 1e6)
         self._metrics["disk_available_megabytes"].append(disk_usage.free / 1e6)
+
+    def aggregate_metrics(self):
+        metrics = {}
+        for name, values in self._metrics.items():
+            if len(values) > 0:
+                metrics[name] = round(sum(values) / len(values), 1)
+        return metrics

--- a/mlflow/system_metrics/metrics/gpu_monitor.py
+++ b/mlflow/system_metrics/metrics/gpu_monitor.py
@@ -46,3 +46,10 @@ class GPUMonitor(BaseMetricsMonitor):
 
             device_utilization = pynvml.nvmlDeviceGetUtilizationRates(handle)
             self._metrics[f"gpu_{i}_utilization_percentage"].append(device_utilization.gpu)
+
+    def aggregate_metrics(self):
+        metrics = {}
+        for name, values in self._metrics.items():
+            if len(values) > 0:
+                metrics[name] = round(sum(values) / len(values), 1)
+        return metrics

--- a/mlflow/system_metrics/metrics/network_monitor.py
+++ b/mlflow/system_metrics/metrics/network_monitor.py
@@ -7,8 +7,29 @@ from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonito
 
 
 class NetworkMonitor(BaseMetricsMonitor):
+    def __init__(self):
+        super().__init__()
+        self._set_initial_metrics()
+
+    def _set_initial_metrics(self):
+        # Set initial network usage metrics. `psutil.net_io_counters()` counts the stats since the
+        # system boot, so to set network usage metrics as 0 when we start logging, we need to keep
+        # the initial network usage metrics.
+        network_usage = psutil.net_io_counters()
+        self._initial_receive_megabytes = network_usage.bytes_recv / 1e6
+        self._initial_transmit_megabytes = network_usage.bytes_sent / 1e6
+
     def collect_metrics(self):
         # Get network usage metrics.
         network_usage = psutil.net_io_counters()
-        self._metrics["network_receive_megabytes"].append(network_usage.bytes_recv / 1e6)
-        self._metrics["network_transmit_megabytes"].append(network_usage.bytes_sent / 1e6)
+        # Usage metrics will be the diff between current and initial metrics.
+        self._metrics["network_receive_megabytes"] = (
+            network_usage.bytes_recv / 1e6 - self._initial_receive_megabytes
+        )
+        self._metrics["network_transmit_megabytes"] = (
+            network_usage.bytes_sent / 1e6 - self._initial_transmit_megabytes
+        )
+
+    def aggregate_metrics(self):
+        # Network metrics don't need to be averaged.
+        return dict(self._metrics)

--- a/tests/system_metrics/test_collect_metrics.py
+++ b/tests/system_metrics/test_collect_metrics.py
@@ -70,8 +70,8 @@ def test_network_monitor():
     network_monitor.collect_metrics()
 
     assert len(network_monitor.metrics.keys()) > 0
-    assert isinstance(network_monitor.metrics["network_receive_megabytes"], list)
-    assert isinstance(network_monitor.metrics["network_transmit_megabytes"], list)
+    assert isinstance(network_monitor.metrics["network_receive_megabytes"], float)
+    assert isinstance(network_monitor.metrics["network_transmit_megabytes"], float)
 
     network_monitor.collect_metrics()
     aggregated_metrics = network_monitor.aggregate_metrics()


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->
<!-- Resolve --> #xxx

## What changes are proposed in this pull request?

`psutil.net_io_counters()` counts stats from system boots, so we need to calculate the diff to let network usage stats start from 0.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
