### PR TITLE
Update a validation message when recreating experiments

### DIFF
--- a/mlflow/server/js/src/common/forms/validations.ts
+++ b/mlflow/server/js/src/common/forms/validations.ts
@@ -25,8 +25,8 @@ export const getExperimentNameValidator = (getExistingExperimentNames: any) => {
         .then((res) =>
           callback(`Experiment "${value}" already exists in deleted state.
                                  You can restore the experiment, or permanently delete the
-                                 experiment from the .trash folder (under tracking server's
-                                 root folder) in order to use this experiment name again.`),
+                                 experiment by \`mlflow gc --experiment-ids ...\` command
+                                 in order to use this experiment name again.`),
         )
         .catch((e) => callback(undefined)); // no experiment returned
     }

--- a/mlflow/server/js/src/common/forms/validations.ts
+++ b/mlflow/server/js/src/common/forms/validations.ts
@@ -24,9 +24,9 @@ export const getExperimentNameValidator = (getExistingExperimentNames: any) => {
       MlflowService.getExperimentByName({ experiment_name: value })
         .then((res) =>
           callback(`Experiment "${value}" already exists in deleted state.
-                                 You can restore the experiment, or permanently delete the
-                                 experiment by \`mlflow gc --experiment-ids ...\` command
-                                 in order to use this experiment name again.`),
+                                You can restore the experiment, or permanently delete it
+                                by \`$ mlflow gc --experiment-ids ...\` in order to use
+                                this experiment name again.`),
         )
         .catch((e) => callback(undefined)); // no experiment returned
     }


### PR DESCRIPTION
## Related Issues/PRs

<!-- Can this PR close the linked issue? If yes, uncomment "Resolve". -->

## What changes are proposed in this pull request?

Improve validation message when recreating an experiment with which a same name experiment was already marked as deleted.  
The 3 years old current message says `delete the experiment from the .trash folder (under tracking server's root folder)` but probably it depends on the backend stores.
IMO, encouraging to use the `mlflow gc` command looks better.

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
