### PR TITLE
Ensuring that YAML generated via R is consistent with Python

### DIFF
--- a/mlflow/R/mlflow/R/model-utils.R
+++ b/mlflow/R/mlflow/R/model-utils.R
@@ -15,9 +15,9 @@ create_default_conda_env_if_absent <- function(
 
     basename(conda_env)
   } else { # create default conda environment
-    conda_env_file_name <- "conda_env.yaml"
+    conda_env_file_name <- "conda.yaml"
     create_conda_env(
-      name = "conda_env",
+      name = "mlflow-env",
       path = file.path(model_path, conda_env_file_name),
       conda_deps = default_conda_deps,
       pip_deps = default_pip_deps


### PR DESCRIPTION
Ensuring that YAML generated via R is consistent with Python.
`mlflow.utils.environment`'s `_CONDA_ENV_FILE_NAME`).

<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs
N/A

## What changes are proposed in this pull request?

This will change the name of the `YAML` file written by most flavours when it relies on `create_default_conda_env_if_absent()` internally, previously the `YAML` was written out with the filename `conda_env.yaml` which deviates from python convention `conda.yaml` (`mlflow.utils.environment`'s `_CONDA_ENV_FILE_NAME`, [ref](https://github.com/mlflow/mlflow/blob/14e4299fe6e9d801989726d02c79daf45cadab31/mlflow/utils/environment.py#L29)).

This will allow XGBoost models logged from R to be compatible with Databricks model serving.

## How is this patch tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)

I manually was able to log a xgboost model in R on Databricks, I was then able to directly serve that with the serverless inference and make successfully requests.

## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

XGBoost models trained using R can now be directly served on Databricks model serving without using python as an intermediary.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
