### PR TITLE
Updating the concept of variables for eval_fn

### DIFF
--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -2,7 +2,8 @@ import json
 import logging
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from inspect import Parameter, Signature
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from mlflow.exceptions import MlflowException
 from mlflow.metrics.base import EvaluationExample, MetricValue
@@ -14,19 +15,18 @@ from mlflow.utils.class_utils import _get_class_from_string
 
 if TYPE_CHECKING:
     import pandas as pd
-    import pyspark
 
 _logger = logging.getLogger(__name__)
 
 
-def _format_variable_string(variables: Dict[str, Any], eval_df, indx) -> str:
+def _format_variable_string(variables: Optional[List[str]], eval_variables, indx) -> str:
     variables_dict = {}
     for variable in variables:
-        if variable in eval_df.columns:
-            variables_dict[variable] = eval_df[variable].tolist()[indx]
+        if variable in eval_variables:
+            variables_dict[variable] = eval_variables[variable][indx]
         else:
             raise MlflowException(
-                f"{variable} does not exist in the Eval DataFrame {eval_df.columns}."
+                f"{variable} does not exist in the eval function {list(eval_variables.keys())}."
             )
 
     return (
@@ -169,12 +169,16 @@ def make_genai_metric(
     """
 
     def eval_fn(
-        eval_df: Union["pd.DataFrame", "pyspark.sql.DataFrame"], metrics: Dict[str, MetricValue]
+        predictions: "pd.Series",
+        metrics: Dict[str, MetricValue],
+        inputs: "pd.Series",
+        *args,
     ) -> MetricValue:
         """
         This is the function that is called when the metric is evaluated.
         """
 
+        eval_variables = dict(zip(variables, args))
         class_name = f"mlflow.metrics.genai.prompts.{version}.EvaluationModel"
         try:
             evaluation_model_class_module = _get_class_from_string(class_name)
@@ -199,8 +203,8 @@ def make_genai_metric(
             *(parameters,) if parameters is not None else (),
         ).to_dict()
 
-        outputs = eval_df["prediction"].tolist()
-        inputs = eval_df["input"].tolist()
+        outputs = predictions.to_list()
+        inputs = inputs.to_list()
         eval_model = evaluation_context["model"]
         eval_parameters = evaluation_context["parameters"]
 
@@ -215,9 +219,16 @@ def make_genai_metric(
             )
 
         def score_model_on_one_payload(
-            indx, input, output, variables, eval_df, evaluation_context, eval_parameters, eval_model
+            indx,
+            input,
+            output,
+            variables,
+            eval_variables,
+            evaluation_context,
+            eval_parameters,
+            eval_model,
         ):
-            variable_string = _format_variable_string(variables, eval_df, indx)
+            variable_string = _format_variable_string(variables, eval_variables, indx)
             payload = {
                 "prompt": evaluation_context["eval_prompt"].format(
                     input=input, output=output, variables=variable_string
@@ -242,7 +253,7 @@ def make_genai_metric(
                     input,
                     output,
                     variables,
-                    eval_df,
+                    eval_variables,
                     evaluation_context,
                     eval_parameters,
                     eval_model,
@@ -284,10 +295,18 @@ def make_genai_metric(
 
         return MetricValue(scores, justifications, aggregate_results)
 
+    signature_parameters = [
+        Parameter("predictions", Parameter.POSITIONAL_OR_KEYWORD, annotation="pd.Series"),
+        Parameter("metrics", Parameter.POSITIONAL_OR_KEYWORD, annotation=Dict[str, MetricValue]),
+        Parameter("inputs", Parameter.POSITIONAL_OR_KEYWORD, annotation="pd.Series"),
+    ]
+
+    # Add variables to signature list
+    for var in variables:
+        signature_parameters.append(Parameter(var, Parameter.POSITIONAL_OR_KEYWORD))
+
+    eval_fn.__signature__ = Signature(signature_parameters)
+
     return make_metric(
-        eval_fn=eval_fn,
-        greater_is_better=greater_is_better,
-        name=name,
-        version=version,
-        variables=variables,
+        eval_fn=eval_fn, greater_is_better=greater_is_better, name=name, version=version
     )

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1342,28 +1342,19 @@ def test_evaluate_custom_metric_backwards_compatible():
     def old_fn(eval_df, builtin_metrics):
         return builtin_metrics["mean_absolute_error"] * 1.5
 
-    res_metric = _evaluate_custom_metric(
-        _CustomMetric(old_fn, "old_fn", 0), eval_df, builtin_metrics, metrics
-    )
+    eval_fn_args = [eval_df, builtin_metrics]
+    res_metric = _evaluate_custom_metric(_CustomMetric(old_fn, "old_fn", 0), eval_fn_args)
     assert res_metric.scores is None
     assert res_metric.justifications is None
     assert res_metric.aggregate_results["old_fn"] == builtin_metrics["mean_absolute_error"] * 1.5
 
-    def new_fn_no_type_hint(eval_df, metrics):
-        return metrics["mean_absolute_error"].aggregate_results["mean_absolute_error"] * 1.5
-
-    with pytest.raises(
-        AttributeError, match="'numpy.float64' object has no attribute 'aggregate_results'"
-    ):
-        _evaluate_custom_metric(
-            _CustomMetric(new_fn_no_type_hint, "new_fn", 0), eval_df, builtin_metrics, metrics
-        )
+    new_eval_fn_args = [eval_df, metrics]
 
     def new_fn_with_type_hint(eval_df, metrics: Dict[str, MetricValue]):
         return metrics["mean_absolute_error"].aggregate_results["mean_absolute_error"] * 1.5
 
     res_metric = _evaluate_custom_metric(
-        _CustomMetric(new_fn_with_type_hint, "new_fn", 0), eval_df, builtin_metrics, metrics
+        _CustomMetric(new_fn_with_type_hint, "new_fn", 0), new_eval_fn_args
     )
     assert res_metric.scores is None
     assert res_metric.justifications is None
@@ -1375,15 +1366,13 @@ def test_evaluate_custom_metric_incorrect_return_formats():
     builtin_metrics = _get_regressor_metrics(
         eval_df["target"], eval_df["prediction"], sample_weights=None
     )
-    metrics = _get_aggregate_metrics_values(builtin_metrics)
+    eval_fn_args = [eval_df, builtin_metrics]
 
     def dummy_fn(*_):
         pass
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_custom_metric(
-            _CustomMetric(dummy_fn, "dummy_fn", 0), eval_df, builtin_metrics, metrics
-        )
+        _evaluate_custom_metric(_CustomMetric(dummy_fn, "dummy_fn", 0), eval_fn_args)
         mock_warning.assert_called_once_with(
             "Did not log custom metric 'dummy_fn' at index 0 in the `custom_metrics` parameter"
             " because it returned None."
@@ -1394,10 +1383,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_custom_metric(
-            _CustomMetric(incorrect_return_type, incorrect_return_type.__name__, 0),
-            eval_df,
-            builtin_metrics,
-            metrics,
+            _CustomMetric(incorrect_return_type, incorrect_return_type.__name__, 0), eval_fn_args
         )
         mock_warning.assert_called_once_with(
             f"Did not log custom metric '{incorrect_return_type.__name__}' at index 0 in the "
@@ -1409,10 +1395,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_custom_metric(
-            _CustomMetric(non_list_scores, non_list_scores.__name__, 0),
-            eval_df,
-            builtin_metrics,
-            metrics,
+            _CustomMetric(non_list_scores, non_list_scores.__name__, 0), eval_fn_args
         )
         mock_warning.assert_called_once_with(
             f"Did not log custom metric '{non_list_scores.__name__}' at index 0 in the "
@@ -1424,10 +1407,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_custom_metric(
-            _CustomMetric(non_numeric_scores, non_numeric_scores.__name__, 0),
-            eval_df,
-            builtin_metrics,
-            metrics,
+            _CustomMetric(non_numeric_scores, non_numeric_scores.__name__, 0), eval_fn_args
         )
         mock_warning.assert_called_once_with(
             f"Did not log custom metric '{non_numeric_scores.__name__}' at index 0 in the "
@@ -1440,9 +1420,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_custom_metric(
             _CustomMetric(non_list_justifications, non_list_justifications.__name__, 0),
-            eval_df,
-            builtin_metrics,
-            metrics,
+            eval_fn_args,
         )
         mock_warning.assert_called_once_with(
             f"Did not log custom metric '{non_list_justifications.__name__}' at index 0 in the "
@@ -1455,10 +1433,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_custom_metric(
-            _CustomMetric(non_str_justifications, non_str_justifications.__name__, 0),
-            eval_df,
-            builtin_metrics,
-            metrics,
+            _CustomMetric(non_str_justifications, non_str_justifications.__name__, 0), eval_fn_args
         )
         mock_warning.assert_called_once_with(
             f"Did not log custom metric '{non_str_justifications.__name__}' at index 0 in the "
@@ -1471,10 +1446,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_custom_metric(
-            _CustomMetric(non_dict_aggregates, non_dict_aggregates.__name__, 0),
-            eval_df,
-            builtin_metrics,
-            metrics,
+            _CustomMetric(non_dict_aggregates, non_dict_aggregates.__name__, 0), eval_fn_args
         )
         mock_warning.assert_called_once_with(
             f"Did not log custom metric '{non_dict_aggregates.__name__}' at index 0 in the "
@@ -1487,10 +1459,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_custom_metric(
-            _CustomMetric(wrong_type_aggregates, wrong_type_aggregates.__name__, 0),
-            eval_df,
-            builtin_metrics,
-            metrics,
+            _CustomMetric(wrong_type_aggregates, wrong_type_aggregates.__name__, 0), eval_fn_args
         )
         mock_warning.assert_called_once_with(
             f"Did not log custom metric '{wrong_type_aggregates.__name__}' at index 0 in the "
@@ -1522,8 +1491,9 @@ def test_evaluate_custom_metric_lambda(fn):
         eval_df["target"], eval_df["prediction"], sample_weights=None
     )
     metrics = _get_aggregate_metrics_values(builtin_metrics)
+    eval_fn_args = [eval_df, metrics]
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_custom_metric(_CustomMetric(fn, "<lambda>", 0), eval_df, builtin_metrics, metrics)
+        _evaluate_custom_metric(_CustomMetric(fn, "<lambda>", 0), eval_fn_args)
         mock_warning.assert_not_called()
 
 
@@ -1545,11 +1515,9 @@ def test_evaluate_custom_metric_success():
             },
         )
 
+    eval_fn_args = [eval_df, _get_aggregate_metrics_values(builtin_metrics)]
     res_metric = _evaluate_custom_metric(
-        _CustomMetric(example_count_times_1_point_5, "", 0),
-        eval_df,
-        builtin_metrics,
-        _get_aggregate_metrics_values(builtin_metrics),
+        _CustomMetric(example_count_times_1_point_5, "", 0), eval_fn_args
     )
     assert (
         res_metric.aggregate_results["example_count_times_1_point_5"]
@@ -2671,18 +2639,26 @@ def language_model_with_context(inputs: List[str]) -> List[Dict[str, str]]:
 def test_constructing_eval_df_for_custom_metrics():
     test_eval_df_value = pd.DataFrame(
         {
-            "prediction": ["text_a", "text_b"],
-            "target": ["target_a", "target_b"],
+            "predictions": ["text_a", "text_b"],
+            "targets": ["target_a", "target_b"],
+            "inputs": ["text_a", "text_b"],
             "truth": ["truth_a", "truth_b"],
             "context": ["context_text_a", "context_text_b"],
-            "input": ["text_a", "text_b"],
         }
     )
 
-    def test_eval_df(eval_df, _builtin_metrics):
+    def test_eval_df(predictions, targets, metrics, inputs, truth, context):
         global eval_df_value
-        eval_df_value = eval_df
-        return eval_df["prediction"].eq(eval_df["target"]).mean()
+        eval_df_value = pd.DataFrame(
+            {
+                "predictions": predictions,
+                "targets": targets,
+                "inputs": inputs,
+                "truth": truth,
+                "context": context,
+            }
+        )
+        return predictions.eq(targets).mean()
 
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model(
@@ -2694,21 +2670,17 @@ def test_constructing_eval_df_for_custom_metrics():
             {
                 "text": ["text_a", "text_b"],
                 "truth": ["truth_a", "truth_b"],
-                "target": ["target_a", "target_b"],
+                "targets": ["target_a", "target_b"],
             }
         )
         mlflow.evaluate(
             model_info.model_uri,
             data,
-            targets="target",
+            targets="targets",
             model_type="text",
-            custom_metrics=[
-                make_metric(
-                    eval_fn=test_eval_df, greater_is_better=True, variables=["truth", "context"]
-                )
-            ],
+            custom_metrics=[make_metric(eval_fn=test_eval_df, greater_is_better=True)],
             evaluators="default",
-            evaluator_config={"input": "text"},
+            evaluator_config={"inputs": "text"},
         )
 
     assert eval_df_value.equals(test_eval_df_value)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Updating the concept of variables for eval_fn

## How is this patch tested?
- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (describe details, including test results, below)


## Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
