### PR TITLE
Fixing the naming for token_count and latency metrics

### DIFF
--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2146,8 +2146,8 @@ def validate_question_answering_logged_data(logged_data, with_targets=True):
         "flesch_kincaid_grade_level/v1/score",
         "ari_grade_level/v1/score",
         "perplexity/v1/score",
-        "latency/score",
-        "token_count/score",
+        "latency",
+        "token_count",
     }
     if with_targets:
         columns.update({"answer"})
@@ -2163,8 +2163,8 @@ def validate_question_answering_logged_data(logged_data, with_targets=True):
         isinstance(grade, float) for grade in logged_data["flesch_kincaid_grade_level/v1/score"]
     )
     assert all(isinstance(grade, float) for grade in logged_data["ari_grade_level/v1/score"])
-    assert all(isinstance(grade, float) for grade in logged_data["latency/score"])
-    assert all(isinstance(grade, int) for grade in logged_data["token_count/score"])
+    assert all(isinstance(grade, float) for grade in logged_data["latency"])
+    assert all(isinstance(grade, int) for grade in logged_data["token_count"])
 
     if with_targets:
         assert logged_data["answer"].tolist() == ["words random", "This is a sentence."]
@@ -2221,7 +2221,7 @@ def test_evaluate_question_answering_with_numerical_targets():
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     pd.testing.assert_frame_equal(
-        logged_data.drop("latency/score", axis=1).drop("token_count/score", axis=1),
+        logged_data.drop("latency", axis=1).drop("token_count", axis=1),
         data.assign(outputs=[0, 1]),
     )
     assert results.metrics == {"exact_match/v1": 1.0}
@@ -2257,8 +2257,8 @@ def validate_text_summarization_logged_data(logged_data, with_targets=True):
         "flesch_kincaid_grade_level/v1/score",
         "ari_grade_level/v1/score",
         "perplexity/v1/score",
-        "latency/score",
-        "token_count/score",
+        "latency",
+        "token_count",
     }
     if with_targets:
         columns.update(
@@ -2281,8 +2281,8 @@ def validate_text_summarization_logged_data(logged_data, with_targets=True):
         isinstance(grade, float) for grade in logged_data["flesch_kincaid_grade_level/v1/score"]
     )
     assert all(isinstance(grade, float) for grade in logged_data["ari_grade_level/v1/score"])
-    assert all(isinstance(grade, float) for grade in logged_data["latency/score"])
-    assert all(isinstance(grade, int) for grade in logged_data["token_count/score"])
+    assert all(isinstance(grade, float) for grade in logged_data["latency"])
+    assert all(isinstance(grade, int) for grade in logged_data["token_count"])
 
     if with_targets:
         assert logged_data["summary"].tolist() == ["a", "b"]
@@ -2424,8 +2424,8 @@ def test_evaluate_text_summarization_fails_to_load_evaluate_metrics():
         "outputs",
         "flesch_kincaid_grade_level/v1/score",
         "ari_grade_level/v1/score",
-        "latency/score",
-        "token_count/score",
+        "latency",
+        "token_count",
     }
     assert logged_data["text"].tolist() == ["a", "b"]
     assert logged_data["summary"].tolist() == ["a", "b"]
@@ -2455,8 +2455,8 @@ def test_evaluate_text_and_text_metrics():
         "flesch_kincaid_grade_level/v1/score",
         "ari_grade_level/v1/score",
         "perplexity/v1/score",
-        "latency/score",
-        "token_count/score",
+        "latency",
+        "token_count",
     }
     assert logged_data["text"].tolist() == ["sentence not", "All women are bad."]
     assert logged_data["outputs"].tolist() == ["sentence not", "All women are bad."]
@@ -2549,8 +2549,8 @@ def test_eval_results_table_json_can_be_prefixed_with_metric_prefix(metric_prefi
         f"{metric_prefix}flesch_kincaid_grade_level/v1/score",
         f"{metric_prefix}ari_grade_level/v1/score",
         f"{metric_prefix}perplexity/v1/score",
-        f"{metric_prefix}latency/score",
-        f"{metric_prefix}token_count/score",
+        f"{metric_prefix}latency",
+        f"{metric_prefix}token_count",
     }
 
 


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fixing the naming for token_count and latency metrics 

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
