### PR TITLE
Pin werkzeug for spacy

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -274,7 +274,7 @@ spacy:
     maximum: "3.6.1"
     requirements:
       ">= 0.0.0": ["scikit-learn", "click<8.1.0"]
-      "<= 3.0.9": ["flask<2.1.0"]
+      "<= 3.0.9": ["flask<2.1.0", "werkzeug<3"]
       "<3.4.0": ["typing_extensions<4.6.0"]
     run: |
       pytest tests/spacy/test_spacy_model_export.py

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -385,7 +385,7 @@ def test_pyfunc_serve_and_score(spacy_model_with_data):
     model, inference_dataframe = spacy_model_with_data
     artifact_path = "model"
     with mlflow.start_run():
-        if spacy_version <= Version("3.0.8"):
+        if spacy_version <= Version("3.0.9"):
             extra_pip_requirements = ["click<8.1.0", "flask<2.1.0", "werkzeug<3"]
         elif spacy_version < Version("3.2.4"):
             extra_pip_requirements = ["click<8.1.0"]

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -386,7 +386,7 @@ def test_pyfunc_serve_and_score(spacy_model_with_data):
     artifact_path = "model"
     with mlflow.start_run():
         if spacy_version <= Version("3.0.8"):
-            extra_pip_requirements = ["click<8.1.0", "flask<2.1.0"]
+            extra_pip_requirements = ["click<8.1.0", "flask<2.1.0", "werkzeug<3"]
         elif spacy_version < Version("3.2.4"):
             extra_pip_requirements = ["click<8.1.0"]
         else:


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/9784?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

https://github.com/mlflow-automation/mlflow/actions/runs/6370871713/job/17294712353#step:13:37

```
___________ ERROR collecting tests/spacy/test_spacy_model_export.py ____________
ImportError while importing test module '/home/runner/work/mlflow/mlflow/tests/spacy/test_spacy_model_export.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/spacy/test_spacy_model_export.py:16: in <module>
    import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
mlflow/pyfunc/scoring_server/__init__.py:24: in <module>
    import flask
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/flask/__init__.py:7: in <module>
    from .app import Flask as Flask
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/flask/app.py:28: in <module>
    from . import cli
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/flask/cli.py:18: in <module>
    from .helpers import get_debug_flag
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/flask/helpers.py:16: in <module>
    from werkzeug.urls import url_quote
E   ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/werkzeug/urls.py)
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
