### PR TITLE
Use `tests/datasets/apollo11_launch.wav` in `examples/transformers/whisper.py`

### DIFF
--- a/examples/transformers/whisper.py
+++ b/examples/transformers/whisper.py
@@ -4,7 +4,11 @@ import transformers
 import mlflow
 
 # Acquire an audio file
-audio = requests.get("https://www.nasa.gov/62283main_landing.wav").content
+resp = requests.get(
+    "https://github.com/mlflow/mlflow/raw/master/tests/datasets/apollo11_launch.wav"
+)
+resp.raise_for_status()
+audio = resp.content
 
 task = "automatic-speech-recognition"
 architecture = "openai/whisper-tiny"


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/9787?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix https://github.com/mlflow-automation/mlflow/actions/runs/6370822759/job/17292234425:

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/mlflow/transformers/__init__.py", line 1646, in _validate_inference_config_and_return_output
    return self.pipeline(data, **self.inference_config)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/transformers/pipelines/automatic_speech_recognition.py", line 356, in __call__
    return super().__call__(inputs, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/transformers/pipelines/base.py", line 1132, in __call__
    return next(
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/transformers/pipelines/pt_utils.py", line 124, in __next__
    item = next(self.iterator)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/transformers/pipelines/pt_utils.py", line 266, in __next__
    processed = self.infer(next(self.iterator), **self.params)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 633, in __next__
    data = self._next_data()
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 677, in _next_data
    data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/torch/utils/data/_utils/fetch.py", line 32, in fetch
    data.append(next(self.dataset_iter))
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/transformers/pipelines/pt_utils.py", line 183, in __next__
    processed = next(self.subiterator)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/transformers/pipelines/automatic_speech_recognition.py", line 433, in preprocess
    inputs = ffmpeg_read(inputs, self.feature_extractor.sampling_rate)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/transformers/pipelines/audio_utils.py", line 41, in ffmpeg_read
    raise ValueError("Malformed soundfile")
ValueError: Malformed soundfile

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "whisper.py", line 26, in <module>
    mlflow.transformers.generate_signature_output(audio_transcription_pipeline, audio),
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/mlflow/transformers/__init__.py", line 1583, in generate_signature_output
    return _TransformersWrapper(pipeline=pipeline, inference_config=inference_config).predict(
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/mlflow/transformers/__init__.py", line 1717, in predict
    return self._predict(input_data)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/mlflow/transformers/__init__.py", line 1795, in _predict
    raw_output = self._validate_inference_config_and_return_output(data)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/mlflow/transformers/__init__.py", line 1660, in _validate_inference_config_and_return_output
    raise MlflowException.invalid_parameter_value(
mlflow.exceptions.MlflowException: Failed to process the input audio data. Either the audio file is corrupted or a uri was passed in without overriding the default model signature. If submitting a string uri, please ensure that the model has been saved with a signature that defines a string input type.
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
