### PR TITLE
Add system prefix to system metrics

### DIFF
--- a/mlflow/system_metrics/system_metrics_monitor.py
+++ b/mlflow/system_metrics/system_metrics_monitor.py
@@ -26,6 +26,8 @@ class SystemMetricsMonitor:
     environment variables, e.g., run `export MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL=10` in terminal
     will set the sampling interval to 10 seconds.
 
+    System metrics are logged with a prefix "system/", e.g., "system/cpu_utilization_percentage".
+
     Args:
         run_id: string, the MLflow run ID.
         sampling_interval: float, default to 10. The interval (in seconds) at which to pull system
@@ -59,7 +61,7 @@ class SystemMetricsMonitor:
         self._shutdown_event = threading.Event()
         self._process = None
         self._logging_step = 0
-        self._metrics_name_prefix = "system/"
+        self._metrics_prefix = "system/"
 
     def start(self):
         """Start monitoring system metrics."""
@@ -121,7 +123,7 @@ class SystemMetricsMonitor:
     def publish_metrics(self, metrics):
         """Log collected metrics to MLflow."""
         # Add prefix "system/" to the metrics name for grouping.
-        metrics = {self._metrics_name_prefix + k: v for k, v in metrics.items()}
+        metrics = {self._metrics_prefix + k: v for k, v in metrics.items()}
 
         self.mlflow_logger.record_metrics(metrics, self._logging_step)
         self._logging_step += 1

--- a/mlflow/system_metrics/system_metrics_monitor.py
+++ b/mlflow/system_metrics/system_metrics_monitor.py
@@ -59,6 +59,7 @@ class SystemMetricsMonitor:
         self._shutdown_event = threading.Event()
         self._process = None
         self._logging_step = 0
+        self._metrics_name_prefix = "system/"
 
     def start(self):
         """Start monitoring system metrics."""
@@ -119,6 +120,9 @@ class SystemMetricsMonitor:
 
     def publish_metrics(self, metrics):
         """Log collected metrics to MLflow."""
+        # Add prefix "system/" to the metrics name for grouping.
+        metrics = {self._metrics_name_prefix + k: v for k, v in metrics.items()}
+
         self.mlflow_logger.record_metrics(metrics, self._logging_step)
         self._logging_step += 1
         for monitor in self.monitors:

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -36,12 +36,13 @@ def test_manual_system_metrics_monitor():
         "network_receive_megabytes",
         "network_transmit_megabytes",
     ]
+    expected_metrics_name = [f"system/{name}" for name in expected_metrics_name]
     for name in expected_metrics_name:
         assert name in metrics
 
     # Check the step is correctly logged.
     metrics_history = mlflow.tracking.MlflowClient().get_metric_history(
-        run.info.run_id, "cpu_utilization_percentage"
+        run.info.run_id, "system/cpu_utilization_percentage"
     )
     assert metrics_history[-1].step > 0
 
@@ -76,12 +77,13 @@ def test_automatic_system_metrics_monitor():
         "network_receive_megabytes",
         "network_transmit_megabytes",
     ]
+    expected_metrics_name = [f"system/{name}" for name in expected_metrics_name]
     for name in expected_metrics_name:
         assert name in metrics
 
     # Check the step is correctly logged.
     metrics_history = mlflow.tracking.MlflowClient().get_metric_history(
-        run.info.run_id, "cpu_utilization_percentage"
+        run.info.run_id, "system/cpu_utilization_percentage"
     )
     assert metrics_history[-1].step > 0
 


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/9794?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add a prefix to system metrics so that MLflow server can group system metrics together.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
