### PR TITLE
Rename custom_metrics to extra_metrics

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -700,7 +700,7 @@ class ModelEvaluator(metaclass=ABCMeta):
         dataset,
         run_id,
         evaluator_config,
-        custom_metrics=None,
+        extra_metrics=None,
         custom_artifacts=None,
         baseline_model=None,
         **kwargs,
@@ -718,7 +718,7 @@ class ModelEvaluator(metaclass=ABCMeta):
         :param run_id: The ID of the MLflow Run to which to log results.
         :param evaluator_config: A dictionary of additional configurations for
                                  the evaluator.
-        :param custom_metrics: A list of :py:class:`EvaluationMetric` objects.
+        :param extra_metrics: A list of :py:class:`EvaluationMetric` objects.
         :param custom_artifacts: A list of callable custom artifact functions.
         :param kwargs: For forwards compatibility, a placeholder for additional arguments that
                        may be added to the evaluation interface in the future.
@@ -995,7 +995,7 @@ def _evaluate(
     run_id,
     evaluator_name_list,
     evaluator_name_to_conf_map,
-    custom_metrics,
+    extra_metrics,
     custom_artifacts,
     baseline_model,
 ):
@@ -1033,7 +1033,7 @@ def _evaluate(
                 dataset=dataset,
                 run_id=run_id,
                 evaluator_config=config,
-                custom_metrics=custom_metrics,
+                extra_metrics=extra_metrics,
                 custom_artifacts=custom_artifacts,
                 baseline_model=baseline_model,
             )
@@ -1071,7 +1071,7 @@ def evaluate(
     feature_names: list = None,
     evaluators=None,
     evaluator_config=None,
-    custom_metrics=None,
+    extra_metrics=None,
     custom_artifacts=None,
     validation_thresholds=None,
     baseline_model=None,
@@ -1349,7 +1349,7 @@ def evaluate(
                              If multiple evaluators are specified, each configuration should be
                              supplied as a nested dictionary whose key is the evaluator name.
 
-    :param custom_metrics:
+    :param extra_metrics:
         (Optional) A list of :py:class:`EvaluationMetric <mlflow.models.EvaluationMetric>` objects.
 
         .. code-block:: python
@@ -1367,7 +1367,7 @@ def evaluate(
                 eval_fn=root_mean_squared_error,
                 greater_is_better=False,
             )
-            mlflow.evaluate(..., custom_metrics=[rmse_metric])
+            mlflow.evaluate(..., extra_metrics=[rmse_metric])
 
     :param custom_artifacts:
         (Optional) A list of custom artifact functions with the following signature:
@@ -1439,8 +1439,8 @@ def evaluate(
 
     :param validation_thresholds: (Optional) A dictionary of metric name to
         :py:class:`mlflow.models.MetricThreshold` used for model validation. Each metric name must
-        either be the name of a builtin metric or the name of a custom metric defined in the
-        ``custom_metrics`` parameter.
+        either be the name of a builtin metric or the name of a metric defined in the
+        ``extra_metrics`` parameter.
 
         .. code-block:: python
             :caption: Example of Model Validation
@@ -1601,7 +1601,7 @@ def evaluate(
                 run_id=run_id,
                 evaluator_name_list=evaluator_name_list,
                 evaluator_name_to_conf_map=evaluator_name_to_conf_map,
-                custom_metrics=custom_metrics,
+                extra_metrics=extra_metrics,
                 custom_artifacts=custom_artifacts,
                 baseline_model=baseline_model,
             )

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -472,7 +472,7 @@ class _CustomMetric(NamedTuple):
 
     function : the custom metric function
     name : the name of the custom metric function
-    index : the index of the function in the ``custom_metrics`` argument of mlflow.evaluate
+    index : the index of the function in the ``extra_metrics`` argument of mlflow.evaluate
     """
 
     function: Callable
@@ -500,30 +500,30 @@ def _is_numeric(value):
     return isinstance(value, (int, float, np.number))
 
 
-def _evaluate_custom_metric(custom_metric_tuple, eval_fn_args):
+def _evaluate_extra_metric(extra_metric_tuple, eval_fn_args):
     """
-    This function calls the `custom_metric` function and performs validations on the returned
+    This function calls the `extra_metric` function and performs validations on the returned
     result to ensure that they are in the expected format. It will warn and will not log metrics
     that are in the wrong format.
 
-    :param custom_metric_tuple: Containing a user provided function and its index in the
-        ``custom_metrics`` parameter of ``mlflow.evaluate``
+    :param extra_metric_tuple: Containing a user provided function and its index in the
+        ``extra_metrics`` parameter of ``mlflow.evaluate``
     :param eval_fn_args: A dictionary of args needed to compute the eval metrics.
     :return: MetricValue
     """
     exception_header = (
-        f"Did not log custom metric '{custom_metric_tuple.name}' at index "
-        f"{custom_metric_tuple.index} in the `custom_metrics` parameter because it"
+        f"Did not log metric '{extra_metric_tuple.name}' at index "
+        f"{extra_metric_tuple.index} in the `extra_metrics` parameter because it"
     )
 
-    metric = custom_metric_tuple.function(*eval_fn_args)
+    metric = extra_metric_tuple.function(*eval_fn_args)
 
     if metric is None:
         _logger.warning(f"{exception_header} returned None.")
         return
 
     if _is_numeric(metric):
-        return MetricValue(aggregate_results={custom_metric_tuple.name: metric})
+        return MetricValue(aggregate_results={extra_metric_tuple.name: metric})
 
     if not isinstance(metric, MetricValue):
         _logger.warning(f"{exception_header} did not return a MetricValue.")
@@ -583,7 +583,7 @@ def _evaluate_custom_artifacts(custom_artifact_tuple, eval_df, builtin_metrics):
     result to ensure that they are in the expected format. It will raise a MlflowException if
     the result is not in the expected format.
 
-    :param custom_metric_tuple: Containing a user provided function and its index in the
+    :param custom_artifact_tuple: Containing a user provided function and its index in the
                                 ``custom_artifacts`` parameter of ``mlflow.evaluate``
     :param eval_df: A Pandas dataframe object containing a prediction and a target column.
     :param builtin_metrics: A dictionary of metrics produced by the default evaluator.
@@ -1043,7 +1043,7 @@ class DefaultEvaluator(ModelEvaluator):
 
         exception_and_warning_header = (
             f"Custom metric function '{custom_metric_tuple.name}' at index "
-            f"{custom_metric_tuple.index} in the `custom_metrics` parameter"
+            f"{custom_metric_tuple.index} in the `custom_artifacts` parameter"
         )
 
         inferred_from_path, inferred_type, inferred_ext = _infer_artifact_type_and_ext(
@@ -1103,12 +1103,12 @@ class DefaultEvaluator(ModelEvaluator):
         artifact._load(artifact_file_local_path)
         return artifact
 
-    def _get_args_for_metrics(self, custom_metric, eval_df):
-        # deepcopying eval_df and builtin_metrics for each custom metric function call,
+    def _get_args_for_metrics(self, extra_metric, eval_df):
+        # deepcopying eval_df and builtin_metrics for each metric function call,
         # in case the user modifies them inside their function(s).
         eval_df_copy = eval_df.copy()
         input_df = self.X.copy_to_avoid_mutation()
-        parameters = dict(inspect.signature(custom_metric.eval_fn).parameters)
+        parameters = dict(inspect.signature(extra_metric.eval_fn).parameters)
         eval_fn_args = []
         if len(parameters) == 2:
             eval_fn_args.append(eval_df_copy)
@@ -1145,23 +1145,23 @@ class DefaultEvaluator(ModelEvaluator):
 
         return eval_fn_args
 
-    def _evaluate_custom_metrics(self, eval_df):
-        if not self.custom_metrics:
+    def _evaluate_extra_metrics(self, eval_df):
+        if not self.extra_metrics:
             return
-        for index, custom_metric in enumerate(self.custom_metrics):
-            eval_fn_args = self._get_args_for_metrics(custom_metric, eval_df)
-            _logger.info("Evaluating custom metrics:", custom_metric.name)
-            custom_metric_tuple = _CustomMetric(
-                function=custom_metric.eval_fn,
+        for index, extra_metric in enumerate(self.extra_metrics):
+            eval_fn_args = self._get_args_for_metrics(extra_metric, eval_df)
+            _logger.info("Evaluating custom metrics:", extra_metric.name)
+            extra_metric_tuple = _CustomMetric(
+                function=extra_metric.eval_fn,
                 index=index,
-                name=custom_metric.name,
+                name=extra_metric.name,
             )
-            metric_value = _evaluate_custom_metric(custom_metric_tuple, eval_fn_args)
+            metric_value = _evaluate_extra_metric(extra_metric_tuple, eval_fn_args)
             if metric_value:
                 name = (
-                    f"{custom_metric.name}/{custom_metric.version}"
-                    if custom_metric.version
-                    else custom_metric.name
+                    f"{extra_metric.name}/{extra_metric.version}"
+                    if extra_metric.version
+                    else extra_metric.name
                 )
                 self.metrics_values.update({name: metric_value})
 
@@ -1504,7 +1504,7 @@ class DefaultEvaluator(ModelEvaluator):
 
                 self._evaluate_builtin_metrics(eval_df)
                 self._update_metrics()
-                self._evaluate_custom_metrics(eval_df)
+                self._evaluate_extra_metrics(eval_df)
                 if not is_baseline_model:
                     self._log_custom_artifacts(eval_df)
 
@@ -1537,7 +1537,7 @@ class DefaultEvaluator(ModelEvaluator):
         dataset,
         run_id,
         evaluator_config,
-        custom_metrics=None,
+        extra_metrics=None,
         custom_artifacts=None,
         baseline_model=None,
         **kwargs,
@@ -1547,7 +1547,7 @@ class DefaultEvaluator(ModelEvaluator):
         self.model_type = model_type
         self.evaluator_config = evaluator_config
         self.feature_names = dataset.feature_names
-        self.custom_metrics = custom_metrics
+        self.extra_metrics = extra_metrics
         self.custom_artifacts = custom_artifacts
         self.y = dataset.labels_data
         self.pos_label = self.evaluator_config.get("pos_label")

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -42,7 +42,7 @@ from mlflow.models.evaluation.default_evaluator import (
     _CustomArtifact,
     _CustomMetric,
     _evaluate_custom_artifacts,
-    _evaluate_custom_metric,
+    _evaluate_extra_metric,
     _extract_output_and_other_columns,
     _extract_predict_fn,
     _extract_raw_model,
@@ -1332,7 +1332,7 @@ def test_gen_multiclass_roc_curve_with_sample_weights():
     np.testing.assert_allclose(results.auc, expected_auc, rtol=1e-3)
 
 
-def test_evaluate_custom_metric_backwards_compatible():
+def test_evaluate_extra_metric_backwards_compatible():
     eval_df = pd.DataFrame({"prediction": [1.2, 1.9, 3.2], "target": [1, 2, 3]})
     builtin_metrics = _get_regressor_metrics(
         eval_df["target"], eval_df["prediction"], sample_weights=None
@@ -1343,7 +1343,7 @@ def test_evaluate_custom_metric_backwards_compatible():
         return builtin_metrics["mean_absolute_error"] * 1.5
 
     eval_fn_args = [eval_df, builtin_metrics]
-    res_metric = _evaluate_custom_metric(_CustomMetric(old_fn, "old_fn", 0), eval_fn_args)
+    res_metric = _evaluate_extra_metric(_CustomMetric(old_fn, "old_fn", 0), eval_fn_args)
     assert res_metric.scores is None
     assert res_metric.justifications is None
     assert res_metric.aggregate_results["old_fn"] == builtin_metrics["mean_absolute_error"] * 1.5
@@ -1353,7 +1353,7 @@ def test_evaluate_custom_metric_backwards_compatible():
     def new_fn_with_type_hint(eval_df, metrics: Dict[str, MetricValue]):
         return metrics["mean_absolute_error"].aggregate_results["mean_absolute_error"] * 1.5
 
-    res_metric = _evaluate_custom_metric(
+    res_metric = _evaluate_extra_metric(
         _CustomMetric(new_fn_with_type_hint, "new_fn", 0), new_eval_fn_args
     )
     assert res_metric.scores is None
@@ -1361,7 +1361,7 @@ def test_evaluate_custom_metric_backwards_compatible():
     assert res_metric.aggregate_results["new_fn"] == builtin_metrics["mean_absolute_error"] * 1.5
 
 
-def test_evaluate_custom_metric_incorrect_return_formats():
+def test_evaluate_extra_metric_incorrect_return_formats():
     eval_df = pd.DataFrame({"prediction": [1.2, 1.9, 3.2], "target": [1, 2, 3]})
     builtin_metrics = _get_regressor_metrics(
         eval_df["target"], eval_df["prediction"], sample_weights=None
@@ -1372,9 +1372,9 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         pass
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_custom_metric(_CustomMetric(dummy_fn, "dummy_fn", 0), eval_fn_args)
+        _evaluate_extra_metric(_CustomMetric(dummy_fn, "dummy_fn", 0), eval_fn_args)
         mock_warning.assert_called_once_with(
-            "Did not log custom metric 'dummy_fn' at index 0 in the `custom_metrics` parameter"
+            "Did not log metric 'dummy_fn' at index 0 in the `extra_metrics` parameter"
             " because it returned None."
         )
 
@@ -1382,49 +1382,49 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return "stuff", 3
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_custom_metric(
+        _evaluate_extra_metric(
             _CustomMetric(incorrect_return_type, incorrect_return_type.__name__, 0), eval_fn_args
         )
         mock_warning.assert_called_once_with(
-            f"Did not log custom metric '{incorrect_return_type.__name__}' at index 0 in the "
-            "`custom_metrics` parameter because it did not return a MetricValue."
+            f"Did not log metric '{incorrect_return_type.__name__}' at index 0 in the "
+            "`extra_metrics` parameter because it did not return a MetricValue."
         )
 
     def non_list_scores(*_):
         return MetricValue(scores=5)
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_custom_metric(
+        _evaluate_extra_metric(
             _CustomMetric(non_list_scores, non_list_scores.__name__, 0), eval_fn_args
         )
         mock_warning.assert_called_once_with(
-            f"Did not log custom metric '{non_list_scores.__name__}' at index 0 in the "
-            "`custom_metrics` parameter because it must return MetricValue with scores as a list."
+            f"Did not log metric '{non_list_scores.__name__}' at index 0 in the "
+            "`extra_metrics` parameter because it must return MetricValue with scores as a list."
         )
 
     def non_numeric_scores(*_):
         return MetricValue(scores=["string"])
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_custom_metric(
+        _evaluate_extra_metric(
             _CustomMetric(non_numeric_scores, non_numeric_scores.__name__, 0), eval_fn_args
         )
         mock_warning.assert_called_once_with(
-            f"Did not log custom metric '{non_numeric_scores.__name__}' at index 0 in the "
-            "`custom_metrics` parameter because it must return MetricValue with numeric scores."
+            f"Did not log metric '{non_numeric_scores.__name__}' at index 0 in the "
+            "`extra_metrics` parameter because it must return MetricValue with numeric scores."
         )
 
     def non_list_justifications(*_):
         return MetricValue(justifications="string")
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_custom_metric(
+        _evaluate_extra_metric(
             _CustomMetric(non_list_justifications, non_list_justifications.__name__, 0),
             eval_fn_args,
         )
         mock_warning.assert_called_once_with(
-            f"Did not log custom metric '{non_list_justifications.__name__}' at index 0 in the "
-            "`custom_metrics` parameter because it must return MetricValue with justifications "
+            f"Did not log metric '{non_list_justifications.__name__}' at index 0 in the "
+            "`extra_metrics` parameter because it must return MetricValue with justifications "
             "as a list."
         )
 
@@ -1432,12 +1432,12 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return MetricValue(justifications=[3, 4])
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_custom_metric(
+        _evaluate_extra_metric(
             _CustomMetric(non_str_justifications, non_str_justifications.__name__, 0), eval_fn_args
         )
         mock_warning.assert_called_once_with(
-            f"Did not log custom metric '{non_str_justifications.__name__}' at index 0 in the "
-            "`custom_metrics` parameter because it must return MetricValue with string "
+            f"Did not log metric '{non_str_justifications.__name__}' at index 0 in the "
+            "`extra_metrics` parameter because it must return MetricValue with string "
             "justifications."
         )
 
@@ -1445,12 +1445,12 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return MetricValue(aggregate_results=[5.0, 4.0])
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_custom_metric(
+        _evaluate_extra_metric(
             _CustomMetric(non_dict_aggregates, non_dict_aggregates.__name__, 0), eval_fn_args
         )
         mock_warning.assert_called_once_with(
-            f"Did not log custom metric '{non_dict_aggregates.__name__}' at index 0 in the "
-            "`custom_metrics` parameter because it must return MetricValue with aggregate_results "
+            f"Did not log metric '{non_dict_aggregates.__name__}' at index 0 in the "
+            "`extra_metrics` parameter because it must return MetricValue with aggregate_results "
             "as a dict."
         )
 
@@ -1458,12 +1458,12 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         return MetricValue(aggregate_results={"toxicity": 0.0, "hi": "hi"})
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_custom_metric(
+        _evaluate_extra_metric(
             _CustomMetric(wrong_type_aggregates, wrong_type_aggregates.__name__, 0), eval_fn_args
         )
         mock_warning.assert_called_once_with(
-            f"Did not log custom metric '{wrong_type_aggregates.__name__}' at index 0 in the "
-            "`custom_metrics` parameter because it must return MetricValue with aggregate_results "
+            f"Did not log metric '{wrong_type_aggregates.__name__}' at index 0 in the "
+            "`extra_metrics` parameter because it must return MetricValue with aggregate_results "
             "with str keys and numeric values."
         )
 
@@ -1493,7 +1493,7 @@ def test_evaluate_custom_metric_lambda(fn):
     metrics = _get_aggregate_metrics_values(builtin_metrics)
     eval_fn_args = [eval_df, metrics]
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
-        _evaluate_custom_metric(_CustomMetric(fn, "<lambda>", 0), eval_fn_args)
+        _evaluate_extra_metric(_CustomMetric(fn, "<lambda>", 0), eval_fn_args)
         mock_warning.assert_not_called()
 
 
@@ -1516,7 +1516,7 @@ def test_evaluate_custom_metric_success():
         )
 
     eval_fn_args = [eval_df, _get_aggregate_metrics_values(builtin_metrics)]
-    res_metric = _evaluate_custom_metric(
+    res_metric = _evaluate_extra_metric(
         _CustomMetric(example_count_times_1_point_5, "", 0), eval_fn_args
     )
     assert (
@@ -1552,7 +1552,7 @@ def test_evaluate_custom_artifacts_success():
 
 
 def _get_results_for_custom_metrics_tests(
-    model_uri, dataset, *, custom_metrics=None, custom_artifacts=None
+    model_uri, dataset, *, extra_metrics=None, custom_artifacts=None
 ):
     with mlflow.start_run() as run:
         result = evaluate(
@@ -1561,7 +1561,7 @@ def _get_results_for_custom_metrics_tests(
             model_type="classifier",
             targets=dataset._constructor_args["targets"],
             evaluators="default",
-            custom_metrics=custom_metrics,
+            extra_metrics=extra_metrics,
             custom_artifacts=custom_artifacts,
         )
     _, metrics, _, artifacts = get_run_data(run.info.run_id)
@@ -1613,7 +1613,7 @@ def test_custom_metric_mixed(binary_logistic_regressor_model_uri, breast_cancer_
     result, metrics, artifacts = _get_results_for_custom_metrics_tests(
         binary_logistic_regressor_model_uri,
         breast_cancer_dataset,
-        custom_metrics=[
+        extra_metrics=[
             make_metric(eval_fn=true_count, greater_is_better=True),
             make_metric(eval_fn=positive_count, greater_is_better=True),
         ],
@@ -2070,7 +2070,7 @@ def test_custom_metrics():
             model_type="classifier",
             targets="target",
             evaluators="default",
-            custom_metrics=[
+            extra_metrics=[
                 make_metric(
                     eval_fn=lambda _eval_df, _builtin_metrics: MetricValue(
                         aggregate_results={"cm": 1.0}
@@ -2495,7 +2495,7 @@ def test_evaluate_text_custom_metrics():
             data,
             targets="target",
             model_type="text",
-            custom_metrics=[
+            extra_metrics=[
                 make_metric(eval_fn=very_toxic, greater_is_better=True, version="v2"),
                 make_metric(eval_fn=per_row_metric, greater_is_better=False, name="no_version"),
             ],
@@ -2678,7 +2678,7 @@ def test_constructing_eval_df_for_custom_metrics():
             data,
             targets="targets",
             model_type="text",
-            custom_metrics=[make_metric(eval_fn=test_eval_df, greater_is_better=True)],
+            extra_metrics=[make_metric(eval_fn=test_eval_df, greater_is_better=True)],
             evaluators="default",
             evaluator_config={"inputs": "text"},
         )


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
