### PR TITLE
Add PaLM as a provider to MLflow AI Gateway

### DIFF
--- a/docs/source/gateway/index.rst
+++ b/docs/source/gateway/index.rst
@@ -240,19 +240,19 @@ With the rapid development of LLMs, there is no guarantee that this list will be
 below can be used as a helpful guide when configuring a given route for any newly released model types as they become available with a given provider.
 ``N/A`` means that the provider currently doesn't support the route type.
 
-+--------------------+--------------------------+--------------------+------------------+-----------------------------+--------------------------+--------------------------+
-| Route Type         | OpenAI                   | MosaicML           | Anthropic        | Cohere                      | Azure OpenAI             | MLflow                   |
-+====================+==========================+====================+==================+=============================+==========================+==========================+
-| llm/v1/completions | - gpt-3.5-turbo          | - mpt-7b-instruct  | - claude-1       | - command                   | - text-davinci-003       | - MLflow served models*  |
-|                    | - gpt-4                  | - mpt-30b-instruct | - claude-1.3-100k| - command-light-nightly     | - gpt-35-turbo           |                          |
-|                    |                          | - llama2-70b-chat† | - claude-2       |                             |                          |                          |
-+--------------------+--------------------------+--------------------+------------------+-----------------------------+--------------------------+--------------------------+
-| llm/v1/chat        | - gpt-3.5-turbo          | - llama2-70b-chat† | N/A              | N/A                         | - gpt-35-turbo           | - MLflow served models*  |
-|                    | - gpt-4                  |                    |                  |                             | - gpt-4                  |                          |
-+--------------------+--------------------------+--------------------+------------------+-----------------------------+--------------------------+--------------------------+
-| llm/v1/embeddings  | - text-embedding-ada-002 | - instructor-large | N/A              | - embed-english-v2.0        | - text-embedding-ada-002 | - MLflow served models** |
-|                    |                          | - instructor-xl    |                  | - embed-multilingual-v2.0   |                          |                          |
-+--------------------+--------------------------+--------------------+------------------+-----------------------------+--------------------------+--------------------------+
++--------------------+--------------------------+--------------------+------------------+-----------------------------+--------------------------+-----------------------+--------------------------+
+| Route Type         | OpenAI                   | MosaicML           | Anthropic        | Cohere                      | Azure OpenAI             | PaLM                  | MLflow                   |
++====================+==========================+====================+==================+=============================+==========================+=======================+==========================+
+| llm/v1/completions | - gpt-3.5-turbo          | - mpt-7b-instruct  | - claude-1       | - command                   | - text-davinci-003       | - text-bison-001      | - MLflow served models*  |
+|                    | - gpt-4                  | - mpt-30b-instruct | - claude-1.3-100k| - command-light-nightly     | - gpt-35-turbo           |                       |                          |
+|                    |                          | - llama2-70b-chat† | - claude-2       |                             |                          |                       |                          |
++--------------------+--------------------------+--------------------+------------------+-----------------------------+--------------------------+-----------------------+--------------------------+
+| llm/v1/chat        | - gpt-3.5-turbo          | - llama2-70b-chat† | N/A              | N/A                         | - gpt-35-turbo           | - chat-bison-001      | - MLflow served models*  |
+|                    | - gpt-4                  |                    |                  |                             | - gpt-4                  |                       |                          |
++--------------------+--------------------------+--------------------+------------------+-----------------------------+--------------------------+-----------------------+--------------------------+
+| llm/v1/embeddings  | - text-embedding-ada-002 | - instructor-large | N/A              | - embed-english-v2.0        | - text-embedding-ada-002 | - embedding-gecko-001 | - MLflow served models** |
+|                    |                          | - instructor-xl    |                  | - embed-multilingual-v2.0   |                          |                       |                          |
++--------------------+--------------------------+--------------------+------------------+-----------------------------+--------------------------+-----------------------+--------------------------+
 
 † Llama 2 is licensed under the `LLAMA 2 Community License <https://ai.meta.com/llama/license/>`_, Copyright © Meta Platforms, Inc. All Rights Reserved.
 
@@ -289,6 +289,7 @@ As of now, the MLflow AI Gateway supports the following providers:
 * **openai**: This is used for models offered by `OpenAI <https://platform.openai.com/>`_ and the `Azure <https://learn.microsoft.com/en-gb/azure/cognitive-services/openai/>`_ integrations for Azure OpenAI and Azure OpenAI with AAD.
 * **anthropic**: This is used for models offered by `Anthropic <https://docs.anthropic.com/claude/docs>`_.
 * **cohere**: This is used for models offered by `Cohere <https://docs.cohere.com/docs>`_.
+* **palm**: This is used for models offered by `PaLM <https://developers.generativeai.google/api/rest/generativelanguage/models/>`_.
 
 More providers are being added continually. Check the latest version of the MLflow AI Gateway Docs for the
 most up-to-date list of supported providers.
@@ -478,6 +479,7 @@ Each route has the following configuration parameters:
     - "mosaicml"
     - "anthropic"
     - "cohere"
+    - "palm"
     - "azure" / "azuread"
     - "mlflow-model-serving"
 
@@ -525,6 +527,16 @@ Cohere
 | Configuration Parameter  | Required | Default                  | Description                                           |
 +==========================+==========+==========================+=======================================================+
 | **cohere_api_key**       | Yes      | N/A                      | This is the API key for the Cohere service.           |
++--------------------------+----------+--------------------------+-------------------------------------------------------+
+
+
+PaLM
+++++
+
++--------------------------+----------+--------------------------+-------------------------------------------------------+
+| Configuration Parameter  | Required | Default                  | Description                                           |
++==========================+==========+==========================+=======================================================+
+| **palm_api_key**         | Yes      | N/A                      | This is the API key for the PaLM service.             |
 +--------------------------+----------+--------------------------+-------------------------------------------------------+
 
 
@@ -710,7 +722,7 @@ Additional Query Parameters
 In addition to the :ref:`standard_query_parameters`, you can pass any additional parameters supported by the route's provider as part of your query. For example:
 
 - ``logit_bias`` (supported by OpenAI, Cohere)
-- ``top_k`` (supported by MosaicML, Anthropic, Cohere)
+- ``top_k`` (supported by MosaicML, Anthropic, PaLM, Cohere)
 - ``frequency_penalty`` (supported by OpenAI, Cohere)
 - ``presence_penalty`` (supported by OpenAI, Cohere)
 

--- a/examples/gateway/README.md
+++ b/examples/gateway/README.md
@@ -44,6 +44,7 @@ For full examples of configurations and supported route types, see:
 - [MosaicML](mosaicml/config.yaml)
 - [Anthropic](anthropic/config.yaml)
 - [Cohere](cohere/config.yaml)
+- [PaLM](palm/config.yaml)
 - [AzureOpenAI](azure_openai/config.yaml)
 
 ## Step 3: Setting Access Keys

--- a/examples/gateway/palm/README.md
+++ b/examples/gateway/palm/README.md
@@ -1,0 +1,13 @@
+## Example route configuration for PaLM
+
+To see an example of specifying both the completions and the embeddings routes for PaLM, see [the configuration](config.yaml) YAML file.
+
+This configuration file specifies three routes: 'completions', 'embeddings', and 'chat', using PaLM's models 'text-bison-001', 'embedding-gecko-001', and 'chat-bison-001', respectively.
+
+## Setting a PaLM API Key
+
+This example requires a [PaLM API key](https://developers.generativeai.google/tutorials/setup):
+
+```sh
+export PALM_API_KEY=...
+```

--- a/examples/gateway/palm/config.yaml
+++ b/examples/gateway/palm/config.yaml
@@ -1,0 +1,24 @@
+routes:
+  - name: completions
+    route_type: llm/v1/completions
+    model:
+      provider: palm
+      name: text-bison-001
+      config:
+        palm_api_key: $PALM_API_KEY
+
+  - name: embeddings
+    route_type: llm/v1/embeddings
+    model:
+      provider: palm
+      name: embedding-gecko-001
+      config:
+        palm_api_key: $PALM_API_KEY
+
+  - name: chat
+    route_type: llm/v1/chat
+    model:
+      provider: palm
+      name: chat-bison-001
+      config:
+        palm_api_key: $PALM_API_KEY

--- a/examples/gateway/palm/example.py
+++ b/examples/gateway/palm/example.py
@@ -1,0 +1,45 @@
+from mlflow.gateway import query, set_gateway_uri
+
+
+def main():
+    # Set the URI for the MLflow AI Gateway
+    set_gateway_uri("http://localhost:5000")
+
+    # Completions request
+    response_completions = query(
+        route="completions",
+        data={
+            "prompt": "What is the world record for flapjack consumption in a single sitting?",
+            "temperature": 0.1,
+        },
+    )
+    print(f"PaLM response for completions: {response_completions}")
+
+    # Embeddings request
+    response_embeddings = query(
+        route="embeddings", data={"text": ["Do you carry the Storm Trooper costume in size 2T?"]}
+    )
+    print(f"PaLM response for embeddings: {response_embeddings}")
+
+    # Chat example
+    response_chat = query(
+        route="chat",
+        data={
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a talented European rapper with a background in US history",
+                },
+                {
+                    "role": "user",
+                    "content": "Please recite the preamble to the US Constitution as if it were "
+                    "written today by a rapper from Reykjavík",
+                },
+            ]
+        },
+    )
+    print(f"PaLM response for chat: {response_chat}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -38,6 +38,7 @@ class Provider(str, Enum):
     AI21LABS = "ai21labs"
     MLFLOW_MODEL_SERVING = "mlflow-model-serving"
     MOSAICML = "mosaicml"
+    PALM = "palm"
     # Note: The following providers are only supported on Databricks
     DATABRICKS_MODEL_SERVING = "databricks-model-serving"
     DATABRICKS = "databricks"
@@ -167,6 +168,15 @@ class AnthropicConfig(ConfigModel):
         return _resolve_api_key_from_input(value)
 
 
+class PaLMConfig(ConfigModel):
+    palm_api_key: str
+
+    # pylint: disable=no-self-argument
+    @validator("palm_api_key", pre=True)
+    def validate_palm_api_key(cls, value):
+        return _resolve_api_key_from_input(value)
+
+
 class MlflowModelServingConfig(ConfigModel):
     model_server_url: str
 
@@ -178,6 +188,7 @@ config_types = {
     Provider.AI21LABS: AI21LabsConfig,
     Provider.MOSAICML: MosaicMLConfig,
     Provider.MLFLOW_MODEL_SERVING: MlflowModelServingConfig,
+    Provider.PALM: PaLMConfig,
 }
 
 
@@ -234,6 +245,7 @@ class Model(ConfigModel):
             AnthropicConfig,
             MosaicMLConfig,
             MlflowModelServingConfig,
+            PaLMConfig,
         ]
     ] = None
 

--- a/mlflow/gateway/providers/__init__.py
+++ b/mlflow/gateway/providers/__init__.py
@@ -7,6 +7,7 @@ from mlflow.gateway.providers.cohere import CohereProvider
 from mlflow.gateway.providers.mlflow import MlflowModelServingProvider
 from mlflow.gateway.providers.mosaicml import MosaicMLProvider
 from mlflow.gateway.providers.openai import OpenAIProvider
+from mlflow.gateway.providers.palm import PaLMProvider
 
 
 def get_provider(provider: Provider) -> BaseProvider:
@@ -16,6 +17,7 @@ def get_provider(provider: Provider) -> BaseProvider:
         Provider.COHERE: CohereProvider,
         Provider.AI21LABS: AI21LabsProvider,
         Provider.MOSAICML: MosaicMLProvider,
+        Provider.PALM: PaLMProvider,
         Provider.MLFLOW_MODEL_SERVING: MlflowModelServingProvider,
     }
     if prov := provider_to_class.get(provider):

--- a/mlflow/gateway/providers/cohere.py
+++ b/mlflow/gateway/providers/cohere.py
@@ -38,7 +38,7 @@ class CohereProvider(BaseProvider):
         for k1, k2 in key_mapping.items():
             if k2 in payload:
                 raise HTTPException(
-                    status_code=400, detail=f"Invalid parameter {k2}. Use {k1} instead."
+                    status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
         # The range of Cohere's temperature is 0-5, but ours is 0-1, so we scale it.
         payload["temperature"] = 5 * payload["temperature"]
@@ -83,7 +83,7 @@ class CohereProvider(BaseProvider):
         for k1, k2 in key_mapping.items():
             if k2 in payload:
                 raise HTTPException(
-                    status_code=400, detail=f"Invalid parameter {k2}. Use {k1} instead."
+                    status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
         payload = rename_payload_keys(payload, key_mapping)
         resp = await self._request(

--- a/mlflow/gateway/providers/mosaicml.py
+++ b/mlflow/gateway/providers/mosaicml.py
@@ -156,7 +156,7 @@ class MosaicMLProvider(BaseProvider):
         for k1, k2 in key_mapping.items():
             if k2 in payload:
                 raise HTTPException(
-                    status_code=400, detail=f"Invalid parameter {k2}. Use {k1} instead."
+                    status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
         payload = rename_payload_keys(payload, key_mapping)
 
@@ -216,7 +216,7 @@ class MosaicMLProvider(BaseProvider):
         for k1, k2 in key_mapping.items():
             if k2 in payload:
                 raise HTTPException(
-                    status_code=400, detail=f"Invalid parameter {k2}. Use {k1} instead."
+                    status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
         payload = rename_payload_keys(payload, key_mapping)
 

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -81,7 +81,7 @@ class OpenAIProvider(BaseProvider):
         self.check_for_model_field(payload)
         if "n" in payload:
             raise HTTPException(
-                status_code=400, detail="Invalid parameter `n`. Use `candidate_count` instead."
+                status_code=422, detail="Invalid parameter `n`. Use `candidate_count` instead."
             )
 
         payload = rename_payload_keys(
@@ -150,7 +150,7 @@ class OpenAIProvider(BaseProvider):
         self.check_for_model_field(payload)
         if "n" in payload:
             raise HTTPException(
-                status_code=400, detail="Invalid parameter `n`. Use `candidate_count` instead."
+                status_code=422, detail="Invalid parameter `n`. Use `candidate_count` instead."
             )
         payload = rename_payload_keys(
             payload,

--- a/mlflow/gateway/providers/palm.py
+++ b/mlflow/gateway/providers/palm.py
@@ -28,10 +28,13 @@ class PaLMProvider(BaseProvider):
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
+        if "max_tokens" in payload or "maxOutputTokens" in payload:
+            raise HTTPException(
+                status_code=422, detail="Max tokens is not supported for PaLM chat."
+            )
         key_mapping = {
             "stop": "stopSequences",
             "candidate_count": "candidateCount",
-            "max_tokens": "maxOutputTokens",
         }
         for k1, k2 in key_mapping.items():
             if k2 in payload:

--- a/mlflow/gateway/providers/palm.py
+++ b/mlflow/gateway/providers/palm.py
@@ -41,8 +41,7 @@ class PaLMProvider(BaseProvider):
 
         # Replace 'role' with 'author' in payload
         for m in payload["messages"]:
-            if "role" in m:
-                m["author"] = m.pop("role")
+            m["author"] = m.pop("role")
 
         # Map 'messages', 'examples, and 'context' to 'prompt'
         prompt = {"messages": payload.pop("messages")}

--- a/mlflow/gateway/providers/palm.py
+++ b/mlflow/gateway/providers/palm.py
@@ -1,0 +1,189 @@
+from typing import Any, Dict
+
+from fastapi import HTTPException
+from fastapi.encoders import jsonable_encoder
+
+from mlflow.gateway.config import PaLMConfig, RouteConfig
+from mlflow.gateway.providers.base import BaseProvider
+from mlflow.gateway.providers.utils import rename_payload_keys, send_request
+from mlflow.gateway.schemas import chat, completions, embeddings
+
+
+class PaLMProvider(BaseProvider):
+    def __init__(self, config: RouteConfig) -> None:
+        super().__init__(config)
+        if config.model.config is None or not isinstance(config.model.config, PaLMConfig):
+            raise TypeError(f"Unexpected config type {config.model.config}")
+        self.palm_config: PaLMConfig = config.model.config
+
+    async def _request(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return await send_request(
+            headers={},
+            base_url="https://generativelanguage.googleapis.com/v1beta3/models/",
+            path=path + f"?key={self.palm_config.palm_api_key}",
+            payload=payload,
+        )
+
+    async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        payload = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload)
+        key_mapping = {
+            "stop": "stopSequences",
+            "candidate_count": "candidateCount",
+            "max_tokens": "maxOutputTokens",
+        }
+        for k1, k2 in key_mapping.items():
+            if k2 in payload:
+                raise HTTPException(
+                    status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
+                )
+        payload = rename_payload_keys(payload, key_mapping)
+
+        # Replace 'role' with 'author' in payload
+        for m in payload["messages"]:
+            if "role" in m:
+                m["author"] = m.pop("role")
+
+        # Map 'messages', 'examples, and 'context' to 'prompt'
+        prompt = {"messages": payload.pop("messages")}
+        if "examples" in payload:
+            prompt["examples"] = payload.pop("examples")
+        if "context" in payload:
+            prompt["context"] = payload.pop("context")
+        payload["prompt"] = prompt
+
+        resp = await self._request(
+            f"{self.config.model.name}:generateMessage",
+            payload,
+        )
+
+        # Response example
+        # (https://developers.generativeai.google/api/rest/generativelanguage/models/generateMessage)
+        # ```
+        # {
+        #   "candidates": [
+        #     {
+        #       "author": "1",
+        #       "content": "Hi there! How can I help you today?"
+        #     }
+        #   ],
+        #   "messages": [
+        #     {
+        #       "author": "0",
+        #       "content": "hi"
+        #     }
+        #   ]
+        # }
+        # ```
+        return chat.ResponsePayload(
+            **{
+                "candidates": [
+                    {
+                        "message": {
+                            "role": c["author"],
+                            "content": c["content"],
+                        },
+                        "metadata": {},
+                    }
+                    for c in resp["candidates"]
+                ],
+                "metadata": {
+                    "model": self.config.model.name,
+                    "route_type": self.config.route_type,
+                },
+            }
+        )
+
+    async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
+        payload = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload)
+        key_mapping = {
+            "stop": "stopSequences",
+            "candidate_count": "candidateCount",
+            "max_tokens": "maxOutputTokens",
+        }
+        for k1, k2 in key_mapping.items():
+            if k2 in payload:
+                raise HTTPException(
+                    status_code=400, detail=f"Invalid parameter {k2}. Use {k1} instead."
+                )
+        payload = rename_payload_keys(payload, key_mapping)
+        payload["prompt"] = {"text": payload["prompt"]}
+        resp = await self._request(
+            f"{self.config.model.name}:generateText",
+            payload,
+        )
+        # Response example (https://developers.generativeai.google/api/rest/generativelanguage/models/generateText)
+        # ```
+        # {
+        #   "candidates": [
+        #     {
+        #       "output": "Once upon a time, there was a young girl named Lily...",
+        #       "safetyRatings": [
+        #         {
+        #           "category": "HARM_CATEGORY_DEROGATORY",
+        #           "probability": "NEGLIGIBLE"
+        #         }, ...
+        #       ]
+        #     {
+        #       "output": "Once upon a time, there was a young boy named Billy...",
+        #       "safetyRatings": [
+        #           ...
+        #       ]
+        #     }
+        #   ]
+        # }
+        # ```
+        return completions.ResponsePayload(
+            **{
+                "candidates": [
+                    {
+                        "text": c["output"],
+                        "metadata": {},
+                    }
+                    for c in resp["candidates"]
+                ],
+                "metadata": {
+                    "model": self.config.model.name,
+                    "route_type": self.config.route_type,
+                },
+            }
+        )
+
+    async def embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
+        payload = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload)
+
+        # Ensure 'text' is a string
+        if isinstance(payload["text"], list):
+            payload["text"] = ",".join(payload["text"])
+
+        resp = await self._request(
+            f"{self.config.model.name}:embedText",
+            payload,
+        )
+        # Response example (https://developers.generativeai.google/api/rest/generativelanguage/models/embedText):
+        # ```
+        # {
+        #   "embedding": {
+        #     "value": [
+        #       3.25,
+        #       0.7685547,
+        #       2.65625,
+        #       ...
+        #       -0.30126953,
+        #       -2.3554688,
+        #       1.2597656
+        #     ]
+        #   }
+        # }
+        # ```
+        return embeddings.ResponsePayload(
+            **{
+                "embeddings": [resp["embedding"]["value"]],
+                "metadata": {
+                    "model": self.config.model.name,
+                    "route_type": self.config.route_type,
+                },
+            }
+        )

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -8,7 +8,7 @@ from mlflow.gateway.config import RouteType
 
 
 class RequestMessage(RequestModel):
-    role: Optional[str]
+    role: str
     content: str
 
 

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -8,7 +8,7 @@ from mlflow.gateway.config import RouteType
 
 
 class RequestMessage(RequestModel):
-    role: str
+    role: Optional[str]
     content: str
 
 

--- a/tests/gateway/providers/test_palm.py
+++ b/tests/gateway/providers/test_palm.py
@@ -174,10 +174,30 @@ def embeddings_response():
     }
 
 
-@pytest.mark.parametrize("prompt", ["This is a test", ["This is a test"]])
+def batch_embeddings_response():
+    return {
+        "embeddings": [
+            {
+                "value": [
+                    3.25,
+                    0.7685547,
+                    2.65625,
+                    -0.30126953,
+                    -2.3554688,
+                    1.2597656,
+                ]
+            }
+        ],
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+@pytest.mark.parametrize(
+    "prompt, resp",
+    [("This is a test", embeddings_response()), (["This is a test"], batch_embeddings_response())],
+)
 @pytest.mark.asyncio
-async def test_embeddings(prompt):
-    resp = embeddings_response()
+async def test_embeddings(prompt, resp):
     config = embeddings_config()
     with mock.patch(
         "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)

--- a/tests/gateway/providers/test_palm.py
+++ b/tests/gateway/providers/test_palm.py
@@ -106,12 +106,6 @@ def chat_response():
             "temperature": 0.5,
             "max_tokens": 1000,
         },
-        {
-            "messages": [
-                {"content": "You're funny"},
-                {"content": "Tell me a joke"},
-            ]
-        },
     ],
 )
 @pytest.mark.asyncio
@@ -193,7 +187,7 @@ def batch_embeddings_response():
 
 
 @pytest.mark.parametrize(
-    "prompt, resp",
+    ("prompt", "resp"),
     [("This is a test", embeddings_response()), (["This is a test"], batch_embeddings_response())],
 )
 @pytest.mark.asyncio

--- a/tests/gateway/providers/test_palm.py
+++ b/tests/gateway/providers/test_palm.py
@@ -154,22 +154,6 @@ def embeddings_config():
 
 def embeddings_response():
     return {
-        "embedding": {
-            "value": [
-                3.25,
-                0.7685547,
-                2.65625,
-                -0.30126953,
-                -2.3554688,
-                1.2597656,
-            ]
-        },
-        "headers": {"Content-Type": "application/json"},
-    }
-
-
-def batch_embeddings_response():
-    return {
         "embeddings": [
             {
                 "value": [
@@ -186,15 +170,12 @@ def batch_embeddings_response():
     }
 
 
-@pytest.mark.parametrize(
-    ("prompt", "resp"),
-    [("This is a test", embeddings_response()), (["This is a test"], batch_embeddings_response())],
-)
+@pytest.mark.parametrize("prompt", ["This is a test", ["This is a test"]])
 @pytest.mark.asyncio
-async def test_embeddings(prompt, resp):
+async def test_embeddings(prompt):
     config = embeddings_config()
     with mock.patch(
-        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(embeddings_response())
     ) as mock_post:
         provider = PaLMProvider(RouteConfig(**config))
         payload = {"text": prompt}

--- a/tests/gateway/providers/test_palm.py
+++ b/tests/gateway/providers/test_palm.py
@@ -1,0 +1,232 @@
+from unittest import mock
+
+import pytest
+from fastapi import HTTPException
+from fastapi.encoders import jsonable_encoder
+from pydantic import ValidationError
+
+from mlflow.gateway.config import RouteConfig
+from mlflow.gateway.providers.palm import PaLMProvider
+from mlflow.gateway.schemas import chat, completions, embeddings
+
+from tests.gateway.tools import MockAsyncResponse
+
+
+def completions_config():
+    return {
+        "name": "completions",
+        "route_type": "llm/v1/completions",
+        "model": {
+            "provider": "palm",
+            "name": "text-bison",
+            "config": {
+                "palm_api_key": "key",
+            },
+        },
+    }
+
+
+def completions_response():
+    return {
+        "candidates": [
+            {
+                "output": "This is a test",
+                "safetyRatings": [
+                    {"category": "HARM_CATEGORY_DEROGATORY", "probability": "NEGLIGIBLE"}
+                ],
+            }
+        ],
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_completions():
+    resp = completions_response()
+    config = completions_config()
+    with mock.patch(
+        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+    ) as mock_post:
+        provider = PaLMProvider(RouteConfig(**config))
+        payload = {
+            "prompt": "This is a test",
+        }
+        response = await provider.completions(completions.RequestPayload(**payload))
+        assert jsonable_encoder(response) == {
+            "candidates": [
+                {
+                    "text": "This is a test",
+                    "metadata": {},
+                }
+            ],
+            "metadata": {
+                "input_tokens": None,
+                "output_tokens": None,
+                "total_tokens": None,
+                "model": "text-bison",
+                "route_type": "llm/v1/completions",
+            },
+        }
+        mock_post.assert_called_once()
+
+
+def chat_config():
+    return {
+        "name": "chat",
+        "route_type": "llm/v1/chat",
+        "model": {
+            "provider": "palm",
+            "name": "chat-bison",
+            "config": {
+                "palm_api_key": "key",
+            },
+        },
+    }
+
+
+def chat_response():
+    return {
+        "candidates": [{"author": "1", "content": "Hi there! How can I help you today?"}],
+        "messages": [{"author": "0", "content": "hi"}],
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"messages": [{"role": "user", "content": "Tell me a joke"}]},
+        {
+            "messages": [
+                {"role": "system", "content": "You're funny"},
+                {"role": "user", "content": "Tell me a joke"},
+            ]
+        },
+        {
+            "messages": [{"role": "user", "content": "Tell me a joke"}],
+            "temperature": 0.5,
+            "max_tokens": 1000,
+        },
+        {
+            "messages": [
+                {"content": "You're funny"},
+                {"content": "Tell me a joke"},
+            ]
+        },
+    ],
+)
+@pytest.mark.asyncio
+async def test_chat(payload):
+    resp = chat_response()
+    config = chat_config()
+    with mock.patch(
+        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+    ) as mock_post:
+        provider = PaLMProvider(RouteConfig(**config))
+        response = await provider.chat(chat.RequestPayload(**payload))
+        assert jsonable_encoder(response) == {
+            "candidates": [
+                {
+                    "message": {
+                        "role": "1",
+                        "content": "Hi there! How can I help you today?",
+                    },
+                    "metadata": {"finish_reason": None},
+                }
+            ],
+            "metadata": {
+                "input_tokens": None,
+                "output_tokens": None,
+                "total_tokens": None,
+                "model": "chat-bison",
+                "route_type": "llm/v1/chat",
+            },
+        }
+        mock_post.assert_called_once()
+
+
+def embeddings_config():
+    return {
+        "name": "embeddings",
+        "route_type": "llm/v1/embeddings",
+        "model": {
+            "provider": "palm",
+            "name": "embedding-gecko",
+            "config": {
+                "palm_api_key": "key",
+            },
+        },
+    }
+
+
+def embeddings_response():
+    return {
+        "embedding": {
+            "value": [
+                3.25,
+                0.7685547,
+                2.65625,
+                -0.30126953,
+                -2.3554688,
+                1.2597656,
+            ]
+        },
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+@pytest.mark.parametrize("prompt", ["This is a test", ["This is a test"]])
+@pytest.mark.asyncio
+async def test_embeddings(prompt):
+    resp = embeddings_response()
+    config = embeddings_config()
+    with mock.patch(
+        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+    ) as mock_post:
+        provider = PaLMProvider(RouteConfig(**config))
+        payload = {"text": prompt}
+        response = await provider.embeddings(embeddings.RequestPayload(**payload))
+        assert jsonable_encoder(response) == {
+            "embeddings": [
+                [
+                    3.25,
+                    0.7685547,
+                    2.65625,
+                    -0.30126953,
+                    -2.3554688,
+                    1.2597656,
+                ]
+            ],
+            "metadata": {
+                "input_tokens": None,
+                "output_tokens": None,
+                "total_tokens": None,
+                "model": "embedding-gecko",
+                "route_type": "llm/v1/embeddings",
+            },
+        }
+        mock_post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_param_model_is_not_permitted():
+    config = embeddings_config()
+    provider = PaLMProvider(RouteConfig(**config))
+    payload = {
+        "prompt": "This should fail",
+        "max_tokens": 5000,
+        "model": "something-else",
+    }
+    with pytest.raises(HTTPException, match=r".*") as e:
+        await provider.completions(completions.RequestPayload(**payload))
+    assert "The parameter 'model' is not permitted" in e.value.detail
+    assert e.value.status_code == 422
+
+
+@pytest.mark.parametrize("prompt", [{"set1", "set2"}, ["list1"], [1], ["list1", "list2"], [1, 2]])
+@pytest.mark.asyncio
+async def test_completions_throws_if_prompt_contains_non_string(prompt):
+    config = completions_config()
+    provider = PaLMProvider(RouteConfig(**config))
+    payload = {"prompt": prompt}
+    with pytest.raises(ValidationError, match=r"prompt"):
+        await provider.completions(completions.RequestPayload(**payload))

--- a/tests/gateway/test_integration.py
+++ b/tests/gateway/test_integration.py
@@ -5,7 +5,6 @@ import pytest
 import requests
 
 import mlflow
-from mlflow.gateway.providers.palm import PaLMProvider
 import mlflow.gateway.utils
 from mlflow.exceptions import MlflowException
 from mlflow.gateway import MlflowGatewayClient, get_route, query, set_gateway_uri
@@ -16,6 +15,7 @@ from mlflow.gateway.providers.cohere import CohereProvider
 from mlflow.gateway.providers.mlflow import MlflowModelServingProvider
 from mlflow.gateway.providers.mosaicml import MosaicMLProvider
 from mlflow.gateway.providers.openai import OpenAIProvider
+from mlflow.gateway.providers.palm import PaLMProvider
 from mlflow.utils.request_utils import _cached_get_request_session
 
 from tests.gateway.tools import (
@@ -247,7 +247,7 @@ def test_create_gateway_client_with_declared_url(gateway):
     assert gateway_client.gateway_uri == gateway.url
     assert isinstance(gateway_client.get_route("chat-openai"), Route)
     routes = gateway_client.search_routes()
-    assert len(routes) == 13
+    assert len(routes) == 15
     assert all(isinstance(route, Route) for route in routes)
 
 

--- a/tests/gateway/test_integration.py
+++ b/tests/gateway/test_integration.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 
 import mlflow
+from mlflow.gateway.providers.palm import PaLMProvider
 import mlflow.gateway.utils
 from mlflow.exceptions import MlflowException
 from mlflow.gateway import MlflowGatewayClient, get_route, query, set_gateway_uri
@@ -106,6 +107,28 @@ def basic_config_dict():
                 },
             },
             {
+                "name": "completions-palm",
+                "route_type": "llm/v1/completions",
+                "model": {
+                    "provider": "palm",
+                    "name": "text-bison-001",
+                    "config": {
+                        "palm_api_key": "$PALM_API_KEY",
+                    },
+                },
+            },
+            {
+                "name": "chat-palm",
+                "route_type": "llm/v1/chat",
+                "model": {
+                    "provider": "palm",
+                    "name": "chat-bison-001",
+                    "config": {
+                        "palm_api_key": "$PALM_API_KEY",
+                    },
+                },
+            },
+            {
                 "name": "chat-mosaicml",
                 "route_type": "llm/v1/chat",
                 "model": {
@@ -135,6 +158,17 @@ def basic_config_dict():
                     "name": "instructor-large",
                     "config": {
                         "mosaicml_api_key": "$MOSAICML_API_KEY",
+                    },
+                },
+            },
+            {
+                "name": "embeddings-palm",
+                "route_type": "llm/v1/embeddings",
+                "model": {
+                    "provider": "palm",
+                    "name": "embedding-gecko-001",
+                    "config": {
+                        "palm_api_key": "$PALM_API_KEY",
                     },
                 },
             },
@@ -189,6 +223,7 @@ def env_setup(monkeypatch):
     monkeypatch.setenv("COHERE_API_KEY", "test_cohere_key")
     monkeypatch.setenv("AI21LABS_API_KEY", "test_ai21labs_key")
     monkeypatch.setenv("MOSAICML_API_KEY", "test_mosaicml_key")
+    monkeypatch.setenv("PALM_API_KEY", "test_palm_key")
 
 
 @pytest.fixture
@@ -453,6 +488,67 @@ def test_mosaicml_chat(gateway):
     assert response == expected_output
 
 
+def test_palm_completions(gateway):
+    client = MlflowGatewayClient(gateway_uri=gateway.url)
+    route = client.get_route("completions-palm")
+    expected_output = {
+        "candidates": [
+            {
+                "text": "mock using MagicMock please",
+                "metadata": {},
+            }
+        ],
+        "metadata": {
+            "input_tokens": None,
+            "output_tokens": None,
+            "total_tokens": None,
+            "model": "text-bison-001",
+            "route_type": "llm/v1/completions",
+        },
+    }
+
+    data = {"prompt": "mock my test", "max_tokens": 50}
+
+    async def mock_completions(self, payload):
+        return expected_output
+
+    with patch.object(PaLMProvider, "completions", mock_completions):
+        response = client.query(route=route.name, data=data)
+    assert response == expected_output
+
+
+def test_palm_chat(gateway):
+    client = MlflowGatewayClient(gateway_uri=gateway.url)
+    route = client.get_route("chat-palm")
+    expected_output = {
+        "candidates": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "test",
+                },
+                "metadata": {"finish_reason": None},
+            }
+        ],
+        "metadata": {
+            "input_tokens": None,
+            "output_tokens": None,
+            "total_tokens": None,
+            "model": "chat-bison-001",
+            "route_type": "llm/v1/chat",
+        },
+    }
+
+    data = {"messages": [{"role": "user", "content": "test"}]}
+
+    async def mock_chat(self, payload):
+        return expected_output
+
+    with patch.object(PaLMProvider, "chat", mock_chat):
+        response = client.query(route=route.name, data=data)
+    assert response == expected_output
+
+
 def test_cohere_embeddings(gateway):
     client = MlflowGatewayClient(gateway_uri=gateway.url)
     route = client.get_route("embeddings-cohere")
@@ -497,6 +593,30 @@ def test_mosaicml_embeddings(gateway):
         return expected_output
 
     with patch.object(MosaicMLProvider, "embeddings", mock_embeddings):
+        response = client.query(route=route.name, data=data)
+    assert response == expected_output
+
+
+def test_palm_embeddings(gateway):
+    client = MlflowGatewayClient(gateway_uri=gateway.url)
+    route = client.get_route("embeddings-palm")
+    expected_output = {
+        "embeddings": [[0.1, 0.2, 0.3]],
+        "metadata": {
+            "input_tokens": None,
+            "output_tokens": None,
+            "total_tokens": None,
+            "model": "embedding-gecko-001",
+            "route_type": "llm/v1/embeddings",
+        },
+    }
+
+    data = {"text": "mock me and my test"}
+
+    async def mock_embeddings(self, payload):
+        return expected_output
+
+    with patch.object(PaLMProvider, "embeddings", mock_embeddings):
         response = client.query(route=route.name, data=data)
     assert response == expected_output
 

--- a/tests/gateway/test_integration.py
+++ b/tests/gateway/test_integration.py
@@ -247,7 +247,7 @@ def test_create_gateway_client_with_declared_url(gateway):
     assert gateway_client.gateway_uri == gateway.url
     assert isinstance(gateway_client.get_route("chat-openai"), Route)
     routes = gateway_client.search_routes()
-    assert len(routes) == 15
+    assert len(routes) == 16
     assert all(isinstance(route, Route) for route in routes)
 
 


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/arpitjasa-db/mlflow/pull/9797?quickstart=1)

### What changes are proposed in this pull request?

Add PaLM as a provider to MLflow AI Gateway

### How is this PR tested?

- [X] Existing unit/integration tests
- [x] New unit/integration tests
- [X] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [X] Examples
  - [X] API references
  - [X] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add PaLM as a provider to MLflow AI Gateway

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
