### PR TITLE
Replace `shutil.copyfile` with `shutil.copy2`

### DIFF
--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -448,9 +448,9 @@ def _save_jars_and_lic(dst_dir, store_license=False):
 
     suite = get_install_suite_from_jsl_home(False)
     if suite.hc.get_java_path():
-        shutil.copyfile(suite.hc.get_java_path(), deps_data_path / "hc_jar.jar")
+        shutil.copy2(suite.hc.get_java_path(), deps_data_path / "hc_jar.jar")
     if suite.nlp.get_java_path():
-        shutil.copyfile(suite.nlp.get_java_path(), deps_data_path / "os_jar.jar")
+        shutil.copy2(suite.nlp.get_java_path(), deps_data_path / "os_jar.jar")
 
     if store_license:
         # Read the secrets from env vars and write to license.json

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -101,7 +101,7 @@ def _install_pyfunc_deps(
             env_path_dst_dir = os.path.dirname(env_path_dst)
             if not os.path.exists(env_path_dst_dir):
                 os.makedirs(env_path_dst_dir)
-            shutil.copyfile(os.path.join(MODEL_PATH, env), env_path_dst)
+            shutil.copy2(os.path.join(MODEL_PATH, env), env_path_dst)
             if env_manager == em.CONDA:
                 conda_create_model_env = f"conda env create -n custom_env -f {env_path_dst}"
                 if Popen(["bash", "-c", conda_create_model_env]).wait() != 0:

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -963,7 +963,7 @@ class DefaultEvaluator(ModelEvaluator):
         # be supplied through file. Which is handled by the first if clause. This is because
         # DataFrame objects default to be stored as CsvEvaluationArtifact.
         if inferred_from_path:
-            shutil.copyfile(raw_artifact, artifact_file_local_path)
+            shutil.copy2(raw_artifact, artifact_file_local_path)
         elif inferred_type is JsonEvaluationArtifact:
             with open(artifact_file_local_path, "w") as f:
                 if isinstance(raw_artifact, str):

--- a/mlflow/models/wheeled_model.py
+++ b/mlflow/models/wheeled_model.py
@@ -130,9 +130,7 @@ class WheeledModel:
         )
 
         # Keep a copy of the original requirement.txt
-        shutil.copyfile(
-            pip_requirements_path, os.path.join(local_model_path, _ORIGINAL_REQ_FILE_NAME)
-        )
+        shutil.copy2(pip_requirements_path, os.path.join(local_model_path, _ORIGINAL_REQ_FILE_NAME))
 
         # Update requirements.txt with wheels
         pip_deps = self._overwrite_pip_requirements_with_wheels(

--- a/mlflow/recipes/utils/tracking.py
+++ b/mlflow/recipes/utils/tracking.py
@@ -287,7 +287,7 @@ def log_code_snapshot(
             if file_path.exists():
                 tmp_path = tmpdir.joinpath(file_path.relative_to(recipe_root))
                 tmp_path.parent.mkdir(exist_ok=True, parents=True)
-                shutil.copyfile(file_path, tmp_path)
+                shutil.copy2(file_path, tmp_path)
         if recipe_config is not None:
             import yaml
 

--- a/mlflow/store/artifact/local_artifact_repo.py
+++ b/mlflow/store/artifact/local_artifact_repo.py
@@ -35,7 +35,7 @@ class LocalArtifactRepository(ArtifactRepository):
         if not os.path.exists(artifact_dir):
             mkdir(artifact_dir)
         try:
-            shutil.copyfile(local_file, os.path.join(artifact_dir, os.path.basename(local_file)))
+            shutil.copy2(local_file, os.path.join(artifact_dir, os.path.basename(local_file)))
         except shutil.SameFileError:
             pass
 
@@ -103,7 +103,7 @@ class LocalArtifactRepository(ArtifactRepository):
         # NOTE: The remote_file_path is expected to be in posix format.
         # Posix paths work fine on windows but just in case we normalize it here.
         remote_file_path = os.path.join(self.artifact_dir, os.path.normpath(remote_file_path))
-        shutil.copyfile(remote_file_path, local_path)
+        shutil.copy2(remote_file_path, local_path)
 
     def delete_artifacts(self, artifact_path=None):
         artifact_path = local_file_uri_to_path(

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -415,7 +415,7 @@ def save_model(
             with tempfile.NamedTemporaryFile(suffix=".h5") as f:
                 model.save(f.name, **keras_model_kwargs)
                 f.flush()  # force flush the data
-                shutil.copyfile(src=f.name, dst=model_path)
+                shutil.copy2(src=f.name, dst=model_path)
         else:
             model.save(model_path, **keras_model_kwargs)
 

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -931,7 +931,7 @@ def shutil_copytree_without_file_permissions(src_dir, dst_dir):
             file_path = os.path.join(dirpath, filename)
             relative_file_path = os.path.relpath(file_path, src_dir)
             abs_file_path = os.path.join(dst_dir, relative_file_path)
-            shutil.copyfile(file_path, abs_file_path)
+            shutil.copy2(file_path, abs_file_path)
 
 
 def contains_path_separator(path):

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -234,7 +234,7 @@ def test_log_artifact_windows_path_with_hostname(text_artifact):
         "test_exp_d", experiment_test_1_artifact_location
     )
     with mlflow.start_run(experiment_id=experiment_test_1_id) as run:
-        with mock.patch("shutil.copyfile") as copyfile_mock, mock.patch(
+        with mock.patch("shutil.copy2") as copyfile_mock, mock.patch(
             "os.path.exists", return_value=True
         ) as exists_mock:
             mlflow.log_artifact(text_artifact.artifact_path)
@@ -253,7 +253,7 @@ def test_log_artifact_windows_path_with_hostname(text_artifact):
         "test_exp_e", experiment_test_2_artifact_location
     )
     with mlflow.start_run(experiment_id=experiment_test_2_id) as run:
-        with mock.patch("shutil.copyfile") as copyfile_mock, mock.patch(
+        with mock.patch("shutil.copy2") as copyfile_mock, mock.patch(
             "os.path.exists", return_value=True
         ) as exists_mock:
             mlflow.log_artifact(text_artifact.artifact_path)

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -1080,7 +1080,7 @@ def test_artifact_logging(databricks_artifact_repo, tmp_path):
         time.sleep(2)
         dst_run_relative_artifact_path = dst_dir.joinpath(artifact_file_path)
         dst_run_relative_artifact_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(src=src_file_path, dst=dst_run_relative_artifact_path)
+        shutil.copy2(src=src_file_path, dst=dst_run_relative_artifact_path)
 
     with mock.patch(
         f"{DATABRICKS_ARTIFACT_REPOSITORY}._get_write_credential_infos",

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2797,7 +2797,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         with TempDir() as tmp_db_dir:
             db_path = tmp_db_dir.path("tmp_db.sql")
             db_url = "sqlite:///" + db_path
-            shutil.copyfile(
+            shutil.copy2(
                 src=os.path.join(db_resources_path, "db_version_7ac759974ad8_with_metrics.sql"),
                 dst=db_path,
             )


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/9799?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #9789

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Replace `shutil.copyfile` with `shutil.copy2` to preserve file metadata.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
