### PR TITLE
Remove fastapi dependency

### DIFF
--- a/mlflow/gateway/providers/__init__.py
+++ b/mlflow/gateway/providers/__init__.py
@@ -1,14 +1,15 @@
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import Provider
-from mlflow.gateway.providers.anthropic import AnthropicProvider
 from mlflow.gateway.providers.base import BaseProvider
-from mlflow.gateway.providers.cohere import CohereProvider
-from mlflow.gateway.providers.mlflow import MlflowModelServingProvider
-from mlflow.gateway.providers.mosaicml import MosaicMLProvider
-from mlflow.gateway.providers.openai import OpenAIProvider
 
 
 def get_provider(provider: Provider) -> BaseProvider:
+    from mlflow.gateway.providers.anthropic import AnthropicProvider
+    from mlflow.gateway.providers.cohere import CohereProvider
+    from mlflow.gateway.providers.mlflow import MlflowModelServingProvider
+    from mlflow.gateway.providers.mosaicml import MosaicMLProvider
+    from mlflow.gateway.providers.openai import OpenAIProvider
+
     provider_to_class = {
         Provider.OPENAI: OpenAIProvider,
         Provider.ANTHROPIC: AnthropicProvider,

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from typing import Tuple
 
-from fastapi import HTTPException
-
 from mlflow.gateway.config import RouteConfig
 from mlflow.gateway.schemas import chat, completions, embeddings
 
@@ -29,6 +27,8 @@ class BaseProvider(ABC):
 
     @staticmethod
     def check_for_model_field(payload):
+        from fastapi import HTTPException
+
         if "model" in payload:
             raise HTTPException(
                 status_code=422,

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -1,4 +1,3 @@
-import requests
 
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import OpenAIAPIType, OpenAIConfig, RouteConfig
@@ -176,18 +175,6 @@ class OpenAIProvider(BaseProvider):
                 },
             }
         )
-
-    def sync_completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
-        payload = self._prepare_completion_request_payload(payload)
-
-        # use python requests instead of aiohttp
-        resp = requests.post(
-            url=append_to_uri_path(self._request_base_url, "chat/completions"),
-            headers=self._request_headers,
-            json=self._add_model_to_payload_if_necessary(payload),
-        ).json()
-
-        return self._prepare_completion_response_payload(resp)
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
         from fastapi import HTTPException

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -148,12 +148,6 @@ class OpenAIProvider(BaseProvider):
         )
 
     def _prepare_completion_request_payload(self, payload):
-        # payload = jsonable_encoder(payload, exclude_none=True)
-        # self.check_for_model_field(payload)
-        # if "n" in payload:
-        #     raise HTTPException(
-        #         status_code=400, detail="Invalid parameter `n`. Use `candidate_count` instead."
-        #     )
         payload = rename_payload_keys(
             payload,
             {"candidate_count": "n"},
@@ -196,6 +190,15 @@ class OpenAIProvider(BaseProvider):
         return self._prepare_completion_response_payload(resp)
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
+        from fastapi import HTTPException
+        from fastapi.encoders import jsonable_encoder
+
+        payload = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload)
+        if "n" in payload:
+            raise HTTPException(
+                status_code=400, detail="Invalid parameter `n`. Use `candidate_count` instead."
+            )
         payload = self._prepare_completion_request_payload(payload)
 
         resp = await send_request(

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -1,4 +1,3 @@
-
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import OpenAIAPIType, OpenAIConfig, RouteConfig
 from mlflow.gateway.providers.base import BaseProvider

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -1,6 +1,4 @@
 import requests
-from fastapi import HTTPException
-from fastapi.encoders import jsonable_encoder
 
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import OpenAIAPIType, OpenAIConfig, RouteConfig
@@ -78,6 +76,9 @@ class OpenAIProvider(BaseProvider):
             return payload
 
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        from fastapi import HTTPException
+        from fastapi.encoders import jsonable_encoder
+
         payload = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload)
         if "n" in payload:
@@ -147,12 +148,12 @@ class OpenAIProvider(BaseProvider):
         )
 
     def _prepare_completion_request_payload(self, payload):
-        payload = jsonable_encoder(payload, exclude_none=True)
-        self.check_for_model_field(payload)
-        if "n" in payload:
-            raise HTTPException(
-                status_code=400, detail="Invalid parameter `n`. Use `candidate_count` instead."
-            )
+        # payload = jsonable_encoder(payload, exclude_none=True)
+        # self.check_for_model_field(payload)
+        # if "n" in payload:
+        #     raise HTTPException(
+        #         status_code=400, detail="Invalid parameter `n`. Use `candidate_count` instead."
+        #     )
         payload = rename_payload_keys(
             payload,
             {"candidate_count": "n"},
@@ -228,6 +229,8 @@ class OpenAIProvider(BaseProvider):
         return self._prepare_completion_response_payload(resp)
 
     async def embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
         payload = rename_payload_keys(
             jsonable_encoder(payload, exclude_none=True),
             {"text": "input"},

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict
 
 import aiohttp
-from fastapi import HTTPException
 
 from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
 from mlflow.utils.uri import append_to_uri_path
@@ -18,6 +17,8 @@ async def send_request(headers: Dict[str, str], base_url: str, path: str, payloa
     :return: The server's response as a JSON object.
     :raise: HTTPException if the HTTP request fails.
     """
+    from fastapi import HTTPException
+
     async with aiohttp.ClientSession(headers=headers) as session:
         url = append_to_uri_path(base_url, path)
         timeout = aiohttp.ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS)


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Move logic from `OpenaiProvider.sync_completions` into `model_utils` . `sync_completions` was added by us for LLM scoring.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
