### PR TITLE
Add AI21labs as a provider in  MLflow AI Gateway

### DIFF
--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -21,9 +21,9 @@ from mlflow.gateway.constants import (
 )
 from mlflow.gateway.utils import (
     check_configuration_route_name_collisions,
+    is_valid_ai21labs_model,
     is_valid_endpoint_name,
     is_valid_mosiacml_chat_model,
-    is_valid_ai21labs_model,
 )
 
 _logger = logging.getLogger(__name__)
@@ -311,7 +311,7 @@ class RouteConfig(ConfigModel):
                 f"Ensure the model selected starts with one of: "
                 f"{MLFLOW_AI_GATEWAY_MOSAICML_CHAT_SUPPORTED_MODEL_PREFIXES}"
             )
-        if (model and model.provider == "ai21labs" and not is_valid_ai21labs_model(model.name)):
+        if model and model.provider == "ai21labs" and not is_valid_ai21labs_model(model.name):
             raise MlflowException.invalid_parameter_value(
                 f"An Unsupported AI21Labs model has been specified: '{model.name}'. "
                 f"Please see documentation for supported models."

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -64,7 +64,7 @@ class CohereConfig(ConfigModel):
 class AI21LabsConfig(ConfigModel):
     ai21labs_api_key: str
 
-    #pylint: disable=no-self-argument
+    # pylint: disable=no-self-argument
     @validator("ai21labs_api_key", pre=True)
     def validate_ai21labs_api_key(cls, value):
         return _resolve_api_key_from_input(value)

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -34,6 +34,7 @@ class Provider(str, Enum):
     OPENAI = "openai"
     ANTHROPIC = "anthropic"
     COHERE = "cohere"
+    AI21LABS = "ai21labs"
     MLFLOW_MODEL_SERVING = "mlflow-model-serving"
     MOSAICML = "mosaicml"
     # Note: The following providers are only supported on Databricks
@@ -57,6 +58,15 @@ class CohereConfig(ConfigModel):
     # pylint: disable=no-self-argument
     @validator("cohere_api_key", pre=True)
     def validate_cohere_api_key(cls, value):
+        return _resolve_api_key_from_input(value)
+
+
+class AI21LabsConfig(ConfigModel):
+    ai21labs_api_key: str
+
+    #pylint: disable=no-self-argument
+    @validator("ai21labs_api_key", pre=True)
+    def validate_ai21labs_api_key(cls, value):
         return _resolve_api_key_from_input(value)
 
 
@@ -164,6 +174,7 @@ config_types = {
     Provider.COHERE: CohereConfig,
     Provider.OPENAI: OpenAIConfig,
     Provider.ANTHROPIC: AnthropicConfig,
+    Provider.AI21LABS: AI21LabsConfig,
     Provider.MOSAICML: MosaicMLConfig,
     Provider.MLFLOW_MODEL_SERVING: MlflowModelServingConfig,
 }
@@ -218,6 +229,7 @@ class Model(ConfigModel):
         Union[
             CohereConfig,
             OpenAIConfig,
+            AI21LabsConfig,
             AnthropicConfig,
             MosaicMLConfig,
             MlflowModelServingConfig,

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -23,6 +23,7 @@ from mlflow.gateway.utils import (
     check_configuration_route_name_collisions,
     is_valid_endpoint_name,
     is_valid_mosiacml_chat_model,
+    is_valid_ai21labs_model,
 )
 
 _logger = logging.getLogger(__name__)
@@ -309,6 +310,11 @@ class RouteConfig(ConfigModel):
                 f"An invalid model has been specified for the chat route. '{model.name}'. "
                 f"Ensure the model selected starts with one of: "
                 f"{MLFLOW_AI_GATEWAY_MOSAICML_CHAT_SUPPORTED_MODEL_PREFIXES}"
+            )
+        if (model and model.provider == "ai21labs" and not is_valid_ai21labs_model(model.name)):
+            raise MlflowException.invalid_parameter_value(
+                f"An Unsupported AI21Labs model has been specified: '{model.name}'. "
+                f"Please see documentation for supported models."
             )
         return values
 

--- a/mlflow/gateway/providers/__init__.py
+++ b/mlflow/gateway/providers/__init__.py
@@ -5,6 +5,7 @@ from mlflow.gateway.providers.base import BaseProvider
 from mlflow.gateway.providers.cohere import CohereProvider
 from mlflow.gateway.providers.mlflow import MlflowModelServingProvider
 from mlflow.gateway.providers.mosaicml import MosaicMLProvider
+from mlflow.gateway.providers.ai21labs import AI21LabsProvider
 from mlflow.gateway.providers.openai import OpenAIProvider
 
 
@@ -13,6 +14,7 @@ def get_provider(provider: Provider) -> BaseProvider:
         Provider.OPENAI: OpenAIProvider,
         Provider.ANTHROPIC: AnthropicProvider,
         Provider.COHERE: CohereProvider,
+        Provider.AI21LABS: AI21LabsProvider,
         Provider.MOSAICML: MosaicMLProvider,
         Provider.MLFLOW_MODEL_SERVING: MlflowModelServingProvider,
     }

--- a/mlflow/gateway/providers/__init__.py
+++ b/mlflow/gateway/providers/__init__.py
@@ -1,11 +1,11 @@
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import Provider
+from mlflow.gateway.providers.ai21labs import AI21LabsProvider
 from mlflow.gateway.providers.anthropic import AnthropicProvider
 from mlflow.gateway.providers.base import BaseProvider
 from mlflow.gateway.providers.cohere import CohereProvider
 from mlflow.gateway.providers.mlflow import MlflowModelServingProvider
 from mlflow.gateway.providers.mosaicml import MosaicMLProvider
-from mlflow.gateway.providers.ai21labs import AI21LabsProvider
 from mlflow.gateway.providers.openai import OpenAIProvider
 
 

--- a/mlflow/gateway/providers/ai21labs.py
+++ b/mlflow/gateway/providers/ai21labs.py
@@ -17,10 +17,11 @@ class AI21LabsProvider(BaseProvider):
         self.ai21labs_config: AI21LabsConfig = config.model.config
         self.headers = {"Authorization": f"Bearer {self.ai21labs_config.ai21labs_api_key}"}
         self.base_url = f"https://api.ai21.com/studio/v1/{self.config.model.name}/"
-        if (self.config.model.name not in self.allowed_models):
+        if self.config.model.name not in self.allowed_models:
             raise TypeError(
                 f"Invalid modelName: {self.config.model.name}.” \
-                “ Supported models for AI21Labs are {self.allowed_models}.")
+                “ Supported models for AI21Labs are {self.allowed_models}."
+            )
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
         payload = jsonable_encoder(payload, exclude_none=True)

--- a/mlflow/gateway/providers/ai21labs.py
+++ b/mlflow/gateway/providers/ai21labs.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict
-
 from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 
@@ -10,7 +8,8 @@ from mlflow.gateway.schemas import chat, completions, embeddings
 
 
 class AI21LabsProvider(BaseProvider):
-    allowed_models = set(["j2-ultra", "j2-mid", "j2-light"])
+    allowed_models = {"j2-ultra", "j2-mid", "j2-light"}
+
     def __init__(self, config: RouteConfig) -> None:
         super().__init__(config)
         if config.model.config is None or not isinstance(config.model.config, AI21LabsConfig):
@@ -18,8 +17,10 @@ class AI21LabsProvider(BaseProvider):
         self.ai21labs_config: AI21LabsConfig = config.model.config
         self.headers = {"Authorization": f"Bearer {self.ai21labs_config.ai21labs_api_key}"}
         self.base_url = f"https://api.ai21.com/studio/v1/{self.config.model.name}/"
-        if (self.config.model.name not in self.allowed_models):
-            raise TypeError(f"Invalid modelName: {self.config.model.name}. Supported models for AI21Labs are {self.allowed_models}.")
+        if self.config.model.name not in self.allowed_models:
+            raise TypeError(
+                f"Invalid modelName: {self.config.model.name}. Supported models for AI21Labs are {self.allowed_models}."
+            )
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
         payload = jsonable_encoder(payload, exclude_none=True)
@@ -44,7 +45,7 @@ class AI21LabsProvider(BaseProvider):
         resp = await send_request(
             headers=self.headers,
             base_url=self.base_url,
-            path='complete',
+            path="complete",
             payload=payload,
         )
         # Response example (https://docs.ai21.com/reference/j2-complete-ref)

--- a/mlflow/gateway/providers/ai21labs.py
+++ b/mlflow/gateway/providers/ai21labs.py
@@ -19,7 +19,9 @@ class AI21LabsProvider(BaseProvider):
         self.headers = {"Authorization": f"Bearer {self.ai21labs_config.ai21labs_api_key}"}
         self.base_url = f"https://api.ai21.com/studio/v1/{self.config.model.name}/"
         if (self.config.model.name not in self.allowed_models):
-            raise TypeError(f"Invalid modelName: {self.config.model.name}. Supported models for AI21Labs are {self.allowed_models}.")
+            raise TypeError(
+                f"Invalid modelName: {self.config.model.name}.” \
+                “ Supported models for AI21Labs are {self.allowed_models}.")
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
         payload = jsonable_encoder(payload, exclude_none=True)

--- a/mlflow/gateway/providers/ai21labs.py
+++ b/mlflow/gateway/providers/ai21labs.py
@@ -1,0 +1,94 @@
+from typing import Any, Dict
+
+from fastapi import HTTPException
+from fastapi.encoders import jsonable_encoder
+
+from mlflow.gateway.config import AI21LabsConfig, RouteConfig
+from mlflow.gateway.providers.base import BaseProvider
+from mlflow.gateway.providers.utils import rename_payload_keys, send_request
+from mlflow.gateway.schemas import chat, completions, embeddings
+
+
+class AI21LabsProvider(BaseProvider):
+    def __init__(self, config: RouteConfig) -> None:
+        super().__init__(config)
+        if config.model.config is None or not isinstance(config.model.config, AI21LabsConfig):
+            raise TypeError(f"Unexpected config type {config.model.config}")
+        self.ai21labs_config: AI21LabsConfig = config.model.config
+        self.headers = {"Authorization": f"Bearer {self.anthropic_config.anthropic_api_key}"}
+        self.base_url = f"https://api.ai21.com/studio/v1/{self.config.model.name}/"
+
+    async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
+        payload = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload)
+        key_mapping = {
+            "stop": "stopSequences",
+            "candidate_count": "numResults",
+            "max_tokens": "maxTokens",
+        }
+        for k1, k2 in key_mapping.items():
+            if k2 in payload:
+                raise HTTPException(
+                    status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
+                )
+        if payload.get("stream", None) == "true":
+            raise HTTPException(
+                status_code=422,
+                detail="Setting the 'stream' parameter to 'true' is not supported with the MLflow "
+                "Gateway.",
+            )
+        payload = rename_payload_keys(payload, key_mapping)
+        payload["prompt"] = {"text": payload["prompt"]}
+        resp = await send_request(
+            headers=self.headers,
+            base_url=self.base_url,
+            path='complete',
+            payload={"model": self.config.model.name, **payload},
+        )
+        # Response example (https://docs.ai21.com/reference/j2-complete-ref)
+        # ```
+        # {
+        #   "id": "7921a78e-d905-c9df-27e3-88e4831e3c3b",
+        #   "prompt": {
+        #     "text": "I will"
+        #   },
+        #   "completions": [
+        #     {
+        #       "data": {
+        #         "text": " complete this"
+        #       },
+        #       "finishReason": {
+        #         "reason": "length",
+        #         "length": 2
+        #       }
+        #     }
+        #   ]
+        # }
+        # ```
+        return completions.ResponsePayload(
+            **{
+                "candidates": [
+                    {
+                        "text": c["data"]["text"],
+                        "metadata": {"finish_reason": c["finishReason"]["reason"]},
+                    }
+                    for c in resp["completions"]
+                ],
+                "metadata": {
+                    "model": self.config.model.name,
+                    "route_type": self.config.route_type,
+                },
+            }
+        )
+
+    async def chat(self, payload: chat.RequestPayload) -> None:
+        # AI21Labs does not have a chat endpoint
+        raise HTTPException(
+            status_code=404, detail="The chat route is not available for AI21Labs models."
+        )
+
+    async def embeddings(self, payload: embeddings.RequestPayload) -> None:
+        # AI21Labs does not have an embeddings endpoint
+        raise HTTPException(
+            status_code=404, detail="The embeddings route is not available for AI21Labs models."
+        )

--- a/mlflow/gateway/providers/ai21labs.py
+++ b/mlflow/gateway/providers/ai21labs.py
@@ -8,7 +8,6 @@ from mlflow.gateway.schemas import chat, completions, embeddings
 
 
 class AI21LabsProvider(BaseProvider):
-
     def __init__(self, config: RouteConfig) -> None:
         super().__init__(config)
         if config.model.config is None or not isinstance(config.model.config, AI21LabsConfig):

--- a/mlflow/gateway/providers/ai21labs.py
+++ b/mlflow/gateway/providers/ai21labs.py
@@ -8,7 +8,6 @@ from mlflow.gateway.schemas import chat, completions, embeddings
 
 
 class AI21LabsProvider(BaseProvider):
-    allowed_models = {"j2-ultra", "j2-mid", "j2-light"}
 
     def __init__(self, config: RouteConfig) -> None:
         super().__init__(config)
@@ -17,11 +16,6 @@ class AI21LabsProvider(BaseProvider):
         self.ai21labs_config: AI21LabsConfig = config.model.config
         self.headers = {"Authorization": f"Bearer {self.ai21labs_config.ai21labs_api_key}"}
         self.base_url = f"https://api.ai21.com/studio/v1/{self.config.model.name}/"
-        if self.config.model.name not in self.allowed_models:
-            raise TypeError(
-                f"Invalid modelName: {self.config.model.name}.” \
-                “ Supported models for AI21Labs are {self.allowed_models}."
-            )
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
         payload = jsonable_encoder(payload, exclude_none=True)

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -178,5 +178,6 @@ def is_valid_mosiacml_chat_model(model_name: str) -> bool:
         for supported in MLFLOW_AI_GATEWAY_MOSAICML_CHAT_SUPPORTED_MODEL_PREFIXES
     )
 
+
 def is_valid_ai21labs_model(model_name: str) -> bool:
-    return model_name in set(["j2-ultra", "j2-mid", "j2-light"])
+    return model_name in {"j2-ultra", "j2-mid", "j2-light"}

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -177,3 +177,6 @@ def is_valid_mosiacml_chat_model(model_name: str) -> bool:
         model_name.lower().startswith(supported)
         for supported in MLFLOW_AI_GATEWAY_MOSAICML_CHAT_SUPPORTED_MODEL_PREFIXES
     )
+
+def is_valid_ai21labs_model(model_name: str) -> bool:
+    return model_name in set(["j2-ultra", "j2-mid", "j2-light"])

--- a/tests/gateway/providers/test_ai21labs.py
+++ b/tests/gateway/providers/test_ai21labs.py
@@ -3,11 +3,10 @@ from unittest import mock
 import pytest
 from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
-from pydantic import ValidationError
 
 from mlflow.gateway.config import RouteConfig
 from mlflow.gateway.providers.ai21labs import AI21LabsProvider
-from mlflow.gateway.schemas import completions, embeddings, chat
+from mlflow.gateway.schemas import chat, completions, embeddings
 
 from tests.gateway.tools import MockAsyncResponse
 
@@ -24,6 +23,8 @@ def completions_config():
             },
         },
     }
+
+
 def completions_config_invalid_model():
     return {
         "name": "completions",
@@ -36,6 +37,7 @@ def completions_config_invalid_model():
             },
         },
     }
+
 
 def embedding_config():
     return {
@@ -50,6 +52,7 @@ def embedding_config():
         },
     }
 
+
 def chat_config():
     return {
         "name": "chat",
@@ -63,23 +66,17 @@ def chat_config():
         },
     }
 
+
 def completions_response():
     return {
         "id": "7921a78e-d905-c9df-27e3-88e4831e3c3b",
-        "prompt": {
-            "text": "This is a test"
-        },
+        "prompt": {"text": "This is a test"},
         "completions": [
             {
-                "data": {
-                    "text": "this is a test response"
-                },
-                "finishReason": {
-                    "reason": "length",
-                    "length": 2
-                }
+                "data": {"text": "this is a test response"},
+                "finishReason": {"reason": "length", "length": 2},
             }
-        ]
+        ],
     }
 
 
@@ -112,11 +109,13 @@ async def test_completions():
         }
         mock_post.assert_called_once()
 
+
 @pytest.mark.asyncio
 async def test_param_invalid_model_name_is_not_permitted():
     config = completions_config_invalid_model()
-    with pytest.raises(TypeError, match=r"Invalid modelName.*") as e:
-        provider = AI21LabsProvider(RouteConfig(**config))
+    with pytest.raises(TypeError, match=r"Invalid modelName.*"):
+        AI21LabsProvider(RouteConfig(**config))
+
 
 @pytest.mark.asyncio
 async def test_param_maxTokens_is_not_permitted():
@@ -131,6 +130,7 @@ async def test_param_maxTokens_is_not_permitted():
     assert "Invalid parameter maxTokens. Use max_tokens instead." in e.value.detail
     assert e.value.status_code == 422
 
+
 @pytest.mark.asyncio
 async def test_param_model_is_not_permitted():
     config = completions_config()
@@ -144,6 +144,7 @@ async def test_param_model_is_not_permitted():
     assert "The parameter 'model' is not permitted" in e.value.detail
     assert e.value.status_code == 422
 
+
 @pytest.mark.asyncio
 async def test_chat_is_not_supported_for_ai21labs():
     config = chat_config()
@@ -156,6 +157,7 @@ async def test_chat_is_not_supported_for_ai21labs():
         await provider.chat(chat.RequestPayload(**payload))
     assert "The chat route is not available for AI21Labs models" in e.value.detail
     assert e.value.status_code == 404
+
 
 @pytest.mark.asyncio
 async def test_embeddings_are_not_supported_for_ai21labs():

--- a/tests/gateway/providers/test_ai21labs.py
+++ b/tests/gateway/providers/test_ai21labs.py
@@ -1,0 +1,101 @@
+from unittest import mock
+
+import pytest
+from fastapi import HTTPException
+from fastapi.encoders import jsonable_encoder
+from pydantic import ValidationError
+
+from mlflow.gateway.config import RouteConfig
+from mlflow.gateway.providers.ai21labs import AI21LabsProvider
+from mlflow.gateway.schemas import completions, embeddings
+
+from tests.gateway.tools import MockAsyncResponse
+
+
+def completions_config():
+    return {
+        "name": "completions",
+        "route_type": "llm/v1/completions",
+        "model": {
+            "provider": "ai21labs",
+            "name": "command",
+            "config": {
+                "ai21labs_api_key": "key",
+            },
+        },
+    }
+
+
+def completions_response():
+    return
+    {
+        "id": "7921a78e-d905-c9df-27e3-88e4831e3c3b",
+        "prompt": {
+            "text": "This is a test"
+        },
+        "completions": [
+            {
+                "data": {
+                    "text": "this is a test response"
+                },
+                "finishReason": {
+                    "reason": "length",
+                    "length": 2
+                }
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_completions():
+    resp = completions_response()
+    config = completions_config()
+    with mock.patch(
+        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+    ) as mock_post:
+        provider = AI21LabsProvider(RouteConfig(**config))
+        payload = {
+            "prompt": "This is a test",
+        }
+        response = await provider.completions(completions.RequestPayload(**payload))
+        assert jsonable_encoder(response) == {
+            "candidates": [
+                {
+                    "text": "this is a test response",
+                    "metadata": {"finish_reason": "length"},
+                }
+            ],
+            "metadata": {
+                "input_tokens": None,
+                "output_tokens": None,
+                "total_tokens": None,
+                "model": "command",
+                "route_type": "llm/v1/completions",
+            },
+        }
+        mock_post.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_param_model_is_not_permitted():
+    config = embeddings_config()
+    provider = CohereProvider(RouteConfig(**config))
+    payload = {
+        "prompt": "This should fail",
+        "max_tokens": 5000,
+        "model": "something-else",
+    }
+    with pytest.raises(HTTPException, match=r".*") as e:
+        await provider.completions(completions.RequestPayload(**payload))
+    assert "The parameter 'model' is not permitted" in e.value.detail
+    assert e.value.status_code == 422
+
+
+@pytest.mark.parametrize("prompt", [{"set1", "set2"}, ["list1"], [1], ["list1", "list2"], [1, 2]])
+@pytest.mark.asyncio
+async def test_completions_throws_if_prompt_contains_non_string(prompt):
+    config = completions_config()
+    provider = CohereProvider(RouteConfig(**config))
+    payload = {"prompt": prompt}
+    with pytest.raises(ValidationError, match=r"prompt"):
+        await provider.completions(completions.RequestPayload(**payload))

--- a/tests/gateway/providers/test_ai21labs.py
+++ b/tests/gateway/providers/test_ai21labs.py
@@ -7,6 +7,7 @@ from fastapi.encoders import jsonable_encoder
 from mlflow.gateway.config import RouteConfig
 from mlflow.gateway.providers.ai21labs import AI21LabsProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
+from mlflow.exceptions import MlflowException
 
 from tests.gateway.tools import MockAsyncResponse
 
@@ -113,8 +114,8 @@ async def test_completions():
 @pytest.mark.asyncio
 async def test_param_invalid_model_name_is_not_permitted():
     config = completions_config_invalid_model()
-    with pytest.raises(TypeError, match=r"Invalid modelName.*"):
-        AI21LabsProvider(RouteConfig(**config))
+    with pytest.raises(MlflowException, match=r"An Unsupported AI21Labs model.*"):
+        RouteConfig(**config)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/providers/test_ai21labs.py
+++ b/tests/gateway/providers/test_ai21labs.py
@@ -4,10 +4,10 @@ import pytest
 from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 
+from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import RouteConfig
 from mlflow.gateway.providers.ai21labs import AI21LabsProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
-from mlflow.exceptions import MlflowException
 
 from tests.gateway.tools import MockAsyncResponse
 

--- a/tests/gateway/test_integration.py
+++ b/tests/gateway/test_integration.py
@@ -9,12 +9,12 @@ import mlflow.gateway.utils
 from mlflow.exceptions import MlflowException
 from mlflow.gateway import MlflowGatewayClient, get_route, query, set_gateway_uri
 from mlflow.gateway.config import Route
+from mlflow.gateway.providers.ai21labs import AI21LabsProvider
 from mlflow.gateway.providers.anthropic import AnthropicProvider
 from mlflow.gateway.providers.cohere import CohereProvider
 from mlflow.gateway.providers.mlflow import MlflowModelServingProvider
 from mlflow.gateway.providers.mosaicml import MosaicMLProvider
 from mlflow.gateway.providers.openai import OpenAIProvider
-from mlflow.gateway.providers.ai21labs import AI21LabsProvider
 from mlflow.utils.request_utils import _cached_get_request_session
 
 from tests.gateway.tools import (

--- a/tests/gateway/test_integration.py
+++ b/tests/gateway/test_integration.py
@@ -14,6 +14,7 @@ from mlflow.gateway.providers.cohere import CohereProvider
 from mlflow.gateway.providers.mlflow import MlflowModelServingProvider
 from mlflow.gateway.providers.mosaicml import MosaicMLProvider
 from mlflow.gateway.providers.openai import OpenAIProvider
+from mlflow.gateway.providers.ai21labs import AI21LabsProvider
 from mlflow.utils.request_utils import _cached_get_request_session
 
 from tests.gateway.tools import (
@@ -68,6 +69,17 @@ def basic_config_dict():
                     "name": "claude-instant-1.1",
                     "config": {
                         "anthropic_api_key": "$ANTHROPIC_API_KEY",
+                    },
+                },
+            },
+            {
+                "name": "completions-ai21labs",
+                "route_type": "llm/v1/completions",
+                "model": {
+                    "provider": "ai21labs",
+                    "name": "j2-ultra",
+                    "config": {
+                        "ai21labs_api_key": "$AI21LABS_API_KEY",
                     },
                 },
             },
@@ -175,6 +187,7 @@ def env_setup(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test_anthropic_key")
     monkeypatch.setenv("OPENAI_API_KEY", "test_openai_key")
     monkeypatch.setenv("COHERE_API_KEY", "test_cohere_key")
+    monkeypatch.setenv("AI21LABS_API_KEY", "test_ai21labs_key")
     monkeypatch.setenv("MOSAICML_API_KEY", "test_mosaicml_key")
 
 
@@ -199,7 +212,7 @@ def test_create_gateway_client_with_declared_url(gateway):
     assert gateway_client.gateway_uri == gateway.url
     assert isinstance(gateway_client.get_route("chat-openai"), Route)
     routes = gateway_client.search_routes()
-    assert len(routes) == 12
+    assert len(routes) == 13
     assert all(isinstance(route, Route) for route in routes)
 
 
@@ -318,6 +331,35 @@ def test_anthropic_completions(gateway):
 
     with patch.object(AnthropicProvider, "completions", mock_completions):
         response = query(route=route.name, data=data)
+    assert response == expected_output
+
+
+def test_ai21labs_completions(gateway):
+    client = MlflowGatewayClient(gateway_uri=gateway.url)
+    route = client.get_route("completions-ai21labs")
+    expected_output = {
+        "candidates": [
+            {
+                "text": "mock using MagicMock please",
+                "metadata": {},
+            }
+        ],
+        "metadata": {
+            "input_tokens": None,
+            "output_tokens": None,
+            "total_tokens": None,
+            "model": "j2-ultra",
+            "route_type": "llm/v1/completions",
+        },
+    }
+
+    data = {"prompt": "mock my test", "max_tokens": 50}
+
+    async def mock_completions(self, payload):
+        return expected_output
+
+    with patch.object(AI21LabsProvider, "completions", mock_completions):
+        response = client.query(route=route.name, data=data)
     assert response == expected_output
 
 


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/zhe-db/mlflow/pull/9828?quickstart=1)

### Related Issues/PRs
Add AI21labs as a provider in  MLflow AI Gateway

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
