### PR TITLE
Get context for langchain

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -331,7 +331,11 @@ def save_model(
 
 
 def _validate_and_wrap_lc_model(lc_model, loader_fn):
-    import langchain
+    import langchain.agents
+    import langchain.chains
+    import langchain.llms.huggingface_hub
+    import langchain.llms.openai
+    import langchain.schema
 
     if not isinstance(
         lc_model,

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -769,6 +769,8 @@ class _TestLangChainWrapper(_LangChainModelWrapper):
         ):
             for res in result:
                 res["source_documents"] = TEST_SOURCE_DOCUMENTS
+                if params.get("mlflow_return_context", False):
+                    res["context"] = TEST_SOURCE_DOCUMENTS
         if (
             hasattr(self.lc_model, "return_intermediate_steps")
             and self.lc_model.return_intermediate_steps

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -25,8 +25,8 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Union
 
 import langchain
-from langchain.schema import AgentAction
 from langchain.chains.retrieval_qa.base import BaseRetrievalQA
+from langchain.schema import AgentAction
 
 import mlflow
 
@@ -114,8 +114,6 @@ class APIRequest:
                 for doc in response["source_documents"]
             ]
             if self.return_context:
-                print("!@*#&^$)*&")
-
                 response["context"] = response["source_documents"].copy()
 
     def call_api(self, status_tracker: StatusTracker):
@@ -169,8 +167,6 @@ def process_api_requests(
 
     results: list[tuple[int, str]] = []
     requests_iter = enumerate(requests)
-    print("!#!")
-    print("return_context", return_context)
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         while True:
             # get next request (if one is not already waiting for capacity)

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Union
 
 import langchain
 from langchain.schema import AgentAction
+from langchain.chains.retrieval_qa.base import BaseRetrievalQA
 
 import mlflow
 
@@ -112,6 +113,10 @@ class APIRequest:
                 {"page_content": doc.page_content, "metadata": doc.metadata}
                 for doc in response["source_documents"]
             ]
+            if self.return_context:
+                print("!@*#&^$)*&")
+
+                response["context"] = response["source_documents"].copy()
 
     def call_api(self, status_tracker: StatusTracker):
         """
@@ -128,6 +133,8 @@ class APIRequest:
                     {"page_content": doc.page_content, "metadata": doc.metadata} for doc in docs
                 ]
             else:
+                if isinstance(self.lc_model, BaseRetrievalQA) and self.return_context:
+                    self.lc_model.return_source_documents = True
                 response = self.lc_model(self.request_json, return_only_outputs=True)
 
                 # to maintain existing code, single output chains will still return only the result
@@ -162,6 +169,8 @@ def process_api_requests(
 
     results: list[tuple[int, str]] = []
     requests_iter = enumerate(requests)
+    print("!#!")
+    print("return_context", return_context)
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         while True:
             # get next request (if one is not already waiting for capacity)

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -74,6 +74,7 @@ class APIRequest:
     lc_model: langchain.chains.base.Chain
     request_json: dict
     results: list[tuple[int, str]]
+    return_context: bool
 
     def _prepare_to_serialize(self, response: dict):
         """
@@ -148,6 +149,7 @@ def process_api_requests(
     lc_model,
     requests: List[Union[str, Dict[str, Any]]] = None,
     max_workers: int = 10,
+    return_context: bool = False,
 ):
     """
     Processes API requests in parallel.
@@ -171,7 +173,11 @@ def process_api_requests(
                     # get new request
                     index, request_json = req
                     next_request = APIRequest(
-                        index=index, lc_model=lc_model, request_json=request_json, results=results
+                        index=index,
+                        lc_model=lc_model,
+                        request_json=request_json,
+                        results=results,
+                        return_context=return_context,
                     )
                     status_tracker.start_task()
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -553,6 +553,7 @@ langchain:
           "psutil",
           "faiss-cpu",
           "langchain-experimental",
+          "numexpr",
         ]
     run: |
       pytest tests/langchain/test_langchain_model_export.py

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -446,7 +446,7 @@ def test_log_and_load_retrieval_qa_chain_multiple_output(tmp_path):
     langchain_output = [
         {loaded_model.output_key: TEST_CONTENT, "source_documents": TEST_SOURCE_DOCUMENTS}
     ]
-    result = loaded_pyfunc_model.predict([langchain_input])
+    result = loaded_pyfunc_model.predict([langchain_input], params={"mlflow_return_context": True})
 
     assert result == langchain_output
 
@@ -464,6 +464,7 @@ def test_log_and_load_retrieval_qa_chain_multiple_output(tmp_path):
     assert (
         PredictionsResponse.from_json(response.content.decode("utf-8")) == langchain_output_serving
     )
+    assert False
 
 
 # Define a special embedding for testing

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -465,6 +465,7 @@ def test_log_and_load_retrieval_qa_chain_multiple_output(tmp_path):
         PredictionsResponse.from_json(response.content.decode("utf-8")) == langchain_output_serving
     )
 
+
 @pytest.mark.skipif(
     version.parse(langchain.__version__) < version.parse("0.0.194"),
     reason="Saving RetrievalQA chains requires langchain>=0.0.194",
@@ -481,9 +482,7 @@ def test_langchain_context(tmp_path):
     db.save_local(persist_dir)
 
     # Create the RetrievalQA chain
-    retrievalQA = RetrievalQA.from_llm(
-        llm=OpenAI(), retriever=db.as_retriever()
-    )
+    retrievalQA = RetrievalQA.from_llm(llm=OpenAI(), retriever=db.as_retriever())
 
     # Log the RetrievalQA chain
     def load_retriever(persist_directory):
@@ -509,7 +508,11 @@ def test_langchain_context(tmp_path):
     loaded_pyfunc_model = mlflow.pyfunc.load_model(logged_model.model_uri)
     langchain_input = {"query": "What did the president say about Ketanji Brown Jackson"}
     langchain_output = [
-        {loaded_model.output_key: TEST_CONTENT, "source_documents": TEST_SOURCE_DOCUMENTS, "context": TEST_SOURCE_DOCUMENTS}
+        {
+            loaded_model.output_key: TEST_CONTENT,
+            "source_documents": TEST_SOURCE_DOCUMENTS,
+            "context": TEST_SOURCE_DOCUMENTS,
+        }
     ]
     result = loaded_pyfunc_model.predict([langchain_input], params={"mlflow_return_context": True})
     assert result == langchain_output

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -779,9 +779,13 @@ def test_saving_not_implemented_for_memory():
 
 def test_saving_not_implemented_chain_type():
     chain = FakeChain()
+    if version.parse(langchain.__version__) < version.parse("0.0.309"):
+        error_message = "Saving not supported for this chain type"
+    else:
+        error_message = f"Chain {chain} does not support saving."
     with pytest.raises(
         NotImplementedError,
-        match="Saving not supported for this chain type",
+        match=error_message,
     ):
         with mlflow.start_run():
             mlflow.langchain.log_model(chain, "fake_chain")

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -519,8 +519,7 @@ def test_langchain_context(tmp_path):
 
     # Serve the chain
     inference_payload = json.dumps({"inputs": langchain_input})
-    langchain_output = [{loaded_model.output_key: TEST_CONTENT}]
-    langchain_output_serving = {"predictions": langchain_output}
+    langchain_output_serving = {"predictions": [TEST_CONTENT]}
 
     response = pyfunc_serve_and_score_model(
         logged_model.model_uri,


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
