### PR TITLE
clean up mlflow/__init__.py

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -88,26 +88,6 @@ xgboost = LazyLoader("mlflow.xgboost", globals(), "mlflow.xgboost")
 
 _configure_mlflow_loggers(root_module_name=__name__)
 
-# TODO: Comment out this block when we deprecate support for python 3.8.
-# _major = 3
-# _minor = 8
-# _deprecated_version = (_major, _minor)
-# _min_supported_version = (_major, _minor + 1)
-
-# if sys.version_info[:2] == _deprecated_version:
-#     warnings.warn(
-#         "MLflow support for Python {dep_ver} is deprecated and will be dropped in "
-#         "an upcoming release. At that point, existing Python {dep_ver} workflows "
-#         "that use MLflow will continue to work without modification, but Python {dep_ver} "
-#         "users will no longer get access to the latest MLflow features and bugfixes. "
-#         "We recommend that you upgrade to Python {min_ver} or newer.".format(
-#             dep_ver=".".join(map(str, _deprecated_version)),
-#             min_ver=".".join(map(str, _min_supported_version)),
-#         ),
-#         FutureWarning,
-#         stacklevel=2,
-#     )
-
 from mlflow._doctor import doctor
 from mlflow.client import MlflowClient
 from mlflow.exceptions import MlflowException
@@ -172,58 +152,58 @@ from mlflow.utils.credentials import login
 
 __all__ = [
     "ActiveRun",
-    "log_param",
-    "log_params",
-    "log_metric",
-    "log_metrics",
-    "set_experiment_tags",
-    "set_experiment_tag",
-    "set_tag",
-    "set_tags",
-    "delete_tag",
-    "log_artifacts",
-    "log_artifact",
-    "log_text",
-    "log_dict",
-    "log_figure",
-    "log_table",
-    "load_table",
-    "log_image",
-    "log_input",
-    "active_run",
-    "start_run",
-    "end_run",
-    "search_runs",
-    "get_artifact_uri",
-    "get_tracking_uri",
-    "set_tracking_uri",
-    "is_tracking_uri_set",
-    "get_experiment",
-    "get_experiment_by_name",
-    "search_experiments",
-    "search_registered_models",
-    "search_model_versions",
-    "create_experiment",
-    "set_experiment",
-    "delete_experiment",
-    "get_run",
-    "get_parent_run",
-    "delete_run",
-    "run",
-    "register_model",
-    "get_registry_uri",
-    "set_registry_uri",
-    "autolog",
-    "evaluate",
-    "last_active_run",
-    "doctor",
     "MlflowClient",
     "MlflowException",
+    "active_run",
+    "autolog",
+    "create_experiment",
+    "delete_experiment",
+    "delete_run",
+    "delete_tag",
     "disable_system_metrics_logging",
+    "doctor",
     "enable_system_metrics_logging",
-    "set_system_metrics_sampling_interval",
-    "set_system_metrics_samples_before_logging",
+    "end_run",
+    "evaluate",
+    "get_artifact_uri",
+    "get_experiment",
+    "get_experiment_by_name",
+    "get_parent_run",
+    "get_registry_uri",
+    "get_run",
+    "get_tracking_uri",
+    "is_tracking_uri_set",
+    "last_active_run",
+    "load_table",
+    "log_artifact",
+    "log_artifacts",
+    "log_dict",
+    "log_figure",
+    "log_image",
+    "log_input",
+    "log_metric",
+    "log_metrics",
+    "log_param",
+    "log_params",
+    "log_table",
+    "log_text",
     "login",
+    "register_model",
+    "run",
+    "search_experiments",
+    "search_model_versions",
+    "search_registered_models",
+    "search_runs",
+    "set_experiment",
+    "set_experiment_tag",
+    "set_experiment_tags",
+    "set_registry_uri",
+    "set_system_metrics_samples_before_logging",
+    "set_system_metrics_sampling_interval",
+    "set_tag",
+    "set_tags",
+    "set_tracking_uri",
+    "start_run",
 ]
 
 


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/9831?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

1. Sort the order in `__all__`.
2. Delete the comment block related to deprecating python 3.8. We should add it when we actually need it.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
