### PR TITLE
Revert "Drop old pytorch-lightning versions"

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -57,10 +57,11 @@ pytorch-lightning:
       pip install git+https://github.com/PytorchLightning/pytorch-lightning.git
 
   autologging:
-    minimum: "1.4.9"
+    minimum: "1.0.5"
     maximum: "2.0.8"
     requirements:
       ">= 0.0.0": ["scikit-learn", "torchvision", "protobuf<4.0.0", "tensorboard"]
+      "< 1.2.0": ["torch<1.11.0"]
       # torchmetrics==0.8.0 released a breaking change for versions 1.3 and 1.4 where
       # torchmetrics dependency was defined as non-upper-bounded in its requirements.
       # see: https://github.com/PyTorchLightning/metrics/commit/c537c9b3e8e801772a7e5670ff273321ed26e77b


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/9836?quickstart=1)

Reverts mlflow/mlflow#9802