### PR TITLE
Support for completions in OpenAI flavor

### DIFF
--- a/examples/openai/completions.py
+++ b/examples/openai/completions.py
@@ -1,0 +1,19 @@
+import os
+
+import openai
+
+import mlflow
+
+assert "OPENAI_API_KEY" in os.environ, " OPENAI_API_KEY environment variable must be set"
+
+
+with mlflow.start_run():
+    model_info = mlflow.openai.log_model(
+        model="text-davinci-002",
+        task=openai.Completion,
+        artifact_path="model",
+        prompt="Clasify the following tweet's sentiment: '{tweet}'.",
+    )
+
+model = mlflow.pyfunc.load_model(model_info.model_uri)
+print(model.predict(["I believe in a better world"]))

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -572,7 +572,7 @@ def _load_model(path):
         return yaml.safe_load(f)
 
 
-def _has_content_and_role(d):
+def _is_valid_message(d):
     return isinstance(d, Dict) and "content" in d and "role" in d
 
 

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -591,7 +591,7 @@ class _ContentFormatter:
         elif type == "chat.completions":
             if not template:
                 template = [{"role": "user", "content": "{content}"}]
-            if not all(_has_content_and_role(message) for message in template):
+            if not all(map(_has_content_and_role, template)):
                 raise mlflow.MlflowException.invalid_parameter_value(
                     f"Template for task {type} expects type `dict` with keys 'content' "
                     f"and 'role', but got {type(template)}."

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -371,7 +371,7 @@ def save_model(
             outputs=Schema([ColSpec(type="string", name=None)]),
         )
     elif task == "completions":
-        prompt = kwargs.get("prompt", None)
+        prompt = kwargs.get("prompt")
         mlflow_model.signature = ModelSignature(
             inputs=_get_input_schema(task, prompt),
             outputs=Schema([ColSpec(type="string", name=None)]),

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -588,7 +588,7 @@ class _ContentFormatter:
 
             self.template = template
             self.format_fn = self.format_prompt
-            self.variables = _parse_format_fields(self.template)
+            self.variables = sorted(_parse_format_fields(self.template))
         elif type == "chat.completions":
             if not template:
                 template = [{"role": "user", "content": "{content}"}]
@@ -597,20 +597,20 @@ class _ContentFormatter:
                     f"Type {type(template)} is not a valid type for template of task {type}."
                 )
 
-            self.template = template
+            self.template = template.copy()
             self.format_fn = self.format_chat
             self.variables = sorted(
                 set(
                     itertools.chain.from_iterable(
                         _parse_format_fields(message.get("content"))
-                        + _parse_format_fields(message.get("role"))
-                        for message in template
+                        | _parse_format_fields(message.get("role"))
+                        for message in self.template
                     )
                 )
             )
             if not self.variables:
                 self.template.append({"role": "user", "content": "{content}"})
-                self.variables = "content"
+                self.variables.append("content")
         else:
             raise mlflow.MlflowException.invalid_parameter_value(
                 f"Task type ``{type}`` is not supported for formatting."

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -579,8 +579,7 @@ def _has_content_and_role(d):
 class _ContentFormatter:
     def __init__(self, type, template=None):
         if type == "completions":
-            if not template:
-                template = "{prompt}"
+            template = template or "{prompt}"
             if not isinstance(template, str):
                 raise mlflow.MlflowException.invalid_parameter_value(
                     f"Template for task {type} expects type `str`, but got {type(template)}."

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -573,7 +573,7 @@ def _load_model(path):
 
 
 def _has_content_and_role(d):
-    return "content" in d and "role" in d
+    return isinstance(d, Dict) and "content" in d and "role" in d
 
 
 class _ContentFormatter:
@@ -583,7 +583,7 @@ class _ContentFormatter:
                 template = "{prompt}"
             if not isinstance(template, str):
                 raise mlflow.MlflowException.invalid_parameter_value(
-                    f"Type {type(template)} is not a valid type for template of task {type}."
+                    f"Template for task {type} expects type `str`, but got {type(template)}."
                 )
 
             self.template = template
@@ -592,9 +592,10 @@ class _ContentFormatter:
         elif type == "chat.completions":
             if not template:
                 template = [{"role": "user", "content": "{content}"}]
-            if not all(isinstance(message, Dict) for message in template):
+            if not all(_has_content_and_role(message) for message in template):
                 raise mlflow.MlflowException.invalid_parameter_value(
-                    f"Type {type(template)} is not a valid type for template of task {type}."
+                    f"Template for task {type} expects type `dict` with keys 'content' "
+                    f"and 'role', but got {type(template)}."
                 )
 
             self.template = template.copy()

--- a/mlflow/openai/utils.py
+++ b/mlflow/openai/utils.py
@@ -9,22 +9,6 @@ import requests
 import mlflow
 
 TEST_CONTENT = "test"
-TEST_SOURCE_DOCUMENTS = [
-    {
-        "page_content": "We see the unity among leaders ...",
-        "metadata": {"source": "tests/langchain/state_of_the_union.txt"},
-    },
-]
-TEST_INTERMEDIATE_STEPS = (
-    [
-        {
-            "tool": "Search",
-            "tool_input": "High temperature in SF yesterday",
-            "log": " I need to find the temperature first...",
-            "result": "San Francisco...",
-        },
-    ],
-)
 
 
 class _MockResponse:
@@ -53,6 +37,17 @@ def _chat_completion_json_sample(content):
     }
 
 
+def _completion_json_sample(content):
+    return {
+        "id": "cmpl-123",
+        "object": "text_completion",
+        "created": 1589478378,
+        "model": "text-davinci-003",
+        "choices": [{"text": content, "index": 0, "finish_reason": "length"}],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+    }
+
+
 def _models_retrieve_json_sample():
     # https://platform.openai.com/docs/api-reference/models/retrieve
     return {
@@ -65,6 +60,10 @@ def _models_retrieve_json_sample():
 
 def _mock_chat_completion_response(content=TEST_CONTENT):
     return _MockResponse(200, _chat_completion_json_sample(content))
+
+
+def _mock_completion_response(content=TEST_CONTENT):
+    return _MockResponse(200, _completion_json_sample(content))
 
 
 def _mock_embeddings_response(num_texts):
@@ -110,6 +109,9 @@ def _mock_openai_request():
         if url.endswith("/chat/completions"):
             messages = json.loads(kwargs.get("data")).get("messages")
             return _mock_chat_completion_response(content=json.dumps(messages))
+        elif url.endswith("/completions"):
+            prompt = json.loads(kwargs.get("data")).get("prompt")
+            return _mock_completion_response(content=json.dumps(prompt))
         elif url.endswith("/embeddings"):
             inp = json.loads(kwargs.get("data")).get("input")
             return _mock_embeddings_response(len(inp) if isinstance(inp, list) else 1)

--- a/tests/openai/test_openai_model_export.py
+++ b/tests/openai/test_openai_model_export.py
@@ -98,7 +98,7 @@ def test_chat_single_variable(tmp_path):
     assert list(map(json.loads, model.predict(data))) == expected_output
 
 
-def test_prompt_single_variable(tmp_path):
+def test_completion_single_variable(tmp_path):
     mlflow.openai.save_model(
         model="text-davinci-003",
         task=openai.Completion,
@@ -209,7 +209,7 @@ def test_chat_role_content(tmp_path):
     assert list(map(json.loads, model.predict(data))) == expected_output
 
 
-def test_prompt_multiple_variables(tmp_path):
+def test_completion_multiple_variables(tmp_path):
     mlflow.openai.save_model(
         model="text-davinci-003",
         task=openai.Completion,
@@ -333,7 +333,7 @@ def test_chat_no_variables(tmp_path):
     assert list(map(json.loads, model.predict(data))) == expected_output
 
 
-def test_prompt_no_variable(tmp_path):
+def test_completion_no_variable(tmp_path):
     mlflow.openai.save_model(
         model="text-davinci-003",
         task=openai.Completion,

--- a/tests/openai/test_openai_model_export.py
+++ b/tests/openai/test_openai_model_export.py
@@ -338,7 +338,6 @@ def test_prompt_no_variable(tmp_path):
         model="text-davinci-003",
         task=openai.Completion,
         path=tmp_path,
-        suffix="Say ",
     )
 
     model = mlflow.pyfunc.load_model(tmp_path)


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/santiagxf/mlflow/pull/9838?quickstart=1)

### Related Issues/PRs

* https://github.com/mlflow/mlflow/issues/9436

### What changes are proposed in this pull request?

Extending support in OpenAI flavor to support completions. It also introduces a refactor to the way OpenAI Chat Completions are implemented so all type of completions uses the same logic.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introducing support for completions for OpenAI flavor.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category-completions"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
