### PR TITLE
Improve HuggingFace dataset logging

### DIFF
--- a/mlflow/data/huggingface_dataset.py
+++ b/mlflow/data/huggingface_dataset.py
@@ -181,44 +181,37 @@ def from_huggingface(
     data_dir: Optional[str] = None,
     data_files: Optional[Union[str, Sequence[str], Mapping[str, Union[str, Sequence[str]]]]] = None,
     revision=None,
-    task=None,
     name: Optional[str] = None,
     digest: Optional[str] = None,
 ) -> HuggingFaceDataset:
-    """
-    Given a Hugging Face ``datasets.Dataset``, constructs an MLflow :py:class:`HuggingFaceDataset`
-    object for use with MLflow Tracking.
+    """Create `mlflow.data.huggingface_dataset.HuggingFaceDataset` from a Hugging Face dataset.
 
-    :param ds: A Hugging Face dataset. Must be an instance of ``datasets.Dataset``.
-               Other types, such as ``datasets.DatasetDict``, are not supported.
-    :param path: The path of the Hugging Face dataset used to construct the source. This is used by
-                 the ``datasets.load_dataset()`` function to reload the dataset upon request via
-                 :py:func:`HuggingFaceDataset.source.load()
-                 <mlflow.data.huggingface_dataset_source.HuggingFaceDatasetSource.load>`.
-                 If no path is specified, a CodeDatasetSource is used, which will source
-                 information from the run context.
-    :param targets: The name of the Hugging Face ``dataset.Dataset`` column containing targets
-                    (labels) for supervised learning.
-    :param data_dir: The `data_dir` of the Hugging Face dataset configuration. This is used by the
-                     ``datasets.load_dataset()`` function to reload the dataset upon request via
-                     :py:func:`HuggingFaceDataset.source.load()
-                     <mlflow.data.huggingface_dataset_source.HuggingFaceDatasetSource.load>`.
-    :param data_files: Paths to source data file(s) for the Hugging Face dataset configuration.
-                       This is used by the ``datasets.load_dataset()`` function to reload the
-                       dataset upon request via :py:func:`HuggingFaceDataset.source.load()
-                       <mlflow.data.huggingface_dataset_source.HuggingFaceDatasetSource.load>`.
-    :param revision: Version of the dataset script to load. This is used by the
-                     ``datasets.load_dataset()`` function to reload the dataset upon request via
-                     :py:func:`HuggingFaceDataset.source.load()
-                     <mlflow.data.huggingface_dataset_source.HuggingFaceDatasetSource.load>`.
-    :param task: The task to prepare the Hugging Face dataset for during training and evaluation.
-                 This is used by the ``datasets.load_dataset()`` function to reload the dataset
-                 upon request via :py:func:`HuggingFaceDataset.source.load()
-                 <mlflow.data.huggingface_dataset_source.HuggingFaceDatasetSource.load>`.
-    :param name: The name of the dataset. E.g. "wiki_train". If unspecified, a name is
-                 automatically generated.
-    :param digest: The digest (hash, fingerprint) of the dataset. If unspecified, a digest
-                   is automatically computed.
+    Args:
+        ds: A Hugging Face dataset. Must be an instance of `datasets.Dataset`. Other types, such as
+            `datasets.DatasetDict`, are not supported.
+        path: The path of the Hugging Face dataset used to construct the source. This is the same
+            argument as `path` in `datasets.load_dataset()` function. To be able to reload the
+            dataset via MLflow, `path` must match the path of the dataset on the hub, e.g.,
+            "databricks/databricks-dolly-15k". If no path is specified, a `CodeDatasetSource` is,
+            used which will source information from the run context.
+        targets: The name of the Hugging Face `dataset.Dataset` column containing targets (labels)
+            for supervised learning.
+        data_dir: The `data_dir` of the Hugging Face dataset configuration. This is used by the
+            `datasets.load_dataset()` function to reload the dataset upon request via
+            :py:func:`HuggingFaceDataset.source.load()
+            <mlflow.data.huggingface_dataset_source.HuggingFaceDatasetSource.load>`.
+        data_files: Paths to source data file(s) for the Hugging Face dataset configuration.
+            This is used by the `datasets.load_dataset()` function to reload the
+            dataset upon request via :py:func:`HuggingFaceDataset.source.load()
+            <mlflow.data.huggingface_dataset_source.HuggingFaceDatasetSource.load>`.
+        revision: Version of the dataset script to load. This is used by the
+            `datasets.load_dataset()` function to reload the dataset upon request via
+            :py:func:`HuggingFaceDataset.source.load()
+            <mlflow.data.huggingface_dataset_source.HuggingFaceDatasetSource.load>`.
+        name: The name of the dataset. E.g. "wiki_train". If unspecified, a name is automatically
+            generated.
+        digest: The digest (hash, fingerprint) of the dataset. If unspecified, a digest is
+            automatically computed.
     """
     import datasets
 
@@ -227,13 +220,13 @@ def from_huggingface(
 
     if not isinstance(ds, datasets.Dataset):
         raise MlflowException(
-            f"The specified Hugging Face dataset must be an instance of ``datasets.Dataset``."
+            f"The specified Hugging Face dataset must be an instance of `datasets.Dataset`."
             f" Instead, found an instance of: {type(ds)}",
             INVALID_PARAMETER_VALUE,
         )
 
-    # if arguments for source are passed in directly, use them.
-    # otherwise construct a CodeDatasetSource.
+    # Set the source to a `HuggingFaceDatasetSource` if a path is specified, otherwise set it to a
+    # `CodeDatasetSource`.
     if path is not None:
         source = HuggingFaceDatasetSource(
             path=path,
@@ -242,7 +235,6 @@ def from_huggingface(
             data_files=data_files,
             split=ds.split,
             revision=revision,
-            task=task,
         )
     else:
         context_tags = registry.resolve_tags()

--- a/mlflow/data/huggingface_dataset.py
+++ b/mlflow/data/huggingface_dataset.py
@@ -184,7 +184,7 @@ def from_huggingface(
     name: Optional[str] = None,
     digest: Optional[str] = None,
 ) -> HuggingFaceDataset:
-    """Create `mlflow.data.huggingface_dataset.HuggingFaceDataset` from a Hugging Face dataset.
+    """Create a `mlflow.data.huggingface_dataset.HuggingFaceDataset` from a Hugging Face dataset.
 
     Args:
         ds: A Hugging Face dataset. Must be an instance of `datasets.Dataset`. Other types, such as

--- a/mlflow/data/huggingface_dataset_source.py
+++ b/mlflow/data/huggingface_dataset_source.py
@@ -9,9 +9,7 @@ if TYPE_CHECKING:
 
 @experimental
 class HuggingFaceDatasetSource(DatasetSource):
-    """
-    Represents the source of a Hugging Face dataset used in MLflow Tracking.
-    """
+    """Represents the source of a Hugging Face dataset used in MLflow Tracking."""
 
     def __init__(
         self,
@@ -23,53 +21,68 @@ class HuggingFaceDatasetSource(DatasetSource):
         ] = None,
         split: Optional[Union[str, "datasets.Split"]] = None,
         revision: Optional[Union[str, "datasets.Version"]] = None,
-        task: Optional[Union[str, "datasets.TaskTemplate"]] = None,
     ):
+        """Create a `HuggingFaceDatasetSource` instance.
+
+        Arguments in `__init__` match arguments of the same name in
+        [`datasets.load_dataset()`](https://huggingface.co/docs/datasets/v2.14.5/en/package_reference/loading_methods#datasets.load_dataset).
+        The only exception is `config_name` matches `name` in `datasets.load_dataset()`, because
+        `mlflow.data.Dataset` already has a `name` argument.
+
+        Args:
+            path: The path of the Hugging Face dataset, if it is a dataset from HuggingFace hub,
+                `path` must match the path of the dataset on the hub, e.g.,
+                "databricks/databricks-dolly-15k".
+            config_name: The name of of the Hugging Face dataset configuration.
+            data_dir: The `data_dir` of the Hugging Face dataset configuration.
+            data_files: Paths to source data file(s) for the Hugging Face dataset configuration.
+            split: Which split of the data to load.
+            revision: Version of the dataset script to load.
         """
-        :param path: The path of the Hugging Face dataset.
-        :param config_name: The name of of the Hugging Face dataset configuration.
-        :param data_dir: The `data_dir` of the Hugging Face dataset configuration.
-        :param data_files: Paths to source data file(s) for the Hugging Face dataset configuration.
-        :param revision: Version of the dataset script to load.
-        :param task: The task to prepare the Hugging Face dataset for during training and
-                     evaluation.
-        """
-        self._path = path
-        self._config_name = config_name
-        self._data_dir = data_dir
-        self._data_files = data_files
-        self._split = split
-        self._revision = revision
-        self._task = task
+        self.path = path
+        self.config_name = config_name
+        self.data_dir = data_dir
+        self.data_files = data_files
+        self.split = split
+        self.revision = revision
 
     @staticmethod
     def _get_source_type() -> str:
         return "hugging_face"
 
     def load(self, **kwargs):
-        """
-        Loads the dataset source as a Hugging Face Dataset.
+        """Load the Hugging Face dataset based on `HuggingFaceDatasetSource`.
 
-        :param kwargs: Additional keyword arguments used for loading the dataset with
-                       the Hugging Face ``datasets.load_dataset()`` method. The following keyword
-                       arguments are used automatically from the dataset source but may be
-                       overridden by values passed in ``**kwargs``: ``path``, ``name``,
-                       ``data_dir``, ``data_files``, ``split``, ``revision``, ``task``.
-        :return: An instance of ``datasets.Dataset``.
+        Args:
+            kwargs: Additional keyword arguments used for loading the dataset with the Hugging Face
+                `datasets.load_dataset()` method.
+
+        Returns:
+            An instance of `datasets.Dataset`.
         """
         import datasets
 
-        load_kwargs = {
-            "path": self._path,
-            "name": self._config_name,
-            "data_dir": self._data_dir,
-            "data_files": self._data_files,
-            "split": self._split,
-            "revision": self._revision,
-            "task": self._task,
-        }
+        keys = ["path", "data_dir", "data_files", "split", "revision"]
+        load_kwargs = {}
+        for key in keys:
+            # Populate `load_kwargs` with non-None values from `HuggingFaceDatasetSource`.
+            value = getattr(self, key, None)
+            if value is None:
+                continue
+            if key in kwargs:
+                # Same key must not be specified in both `HuggingFaceDatasetSource` and `kwargs`.
+                raise KeyError(
+                    f"Found duplicated arguments {key} in `HuggingFaceDatasetSource` and `kwargs`: "
+                    f"in `HuggingFaceDatasetSource` `{key}={value}`, and in `kwargs` "
+                    f"`{key}={kwargs[key]}`. Please remove {key} from `kwargs`."
+                )
+            load_kwargs[key] = value
+        # "name" should always come from `HuggingFaceDatasetSource`.
+        load_kwargs["name"] = self.config_name
+        if "name" in kwargs:
+            raise KeyError(f"'name' must not be specified in `kwargs`, received `kwargs={kwargs}`.")
+        # Insert args from `kwargs` into `load_kwargs`.
         load_kwargs.update(kwargs)
-
         return datasets.load_dataset(**load_kwargs)
 
     @staticmethod
@@ -85,13 +98,12 @@ class HuggingFaceDatasetSource(DatasetSource):
 
     def _to_dict(self) -> Dict[Any, Any]:
         return {
-            "path": self._path,
-            "config_name": self._config_name,
-            "data_dir": self._data_dir,
-            "data_files": self._data_files,
-            "split": str(self._split),
-            "revision": self._revision,
-            "task": self._task,
+            "path": self.path,
+            "config_name": self.config_name,
+            "data_dir": self.data_dir,
+            "data_files": self.data_files,
+            "split": str(self.split),
+            "revision": self.revision,
         }
 
     @classmethod
@@ -103,5 +115,4 @@ class HuggingFaceDatasetSource(DatasetSource):
             data_files=source_dict.get("data_files"),
             split=source_dict.get("split"),
             revision=source_dict.get("revision"),
-            task=source_dict.get("task"),
         )

--- a/mlflow/data/huggingface_dataset_source.py
+++ b/mlflow/data/huggingface_dataset_source.py
@@ -69,15 +69,13 @@ class HuggingFaceDatasetSource(DatasetSource):
             "split": self.split,
             "revision": self.revision,
         }
-        for k, v in kwargs.items():
-            if load_kwargs.get(k, None):
-                raise KeyError(
-                    f"Found duplicated arguments {k} in `HuggingFaceDatasetSource` and `kwargs`: "
-                    f"`HuggingFaceDatasetSource` has `{k}={v}`, and `kwargs` has `{k}={kwargs[k]}`"
-                    f"Please remove {k} from `kwargs`."
-                )
-            # Copy `kwargs` to `load_kwargs`.
-            load_kwargs[k] = v
+        intersecting_keys = set(load_kwargs.keys()) & set(kwargs.keys())
+        if intersecting_keys:
+            raise KeyError(
+                f"Found duplicated arguments in `HuggingFaceDatasetSource` and "
+                f"`kwargs`: {intersecting_keys}. Please remove them from `kwargs`."
+            )
+            load_kwargs.update(kwargs)
         return datasets.load_dataset(**load_kwargs)
 
     @staticmethod


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/9845?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

A few things:
- Remove the `task` argument since it's deprecated and we are in experimental phase. Please refer to [HF's doc](https://huggingface.co/docs/datasets/v2.14.5/en/package_reference/loading_methods#datasets.load_dataset).
- Modify the docstring to state that these args are the same as `datasets.load_dataset()`, and call out users need to specify the exact path. 
- For `load()` method, if the same key appears both in `kwargs` and  the instance itself, raise an error instead of silent overwriting. 
- General docstring refactoring, reflecting our offline discussions.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
