### PR TITLE
Prepend `sys.executable -m` to command lauching tracking server

### DIFF
--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -188,6 +188,8 @@ def get_app_client(app_name: str, *args, **kwargs):
 def _build_waitress_command(waitress_opts, host, port, app_name, is_factory):
     opts = shlex.split(waitress_opts) if waitress_opts else []
     return [
+        sys.executable,
+        "-m",
         "waitress-serve",
         *opts,
         f"--host={host}",
@@ -202,6 +204,8 @@ def _build_gunicorn_command(gunicorn_opts, host, port, workers, app_name):
     bind_address = f"{host}:{port}"
     opts = shlex.split(gunicorn_opts) if gunicorn_opts else []
     return [
+        sys.executable,
+        "-m",
         "gunicorn",
         *opts,
         "-b",

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -190,7 +190,7 @@ def _build_waitress_command(waitress_opts, host, port, app_name, is_factory):
     return [
         sys.executable,
         "-m",
-        "waitress-serve",
+        "waitress",
         *opts,
         f"--host={host}",
         f"--port={port}",

--- a/tests/server/test_init.py
+++ b/tests/server/test_init.py
@@ -29,7 +29,7 @@ def test_build_waitress_command():
     ) == [
         sys.executable,
         "-m",
-        "waitress-serve",
+        "waitress",
         "--host=localhost",
         "--port=5000",
         "--ident=mlflow",
@@ -41,7 +41,7 @@ def test_build_waitress_command():
     ) == [
         sys.executable,
         "-m",
-        "waitress-serve",
+        "waitress",
         "--host=localhost",
         "--port=5000",
         "--ident=mlflow",

--- a/tests/server/test_init.py
+++ b/tests/server/test_init.py
@@ -1,3 +1,4 @@
+import sys
 from unittest import mock
 
 import pytest
@@ -26,6 +27,8 @@ def test_build_waitress_command():
     assert server._build_waitress_command(
         "", "localhost", "5000", f"{server.__name__}:app", is_factory=True
     ) == [
+        sys.executable,
+        "-m",
         "waitress-serve",
         "--host=localhost",
         "--port=5000",
@@ -36,6 +39,8 @@ def test_build_waitress_command():
     assert server._build_waitress_command(
         "", "localhost", "5000", f"{server.__name__}:app", is_factory=False
     ) == [
+        sys.executable,
+        "-m",
         "waitress-serve",
         "--host=localhost",
         "--port=5000",
@@ -47,7 +52,16 @@ def test_build_waitress_command():
 def test_build_gunicorn_command():
     assert server._build_gunicorn_command(
         "", "localhost", "5000", "4", f"{server.__name__}:app"
-    ) == ["gunicorn", "-b", "localhost:5000", "-w", "4", "mlflow.server:app"]
+    ) == [
+        sys.executable,
+        "-m",
+        "gunicorn",
+        "-b",
+        "localhost:5000",
+        "-w",
+        "4",
+        "mlflow.server:app",
+    ]
 
 
 def test_run_server(mock_exec_cmd):


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/9848?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Prepend `sys.executable -m` to command lauching tracking server.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
