### PR TITLE
Remove usage of mlflowdbfs

### DIFF
--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -290,19 +290,22 @@ def log_model(
     run_id = mlflow.tracking.fluent._get_or_start_run().info.run_id
     run_root_artifact_uri = mlflow.get_artifact_uri()
     remote_model_path = None
-    if _should_use_mlflowdbfs(run_root_artifact_uri):
-        remote_model_path = append_to_uri_path(
-            run_root_artifact_uri, artifact_path, _JOHNSNOWLABS_MODEL_PATH_SUB
-        )
-        mlflowdbfs_path = _mlflowdbfs_path(run_id, artifact_path)
-        with databricks_utils.MlflowCredentialContext(
-            get_databricks_profile_uri_from_artifact_uri(run_root_artifact_uri)
-        ):
-            try:
-                _unpack_and_save_model(spark_model, mlflowdbfs_path)
 
-            except Exception as e:
-                raise MlflowException("failed to save johnsnowlabs model via mlflowdbfs") from e
+    # commented for now because spark flavor is mlflowdbfs it, but it has many issues on databricks
+    # See https://github.com/mlflow/mlflow/issues/9869
+    # if _should_use_mlflowdbfs(run_root_artifact_uri):
+    #     remote_model_path = append_to_uri_path(
+    #         run_root_artifact_uri, artifact_path, _JOHNSNOWLABS_MODEL_PATH_SUB
+    #     )
+    #     mlflowdbfs_path = _mlflowdbfs_path(run_id, artifact_path)
+    #     with databricks_utils.MlflowCredentialContext(
+    #         get_databricks_profile_uri_from_artifact_uri(run_root_artifact_uri)
+    #     ):
+    #         try:
+    #             _unpack_and_save_model(spark_model, mlflowdbfs_path)
+    #
+    #         except Exception as e:
+    #             raise MlflowException("failed to save johnsnowlabs model via mlflowdbfs") from e
 
     # If the artifact URI is a local filesystem path, defer to Model.log() to persist the model,
     # since Spark may not be able to write directly to the driver's filesystem. For example,
@@ -310,7 +313,7 @@ def log_model(
     # be incorrect on multi-node clusters.
     # If the artifact URI is not a local filesystem path we attempt to write directly to the
     # artifact repo via Spark. If this fails, we defer to Model.log().
-    elif is_local_uri(run_root_artifact_uri) or not _maybe_save_model(
+    if is_local_uri(run_root_artifact_uri) or not _maybe_save_model(
         spark_model,
         append_to_uri_path(run_root_artifact_uri, artifact_path),
     ):


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/C-K-Loan/mlflow/pull/9871?quickstart=1)


### Related Issues/PRs
First pr of a couple more to come 
Resolve --> https://github.com/mlflow/mlflow/issues/9869

### What changes are proposed in this pull request?

Stop using mlflowdbfs

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests in johnsnowlabs repo
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
See https://github.com/mlflow/mlflow/issues/9869 
### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
See https://github.com/mlflow/mlflow/issues/9869 
#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
