### PR TITLE
Optional `model_type`

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1355,7 +1355,7 @@ def evaluate(
                        - ``'text-summarization'``
                        - ``'text'``
 
-                       If no ``model_type`` is specified, then you must provide a a list of 
+                       If no ``model_type`` is specified, then you must provide a a list of
                        metrics to compute via the``extra_metrics`` param.
 
                        .. note::

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -15,7 +15,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from decimal import Decimal
 from types import FunctionType
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import mlflow
 from mlflow.data.dataset import Dataset
@@ -1096,7 +1096,7 @@ def evaluate(
     model: str,
     data,
     *,
-    model_type: str,
+    model_type: Optional[str] = None,
     targets=None,
     dataset_path=None,
     feature_names: list = None,
@@ -1346,7 +1346,7 @@ def evaluate(
                     ``data`` is a :py:class`mlflow.data.dataset.Dataset` that defines targets,
                     then ``targets`` is optional.
 
-    :param model_type: A string describing the model type. The default evaluator
+    :param model_type: (Optional) A string describing the model type. The default evaluator
                        supports the following model types:
 
                        - ``'classifier'``
@@ -1354,6 +1354,8 @@ def evaluate(
                        - ``'question-answering'``
                        - ``'text-summarization'``
                        - ``'text'``
+
+                       If no ``model_type`` is specified, then the default evaluator will only compute the metrics specified in the ``extra_metrics`` param.
 
                        .. note::
                             ``'question-answering'``, ``'text-summarization'``, and ``'text'``

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1355,8 +1355,7 @@ def evaluate(
                        - ``'text-summarization'``
                        - ``'text'``
 
-                       If no ``model_type`` is specified, then the default evaluator will only
-                       compute the metrics specified in the ``extra_metrics`` param.
+                       If no ``model_type`` is specified, then you must provide a a list of metrics to compute via the``extra_metrics`` param.
 
                        .. note::
                             ``'question-answering'``, ``'text-summarization'``, and ``'text'``
@@ -1550,6 +1549,12 @@ def evaluate(
                     f"The targets argument must be specified for {model_type} models.",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
+    elif model_type is None:
+        if not extra_metrics:
+            raise MlflowException(
+                message="The extra_metrics argument must be specified model_type is None.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
 
     if isinstance(model, str):
         model = _load_model_or_server(model, env_manager)

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1355,7 +1355,8 @@ def evaluate(
                        - ``'text-summarization'``
                        - ``'text'``
 
-                       If no ``model_type`` is specified, then the default evaluator will only compute the metrics specified in the ``extra_metrics`` param.
+                       If no ``model_type`` is specified, then the default evaluator will only
+                       compute the metrics specified in the ``extra_metrics`` param.
 
                        .. note::
                             ``'question-answering'``, ``'text-summarization'``, and ``'text'``

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1355,7 +1355,8 @@ def evaluate(
                        - ``'text-summarization'``
                        - ``'text'``
 
-                       If no ``model_type`` is specified, then you must provide a a list of metrics to compute via the``extra_metrics`` param.
+                       If no ``model_type`` is specified, then you must provide a a list of 
+                       metrics to compute via the``extra_metrics`` param.
 
                        .. note::
                             ``'question-answering'``, ``'text-summarization'``, and ``'text'``

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -643,7 +643,7 @@ class DefaultEvaluator(ModelEvaluator):
 
     # pylint: disable=unused-argument
     def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
-        return model_type in _ModelType.values()
+        return model_type in _ModelType.values() or model_type is None
 
     def _log_metrics(self):
         """
@@ -1485,7 +1485,7 @@ class DefaultEvaluator(ModelEvaluator):
 
             text_metrics = [toxicity, perplexity, flesch_kincaid_grade_level, ari_grade_level]
 
-            if self.model_type not in _ModelType.values():
+            if self.model_type not in _ModelType.values() and self.model_type is not None:
                 raise MlflowException(
                     message=f"Unsupported model type {self.model_type}",
                     error_code=INVALID_PARAMETER_VALUE,

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1485,11 +1485,6 @@ class DefaultEvaluator(ModelEvaluator):
 
             text_metrics = [toxicity, perplexity, flesch_kincaid_grade_level, ari_grade_level]
 
-            if self.model_type not in _ModelType.values() and self.model_type is not None:
-                raise MlflowException(
-                    message=f"Unsupported model type {self.model_type}",
-                    error_code=INVALID_PARAMETER_VALUE,
-                )
             with mlflow.utils.autologging_utils.disable_autologging():
                 self._generate_model_predictions()
                 if self.model_type in (_ModelType.CLASSIFIER, _ModelType.REGRESSOR):

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1412,17 +1412,13 @@ class DefaultEvaluator(ModelEvaluator):
             self._log_model_explainability()
 
     def _log_eval_table(self):
-        if (
-            self.model_type
-            not in (
-                _ModelType.QUESTION_ANSWERING,
-                _ModelType.TEXT_SUMMARIZATION,
-                _ModelType.TEXT,
-            )
-            and not self.extra_metrics
-            and not self.builtin_metrics
+        # only log eval table if there are per row metrics recorded
+        if not any(
+            metric_value.scores is not None or metric_value.justifications is not None
+                for _, metric_value in self.metrics_values.items()
         ):
             return
+
         metric_prefix = self.evaluator_config.get("metric_prefix", "")
         if not isinstance(metric_prefix, str):
             metric_prefix = ""

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1412,10 +1412,15 @@ class DefaultEvaluator(ModelEvaluator):
             self._log_model_explainability()
 
     def _log_eval_table(self):
-        if self.model_type not in (
-            _ModelType.QUESTION_ANSWERING,
-            _ModelType.TEXT_SUMMARIZATION,
-            _ModelType.TEXT,
+        if (
+            self.model_type
+            not in (
+                _ModelType.QUESTION_ANSWERING,
+                _ModelType.TEXT_SUMMARIZATION,
+                _ModelType.TEXT,
+            )
+            and not self.extra_metrics
+            and not self.builtin_metrics
         ):
             return
         metric_prefix = self.evaluator_config.get("metric_prefix", "")

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1415,7 +1415,7 @@ class DefaultEvaluator(ModelEvaluator):
         # only log eval table if there are per row metrics recorded
         if not any(
             metric_value.scores is not None or metric_value.justifications is not None
-                for _, metric_value in self.metrics_values.items()
+            for _, metric_value in self.metrics_values.items()
         ):
             return
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2774,6 +2774,12 @@ def test_evaluate_no_model_type_with_builtin_metric():
             "perplexity/v1/variance",
             "perplexity/v1/p90",
         }
+        assert len(results.table) == 1
+        assert results.table["eval_results_table"].columns.tolist() == [
+            "text",
+            "outputs",
+            "perplexity/v1/score",
+        ]
 
 
 def test_evaluate_no_model_type_with_custom_metric():
@@ -2803,6 +2809,12 @@ def test_evaluate_no_model_type_with_custom_metric():
             "word_count/p90",
         }
         assert results.metrics["word_count/mean"] == 3.0
+        assert len(results.table) == 1
+        assert results.table["eval_results_table"].columns.tolist() == [
+            "text",
+            "outputs",
+            "word_count/score",
+        ]
 
 
 def identity_model(inputs):

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2770,7 +2770,6 @@ def test_evaluate_no_model_type_with_builtin_metric():
             "perplexity/v1/variance",
             "perplexity/v1/p90",
         }
-        # assert len(results.table) == 1
 
 
 def test_evaluate_no_model_type_with_custom_metric():
@@ -2800,4 +2799,3 @@ def test_evaluate_no_model_type_with_custom_metric():
             "word_count/p90",
         }
         assert results.metrics["word_count/mean"] == 3.0
-        # assert len(results.table) == 1

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2748,10 +2748,14 @@ def test_evaluate_no_model_type():
             artifact_path="model", python_model=language_model, input_example=["a", "b"]
         )
         data = pd.DataFrame({"text": ["Hello world", "My name is MLflow"]})
-        mlflow.evaluate(
-            model_info.model_uri,
-            data,
-        )
+        with pytest.raises(
+            MlflowException,
+            match="The extra_metrics argument must be specified model_type is None.",
+        ):
+            mlflow.evaluate(
+                model_info.model_uri,
+                data,
+            )
 
 
 def test_evaluate_no_model_type_with_builtin_metric():

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2740,3 +2740,64 @@ def test_constructing_eval_df_for_custom_metrics():
         "flesch_kincaid_grade_level/v1/score",
         "ari_grade_level/v1/score",
     ]
+
+
+def test_evaluate_no_model_type():
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            artifact_path="model", python_model=language_model, input_example=["a", "b"]
+        )
+        data = pd.DataFrame({"text": ["Hello world", "My name is MLflow"]})
+        mlflow.evaluate(
+            model_info.model_uri,
+            data,
+        )
+
+
+def test_evaluate_no_model_type_with_builtin_metric():
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            artifact_path="model", python_model=language_model, input_example=["a", "b"]
+        )
+        data = pd.DataFrame({"text": ["Hello world", "My name is MLflow"]})
+        results = mlflow.evaluate(
+            model_info.model_uri,
+            data,
+            extra_metrics=[mlflow.metrics.perplexity],
+        )
+        assert results.metrics.keys() == {
+            "perplexity/v1/mean",
+            "perplexity/v1/variance",
+            "perplexity/v1/p90",
+        }
+        # assert len(results.table) == 1
+
+
+def test_evaluate_no_model_type_with_custom_metric():
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            artifact_path="model", python_model=language_model, input_example=["a", "b"]
+        )
+        data = pd.DataFrame({"text": ["Hello world", "My name is MLflow"]})
+        from mlflow.metrics import make_metric
+        from mlflow.metrics.metric_definitions import standard_aggregations
+
+        def word_count_eval(predictions, targets, metrics):
+            scores = []
+            for prediction in predictions:
+                scores.append(len(prediction.split(" ")))
+            return MetricValue(
+                scores=scores,
+                aggregate_results=standard_aggregations(scores),
+            )
+
+        word_count = make_metric(eval_fn=word_count_eval, greater_is_better=True, name="word_count")
+
+        results = mlflow.evaluate(model_info.model_uri, data, extra_metrics=[word_count])
+        assert results.metrics.keys() == {
+            "word_count/mean",
+            "word_count/variance",
+            "word_count/p90",
+        }
+        assert results.metrics["word_count/mean"] == 3.0
+        # assert len(results.table) == 1


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Make `model_type` arg in mlflow evaluate optional. Users must provide `extra_metrics` in this case, else users should use `predict` instead of `evaluate`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
