### PR TITLE
Latency and token count via metrics

### DIFF
--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -36,6 +36,13 @@ from mlflow.models import (
     make_metric,
 )
 
+# latency is a special metric with an eval_fn that returns an empty metric value
+latency = make_metric(
+    eval_fn=lambda x: MetricValue(),
+    greater_is_better=False,
+    name="latency",
+)
+
 # general text metrics
 token_count = make_metric(
     eval_fn=_token_count_eval_fn,
@@ -374,4 +381,6 @@ __all__ = [
     "correctness",
     "relevance",
     "strict_correctness",
+    "token_count",
+    "latency",
 ]

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -44,7 +44,7 @@ latency = make_metric(
 """
 .. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
-A metric for calculating `latency`_. Latency is determined by the time it takes to generate a
+A metric for calculating latency. Latency is determined by the time it takes to generate a
 prediction for a given input. Note that computing latency requires each row to be predicted 
 sequentially, which will likely slow down the evaluation process. 
 """
@@ -58,7 +58,7 @@ token_count = make_metric(
 """
 .. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
-A metric for calculating `token_count`_. Token count is calculated using tiktoken by using the 
+A metric for calculating token_count. Token count is calculated using tiktoken by using the 
 `cl100k_base` tokenizer.
 """
 

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -36,12 +36,18 @@ from mlflow.models import (
     make_metric,
 )
 
-# latency is a special metric with an eval_fn that returns an empty metric value
 latency = make_metric(
     eval_fn=lambda x: MetricValue(),
     greater_is_better=False,
     name="latency",
 )
+"""
+.. Note:: Experimental: This metric may change or be removed in a future release without warning.
+
+A metric for calculating `latency`_. Latency is determined by the time it takes to generate a
+prediction for a given input. Note that computing latency requires each row to be predicted 
+sequentially, which will likely slow down the evaluation process. 
+"""
 
 # general text metrics
 token_count = make_metric(
@@ -50,7 +56,10 @@ token_count = make_metric(
     name="token_count",
 )
 """
-A metric for calculating `token_count`_.
+.. Note:: Experimental: This metric may change or be removed in a future release without warning.
+
+A metric for calculating `token_count`_. Token count is calculated using tiktoken by using the 
+`cl100k_base` tokenizer.
 """
 
 toxicity = make_metric(
@@ -61,7 +70,7 @@ toxicity = make_metric(
     version="v1",
 )
 """
-.. Note:: Experimental: This jmetric may change or be removed in a future release without warning.
+.. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
 A metric for evaluating `toxicity`_ using the model `roberta-hate-speech-dynabench-r4`_, 
 which defines hate as "abusive speech targeting specific group characteristics, such as 
@@ -85,7 +94,7 @@ perplexity = make_metric(
     version="v1",
 )
 """
-.. Note:: Experimental: This jmetric may change or be removed in a future release without warning.
+.. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
 A metric for evaluating `perplexity`_ using the model gpt2.
 
@@ -105,7 +114,7 @@ flesch_kincaid_grade_level = make_metric(
     version="v1",
 )
 """
-.. Note:: Experimental: This jmetric may change or be removed in a future release without warning.
+.. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
 A metric for calculating `flesch kincaid grade level`_ using `textstat`_.
     
@@ -128,7 +137,7 @@ ari_grade_level = make_metric(
     version="v1",
 )
 """
-.. Note:: Experimental: This jmetric may change or be removed in a future release without warning.
+.. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
 A metric for calculating `automated readability index`_ using `textstat`_.
     
@@ -148,7 +157,7 @@ exact_match = make_metric(
     eval_fn=_accuracy_eval_fn, greater_is_better=True, name="exact_match", version="v1"
 )
 """
-.. Note:: Experimental: This jmetric may change or be removed in a future release without warning.
+.. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
 A metric for calculating `accuracy`_ using sklearn.
 
@@ -166,7 +175,7 @@ rouge1 = make_metric(
     version="v1",
 )
 """
-.. Note:: Experimental: This jmetric may change or be removed in a future release without warning.
+.. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
 A metric for evaluating `rouge1`_.
     
@@ -186,7 +195,7 @@ rouge2 = make_metric(
     version="v1",
 )
 """
-.. Note:: Experimental: This jmetric may change or be removed in a future release without warning.
+.. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
 A metric for evaluating `rouge2`_.
     
@@ -206,7 +215,7 @@ rougeL = make_metric(
     version="v1",
 )
 """
-.. Note:: Experimental: This jmetric may change or be removed in a future release without warning.
+.. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
 A metric for evaluating `rougeL`_.
     
@@ -226,7 +235,7 @@ rougeLsum = make_metric(
     version="v1",
 )
 """
-.. Note:: Experimental: This jmetric may change or be removed in a future release without warning.
+.. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
 A metric for evaluating `rougeLsum`_.
     

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -28,6 +28,7 @@ from mlflow.metrics.metric_definitions import (
     _rouge2_eval_fn,
     _rougeL_eval_fn,
     _rougeLsum_eval_fn,
+    _token_count_eval_fn,
     _toxicity_eval_fn,
 )
 from mlflow.models import (
@@ -36,6 +37,15 @@ from mlflow.models import (
 )
 
 # general text metrics
+token_count = make_metric(
+    eval_fn=_token_count_eval_fn,
+    greater_is_better=True,
+    name="token_count",
+)
+"""
+A metric for calculating `token_count`_.
+"""
+
 toxicity = make_metric(
     eval_fn=_toxicity_eval_fn,
     greater_is_better=False,

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import numpy as np
 
@@ -29,6 +30,30 @@ def _validate_text_data(data, metric_name, column_name):
             return False
 
     return True
+
+
+def _token_count_eval_fn(predictions, targets, metrics):
+    if not _validate_text_data(predictions, "token_count", "predictions"):
+        return
+
+    import tiktoken
+
+    # ref: https://github.com/openai/tiktoken/issues/75
+    os.environ["TIKTOKEN_CACHE_DIR"] = ""
+    encoding = tiktoken.get_encoding("cl100k_base")
+
+    _logger.info("Computing token count metric:")
+
+    num_tokens = []
+    for prediction in predictions:
+        if isinstance(prediction, str):
+            num_tokens.append(encoding.encode(prediction))
+        else:
+            num_tokens.append(None)
+
+    return MetricValue(
+        scores=num_tokens,
+    )
 
 
 def _toxicity_eval_fn(predictions, targets, metrics):

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -33,9 +33,6 @@ def _validate_text_data(data, metric_name, column_name):
 
 
 def _token_count_eval_fn(predictions, targets, metrics):
-    if not _validate_text_data(predictions, "token_count", "predictions"):
-        return
-
     import tiktoken
 
     # ref: https://github.com/openai/tiktoken/issues/75

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -44,7 +44,7 @@ def _token_count_eval_fn(predictions, targets, metrics):
     num_tokens = []
     for prediction in predictions:
         if isinstance(prediction, str):
-            num_tokens.append(encoding.encode(prediction))
+            num_tokens.append(len(encoding.encode(prediction)))
         else:
             num_tokens.append(None)
 

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1289,9 +1289,6 @@ def evaluate(
           parameter will be ignored.
         - **sample_weights**: Weights for each sample to apply when computing model performance
           metrics.
-        - **compute_latency**: A boolean value specifying whether or not to compute the latency.
-          Default value is False. Note that computing latency requires each row to be predicted
-          sequentially, which will likely slow down the evaluation process.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1289,6 +1289,8 @@ def evaluate(
           parameter will be ignored.
         - **sample_weights**: Weights for each sample to apply when computing model performance
           metrics.
+        - **compute_latency**: A boolean value specifying whether or not to compute the latency.
+          Default value is False. Note that computing latency requires each row to be predicted sequentially, which will likely slow down the evaluation process.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1290,7 +1290,8 @@ def evaluate(
         - **sample_weights**: Weights for each sample to apply when computing model performance
           metrics.
         - **compute_latency**: A boolean value specifying whether or not to compute the latency.
-          Default value is False. Note that computing latency requires each row to be predicted sequentially, which will likely slow down the evaluation process.
+          Default value is False. Note that computing latency requires each row to be predicted
+          sequentially, which will likely slow down the evaluation process.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1486,7 +1486,14 @@ class DefaultEvaluator(ModelEvaluator):
             ]
 
             with mlflow.utils.autologging_utils.disable_autologging():
-                compute_latency = self.evaluator_config.get("compute_latency", False)
+                # compute the latency if a metric named latency is provided in extra_metrics, and  remove the latency metric from extra_metrics
+                compute_latency = False
+                if self.extra_metrics:
+                    for extra_metric in self.extra_metrics:
+                        if extra_metric.name == _LATENCY_METRIC_NAME:
+                            compute_latency = True
+                            self.extra_metrics.remove(extra_metric)
+                            break
                 self._generate_model_predictions(compute_latency=compute_latency)
                 if self.model_type in (_ModelType.CLASSIFIER, _ModelType.REGRESSOR):
                     self._compute_builtin_metrics()

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1352,7 +1352,7 @@ class DefaultEvaluator(ModelEvaluator):
                 for row in model_predictions:
                     num_tokens_list.append(compute_num_tokens(row))
             elif isinstance(model_predictions, pd.Series):
-                for _, row in model_predictions.iteritems():
+                for _, row in model_predictions.items():
                     num_tokens_list.append(compute_num_tokens(row))
 
             self.metrics_values.update(

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1277,15 +1277,16 @@ class DefaultEvaluator(ModelEvaluator):
                     error_code=INVALID_PARAMETER_VALUE,
                 )
 
+        X_copy = self.X.copy_to_avoid_mutation()
+        if compute_latency:
+            model_predictions = predict_with_latency(X_copy)
+        else:
+            model_predictions = self.model.predict(X_copy)
+
         if self.model_type == _ModelType.CLASSIFIER:
             self.label_list = np.unique(self.y)
             self.num_classes = len(self.label_list)
 
-            X_copy = self.X.copy_to_avoid_mutation()
-            if compute_latency:
-                model_predictions = predict_with_latency(X_copy)
-            else:
-                model_predictions = self.model.predict(X_copy)
             self.is_binomial = self.num_classes <= 2
 
             if self.is_binomial:
@@ -1310,23 +1311,6 @@ class DefaultEvaluator(ModelEvaluator):
                 self.y_probs = self.predict_proba_fn(self.X.copy_to_avoid_mutation())
             else:
                 self.y_probs = None
-        elif self.model_type in (
-            _ModelType.QUESTION_ANSWERING,
-            _ModelType.TEXT_SUMMARIZATION,
-            _ModelType.TEXT,
-        ):
-            X_copy = self.X.copy_to_avoid_mutation()
-            if compute_latency:
-                model_predictions = predict_with_latency(X_copy)
-            else:
-                model_predictions = self.model.predict(X_copy)
-
-        else:
-            X_copy = self.X.copy_to_avoid_mutation()
-            if compute_latency:
-                model_predictions = predict_with_latency(X_copy)
-            else:
-                model_predictions = self.model.predict(X_copy)
 
         output_column_name = self.evaluator_config.get(_Y_PREDICTED_OUTPUT_COLUMN_NAME, "output")
         self.y_pred, self.other_output_columns = _extract_output_and_other_columns(

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1486,10 +1486,12 @@ class DefaultEvaluator(ModelEvaluator):
             ]
 
             with mlflow.utils.autologging_utils.disable_autologging():
-                # compute the latency if a metric named latency is provided in extra_metrics, and  remove the latency metric from extra_metrics
                 compute_latency = False
                 if self.extra_metrics:
                     for extra_metric in self.extra_metrics:
+                        # If latency metric is specified, we will compute latency for the model
+                        # during prediction, and we will remove the metric from the list of extra
+                        # metrics to be computed after prediction.
                         if extra_metric.name == _LATENCY_METRIC_NAME:
                             compute_latency = True
                             self.extra_metrics.remove(extra_metric)

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1235,15 +1235,57 @@ class DefaultEvaluator(ModelEvaluator):
             )
         return
 
-    def _generate_model_predictions(self):
+    def _generate_model_predictions(self, compute_latency=False):
         """
         Helper method for generating model predictions
         """
+
+        def predict_with_latency(X_copy):
+            y_pred_list = []
+            pred_latencies = []
+            if len(X_copy) == 0:
+                raise ValueError("Empty input data")
+
+            is_dataframe = isinstance(X_copy, pd.DataFrame)
+
+            for row in X_copy.iterrows() if is_dataframe else enumerate(X_copy):
+                i, row_data = row
+                single_input = row_data.to_frame().T if is_dataframe else row_data
+                start_time = time.time()
+                y_pred = self.model.predict(single_input)
+                end_time = time.time()
+                pred_latencies.append(end_time - start_time)
+                y_pred_list.append(y_pred)
+
+            # Update latency metric
+            self.metrics_values.update({_LATENCY_METRIC_NAME: MetricValue(scores=pred_latencies)})
+
+            # Aggregate all predictions into model_predictions
+            sample_pred = y_pred_list[0]
+            if isinstance(sample_pred, pd.DataFrame):
+                return pd.concat(y_pred_list)
+            elif isinstance(sample_pred, np.ndarray):
+                return np.concatenate(y_pred_list, axis=0)
+            elif isinstance(sample_pred, list):
+                return sum(y_pred_list, [])
+            elif isinstance(sample_pred, pd.Series):
+                return pd.concat(y_pred_list)
+            else:
+                raise MlflowException(
+                    message=f"Unsupported prediction type {type(sample_pred)} for model type "
+                    f"{self.model_type}.",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+
         if self.model_type == _ModelType.CLASSIFIER:
             self.label_list = np.unique(self.y)
             self.num_classes = len(self.label_list)
 
-            model_predictions = self.predict_fn(self.X.copy_to_avoid_mutation())
+            X_copy = self.X.copy_to_avoid_mutation()
+            if compute_latency:
+                model_predictions = predict_with_latency(X_copy)
+            else:
+                model_predictions = self.model.predict(X_copy)
             self.is_binomial = self.num_classes <= 2
 
             if self.is_binomial:
@@ -1273,17 +1315,19 @@ class DefaultEvaluator(ModelEvaluator):
             _ModelType.TEXT_SUMMARIZATION,
             _ModelType.TEXT,
         ):
-            y_pred_list = []
-            pred_latencies = []
-            num_tokens_list = []
             X_copy = self.X.copy_to_avoid_mutation()
+            if compute_latency:
+                model_predictions = predict_with_latency(X_copy)
+            else:
+                model_predictions = self.model.predict(X_copy)
 
             import tiktoken
 
             # ref: https://github.com/openai/tiktoken/issues/75
             os.environ["TIKTOKEN_CACHE_DIR"] = ""
-
             encoding = tiktoken.get_encoding("cl100k_base")
+
+            num_tokens_list = []
 
             def compute_num_tokens(y_pred):
                 # parse out the output from y_pred
@@ -1299,45 +1343,19 @@ class DefaultEvaluator(ModelEvaluator):
                 else:
                     return None
 
-            if len(X_copy) == 0:
-                raise ValueError("Empty input data")
-
-            is_dataframe = isinstance(X_copy, pd.DataFrame)
-
-            for row in X_copy.iterrows() if is_dataframe else enumerate(X_copy):
-                i, row_data = row
-                single_input = row_data.to_frame().T if is_dataframe else row_data
-                start_time = time.time()
-                y_pred = self.model.predict(single_input)
-                end_time = time.time()
+            for y_pred in model_predictions:
                 num_tokens_list.append(compute_num_tokens(y_pred))
-                pred_latencies.append(end_time - start_time)
-                y_pred_list.append(y_pred)
 
-            # Aggregate all predictions into model_predictions
-            sample_pred = y_pred_list[0]
-            if isinstance(sample_pred, pd.DataFrame):
-                model_predictions = pd.concat(y_pred_list)
-            elif isinstance(sample_pred, np.ndarray):
-                model_predictions = np.concatenate(y_pred_list, axis=0)
-            elif isinstance(sample_pred, list):
-                model_predictions = sum(y_pred_list, [])
-            # handle if sample_pred is a pandas series
-            elif isinstance(sample_pred, pd.Series):
-                model_predictions = pd.concat(y_pred_list)
-            else:
-                raise MlflowException(
-                    message=f"Unsupported prediction type {type(sample_pred)} for model type "
-                    f"{self.model_type}.",
-                    error_code=INVALID_PARAMETER_VALUE,
-                )
-
-            self.metrics_values.update({_LATENCY_METRIC_NAME: MetricValue(scores=pred_latencies)})
             self.metrics_values.update(
                 {_TOKEN_COUNT_METRIC_NAME: MetricValue(scores=num_tokens_list)}
             )
+
         else:
-            model_predictions = self.model.predict(self.X.copy_to_avoid_mutation())
+            X_copy = self.X.copy_to_avoid_mutation()
+            if compute_latency:
+                model_predictions = predict_with_latency(X_copy)
+            else:
+                model_predictions = self.model.predict(X_copy)
 
         output_column_name = self.evaluator_config.get(_Y_PREDICTED_OUTPUT_COLUMN_NAME, "output")
         self.y_pred, self.other_output_columns = _extract_output_and_other_columns(

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2859,7 +2859,7 @@ def test_evaluate_with_latency():
             data,
             model_type="text",
             evaluators="default",
-            evaluator_config={"compute_latency": True},
+            extra_metrics=[mlflow.metrics.latency],
         )
 
     client = mlflow.MlflowClient()

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2480,6 +2480,8 @@ def test_evaluate_text_and_text_metrics():
             model_info.model_uri,
             data,
             model_type="text",
+            evaluators="default",
+            evaluator_config={"compute_latency": True},
         )
 
     client = mlflow.MlflowClient()

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2283,7 +2283,6 @@ def test_evaluate_question_answering_without_targets():
     assert set(results.metrics.keys()) == set(
         get_question_answering_metrics_keys(with_targets=False)
     )
-    assert False
 
 
 def validate_text_summarization_logged_data(logged_data, with_targets=True):

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2146,7 +2146,6 @@ def validate_question_answering_logged_data(logged_data, with_targets=True):
         "flesch_kincaid_grade_level/v1/score",
         "ari_grade_level/v1/score",
         "perplexity/v1/score",
-        "latency",
         "token_count",
     }
     if with_targets:
@@ -2163,7 +2162,6 @@ def validate_question_answering_logged_data(logged_data, with_targets=True):
         isinstance(grade, float) for grade in logged_data["flesch_kincaid_grade_level/v1/score"]
     )
     assert all(isinstance(grade, float) for grade in logged_data["ari_grade_level/v1/score"])
-    assert all(isinstance(grade, float) for grade in logged_data["latency"])
     assert all(isinstance(grade, int) for grade in logged_data["token_count"])
 
     if with_targets:
@@ -2259,7 +2257,7 @@ def test_evaluate_question_answering_with_numerical_targets():
     assert "eval_results_table.json" in artifacts
     logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
     pd.testing.assert_frame_equal(
-        logged_data.drop("latency", axis=1).drop("token_count", axis=1),
+        logged_data.drop("token_count", axis=1),
         data.assign(outputs=[0, 1]),
     )
     assert results.metrics == {"exact_match/v1": 1.0}
@@ -2295,7 +2293,6 @@ def validate_text_summarization_logged_data(logged_data, with_targets=True):
         "flesch_kincaid_grade_level/v1/score",
         "ari_grade_level/v1/score",
         "perplexity/v1/score",
-        "latency",
         "token_count",
     }
     if with_targets:
@@ -2319,7 +2316,6 @@ def validate_text_summarization_logged_data(logged_data, with_targets=True):
         isinstance(grade, float) for grade in logged_data["flesch_kincaid_grade_level/v1/score"]
     )
     assert all(isinstance(grade, float) for grade in logged_data["ari_grade_level/v1/score"])
-    assert all(isinstance(grade, float) for grade in logged_data["latency"])
     assert all(isinstance(grade, int) for grade in logged_data["token_count"])
 
     if with_targets:
@@ -2462,7 +2458,6 @@ def test_evaluate_text_summarization_fails_to_load_evaluate_metrics():
         "outputs",
         "flesch_kincaid_grade_level/v1/score",
         "ari_grade_level/v1/score",
-        "latency",
         "token_count",
     }
     assert logged_data["text"].tolist() == ["a", "b"]
@@ -2480,8 +2475,6 @@ def test_evaluate_text_and_text_metrics():
             model_info.model_uri,
             data,
             model_type="text",
-            evaluators="default",
-            evaluator_config={"compute_latency": True},
         )
 
     client = mlflow.MlflowClient()
@@ -2495,7 +2488,6 @@ def test_evaluate_text_and_text_metrics():
         "flesch_kincaid_grade_level/v1/score",
         "ari_grade_level/v1/score",
         "perplexity/v1/score",
-        "latency",
         "token_count",
     }
     assert logged_data["text"].tolist() == ["sentence not", "All women are bad."]
@@ -2735,7 +2727,6 @@ def test_constructing_eval_df_for_custom_metrics():
         "truth",
         "targets",
         "outputs",
-        "latency",
         "token_count",
         "toxicity/v1/score",
         "perplexity/v1/score",
@@ -2780,3 +2771,34 @@ def test_default_metrics_as_custom_metrics():
         for measure in ["mean", "p90", "variance"]:
             assert f"{metric}/v1/{measure}" in results.metrics.keys()
     assert "exact_match/v1" in results.metrics.keys()
+
+
+def test_evaluate_with_latency():
+    with mlflow.start_run() as run:
+        model_info = mlflow.pyfunc.log_model(
+            artifact_path="model", python_model=language_model, input_example=["a", "b"]
+        )
+        data = pd.DataFrame({"text": ["sentence not", "All women are bad."]})
+        results = mlflow.evaluate(
+            model_info.model_uri,
+            data,
+            model_type="text",
+            evaluators="default",
+            evaluator_config={"compute_latency": True},
+        )
+
+    client = mlflow.MlflowClient()
+    artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
+    assert "eval_results_table.json" in artifacts
+    logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
+    assert set(logged_data.columns.tolist()) == {
+        "text",
+        "outputs",
+        "toxicity/v1/score",
+        "flesch_kincaid_grade_level/v1/score",
+        "ari_grade_level/v1/score",
+        "perplexity/v1/score",
+        "latency",
+        "token_count",
+    }
+    assert all(isinstance(grade, float) for grade in logged_data["latency"])

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2283,6 +2283,7 @@ def test_evaluate_question_answering_without_targets():
     assert set(results.metrics.keys()) == set(
         get_question_answering_metrics_keys(with_targets=False)
     )
+    assert False
 
 
 def validate_text_summarization_logged_data(logged_data, with_targets=True):

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2581,7 +2581,6 @@ def test_eval_results_table_json_can_be_prefixed_with_metric_prefix(metric_prefi
         f"{metric_prefix}flesch_kincaid_grade_level/v1/score",
         f"{metric_prefix}ari_grade_level/v1/score",
         f"{metric_prefix}perplexity/v1/score",
-        f"{metric_prefix}latency",
         f"{metric_prefix}token_count",
     }
 


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Remove latency calculation by default for model type question-answering, summarization-text in `mlflow.evaluate`. Instead users can opt-in to latency calculation by passing in `mlflow.metrics.latency` to `extra_metrics`. Additionally, we move the token count calculation to metrics. This is available via `mlflow.metrics.token_count`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
