### PR TITLE
Fix `eval_results_table.json` saving path

### DIFF
--- a/mlflow/utils/promptlab_utils.py
+++ b/mlflow/utils/promptlab_utils.py
@@ -101,6 +101,7 @@ def _create_promptlab_run_impl(
         from mlflow._promptlab import save_model
         from mlflow.server.handlers import (
             _get_artifact_repo_mlflow_artifacts,
+            _get_proxied_run_artifact_destination_path,
             _is_servable_proxied_run_artifact_root,
         )
 
@@ -129,12 +130,10 @@ def _create_promptlab_run_impl(
 
             if _is_servable_proxied_run_artifact_root(run.info.artifact_uri):
                 artifact_repo = _get_artifact_repo_mlflow_artifacts()
-                artifact_repo.log_artifacts(
-                    local_dir,
-                    artifact_path=os.path.join(
-                        run.info.experiment_id, run.info.run_id, "artifacts"
-                    ),
+                artifact_path = _get_proxied_run_artifact_destination_path(
+                    proxied_artifact_root=run.info.artifact_uri,
                 )
+                artifact_repo.log_artifacts(local_dir, artifact_path=artifact_path)
             else:
                 artifact_repo = get_artifact_repository(artifact_dir)
                 artifact_repo.log_artifacts(local_dir)


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/9901?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Close #9752

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix `eval_results_table.json` saving path.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Before:

https://github.com/mlflow/mlflow/assets/17039389/19ed5312-4a14-43fe-8434-830ac2012055

After:

https://github.com/mlflow/mlflow/assets/17039389/1209d134-1387-406e-834d-a198e899d73f

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
