### PR TITLE
Added dash to gitlab URL

### DIFF
--- a/mlflow/server/js/src/common/utils/Utils.test.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.test.tsx
@@ -325,7 +325,7 @@ test('formatSource & renderSource', () => {
     'mlflow.source.type': { value: 'PROJECT' },
     'mlflow.project.entryPoint': { value: 'entry' },
   };
-  expect(Utils.formatSource(gitlab_long_url)).toEqual('mlflow-apps#tmp:entry');
+  expect(Utils.formatSource(gitlab_long_url)).toEqual('mlflow-apps:entry');
   // @ts-expect-error TS(2554): Expected 3 arguments, but got 1.
   expect(Utils.renderSource(gitlab_long_url)).toEqual(
     <a href='https://gitlab.com/mlflow/mlflow-apps/-/tree/master/tmp' target='_top'>

--- a/mlflow/server/js/src/common/utils/Utils.test.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.test.tsx
@@ -321,14 +321,14 @@ test('formatSource & renderSource', () => {
   );
 
   const gitlab_long_url = {
-    'mlflow.source.name': { value: 'git@gitlab.com:mlflow/mlflow-apps.git#hello.py' },
+    'mlflow.source.name': { value: 'git@gitlab.com:mlflow/mlflow-apps.git#tmp' },
     'mlflow.source.type': { value: 'PROJECT' },
     'mlflow.project.entryPoint': { value: 'entry' },
   };
-  expect(Utils.formatSource(gitlab_long_url)).toEqual('mlflow-apps:entry');
+  expect(Utils.formatSource(gitlab_long_url)).toEqual('mlflow-apps#tmp:entry');
   // @ts-expect-error TS(2554): Expected 3 arguments, but got 1.
   expect(Utils.renderSource(gitlab_long_url)).toEqual(
-    <a href='https://gitlab.com/mlflow/mlflow-apps/-/tree/master/hello.py' target='_top'>
+    <a href='https://gitlab.com/mlflow/mlflow-apps/-/tree/master/tmp' target='_top'>
       mlflow-apps:entry
     </a>,
   );

--- a/mlflow/server/js/src/common/utils/Utils.test.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.test.tsx
@@ -320,6 +320,19 @@ test('formatSource & renderSource', () => {
     </a>,
   );
 
+  const gitlab_long_url = {
+    'mlflow.source.name': { value: 'git@gitlab.com:mlflow/mlflow-apps.git#hello.py' },
+    'mlflow.source.type': { value: 'PROJECT' },
+    'mlflow.project.entryPoint': { value: 'entry' },
+  };
+  expect(Utils.formatSource(gitlab_long_url)).toEqual('mlflow-apps:entry');
+  // @ts-expect-error TS(2554): Expected 3 arguments, but got 1.
+  expect(Utils.renderSource(gitlab_long_url)).toEqual(
+    <a href='https://gitlab.com/mlflow/mlflow-apps/-/tree/master/hello.py' target='_top'>
+      mlflow-apps:entry
+    </a>,
+  );
+
   const bitbucket_url = {
     'mlflow.source.name': { value: 'git@bitbucket.org:mlflow/mlflow-apps.git' },
     'mlflow.source.type': { value: 'PROJECT' },
@@ -470,6 +483,50 @@ test('getGitHubRegex', () => {
   urlAndExpected.forEach((lst) => {
     const url = lst[0];
     const match = (url as any).match(gitHubRegex);
+    if (match) {
+      match[2] = match[2].replace(/.git/, '');
+    }
+    expect([].concat(match)).toEqual(lst[1]);
+  });
+});
+
+test('getGitLabRegex', () => {
+  const gitLabRegex = Utils.getGitLabRegex();
+  const urlAndExpected = [
+    [
+      'http://gitlab.com/mlflow/mlflow-apps',
+      ['/gitlab.com/mlflow/mlflow-apps', 'mlflow', 'mlflow-apps', ''],
+    ],
+    [
+      'https://gitlab.com/mlflow/mlflow-apps',
+      ['/gitlab.com/mlflow/mlflow-apps', 'mlflow', 'mlflow-apps', ''],
+    ],
+    [
+      'http://gitlab.com/mlflow/mlflow-apps.git',
+      ['/gitlab.com/mlflow/mlflow-apps.git', 'mlflow', 'mlflow-apps', ''],
+    ],
+    [
+      'https://gitlab.com/mlflow/mlflow-apps.git',
+      ['/gitlab.com/mlflow/mlflow-apps.git', 'mlflow', 'mlflow-apps', ''],
+    ],
+    [
+      'https://gitlab.com/mlflow/mlflow#example/tutorial',
+      ['/gitlab.com/mlflow/mlflow#example/tutorial', 'mlflow', 'mlflow', 'example/tutorial'],
+    ],
+    [
+      'https://gitlab.com/username/repo.name#mlproject',
+      ['/gitlab.com/username/repo.name#mlproject', 'username', 'repo.name', 'mlproject'],
+    ],
+    [
+      'git@gitlab.com:mlflow/mlflow-apps.git',
+      ['@gitlab.com:mlflow/mlflow-apps.git', 'mlflow', 'mlflow-apps', ''],
+    ],
+    ['https://some-other-site.com?q=gitlab.com/mlflow/mlflow-apps.git', [null]],
+    ['ssh@some-server:mlflow/mlflow-apps.git', [null]],
+  ];
+  urlAndExpected.forEach((lst) => {
+    const url = lst[0];
+    const match = (url as any).match(gitLabRegex);
     if (match) {
       match[2] = match[2].replace(/.git/, '');
     }

--- a/mlflow/server/js/src/common/utils/Utils.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.tsx
@@ -279,23 +279,23 @@ class Utils {
     if (gitHubMatch) {
       url = `https://github.com/${gitHubMatch[1]}/${gitHubMatch[2].replace(/.git/, '')}`;
       if (gitHubMatch[3]) {
-        url = url + `/tree/master/${gitHubMatch[3]}`;
+        url += `/tree/master/${gitHubMatch[3]}`;
       }
     } else if (gitLabMatch) {
       url = `https://gitlab.com/${gitLabMatch[1]}/${gitLabMatch[2].replace(/.git/, '')}`;
       if (gitLabMatch[3]) {
-        url = url + `/-/tree/master${gitLabMatch[3]}`;
+        url += `/-/tree/master${gitLabMatch[3]}`;
       }
     } else if (bitbucketMatch) {
       url = `https://bitbucket.org/${bitbucketMatch[1]}/${bitbucketMatch[2].replace(/.git/, '')}`;
       if (bitbucketMatch[3]) {
-        url = url + `/src/master/${bitbucketMatch[3]}`;
+        url += `/src/master/${bitbucketMatch[3]}`;
       }
     } else if (gitMatch) {
       const [, baseUrl, repoDir, fileDir] = gitMatch;
       url = baseUrl.replace(/git@/, 'https://') + '/' + repoDir.replace(/.git/, '');
       if (fileDir) {
-        url = url + `/tree/master/${fileDir}`;
+        url += `/tree/master/${fileDir}`;
       }
     }
     return url;

--- a/mlflow/server/js/src/common/utils/Utils.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.tsx
@@ -248,6 +248,7 @@ class Utils {
   }
 
   static getGitHubRegex() {
+    // 
     return /[@/]github.com[:/]([^/.]+)\/([^/#]+)#?(.*)/;
   }
 
@@ -279,7 +280,11 @@ class Utils {
     if (gitHubMatch || gitLabMatch) {
       const baseUrl = gitHubMatch ? 'https://github.com/' : 'https://gitlab.com/';
       const match = gitHubMatch || gitLabMatch;
-      url = baseUrl + match[1] + '/' + match[2].replace(/.git/, '');
+      if (gitHubMatch) {
+        url = baseUrl + match[1] + '/' + match[2].replace(/.git/, '');
+      } else {
+        url = baseUrl + match[1] + '/-/' + match[2].replace(/.git/, '');
+      }
       if (match[3]) {
         url = url + '/tree/master/' + match[3];
       }

--- a/mlflow/server/js/src/common/utils/Utils.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.tsx
@@ -277,26 +277,25 @@ class Utils {
     const gitMatch = sourceName.match(Utils.getGitRegex());
     let url = null;
     if (gitHubMatch) {
-      url = 'https://github.com/' + gitHubMatch[1] + '/' + gitHubMatch[2].replace(/.git/, '');
+      url = `https://github.com/${gitHubMatch[1]}/${gitHubMatch[2].replace(/.git/, '')}`;
       if (gitHubMatch[3]) {
-        url = url + '/tree/master/' + gitHubMatch[3];
+        url = url + `/tree/master/${gitHubMatch[3]}`;
       }
     } else if (gitLabMatch) {
-      url = 'https://gitlab.com/' + gitLabMatch[1] + '/' + gitLabMatch[2].replace(/.git/, '');
+      url = `https://gitlab.com/${gitLabMatch[1]}/${gitLabMatch[2].replace(/.git/, '')}`;
       if (gitLabMatch[3]) {
-        url = url + '/-/tree/master' + gitLabMatch[3];
+        url = url + `/-/tree/master${gitLabMatch[3]}`;
       }
     } else if (bitbucketMatch) {
-      const baseUrl = 'https://bitbucket.org/';
-      url = baseUrl + bitbucketMatch[1] + '/' + bitbucketMatch[2].replace(/.git/, '');
+      url = `https://bitbucket.org/${bitbucketMatch[1]}/${bitbucketMatch[2].replace(/.git/, '')}`;
       if (bitbucketMatch[3]) {
-        url = url + '/src/master/' + bitbucketMatch[3];
+        url = url + `/src/master/${bitbucketMatch[3]}`;
       }
     } else if (gitMatch) {
       const [, baseUrl, repoDir, fileDir] = gitMatch;
       url = baseUrl.replace(/git@/, 'https://') + '/' + repoDir.replace(/.git/, '');
       if (fileDir) {
-        url = url + '/tree/master/' + fileDir;
+        url = url + `/tree/master/${fileDir}`;
       }
     }
     return url;
@@ -309,46 +308,18 @@ class Utils {
     const gitMatch = sourceName.match(Utils.getGitRegex());
     let url = null;
     if (gitHubMatch) {
-      url =
-        'https://github.com/' +
-        gitHubMatch[1] +
-        '/' +
-        gitHubMatch[2].replace(/.git/, '') +
-        '/tree/' +
-        sourceVersion +
-        '/' +
-        gitHubMatch[3];
+      url = `https://github.com/${gitHubMatch[1]}/${gitHubMatch[2].replace(/.git/, '')}\
+      /tree/${sourceVersion}/${gitHubMatch[3]}`;
     } else if (gitLabMatch) {
-      url =
-        'https://gitlab.com/' +
-        gitLabMatch[1] +
-        '/' +
-        gitLabMatch[2].replace(/.git/, '') +
-        '/-/tree/' +
-        sourceVersion +
-        '/' +
-        gitLabMatch[3];
+      url = `https://gitlab.com/${gitLabMatch[1]}/${gitLabMatch[2].replace(/.git/, '')}\
+      /-/tree/${sourceVersion}/${gitLabMatch[3]}`;
     } else if (bitbucketMatch) {
-      const baseUrl = 'https://bitbucket.org/';
-      url =
-        baseUrl +
-        bitbucketMatch[1] +
-        '/' +
-        bitbucketMatch[2].replace(/.git/, '') +
-        '/src/' +
-        sourceVersion +
-        '/' +
-        bitbucketMatch[3];
+      url = `https://bitbucket.org/${bitbucketMatch[1]}/${bitbucketMatch[2].replace(/.git/, '')}\
+      /src/${sourceVersion}/${bitbucketMatch[3]}`;
     } else if (gitMatch) {
       const [, baseUrl, repoDir, fileDir] = gitMatch;
-      url =
-        baseUrl.replace(/git@/, 'https://') +
-        '/' +
-        repoDir.replace(/.git/, '') +
-        '/tree/' +
-        sourceVersion +
-        '/' +
-        fileDir;
+      url = `${baseUrl.replace(/git@/, 'https://')}/${repoDir.replace(/.git/, '')}\
+      /tree/${sourceVersion}/${fileDir}`;
     }
     return url;
   }

--- a/mlflow/server/js/src/common/utils/Utils.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.tsx
@@ -284,7 +284,7 @@ class Utils {
     } else if (gitLabMatch) {
       url = `https://gitlab.com/${gitLabMatch[1]}/${gitLabMatch[2].replace(/.git/, '')}`;
       if (gitLabMatch[3]) {
-        url += `/-/tree/master${gitLabMatch[3]}`;
+        url += `/-/tree/master/${gitLabMatch[3]}`;
       }
     } else if (bitbucketMatch) {
       url = `https://bitbucket.org/${bitbucketMatch[1]}/${bitbucketMatch[2].replace(/.git/, '')}`;

--- a/mlflow/server/js/src/common/utils/Utils.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.tsx
@@ -248,7 +248,6 @@ class Utils {
   }
 
   static getGitHubRegex() {
-    // 
     return /[@/]github.com[:/]([^/.]+)\/([^/#]+)#?(.*)/;
   }
 
@@ -283,6 +282,7 @@ class Utils {
       if (gitHubMatch) {
         url = baseUrl + match[1] + '/' + match[2].replace(/.git/, '');
       } else {
+        //[ML-35426] GitLab has a dash in its URL
         url = baseUrl + match[1] + '/-/' + match[2].replace(/.git/, '');
       }
       if (match[3]) {

--- a/mlflow/server/js/src/common/utils/Utils.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.tsx
@@ -276,17 +276,15 @@ class Utils {
     const bitbucketMatch = sourceName.match(Utils.getBitbucketRegex());
     const gitMatch = sourceName.match(Utils.getGitRegex());
     let url = null;
-    if (gitHubMatch || gitLabMatch) {
-      const baseUrl = gitHubMatch ? 'https://github.com/' : 'https://gitlab.com/';
-      const match = gitHubMatch || gitLabMatch;
-      if (gitHubMatch) {
-        url = baseUrl + match[1] + '/' + match[2].replace(/.git/, '');
-      } else {
-        //[ML-35426] GitLab has a dash in its URL
-        url = baseUrl + match[1] + '/-/' + match[2].replace(/.git/, '');
+    if (gitHubMatch) {
+      url = 'https://github.com/' + gitHubMatch[1] + '/' + gitHubMatch[2].replace(/.git/, '');
+      if (gitHubMatch[3]) {
+        url = url + '/tree/master/' + gitHubMatch[3];
       }
-      if (match[3]) {
-        url = url + '/tree/master/' + match[3];
+    } else if (gitLabMatch) {
+      url = 'https://gitlab.com/' + gitLabMatch[1] + '/' + gitLabMatch[2].replace(/.git/, '');
+      if (gitLabMatch[3]) {
+        url = url + '/-/tree/master' + gitLabMatch[3];
       }
     } else if (bitbucketMatch) {
       const baseUrl = 'https://bitbucket.org/';
@@ -310,18 +308,26 @@ class Utils {
     const bitbucketMatch = sourceName.match(Utils.getBitbucketRegex());
     const gitMatch = sourceName.match(Utils.getGitRegex());
     let url = null;
-    if (gitHubMatch || gitLabMatch) {
-      const baseUrl = gitHubMatch ? 'https://github.com/' : 'https://gitlab.com/';
-      const match = gitHubMatch || gitLabMatch;
+    if (gitHubMatch) {
       url =
-        baseUrl +
-        match[1] +
+        'https://github.com/' +
+        gitHubMatch[1] +
         '/' +
-        match[2].replace(/.git/, '') +
+        gitHubMatch[2].replace(/.git/, '') +
         '/tree/' +
         sourceVersion +
         '/' +
-        match[3];
+        gitHubMatch[3];
+    } else if (gitLabMatch) {
+      url =
+        'https://gitlab.com/' +
+        gitLabMatch[1] +
+        '/' +
+        gitLabMatch[2].replace(/.git/, '') +
+        '/-/tree/' +
+        sourceVersion +
+        '/' +
+        gitLabMatch[3];
     } else if (bitbucketMatch) {
       const baseUrl = 'https://bitbucket.org/';
       url =


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jessechancy/mlflow/pull/9906?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Added dash to GitLab URL construction

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
