### PR TITLE
DBConnect support for `spark_udf`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -296,7 +296,7 @@ jobs:
       - name: Install dependencies
         run: |
           source ./dev/install-common-deps.sh
-          pip install tensorflow pyspark
+          pip install tensorflow 'pyspark[connect]'
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -301,7 +301,10 @@ jobs:
       - name: Run tests
         run: |
           export MLFLOW_HOME=$(pwd)
-          pytest --durations=30 tests/pyfunc
+          pytest --durations=30 tests/pyfunc --ignore tests/pyfunc/test_spark_connect.py
+
+          # test_spark_connect.py fails if it's run with ohter tests, so run it separately.
+          pytest tests/pyfunc/test_spark_connect.py
 
   sagemaker:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false

--- a/examples/databricks/dbconnect.py
+++ b/examples/databricks/dbconnect.py
@@ -1,21 +1,10 @@
 """
-python examples/databricks/dbconnect.py [--mlflow-req ]
+python examples/databricks/dbconnect.py --cluster-id abc
 """
 import argparse
-import contextlib
-import time
-import uuid
-from typing import Generator
 
 from databricks.connect import DatabricksSession
 from databricks.sdk import WorkspaceClient
-from databricks.sdk.service.compute import (
-    ClusterDetails,
-    DataSecurityMode,
-    Library,
-    LibraryFullStatusStatus,
-    PythonPyPiLibrary,
-)
 from pyspark.sql.types import DoubleType
 from sklearn import datasets
 from sklearn.neighbors import KNeighborsClassifier
@@ -24,64 +13,15 @@ import mlflow
 from mlflow.models import infer_signature
 
 
-@contextlib.contextmanager
-def start_cluster(
-    cluster_name: str, wc: WorkspaceClient, mlflow_req: str
-) -> Generator[ClusterDetails, None, None]:
-    cluster = None
-    try:
-        print("Creating new cluster (this may take a few minutes)...")
-        cluster = wc.clusters.create_and_wait(
-            cluster_name=cluster_name,
-            spark_version="13.2.x-scala2.12",
-            num_workers=1,
-            node_type_id="i3.xlarge",
-            autotermination_minutes=10,
-            custom_tags={"PythonUDF.enabled": "true"},
-        )
-        print("Installing mlflow...")
-        wc.libraries.install(
-            cluster_id=cluster.cluster_id,
-            libraries=[Library(pypi=PythonPyPiLibrary(mlflow_req))],
-        )
-        # clusters-create doesn't support data_security_mode, but clusters-edit does
-        print("Updating access mode (this may take a few minutes)...")
-        wc.clusters.edit_and_wait(
-            cluster_name=cluster.cluster_name,
-            cluster_id=cluster.cluster_id,
-            spark_version=cluster.spark_version,
-            node_type_id=cluster.node_type_id,
-            num_workers=cluster.num_workers,
-            autotermination_minutes=cluster.autotermination_minutes,
-            custom_tags=cluster.custom_tags,
-            data_security_mode=DataSecurityMode.SINGLE_USER,
-            single_user_name=cluster.creator_user_name,
-        )
-        for _ in range(30):
-            resp = wc.libraries.cluster_status(cluster_id=cluster.cluster_id)
-            if any(ls.status == LibraryFullStatusStatus.INSTALLED for ls in resp.library_statuses):
-                break
-            print("Waiting for mlflow to be installed...")
-            time.sleep(10)
-        else:
-            raise RuntimeError("Failed to install mlflow")
-
-        print("Cluster is ready")
-        yield cluster.cluster_id
-    finally:
-        if cluster:
-            print("Deleting cluster...")
-            wc.clusters.delete_and_wait(cluster_id=cluster.cluster_id)
-
-
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--mlflow-req", default="mlflow")
+    parser.add_argument("--cluster-id", required=True)
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
+    wc = WorkspaceClient()
 
     # Train a model
     X, y = datasets.load_iris(as_frame=True, return_X_y=True)
@@ -91,29 +31,24 @@ def main() -> None:
 
     # Log the model
     mlflow.set_tracking_uri("databricks")
-    wc = WorkspaceClient()
     mlflow.set_experiment(f"/Users/{wc.current_user.me().user_name}/dbconnect")
     with mlflow.start_run():
         model_info = mlflow.sklearn.log_model(model, "model", signature=signature)
 
-    # Make predictions
-    with start_cluster(
-        cluster_name=f"cluster-{uuid.uuid4().hex}", wc=wc, mlflow_req=args.mlflow_req
-    ) as cluster_id:
-        spark = DatabricksSession.builder.remote(
-            host=wc.config.host,
-            token=wc.config.token,
-            cluster_id=cluster_id,
-        ).getOrCreate()
-        sdf = spark.createDataFrame(X.head(5))
-        pyfunc_udf = mlflow.pyfunc.spark_udf(
-            spark,
-            model_info.model_uri,
-            env_manager="local",
-            result_type=DoubleType(),
-        )
-        result = sdf.select(pyfunc_udf(*X.columns).alias("preds"))
-        result.show()
+    spark = DatabricksSession.builder.remote(
+        host=wc.config.host,
+        token=wc.config.token,
+        cluster_id=args.cluster_id,
+    ).getOrCreate()
+    sdf = spark.createDataFrame(X.head(5))
+    pyfunc_udf = mlflow.pyfunc.spark_udf(
+        spark,
+        model_info.model_uri,
+        env_manager="local",
+        result_type=DoubleType(),
+    )
+    preds = sdf.select(pyfunc_udf(*X.columns).alias("preds"))
+    preds.show()
 
 
 if __name__ == "__main__":

--- a/examples/databricks/dbconnect.py
+++ b/examples/databricks/dbconnect.py
@@ -1,5 +1,5 @@
 """
-python examples/databricks/dbconnect.py --cluster-id abc
+python examples/databricks/dbconnect.py --cluster-id <cluster-id>
 """
 import argparse
 

--- a/examples/databricks/dbconnect.py
+++ b/examples/databricks/dbconnect.py
@@ -1,0 +1,120 @@
+"""
+python examples/databricks/dbconnect.py [--mlflow-req ]
+"""
+import argparse
+import contextlib
+import time
+import uuid
+from typing import Generator
+
+from databricks.connect import DatabricksSession
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.compute import (
+    ClusterDetails,
+    DataSecurityMode,
+    Library,
+    LibraryFullStatusStatus,
+    PythonPyPiLibrary,
+)
+from pyspark.sql.types import DoubleType
+from sklearn import datasets
+from sklearn.neighbors import KNeighborsClassifier
+
+import mlflow
+from mlflow.models import infer_signature
+
+
+@contextlib.contextmanager
+def start_cluster(
+    cluster_name: str, wc: WorkspaceClient, mlflow_req: str
+) -> Generator[ClusterDetails, None, None]:
+    cluster = None
+    try:
+        print("Creating new cluster (this may take a few minutes)...")
+        cluster = wc.clusters.create_and_wait(
+            cluster_name=cluster_name,
+            spark_version="13.2.x-scala2.12",
+            num_workers=1,
+            node_type_id="i3.xlarge",
+            autotermination_minutes=10,
+            custom_tags={"PythonUDF.enabled": "true"},
+        )
+        print("Installing mlflow...")
+        wc.libraries.install(
+            cluster_id=cluster.cluster_id,
+            libraries=[Library(pypi=PythonPyPiLibrary(mlflow_req))],
+        )
+        # clusters-create doesn't support data_security_mode, but clusters-edit does
+        print("Updating access mode (this may take a few minutes)...")
+        wc.clusters.edit_and_wait(
+            cluster_name=cluster.cluster_name,
+            cluster_id=cluster.cluster_id,
+            spark_version=cluster.spark_version,
+            node_type_id=cluster.node_type_id,
+            num_workers=cluster.num_workers,
+            autotermination_minutes=cluster.autotermination_minutes,
+            custom_tags=cluster.custom_tags,
+            data_security_mode=DataSecurityMode.SINGLE_USER,
+            single_user_name=cluster.creator_user_name,
+        )
+        for _ in range(30):
+            resp = wc.libraries.cluster_status(cluster_id=cluster.cluster_id)
+            if any(ls.status == LibraryFullStatusStatus.INSTALLED for ls in resp.library_statuses):
+                break
+            print("Waiting for mlflow to be installed...")
+            time.sleep(10)
+        else:
+            raise RuntimeError("Failed to install mlflow")
+
+        print("Cluster is ready")
+        yield cluster.cluster_id
+    finally:
+        if cluster:
+            print("Deleting cluster...")
+            wc.clusters.delete_and_wait(cluster_id=cluster.cluster_id)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mlflow-req", default="mlflow")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    # Train a model
+    X, y = datasets.load_iris(as_frame=True, return_X_y=True)
+    model = KNeighborsClassifier().fit(X, y)
+    predictions = model.predict(X)
+    signature = infer_signature(X, predictions)
+
+    # Log the model
+    mlflow.set_tracking_uri("databricks")
+    wc = WorkspaceClient()
+    mlflow.set_experiment(f"/Users/{wc.current_user.me().user_name}/dbconnect")
+    with mlflow.start_run():
+        model_info = mlflow.sklearn.log_model(model, "model", signature=signature)
+
+    # Make predictions
+    with start_cluster(
+        cluster_name=f"cluster-{uuid.uuid4().hex}", wc=wc, mlflow_req=args.mlflow_req
+    ) as cluster_id:
+        spark = DatabricksSession.builder.remote(
+            host=wc.config.host,
+            token=wc.config.token,
+            cluster_id=cluster_id,
+        ).getOrCreate()
+        sdf = spark.createDataFrame(X.head(5))
+        pyfunc_udf = mlflow.pyfunc.spark_udf(
+            spark,
+            model_info.model_uri,
+            env_manager="local",
+            result_type=DoubleType(),
+        )
+        result = sdf.select(pyfunc_udf(*X.columns).alias("preds"))
+        result.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1238,7 +1238,7 @@ def spark_udf(
     is_spark_connect = _is_spark_connect()
     if is_spark_connect and env_manager in (_EnvManager.VIRTUALENV, _EnvManager.CONDA):
         raise MlflowException.invalid_parameter_value(
-            f"Environment manager {env_manager!r} is not supported for Spark Connect",
+            f"Environment manager {env_manager!r} is not supported in Spark connect mode.",
         )
     # Used in test to force install local version of mlflow when starting a model server
     mlflow_home = os.environ.get("MLFLOW_HOME")

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -209,6 +209,7 @@ You may prefer the second, lower-level workflow for the following reasons:
 
 import collections
 import functools
+import hashlib
 import importlib
 import inspect
 import logging
@@ -1090,6 +1091,14 @@ def _check_udf_return_type(data_type):
     return False
 
 
+def _is_spark_connect():
+    try:
+        from pyspark.sql.utils import is_remote
+    except ImportError:
+        return False
+    return is_remote()
+
+
 def spark_udf(
     spark,
     model_uri,
@@ -1226,6 +1235,11 @@ def spark_udf(
     from mlflow.pyfunc.spark_model_cache import SparkModelCache
     from mlflow.utils._spark_utils import _SparkDirectoryDistributor
 
+    is_spark_connect = _is_spark_connect()
+    if is_spark_connect and env_manager in (_EnvManager.VIRTUALENV, _EnvManager.CONDA):
+        raise MlflowException.invalid_parameter_value(
+            f"Environment manager {env_manager!r} is not supported for Spark Connect",
+        )
     # Used in test to force install local version of mlflow when starting a model server
     mlflow_home = os.environ.get("MLFLOW_HOME")
     openai_env_vars = mlflow.openai._OpenAIEnvVar.read_environ()
@@ -1239,7 +1253,9 @@ def spark_udf(
 
     nfs_root_dir = get_nfs_cache_root_dir()
     should_use_nfs = nfs_root_dir is not None
-    should_use_spark_to_broadcast_file = not (is_spark_in_local_mode or should_use_nfs)
+    should_use_spark_to_broadcast_file = not (
+        is_spark_in_local_mode or should_use_nfs or is_spark_connect
+    )
 
     local_model_path = _download_artifact_from_uri(
         artifact_uri=model_uri,
@@ -1556,7 +1572,18 @@ Compound types:
                 return client.invoke(pdf).get_predictions()
 
         elif env_manager == _EnvManager.LOCAL:
-            if should_use_spark_to_broadcast_file:
+            if is_spark_connect:
+                model_path = os.path.join(
+                    tempfile.gettempdir(),
+                    "mlflow",
+                    hashlib.sha1(model_uri.encode()).hexdigest(),
+                )
+                try:
+                    loaded_model = mlflow.pyfunc.load_model(model_path)
+                except Exception:
+                    os.makedirs(model_path, exist_ok=True)
+                    loaded_model = mlflow.pyfunc.load_model(model_uri, dst_path=model_path)
+            elif should_use_spark_to_broadcast_file:
                 loaded_model, _ = SparkModelCache.get_or_load(archive_path)
             else:
                 loaded_model = mlflow.pyfunc.load_model(local_model_path)

--- a/tests/pyfunc/test_spark_connect.py
+++ b/tests/pyfunc/test_spark_connect.py
@@ -1,0 +1,43 @@
+import numpy as np
+import pandas as pd
+import pyspark
+import pytest
+from pyspark.sql import SparkSession
+from sklearn.datasets import load_iris
+from sklearn.linear_model import LogisticRegression
+
+import mlflow
+
+
+@pytest.fixture(scope="module")
+def spark():
+    spark = (
+        SparkSession.builder.remote("local[2]")
+        .config(
+            # The jars for spark-connect are not bundled in the pyspark package
+            "spark.jars.packages",
+            f"org.apache.spark:spark-connect_2.12:{pyspark.__version__}",
+        )
+        .getOrCreate()
+    )
+    yield spark
+    spark.stop()
+
+
+def test_spark_udf_spark_connect(spark, tmp_path):
+    X, y = load_iris(return_X_y=True)
+    model = LogisticRegression().fit(X, y)
+    mlflow.sklearn.save_model(model, tmp_path)
+    sdf = spark.createDataFrame(pd.DataFrame(X, columns=list("abcd")))
+    udf = mlflow.pyfunc.spark_udf(spark, str(tmp_path), env_manager="local")
+    result = sdf.select(udf(*sdf.columns).alias("preds")).toPandas()
+    np.testing.assert_almost_equal(result["preds"].to_numpy(), model.predict(X))
+
+
+@pytest.mark.parametrize("env_manager", ["conda", "virtualenv"])
+def test_spark_udf_spark_connect_unsupported_env_manager(spark, tmp_path, env_manager):
+    with pytest.raises(
+        mlflow.MlflowException,
+        match=f"Environment manager {env_manager!r} is not supported",
+    ):
+        mlflow.pyfunc.spark_udf(spark, str(tmp_path), env_manager=env_manager)


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/9910?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

#9024

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
