### PR TITLE
Include input/output schema in error message

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1145,6 +1145,7 @@ class DefaultEvaluator(ModelEvaluator):
                         output_columns = [output_column_name]
                         if self.other_output_columns is not None:
                             output_columns.extend(self.other_output_columns.columns)
+                        input_columns = list(input_df.columns)
                         raise MlflowException(
                             "Error: Metric Calculation Failed\n"
                             f"Metric '{extra_metric.name}' requires the column '{param_name}' to "
@@ -1152,7 +1153,7 @@ class DefaultEvaluator(ModelEvaluator):
                             f"To resolve this issue, you may want to map {param_name} to an "
                             "existing column using the following configuration:\n"
                             f"evaluator_config={{'col_mapping': {{'{param_name}': 'col_name'}}}}\n"
-                            f"Input Schema: {input_df.columns}\n"
+                            f"Input Schema: {input_columns}\n"
                             f"Output Schema: {output_columns}"
                         )
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1143,7 +1143,7 @@ class DefaultEvaluator(ModelEvaluator):
                     elif param.default == inspect.Parameter.empty:
                         output_column_name = self.evaluator_config.get(_Y_PREDICTED_OUTPUT_COLUMN_NAME, "output")
                         output_columns = [output_column_name]
-                        if self.other_output_columns:
+                        if self.other_output_columns is not None:
                             output_columns.extend(self.other_output_columns.columns)
                         raise MlflowException(
                             "Error: Metric Calculation Failed\n"

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1152,7 +1152,7 @@ class DefaultEvaluator(ModelEvaluator):
                             f"To resolve this issue, you may want to map {param_name} to an "
                             "existing column using the following configuration:\n"
                             f"evaluator_config={{'col_mapping': {{'{param_name}': 'col_name'}}}}\n"
-                            f"Input Schema: {input_df.columns}"
+                            f"Input Schema: {input_df.columns}\n"
                             f"Output Schema: {output_columns}"
                         )
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1147,7 +1147,9 @@ class DefaultEvaluator(ModelEvaluator):
                             "be defined in either the input data or resulting output data.\n"
                             f"To resolve this issue, you may want to map {param_name} to an "
                             "existing column using the following configuration:\n"
-                            f"evaluator_config={{'col_mapping': {{'{param_name}': 'col_name'}}}}"
+                            f"evaluator_config={{'col_mapping': {{'{param_name}': 'col_name'}}}}\n"
+                            f"Input Schema: {input_df.columns}"
+                            f"Output Schema: {self.other_output_columns.columns}"
                         )
 
         return eval_fn_args

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1152,7 +1152,7 @@ class DefaultEvaluator(ModelEvaluator):
                             "be defined in either the input data or resulting output data.\n"
                             f"To resolve this issue, you may want to map {param_name} to an "
                             "existing column using the following configuration:\n"
-                            f"evaluator_config={{'col_mapping': {{'{param_name}': 'col_name'}}}}\n"
+                            f"evaluator_config={{'col_mapping': {{'{param_name}': '{{existing column name here}}'}}}}\n"
                             f"Input Schema: {input_columns}\n"
                             f"Output Schema: {output_columns}"
                         )

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1142,7 +1142,9 @@ class DefaultEvaluator(ModelEvaluator):
                         eval_fn_args.append(self.other_output_columns[column])
                     elif param.default == inspect.Parameter.empty:
                         output_column_name = self.evaluator_config.get(_Y_PREDICTED_OUTPUT_COLUMN_NAME, "output")
-                        output_columns = (self.other_output_columns.columns if self.other_output_columns else []).append(output_column_name)
+                        output_columns = [output_column_name]
+                        if self.other_output_columns:
+                            output_columns.extend(self.other_output_columns.columns)
                         raise MlflowException(
                             "Error: Metric Calculation Failed\n"
                             f"Metric '{extra_metric.name}' requires the column '{param_name}' to "

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1156,7 +1156,7 @@ class DefaultEvaluator(ModelEvaluator):
                             f"To resolve this issue, you may want to map {param_name} to an "
                             "existing column using the following configuration:\n"
                             f"evaluator_config={{'col_mapping': {{'{param_name}': "
-                            "'[insert existing column name]'}}}}\n"
+                            "'[insert existing column name]'}}\n"
                         )
 
         return eval_fn_args

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1141,6 +1141,8 @@ class DefaultEvaluator(ModelEvaluator):
                     ):
                         eval_fn_args.append(self.other_output_columns[column])
                     elif param.default == inspect.Parameter.empty:
+                        output_column_name = self.evaluator_config.get(_Y_PREDICTED_OUTPUT_COLUMN_NAME, "output")
+                        output_columns = (self.other_output_columns.columns if self.other_output_columns else []).append(output_column_name)
                         raise MlflowException(
                             "Error: Metric Calculation Failed\n"
                             f"Metric '{extra_metric.name}' requires the column '{param_name}' to "
@@ -1149,7 +1151,7 @@ class DefaultEvaluator(ModelEvaluator):
                             "existing column using the following configuration:\n"
                             f"evaluator_config={{'col_mapping': {{'{param_name}': 'col_name'}}}}\n"
                             f"Input Schema: {input_df.columns}"
-                            f"Output Schema: {self.other_output_columns.columns}"
+                            f"Output Schema: {output_columns}"
                         )
 
         return eval_fn_args

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1150,11 +1150,13 @@ class DefaultEvaluator(ModelEvaluator):
                             "Error: Metric Calculation Failed\n"
                             f"Metric '{extra_metric.name}' requires the column '{param_name}' to "
                             "be defined in either the input data or resulting output data.\n"
+                            "Below are the existing column names for the input/output data:\n"
+                            f"Input Columns: {input_columns}\n"
+                            f"Output Columns: {output_columns}\n"
                             f"To resolve this issue, you may want to map {param_name} to an "
                             "existing column using the following configuration:\n"
-                            f"evaluator_config={{'col_mapping': {{'{param_name}': '{{existing column name here}}'}}}}\n"
-                            f"Input Schema: {input_columns}\n"
-                            f"Output Schema: {output_columns}"
+                            f"evaluator_config={{'col_mapping': {{'{param_name}': "
+                            "'[insert existing column name]'}}}}\n"
                         )
 
         return eval_fn_args


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
