### PR TITLE
Rename 'table' to 'tables'

### DIFF
--- a/examples/evaluation/evaluate_with_custom_code_metrics.py
+++ b/examples/evaluation/evaluate_with_custom_code_metrics.py
@@ -66,5 +66,5 @@ with mlflow.start_run() as run:
     )
     print(results)
 
-    eval_table = results.table["eval_results_table"]
+    eval_table = results.tables["eval_results_table"]
     print(eval_table)

--- a/examples/evaluation/evaluate_with_llm_judge.py
+++ b/examples/evaluation/evaluate_with_llm_judge.py
@@ -65,5 +65,5 @@ with mlflow.start_run() as run:
     )
     print(results)
 
-    eval_table = results.table["eval_results_table"]
+    eval_table = results.tables["eval_results_table"]
     print(eval_table)

--- a/examples/evaluation/evaluate_with_qa_metrics.py
+++ b/examples/evaluation/evaluate_with_qa_metrics.py
@@ -39,5 +39,5 @@ with mlflow.start_run() as run:
     )
     print(results.metrics)
 
-    eval_table = results.table["eval_results_table"]
+    eval_table = results.tables["eval_results_table"]
     print(eval_table)

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -343,25 +343,25 @@ class EvaluationResult:
 
     @experimental
     @property
-    def table(self) -> Dict[str, "pd.DataFrame"]:
+    def tables(self) -> Dict[str, "pd.DataFrame"]:
         """
         A dictionary mapping standardized artifact names (e.g. "eval_results_table") to
         corresponding table content as pandas DataFrame.
         """
-        eval_table = {}
+        eval_tables = {}
         if self._run_id is None:
             _logger.warning("Cannot load eval_results_table because run_id is not specified.")
-            return eval_table
+            return eval_tables
 
         for table_name, table_path in self._artifacts.items():
             path = urllib.parse.urlparse(table_path.uri).path
             table_fileName = os.path.basename(path)
             try:
-                eval_table[table_name] = mlflow.load_table(table_fileName, run_ids=[self._run_id])
+                eval_tables[table_name] = mlflow.load_table(table_fileName, run_ids=[self._run_id])
             except Exception:
                 pass  # Swallow the exception since we assume its not a table.
 
-        return eval_table
+        return eval_tables
 
 
 _cached_mlflow_client = None

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2732,8 +2732,8 @@ def test_constructing_eval_df_for_custom_metrics():
 
     assert eval_df_value.equals(test_eval_df_value)
     assert len(eval_results.artifacts) == 2
-    assert len(eval_results.table) == 1
-    assert eval_results.table["eval_results_table"].columns.tolist() == [
+    assert len(eval_results.tables) == 1
+    assert eval_results.tables["eval_results_table"].columns.tolist() == [
         "text",
         "truth",
         "targets",
@@ -2779,8 +2779,8 @@ def test_evaluate_no_model_type_with_builtin_metric():
             "perplexity/v1/variance",
             "perplexity/v1/p90",
         }
-        assert len(results.table) == 1
-        assert results.table["eval_results_table"].columns.tolist() == [
+        assert len(results.tables) == 1
+        assert results.tables["eval_results_table"].columns.tolist() == [
             "text",
             "outputs",
             "perplexity/v1/score",
@@ -2814,8 +2814,8 @@ def test_evaluate_no_model_type_with_custom_metric():
             "word_count/p90",
         }
         assert results.metrics["word_count/mean"] == 3.0
-        assert len(results.table) == 1
-        assert results.table["eval_results_table"].columns.tolist() == [
+        assert len(results.tables) == 1
+        assert results.tables["eval_results_table"].columns.tolist() == [
             "text",
             "outputs",
             "word_count/score",


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/prithvikannan/mlflow/pull/9920?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Cherry pick #9918

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
