### PR TITLE
Improve error message for predicted-column

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -454,15 +454,33 @@ def _extract_output_and_other_columns(model_predictions, output_column_name):
             other_output_columns = pd.DataFrame(
                 [{k: v for k, v in p.items() if k != output_column_name} for p in model_predictions]
             )
+        elif len(model_predictions) > 1:
+            raise MlflowException(
+                f"Output column name '{output_column_name}' is not found in the model "
+                f"predictions list: {model_predictions}. Please set the correct output column "
+                "name using the `predicted_column` parameter in evaluator config."
+            )
     elif isinstance(model_predictions, pd.DataFrame):
         if output_column_name in model_predictions.columns:
             y_pred = model_predictions[output_column_name]
             other_output_columns = model_predictions.drop(columns=output_column_name)
+        elif model_predictions.shape[1] > 1:
+            raise MlflowException(
+                f"Output column name '{output_column_name}' is not found in the model "
+                f"predictions dataframe {model_predictions.columns}. Please set the correct "
+                "output column name using the `predicted_column` parameter in evaluator config."
+            )
     elif isinstance(model_predictions, dict):
         if output_column_name in model_predictions:
             y_pred = pd.Series(model_predictions[output_column_name], name=output_column_name)
             other_output_columns = pd.DataFrame(
                 {k: v for k, v in model_predictions.items() if k != output_column_name}
+            )
+        elif len(model_predictions) > 1:
+            raise MlflowException(
+                f"Output column name '{output_column_name}' is not found in the "
+                f"model predictions dict {model_predictions}. Please set the correct "
+                "output column name using the `predicted_column` parameter in evaluator config."
             )
 
     return y_pred if y_pred is not None else model_predictions, other_output_columns

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2389,21 +2389,21 @@ def test_evaluate_text_summarization_with_targets():
     assert set(metrics.keys()) == set(get_text_summarization_metrics_keys(with_targets=True))
 
 
-def another_language_model(x):
-    return x
-
-
 def test_evaluate_text_summarization_with_targets_no_type_hints():
+    def another_language_model(x):
+        return x
+
     with mlflow.start_run() as run:
         model_info = mlflow.pyfunc.log_model(
             artifact_path="model", python_model=another_language_model, input_example=["a", "b"]
         )
         data = pd.DataFrame({"text": ["a", "b"], "summary": ["a", "b"]})
-        results = mlflow.evaluate(
+        results = evaluate(
             model_info.model_uri,
             data,
             targets="summary",
             model_type="text-summarization",
+            evaluators="default",
         )
 
     client = mlflow.MlflowClient()
@@ -2834,13 +2834,14 @@ def test_default_metrics_as_custom_metrics():
         data = pd.DataFrame(
             {
                 "question": ["words random", "This is a sentence."],
+                "truth": ["words random", "This is a sentence."],
                 "answer": ["words random", "This is a sentence."],
             }
         )
-        results = mlflow.evaluate(
+        results = evaluate(
             model_info.model_uri,
             data,
-            targets="answer",
+            targets="truth",
             model_type="question-answering",
             custom_metrics=[
                 mlflow.metrics.flesch_kincaid_grade_level,
@@ -2849,6 +2850,10 @@ def test_default_metrics_as_custom_metrics():
                 mlflow.metrics.toxicity,
                 mlflow.metrics.exact_match,
             ],
+            evaluators="default",
+            evaluator_config={
+                "predicted_column": "answer",
+            },
         )
 
     client = mlflow.MlflowClient()


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sunishsheth2009/mlflow/pull/9924?quickstart=1)

### What changes are proposed in this pull request?
Improve error message for predicted-column

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
