### PR TITLE
Deprecate `MLFLOW_OPENAI_SECRET_SCOPE`

### DIFF
--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -425,12 +425,6 @@ def save_model(
             )
             check_databricks_secret_scope_access(scope)
             _log_secrets_yaml(path, scope)
-        else:
-            _logger.info(
-                "No secret scope specified, skipping logging of secrets for OpenAI credentials. "
-                "See https://mlflow.org/docs/latest/python_api/openai/index.html#credential-management-for-openai-on-databricks "
-                "for more information."
-            )
 
     if conda_env is None:
         if pip_requirements is None:

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -4,6 +4,12 @@ The ``mlflow.openai`` module provides an API for logging and loading OpenAI mode
 Credential management for OpenAI on Databricks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. warning::
+
+    Specifying secrets for model serving with ``MLFLOW_OPENAI_SECRET_SCOPE`` is deprecated.
+    Use `secrets-based environment variables <https://docs.databricks.com/en/machine-learning/model-serving/store-env-variable-model-serving.html>`_
+    instead.
+
 When this flavor logs a model on Databricks, it saves a YAML file with the following contents as
 ``openai.yaml`` if the ``MLFLOW_OPENAI_SECRET_SCOPE`` environment variable is set.
 
@@ -28,6 +34,7 @@ for how to set up secrets on Databricks.
 import itertools
 import logging
 import os
+import warnings
 from enum import Enum
 from string import Formatter
 from typing import Any, Dict, NamedTuple, Optional, Set
@@ -410,6 +417,12 @@ def save_model(
 
     if is_in_databricks_runtime():
         if scope := MLFLOW_OPENAI_SECRET_SCOPE.get():
+            url = "https://docs.databricks.com/en/machine-learning/model-serving/store-env-variable-model-serving.html"
+            warnings.warn(
+                "Specifying secrets for model serving with `MLFLOW_OPENAI_SECRET_SCOPE` is "
+                f"deprecated. Use secrets-based environment variables ({url}) instead.",
+                FutureWarning,
+            )
             check_databricks_secret_scope_access(scope)
             _log_secrets_yaml(path, scope)
         else:

--- a/tests/openai/test_openai_model_export.py
+++ b/tests/openai/test_openai_model_export.py
@@ -445,7 +445,8 @@ def test_save_model_with_secret_scope(tmp_path, monkeypatch):
     with mock.patch("mlflow.openai.is_in_databricks_runtime", return_value=True), mock.patch(
         "mlflow.openai.check_databricks_secret_scope_access"
     ):
-        mlflow.openai.save_model(model="gpt-3.5-turbo", task="chat.completions", path=tmp_path)
+        with pytest.warns(FutureWarning, match="MLFLOW_OPENAI_SECRET_SCOPE.+deprecated"):
+            mlflow.openai.save_model(model="gpt-3.5-turbo", task="chat.completions", path=tmp_path)
     with tmp_path.joinpath("openai.yaml").open() as f:
         creds = yaml.safe_load(f)
         assert creds == {


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/9932?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Deprecate `MLFLOW_OPENAI_SECRET_SCOPE`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<img width="1227" alt="Screen Shot 2023-10-13 at 17 06 37" src="https://github.com/mlflow/mlflow/assets/17039389/3d060388-5746-4591-aff2-1dad7c9b559a">

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
