### PR TITLE
Fix `targets` and `predictions` error message in mlflow evaluate

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1643,43 +1643,34 @@ def evaluate(
 
     _EnvManager.validate(env_manager)
 
+    # If Dataset is provided, the targets and predictions can only be specified by the Dataset,
+    # not the targets and predictions parameters of the mlflow.evaluate() API.
+    if isinstance(data, Dataset) and targets is not None:
+        raise MlflowException(
+            message="The top-level targets parameter should not be specified since a Dataset "
+            "is used. Please only specify the targets column name in the Dataset. "
+            "Meanwhile, please specify `mlflow.evaluate(..., targets=None, ...)`.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+    if isinstance(data, Dataset) and predictions is not None:
+        raise MlflowException(
+            message="The top-level predictions parameter should not be specified since a Dataset "
+            "is used. Please only specify the predictions column name in the Dataset. "
+            "Meanwhile, please specify `mlflow.evaluate(..., predictions=None, ...)`.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
     if model_type in [_ModelType.REGRESSOR, _ModelType.CLASSIFIER]:
         if isinstance(data, Dataset):
             if getattr(data, "targets", None) is not None:
-                if targets == data.targets:
-                    # It's allowed to have redundent targets parameter
-                    pass
-                elif targets is None:
-                    targets = data.targets
-                else:
-                    # targets is not None and not equal to data.targets
-                    raise MlflowException(
-                        message="The targets parameter must only be specified by the provided "
-                        "Dataset. Please use `targets=None` in `mlflow.evaluate()`.",
-                        error_code=INVALID_PARAMETER_VALUE,
-                    )
+                targets = data.targets
             else:
-                if targets is None:
-                    # User didn't specify targets parameter and data.targets is None, so
-                    # the error message should not mention "rather than using the `targets`
-                    # argument in `mlflow.evaluate()`".
-                    raise MlflowException(
-                        message="The targets parameter must be specified by the provided Dataset "
-                        f"for {model_type} models. For example: "
-                        "`data = mlflow.data.from_pandas(df=X.assign(y=y), targets='y')`",
-                        error_code=INVALID_PARAMETER_VALUE,
-                    )
-                else:
-                    # User specified targets parameter but data.targets is None, so
-                    # the error message should mention "rather than using the `targets`
-                    # argument in `mlflow.evaluate()`".
-                    raise MlflowException(
-                        message="The targets parameter must be specified by the provided Dataset "
-                        "rather than using the `targets` argument in `mlflow.evaluate()` for "
-                        f"{model_type} models. For example: "
-                        "`data = mlflow.data.from_pandas(df=X.assign(y=y), targets='y')`",
-                        error_code=INVALID_PARAMETER_VALUE,
-                    )
+                raise MlflowException(
+                    message="The targets column name must be specified in the provided Dataset "
+                    f"for {model_type} models. For example: "
+                    "`data = mlflow.data.from_pandas(df=X.assign(y=y), targets='y')`",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
         else:
             if targets is None:
                 raise MlflowException(
@@ -1722,29 +1713,14 @@ def evaluate(
                     "parameter when model=None.",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
-            if predictions not in data.columns:
-                raise MlflowException(
-                    message=f"The specified predictions column '{predictions}' is not "
-                    "found in the specified data.",
-                    error_code=INVALID_PARAMETER_VALUE,
-                )
         elif isinstance(data, mlflow.data.pandas_dataset.PandasDataset):
             # If data is a mlflow PandasDataset with predictions specified
             # check that exact one predictions column is specified
-            if data.predictions is not None:
-                if predictions is not None and predictions != data.predictions:
-                    raise MlflowException(
-                        message="The predictions parameter must be None or the same as "
-                        "data.predictions when data.predictions is specified. Found "
-                        f"predictions='{predictions}', data.predictions='{data.predictions}'.",
-                        error_code=INVALID_PARAMETER_VALUE,
-                    )
-                else:  # predictions is None or predictions == data.predictions
-                    pass  # OK: exact one predictions column is specified
-            else:
+            if data.predictions is None:
                 raise MlflowException(
                     message="The predictions parameter must be specified with the provided "
-                    "PandasDataset when model=None.",
+                    "PandasDataset when model=None. For example: "
+                    "`data = mlflow.data.from_pandas(df=X.assign(y=y), predictions='y')`",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
         else:

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1581,8 +1581,9 @@ def evaluate(
                 targets = data.targets
             else:
                 raise MlflowException(
-                    message="The targets argument is required when data is a Dataset and does not "
-                    "define targets.",
+                    message="The targets parameter must be specified with the provided Dataset "
+                    f"for {model_type} models. For example: "
+                    "`data = mlflow.data.from_pandas(df=X.assign(y=y), targets='y')`",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
         else:

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1714,8 +1714,7 @@ def evaluate(
                     error_code=INVALID_PARAMETER_VALUE,
                 )
         elif isinstance(data, mlflow.data.pandas_dataset.PandasDataset):
-            # If data is a mlflow PandasDataset with predictions specified
-            # check that exact one predictions column is specified
+            # If data is a mlflow PandasDataset, data.predictions must be specified
             if data.predictions is None:
                 raise MlflowException(
                     message="The predictions parameter must be specified with the provided "

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1581,8 +1581,9 @@ def evaluate(
                 targets = data.targets
             else:
                 raise MlflowException(
-                    message="The targets parameter must be specified with the provided Dataset "
-                    f"for {model_type} models. For example: "
+                    message="The targets parameter must be specified by the provided Dataset "
+                    "rather than using the `targets` argument in `mlflow.evaluate()` for "
+                    f"{model_type} models. For example: "
                     "`data = mlflow.data.from_pandas(df=X.assign(y=y), targets='y')`",
                     error_code=INVALID_PARAMETER_VALUE,
                 )

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1648,14 +1648,16 @@ def evaluate(
     if isinstance(data, Dataset) and targets is not None:
         raise MlflowException(
             message="The top-level targets parameter should not be specified since a Dataset "
-            "is used. Please only specify the targets column name in the Dataset. "
+            "is used. Please only specify the targets column name in the Dataset. For example: "
+            "`data = mlflow.data.from_pandas(df=X.assign(y=y), targets='y')`. "
             "Meanwhile, please specify `mlflow.evaluate(..., targets=None, ...)`.",
             error_code=INVALID_PARAMETER_VALUE,
         )
     if isinstance(data, Dataset) and predictions is not None:
         raise MlflowException(
             message="The top-level predictions parameter should not be specified since a Dataset "
-            "is used. Please only specify the predictions column name in the Dataset. "
+            "is used. Please only specify the predictions column name in the Dataset. For example:"
+            " `data = mlflow.data.from_pandas(df=X.assign(y=y), predictions='y')`"
             "Meanwhile, please specify `mlflow.evaluate(..., predictions=None, ...)`.",
             error_code=INVALID_PARAMETER_VALUE,
         )

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1330,7 +1330,8 @@ def test_evaluate_with_targets_in_pandas_dataset_error_handling():
     with mlflow.start_run():
         with pytest.raises(
             MlflowException,
-            match="The targets parameter must be specified with the provided Dataset for "
+            match="The targets parameter must be specified by the provided Dataset rather than "
+            "using the `targets` argument in `mlflow.evaluate\(\)` for "
             "regressor models. For example: `data = mlflow.data.from_pandas"
             "\(df=X.assign\(y=y\), targets='y'\)`",
         ):

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -2,6 +2,7 @@ import hashlib
 import io
 import json
 import os
+import re
 import signal
 import uuid
 from collections import namedtuple
@@ -1330,10 +1331,12 @@ def test_evaluate_with_targets_in_pandas_dataset_error_handling():
     with mlflow.start_run():
         with pytest.raises(
             MlflowException,
-            match="The targets parameter must be specified by the provided Dataset rather than "
-            "using the `targets` argument in `mlflow.evaluate\(\)` for "
-            "regressor models. For example: `data = mlflow.data.from_pandas"
-            "\(df=X.assign\(y=y\), targets='y'\)`",
+            match=re.escape(
+                "The targets parameter must be specified by the provided Dataset rather than "
+                "using the `targets` argument in `mlflow.evaluate()` for "
+                "regressor models. For example: `data = mlflow.data.from_pandas"
+                "(df=X.assign(y=y), targets='y')`"
+            ),
         ):
             mlflow.evaluate(
                 model=model,

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -606,7 +606,6 @@ def test_pandas_df_regressor_evaluation_mlflow_dataset_with_metric_prefix(
         eval_result = evaluate(
             linear_regressor_model_uri,
             data=mlflow_df,
-            targets="y",
             model_type="regressor",
             evaluators=["default"],
             evaluator_config={
@@ -634,7 +633,6 @@ def test_pandas_df_regressor_evaluation_mlflow_dataset(linear_regressor_model_ur
         eval_result = evaluate(
             linear_regressor_model_uri,
             data=mlflow_df,
-            targets="y",
             model_type="regressor",
             evaluators=["default"],
         )
@@ -1450,20 +1448,6 @@ def test_evaluate_with_static_mlflow_dataset_input():
         mlflow.evaluate(
             data=data,
             model_type="regressor",
-        )
-
-    run = mlflow.get_run(run.info.run_id)
-    assert "mean_absolute_error" in run.data.metrics
-    assert "mean_squared_error" in run.data.metrics
-    assert "root_mean_squared_error" in run.data.metrics
-
-    # redundent predictions parameter is allowed
-    with mlflow.start_run() as run:
-        mlflow.evaluate(
-            data=data,
-            model_type="regressor",
-            targets="y",
-            predictions="model_output",  # same as data.predictions
         )
 
     run = mlflow.get_run(run.info.run_id)

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -680,8 +680,12 @@ def test_pandas_df_regressor_evaluation_mlflow_dataset_without_targets(linear_re
     with mlflow.start_run():
         with pytest.raises(
             MlflowException,
-            match="The targets argument is required when data is a Dataset and does not define "
-            "targets.",
+            match=re.escape(
+                "The targets parameter must be specified by the provided Dataset rather than "
+                "using the `targets` argument in `mlflow.evaluate()` for "
+                "regressor models. For example: `data = mlflow.data.from_pandas"
+                "(df=X.assign(y=y), targets='y')`"
+            ),
         ):
             evaluate(
                 linear_regressor_model_uri,

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1307,7 +1307,8 @@ def test_evaluate_with_targets_error_handling():
     model = lgb.train({"objective": "regression"}, lgb_data, num_boost_round=5)
     ERROR_TYPE_1 = (
         "The top-level targets parameter should not be specified since a Dataset "
-        "is used. Please only specify the targets column name in the Dataset. "
+        "is used. Please only specify the targets column name in the Dataset. For example: "
+        "`data = mlflow.data.from_pandas(df=X.assign(y=y), targets='y')`. "
         "Meanwhile, please specify `mlflow.evaluate(..., targets=None, ...)`."
     )
     ERROR_TYPE_2 = (
@@ -1549,16 +1550,16 @@ def test_evaluate_with_static_dataset_error_handling_pandas_dataset():
     )
     dataset_no_predictions = mlflow.data.from_pandas(df=X.assign(y=y, model_output=y), targets="y")
     ERROR_MESSAGE = (
-        "The top-level targets parameter should not be specified since a Dataset is "
-        "used. Please only specify the targets column name in the Dataset. "
-        "Meanwhile, please specify `mlflow.evaluate(..., targets=None, ...)`."
+        "The top-level predictions parameter should not be specified since a Dataset is "
+        "used. Please only specify the predictions column name in the Dataset. For example: "
+        "`data = mlflow.data.from_pandas(df=X.assign(y=y), predictions='y')`"
+        "Meanwhile, please specify `mlflow.evaluate(..., predictions=None, ...)`."
     )
     with mlflow.start_run():
         with pytest.raises(MlflowException, match=re.escape(ERROR_MESSAGE)):
             mlflow.evaluate(
                 data=dataset_with_predictions,
                 model_type="regressor",
-                targets="y",
                 predictions="model_output",
             )
 
@@ -1566,6 +1567,5 @@ def test_evaluate_with_static_dataset_error_handling_pandas_dataset():
             mlflow.evaluate(
                 data=dataset_no_predictions,
                 model_type="regressor",
-                targets="y",
                 predictions="model_output",
             )


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/liangz1/mlflow/pull/9958?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Update error message to match the actual behavior.

#### Targets

| Is (regressor or classifier)? | Is Dataset? | data.targets is specified? | targets is specified? | Behavior | Explain |
|------------------------------|--------------|----------------------------|----------------------|----------|--------|
| Y                            | Y            | Y                          | Y                    | ❌        | ERROR_TYPE_1 top-level targets parameter should not be specified since Dataset is used |
| Y                            | Y            | Y                          | N                    | ✅        | |
| Y                            | Y            | N                          | Y                    | ❌        | ERROR_TYPE_1 top-level targets parameter should not be specified since Dataset is used |
| Y                            | Y            | N                          | N                    | ❌        | ERROR_TYPE_2 regressor or classifier must have targets |
| Y                            | N            | -                          | Y                    | ✅        | |
| Y                            | N            | -                          | N                    | ❌        | ERROR_TYPE_3 regressor or classifier must have targets |
| N                            | Y            | Y                          | Y                    | ❌        | ERROR_TYPE_1 top-level targets parameter should not be specified since Dataset is used |
| N                            | Y            | Y                          | N                    | ✅        | |
| N                            | Y            | N                          | Y                    | ❌        | ERROR_TYPE_1 top-level targets parameter should not be specified since Dataset is used |
| N                            | Y            | N                          | N                    | ✅        | |
| N                            | N            | -                          | Y                    | ✅        | |
| N                            | N            | -                          | N                    | ✅        | |


#### Predictions (when model=None)

| Is Dataset? | data.predictions is specified? | predictions is specified? | Behavior | Explain |
|-------------|-------------------------------|--------------------------|----------|--------|
| Y           | Y                             | Y                        | ❌        | top-level predictions parameter should not be specified since Dataset is used |
| Y           | Y                             | N                        | ✅        | |
| Y           | N                             | Y                        | ❌        | top-level predictions parameter should not be specified since Dataset is used |
| Y           | N                             | N                        | ❌        | model=None must have predictions |
| N           | -                             | Y                        | ✅        | |
| N           | -                             | N                        | ❌        | model=None must have predictions |


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
