### PR TITLE
Retriever model-type with precision_at_k built-in metric

### DIFF
--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -265,7 +265,10 @@ def rougeLsum() -> EvaluationMetric:
 
 
 precision_at_k = make_metric(
-    eval_fn=_precision_at_k_eval_fn, greater_is_better=True, name="precision_at_k", version="v1"
+    eval_fn=_precision_at_k_eval_fn,
+    greater_is_better=True,
+    name="precision_at_k",
+    version="v1",
 )
 """
 .. Note:: Experimental: This metric may change or be removed in a future release without warning.

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -20,6 +20,7 @@ from mlflow.metrics.metric_definitions import (
     _max_error_eval_fn,
     _mse_eval_fn,
     _perplexity_eval_fn,
+    _precision_at_k_eval_fn,
     _precision_eval_fn,
     _r2_score_eval_fn,
     _recall_eval_fn,
@@ -261,6 +262,20 @@ def rougeLsum() -> EvaluationMetric:
         name="rougeLsum",
         version="v1",
     )
+
+
+precision_at_k = make_metric(
+    eval_fn=_precision_at_k_eval_fn, greater_is_better=True, name="precision_at_k", version="v1"
+)
+"""
+.. Note:: Experimental: This metric may change or be removed in a future release without warning.
+
+A metric for calculating `accuracy`_ using sklearn.
+
+This metric only computes an aggregate score which ranges from 0 to 1.
+
+.. _accuracy: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.accuracy_score.html
+"""
 
 
 # General Regression Metrics

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -273,11 +273,20 @@ precision_at_k = make_metric(
 """
 .. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
-A metric for calculating `accuracy`_ using sklearn.
+A metric for calculating ``precision_at_k`` for the retriever model type.
 
-This metric only computes an aggregate score which ranges from 0 to 1.
+This metric computes a score between 0 and 1 for each row representing the precision of the
+retriever model at the given k value. The score is calculated by dividing the number of relevant
+documents retrieved by the total number of documents retrieved or k, whichever is smaller.
+If no relevant documents are retrieved, the score is 1, indication that no false positives were
+retrieved.
 
-.. _accuracy: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.accuracy_score.html
+This metric requires the ``retriever`` model type. The model output should be a pandas dataframe
+with a column containing a tuple of strings on each row. The strings in the tuple represent the
+document IDs. The label column should contain a tuple of strings representing the relevant document
+IDs for each row, provided by the input ``data`` parameter. The ``k`` parameter should be an
+integer representing the number of documents to evaluate for each row, provided by the
+``evaluator_config`` parameter.
 """
 
 

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -254,11 +254,19 @@ def _rougeLsum_eval_fn(predictions, targets, metrics):
         )
 
 
-def _precision_at_k_eval_fn(predictions, targets, k):
+def _precision_at_k_eval_fn(predictions, targets, k, metrics, sample_weight=None):
+    assert targets is not None
+    assert len(targets) != 0
+    import pandas as pd
+
     if targets is not None and len(targets) != 0:
-        assert predictions == {}
-        assert targets == {}
-        return MetricValue(scores=[], aggregate_results=standard_aggregations([]))
+        assert isinstance(predictions, pd.Series)
+        assert isinstance(targets, pd.Series)
+        assert isinstance(k, pd.Series)
+        assert (predictions == pd.Series([("doc1", "doc3")] * 3, name="prediction")).all()
+        assert (targets == pd.Series([("doc1", "doc2")] * 3, name="target")).all()
+        assert (k == pd.Series([2, 2, 2], name="k")).all()
+        return MetricValue(scores=[2, 2, 2], aggregate_results=standard_aggregations([2, 2, 2]))
 
 
 def _mae_eval_fn(predictions, targets, metrics, sample_weight=None):

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -55,28 +55,6 @@ def _validate_and_fix_text_tuple_data(data, metric_name, column_name):
     return True
 
 
-def _validate_and_fix_text_tuple_data(data, metric_name, column_name):
-    """Validates that the data is a list of a tuple of strings and is non-empty"""
-    if data is None or len(data) == 0:
-        return False
-
-    for row, tup in enumerate(data):
-        if not isinstance(tup, tuple) or not all(isinstance(val, str) for val in tup):
-            if isinstance(tup, str):
-                # Single entry tuples get unpacked.
-                # So if the entry is a string, put them back into a tuple.
-                data[row] = (tup,)
-            else:
-                _logger.warning(
-                    f"Cannot calculate {metric_name} for non-tuple[str] inputs."
-                    f"Row {row} of column {column_name} has a non-tuple[str] value of:"
-                    f"{tup}. Skipping metric logging."
-                )
-                return False
-
-    return True
-
-
 def _token_count_eval_fn(predictions, targets=None, metrics=None):
     import tiktoken
 

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -254,6 +254,13 @@ def _rougeLsum_eval_fn(predictions, targets, metrics):
         )
 
 
+def _precision_at_k_eval_fn(predictions, targets, k):
+    if targets is not None and len(targets) != 0:
+        assert predictions == {}
+        assert targets == {}
+        return MetricValue(scores=[], aggregate_results=standard_aggregations([]))
+
+
 def _mae_eval_fn(predictions, targets, metrics, sample_weight=None):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import mean_absolute_error

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1317,6 +1317,12 @@ def evaluate(
         .. _textstat:
             https://pypi.org/project/textstat
 
+    - For retriever models, the default evaluator logs:
+        - **metrics**: ``precision_at_k``: precision at k, where k is specified by the
+            ``evaluator_config`` argument. The default value of k is 3.
+        - **artifacts**: A JSON file containing the inputs, outputs, targets (if the ``targets``
+          argument is supplied), and per-row metrics of the model in tabular format.
+
      - For sklearn models, the default evaluator additionally logs the model's evaluation criterion
        (e.g. mean accuracy for a classifier) computed by `model.score` method.
 
@@ -1360,6 +1366,8 @@ def evaluate(
           metrics.
         - **col_mapping**: A dictionary mapping column names in the input dataset or output
           predictions to column names used when invoking the evaluation functions.
+        - **k**: The number of top predictions to use when computing the built-in metric
+          precision_at_k.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.
@@ -1479,13 +1487,15 @@ def evaluate(
                        - ``'question-answering'``
                        - ``'text-summarization'``
                        - ``'text'``
+                       - ``'retriever'``
 
                        If no ``model_type`` is specified, then you must provide a a list of
                        metrics to compute via the ``extra_metrics`` param.
 
                        .. note::
-                            ``'question-answering'``, ``'text-summarization'``, and ``'text'``
-                            are experimental and may be changed or removed in a future release.
+                            ``'question-answering'``, ``'text-summarization'``, ``'text'``, and
+                            ``'retriever'`` are experimental and may be changed or removed in a
+                            future release.
 
     :param dataset_path: (Optional) The path where the data is stored. Must not contain double
                          quotes (``“``). If specified, the path is logged to the ``mlflow.datasets``

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1319,7 +1319,7 @@ def evaluate(
 
     - For retriever models, the default evaluator logs:
         - **metrics**: ``precision_at_k``: precision at k, where k is specified by the
-            ``evaluator_config`` argument. The default value of k is 3.
+            ``evaluator_config`` argument.
         - **artifacts**: A JSON file containing the inputs, outputs, targets (if the ``targets``
           argument is supplied), and per-row metrics of the model in tabular format.
 
@@ -1366,7 +1366,7 @@ def evaluate(
           metrics.
         - **col_mapping**: A dictionary mapping column names in the input dataset or output
           predictions to column names used when invoking the evaluation functions.
-        - **k**: The number of top predictions to use when computing the built-in metric
+        - **k**: The number of top retrieved documents to use when computing the built-in metric
           precision_at_k.
 
      - Limitations of evaluation dataset:

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -54,7 +54,7 @@ class _ModelType:
     QUESTION_ANSWERING = "question-answering"
     TEXT_SUMMARIZATION = "text-summarization"
     TEXT = "text"
-    # TODO: Add 'retrieval' model type
+    RETRIEVER = "retriever"
 
     def __init__(self):
         raise NotImplementedError("This class is not meant to be instantiated.")
@@ -67,6 +67,7 @@ class _ModelType:
             cls.QUESTION_ANSWERING,
             cls.TEXT_SUMMARIZATION,
             cls.TEXT,
+            cls.RETRIEVER,
         )
 
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1172,8 +1172,6 @@ class DefaultEvaluator(ModelEvaluator):
                         eval_fn_args.append(None)
                 elif column == "metrics":
                     eval_fn_args.append(copy.deepcopy(self.metrics_values))
-                elif param_name == "k":
-                    eval_fn_args.append(eval_df_copy["k"])
                 else:
                     # case when column passed in col_mapping contains the entire column
                     if not isinstance(column, str):
@@ -1656,8 +1654,6 @@ class DefaultEvaluator(ModelEvaluator):
                 eval_df = pd.DataFrame({"prediction": copy.deepcopy(self.y_pred)})
                 if self.dataset.has_targets:
                     eval_df["target"] = self.y
-                if self.model_type == _ModelType.RETRIEVER:
-                    eval_df["k"] = self.evaluator_config.get("k", 3)  # default K
 
                 self._evaluate_metrics(eval_df)
                 if not is_baseline_model:

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1644,6 +1644,8 @@ class DefaultEvaluator(ModelEvaluator):
                     ]
                 elif self.model_type == _ModelType.TEXT:
                     self.builtin_metrics = text_metrics
+                elif self.model_type == _ModelType.RETRIEVER:
+                    self.builtin_metrics = [token_count]
 
                 self.y_pred = (
                     self.y_pred.squeeze() if isinstance(self.y_pred, pd.DataFrame) else self.y_pred

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import re
 from os.path import join as path_join
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -3290,7 +3291,10 @@ def test_evaluate_retriever_error_handling():
     def fn(X):
         return pd.DataFrame({"output": [("doc1", "doc3", "doc2")] * len(X)})
 
-    with pytest.raises(MlflowException, match="Missing k in evaluator_config"):
+    # TODO: improve error message, avoid saying "columns ['k']"
+    with pytest.raises(
+        MlflowException, match=re.escape("Metric 'precision_at_k' requires the columns ['k']")
+    ):
         mlflow.evaluate(
             model=fn,
             data=X,
@@ -3298,16 +3302,6 @@ def test_evaluate_retriever_error_handling():
             model_type="retriever",
             evaluators="default",
             evaluator_config={},
-        )
-
-    with pytest.raises(MlflowException, match="k should be a positive integer"):
-        mlflow.evaluate(
-            model=fn,
-            data=X,
-            targets="ground_truth",
-            model_type="retriever",
-            evaluators="default",
-            evaluator_config={"k": 0},
         )
 
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -3276,3 +3276,30 @@ def test_evaluate_retriever():
         "precision_at_k/v1/variance": 0,
         "precision_at_k/v1/p90": 1,
     }
+
+
+def test_evaluate_retriever_error_handling():
+    X = pd.DataFrame({"question": ["q1?"] * 3, "ground_truth": [("doc1", "doc2")] * 3})
+
+    def fn(X):
+        return pd.DataFrame({"output": [("doc1", "doc3", "doc2")] * len(X)})
+
+    with pytest.raises(MlflowException, match="Missing k in evaluator_config"):
+        mlflow.evaluate(
+            model=fn,
+            data=X,
+            targets="ground_truth",
+            model_type="retriever",
+            evaluators="default",
+            evaluator_config={},
+        )
+
+    with pytest.raises(MlflowException, match="k should be a positive integer"):
+        mlflow.evaluate(
+            model=fn,
+            data=X,
+            targets="ground_truth",
+            model_type="retriever",
+            evaluators="default",
+            evaluator_config={"k": 0},
+        )

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1589,14 +1589,16 @@ def test_evaluate_with_static_dataset_error_handling_pandas_dataset():
 
 def test_evaluate_retriever():
     X = pd.DataFrame({"question": ["What is GPT-4?", "How does it work?", "Who developed it?"]})
+    X["ground_truth"] = [["doc1", "doc2"]] * len(X)
 
     def fn(X):
-        return pd.DataFrame({"output": [["doc1", "doc2"]] * len(X)})
+        return pd.DataFrame({"output": [["doc1", "doc3"]] * len(X)})
 
     with mlflow.start_run() as run:
         mlflow.evaluate(
             fn,
             X,
+            targets="ground_truth",
             model_type="retriever",
         )
     run = mlflow.get_run(run.info.run_id)

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1448,6 +1448,37 @@ def test_evaluate_with_loaded_pyfunc_model():
     assert "root_mean_squared_error" in run.data.metrics
 
 
+def test_evaluate_retriever():
+    X = pd.DataFrame(
+        {
+            "question": ["What is GPT-4?", "How does it work?", "Who developed it?"],
+            "ground_truth": [("doc1", "doc2")] * 3,
+        }
+    )
+
+    def fn(X):
+        return pd.DataFrame({"output": [("doc1", "doc3")] * len(X)})
+
+    with mlflow.start_run() as run:
+        mlflow.evaluate(
+            model=fn,
+            data=X,
+            targets="ground_truth",
+            model_type="retriever",
+            evaluator_config={
+                "default": {
+                    "k": 2,
+                }
+            },
+        )
+    run = mlflow.get_run(run.info.run_id)
+    assert run.data.metrics == {
+        "precision_at_k/v1/mean": 2.0,
+        "precision_at_k/v1/variance": 0.0,
+        "precision_at_k/v1/p90": 2.0,
+    }
+
+
 def test_evaluate_with_static_dataset_input_single_output():
     X, y = sklearn.datasets.load_diabetes(return_X_y=True, as_frame=True)
     X = X[::5]

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1448,37 +1448,6 @@ def test_evaluate_with_loaded_pyfunc_model():
     assert "root_mean_squared_error" in run.data.metrics
 
 
-def test_evaluate_retriever():
-    X = pd.DataFrame(
-        {
-            "question": ["What is GPT-4?", "How does it work?", "Who developed it?"],
-            "ground_truth": [("doc1", "doc2")] * 3,
-        }
-    )
-
-    def fn(X):
-        return pd.DataFrame({"output": [("doc1", "doc3")] * len(X)})
-
-    with mlflow.start_run() as run:
-        mlflow.evaluate(
-            model=fn,
-            data=X,
-            targets="ground_truth",
-            model_type="retriever",
-            evaluator_config={
-                "default": {
-                    "k": 2,
-                }
-            },
-        )
-    run = mlflow.get_run(run.info.run_id)
-    assert run.data.metrics == {
-        "precision_at_k/v1/mean": 2.0,
-        "precision_at_k/v1/variance": 0.0,
-        "precision_at_k/v1/p90": 2.0,
-    }
-
-
 def test_evaluate_with_static_dataset_input_single_output():
     X, y = sklearn.datasets.load_diabetes(return_X_y=True, as_frame=True)
     X = X[::5]
@@ -1616,21 +1585,3 @@ def test_evaluate_with_static_dataset_error_handling_pandas_dataset():
                 model_type="regressor",
                 predictions="model_output",
             )
-
-
-def test_evaluate_retriever():
-    X = pd.DataFrame({"question": ["What is GPT-4?", "How does it work?", "Who developed it?"]})
-    X["ground_truth"] = [["doc1", "doc2"]] * len(X)
-
-    def fn(X):
-        return pd.DataFrame({"output": [["doc1", "doc3"]] * len(X)})
-
-    with mlflow.start_run() as run:
-        mlflow.evaluate(
-            fn,
-            X,
-            targets="ground_truth",
-            model_type="retriever",
-        )
-    run = mlflow.get_run(run.info.run_id)
-    assert run.data.metrics == {}

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1585,3 +1585,19 @@ def test_evaluate_with_static_dataset_error_handling_pandas_dataset():
                 model_type="regressor",
                 predictions="model_output",
             )
+
+
+def test_evaluate_retriever():
+    X = pd.DataFrame({"question": ["What is GPT-4?", "How does it work?", "Who developed it?"]})
+
+    def fn(X):
+        return pd.DataFrame({"output": [["doc1", "doc2"]] * len(X)})
+
+    with mlflow.start_run() as run:
+        mlflow.evaluate(
+            fn,
+            X,
+            model_type="retriever",
+        )
+    run = mlflow.get_run(run.info.run_id)
+    assert run.data.metrics == {}


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
