### PR TITLE
Add timeout to openai

### DIFF
--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -84,7 +84,7 @@ def make_genai_metric(
     aggregations: Optional[List[str]] = None,
     greater_is_better: bool = True,
     max_workers: int = 10,
-    judge_request_timeout: int = 15,
+    judge_request_timeout: int = 60,
 ) -> EvaluationMetric:
     """
     Create a genai metric used to evaluate LLM using LLM as a judge in MLflow.
@@ -106,7 +106,7 @@ def make_genai_metric(
     :param max_workers: (Optional) The maximum number of workers to use for judge scoring.
         Defaults to 10 workers.
     :param judge_request_timeout: (Optional) The timeout in seconds for each judge scoring request.
-        Defaults to 15 seconds.
+        Defaults to 60 seconds.
 
     :return: A metric object.
 
@@ -162,9 +162,9 @@ def make_genai_metric(
             ),
             examples=[example],
             version="v1",
-            model="gateway:/gpt4",
+            model="openai:/gpt-3.5-turbo-16k",
             grading_context_columns=["ground_truth"],
-            parameters={"temperature": 1.0},
+            parameters={"temperature": 0.0},
             aggregations=["mean", "variance", "p90"],
             greater_is_better=True,
         )
@@ -241,7 +241,9 @@ def make_genai_metric(
                 **eval_parameters,
             }
             try:
-                raw_result = model_utils.score_model_on_payload(eval_model, payload)
+                raw_result = model_utils.score_model_on_payload(
+                    eval_model, payload, judge_request_timeout
+                )
                 return _extract_score_and_justification(raw_result)
             except Exception as e:
                 _logger.info(f"Failed to score model on payload. Error: {e!r}")

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -12,13 +12,13 @@ ROUTE_TYPE = "llm/v1/completions"
 
 
 # TODO: improve this name
-def score_model_on_payload(model_uri, payload):
+def score_model_on_payload(model_uri, payload, timeout):
     """Call the model identified by the given uri with the given payload."""
 
     prefix, suffix = _parse_model_uri(model_uri)
 
     if prefix == "openai":
-        return _call_openai_api(suffix, payload)
+        return _call_openai_api(suffix, payload, timeout)
     elif prefix == "gateway":
         return _call_gateway_api(suffix, payload)
     elif prefix in ("model", "runs"):
@@ -43,7 +43,7 @@ def _parse_model_uri(model_uri):
     return scheme, path
 
 
-def _call_openai_api(openai_uri, payload):
+def _call_openai_api(openai_uri, payload, timeout):
     """Wrapper around the OpenAI API to make it compatible with the MLflow Gateway API."""
     from mlflow.gateway.config import RouteConfig
     from mlflow.gateway.providers.openai import OpenAIProvider
@@ -72,6 +72,7 @@ def _call_openai_api(openai_uri, payload):
         url=append_to_uri_path(openai_provider._request_base_url, "chat/completions"),
         headers=openai_provider._request_headers,
         json=openai_provider._add_model_to_payload_if_necessary(payload),
+        timeout=timeout,
     ).json()
 
     return json.loads(openai_provider._prepare_completion_response_payload(resp).json())

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -43,12 +43,12 @@ def test_parse_model_uri_throws_for_malformed():
 
 def test_score_model_on_payload_throws_for_invalid():
     with pytest.raises(MlflowException, match="Unknown model uri prefix"):
-        score_model_on_payload("myprovider:/gpt-3.5-turbo", {})
+        score_model_on_payload("myprovider:/gpt-3.5-turbo", {}, 10)
 
 
 def test_score_model_openai_without_key():
     with pytest.raises(MlflowException, match="OPENAI_API_KEY environment variable not set"):
-        score_model_on_payload("openai:/gpt-3.5-turbo", {})
+        score_model_on_payload("openai:/gpt-3.5-turbo", {}, 10)
 
 
 def test_score_model_openai(set_envs):
@@ -86,7 +86,9 @@ def test_score_model_openai(set_envs):
     }
 
     with mock.patch("requests.post", return_value=MockResponse(resp, 200)) as mock_post:
-        score_model_on_payload("openai:/gpt-3.5-turbo", {"prompt": "my prompt", "temperature": 0.1})
+        score_model_on_payload(
+            "openai:/gpt-3.5-turbo", {"prompt": "my prompt", "temperature": 0.1}, 10
+        )
         mock_post.assert_called_once_with(
             url="https://api.openai.com/v1/chat/completions",
             headers={"Authorization": "Bearer test"},
@@ -95,6 +97,7 @@ def test_score_model_openai(set_envs):
                 "temperature": 0.2,
                 "messages": [{"role": "user", "content": "my prompt"}],
             },
+            timeout=10,
         )
 
 
@@ -120,5 +123,5 @@ def test_score_model_gateway():
     }
 
     with mock.patch("mlflow.gateway.query", return_value=expected_output):
-        response = score_model_on_payload("gateway:/my-route", {})
+        response = score_model_on_payload("gateway:/my-route", {}, 10)
         assert response == expected_output


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/prithvikannan/mlflow/pull/9960?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
