### PR TITLE
Call `hashlib.md5` with `usedforsecurity=False` for FIPS

### DIFF
--- a/examples/databricks/multipart.py
+++ b/examples/databricks/multipart.py
@@ -43,7 +43,7 @@ def show_system_info():
 
 
 def md5_checksum(path):
-    file_hash = hashlib.md5()
+    file_hash = hashlib.sha256()
     with open(path, "rb") as f:
         while chunk := f.read(1024**2):
             file_hash.update(chunk)

--- a/mlflow/data/digest_utils.py
+++ b/mlflow/data/digest_utils.py
@@ -1,10 +1,10 @@
-import hashlib
 from typing import Any, List
 
 from packaging.version import Version
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.utils import _insecure_md5
 
 MAX_ROWS = 10000
 
@@ -159,7 +159,7 @@ def get_normalized_md5_digest(elements: List[Any]) -> str:
             INVALID_PARAMETER_VALUE,
         )
 
-    md5 = hashlib.md5()
+    md5 = _insecure_md5()
     for element in elements:
         md5.update(element)
 

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import logging
 import math
@@ -31,7 +30,7 @@ from mlflow.models.evaluation.validation import (
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.tracking.client import MlflowClient
-from mlflow.utils import _get_fully_qualified_class_name
+from mlflow.utils import _get_fully_qualified_class_name, _insecure_md5
 from mlflow.utils.annotations import developer_stable, experimental
 from mlflow.utils.class_utils import _get_class_from_string
 from mlflow.utils.file_utils import TempDir
@@ -597,7 +596,7 @@ class EvaluationDataset:
             )
 
         # generate dataset hash
-        md5_gen = hashlib.md5()
+        md5_gen = _insecure_md5()
         _gen_md5_for_arraylike_obj(md5_gen, self._features_data)
         if self._labels_data is not None:
             _gen_md5_for_arraylike_obj(md5_gen, self._labels_data)

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import logging
 import os
@@ -46,7 +45,7 @@ from mlflow.store.tracking import (
     SEARCH_MAX_RESULTS_THRESHOLD,
 )
 from mlflow.store.tracking.abstract_store import AbstractStore
-from mlflow.utils import get_results_from_paginated_fn
+from mlflow.utils import _insecure_md5, get_results_from_paginated_fn
 from mlflow.utils.file_utils import (
     append_to,
     exists,
@@ -1128,13 +1127,13 @@ class FileStore(AbstractStore):
 
     @staticmethod
     def _get_dataset_id(dataset_name: str, dataset_digest: str) -> str:
-        md5 = hashlib.md5(dataset_name.encode("utf-8"))
+        md5 = _insecure_md5(dataset_name.encode("utf-8"))
         md5.update(dataset_digest.encode("utf-8"))
         return md5.hexdigest()
 
     @staticmethod
     def _get_input_id(dataset_id: str, run_id: str) -> str:
-        md5 = hashlib.md5(dataset_id.encode("utf-8"))
+        md5 = _insecure_md5(dataset_id.encode("utf-8"))
         md5.update(run_id.encode("utf-8"))
         return md5.hexdigest()
 

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -1,8 +1,10 @@
 import base64
+import hashlib
 import inspect
 import logging
 import socket
 import subprocess
+import sys
 import uuid
 from contextlib import closing
 from itertools import islice
@@ -268,3 +270,21 @@ def get_results_from_paginated_fn(paginated_fn, max_results_per_page, max_result
         else:
             break
     return all_results
+
+
+def _insecure_md5(string=b""):
+    """
+    Do not use this function for security purposes (e.g., password hashing).
+
+    In Python >= 3.9, `hashlib.md5` fails in FIPS-compliant environments. This function
+    provides a workaround for this issue by using `hashlib.md5` with `usedforsecurity=False`.
+
+    References:
+    - https://github.com/mlflow/mlflow/issues/9905
+    - https://docs.python.org/3/library/hashlib.html
+    """
+    return (
+        hashlib.md5(string, usedforsecurity=False)
+        if sys.version_info >= (3, 9)
+        else hashlib.md5(string)
+    )

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1,4 +1,3 @@
-import hashlib
 import io
 import json
 import os
@@ -55,6 +54,7 @@ from mlflow.models.evaluation.evaluator_registry import _model_evaluation_regist
 from mlflow.pyfunc import _ServedPyFuncModel
 from mlflow.pyfunc.scoring_server.client import ScoringServerClient
 from mlflow.tracking.artifact_utils import get_artifact_uri
+from mlflow.utils import _insecure_md5
 from mlflow.utils.file_utils import TempDir
 
 
@@ -710,7 +710,7 @@ def test_dataset_metadata():
 
 def test_gen_md5_for_arraylike_obj():
     def get_md5(data):
-        md5_gen = hashlib.md5()
+        md5_gen = _insecure_md5()
         _gen_md5_for_arraylike_obj(md5_gen, data)
         return md5_gen.hexdigest()
 

--- a/tests/resources/data/dataset.py
+++ b/tests/resources/data/dataset.py
@@ -1,5 +1,4 @@
 import base64
-import hashlib
 import json
 from typing import Any, Dict, List, Optional
 
@@ -9,6 +8,7 @@ import pandas as pd
 from mlflow.data.dataset import Dataset
 from mlflow.types import Schema
 from mlflow.types.utils import _infer_schema
+from mlflow.utils import _insecure_md5
 
 from tests.resources.data.dataset_source import TestDatasetSource
 
@@ -29,7 +29,7 @@ class TestDataset(Dataset):
         Computes a digest for the dataset. Called if the user doesn't supply
         a digest when constructing the dataset.
         """
-        hash_md5 = hashlib.md5()
+        hash_md5 = _insecure_md5()
         for hash_part in pd.util.hash_array(np.array(self._data_list)):
             hash_md5.update(hash_part)
         return base64.b64encode(hash_md5.digest()).decode("ascii")

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import os
 import posixpath
@@ -38,6 +37,7 @@ from mlflow.protos.databricks_pb2 import (
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.tracking.file_store import FileStore
+from mlflow.utils import _insecure_md5
 from mlflow.utils.file_utils import TempDir, path_to_local_file_uri, read_yaml, write_yaml
 from mlflow.utils.mlflow_tags import MLFLOW_DATASET_CONTEXT, MLFLOW_LOGGED_MODELS, MLFLOW_RUN_NAME
 from mlflow.utils.name_utils import _EXPERIMENT_ID_FIXED_WIDTH, _GENERATOR_PREDICATES
@@ -2493,7 +2493,7 @@ def test_log_inputs_uses_expected_input_and_dataset_ids_for_storage(store):
         inputs_dir = os.path.join(run_dir, FileStore.INPUTS_FOLDER_NAME)
         expected_input_storage_ids = []
         for dataset_storage_id in dataset_storage_ids:
-            md5 = hashlib.md5(dataset_storage_id.encode("utf-8"))
+            md5 = _insecure_md5(dataset_storage_id.encode("utf-8"))
             md5.update(run.info.run_id.encode("utf-8"))
             expected_input_storage_ids.append(md5.hexdigest())
         assert set(os.listdir(inputs_dir)) == set(expected_input_storage_ids)


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #9905 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Call hashlib.md5 with usedforsecurity=False for FIPS.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes