### PR TITLE
Fix lightning autolog code example

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -226,7 +226,7 @@ def log_model(
     :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
              metadata of the logged model.
 
-    .. testcode:: python
+    .. code-block:: python
         :caption: Example
 
         import numpy as np
@@ -947,7 +947,7 @@ def autolog(
                                   The registered model is created if it does not already exist.
     :param extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
 
-    .. code-block:: python
+    .. testcode:: python
         :caption: Example
 
         import os

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -226,7 +226,7 @@ def log_model(
     :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
              metadata of the logged model.
 
-    .. code-block:: python
+    .. testcode:: python
         :caption: Example
 
         import numpy as np
@@ -952,30 +952,23 @@ def autolog(
 
         import os
 
-        import pytorch_lightning as pl
+        import lightning as L
         import torch
         from torch.nn import functional as F
-        from torch.utils.data import DataLoader
+        from torch.utils.data import DataLoader, Subset
+        from torchmetrics import Accuracy
         from torchvision import transforms
         from torchvision.datasets import MNIST
-
-        try:
-            from torchmetrics.functional import accuracy
-        except ImportError:
-            from pytorch_lightning.metrics.functional import accuracy
 
         import mlflow.pytorch
         from mlflow import MlflowClient
 
-        # For brevity, here is the simplest most minimal example with just a training
-        # loop step, (no validation, no testing). It illustrates how you can use MLflow
-        # to auto log parameters, metrics, and models.
 
-
-        class MNISTModel(pl.LightningModule):
+        class MNISTModel(L.LightningModule):
             def __init__(self):
                 super().__init__()
                 self.l1 = torch.nn.Linear(28 * 28, 10)
+                self.accuracy = Accuracy("multiclass", num_classes=10)
 
             def forward(self, x):
                 return torch.relu(self.l1(x.view(x.size(0), -1)))
@@ -985,9 +978,9 @@ def autolog(
                 logits = self(x)
                 loss = F.cross_entropy(logits, y)
                 pred = logits.argmax(dim=1)
-                acc = accuracy(pred, y)
+                acc = self.accuracy(pred, y)
 
-                # Use the current of PyTorch logger
+                # PyTorch `self.log` will be automatically captured by MLflow.
                 self.log("train_loss", loss, on_epoch=True)
                 self.log("acc", acc, on_epoch=True)
                 return loss
@@ -1006,51 +999,30 @@ def autolog(
             print(f"tags: {tags}")
 
 
-        # Initialize our model
+        # Initialize our model.
         mnist_model = MNISTModel()
 
-        # Initialize DataLoader from MNIST Dataset
+        # Load MNIST dataset.
         train_ds = MNIST(
             os.getcwd(), train=True, download=True, transform=transforms.ToTensor()
         )
-        train_loader = DataLoader(train_ds, batch_size=32)
+        # Only take a subset of the data for faster training.
+        indices = torch.arange(32)
+        train_ds = Subset(train_ds, indices)
+        train_loader = DataLoader(train_ds, batch_size=8)
 
-        # Initialize a trainer
-        trainer = pl.Trainer(max_epochs=20, progress_bar_refresh_rate=20)
+        # Initialize a trainer.
+        trainer = L.Trainer(max_epochs=3)
 
         # Auto log all MLflow entities
         mlflow.pytorch.autolog()
 
-        # Train the model
+        # Train the model.
         with mlflow.start_run() as run:
             trainer.fit(mnist_model, train_loader)
 
-        # fetch the auto logged parameters and metrics
+        # Fetch the auto logged parameters and metrics.
         print_auto_logged_info(mlflow.get_run(run_id=run.info.run_id))
-
-    .. code-block:: text
-        :caption: Output
-
-        run_id: 42caa17b60cb489c8083900fb52506a7
-        artifacts: ['model/MLmodel', 'model/conda.yaml', 'model/data']
-        params: {'betas': '(0.9, 0.999)',
-                 'weight_decay': '0',
-                 'epochs': '20',
-                 'eps': '1e-08',
-                 'lr': '0.02',
-                 'optimizer_name': 'Adam', '
-                 amsgrad': 'False'}
-        metrics: {'acc_step': 0.0,
-                  'train_loss_epoch': 1.0917967557907104,
-                  'train_loss_step': 1.0794280767440796,
-                  'train_loss': 1.0794280767440796,
-                  'acc_epoch': 0.0033333334140479565,
-                  'acc': 0.0}
-        tags: {'Mode': 'training'}
-
-    .. figure:: ../_static/images/pytorch_lightening_autolog.png
-
-        PyTorch autologged MLflow entities
     """
     try:
         import pytorch_lightning as pl

--- a/requirements/doc-requirements.txt
+++ b/requirements/doc-requirements.txt
@@ -11,3 +11,6 @@ tensorflow-cpu<=2.12.0
 pyspark
 datasets
 keras-core
+torch>=1.11.0
+torchvision>=0.12.0
+lightning>=1.8.1

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -13,7 +13,7 @@ tensorflow-cpu>=2.8.0
 # Required by mlflow.pytorch
 torch>=1.11.0
 torchvision>=0.12.0
-pytorch_lightning>=1.5.10
+lightning>=1.8.1
 # Required by mlflow.xgboost
 xgboost>=0.82
 # Required by mlflow.lightgbm


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/9964?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix example of PyTorch autlogging:
- This code should be tested.
- Replace `pytorch_lightning` with `lightning` as suggested by lightning team.
- Delete the text and image block because its state can easily go stale (already stale), and not in the scope of docstring example. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
