### PR TITLE
Improving prompt to new format

### DIFF
--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -78,26 +78,31 @@ class EvaluationExample:
     justification: str = None
     grading_context: Dict[str, str] = None
 
+    def _format_grading_context(self):
+        return "\n".join(
+            [f"key:\n{key}\nvalue:\n{value}" for key, value in self.grading_context.items()]
+        )
+
     def __str__(self) -> str:
         grading_context = (
             ""
             if self.grading_context is None
-            else "\n".join(
-                [f"Provided {key}: {value}" for key, value in self.grading_context.items()]
-            )
+            else "Additional information used by the model:\n" f"{self._format_grading_context()}"
         )
 
         justification = ""
         if self.justification is not None:
-            justification = f"Justification: {self.justification}\n"
+            justification = f"justification: {self.justification}\n"
 
         return f"""
-Input: {self.input}
+Input:
+{self.input}
 
-Provided output: {self.output}
+Output:
+{self.output}
 
 {grading_context}
 
-Score: {self.score}
+score: {self.score}
 {justification}
         """

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -75,12 +75,12 @@ class EvaluationExample:
     input: str
     output: str
     score: float
-    justification: str = None
+    justification: str
     grading_context: Dict[str, str] = None
 
     def _format_grading_context(self):
         return "\n".join(
-            [f"key:\n{key}\nvalue:\n{value}" for key, value in self.grading_context.items()]
+            [f"key: {key}\nvalue:\n{value}" for key, value in self.grading_context.items()]
         )
 
     def __str__(self) -> str:
@@ -89,10 +89,6 @@ class EvaluationExample:
             if self.grading_context is None
             else "Additional information used by the model:\n" f"{self._format_grading_context()}"
         )
-
-        justification = ""
-        if self.justification is not None:
-            justification = f"justification: {self.justification}\n"
 
         return f"""
 Input:
@@ -104,5 +100,5 @@ Output:
 {grading_context}
 
 score: {self.score}
-{justification}
+justification: {self.justification}
         """

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -33,7 +33,12 @@ def _format_args_string(grading_context_columns: Optional[List[str]], eval_value
     return (
         ""
         if args_dict is None
-        else "\n".join(f"Provided {arg}: {arg_value}" for arg, arg_value in args_dict.items())
+        else (
+            "Additional information used by the model:\n"
+            + "\n".join(
+                [f"key:\n{arg}\nvalue:\n{arg_value}" for arg, arg_value in args_dict.items()]
+            )
+        )
     )
 
 
@@ -51,11 +56,11 @@ def _extract_score_and_justification(output):
         # Attempt to parse JSON
         try:
             data = json.loads(text)
-            score = int(data.get("Score"))
-            justification = data.get("Justification")
+            score = int(data.get("score"))
+            justification = data.get("justification")
         except json.JSONDecodeError:
             # If parsing fails, use regex
-            match = re.search(r"Score: (\d+),?\s*Justification: (.+)", text)
+            match = re.search(r"score: (\d+),?\s*justification: (.+)", text)
             if match:
                 score = int(match.group(1))
                 justification = match.group(2)

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -36,7 +36,7 @@ def _format_args_string(grading_context_columns: Optional[List[str]], eval_value
         else (
             "Additional information used by the model:\n"
             + "\n".join(
-                [f"key:\n{arg}\nvalue:\n{arg_value}" for arg, arg_value in args_dict.items()]
+                [f"key: {arg}\nvalue:\n{arg_value}" for arg, arg_value in args_dict.items()]
             )
         )
     )

--- a/mlflow/metrics/genai/prompts/v1.py
+++ b/mlflow/metrics/genai/prompts/v1.py
@@ -20,7 +20,7 @@ grading_system_prompt_template = PromptTemplate(
 Task:
 You are an impartial judge. You will be given an input that was sent to a machine
 learning model, and you will be given an output that the model produced. You
-could also be given additional information that was used by the model to generate the output.
+may also be given additional information that was used by the model to generate the output.
 
 Your task is to determine a numerical score called {name} based on the input and output.
 A definition of {name} and a grading rubric are provided below.
@@ -45,7 +45,7 @@ Grading rubric:
 
 {examples}
 
-You must output a JSON object with the following fields:
+You must return the following fields in your response one below the other:
 score: Your numerical score for the model's {name} based on the rubric
 justification: Your step-by-step reasoning about the model's {name} score
     """
@@ -71,6 +71,7 @@ class EvaluationModel:
             if self.examples is None or len(self.examples) == 0
             else f"Examples:\n{self._format_examples()}"
         )
+
         return {
             "model": self.model,
             "eval_prompt": grading_system_prompt_template.partial_fill(

--- a/mlflow/metrics/genai/prompts/v1.py
+++ b/mlflow/metrics/genai/prompts/v1.py
@@ -17,17 +17,22 @@ default_parameters = {
 }
 grading_system_prompt_template = PromptTemplate(
     """
-Please act as an impartial judge and evaluate the quality of the provided output which
-attempts to produce output for the provided input based on a provided information.
+Task:
+You are an impartial judge. You will be given an input that was sent to a machine
+learning model, and you will be given an output that the model produced. You
+could also be given additional information that was used by the model to generate the output.
 
-You'll be given a grading format below which you'll call for each provided information,
-input and provided output to submit your justification and score to compute the {name} of
-the output.
+Your task is to determine a numerical score called {name} based on the input and output.
+A definition of {name} and a grading rubric are provided below.
+You must use the grading rubric to determine your score. You must also justify your score.
+
+Examples could be included below for reference. Make sure to use them as references and to
+understand them before completing the task.
 
 Input:
 {input}
 
-Provided output:
+Output:
 {output}
 
 {grading_context_columns}
@@ -35,15 +40,14 @@ Provided output:
 Metric definition:
 {definition}
 
-Below is your grading criteria:
+Grading rubric:
 {grading_prompt}
 
 {examples}
 
-And you'll need to submit your grading for the {name} of the output,
-using the following in json format:
-Score: [your score number for the {name} of the output]
-Justification: [your step by step reasoning about the {name} of the output]
+You must output a JSON object with the following fields:
+score: Your numerical score for the model's {name} based on the rubric
+justification: Your step-by-step reasoning about the model's {name} score
     """
 )
 

--- a/tests/metrics/genai/prompts/test_v1.py
+++ b/tests/metrics/genai/prompts/test_v1.py
@@ -48,23 +48,33 @@ def test_evaluation_model_output():
     assert model1["parameters"] == {"temperature": 1.0}
 
     grading_context = {"ground_truth": "This is an output"}
-    args_string = "\n".join(
-        [f"Provided {arg}: {arg_value}" for arg, arg_value in grading_context.items()]
+    args_string = "Additional information used by the model:\n" + "\n".join(
+        [f"key:\n{arg}\nvalue:\n{arg_value}" for arg, arg_value in grading_context.items()]
     )
     expected_prompt1 = """
-    Please act as an impartial judge and evaluate the quality of the provided output which
-    attempts to produce output for the provided input based on a provided information.
-    You'll be given a grading format below which you'll call for each provided information,
-    input and provided output to submit your justification and score to compute the correctness of
-    the output.
+    Task:
+    You are an impartial judge. You will be given an input that was sent to a machine
+    learning model, and you will be given an output that the model produced. You
+    could also be given additional information that was used by the model to generate the output.
+
+    Your task is to determine a numerical score called correctness based on the input and output.
+    A definition of correctness and a grading rubric are provided below.
+    You must use the grading rubric to determine your score. You must also justify your score.
+
+    Examples could be included below for reference. Make sure to use them as references and to
+    understand them before completing the task.
 
     Input:
     This is an input
 
-    Provided output:
+    Output:
     This is an output
 
-    Provided ground_truth: This is an output
+    Additional information used by the model:
+    key:
+    ground_truth
+    value:
+    This is an output
 
     Metric definition:
     Correctness refers to how well the generated output matches or aligns with the reference or
@@ -72,7 +82,7 @@ def test_evaluation_model_output():
     truth serves as a benchmark against which the provided output is compared to determine the
     level of accuracy and fidelity.
 
-    Below is your grading criteria:
+    Grading rubric:
     Correctness: If the answer correctly answer the question, below are the details for
     different scores:
         - Score 1: the answer is completely incorrect, doesn’t mention anything about the
@@ -84,22 +94,38 @@ def test_evaluation_model_output():
         - Score 5: the answer correctly answer the question and not missing any major aspect
 
     Examples:
-        Input: This is an input
-        Provided output: This is an output
-        Provided ground_truth: This is an output
-        Score: 4
-        Justification: This is a justification
+        Input:
+        This is an input
 
-        Input: This is an example input 2
-        Provided output: This is an example output 2
-        Provided ground_truth: This is an output
-        Score: 4
-        Justification: This is an example justification 2
+        Output:
+        This is an output
 
-    And you'll need to submit your grading for the correctness of the output,
-    using the following in json format:
-    Score: [your score number for the correctness of the output]
-    Justification: [your step by step reasoning about the correctness of the output]
+        Additional information used by the model:
+        key:
+        ground_truth
+        value:
+        This is an output
+
+        score: 4
+        justification: This is a justification
+
+
+        Input:
+        This is an example input 2
+
+        Output:
+        This is an example output 2
+
+        Additional information used by the model:
+        key: ground_truth
+        value: This is an output
+
+        score: 4
+        justification: This is an example justification 2
+
+    You must output a JSON object with the following fields:
+    score: Your numerical score for the model's correctness based on the rubric
+    justification: Your step-by-step reasoning about the model's correctness score
       """
     prompt1 = model1["eval_prompt"].format(
         input="This is an input", output="This is an output", grading_context_columns=args_string
@@ -133,16 +159,22 @@ def test_evaluation_model_output():
     }
     args_string = ""
     expected_prompt2 = """
-    Please act as an impartial judge and evaluate the quality of the provided output which
-    attempts to produce output for the provided input based on a provided information.
-    You'll be given a grading format below which you'll call for each provided information,
-    input and provided output to submit your justification and score to compute the correctness of
-    the output.
+    Task:
+    You are an impartial judge. You will be given an input that was sent to a machine
+    learning model, and you will be given an output that the model produced. You
+    could also be given additional information that was used by the model to generate the output.
+
+    Your task is to determine a numerical score called correctness based on the input and output.
+    A definition of correctness and a grading rubric are provided below.
+    You must use the grading rubric to determine your score. You must also justify your score.
+
+    Examples could be included below for reference. Make sure to use them as references and to
+    understand them before completing the task.
 
     Input:
     This is an input
 
-    Provided output:
+    Output:
     This is an output
 
     Metric definition:
@@ -151,7 +183,7 @@ def test_evaluation_model_output():
     truth serves as a benchmark against which the provided output is compared to determine the
     level of accuracy and fidelity.
 
-    Below is your grading criteria:
+    Grading rubric:
     Correctness: If the answer correctly answer the question, below are the details for different
     scores:
         - Score 1: the answer is completely incorrect, doesn’t mention anything about the question
@@ -162,10 +194,9 @@ def test_evaluation_model_output():
         critical aspect.
         - Score 5: the answer correctly answer the question and not missing any major aspect
 
-    And you'll need to submit your grading for the correctness of the output,
-    using the following in json format:
-    Score: [your score number for the correctness of the output]
-    Justification: [your step by step reasoning about the correctness of the output]
+    You must output a JSON object with the following fields:
+    score: Your numerical score for the model's correctness based on the rubric
+    justification: Your step-by-step reasoning about the model's correctness score
       """
     prompt2 = model2["eval_prompt"].format(
         input="This is an input", output="This is an output", grading_context_columns=args_string
@@ -184,28 +215,33 @@ def test_no_examples(examples):
 
     args_string = ""
     expected_prompt2 = """
-    Please act as an impartial judge and evaluate the quality of the provided output which
-    attempts to produce output for the provided input based on a provided information.
-    You'll be given a grading format below which you'll call for each provided information,
-    input and provided output to submit your justification and score to compute the correctness of
-    the output.
+    Task:
+    You are an impartial judge. You will be given an input that was sent to a machine
+    learning model, and you will be given an output that the model produced. You
+    could also be given additional information that was used by the model to generate the output.
+
+    Your task is to determine a numerical score called correctness based on the input and output.
+    A definition of correctness and a grading rubric are provided below.
+    You must use the grading rubric to determine your score. You must also justify your score.
+
+    Examples could be included below for reference. Make sure to use them as references and to
+    understand them before completing the task.
 
     Input:
     This is an input
 
-    Provided output:
+    Output:
     This is an output
 
     Metric definition:
     definition
 
-    Below is your grading criteria:
+    Grading rubric:
     grading prompt
 
-    And you'll need to submit your grading for the correctness of the output,
-    using the following in json format:
-    Score: [your score number for the correctness of the output]
-    Justification: [your step by step reasoning about the correctness of the output]
+    You must output a JSON object with the following fields:
+    score: Your numerical score for the model's correctness based on the rubric
+    justification: Your step-by-step reasoning about the model's correctness score
       """
     prompt2 = model["eval_prompt"].format(
         input="This is an input", output="This is an output", grading_context_columns=args_string

--- a/tests/metrics/genai/prompts/test_v1.py
+++ b/tests/metrics/genai/prompts/test_v1.py
@@ -49,13 +49,13 @@ def test_evaluation_model_output():
 
     grading_context = {"ground_truth": "This is an output"}
     args_string = "Additional information used by the model:\n" + "\n".join(
-        [f"key:\n{arg}\nvalue:\n{arg_value}" for arg, arg_value in grading_context.items()]
+        [f"key: {arg}\nvalue:\n{arg_value}" for arg, arg_value in grading_context.items()]
     )
     expected_prompt1 = """
     Task:
     You are an impartial judge. You will be given an input that was sent to a machine
     learning model, and you will be given an output that the model produced. You
-    could also be given additional information that was used by the model to generate the output.
+    may also be given additional information that was used by the model to generate the output.
 
     Your task is to determine a numerical score called correctness based on the input and output.
     A definition of correctness and a grading rubric are provided below.
@@ -71,8 +71,7 @@ def test_evaluation_model_output():
     This is an output
 
     Additional information used by the model:
-    key:
-    ground_truth
+    key: ground_truth
     value:
     This is an output
 
@@ -101,8 +100,7 @@ def test_evaluation_model_output():
         This is an output
 
         Additional information used by the model:
-        key:
-        ground_truth
+        key: ground_truth
         value:
         This is an output
 
@@ -118,12 +116,13 @@ def test_evaluation_model_output():
 
         Additional information used by the model:
         key: ground_truth
-        value: This is an output
+        value:
+        This is an output
 
         score: 4
         justification: This is an example justification 2
 
-    You must output a JSON object with the following fields:
+    You must return the following fields in your response one below the other:
     score: Your numerical score for the model's correctness based on the rubric
     justification: Your step-by-step reasoning about the model's correctness score
       """
@@ -162,7 +161,7 @@ def test_evaluation_model_output():
     Task:
     You are an impartial judge. You will be given an input that was sent to a machine
     learning model, and you will be given an output that the model produced. You
-    could also be given additional information that was used by the model to generate the output.
+    may also be given additional information that was used by the model to generate the output.
 
     Your task is to determine a numerical score called correctness based on the input and output.
     A definition of correctness and a grading rubric are provided below.
@@ -194,7 +193,7 @@ def test_evaluation_model_output():
         critical aspect.
         - Score 5: the answer correctly answer the question and not missing any major aspect
 
-    You must output a JSON object with the following fields:
+    You must return the following fields in your response one below the other:
     score: Your numerical score for the model's correctness based on the rubric
     justification: Your step-by-step reasoning about the model's correctness score
       """
@@ -218,7 +217,7 @@ def test_no_examples(examples):
     Task:
     You are an impartial judge. You will be given an input that was sent to a machine
     learning model, and you will be given an output that the model produced. You
-    could also be given additional information that was used by the model to generate the output.
+    may also be given additional information that was used by the model to generate the output.
 
     Your task is to determine a numerical score called correctness based on the input and output.
     A definition of correctness and a grading rubric are provided below.
@@ -239,7 +238,7 @@ def test_no_examples(examples):
     Grading rubric:
     grading prompt
 
-    You must output a JSON object with the following fields:
+    You must return the following fields in your response one below the other:
     score: Your numerical score for the model's correctness based on the rubric
     justification: Your step-by-step reasoning about the model's correctness score
       """

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -37,7 +37,7 @@ openai_justification1 = (
 properly_formatted_openai_response1 = {
     "candidates": [
         {
-            "text": '{\n  "Score": 3,\n  "Justification": "' f"{openai_justification1}" '"\n}',
+            "text": '{\n  "score": 3,\n  "justification": "' f"{openai_justification1}" '"\n}',
             "metadata": {"finish_reason": "stop"},
         }
     ],
@@ -53,7 +53,7 @@ properly_formatted_openai_response1 = {
 properly_formatted_openai_response2 = {
     "candidates": [
         {
-            "text": '{\n  "Score": 2,\n  "Justification": "The provided output gives a correct '
+            "text": '{\n  "score": 2,\n  "justification": "The provided output gives a correct '
             "and adequate explanation of what Apache Spark is, covering its main functions and "
             "components like Spark SQL, Spark Streaming, and MLlib. However, it misses a "
             "critical aspect, which is Spark's development as a response to the limitations "
@@ -78,7 +78,7 @@ properly_formatted_openai_response2 = {
 incorrectly_formatted_openai_response = {
     "candidates": [
         {
-            "text": "Score: 2\nJustification: \n\nThe provided output gives some relevant "
+            "text": "score: 2\njustification: \n\nThe provided output gives some relevant "
             "information about MLflow including its capabilities such as experiment tracking, "
             "model packaging, versioning, and deployment. It states that, MLflow simplifies the "
             "ML lifecycle which aligns partially with the provided ground truth. However, it "
@@ -242,20 +242,24 @@ def test_make_genai_metric_correct_response():
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "openai:/gpt-3.5-turbo"
         assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nPlease act as an impartial judge and evaluate the quality of "
-            "the provided output which\nattempts to produce output for the provided input "
-            "based on a provided information.\n\nYou'll be given a grading format below which "
-            "you'll call for each provided information,\ninput and provided output to submit "
-            "your justification and score to compute the fake_metric of\nthe output."
-            "\n\nInput:\ninput\n\nProvided output:\nprediction\n\nProvided targets: "
-            "ground_truth\n\nMetric definition:\nFake metric definition\n\nBelow is your grading "
-            "criteria:\nFake metric grading prompt\n\nExamples:\n\nInput: example-input\n\n"
-            "Provided output: example-output\n\nProvided targets: example-ground_truth\n\n"
-            "Score: 4\nJustification: example-justification\n\n        \n\nAnd you'll need to "
-            "submit your grading for the fake_metric of the output,\nusing the following in json "
-            "format:\nScore: [your score number for the fake_metric of the "
-            "output]\nJustification: [your step by step reasoning about the fake_metric of the "
-            "output]\n    ",
+            "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
+            "sent to a machine\nlearning model, and you will be given an output that the model "
+            "produced. You\ncould also be given additional information that was used by the model "
+            "to generate the output.\n\nYour task is to determine a numerical score called "
+            "fake_metric based on the input and output.\nA definition of "
+            "fake_metric and a grading rubric are provided below.\nYou must use the "
+            "grading rubric to determine your score. You must also justify your score."
+            "\n\nExamples could be included below for reference. Make sure to use them as "
+            "references and to\nunderstand them before completing the task.\n"
+            "\nInput:\ninput\n\nOutput:\nprediction\n\nAdditional information used by the model:\n"
+            "key:\ntargets\nvalue:\nground_truth\n\nMetric definition:\nFake metric definition\n\n"
+            "Grading rubric:\nFake metric grading prompt\n\nExamples:\n\nInput:\nexample-input\n\n"
+            "Output:\nexample-output\n\nAdditional information used by the model:\nkey:\ntargets\n"
+            "value:\nexample-ground_truth\n\nscore: 4\njustification: "
+            "example-justification\n\n        \n\nYou must output a JSON object with the "
+            "following fields:\nscore: Your numerical score for the model's fake_metric based on "
+            "the rubric\njustification: Your step-by-step reasoning about the model's fake_metric "
+            "score\n    ",
             "temperature": 0.0,
             "max_tokens": 200,
             "top_p": 1.0,
@@ -432,7 +436,10 @@ def test_make_genai_metric_failure():
 def test_format_args_string():
     variable_string = _format_args_string(["foo", "bar"], {"foo": ["foo"], "bar": ["bar"]}, 0)
 
-    assert variable_string == "Provided foo: foo\nProvided bar: bar"
+    assert variable_string == (
+        "Additional information used by the model:\nkey:\nfoo\nvalue:\nfoo"
+        "\nkey:\nbar\nvalue:\nbar"
+    )
 
     with pytest.raises(
         MlflowException,
@@ -446,7 +453,7 @@ def test_extract_score_and_justification():
         output={
             "candidates": [
                 {
-                    "text": '{"Score": 4, "Justification": "This is a justification"}',
+                    "text": '{"score": 4, "justification": "This is a justification"}',
                 }
             ]
         }
@@ -459,7 +466,7 @@ def test_extract_score_and_justification():
         output={
             "candidates": [
                 {
-                    "text": "Score: 2 \nJustification: This is a justification",
+                    "text": "score: 2 \njustification: This is a justification",
                 }
             ]
         }
@@ -482,7 +489,7 @@ def test_extract_score_and_justification():
         output={
             "candidates": [
                 {
-                    "text": '{"Score": "4", "Justification": "This is a justification"}',
+                    "text": '{"score": "4", "justification": "This is a justification"}',
                 }
             ]
         }
@@ -495,7 +502,7 @@ def test_extract_score_and_justification():
         output={
             "candidates": [
                 {
-                    "text": '{"Score": 4, "Justification": {"foo": "bar"}}',
+                    "text": '{"score": 4, "justification": {"foo": "bar"}}',
                 }
             ]
         }
@@ -524,27 +531,32 @@ def test_correctness_metric():
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "gateway:/gpt-3.5-turbo"
         assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nPlease act as an impartial judge and evaluate the quality of "
-            "the provided output which\nattempts to produce output for the provided input "
-            "based on a provided information.\n\nYou'll be given a grading format below which "
-            "you'll call for each provided information,\ninput and provided output to submit "
-            "your justification and score to compute the correctness of\nthe output.\n"
+            "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
+            "sent to a machine\nlearning model, and you will be given an output that the model "
+            "produced. You\ncould also be given additional information that was used by the model "
+            "to generate the output.\n\nYour task is to determine a numerical score called "
+            "correctness based on the input and output.\nA definition of "
+            "correctness and a grading rubric are provided below.\nYou must use the "
+            "grading rubric to determine your score. You must also justify your score."
+            "\n\nExamples could be included below for reference. Make sure to use them as "
+            "references and to\nunderstand them before completing the task.\n"
             f"\nInput:\n{input}\n"
-            f"\nProvided output:\n{mlflow_prediction}\n"
-            f"\nProvided targets: {mlflow_ground_truth}\n"
+            f"\nOutput:\n{mlflow_prediction}\n"
+            "\nAdditional information used by the model:\nkey:\ntargets\nvalue:\n"
+            f"{mlflow_ground_truth}\n"
             f"\nMetric definition:\n{CorrectnessMetric.definition}\n"
-            f"\nBelow is your grading criteria:\n{CorrectnessMetric.grading_prompt}\n"
+            f"\nGrading rubric:\n{CorrectnessMetric.grading_prompt}\n"
             "\nExamples:\n"
-            f"\nInput: {mlflow_example.input}\n"
-            f"\nProvided output: {mlflow_example.output}\n"
-            f"\nProvided targets: {mlflow_ground_truth}\n"
-            f"\nScore: {mlflow_example.score}\n"
-            f"Justification: {mlflow_example.justification}\n\n        \n\n"
-            "And you'll need to submit your grading for the correctness of the output,"
-            "\nusing the following in json format:\n"
-            "Score: [your score number for the correctness of the output]\n"
-            "Justification: [your step by step reasoning about the correctness of the output]"
-            "\n    ",
+            f"\nInput:\n{mlflow_example.input}\n"
+            f"\nOutput:\n{mlflow_example.output}\n"
+            "\nAdditional information used by the model:\nkey:\ntargets\nvalue:\n"
+            f"{mlflow_ground_truth}\n"
+            f"\nscore: {mlflow_example.score}\n"
+            f"justification: {mlflow_example.justification}\n\n        \n"
+            "\nYou must output a JSON object with the following fields:\nscore: "
+            "Your numerical score for the model's correctness based on the "
+            "rubric\njustification: Your step-by-step reasoning about the model's "
+            "correctness score\n    ",
             **CorrectnessMetric.parameters,
         }
 
@@ -585,22 +597,26 @@ def test_relevance_metric():
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "gateway:/gpt-3.5-turbo"
         assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nPlease act as an impartial judge and evaluate the quality of "
-            "the provided output which\nattempts to produce output for the provided input "
-            "based on a provided information.\n\nYou'll be given a grading format below which "
-            "you'll call for each provided information,\ninput and provided output to submit "
-            "your justification and score to compute the relevance of\nthe output.\n"
+            "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
+            "sent to a machine\nlearning model, and you will be given an output that the model "
+            "produced. You\ncould also be given additional information that was used by the model "
+            "to generate the output.\n\nYour task is to determine a numerical score called "
+            "relevance based on the input and output.\nA definition of "
+            "relevance and a grading rubric are provided below.\nYou must use the "
+            "grading rubric to determine your score. You must also justify your score."
+            "\n\nExamples could be included below for reference. Make sure to use them as "
+            "references and to\nunderstand them before completing the task.\n"
             f"\nInput:\n{input}\n"
-            f"\nProvided output:\n{mlflow_prediction}\n"
-            f"\nProvided context: {mlflow_ground_truth}\n"
+            f"\nOutput:\n{mlflow_prediction}\n"
+            "\nAdditional information used by the model:\nkey:\ncontext\nvalue:\n"
+            f"{mlflow_ground_truth}\n"
             f"\nMetric definition:\n{RelevanceMetric.definition}\n"
-            f"\nBelow is your grading criteria:\n{RelevanceMetric.grading_prompt}\n"
+            f"\nGrading rubric:\n{RelevanceMetric.grading_prompt}\n"
             "\n\n"
-            "\nAnd you'll need to submit your grading for the relevance of the output,"
-            "\nusing the following in json format:\n"
-            "Score: [your score number for the relevance of the output]\n"
-            "Justification: [your step by step reasoning about the relevance of the output]"
-            "\n    ",
+            "\nYou must output a JSON object with the following fields:\nscore: "
+            "Your numerical score for the model's relevance based on the "
+            "rubric\njustification: Your step-by-step reasoning about the model's "
+            "relevance score\n    ",
             **RelevanceMetric.parameters,
         }
 
@@ -642,24 +658,27 @@ def test_strict_correctness_metric():
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "openai:/gpt-3.5-turbo-16k"
         assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nPlease act as an impartial judge and evaluate the quality of "
-            "the provided output which\nattempts to produce output for the provided input "
-            "based on a provided information.\n\nYou'll be given a grading format below which "
-            "you'll call for each provided information,\ninput and provided output to submit "
-            "your justification and score to compute the strict_correctness of\nthe output.\n"
+            "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
+            "sent to a machine\nlearning model, and you will be given an output that the model "
+            "produced. You\ncould also be given additional information that was used by the model "
+            "to generate the output.\n\nYour task is to determine a numerical score called "
+            "strict_correctness based on the input and output.\nA definition of "
+            "strict_correctness and a grading rubric are provided below.\nYou must use the "
+            "grading rubric to determine your score. You must also justify your score."
+            "\n\nExamples could be included below for reference. Make sure to use them as "
+            "references and to\nunderstand them before completing the task.\n"
             f"\nInput:\n{input}\n"
-            f"\nProvided output:\n{mlflow_prediction}\n"
-            f"\nProvided targets: {mlflow_ground_truth}\n"
+            f"\nOutput:\n{mlflow_prediction}\n"
+            "\nAdditional information used by the model:\nkey:\ntargets\nvalue:\n"
+            f"{mlflow_ground_truth}\n"
             f"\nMetric definition:\n{StrictCorrectnessMetric.definition}\n"
-            f"\nBelow is your grading criteria:\n{StrictCorrectnessMetric.grading_prompt}\n"
+            f"\nGrading rubric:\n{StrictCorrectnessMetric.grading_prompt}\n"
             "\nExamples:\n"
             f"{examples}\n"
-            "\nAnd you'll need to submit your grading for the strict_correctness of the output,"
-            "\nusing the following in json format:\n"
-            "Score: [your score number for the strict_correctness of the output]\n"
-            "Justification: [your step by step reasoning about the strict_correctness of the "
-            "output]"
-            "\n    ",
+            "\nYou must output a JSON object with the following fields:\nscore: "
+            "Your numerical score for the model's strict_correctness based on the "
+            "rubric\njustification: Your step-by-step reasoning about the model's "
+            "strict_correctness score\n    ",
             **StrictCorrectnessMetric.parameters,
         }
 

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -244,7 +244,7 @@ def test_make_genai_metric_correct_response():
         assert mock_predict_function.call_args[0][1] == {
             "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
             "sent to a machine\nlearning model, and you will be given an output that the model "
-            "produced. You\ncould also be given additional information that was used by the model "
+            "produced. You\nmay also be given additional information that was used by the model "
             "to generate the output.\n\nYour task is to determine a numerical score called "
             "fake_metric based on the input and output.\nA definition of "
             "fake_metric and a grading rubric are provided below.\nYou must use the "
@@ -252,14 +252,14 @@ def test_make_genai_metric_correct_response():
             "\n\nExamples could be included below for reference. Make sure to use them as "
             "references and to\nunderstand them before completing the task.\n"
             "\nInput:\ninput\n\nOutput:\nprediction\n\nAdditional information used by the model:\n"
-            "key:\ntargets\nvalue:\nground_truth\n\nMetric definition:\nFake metric definition\n\n"
+            "key: targets\nvalue:\nground_truth\n\nMetric definition:\nFake metric definition\n\n"
             "Grading rubric:\nFake metric grading prompt\n\nExamples:\n\nInput:\nexample-input\n\n"
-            "Output:\nexample-output\n\nAdditional information used by the model:\nkey:\ntargets\n"
+            "Output:\nexample-output\n\nAdditional information used by the model:\nkey: targets\n"
             "value:\nexample-ground_truth\n\nscore: 4\njustification: "
-            "example-justification\n\n        \n\nYou must output a JSON object with the "
-            "following fields:\nscore: Your numerical score for the model's fake_metric based on "
-            "the rubric\njustification: Your step-by-step reasoning about the model's fake_metric "
-            "score\n    ",
+            "example-justification\n        \n\nYou must return the following fields in your "
+            "response one below the other:\nscore: Your numerical score for the model's "
+            "fake_metric based on the rubric\njustification: Your step-by-step reasoning about "
+            "the model's fake_metric score\n    ",
             "temperature": 0.0,
             "max_tokens": 200,
             "top_p": 1.0,
@@ -437,8 +437,7 @@ def test_format_args_string():
     variable_string = _format_args_string(["foo", "bar"], {"foo": ["foo"], "bar": ["bar"]}, 0)
 
     assert variable_string == (
-        "Additional information used by the model:\nkey:\nfoo\nvalue:\nfoo"
-        "\nkey:\nbar\nvalue:\nbar"
+        "Additional information used by the model:\nkey: foo\nvalue:\nfoo" "\nkey: bar\nvalue:\nbar"
     )
 
     with pytest.raises(
@@ -533,7 +532,7 @@ def test_correctness_metric():
         assert mock_predict_function.call_args[0][1] == {
             "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
             "sent to a machine\nlearning model, and you will be given an output that the model "
-            "produced. You\ncould also be given additional information that was used by the model "
+            "produced. You\nmay also be given additional information that was used by the model "
             "to generate the output.\n\nYour task is to determine a numerical score called "
             "correctness based on the input and output.\nA definition of "
             "correctness and a grading rubric are provided below.\nYou must use the "
@@ -542,18 +541,18 @@ def test_correctness_metric():
             "references and to\nunderstand them before completing the task.\n"
             f"\nInput:\n{input}\n"
             f"\nOutput:\n{mlflow_prediction}\n"
-            "\nAdditional information used by the model:\nkey:\ntargets\nvalue:\n"
+            "\nAdditional information used by the model:\nkey: targets\nvalue:\n"
             f"{mlflow_ground_truth}\n"
             f"\nMetric definition:\n{CorrectnessMetric.definition}\n"
             f"\nGrading rubric:\n{CorrectnessMetric.grading_prompt}\n"
             "\nExamples:\n"
             f"\nInput:\n{mlflow_example.input}\n"
             f"\nOutput:\n{mlflow_example.output}\n"
-            "\nAdditional information used by the model:\nkey:\ntargets\nvalue:\n"
+            "\nAdditional information used by the model:\nkey: targets\nvalue:\n"
             f"{mlflow_ground_truth}\n"
             f"\nscore: {mlflow_example.score}\n"
-            f"justification: {mlflow_example.justification}\n\n        \n"
-            "\nYou must output a JSON object with the following fields:\nscore: "
+            f"justification: {mlflow_example.justification}\n        \n"
+            "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's correctness based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
             "correctness score\n    ",
@@ -599,7 +598,7 @@ def test_relevance_metric():
         assert mock_predict_function.call_args[0][1] == {
             "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
             "sent to a machine\nlearning model, and you will be given an output that the model "
-            "produced. You\ncould also be given additional information that was used by the model "
+            "produced. You\nmay also be given additional information that was used by the model "
             "to generate the output.\n\nYour task is to determine a numerical score called "
             "relevance based on the input and output.\nA definition of "
             "relevance and a grading rubric are provided below.\nYou must use the "
@@ -608,12 +607,12 @@ def test_relevance_metric():
             "references and to\nunderstand them before completing the task.\n"
             f"\nInput:\n{input}\n"
             f"\nOutput:\n{mlflow_prediction}\n"
-            "\nAdditional information used by the model:\nkey:\ncontext\nvalue:\n"
+            "\nAdditional information used by the model:\nkey: context\nvalue:\n"
             f"{mlflow_ground_truth}\n"
             f"\nMetric definition:\n{RelevanceMetric.definition}\n"
             f"\nGrading rubric:\n{RelevanceMetric.grading_prompt}\n"
             "\n\n"
-            "\nYou must output a JSON object with the following fields:\nscore: "
+            "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's relevance based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
             "relevance score\n    ",
@@ -660,7 +659,7 @@ def test_strict_correctness_metric():
         assert mock_predict_function.call_args[0][1] == {
             "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
             "sent to a machine\nlearning model, and you will be given an output that the model "
-            "produced. You\ncould also be given additional information that was used by the model "
+            "produced. You\nmay also be given additional information that was used by the model "
             "to generate the output.\n\nYour task is to determine a numerical score called "
             "strict_correctness based on the input and output.\nA definition of "
             "strict_correctness and a grading rubric are provided below.\nYou must use the "
@@ -669,13 +668,13 @@ def test_strict_correctness_metric():
             "references and to\nunderstand them before completing the task.\n"
             f"\nInput:\n{input}\n"
             f"\nOutput:\n{mlflow_prediction}\n"
-            "\nAdditional information used by the model:\nkey:\ntargets\nvalue:\n"
+            "\nAdditional information used by the model:\nkey: targets\nvalue:\n"
             f"{mlflow_ground_truth}\n"
             f"\nMetric definition:\n{StrictCorrectnessMetric.definition}\n"
             f"\nGrading rubric:\n{StrictCorrectnessMetric.grading_prompt}\n"
             "\nExamples:\n"
             f"{examples}\n"
-            "\nYou must output a JSON object with the following fields:\nscore: "
+            "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's strict_correctness based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
             "strict_correctness score\n    ",

--- a/tests/metrics/test_base.py
+++ b/tests/metrics/test_base.py
@@ -21,8 +21,7 @@ def test_evaluation_example_str():
         This is an output
 
         Additional information used by the model:
-        key:
-        foo
+        key: foo
         value:
         bar
 
@@ -31,7 +30,11 @@ def test_evaluation_example_str():
         """
     assert re.sub(r"\s+", "", example1_expected) == re.sub(r"\s+", "", example1)
 
-    example2 = str(EvaluationExample(input="This is an input", output="This is an output", score=5))
+    example2 = str(
+        EvaluationExample(
+            input="This is an input", output="This is an output", score=5, justification="It works"
+        )
+    )
     example2_expected = """
         Input:
         This is an input
@@ -40,5 +43,6 @@ def test_evaluation_example_str():
         This is an output
 
         score: 5
+        justification: It works
         """
     assert re.sub(r"\s+", "", example2_expected) == re.sub(r"\s+", "", example2)

--- a/tests/metrics/test_base.py
+++ b/tests/metrics/test_base.py
@@ -14,18 +14,31 @@ def test_evaluation_example_str():
         )
     )
     example1_expected = """
-        Input: This is an input
-        Provided output: This is an output
-        Provided foo: bar
-        Score: 5
-        Justification: This is a justification
+        Input:
+        This is an input
+
+        Output:
+        This is an output
+
+        Additional information used by the model:
+        key:
+        foo
+        value:
+        bar
+
+        score: 5
+        justification: This is a justification
         """
     assert re.sub(r"\s+", "", example1_expected) == re.sub(r"\s+", "", example1)
 
     example2 = str(EvaluationExample(input="This is an input", output="This is an output", score=5))
     example2_expected = """
-        Input: This is an input
-        Provided output: This is an output
-        Score: 5
+        Input:
+        This is an input
+
+        Output:
+        This is an output
+
+        score: 5
         """
     assert re.sub(r"\s+", "", example2_expected) == re.sub(r"\s+", "", example2)


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sunishsheth2009/mlflow/pull/9966?quickstart=1)

### What changes are proposed in this pull request?
Improving prompt to new format

Cherry-pick: https://github.com/mlflow/mlflow/pull/9883

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
