### PR TITLE
Fix latency and predictions parameter

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -769,6 +769,7 @@ class ModelEvaluator(metaclass=ABCMeta):
         extra_metrics=None,
         custom_artifacts=None,
         baseline_model=None,
+        predictions=None,
         **kwargs,
     ):
         """
@@ -793,6 +794,9 @@ class ModelEvaluator(metaclass=ABCMeta):
                                           flavor as a baseline model to be compared with the
                                           candidate model (specified by the `model` param) for model
                                           validation. (pyfunc model instance is not allowed)
+        :param predictions: The column name of the model output column that is used for evaluation.
+                            This is only used when a model returns a pandas dataframe that contains
+                            multiple columns.
         :return: A :py:class:`mlflow.models.EvaluationResult` instance containing
                  evaluation metrics for candidate model and baseline model and
                  artifacts for candidate model.
@@ -1066,6 +1070,7 @@ def _evaluate(
     extra_metrics,
     custom_artifacts,
     baseline_model,
+    predictions,
 ):
     """
     The public API "evaluate" will verify argument first, and then pass normalized arguments
@@ -1107,6 +1112,7 @@ def _evaluate(
                 extra_metrics=extra_metrics,
                 custom_artifacts=custom_artifacts,
                 baseline_model=baseline_model,
+                predictions=predictions,
             )
             eval_results.append(eval_result)
 
@@ -1428,8 +1434,32 @@ def evaluate(
                     ``data`` is a :py:class:`mlflow.data.dataset.Dataset` that defines targets,
                     then ``targets`` is optional.
 
-    :param predictions: Optional. Only used when ``model`` is not specified and ``data`` is a pandas
-                        dataframe. The name of the column in ``data`` that contains model outputs.
+    :param predictions: Optional. The name of the column that contains model outputs. There are two
+                        cases where this argument is required:
+
+                        - When ``model`` is specified and outputs multiple columns. The
+                          ``predictions`` should be the name of the column that is used for
+                          evaluation.
+                        - When ``model`` is not specified and ``data`` is a pandas dataframe. The
+                          ``predictions`` should be the name of the column in ``data`` that
+                          contains model outputs.
+
+        .. code-block:: python
+            :caption: Example usage of predictions
+
+            # Evaluate a model that outputs multiple columns
+            data = pd.DataFrame({"question": ["foo"]})
+
+
+            def model(inputs):
+                return pd.DataFrame({"answer": ["bar"], "source": ["baz"]})
+
+
+            results = evalaute(model=model, data=data, predictions="answer", ...)
+
+            # Evaluate a static dataset
+            data = pd.DataFrame({"question": ["foo"], "answer": ["bar"], "source": ["baz"]})
+            results = evalaute(data=data, predictions="answer", ...)
 
     :param model_type: (Optional) A string describing the model type. The default evaluator
                        supports the following model types:
@@ -1633,12 +1663,6 @@ def evaluate(
             message="The data argument cannot be None.", error_code=INVALID_PARAMETER_VALUE
         )
 
-    if predictions is not None and model is not None:
-        raise MlflowException(
-            message="The predictions argument cannot be specified when model is specified.",
-            error_code=INVALID_PARAMETER_VALUE,
-        )
-
     _EnvManager.validate(env_manager)
 
     # If Dataset is provided, the targets and predictions can only be specified by the Dataset,
@@ -1779,9 +1803,12 @@ def evaluate(
     with _start_run_or_reuse_active_run() as run_id:
         if not isinstance(data, Dataset):
             # Convert data to `mlflow.data.dataset.Dataset`.
-            data = _convert_data_to_mlflow_dataset(
-                data=data, targets=targets, predictions=predictions
-            )
+            if model is None:
+                data = _convert_data_to_mlflow_dataset(
+                    data=data, targets=targets, predictions=predictions
+                )
+            else:
+                data = _convert_data_to_mlflow_dataset(data=data, targets=targets)
 
         from mlflow.data.pyfunc_dataset_mixin import PyFuncConvertibleDatasetMixin
 
@@ -1802,6 +1829,7 @@ def evaluate(
                 path=dataset_path,
                 feature_names=feature_names,
             )
+        predictions_expected_in_model_output = predictions if model is not None else None
 
         try:
             evaluate_result = _evaluate(
@@ -1815,6 +1843,7 @@ def evaluate(
                 extra_metrics=extra_metrics,
                 custom_artifacts=custom_artifacts,
                 baseline_model=baseline_model,
+                predictions=predictions_expected_in_model_output,
             )
         finally:
             if isinstance(model, _ServedPyFuncModel):

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -443,6 +443,10 @@ _matplotlib_config = {
 def _extract_output_and_other_columns(model_predictions, output_column_name):
     y_pred = None
     other_output_columns = None
+    ERROR_MISSING_OUTPUT_COLUMN_NAME = (
+        "Output column name is not specified for the multi-output model. "
+        "Please set the correct output column name using the `predictions` parameter."
+    )
 
     if isinstance(model_predictions, list) and all(isinstance(p, dict) for p in model_predictions):
         # Extract 'y_pred' and 'other_output_columns' from list of dictionaries
@@ -454,20 +458,32 @@ def _extract_output_and_other_columns(model_predictions, output_column_name):
                 [{k: v for k, v in p.items() if k != output_column_name} for p in model_predictions]
             )
         elif len(model_predictions) > 1:
+            if output_column_name is None:
+                raise MlflowException(
+                    ERROR_MISSING_OUTPUT_COLUMN_NAME,
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
             raise MlflowException(
                 f"Output column name '{output_column_name}' is not found in the model "
                 f"predictions list: {model_predictions}. Please set the correct output column "
-                "name using the `predictions` parameter."
+                "name using the `predictions` parameter.",
+                error_code=INVALID_PARAMETER_VALUE,
             )
     elif isinstance(model_predictions, pd.DataFrame):
         if output_column_name in model_predictions.columns:
             y_pred = model_predictions[output_column_name]
             other_output_columns = model_predictions.drop(columns=output_column_name)
         elif model_predictions.shape[1] > 1:
+            if output_column_name is None:
+                raise MlflowException(
+                    ERROR_MISSING_OUTPUT_COLUMN_NAME,
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
             raise MlflowException(
                 f"Output column name '{output_column_name}' is not found in the model "
                 f"predictions dataframe {model_predictions.columns}. Please set the correct "
-                "output column name using the `predictions` parameter."
+                "output column name using the `predictions` parameter.",
+                error_code=INVALID_PARAMETER_VALUE,
             )
     elif isinstance(model_predictions, dict):
         if output_column_name in model_predictions:
@@ -476,10 +492,16 @@ def _extract_output_and_other_columns(model_predictions, output_column_name):
                 {k: v for k, v in model_predictions.items() if k != output_column_name}
             )
         elif len(model_predictions) > 1:
+            if output_column_name is None:
+                raise MlflowException(
+                    ERROR_MISSING_OUTPUT_COLUMN_NAME,
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
             raise MlflowException(
                 f"Output column name '{output_column_name}' is not found in the "
                 f"model predictions dict {model_predictions}. Please set the correct "
-                "output column name using the ``predictions` parameter."
+                "output column name using the `predictions` parameter.",
+                error_code=INVALID_PARAMETER_VALUE,
             )
 
     return y_pred if y_pred is not None else model_predictions, other_output_columns
@@ -1159,23 +1181,27 @@ class DefaultEvaluator(ModelEvaluator):
                     ):
                         eval_fn_args.append(self.other_output_columns[column])
                     elif param.default == inspect.Parameter.empty:
-                        output_column_name = (
-                            self.predictions if self.predictions is not None else "output"
-                        )
+                        output_column_name = self.predictions
                         if self.other_output_columns:
                             output_columns = list(self.other_output_columns.columns)
                         else:
                             output_columns = []
                         input_columns = list(input_df.columns)
+                        msg_output_columns = (
+                            (
+                                "Note that this does not include the output column: "
+                                f"'{output_column_name}'\n\n"
+                            )
+                            if output_column_name is not None
+                            else ""
+                        )
                         raise MlflowException(
                             "Error: Metric Calculation Failed\n"
                             f"Metric '{extra_metric.name}' requires the column '{param_name}' to "
                             "be defined in either the input data or resulting output data.\n\n"
                             "Below are the existing column names for the input/output data:\n"
                             f"Input Columns: {input_columns}\n"
-                            f"Output Columns: {output_columns}\n"
-                            "Note that this does not include the output column: "
-                            f"'{output_column_name}'\n\n"
+                            f"Output Columns: {output_columns}\n{msg_output_columns}"
                             f"To resolve this issue, you may want to map {param_name} to an "
                             "existing column using the following configuration:\n"
                             f"evaluator_config={{'col_mapping': {{'{param_name}': "
@@ -1319,12 +1345,15 @@ class DefaultEvaluator(ModelEvaluator):
             if self.dataset.predictions_data is None:
                 raise MlflowException(
                     message="Predictions data is missing when model is not provided. "
-                    "Please provide predictions data in the pandas dataset or provide "
-                    "a model.",
+                    "Please provide predictions data in a dataset or provide a model. "
+                    "See the documentation for mlflow.evaluate() for how to specify "
+                    "the predictions data in a dataset.",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
             if compute_latency:
-                _logger.warning("Returning the latency as zeros because model is not provided.")
+                _logger.warning(
+                    "Setting the latency to 0 for all entries because the model " "is not provided."
+                )
                 self.metrics_values.update(
                     {_LATENCY_METRIC_NAME: MetricValue(scores=[0.0] * len(X_copy))}
                 )
@@ -1363,7 +1392,7 @@ class DefaultEvaluator(ModelEvaluator):
             else:
                 self.y_probs = None
 
-        output_column_name = self.predictions if self.predictions is not None else "output"
+        output_column_name = self.predictions
         self.y_pred, self.other_output_columns = _extract_output_and_other_columns(
             model_predictions, output_column_name
         )

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2964,3 +2964,42 @@ def test_evaluate_with_latency_static_dataset():
     }
     assert all(isinstance(grade, float) for grade in logged_data["latency"])
     assert all(grade == 0.0 for grade in logged_data["latency"])
+
+
+def test_default_metrics_as_custom_metrics_static_dataset():
+    with mlflow.start_run() as run:
+        model_info = mlflow.pyfunc.log_model(
+            artifact_path="model", python_model=identity_model, input_example=["a", "b"]
+        )
+        data = pd.DataFrame(
+            {
+                "question": ["words random", "This is a sentence."],
+                "truth": ["words random", "This is a sentence."],
+                "answer": ["words random", "This is a sentence."],
+            }
+        )
+        results = evaluate(
+            model_info.model_uri,
+            data,
+            targets="truth",
+            model_type="question-answering",
+            custom_metrics=[
+                mlflow.metrics.flesch_kincaid_grade_level,
+                mlflow.metrics.perplexity,
+                mlflow.metrics.ari_grade_level,
+                mlflow.metrics.toxicity,
+                mlflow.metrics.exact_match,
+            ],
+            evaluators="default",
+            evaluator_config={
+                "predicted_column": "answer",
+            },
+        )
+
+    client = mlflow.MlflowClient()
+    artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
+    assert "eval_results_table.json" in artifacts
+    for metric in ["toxicity", "perplexity", "ari_grade_level", "flesch_kincaid_grade_level"]:
+        for measure in ["mean", "p90", "variance"]:
+            assert f"{metric}/v1/{measure}" in results.metrics.keys()
+    assert "exact_match/v1" in results.metrics.keys()

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2763,6 +2763,7 @@ def test_constructing_eval_df_for_custom_metrics():
             model_info.model_uri,
             data,
             targets="targets",
+            predictions="output",
             model_type="text",
             extra_metrics=[make_metric(eval_fn=test_eval_df, greater_is_better=True)],
             custom_artifacts=[example_custom_artifact],

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2889,11 +2889,11 @@ def test_default_metrics_as_custom_metrics():
             predictions="answer",
             model_type="question-answering",
             custom_metrics=[
-                mlflow.metrics.flesch_kincaid_grade_level,
-                mlflow.metrics.perplexity,
-                mlflow.metrics.ari_grade_level,
-                mlflow.metrics.toxicity,
-                mlflow.metrics.exact_match,
+                mlflow.metrics.flesch_kincaid_grade_level(),
+                mlflow.metrics.perplexity(),
+                mlflow.metrics.ari_grade_level(),
+                mlflow.metrics.toxicity(),
+                mlflow.metrics.exact_match(),
             ],
             evaluators="default",
         )
@@ -2960,14 +2960,13 @@ def test_multi_output_model_error_handling():
                 model_info.model_uri,
                 data,
                 targets="truth",
-                predictions="answer",
                 model_type="question-answering",
                 custom_metrics=[
-                    mlflow.metrics.flesch_kincaid_grade_level,
-                    mlflow.metrics.perplexity,
-                    mlflow.metrics.ari_grade_level,
-                    mlflow.metrics.toxicity,
-                    mlflow.metrics.exact_match,
+                    mlflow.metrics.flesch_kincaid_grade_level(),
+                    mlflow.metrics.perplexity(),
+                    mlflow.metrics.ari_grade_level(),
+                    mlflow.metrics.toxicity(),
+                    mlflow.metrics.exact_match(),
                 ],
                 evaluators="default",
             )
@@ -3020,7 +3019,7 @@ def test_evaluate_with_latency_static_dataset():
             model_type="text",
             evaluators="default",
             predictions="model_output",
-            extra_metrics=[mlflow.metrics.latency],
+            extra_metrics=[mlflow.metrics.latency()],
         )
 
     client = mlflow.MlflowClient()

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2968,20 +2968,19 @@ def test_evaluate_with_latency_static_dataset():
 
 def test_default_metrics_as_custom_metrics_static_dataset():
     with mlflow.start_run() as run:
-        model_info = mlflow.pyfunc.log_model(
-            artifact_path="model", python_model=identity_model, input_example=["a", "b"]
-        )
         data = pd.DataFrame(
             {
                 "question": ["words random", "This is a sentence."],
                 "truth": ["words random", "This is a sentence."],
                 "answer": ["words random", "This is a sentence."],
+                "question_model_output": ["words random", "This is a sentence."],
+                "answer_model_output": ["words random", "This is a sentence."],
             }
         )
         results = evaluate(
-            model_info.model_uri,
-            data,
+            data=data,
             targets="truth",
+            predictions="answer_model_output",
             model_type="question-answering",
             custom_metrics=[
                 mlflow.metrics.flesch_kincaid_grade_level,

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2963,3 +2963,4 @@ def test_evaluate_with_latency_static_dataset():
         "token_count",
     }
     assert all(isinstance(grade, float) for grade in logged_data["latency"])
+    assert all(grade == 0.0 for grade in logged_data["latency"])

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2927,3 +2927,39 @@ def test_evaluate_with_latency():
         "token_count",
     }
     assert all(isinstance(grade, float) for grade in logged_data["latency"])
+
+
+def test_evaluate_with_latency_static_dataset():
+    with mlflow.start_run() as run:
+        mlflow.pyfunc.log_model(
+            artifact_path="model", python_model=language_model, input_example=["a", "b"]
+        )
+        data = pd.DataFrame(
+            {
+                "text": ["foo", "bar"],
+                "model_output": ["FOO", "BAR"],
+            }
+        )
+        results = mlflow.evaluate(
+            data=data,
+            model_type="text",
+            evaluators="default",
+            predictions="model_output",
+            extra_metrics=[mlflow.metrics.latency],
+        )
+
+    client = mlflow.MlflowClient()
+    artifacts = [a.path for a in client.list_artifacts(run.info.run_id)]
+    assert "eval_results_table.json" in artifacts
+    logged_data = pd.DataFrame(**results.artifacts["eval_results_table"].content)
+    assert set(logged_data.columns.tolist()) == {
+        "text",
+        "outputs",
+        "toxicity/v1/score",
+        "flesch_kincaid_grade_level/v1/score",
+        "ari_grade_level/v1/score",
+        "perplexity/v1/score",
+        "latency",
+        "token_count",
+    }
+    assert all(isinstance(grade, float) for grade in logged_data["latency"])

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1509,18 +1509,6 @@ def test_evaluate_with_static_dataset_error_handling_pandas_dataframe():
                 model_type="regressor",
             )
 
-        with pytest.raises(
-            MlflowException,
-            match="The predictions argument cannot be specified when model is specified.",
-        ):
-            mlflow.evaluate(
-                model="models:/test",
-                data=X.assign(y=y, model_output=y).to_numpy(),
-                targets="y",
-                predictions="model_output",
-                model_type="regressor",
-            )
-
         with pytest.raises(MlflowException, match="The data argument cannot be None."):
             mlflow.evaluate(
                 data=None,

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -910,6 +910,7 @@ def test_evaluator_evaluation_interface(multiclass_logistic_regressor_model_uri,
                     extra_metrics=None,
                     custom_artifacts=None,
                     baseline_model=None,
+                    predictions=None,
                 )
 
 
@@ -991,6 +992,7 @@ def test_evaluate_with_multi_evaluators(
                 "custom_metrics": None,
                 "custom_artifacts": None,
                 "baseline_model": baseline_model,
+                "predictions": None,
             }
 
         # evaluators = None is the case evaluators unspecified, it should fetch all registered

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1370,6 +1370,32 @@ def test_evaluate_with_targets_error_handling():
             )
 
 
+def test_evaluate_with_predictions_error_handling():
+    import lightgbm as lgb
+
+    X, y = sklearn.datasets.load_diabetes(return_X_y=True, as_frame=True)
+    X = X[::5]
+    y = y[::5]
+    lgb_data = lgb.Dataset(X, label=y)
+    model = lgb.train({"objective": "regression"}, lgb_data, num_boost_round=5)
+    mlflow_dataset_with_predictions = mlflow.data.from_pandas(
+        df=X.assign(y=y, model_output=y),
+        targets="y",
+        predictions="model_output",
+    )
+    with mlflow.start_run():
+        with pytest.raises(
+            MlflowException,
+            match="The predictions parameter should not be specified in the Dataset since a model "
+            "is specified. Please remove the predictions column from the Dataset.",
+        ):
+            mlflow.evaluate(
+                model=model,
+                data=mlflow_dataset_with_predictions,
+                model_type="regressor",
+            )
+
+
 def test_evaluate_with_function_input_single_output():
     import lightgbm as lgb
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/liangz1/mlflow/pull/9983?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/9983/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 9983
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

1. Set latency to 0 when evaluating a static dataset.
2. Extend the semantics of the `predictions` parameter in `mlflow.evaluate()` to indicate the column to be used when model is provided and model has multiple outputs.

Before:
https://github.com/mlflow/mlflow/pull/9958

#### Predictions (when model=None) 

| Is Dataset? | data.predictions is specified? | predictions is specified? | Behavior | Explain |
|-------------|-------------------------------|--------------------------|----------|--------|
| Y           | Y                             | Y                        | ❌        | top-level predictions parameter should not be specified since Dataset is used |
| Y           | Y                             | N                        | ✅        | |
| Y           | N                             | Y                        | ❌        | top-level predictions parameter should not be specified since Dataset is used |
| Y           | N                             | N                        | ❌        | model=None must have predictions |
| N           | -                             | Y                        | ✅        | |
| N           | -                             | N                        | ❌        | model=None must have predictions |

After:

#### Predictions (First 6 rows remain unchanged)

| model is None? | Is Dataset? | data.predictions is specified? | predictions is specified? | Behavior | Explain |
|-------------|-------------|-------------------------------|--------------------------|----------|--------|
| Y | Y           | Y                             | Y                        | ❌        | top-level predictions parameter should not be specified since Dataset is used |
| Y | Y           | Y                             | N                        | ✅        | |
| Y | Y           | N                             | Y                        | ❌        | top-level predictions parameter should not be specified since Dataset is used |
| Y | Y           | N                             | N                        | ❌        | model=None must have predictions |
| Y | N           | -                             | Y                        | ✅        | |
| Y | N           | -                             | N                        | ❌        | model=None must have predictions |
| N | Y           | Y                             | Y                        | ❌        | data.predictions cannot be specified when model is not None |
| N | Y           | Y                             | N                        | ❌        | data.predictions cannot be specified when model is not None |
| N | Y           | N                             | Y                        | ✅        |  |
| N | Y           | N                             | N                        | ✅        |  |
| N | N           | -                             | Y                        | ✅        | |
| N | N           | -                             | N                        | ✅        |  |


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
