### PR TITLE
Gateway dependency

### DIFF
--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -94,10 +94,8 @@ def get_default_pip_requirements(is_spark_connect_model=False):
 
     # Strip the suffix from `dev` versions of PySpark, which are not
     # available for installation from Anaconda or PyPI
-    pyspark_extras = ["connect"] if is_spark_connect_model else None
-    pyspark_req = re.sub(
-        r"(\.?)dev.*$", "", _get_pinned_requirement("pyspark", extras=pyspark_extras)
-    )
+    pyspark_req_str = "pyspark[connect]" if is_spark_connect_model else "pyspark"
+    pyspark_req = re.sub(r"(\.?)dev.*$", "", _get_pinned_requirement(pyspark_req_str))
     reqs = [pyspark_req]
     if Version(pyspark.__version__) < Version("3.4"):
         # Versions of PySpark < 3.4 are incompatible with pandas >= 2

--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -14,7 +14,10 @@ from mlflow.models.model import MLMODEL_FILE_NAME, Model
 from mlflow.pyfunc import MAIN
 from mlflow.utils._spark_utils import _prepare_subprocess_environ_for_creating_local_spark_session
 from mlflow.utils.file_utils import write_to
-from mlflow.utils.requirements_utils import DATABRICKS_MODULES_TO_PACKAGES
+from mlflow.utils.requirements_utils import (
+    DATABRICKS_MODULES_TO_PACKAGES,
+    MLFLOW_MODULES_TO_PACKAGES,
+)
 
 
 def _get_top_level_module(full_module_name):
@@ -78,6 +81,12 @@ class _CaptureImportedModules:
                 if full_module_name.startswith(databricks_module):
                     self.imported_modules.add(databricks_module)
                     return
+
+        # special casing for mlflow extras since they may not be required by default
+        if top_level_module == "mlflow":
+            if second_level_module in MLFLOW_MODULES_TO_PACKAGES:
+                self.imported_modules.add(second_level_module)
+                return
 
         self.imported_modules.add(top_level_module)
 

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -424,7 +424,6 @@ def _infer_requirements(model_uri, flavor):
     ]
     packages = packages - set(excluded_packages)
 
-
     # manually exclude mlflow[gateway] as it isn't listed separately in PYPI_PACKAGE_INDEX
     unrecognized_packages = packages - _PYPI_PACKAGE_INDEX.package_names - {"mlflow[gateway]"}
     if unrecognized_packages:

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -547,8 +547,6 @@ def _check_requirement_satisfied(requirement_str):
     if pkg_name == "mlflow" and "gateway" in req.extras:
         try:
             from mlflow import gateway  # noqa: F401
-
-            gateway.__name__
         except ModuleNotFoundError:
             return _MismatchedPackageInfo(
                 package_name="mlflow[gateway]", installed_version=None, requirement=requirement_str

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -8,6 +8,7 @@ import pytest
 
 import mlflow
 import mlflow.utils.requirements_utils
+from mlflow.utils.environment import infer_pip_requirements
 from mlflow.utils.requirements_utils import (
     _capture_imported_modules,
     _get_installed_version,
@@ -410,3 +411,23 @@ def test_capture_imported_modules_include_deps_by_params():
     captured_modules = _capture_imported_modules(model_info.model_uri, "pyfunc")
     assert "pandas" in captured_modules
     assert "sklearn" in captured_modules
+
+
+def test_capture_imported_modules_includes_extras():
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, _, inputs):
+            import mlflow.gateway  # noqa: F401
+            return inputs
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            python_model=MyModel(),
+            artifact_path="test_model",
+            input_example=([1, 2, 3]),
+        )
+
+    captured_modules = _capture_imported_modules(model_info.model_uri, "pyfunc")
+    assert "mlflow.gateway" in captured_modules
+
+    pip_requirements = infer_pip_requirements(model_info.model_uri, "pyfunc")
+    assert f"mlflow[gateway]=={mlflow.__version__}" in pip_requirements

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -417,6 +417,7 @@ def test_capture_imported_modules_includes_extras():
     class MyModel(mlflow.pyfunc.PythonModel):
         def predict(self, _, inputs):
             import mlflow.gateway  # noqa: F401
+
             return inputs
 
     with mlflow.start_run():

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -413,9 +413,9 @@ def test_capture_imported_modules_include_deps_by_params():
     assert "sklearn" in captured_modules
 
 
-def test_capture_imported_modules_includes_extras():
+def test_capture_imported_modules_includes_gateway_extra():
     class MyModel(mlflow.pyfunc.PythonModel):
-        def predict(self, _, inputs):
+        def predict(self, _, inputs, params=None):
             import mlflow.gateway  # noqa: F401
 
             return inputs


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/9991?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/9991/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 9991
```

</p>
</details>

### What changes are proposed in this pull request?

This PR updates `_capture_modules.py` to detect when `import mlflow.gateway` is called, and append it appropriately to the resulting `requirements.txt` file


### How is this PR tested?

- [x] Existing unit/integration tests
Existing unit tests work:
```
$ pytest tests/utils/test_requirements_utils.py
...
20 passed, 32 warnings in 7.96s
```

- [x] New unit/integration tests
Added a new test:
```
tests/utils/test_requirements_utils.py::test_capture_imported_modules_includes_extras PASSED [100%]
```

- [x] Manual tests
Tried saving a model with `mlflow[gateway]` as a dependency, then switching to an environment that doesn't have `mlflow[gateway]` installed. Expectation here is that it should give me some helpful error message that tells me to install it. I guess the behavior here isn't ideal because it implies that mlflow is not installed at all. I think it should be quite easy to change the `installed_version` param to be more helpful in this case though (see comments below)
<img width="675" alt="Screenshot 2023-10-18 at 3 41 28 PM" src="https://github.com/mlflow/mlflow/assets/148037680/3164d222-2b4c-43e8-abe3-8efeb7b31214">

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
