### PR TITLE
Optimistically use MPU for http artifact repo

### DIFF
--- a/mlflow/entities/multipart_upload.py
+++ b/mlflow/entities/multipart_upload.py
@@ -40,7 +40,7 @@ class MultipartUploadCredential:
         return cls(
             url=dict_["url"],
             part_number=dict_["part_number"],
-            headers=dict_["headers"],
+            headers=dict_.get("headers", {}),
         )
 
 

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -442,13 +442,13 @@ MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING = _EnvironmentVariable(
 )
 
 #: Specifies the minimum file size in bytes to use multipart upload when logging artifacts
-#: (default: ``524_288_000``)
+#: (default: ``524_288_000`` (500 MB))
 MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE = _EnvironmentVariable(
-    "MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE", int, 524_288_000
+    "MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE", int, 500 * 1024 ** 2
 )
 
 #: Specifies the chunk size in bytes to use when performing multipart upload
-#: (default: ``104_857_600``)
+#: (default: ``104_857_600`` (100 MB))
 MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE = _EnvironmentVariable(
-    "MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE", int, 104_857_600
+    "MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE", int, 100 * 1024 ** 2
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -440,3 +440,15 @@ MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL = _EnvironmentVariable(
 MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING = _EnvironmentVariable(
     "MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING", int, None
 )
+
+#: Specifies the minimum file size in bytes to use multipart upload when logging artifacts
+#: (default: ``524_288_000``)
+MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE = _EnvironmentVariable(
+    "MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE", int, 524_288_000
+)
+
+#: Specifies the chunk size in bytes to use when performing multipart upload
+#: (default: ``104_857_600``)
+MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE = _EnvironmentVariable(
+    "MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE", int, 104_857_600
+)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -444,11 +444,11 @@ MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING = _EnvironmentVariable(
 #: Specifies the minimum file size in bytes to use multipart upload when logging artifacts
 #: (default: ``524_288_000`` (500 MB))
 MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE = _EnvironmentVariable(
-    "MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE", int, 500 * 1024 ** 2
+    "MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE", int, 500 * 1024**2
 )
 
 #: Specifies the chunk size in bytes to use when performing multipart upload
 #: (default: ``104_857_600`` (100 MB))
 MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE = _EnvironmentVariable(
-    "MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE", int, 100 * 1024 ** 2
+    "MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE", int, 100 * 1024**2
 )

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -138,3 +138,9 @@ class InvalidUrlException(MlflowException):
     """Exception thrown when a http request fails to send due to an invalid URL"""
 
     pass
+
+
+class UnsupportedMultipartUploadException(MlflowException):
+    """Exception thrown when multipart upload is unsupported by an artifact repository"""
+
+    pass

--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -7,7 +7,10 @@ from requests import HTTPError
 
 from mlflow.entities import FileInfo
 from mlflow.entities.multipart_upload import CreateMultipartUploadResponse, MultipartUploadPart
-from mlflow.environment_variables import MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE, MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE
+from mlflow.environment_variables import (
+    MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE,
+    MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE,
+)
 from mlflow.store.artifact.artifact_repo import (
     ArtifactRepository,
     MultipartUploadMixin,
@@ -146,7 +149,9 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         except HTTPError as e:
             # return False if server does not support multipart upload
             error_message = e.response.json().get("message", "")
-            if isinstance(error_message, str) and error_message.startswith("Multipart upload is not supported for artifact repository"):
+            if isinstance(error_message, str) and error_message.startswith(
+                "Multipart upload is not supported for artifact repository"
+            ):
                 return False
             else:
                 raise
@@ -167,7 +172,7 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
                 )
 
             self.complete_multipart_upload(local_file, create.upload_id, parts, artifact_path)
-        except Exception as e:
+        except Exception:
             self.abort_multipart_upload(local_file, create.upload_id, artifact_path)
             raise
 

--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -165,19 +165,18 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
                 raise
 
         try:
-            for i, credential in enumerate(create.credentials):
-                with open(local_file, "rb") as f:
-                    f.seek(i * chunk_size)
+            with open(local_file, "rb") as f:
+                for credential in create.credentials:
                     chunk = f.read(chunk_size)
 
-                response = requests.put(credential.url, data=chunk)
-                augmented_raise_for_status(response)
-                parts.append(
-                    MultipartUploadPart(
-                        part_number=credential.part_number,
-                        etag=response.headers["ETag"],
+                    response = requests.put(credential.url, data=chunk)
+                    augmented_raise_for_status(response)
+                    parts.append(
+                        MultipartUploadPart(
+                            part_number=credential.part_number,
+                            etag=response.headers["ETag"],
+                        )
                     )
-                )
 
             self.complete_multipart_upload(local_file, create.upload_id, parts, artifact_path)
         except Exception as e:

--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import os
 import posixpath
@@ -21,6 +22,8 @@ from mlflow.tracking._tracking_service.utils import _get_default_host_creds
 from mlflow.utils.file_utils import relative_path_to_artifact_path
 from mlflow.utils.mime_type_utils import _guess_mime_type
 from mlflow.utils.rest_utils import augmented_raise_for_status, http_request
+
+_logger = logging.getLogger(__name__)
 
 
 class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
@@ -177,6 +180,7 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
                 )
 
             self.complete_multipart_upload(local_file, create.upload_id, parts, artifact_path)
-        except Exception:
+        except Exception as e:
             self.abort_multipart_upload(local_file, create.upload_id, artifact_path)
+            _logger.warning(f"Failed to upload file {local_file} using multipart upload: {e}")
             raise

--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -34,9 +34,12 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
 
         # Try to perform multipart upload if the file is large.
         # If the server does not support, or if the upload failed, revert to normal upload.
-        if os.path.getsize(local_file) >= MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE.get():
-            if self._multipart_log_artifact(local_file, artifact_path):
-                return
+        if os.path.getsize(
+            local_file
+        ) >= MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE.get() and self._multipart_log_artifact(
+            local_file, artifact_path
+        ):
+            return
 
         file_name = os.path.basename(local_file)
         mime_type = _guess_mime_type(file_name)

--- a/tests/store/artifact/test_http_artifact_repo.py
+++ b/tests/store/artifact/test_http_artifact_repo.py
@@ -99,7 +99,8 @@ def test_log_artifact(http_artifact_repo, tmp_path, artifact_path, filename, exp
             http_artifact_repo.log_artifact(file_path, artifact_path)
 
     mpu_minimum_file_size = MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE.get()
-    with mock.patch("os.path.getsize", return_value=mpu_minimum_file_size + 1), mock.patch.object(
+    file_path.write_text("0" * (mpu_minimum_file_size + 1))
+    with mock.patch.object(
         http_artifact_repo, "_try_multipart_upload", return_value=200
     ) as mock_mpu:
         http_artifact_repo.log_artifact(file_path, artifact_path)

--- a/tests/store/artifact/test_http_artifact_repo.py
+++ b/tests/store/artifact/test_http_artifact_repo.py
@@ -98,8 +98,7 @@ def test_log_artifact(http_artifact_repo, tmp_path, artifact_path, filename, exp
         with pytest.raises(Exception, match="request failed"):
             http_artifact_repo.log_artifact(file_path, artifact_path)
 
-    mpu_minimum_file_size = MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE.get()
-    file_path.write_text("0" * (mpu_minimum_file_size + 1))
+    file_path.write_text("0" * MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE.get())
     with mock.patch.object(
         http_artifact_repo, "_try_multipart_upload", return_value=200
     ) as mock_mpu:

--- a/tests/store/artifact/test_http_artifact_repo.py
+++ b/tests/store/artifact/test_http_artifact_repo.py
@@ -3,8 +3,13 @@ import posixpath
 from unittest import mock
 
 import pytest
+from requests import HTTPError
 
-from mlflow.entities.multipart_upload import MultipartUploadPart
+from mlflow.entities.multipart_upload import (
+    CreateMultipartUploadResponse,
+    MultipartUploadCredential,
+    MultipartUploadPart,
+)
 from mlflow.environment_variables import (
     MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE,
     MLFLOW_TRACKING_CLIENT_CERT_PATH,
@@ -77,13 +82,10 @@ def http_artifact_repo():
 def test_log_artifact(http_artifact_repo, tmp_path, artifact_path, filename, expected_mime_type):
     file_path = tmp_path.joinpath(filename)
     file_path.write_text("0")
-    with mock.patch(
-        "mlflow.store.artifact.http_artifact_repo.http_request",
-        return_value=MockResponse({}, 200),
-    ) as mock_put:
-        http_artifact_repo.log_artifact(file_path, artifact_path)
+
+    def assert_called_log_artifact(mock_http_request):
         paths = (artifact_path, file_path.name) if artifact_path else (file_path.name,)
-        mock_put.assert_called_once_with(
+        mock_http_request.assert_called_once_with(
             http_artifact_repo._host_creds,
             posixpath.join("/", *paths),
             "PUT",
@@ -93,17 +95,60 @@ def test_log_artifact(http_artifact_repo, tmp_path, artifact_path, filename, exp
 
     with mock.patch(
         "mlflow.store.artifact.http_artifact_repo.http_request",
+        return_value=MockResponse({}, 200),
+    ) as mock_put:
+        http_artifact_repo.log_artifact(file_path, artifact_path)
+        assert_called_log_artifact(mock_put)
+
+    with mock.patch(
+        "mlflow.store.artifact.http_artifact_repo.http_request",
         return_value=MockResponse({}, 400),
     ):
         with pytest.raises(Exception, match="request failed"):
             http_artifact_repo.log_artifact(file_path, artifact_path)
 
+    # assert mpu is triggered when file size is larger than minimum file size
     file_path.write_text("0" * MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE.get())
     with mock.patch.object(
         http_artifact_repo, "_try_multipart_upload", return_value=200
     ) as mock_mpu:
         http_artifact_repo.log_artifact(file_path, artifact_path)
         mock_mpu.assert_called_once()
+
+    # assert reverted to normal upload when mpu is not supported
+    # mock that create_multipart_upload will returns a 400 error with appropriate message
+    with mock.patch.object(
+        http_artifact_repo,
+        "create_multipart_upload",
+        side_effect=HTTPError(
+            response=MockResponse(
+                data={"message": "Multipart upload is not supported for artifact repository"},
+                status_code=400,
+            )
+        ),
+    ), mock.patch(
+        "mlflow.store.artifact.http_artifact_repo.http_request",
+        return_value=MockResponse({}, 200),
+    ) as mock_put:
+        http_artifact_repo.log_artifact(file_path, artifact_path)
+        assert_called_log_artifact(mock_put)
+
+    # assert if mpu is triggered but the uploads failed, mpu is aborted and exception is raised
+    with mock.patch("requests.put", side_effect=Exception("MPU_UPLOAD_FAILS")), mock.patch.object(
+        http_artifact_repo,
+        "create_multipart_upload",
+        return_value=CreateMultipartUploadResponse(
+            upload_id="upload_id",
+            credentials=[MultipartUploadCredential(url="url", part_number=1, headers={})],
+        ),
+    ), mock.patch.object(
+        http_artifact_repo,
+        "abort_multipart_upload",
+        return_value=None,
+    ) as mock_abort:
+        with pytest.raises(Exception, match="MPU_UPLOAD_FAILS"):
+            http_artifact_repo.log_artifact(file_path, artifact_path)
+        mock_abort.assert_called_once()
 
 
 @pytest.mark.parametrize("artifact_path", [None, "dir"])

--- a/tests/store/artifact/test_http_artifact_repo.py
+++ b/tests/store/artifact/test_http_artifact_repo.py
@@ -99,10 +99,8 @@ def test_log_artifact(http_artifact_repo, tmp_path, artifact_path, filename, exp
             http_artifact_repo.log_artifact(file_path, artifact_path)
 
     mpu_minimum_file_size = MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE.get()
-    with mock.patch(
-        "os.path.getsize", return_value=mpu_minimum_file_size + 1
-    ), mock.patch.object(
-        http_artifact_repo,"_multipart_log_artifact", return_value=200
+    with mock.patch("os.path.getsize", return_value=mpu_minimum_file_size + 1), mock.patch.object(
+        http_artifact_repo, "_multipart_log_artifact", return_value=200
     ) as mock_mpu:
         http_artifact_repo.log_artifact(file_path, artifact_path)
         mock_mpu.assert_called_once()

--- a/tests/store/artifact/test_http_artifact_repo.py
+++ b/tests/store/artifact/test_http_artifact_repo.py
@@ -100,7 +100,7 @@ def test_log_artifact(http_artifact_repo, tmp_path, artifact_path, filename, exp
 
     mpu_minimum_file_size = MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE.get()
     with mock.patch("os.path.getsize", return_value=mpu_minimum_file_size + 1), mock.patch.object(
-        http_artifact_repo, "_multipart_log_artifact", return_value=200
+        http_artifact_repo, "_try_multipart_upload", return_value=200
     ) as mock_mpu:
         http_artifact_repo.log_artifact(file_path, artifact_path)
         mock_mpu.assert_called_once()


### PR DESCRIPTION
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/gabrielfu/mlflow/pull/9992?quickstart=1)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

HTTP artifact repo will always try to perform multipart upload when logging large artifact.
If the server doesn't support or if the multipart upload fails, it will revert to normal upload.

Example script:
```shell
mlflow ui --artifacts-destination s3://...
```

```python
import mlflow

mlflow.set_tracking_uri("http://127.0.0.1:5000")
artifact_uri = mlflow.get_artifact_uri()
repo = mlflow.artifacts.get_artifact_repository(artifact_uri)
repo.log_artifact(local_file, artifact_path)
```

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

HTTP artifact repo will always try to perform multipart upload when logging large artifact.
If the server doesn't support or if the multipart upload fails, it will revert to normal upload.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
