### PR TITLE
changed pytest_report_teststatus to report disk during tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -66,9 +66,19 @@ def pytest_report_teststatus(report, config):
 
         (*rest, result) = outcome.get_result()
         mem = psutil.virtual_memory()
-        used = mem.used / 1024**3
-        total = mem.total / 1024**3
-        outcome.force_result((*rest, f"{result} | mem {used:.1f}/{total:.1f} GB"))
+        mem_used = mem.used / 1024**3
+        mem_total = mem.total / 1024**3
+
+        disk = psutil.disk_usage("/")
+        disk_used = disk.used / 1024**3
+        disk_total = disk.total / 1024**3
+        outcome.force_result(
+            (
+                *rest,
+                f"{result} 🧠 {mem_used:.1f}/{mem_total:.1f} GB "
+                f"💿 {disk_used:.1f}/{disk_total:.1f} GB",
+            )
+        )
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/conftest.py
+++ b/conftest.py
@@ -76,9 +76,9 @@ def pytest_report_teststatus(report, config):
             (
                 *rest,
                 (
-                    f"{result} "
-                    f"🧠 {mem_used:.1f}/{mem_total:.1f} GB "
-                    f"💿 {disk_used:.1f}/{disk_total:.1f} GB"
+                    f"{result} | "
+                    f"MEM {mem_used:.1f}/{mem_total:.1f} GB | "
+                    f"DISK {disk_used:.1f}/{disk_total:.1f} GB"
                 ),
             )
         )

--- a/conftest.py
+++ b/conftest.py
@@ -75,8 +75,11 @@ def pytest_report_teststatus(report, config):
         outcome.force_result(
             (
                 *rest,
-                f"{result} 🧠 {mem_used:.1f}/{mem_total:.1f} GB "
-                f"💿 {disk_used:.1f}/{disk_total:.1f} GB",
+                (
+                    f"{result} "
+                    f"🧠 {mem_used:.1f}/{mem_total:.1f} GB "
+                    f"💿 {disk_used:.1f}/{disk_total:.1f} GB"
+                ),
             )
         )
 

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -11,7 +11,7 @@ from mlflow import cli
 from mlflow.utils import process
 from mlflow.utils.virtualenv import _get_mlflow_virtualenv_root
 
-from tests.helper_functions import clear_hub_cache, get_free_disk_space_in_GiB
+from tests.helper_functions import clear_hub_cache
 from tests.integration.utils import invoke_cli_runner
 
 EXAMPLES_DIR = "examples"
@@ -26,14 +26,6 @@ def replace_mlflow_with_dev_version(yml_path: Path) -> None:
     mlflow_dir = Path(mlflow.__path__[0]).parent
     new_src = re.sub(r"- mlflow.*\n", f"- {mlflow_dir}\n", old_src)
     yml_path.write_text(new_src)
-
-
-@pytest.fixture(autouse=True)
-def report_free_disk_space(capsys):
-    yield
-
-    with capsys.disabled():
-        sys.stdout.write(f" | Free disk space: {get_free_disk_space_in_GiB():.1f} GiB")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -4,7 +4,6 @@ import logging
 import numbers
 import os
 import random
-import shutil
 import signal
 import socket
 import subprocess
@@ -636,7 +635,3 @@ def clear_hub_cache():
     except ImportError:
         # Local import check for mlflow-skinny not including huggingface_hub
         pass
-
-
-def get_free_disk_space_in_GiB():
-    return shutil.disk_usage("/").free / (1024**3)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/lightnessofbein/mlflow/pull/9994?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/9994/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 9994
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #9993

### What changes are proposed in this pull request?

Changed pytest_report_teststatus hook to display disk usage.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
