### PR TITLE
Make all metrics in `mlflow.metrics` functions

### DIFF
--- a/docs/source/python_api/mlflow.metrics.rst
+++ b/docs/source/python_api/mlflow.metrics.rst
@@ -54,64 +54,45 @@ Evaluation results are stored as :py:class:`MetricValue <mlflow.metrics.MetricVa
 
 .. autoclass:: mlflow.metrics.MetricValue
 
-We provide the following builtin :py:class:`EvaluationMetric <mlflow.metrics.EvaluationMetric>` for evaluating models. These metrics are computed automatically depending on the ``model_type``. For more information on the ``model_type`` parameter, see :py:func:`mlflow.evaluate()` API.
+We provide the following builtin factory functions to create :py:class:`EvaluationMetric <mlflow.metrics.EvaluationMetric>` for evaluating models. These metrics are computed automatically depending on the ``model_type``. For more information on the ``model_type`` parameter, see :py:func:`mlflow.evaluate()` API.
 
-.. autodata:: mlflow.metrics.mae
-   :annotation:
+.. autofunction:: mlflow.metrics.mae
 
-.. autodata:: mlflow.metrics.mape
-   :annotation:
+.. autofunction:: mlflow.metrics.mape
 
-.. autodata:: mlflow.metrics.max_error
-   :annotation:
+.. autofunction:: mlflow.metrics.max_error
 
-.. autodata:: mlflow.metrics.mse
-   :annotation:
+.. autofunction:: mlflow.metrics.mse
 
-.. autodata:: mlflow.metrics.rmse
-   :annotation:
+.. autofunction:: mlflow.metrics.rmse
 
-.. autodata:: mlflow.metrics.r2_score
-   :annotation:
+.. autofunction:: mlflow.metrics.r2_score
 
-.. autodata:: mlflow.metrics.precision_score
-   :annotation:
+.. autofunction:: mlflow.metrics.precision_score
 
-.. autodata:: mlflow.metrics.recall_score
-   :annotation:
+.. autofunction:: mlflow.metrics.recall_score
 
-.. autodata:: mlflow.metrics.f1_score
-   :annotation:
+.. autofunction:: mlflow.metrics.f1_score
 
-.. autodata:: mlflow.metrics.ari_grade_level
-   :annotation:
+.. autofunction:: mlflow.metrics.ari_grade_level
 
-.. autodata:: mlflow.metrics.flesch_kincaid_grade_level
-   :annotation:
+.. autofunction:: mlflow.metrics.flesch_kincaid_grade_level
 
-.. autodata:: mlflow.metrics.perplexity
-   :annotation:
+.. autofunction:: mlflow.metrics.perplexity
 
-.. autodata:: mlflow.metrics.rouge1
-   :annotation:
+.. autofunction:: mlflow.metrics.rouge1
 
-.. autodata:: mlflow.metrics.rouge2
-   :annotation:
+.. autofunction:: mlflow.metrics.rouge2
 
-.. autodata:: mlflow.metrics.rougeL
-   :annotation:
+.. autofunction:: mlflow.metrics.rougeL
 
-.. autodata:: mlflow.metrics.rougeLsum
-   :annotation:
+.. autofunction:: mlflow.metrics.rougeLsum
 
-.. autodata:: mlflow.metrics.toxicity
-   :annotation:
+.. autofunction:: mlflow.metrics.toxicity
 
-.. autodata:: mlflow.metrics.token_count
-   :annotation:
+.. autofunction:: mlflow.metrics.token_count
 
-.. autodata:: mlflow.metrics.latency
-   :annotation:
+.. autofunction:: mlflow.metrics.latency
 
 Users create their own :py:class:`EvaluationMetric <mlflow.metrics.EvaluationMetric>` using the :py:func:`make_metric <mlflow.metrics.make_metric>` factory function
 

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -300,79 +300,89 @@ def rmse() -> EvaluationMetric:
     )
 
 
-r2_score = make_metric(
-    eval_fn=_r2_score_eval_fn,
-    greater_is_better=True,
-    name="r2_score",
-)
-r2_score.__doc__ = """
-This function will create a metric for evaluating `r2_score`_.
+def r2_score() -> EvaluationMetric:
+    """
+    This function will create a metric for evaluating `r2_score`_.
 
-This metric computes an aggregate score for the coefficient of determination. R2 ranges from
-negative infinity to 1, and measures the percentage of variance explained by the predictor
-variables in a regression.
+    This metric computes an aggregate score for the coefficient of determination. R2 ranges from
+    negative infinity to 1, and measures the percentage of variance explained by the predictor
+    variables in a regression.
 
-.. _r2_score: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.r2_score.html
-"""
+    .. _r2_score: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.r2_score.html
+    """
+    return make_metric(
+        eval_fn=_r2_score_eval_fn,
+        greater_is_better=True,
+        name="r2_score",
+    )
 
-max_error = make_metric(
-    eval_fn=_max_error_eval_fn,
-    greater_is_better=False,
-    name="max_error",
-)
-max_error.__doc__ = """
-This function will create a metric for evaluating `max_error`_.
 
-This metric computes an aggregate score for the maximum residual error for regression.
+def max_error() -> EvaluationMetric:
+    """
+    This function will create a metric for evaluating `max_error`_.
 
-.. _max_error: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.max_error.html
-"""
+    This metric computes an aggregate score for the maximum residual error for regression.
 
-mape = make_metric(
-    eval_fn=_mape_eval_fn,
-    greater_is_better=False,
-    name="mean_absolute_percentage_error",
-)
-mape.__doc__ = """
-This function will create a metric for evaluating `mape`_.
+    .. _max_error: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.max_error.html
+    """
+    return make_metric(
+        eval_fn=_max_error_eval_fn,
+        greater_is_better=False,
+        name="max_error",
+    )
 
-This metric computes an aggregate score for the mean absolute percentage error for regression.
 
-.. _mape: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.mean_absolute_percentage_error.html
-"""
+def mape() -> EvaluationMetric:
+    """
+    This function will create a metric for evaluating `mape`_.
+
+    This metric computes an aggregate score for the mean absolute percentage error for regression.
+
+    .. _mape: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.mean_absolute_percentage_error.html
+    """
+    return make_metric(
+        eval_fn=_mape_eval_fn,
+        greater_is_better=False,
+        name="mean_absolute_percentage_error",
+    )
+
 
 # Binary Classification Metrics
 
-recall_score = make_metric(eval_fn=_recall_eval_fn, greater_is_better=True, name="recall_score")
-recall_score.__doc__ = """
-This function will create a metric for evaluating `recall`_ for classification.
 
-This metric computes an aggregate score between 0 and 1 for the recall of a classification task.
+def recall_score() -> EvaluationMetric:
+    """
+    This function will create a metric for evaluating `recall`_ for classification.
 
-.. _recall: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.recall_score.html
-"""
+    This metric computes an aggregate score between 0 and 1 for the recall of a classification task.
 
-precision_score = make_metric(
-    eval_fn=_precision_eval_fn, greater_is_better=True, name="precision_score"
-)
-precision_score.__doc__ = """
-This function will create a metric for evaluating `precision`_ for classification.
+    .. _recall: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.recall_score.html
+    """
+    return make_metric(eval_fn=_recall_eval_fn, greater_is_better=True, name="recall_score")
 
-This metric computes an aggregate score between 0 and 1 for the precision of
-classification task.
 
-.. _precision: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_score.html
-"""
+def precision_score() -> EvaluationMetric:
+    """
+    This function will create a metric for evaluating `precision`_ for classification.
 
-f1_score = make_metric(eval_fn=_f1_score_eval_fn, greater_is_better=True, name="f1_score")
-f1_score.__doc__ = """
-This function will create a metric for evaluating `f1_score`_ for binary classification.
+    This metric computes an aggregate score between 0 and 1 for the precision of
+    classification task.
 
-This metric computes an aggregate score between 0 and 1 for the F1 score (F-measure) of a
-classification task. F1 score is defined as 2 * (precision * recall) / (precision + recall).
+    .. _precision: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_score.html
+    """
+    return make_metric(eval_fn=_precision_eval_fn, greater_is_better=True, name="precision_score")
 
-.. _f1_score: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html
-"""
+
+def f1_score() -> EvaluationMetric:
+    """
+    This function will create a metric for evaluating `f1_score`_ for binary classification.
+
+    This metric computes an aggregate score between 0 and 1 for the F1 score (F-measure) of a
+    classification task. F1 score is defined as 2 * (precision * recall) / (precision + recall).
+
+    .. _f1_score: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html"""
+    return make_metric(eval_fn=_f1_score_eval_fn, greater_is_better=True, name="f1_score")
+
 
 __all__ = [
     "EvaluationExample",

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -81,8 +81,7 @@ def toxicity() -> EvaluationMetric:
         - ratio (of toxic input texts)
 
     .. _toxicity: https://huggingface.co/spaces/evaluate-measurement/toxicity
-    .. _roberta-hate-speech-dynabench-r4:
-    https://huggingface.co/facebook/roberta-hate-speech-dynabench-r4-target
+    .. _roberta-hate-speech-dynabench-r4: https://huggingface.co/facebook/roberta-hate-speech-dynabench-r4-target
     """
     return make_metric(
         eval_fn=_toxicity_eval_fn,

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -41,9 +41,10 @@ from mlflow.utils.annotations import experimental
 @experimental
 def latency() -> EvaluationMetric:
     """
-    This function will create a metric for calculating latency. Latency is determined by the time it takes to generate a
-    prediction for a given input. Note that computing latency requires each row to be predicted
-    sequentially, which will likely slow down the evaluation process."""
+    This function will create a metric for calculating latency. Latency is determined by the time
+    it takes to generate a prediction for a given input. Note that computing latency requires
+    each row to be predicted sequentially, which will likely slow down the evaluation process.
+    """
     return make_metric(
         eval_fn=lambda x: MetricValue(),
         greater_is_better=False,
@@ -55,8 +56,9 @@ def latency() -> EvaluationMetric:
 @experimental
 def token_count() -> EvaluationMetric:
     """
-    This function will create a metric for calculating token_count. Token count is calculated using tiktoken by using the
-    `cl100k_base` tokenizer."""
+    This function will create a metric for calculating token_count. Token count is calculated
+    using tiktoken by using the `cl100k_base` tokenizer.
+    """
     return make_metric(
         eval_fn=_token_count_eval_fn,
         greater_is_better=True,
@@ -67,9 +69,10 @@ def token_count() -> EvaluationMetric:
 @experimental
 def toxicity() -> EvaluationMetric:
     """
-    This function will create a metric for evaluating `toxicity`_ using the model `roberta-hate-speech-dynabench-r4`_,
-    which defines hate as "abusive speech targeting specific group characteristics, such as
-    ethnic origin, religion, gender, or sexual orientation."
+    This function will create a metric for evaluating `toxicity`_ using the model
+    `roberta-hate-speech-dynabench-r4`_, which defines hate as "abusive speech targeting
+    specific group characteristics, such as ethnic origin, religion, gender, or sexual
+    orientation."
 
     The score ranges from 0 to 1, where scores closer to 1 are more toxic. The default threshold
     for a text to be considered "toxic" is 0.5.
@@ -78,7 +81,8 @@ def toxicity() -> EvaluationMetric:
         - ratio (of toxic input texts)
 
     .. _toxicity: https://huggingface.co/spaces/evaluate-measurement/toxicity
-    .. _roberta-hate-speech-dynabench-r4: https://huggingface.co/facebook/roberta-hate-speech-dynabench-r4-target
+    .. _roberta-hate-speech-dynabench-r4:
+    https://huggingface.co/facebook/roberta-hate-speech-dynabench-r4-target
     """
     return make_metric(
         eval_fn=_toxicity_eval_fn,
@@ -95,7 +99,8 @@ def perplexity() -> EvaluationMetric:
     This function will create a metric for evaluating `perplexity`_ using the model gpt2.
 
     The score ranges from 0 to infinity, where a lower score means that the model is better at
-    predicting the given text and a higher score means that the model is not likely to predict the text.
+    predicting the given text and a higher score means that the model is not likely to predict the
+    text.
 
     Aggregations calculated for this metric:
         - mean
@@ -114,17 +119,19 @@ def perplexity() -> EvaluationMetric:
 @experimental
 def flesch_kincaid_grade_level() -> EvaluationMetric:
     """
-    This function will create a metric for calculating `flesch kincaid grade level`_ using `textstat`_.
+    This function will create a metric for calculating `flesch kincaid grade level`_ using
+    `textstat`_.
 
-    This metric outputs a number that approximates the grade level needed to comprehend the text, which
-    will likely range from around 0 to 15 (although it is not limited to this range).
+    This metric outputs a number that approximates the grade level needed to comprehend the text,
+    which will likely range from around 0 to 15 (although it is not limited to this range).
 
     Aggregations calculated for this metric:
         - mean
 
     .. _flesch kincaid grade level:
         https://en.wikipedia.org/wiki/Flesch%E2%80%93Kincaid_readability_tests#Flesch%E2%80%93Kincaid_grade_level
-    .. _textstat: https://pypi.org/project/textstat/"""
+    .. _textstat: https://pypi.org/project/textstat/
+    """
     return make_metric(
         eval_fn=_flesch_kincaid_eval_fn,
         greater_is_better=False,
@@ -136,16 +143,18 @@ def flesch_kincaid_grade_level() -> EvaluationMetric:
 @experimental
 def ari_grade_level() -> EvaluationMetric:
     """
-    This function will create a metric for calculating `automated readability index`_ using `textstat`_.
+    This function will create a metric for calculating `automated readability index`_ using
+    `textstat`_.
 
-    This metric outputs a number that approximates the grade level needed to comprehend the text, which
-    will likely range from around 0 to 15 (although it is not limited to this range).
+    This metric outputs a number that approximates the grade level needed to comprehend the text,
+    which will likely range from around 0 to 15 (although it is not limited to this range).
 
     Aggregations calculated for this metric:
         - mean
 
     .. _automated readability index: https://en.wikipedia.org/wiki/Automated_readability_index
-    .. _textstat: https://pypi.org/project/textstat/"""
+    .. _textstat: https://pypi.org/project/textstat/
+    """
     return make_metric(
         eval_fn=_ari_eval_fn,
         greater_is_better=False,
@@ -182,7 +191,8 @@ def rouge1() -> EvaluationMetric:
     Aggregations calculated for this metric:
         - mean
 
-    .. _rouge1: https://huggingface.co/spaces/evaluate-metric/rouge"""
+    .. _rouge1: https://huggingface.co/spaces/evaluate-metric/rouge
+    """
     return make_metric(
         eval_fn=_rouge1_eval_fn,
         greater_is_better=True,
@@ -202,7 +212,8 @@ def rouge2() -> EvaluationMetric:
     Aggregations calculated for this metric:
         - mean
 
-    .. _rouge2: https://huggingface.co/spaces/evaluate-metric/rouge"""
+    .. _rouge2: https://huggingface.co/spaces/evaluate-metric/rouge
+    """
     return make_metric(
         eval_fn=_rouge2_eval_fn,
         greater_is_better=True,
@@ -222,7 +233,8 @@ def rougeL() -> EvaluationMetric:
     Aggregations calculated for this metric:
         - mean
 
-    .. _rougeL: https://huggingface.co/spaces/evaluate-metric/rouge"""
+    .. _rougeL: https://huggingface.co/spaces/evaluate-metric/rouge
+    """
     return make_metric(
         eval_fn=_rougeL_eval_fn,
         greater_is_better=True,
@@ -234,8 +246,6 @@ def rougeL() -> EvaluationMetric:
 @experimental
 def rougeLsum() -> EvaluationMetric:
     """
-    .. Note:: Experimental: This metric may change or be removed in a future release without warning.
-
     This function will create a metric for evaluating `rougeLsum`_.
 
     The score ranges from 0 to 1, where a higher score indicates higher similarity.
@@ -244,7 +254,8 @@ def rougeLsum() -> EvaluationMetric:
     Aggregations calculated for this metric:
         - mean
 
-    .. _rougeLsum: https://huggingface.co/spaces/evaluate-metric/rouge"""
+    .. _rougeLsum: https://huggingface.co/spaces/evaluate-metric/rouge
+    """
     return make_metric(
         eval_fn=_rougeLsum_eval_fn,
         greater_is_better=True,
@@ -380,7 +391,8 @@ def f1_score() -> EvaluationMetric:
     This metric computes an aggregate score between 0 and 1 for the F1 score (F-measure) of a
     classification task. F1 score is defined as 2 * (precision * recall) / (precision + recall).
 
-    .. _f1_score: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html"""
+    .. _f1_score: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html
+    """
     return make_metric(eval_fn=_f1_score_eval_fn, greater_is_better=True, name="f1_score")
 
 

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -35,6 +35,7 @@ from mlflow.models import (
     EvaluationMetric,
     make_metric,
 )
+from mlflow.utils.annotations import experimental
 
 latency = make_metric(
     eval_fn=lambda x: MetricValue(),
@@ -49,18 +50,20 @@ prediction for a given input. Note that computing latency requires each row to b
 sequentially, which will likely slow down the evaluation process.
 """
 
-# general text metrics
-token_count = make_metric(
-    eval_fn=_token_count_eval_fn,
-    greater_is_better=True,
-    name="token_count",
-)
-token_count.__doc__ = """
-.. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
-A metric for calculating token_count. Token count is calculated using tiktoken by using the
-`cl100k_base` tokenizer.
-"""
+# general text metrics
+@experimental
+def token_count() -> EvaluationMetric:
+    """
+    This function will create a metric for calculating token_count. Token count is calculated using tiktoken by using the
+    `cl100k_base` tokenizer.
+    """
+    return make_metric(
+        eval_fn=_token_count_eval_fn,
+        greater_is_better=True,
+        name="token_count",
+    )
+
 
 toxicity = make_metric(
     eval_fn=_toxicity_eval_fn,

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -45,7 +45,7 @@ latency = make_metric(
 latency.__doc__ = """
 .. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
-A metric for calculating latency. Latency is determined by the time it takes to generate a
+This function will create a metric for calculating latency. Latency is determined by the time it takes to generate a
 prediction for a given input. Note that computing latency requires each row to be predicted
 sequentially, which will likely slow down the evaluation process.
 """
@@ -56,8 +56,7 @@ sequentially, which will likely slow down the evaluation process.
 def token_count() -> EvaluationMetric:
     """
     This function will create a metric for calculating token_count. Token count is calculated using tiktoken by using the
-    `cl100k_base` tokenizer.
-    """
+    `cl100k_base` tokenizer."""
     return make_metric(
         eval_fn=_token_count_eval_fn,
         greater_is_better=True,
@@ -65,232 +64,241 @@ def token_count() -> EvaluationMetric:
     )
 
 
-toxicity = make_metric(
-    eval_fn=_toxicity_eval_fn,
-    greater_is_better=False,
-    name="toxicity",
-    long_name="toxicity/roberta-hate-speech-dynabench-r4",
-    version="v1",
-)
-toxicity.__doc__ = """
-.. Note:: Experimental: This metric may change or be removed in a future release without warning.
+@experimental
+def toxicity() -> EvaluationMetric:
+    """
+    This function will create a metric for evaluating `toxicity`_ using the model `roberta-hate-speech-dynabench-r4`_,
+    which defines hate as "abusive speech targeting specific group characteristics, such as
+    ethnic origin, religion, gender, or sexual orientation."
 
-A metric for evaluating `toxicity`_ using the model `roberta-hate-speech-dynabench-r4`_,
-which defines hate as "abusive speech targeting specific group characteristics, such as
-ethnic origin, religion, gender, or sexual orientation."
+    The score ranges from 0 to 1, where scores closer to 1 are more toxic. The default threshold
+    for a text to be considered "toxic" is 0.5.
 
-The score ranges from 0 to 1, where scores closer to 1 are more toxic. The default threshold
-for a text to be considered "toxic" is 0.5.
+    Aggregations calculated for this metric:
+        - ratio (of toxic input texts)
 
-Aggregations calculated for this metric:
-    - ratio (of toxic input texts)
+    .. _toxicity: https://huggingface.co/spaces/evaluate-measurement/toxicity
+    .. _roberta-hate-speech-dynabench-r4: https://huggingface.co/facebook/roberta-hate-speech-dynabench-r4-target
+    """
+    return make_metric(
+        eval_fn=_toxicity_eval_fn,
+        greater_is_better=False,
+        name="toxicity",
+        long_name="toxicity/roberta-hate-speech-dynabench-r4",
+        version="v1",
+    )
 
-.. _toxicity: https://huggingface.co/spaces/evaluate-measurement/toxicity
-.. _roberta-hate-speech-dynabench-r4: https://huggingface.co/facebook/roberta-hate-speech-dynabench-r4-target
-"""
 
-perplexity = make_metric(
-    eval_fn=_perplexity_eval_fn,
-    greater_is_better=False,
-    name="perplexity",
-    long_name="perplexity/gpt2",
-    version="v1",
-)
-"""
-.. Note:: Experimental: This metric may change or be removed in a future release without warning.
+@experimental
+def perplexity() -> EvaluationMetric:
+    """
+    This function will create a metric for evaluating `perplexity`_ using the model gpt2.
 
-A metric for evaluating `perplexity`_ using the model gpt2.
+    The score ranges from 0 to infinity, where a lower score means that the model is better at
+    predicting the given text and a higher score means that the model is not likely to predict the text.
 
-The score ranges from 0 to infinity, where a lower score means that the model is better at
-predicting the given text and a higher score means that the model is not likely to predict the text.
+    Aggregations calculated for this metric:
+        - mean
 
-Aggregations calculated for this metric:
-    - mean
+    .. _perplexity: https://huggingface.co/spaces/evaluate-metric/perplexity
+    """
+    return make_metric(
+        eval_fn=_perplexity_eval_fn,
+        greater_is_better=False,
+        name="perplexity",
+        long_name="perplexity/gpt2",
+        version="v1",
+    )
 
-.. _perplexity: https://huggingface.co/spaces/evaluate-metric/perplexity
-"""
 
-flesch_kincaid_grade_level = make_metric(
-    eval_fn=_flesch_kincaid_eval_fn,
-    greater_is_better=False,
-    name="flesch_kincaid_grade_level",
-    version="v1",
-)
-flesch_kincaid_grade_level.__doc__ = """
-.. Note:: Experimental: This metric may change or be removed in a future release without warning.
+@experimental
+def flesch_kincaid_grade_level() -> EvaluationMetric:
+    """
+    This function will create a metric for calculating `flesch kincaid grade level`_ using `textstat`_.
 
-A metric for calculating `flesch kincaid grade level`_ using `textstat`_.
+    This metric outputs a number that approximates the grade level needed to comprehend the text, which
+    will likely range from around 0 to 15 (although it is not limited to this range).
 
-This metric outputs a number that approximates the grade level needed to comprehend the text, which
-will likely range from around 0 to 15 (although it is not limited to this range).
+    Aggregations calculated for this metric:
+        - mean
 
-Aggregations calculated for this metric:
-    - mean
+    .. _flesch kincaid grade level:
+        https://en.wikipedia.org/wiki/Flesch%E2%80%93Kincaid_readability_tests#Flesch%E2%80%93Kincaid_grade_level
+    .. _textstat: https://pypi.org/project/textstat/"""
+    return make_metric(
+        eval_fn=_flesch_kincaid_eval_fn,
+        greater_is_better=False,
+        name="flesch_kincaid_grade_level",
+        version="v1",
+    )
 
-.. _flesch kincaid grade level:
-    https://en.wikipedia.org/wiki/Flesch%E2%80%93Kincaid_readability_tests#Flesch%E2%80%93Kincaid_grade_level
-.. _textstat: https://pypi.org/project/textstat/
-"""
 
-ari_grade_level = make_metric(
-    eval_fn=_ari_eval_fn,
-    greater_is_better=False,
-    name="ari_grade_level",
-    long_name="automated_readability_index_grade_level",
-    version="v1",
-)
-ari_grade_level.__doc__ = """
-.. Note:: Experimental: This metric may change or be removed in a future release without warning.
+@experimental
+def ari_grade_level() -> EvaluationMetric:
+    """
+    This function will create a metric for calculating `automated readability index`_ using `textstat`_.
 
-A metric for calculating `automated readability index`_ using `textstat`_.
+    This metric outputs a number that approximates the grade level needed to comprehend the text, which
+    will likely range from around 0 to 15 (although it is not limited to this range).
 
-This metric outputs a number that approximates the grade level needed to comprehend the text, which
-will likely range from around 0 to 15 (although it is not limited to this range).
+    Aggregations calculated for this metric:
+        - mean
 
-Aggregations calculated for this metric:
-    - mean
+    .. _automated readability index: https://en.wikipedia.org/wiki/Automated_readability_index
+    .. _textstat: https://pypi.org/project/textstat/"""
+    return make_metric(
+        eval_fn=_ari_eval_fn,
+        greater_is_better=False,
+        name="ari_grade_level",
+        long_name="automated_readability_index_grade_level",
+        version="v1",
+    )
 
-.. _automated readability index: https://en.wikipedia.org/wiki/Automated_readability_index
-.. _textstat: https://pypi.org/project/textstat/
-"""
 
 # question answering metrics
+@experimental
+def exact_match() -> EvaluationMetric:
+    """
+    This function will create a metric for calculating `accuracy`_ using sklearn.
 
-exact_match = make_metric(
-    eval_fn=_accuracy_eval_fn, greater_is_better=True, name="exact_match", version="v1"
-)
-exact_match.__doc__ = """
-.. Note:: Experimental: This metric may change or be removed in a future release without warning.
+    This metric only computes an aggregate score which ranges from 0 to 1.
 
-A metric for calculating `accuracy`_ using sklearn.
+    .. _accuracy: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.accuracy_score.html
+    """
+    return make_metric(
+        eval_fn=_accuracy_eval_fn, greater_is_better=True, name="exact_match", version="v1"
+    )
 
-This metric only computes an aggregate score which ranges from 0 to 1.
-
-.. _accuracy: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.accuracy_score.html
-"""
 
 # text summarization metrics
+@experimental
+def rouge1() -> EvaluationMetric:
+    """
+    This function will create a metric for evaluating `rouge1`_.
 
-rouge1 = make_metric(
-    eval_fn=_rouge1_eval_fn,
-    greater_is_better=True,
-    name="rouge1",
-    version="v1",
-)
-rouge1.__doc__ = """
-.. Note:: Experimental: This metric may change or be removed in a future release without warning.
+    The score ranges from 0 to 1, where a higher score indicates higher similarity.
+    `rouge1`_ uses unigram based scoring to calculate similarity.
 
-A metric for evaluating `rouge1`_.
+    Aggregations calculated for this metric:
+        - mean
 
-The score ranges from 0 to 1, where a higher score indicates higher similarity.
-`rouge1`_ uses unigram based scoring to calculate similarity.
+    .. _rouge1: https://huggingface.co/spaces/evaluate-metric/rouge"""
+    return make_metric(
+        eval_fn=_rouge1_eval_fn,
+        greater_is_better=True,
+        name="rouge1",
+        version="v1",
+    )
 
-Aggregations calculated for this metric:
-    - mean
 
-.. _rouge1: https://huggingface.co/spaces/evaluate-metric/rouge
-"""
+@experimental
+def rouge2() -> EvaluationMetric:
+    """
+    This function will create a metric for evaluating `rouge2`_.
 
-rouge2 = make_metric(
-    eval_fn=_rouge2_eval_fn,
-    greater_is_better=True,
-    name="rouge2",
-    version="v1",
-)
-rouge2.__doc__ = """
-.. Note:: Experimental: This metric may change or be removed in a future release without warning.
+    The score ranges from 0 to 1, where a higher score indicates higher similarity.
+    `rouge2`_ uses bigram based scoring to calculate similarity.
 
-A metric for evaluating `rouge2`_.
+    Aggregations calculated for this metric:
+        - mean
 
-The score ranges from 0 to 1, where a higher score indicates higher similarity.
-`rouge2`_ uses bigram based scoring to calculate similarity.
+    .. _rouge2: https://huggingface.co/spaces/evaluate-metric/rouge"""
+    return make_metric(
+        eval_fn=_rouge2_eval_fn,
+        greater_is_better=True,
+        name="rouge2",
+        version="v1",
+    )
 
-Aggregations calculated for this metric:
-    - mean
 
-.. _rouge2: https://huggingface.co/spaces/evaluate-metric/rouge
-"""
+@experimental
+def rougeL() -> EvaluationMetric:
+    """
+    This function will create a metric for evaluating `rougeL`_.
 
-rougeL = make_metric(
-    eval_fn=_rougeL_eval_fn,
-    greater_is_better=True,
-    name="rougeL",
-    version="v1",
-)
-rougeL.__doc__ = """
-.. Note:: Experimental: This metric may change or be removed in a future release without warning.
+    The score ranges from 0 to 1, where a higher score indicates higher similarity.
+    `rougeL`_ uses unigram based scoring to calculate similarity.
 
-A metric for evaluating `rougeL`_.
+    Aggregations calculated for this metric:
+        - mean
 
-The score ranges from 0 to 1, where a higher score indicates higher similarity.
-`rougeL`_ uses unigram based scoring to calculate similarity.
+    .. _rougeL: https://huggingface.co/spaces/evaluate-metric/rouge"""
+    return make_metric(
+        eval_fn=_rougeL_eval_fn,
+        greater_is_better=True,
+        name="rougeL",
+        version="v1",
+    )
 
-Aggregations calculated for this metric:
-    - mean
 
-.. _rougeL: https://huggingface.co/spaces/evaluate-metric/rouge
-"""
+@experimental
+def rougeLsum() -> EvaluationMetric:
+    """
+    .. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
-rougeLsum = make_metric(
-    eval_fn=_rougeLsum_eval_fn,
-    greater_is_better=True,
-    name="rougeLsum",
-    version="v1",
-)
-rougeLsum.__doc__ = """
-.. Note:: Experimental: This metric may change or be removed in a future release without warning.
+    This function will create a metric for evaluating `rougeLsum`_.
 
-A metric for evaluating `rougeLsum`_.
+    The score ranges from 0 to 1, where a higher score indicates higher similarity.
+    `rougeLsum`_ uses longest common subsequence based scoring to calculate similarity.
 
-The score ranges from 0 to 1, where a higher score indicates higher similarity.
-`rougeLsum`_ uses longest common subsequence based scoring to calculate similarity.
+    Aggregations calculated for this metric:
+        - mean
 
-Aggregations calculated for this metric:
-    - mean
+    .. _rougeLsum: https://huggingface.co/spaces/evaluate-metric/rouge"""
+    return make_metric(
+        eval_fn=_rougeLsum_eval_fn,
+        greater_is_better=True,
+        name="rougeLsum",
+        version="v1",
+    )
 
-.. _rougeLsum: https://huggingface.co/spaces/evaluate-metric/rouge
-"""
 
 # General Regression Metrics
+def mae() -> EvaluationMetric:
+    """
+    This function will create a metric for evaluating `mae`_.
 
-mae = make_metric(
-    eval_fn=_mae_eval_fn,
-    greater_is_better=False,
-    name="mean_absolute_error",
-)
-mae.__doc__ = """
-A metric for evaluating `mae`_.
+    This metric computes an aggregate score for the mean absolute error for regression.
 
-This metric computes an aggregate score for the mean absolute error for regression.
+    .. _mae: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.mean_absolute_error.html
+    """
+    return make_metric(
+        eval_fn=_mae_eval_fn,
+        greater_is_better=False,
+        name="mean_absolute_error",
+    )
 
-.. _mae: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.mean_absolute_error.html
-"""
 
-mse = make_metric(
-    eval_fn=_mse_eval_fn,
-    greater_is_better=False,
-    name="mean_squared_error",
-)
-mse.__doc__ = """
-A metric for evaluating `mse`_.
+def mse() -> EvaluationMetric:
+    """
+    This function will create a metric for evaluating `mse`_.
 
-This metric computes an aggregate score for the mean squared error for regression.
+    This metric computes an aggregate score for the mean squared error for regression.
 
-.. _mse: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.mean_squared_error.html
-"""
+    .. _mse: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.mean_squared_error.html
+    """
+    return make_metric(
+        eval_fn=_mse_eval_fn,
+        greater_is_better=False,
+        name="mean_squared_error",
+    )
 
-rmse = make_metric(
-    eval_fn=_rmse_eval_fn,
-    greater_is_better=False,
-    name="root_mean_squared_error",
-)
-rmse.__doc__ = """
-A metric for evaluating the square root of `mse`_.
 
-This metric computes an aggregate score for the root mean absolute error for regression.
+def rmse() -> EvaluationMetric:
+    """
+    This function will create a metric for evaluating the square root of `mse`_.
 
-.. _mse: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.mean_squared_error.html
-"""
+    This metric computes an aggregate score for the root mean absolute error for regression.
+
+    .. _mse: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.mean_squared_error.html
+    """
+
+    return make_metric(
+        eval_fn=_rmse_eval_fn,
+        greater_is_better=False,
+        name="root_mean_squared_error",
+    )
+
 
 r2_score = make_metric(
     eval_fn=_r2_score_eval_fn,
@@ -298,7 +306,7 @@ r2_score = make_metric(
     name="r2_score",
 )
 r2_score.__doc__ = """
-A metric for evaluating `r2_score`_.
+This function will create a metric for evaluating `r2_score`_.
 
 This metric computes an aggregate score for the coefficient of determination. R2 ranges from
 negative infinity to 1, and measures the percentage of variance explained by the predictor
@@ -313,7 +321,7 @@ max_error = make_metric(
     name="max_error",
 )
 max_error.__doc__ = """
-A metric for evaluating `max_error`_.
+This function will create a metric for evaluating `max_error`_.
 
 This metric computes an aggregate score for the maximum residual error for regression.
 
@@ -326,7 +334,7 @@ mape = make_metric(
     name="mean_absolute_percentage_error",
 )
 mape.__doc__ = """
-A metric for evaluating `mape`_.
+This function will create a metric for evaluating `mape`_.
 
 This metric computes an aggregate score for the mean absolute percentage error for regression.
 
@@ -337,7 +345,7 @@ This metric computes an aggregate score for the mean absolute percentage error f
 
 recall_score = make_metric(eval_fn=_recall_eval_fn, greater_is_better=True, name="recall_score")
 recall_score.__doc__ = """
-A metric for evaluating `recall`_ for classification.
+This function will create a metric for evaluating `recall`_ for classification.
 
 This metric computes an aggregate score between 0 and 1 for the recall of a classification task.
 
@@ -348,7 +356,7 @@ precision_score = make_metric(
     eval_fn=_precision_eval_fn, greater_is_better=True, name="precision_score"
 )
 precision_score.__doc__ = """
-A metric for evaluating `precision`_ for classification.
+This function will create a metric for evaluating `precision`_ for classification.
 
 This metric computes an aggregate score between 0 and 1 for the precision of
 classification task.
@@ -358,7 +366,7 @@ classification task.
 
 f1_score = make_metric(eval_fn=_f1_score_eval_fn, greater_is_better=True, name="f1_score")
 f1_score.__doc__ = """
-A metric for evaluating `f1_score`_ for binary classification.
+This function will create a metric for evaluating `f1_score`_ for binary classification.
 
 This metric computes an aggregate score between 0 and 1 for the F1 score (F-measure) of a
 classification task. F1 score is defined as 2 * (precision * recall) / (precision + recall).

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -37,18 +37,18 @@ from mlflow.models import (
 )
 from mlflow.utils.annotations import experimental
 
-latency = make_metric(
-    eval_fn=lambda x: MetricValue(),
-    greater_is_better=False,
-    name="latency",
-)
-latency.__doc__ = """
-.. Note:: Experimental: This metric may change or be removed in a future release without warning.
 
-This function will create a metric for calculating latency. Latency is determined by the time it takes to generate a
-prediction for a given input. Note that computing latency requires each row to be predicted
-sequentially, which will likely slow down the evaluation process.
-"""
+@experimental
+def latency() -> EvaluationMetric:
+    """
+    This function will create a metric for calculating latency. Latency is determined by the time it takes to generate a
+    prediction for a given input. Note that computing latency requires each row to be predicted
+    sequentially, which will likely slow down the evaluation process."""
+    return make_metric(
+        eval_fn=lambda x: MetricValue(),
+        greater_is_better=False,
+        name="latency",
+    )
 
 
 # general text metrics

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1534,9 +1534,15 @@ class DefaultEvaluator(ModelEvaluator):
                 if self.model_type in (_ModelType.CLASSIFIER, _ModelType.REGRESSOR):
                     self._compute_builtin_metrics()
                 elif self.model_type == _ModelType.QUESTION_ANSWERING:
-                    self.builtin_metrics = [*text_metrics, exact_match]
+                    self.builtin_metrics = [*text_metrics, exact_match()]
                 elif self.model_type == _ModelType.TEXT_SUMMARIZATION:
-                    self.builtin_metrics = [*text_metrics, rouge1, rouge2, rougeL, rougeLsum]
+                    self.builtin_metrics = [
+                        *text_metrics,
+                        rouge1(),
+                        rouge2(),
+                        rougeL(),
+                        rougeLsum(),
+                    ]
                 elif self.model_type == _ModelType.TEXT:
                     self.builtin_metrics = text_metrics
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1512,7 +1512,7 @@ class DefaultEvaluator(ModelEvaluator):
             self.builtin_metrics = {}
 
             text_metrics = [
-                token_count,
+                token_count(),
                 toxicity,
                 perplexity,
                 flesch_kincaid_grade_level,

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1513,10 +1513,10 @@ class DefaultEvaluator(ModelEvaluator):
 
             text_metrics = [
                 token_count(),
-                toxicity,
-                perplexity,
-                flesch_kincaid_grade_level,
-                ari_grade_level,
+                toxicity(),
+                perplexity(),
+                flesch_kincaid_grade_level(),
+                ari_grade_level(),
             ]
 
             with mlflow.utils.autologging_utils.disable_autologging():

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2805,7 +2805,7 @@ def test_evaluate_no_model_type_with_builtin_metric():
         results = mlflow.evaluate(
             model_info.model_uri,
             data,
-            extra_metrics=[mlflow.metrics.perplexity],
+            extra_metrics=[mlflow.metrics.perplexity()],
         )
         assert results.metrics.keys() == {
             "perplexity/v1/mean",
@@ -2877,11 +2877,11 @@ def test_default_metrics_as_custom_metrics():
             targets="truth",
             model_type="question-answering",
             custom_metrics=[
-                mlflow.metrics.flesch_kincaid_grade_level,
-                mlflow.metrics.perplexity,
-                mlflow.metrics.ari_grade_level,
-                mlflow.metrics.toxicity,
-                mlflow.metrics.exact_match,
+                mlflow.metrics.flesch_kincaid_grade_level(),
+                mlflow.metrics.perplexity(),
+                mlflow.metrics.ari_grade_level(),
+                mlflow.metrics.toxicity(),
+                mlflow.metrics.exact_match(),
             ],
             evaluators="default",
             evaluator_config={
@@ -2909,7 +2909,7 @@ def test_evaluate_with_latency():
             data,
             model_type="text",
             evaluators="default",
-            extra_metrics=[mlflow.metrics.latency],
+            extra_metrics=[mlflow.metrics.latency()],
         )
 
     client = mlflow.MlflowClient()

--- a/tests/metrics/test_metric_definitions.py
+++ b/tests/metrics/test_metric_definitions.py
@@ -29,15 +29,15 @@ from mlflow.metrics import (
 @pytest.mark.parametrize(
     "metric",
     [
-        ari_grade_level,
-        exact_match,
-        flesch_kincaid_grade_level,
-        perplexity,
-        rouge1,
-        rouge2,
-        rougeL,
-        rougeLsum,
-        toxicity,
+        ari_grade_level(),
+        exact_match(),
+        flesch_kincaid_grade_level(),
+        perplexity(),
+        rouge1(),
+        rouge2(),
+        rougeL(),
+        rougeLsum(),
+        toxicity(),
     ],
 )
 def test_return_type_and_len_with_target(metric):
@@ -61,7 +61,7 @@ def _is_toxic(score):
 
 def test_toxicity():
     predictions = pd.Series(["A normal sentence", "All women are bad"])
-    result = toxicity.eval_fn(predictions, None, {})
+    result = toxicity().eval_fn(predictions, None, {})
     assert not _is_toxic(result.scores[0])
     assert _is_toxic(result.scores[1])
     assert result.aggregate_results["ratio"] == 0.5
@@ -72,7 +72,7 @@ def test_toxicity():
 
 def test_perplexity():
     predictions = pd.Series(["sentence not", "This is a sentence"])
-    result = perplexity.eval_fn(predictions, None, {})
+    result = perplexity().eval_fn(predictions, None, {})
     # A properly structured sentence should have lower perplexity
     assert result.scores[0] > result.scores[1]
     assert result.aggregate_results["mean"] == (result.scores[0] + result.scores[1]) / 2
@@ -90,7 +90,7 @@ def test_flesch_kincaid_grade_level():
             ),
         ]
     )
-    result = flesch_kincaid_grade_level.eval_fn(predictions, None, {})
+    result = flesch_kincaid_grade_level().eval_fn(predictions, None, {})
     assert result.scores[0] < result.scores[1]
     assert result.aggregate_results["mean"] == (result.scores[0] + result.scores[1]) / 2
     assert result.scores[0] < result.aggregate_results["p90"] < result.scores[1]
@@ -107,7 +107,7 @@ def test_ari_grade_level():
             ),
         ]
     )
-    result = ari_grade_level.eval_fn(predictions, None, {})
+    result = ari_grade_level().eval_fn(predictions, None, {})
     assert result.scores[0] < result.scores[1]
     assert result.aggregate_results["mean"] == (result.scores[0] + result.scores[1]) / 2
     assert result.scores[0] < result.aggregate_results["p90"] < result.scores[1]
@@ -118,19 +118,19 @@ def test_exact_match():
     predictions = pd.Series(["sentence not", "random text", "a", "c"])
     targets = pd.Series(["sentence not", "random text", "a", "c"])
 
-    result = exact_match.eval_fn(predictions, targets, {})
+    result = exact_match().eval_fn(predictions, targets, {})
     assert result.aggregate_results["exact_match"] == 1.0
 
     predictions = pd.Series(["not sentence", "random text", "b", "c"])
     targets = pd.Series(["sentence not", "random text", "a", "c"])
-    result = exact_match.eval_fn(predictions, targets, {})
+    result = exact_match().eval_fn(predictions, targets, {})
     assert result.aggregate_results["exact_match"] == 0.5
 
 
 def test_rouge1():
     predictions = pd.Series(["a", "d c"])
     targets = pd.Series(["d", "b c"])
-    result = rouge1.eval_fn(predictions, targets, {})
+    result = rouge1().eval_fn(predictions, targets, {})
     assert result.scores[0] == 0.0
     assert result.scores[1] == 0.5
     assert result.aggregate_results["mean"] == 0.25
@@ -141,7 +141,7 @@ def test_rouge1():
 def test_rouge2():
     predictions = pd.Series(["a e", "b c e"])
     targets = pd.Series(["a e", "b c d"])
-    result = rouge2.eval_fn(predictions, targets, {})
+    result = rouge2().eval_fn(predictions, targets, {})
     assert result.scores[0] == 1.0
     assert result.scores[1] == 0.5
     assert result.aggregate_results["mean"] == 0.75
@@ -152,7 +152,7 @@ def test_rouge2():
 def test_rougeL():
     predictions = pd.Series(["a", "b c"])
     targets = pd.Series(["d", "b c"])
-    result = rougeL.eval_fn(predictions, targets, {})
+    result = rougeL().eval_fn(predictions, targets, {})
     assert result.scores[0] == 0.0
     assert result.scores[1] == 1.0
     assert result.aggregate_results["mean"] == 0.5
@@ -163,7 +163,7 @@ def test_rougeL():
 def test_rougeLsum():
     predictions = pd.Series(["a", "b c"])
     targets = pd.Series(["d", "b c"])
-    result = rougeLsum.eval_fn(predictions, targets, {})
+    result = rougeLsum().eval_fn(predictions, targets, {})
     assert result.scores[0] == 0.0
     assert result.scores[1] == 1.0
     assert result.aggregate_results["mean"] == 0.5
@@ -176,7 +176,7 @@ def test_fails_to_load_metric():
     e = ImportError("mocked error")
     with mock.patch("evaluate.load", side_effect=e) as mock_load:
         with mock.patch("mlflow.metrics.metric_definitions._logger.warning") as mock_warning:
-            toxicity.eval_fn(predictions, None, {})
+            toxicity().eval_fn(predictions, None, {})
             mock_load.assert_called_once_with("toxicity", module_type="measurement")
             mock_warning.assert_called_once_with(
                 f"Failed to load 'toxicity' metric (error: {e!r}), skipping metric logging.",
@@ -186,61 +186,61 @@ def test_fails_to_load_metric():
 def test_mae():
     predictions = pd.Series([1.0, 2.0, 0.0])
     targets = pd.Series([1.0, 2.0, 3.0])
-    result = mae.eval_fn(predictions, targets, {})
+    result = mae().eval_fn(predictions, targets, {})
     assert result.aggregate_results["mean_absolute_error"] == 1.0
 
 
 def test_mse():
     predictions = pd.Series([1.0, 2.0, 0.0])
     targets = pd.Series([1.0, 2.0, 3.0])
-    result = mse.eval_fn(predictions, targets, {})
+    result = mse().eval_fn(predictions, targets, {})
     assert result.aggregate_results["mean_squared_error"] == 3.0
 
 
 def test_rmse():
     predictions = pd.Series([4.0, 5.0, 0.0])
     targets = pd.Series([1.0, 2.0, 3.0])
-    result = rmse.eval_fn(predictions, targets, {})
+    result = rmse().eval_fn(predictions, targets, {})
     assert result.aggregate_results["root_mean_squared_error"] == 3.0
 
 
 def test_r2_score():
     predictions = pd.Series([1.0, 2.0, 3.0])
     targets = pd.Series([3.0, 2.0, 1.0])
-    result = r2_score.eval_fn(predictions, targets, {})
+    result = r2_score().eval_fn(predictions, targets, {})
     assert result.aggregate_results["r2_score"] == -3.0
 
 
 def test_max_error():
     predictions = pd.Series([1.0, 2.0, 3.0])
     targets = pd.Series([3.0, 2.0, 1.0])
-    result = max_error.eval_fn(predictions, targets, {})
+    result = max_error().eval_fn(predictions, targets, {})
     assert result.aggregate_results["max_error"] == 2.0
 
 
 def test_mape_error():
     predictions = pd.Series([1.0, 1.0, 1.0])
     targets = pd.Series([2.0, 2.0, 2.0])
-    result = mape.eval_fn(predictions, targets, {})
+    result = mape().eval_fn(predictions, targets, {})
     assert result.aggregate_results["mean_absolute_percentage_error"] == 0.5
 
 
 def test_binary_recall_score():
     predictions = pd.Series([0, 0, 1, 1, 0, 0, 0, 1])
     targets = pd.Series([1, 1, 1, 1, 0, 0, 0, 0])
-    result = recall_score.eval_fn(predictions, targets, {})
+    result = recall_score().eval_fn(predictions, targets, {})
     assert abs(result.aggregate_results["recall_score"] - 0.5) < 1e-3
 
 
 def test_binary_precision():
     predictions = pd.Series([0, 0, 1, 1, 0, 0, 0, 1])
     targets = pd.Series([1, 1, 1, 1, 0, 0, 0, 0])
-    result = precision_score.eval_fn(predictions, targets, {})
+    result = precision_score().eval_fn(predictions, targets, {})
     assert abs(result.aggregate_results["precision_score"] == 0.666) < 1e-3
 
 
 def test_binary_f1_score():
     predictions = pd.Series([0, 0, 1, 1, 0, 0, 0, 1])
     targets = pd.Series([1, 1, 1, 1, 0, 0, 0, 0])
-    result = f1_score.eval_fn(predictions, targets, {})
+    result = f1_score().eval_fn(predictions, targets, {})
     assert abs(result.aggregate_results["f1_score"] - 0.5713) < 1e-3


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/prithvikannan/mlflow/pull/9999?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/9999/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 9999
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Make all builtin metrics factory functions. instead of `extra_metrics=[mlflow.metrics.mae]`, users will do `extra_metrics=[mlflow.metrics.mae()]`. This is consistent with the genai metrics such as `mlflow.metrics.correctness`, which were already function type.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
