### PR TITLE
Cache `evaluate.load("toxicity")`

### DIFF
--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import os
 
@@ -53,14 +54,19 @@ def _token_count_eval_fn(predictions, targets, metrics):
     )
 
 
+@functools.lru_cache(maxsize=8)
+def _cached_evaluate_load(path, module_type=None):
+    import evaluate
+
+    return evaluate.load(path, module_type=module_type)
+
+
 def _toxicity_eval_fn(predictions, targets, metrics):
     if not _validate_text_data(predictions, "toxicity", "predictions"):
         return
     try:
         _logger.info("Loading toxicity metric:")
-        import evaluate
-
-        toxicity = evaluate.load("toxicity", module_type="measurement")
+        toxicity = _cached_evaluate_load("toxicity", module_type="measurement")
     except Exception as e:
         _logger.warning(
             f"Failed to load 'toxicity' metric (error: {e!r}), skipping metric logging."
@@ -87,9 +93,7 @@ def _perplexity_eval_fn(predictions, targets, metrics):
 
     try:
         _logger.info("Loading perplexity metric:")
-        import evaluate
-
-        perplexity = evaluate.load("perplexity", module_type="metric")
+        perplexity = _cached_evaluate_load("perplexity", module_type="metric")
     except Exception as e:
         _logger.warning(
             f"Failed to load 'perplexity' metric (error: {e!r}), skipping metric logging."
@@ -158,9 +162,7 @@ def _rouge1_eval_fn(predictions, targets, metrics):
             return
 
         try:
-            import evaluate
-
-            rouge = evaluate.load("rouge")
+            rouge = _cached_evaluate_load("rouge")
         except Exception as e:
             _logger.warning(
                 f"Failed to load 'rouge' metric (error: {e!r}), skipping metric logging."
@@ -187,9 +189,7 @@ def _rouge2_eval_fn(predictions, targets, metrics):
             return
 
         try:
-            import evaluate
-
-            rouge = evaluate.load("rouge")
+            rouge = _cached_evaluate_load("rouge")
         except Exception as e:
             _logger.warning(
                 f"Failed to load 'rouge' metric (error: {e!r}), skipping metric logging."
@@ -216,9 +216,7 @@ def _rougeL_eval_fn(predictions, targets, metrics):
             return
 
         try:
-            import evaluate
-
-            rouge = evaluate.load("rouge")
+            rouge = _cached_evaluate_load("rouge")
         except Exception as e:
             _logger.warning(
                 f"Failed to load 'rouge' metric (error: {e!r}), skipping metric logging."
@@ -245,9 +243,7 @@ def _rougeLsum_eval_fn(predictions, targets, metrics):
             return
 
         try:
-            import evaluate
-
-            rouge = evaluate.load("rouge")
+            rouge = _cached_evaluate_load("rouge")
         except Exception as e:
             _logger.warning(
                 f"Failed to load 'rouge' metric (error: {e!r}), skipping metric logging."

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2483,7 +2483,10 @@ def test_evaluate_text_summarization_fails_to_load_evaluate_metrics():
         )
 
         data = pd.DataFrame({"text": ["a", "b"], "summary": ["a", "b"]})
-        with mock.patch("evaluate.load", side_effect=ImportError("mocked error")) as mock_load:
+        with mock.patch(
+            "mlflow.metrics.metric_definitions._cached_evaluate_load",
+            side_effect=ImportError("mocked error"),
+        ) as mock_load:
             results = mlflow.evaluate(
                 model_info.model_uri,
                 data,

--- a/tests/metrics/test_metric_definitions.py
+++ b/tests/metrics/test_metric_definitions.py
@@ -174,7 +174,9 @@ def test_rougeLsum():
 def test_fails_to_load_metric():
     predictions = pd.Series(["random text", "This is a sentence"])
     e = ImportError("mocked error")
-    with mock.patch("evaluate.load", side_effect=e) as mock_load:
+    with mock.patch(
+        "mlflow.metrics.metric_definitions._cached_evaluate_load", side_effect=e
+    ) as mock_load:
         with mock.patch("mlflow.metrics.metric_definitions._logger.warning") as mock_warning:
             toxicity.eval_fn(predictions, None, {})
             mock_load.assert_called_once_with("toxicity", module_type="measurement")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10007?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10007/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10007
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Cache `evaluate.load("toxicity")` as a temporary workaround for https://github.com/huggingface/safetensors/issues/369.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
