### PR TITLE
aliases

### DIFF
--- a/aliases.py
+++ b/aliases.py
@@ -5,18 +5,16 @@ import mlflow
 
 mlflow.set_tracking_uri("sqlite:///:memory:")
 with mlflow.start_run():
-    mlflow.sklearn.log_model(
-        "I am a model",
-        "model",
-        registered_model_name="sklearn",
-    )
+    for _ in range(3):
+        mlflow.sklearn.log_model(
+            "I am a model",
+            "model",
+            registered_model_name="sklearn",
+        )
 
-# set a registered model tag
-mlflow.MlflowClient().set_model_version_tag(
-    name="sklearn", version=1, key="tag-key", value="tag-value"
-)
-mlflow.MlflowClient().set_registered_model_alias(
-    name="sklearn", alias="sklearn-model-alias", version=1
-)
+mlflow.MlflowClient().set_registered_model_alias(name="sklearn", alias="alias-1", version=1)
+mlflow.MlflowClient().set_registered_model_alias(name="sklearn", alias="alias-2", version=1)
+mlflow.MlflowClient().set_registered_model_alias(name="sklearn", alias="alias-3", version=2)
+print("Fetching model versions")  # noqa: T201
 for mv in mlflow.search_model_versions():
     print(mv.aliases)  # noqa: T201

--- a/aliases.py
+++ b/aliases.py
@@ -1,0 +1,22 @@
+"""
+MLFLOW_SQLALCHEMYSTORE_ECHO=true python aliases.py
+"""
+import mlflow
+
+mlflow.set_tracking_uri("sqlite:///:memory:")
+with mlflow.start_run():
+    mlflow.sklearn.log_model(
+        "I am a model",
+        "model",
+        registered_model_name="sklearn",
+    )
+
+# set a registered model tag
+mlflow.MlflowClient().set_model_version_tag(
+    name="sklearn", version=1, key="tag-key", value="tag-value"
+)
+mlflow.MlflowClient().set_registered_model_alias(
+    name="sklearn", alias="sklearn-model-alias", version=1
+)
+for mv in mlflow.search_model_versions():
+    print(mv.aliases)  # noqa: T201

--- a/mlflow/store/model_registry/dbmodels/models.py
+++ b/mlflow/store/model_registry/dbmodels/models.py
@@ -111,7 +111,7 @@ class SqlModelVersion(Base):
             self.status_message,
             [tag.to_mlflow_entity() for tag in self.model_version_tags],
             self.run_link,
-            [],
+            [a.to_mlflow_entity() for a in self.model_version_aliases],
         )
 
 
@@ -193,7 +193,21 @@ class SqlRegisteredModelAlias(Base):
         "SqlRegisteredModel", backref=backref("registered_model_aliases", cascade="all")
     )
 
-    __table_args__ = (PrimaryKeyConstraint("name", "alias", name="registered_model_alias_pk"),)
+    model_version = relationship(
+        "SqlModelVersion",
+        foreign_keys=[name, version],
+        backref=backref("model_version_aliases", cascade="all"),
+    )
+
+    __table_args__ = (
+        PrimaryKeyConstraint("name", "alias", name="registered_model_alias_pk"),
+        ForeignKeyConstraint(
+            ("name", "version"),
+            ("model_versions.name", "model_versions.version"),
+            onupdate="cascade",
+            ondelete="cascade",
+        ),
+    )
 
     def __repr__(self):
         return f"<SqlRegisteredModelAlias ({self.name}, {self.alias}, {self.version})>"

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -146,7 +146,10 @@ class SqlAlchemyStore(AbstractStore):
         # of the eager loading procedure. For more information about relationship loading
         # techniques, see https://docs.sqlalchemy.org/en/13/orm/
         # loading_relationships.html#relationship-loading-techniques
-        return [sqlalchemy.orm.subqueryload(SqlModelVersion.model_version_tags)]
+        return [
+            sqlalchemy.orm.subqueryload(SqlModelVersion.model_version_tags),
+            sqlalchemy.orm.subqueryload(SqlModelVersion.model_version_aliases),
+        ]
 
     def create_registered_model(self, name, tags=None, description=None):
         """


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #9952

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

#9952

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
