### PR TITLE
Surface error "missing targets column" early

### DIFF
--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -33,7 +33,7 @@ def _validate_text_data(data, metric_name, column_name):
     return True
 
 
-def _token_count_eval_fn(predictions, targets, metrics):
+def _token_count_eval_fn(predictions, targets=None, metrics=None):
     import tiktoken
 
     # ref: https://github.com/openai/tiktoken/issues/75
@@ -59,7 +59,7 @@ def _cached_evaluate_load(path, module_type=None):
     return evaluate.load(path, module_type=module_type)
 
 
-def _toxicity_eval_fn(predictions, targets, metrics):
+def _toxicity_eval_fn(predictions, targets=None, metrics=None):
     if not _validate_text_data(predictions, "toxicity", "predictions"):
         return
     try:
@@ -83,7 +83,7 @@ def _toxicity_eval_fn(predictions, targets, metrics):
     )
 
 
-def _perplexity_eval_fn(predictions, targets, metrics):
+def _perplexity_eval_fn(predictions, targets=None, metrics=None):
     if not _validate_text_data(predictions, "perplexity", "predictions"):
         return
 
@@ -102,7 +102,7 @@ def _perplexity_eval_fn(predictions, targets, metrics):
     )
 
 
-def _flesch_kincaid_eval_fn(predictions, targets, metrics):
+def _flesch_kincaid_eval_fn(predictions, targets=None, metrics=None):
     if not _validate_text_data(predictions, "flesch_kincaid", "predictions"):
         return
 
@@ -119,7 +119,7 @@ def _flesch_kincaid_eval_fn(predictions, targets, metrics):
     )
 
 
-def _ari_eval_fn(predictions, targets, metrics):
+def _ari_eval_fn(predictions, targets=None, metrics=None):
     if not _validate_text_data(predictions, "ari", "predictions"):
         return
 
@@ -138,7 +138,7 @@ def _ari_eval_fn(predictions, targets, metrics):
     )
 
 
-def _accuracy_eval_fn(predictions, targets, metrics, sample_weight=None):
+def _accuracy_eval_fn(predictions, targets, metrics=None, sample_weight=None):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import accuracy_score
 
@@ -146,7 +146,7 @@ def _accuracy_eval_fn(predictions, targets, metrics, sample_weight=None):
         return MetricValue(aggregate_results={"exact_match": acc})
 
 
-def _rouge1_eval_fn(predictions, targets, metrics):
+def _rouge1_eval_fn(predictions, targets, metrics=None):
     if targets is not None and len(targets) != 0:
         if not _validate_text_data(targets, "rouge1", "targets") or not _validate_text_data(
             predictions, "rouge1", "predictions"
@@ -173,7 +173,7 @@ def _rouge1_eval_fn(predictions, targets, metrics):
         )
 
 
-def _rouge2_eval_fn(predictions, targets, metrics):
+def _rouge2_eval_fn(predictions, targets, metrics=None):
     if targets is not None and len(targets) != 0:
         if not _validate_text_data(targets, "rouge2", "targets") or not _validate_text_data(
             predictions, "rouge2", "predictions"
@@ -200,7 +200,7 @@ def _rouge2_eval_fn(predictions, targets, metrics):
         )
 
 
-def _rougeL_eval_fn(predictions, targets, metrics):
+def _rougeL_eval_fn(predictions, targets, metrics=None):
     if targets is not None and len(targets) != 0:
         if not _validate_text_data(targets, "rougeL", "targets") or not _validate_text_data(
             predictions, "rougeL", "predictions"
@@ -227,7 +227,7 @@ def _rougeL_eval_fn(predictions, targets, metrics):
         )
 
 
-def _rougeLsum_eval_fn(predictions, targets, metrics):
+def _rougeLsum_eval_fn(predictions, targets, metrics=None):
     if targets is not None and len(targets) != 0:
         if not _validate_text_data(targets, "rougeLsum", "targets") or not _validate_text_data(
             predictions, "rougeLsum", "predictions"
@@ -254,7 +254,7 @@ def _rougeLsum_eval_fn(predictions, targets, metrics):
         )
 
 
-def _mae_eval_fn(predictions, targets, metrics, sample_weight=None):
+def _mae_eval_fn(predictions, targets, metrics=None, sample_weight=None):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import mean_absolute_error
 
@@ -262,7 +262,7 @@ def _mae_eval_fn(predictions, targets, metrics, sample_weight=None):
         return MetricValue(aggregate_results={"mean_absolute_error": mae})
 
 
-def _mse_eval_fn(predictions, targets, metrics, sample_weight=None):
+def _mse_eval_fn(predictions, targets, metrics=None, sample_weight=None):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import mean_squared_error
 
@@ -270,7 +270,7 @@ def _mse_eval_fn(predictions, targets, metrics, sample_weight=None):
         return MetricValue(aggregate_results={"mean_squared_error": mse})
 
 
-def _rmse_eval_fn(predictions, targets, metrics, sample_weight=None):
+def _rmse_eval_fn(predictions, targets, metrics=None, sample_weight=None):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import mean_squared_error
 
@@ -278,7 +278,7 @@ def _rmse_eval_fn(predictions, targets, metrics, sample_weight=None):
         return MetricValue(aggregate_results={"root_mean_squared_error": rmse})
 
 
-def _r2_score_eval_fn(predictions, targets, metrics, sample_weight=None):
+def _r2_score_eval_fn(predictions, targets, metrics=None, sample_weight=None):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import r2_score
 
@@ -286,7 +286,7 @@ def _r2_score_eval_fn(predictions, targets, metrics, sample_weight=None):
         return MetricValue(aggregate_results={"r2_score": r2})
 
 
-def _max_error_eval_fn(predictions, targets, metrics):
+def _max_error_eval_fn(predictions, targets, metrics=None):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import max_error
 
@@ -294,7 +294,7 @@ def _max_error_eval_fn(predictions, targets, metrics):
         return MetricValue(aggregate_results={"max_error": error})
 
 
-def _mape_eval_fn(predictions, targets, metrics, sample_weight=None):
+def _mape_eval_fn(predictions, targets, metrics=None, sample_weight=None):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import mean_absolute_percentage_error
 
@@ -303,7 +303,7 @@ def _mape_eval_fn(predictions, targets, metrics, sample_weight=None):
 
 
 def _recall_eval_fn(
-    predictions, targets, metrics, pos_label=1, average="binary", sample_weight=None
+    predictions, targets, metrics=None, pos_label=1, average="binary", sample_weight=None
 ):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import recall_score
@@ -315,7 +315,7 @@ def _recall_eval_fn(
 
 
 def _precision_eval_fn(
-    predictions, targets, metrics, pos_label=1, average="binary", sample_weight=None
+    predictions, targets, metrics=None, pos_label=1, average="binary", sample_weight=None
 ):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import precision_score
@@ -331,7 +331,7 @@ def _precision_eval_fn(
 
 
 def _f1_score_eval_fn(
-    predictions, targets, metrics, pos_label=1, average="binary", sample_weight=None
+    predictions, targets, metrics=None, pos_label=1, average="binary", sample_weight=None
 ):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import f1_score

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -138,7 +138,7 @@ def _ari_eval_fn(predictions, targets=None, metrics=None):
     )
 
 
-def _accuracy_eval_fn(predictions, targets, metrics=None, sample_weight=None):
+def _accuracy_eval_fn(predictions, targets=None, metrics=None, sample_weight=None):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import accuracy_score
 
@@ -146,7 +146,7 @@ def _accuracy_eval_fn(predictions, targets, metrics=None, sample_weight=None):
         return MetricValue(aggregate_results={"exact_match": acc})
 
 
-def _rouge1_eval_fn(predictions, targets, metrics=None):
+def _rouge1_eval_fn(predictions, targets=None, metrics=None):
     if targets is not None and len(targets) != 0:
         if not _validate_text_data(targets, "rouge1", "targets") or not _validate_text_data(
             predictions, "rouge1", "predictions"
@@ -173,7 +173,7 @@ def _rouge1_eval_fn(predictions, targets, metrics=None):
         )
 
 
-def _rouge2_eval_fn(predictions, targets, metrics=None):
+def _rouge2_eval_fn(predictions, targets=None, metrics=None):
     if targets is not None and len(targets) != 0:
         if not _validate_text_data(targets, "rouge2", "targets") or not _validate_text_data(
             predictions, "rouge2", "predictions"
@@ -200,7 +200,7 @@ def _rouge2_eval_fn(predictions, targets, metrics=None):
         )
 
 
-def _rougeL_eval_fn(predictions, targets, metrics=None):
+def _rougeL_eval_fn(predictions, targets=None, metrics=None):
     if targets is not None and len(targets) != 0:
         if not _validate_text_data(targets, "rougeL", "targets") or not _validate_text_data(
             predictions, "rougeL", "predictions"
@@ -227,7 +227,7 @@ def _rougeL_eval_fn(predictions, targets, metrics=None):
         )
 
 
-def _rougeLsum_eval_fn(predictions, targets, metrics=None):
+def _rougeLsum_eval_fn(predictions, targets=None, metrics=None):
     if targets is not None and len(targets) != 0:
         if not _validate_text_data(targets, "rougeLsum", "targets") or not _validate_text_data(
             predictions, "rougeLsum", "predictions"
@@ -254,7 +254,7 @@ def _rougeLsum_eval_fn(predictions, targets, metrics=None):
         )
 
 
-def _mae_eval_fn(predictions, targets, metrics=None, sample_weight=None):
+def _mae_eval_fn(predictions, targets=None, metrics=None, sample_weight=None):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import mean_absolute_error
 
@@ -262,7 +262,7 @@ def _mae_eval_fn(predictions, targets, metrics=None, sample_weight=None):
         return MetricValue(aggregate_results={"mean_absolute_error": mae})
 
 
-def _mse_eval_fn(predictions, targets, metrics=None, sample_weight=None):
+def _mse_eval_fn(predictions, targets=None, metrics=None, sample_weight=None):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import mean_squared_error
 
@@ -270,7 +270,7 @@ def _mse_eval_fn(predictions, targets, metrics=None, sample_weight=None):
         return MetricValue(aggregate_results={"mean_squared_error": mse})
 
 
-def _rmse_eval_fn(predictions, targets, metrics=None, sample_weight=None):
+def _rmse_eval_fn(predictions, targets=None, metrics=None, sample_weight=None):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import mean_squared_error
 
@@ -278,7 +278,7 @@ def _rmse_eval_fn(predictions, targets, metrics=None, sample_weight=None):
         return MetricValue(aggregate_results={"root_mean_squared_error": rmse})
 
 
-def _r2_score_eval_fn(predictions, targets, metrics=None, sample_weight=None):
+def _r2_score_eval_fn(predictions, targets=None, metrics=None, sample_weight=None):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import r2_score
 
@@ -286,7 +286,7 @@ def _r2_score_eval_fn(predictions, targets, metrics=None, sample_weight=None):
         return MetricValue(aggregate_results={"r2_score": r2})
 
 
-def _max_error_eval_fn(predictions, targets, metrics=None):
+def _max_error_eval_fn(predictions, targets=None, metrics=None):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import max_error
 
@@ -294,7 +294,7 @@ def _max_error_eval_fn(predictions, targets, metrics=None):
         return MetricValue(aggregate_results={"max_error": error})
 
 
-def _mape_eval_fn(predictions, targets, metrics=None, sample_weight=None):
+def _mape_eval_fn(predictions, targets=None, metrics=None, sample_weight=None):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import mean_absolute_percentage_error
 
@@ -303,7 +303,7 @@ def _mape_eval_fn(predictions, targets, metrics=None, sample_weight=None):
 
 
 def _recall_eval_fn(
-    predictions, targets, metrics=None, pos_label=1, average="binary", sample_weight=None
+    predictions, targets=None, metrics=None, pos_label=1, average="binary", sample_weight=None
 ):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import recall_score
@@ -315,7 +315,7 @@ def _recall_eval_fn(
 
 
 def _precision_eval_fn(
-    predictions, targets, metrics=None, pos_label=1, average="binary", sample_weight=None
+    predictions, targets=None, metrics=None, pos_label=1, average="binary", sample_weight=None
 ):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import precision_score
@@ -331,7 +331,7 @@ def _precision_eval_fn(
 
 
 def _f1_score_eval_fn(
-    predictions, targets, metrics=None, pos_label=1, average="binary", sample_weight=None
+    predictions, targets=None, metrics=None, pos_label=1, average="binary", sample_weight=None
 ):
     if targets is not None and len(targets) != 0:
         from sklearn.metrics import f1_score

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1457,7 +1457,7 @@ class DefaultEvaluator(ModelEvaluator):
             Output Columns: {output_columns}
             To resolve this issue, you may want to map the missing column to an existing column
             using the following configuration:
-            evaluator_config={{'col_mapping': {{<missing column name>: <existing column name}}}}"""
+            evaluator_config={{'col_mapping': {{<missing column name>: <existing column name>}}}}"""
             stripped_message = "\n".join(l.lstrip() for l in full_message.splitlines())
             raise MlflowException(stripped_message)
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1439,29 +1439,28 @@ class DefaultEvaluator(ModelEvaluator):
                 failed_metrics.append(result)
 
         if len(failed_metrics) > 0:
-            output_column_name = self.predictions
             output_columns = (
                 [] if self.other_output_columns is None else list(self.other_output_columns.columns)
             )
             input_columns = list(self.X.copy_to_avoid_mutation().columns)
 
-            error_messages = []
-            for metric_name, param_names in failed_metrics:
-                error_messages.append(f"Metric '{metric_name}' requires the columns {param_names}")
-            error_message = "\n".join(error_messages)
-            raise MlflowException(
-                "Error: Metric calculation failed for the following metrics:\n"
-                f"{error_message}\n\n"
-                "Below are the existing column names for the input/output data:\n"
-                f"Input Columns: {input_columns}\n"
-                f"Output Columns: {output_columns}\n"
-                "Note that this does not include the output column: "
-                f"'{output_column_name}'\n\n"
-                f"To resolve this issue, you may want to map the missing column to an "
-                "existing column using the following configuration:\n"
-                f"evaluator_config={{'col_mapping': {{'<missing column name>': "
-                "'<existing column name>'}}\n"
-            )
+            error_messages = [
+                f"Metric '{metric_name}' requires the columns {param_names}"
+                for metric_name, param_names in failed_metrics
+            ]
+            joined_error_message = "\n".join(error_messages)
+            full_message = f"""Error: Metric calculation failed for the following metrics:
+            {joined_error_message}
+
+            Below are the existing column names for the input/output data:
+            Input Columns: {input_columns}
+            Output Columns: {output_columns}
+            To resolve this issue, you may want to map the missing column to an
+            existing column using the following configuration:
+            evaluator_config={{'col_mapping': {{<missing column name>:
+            <existing column name}}}}"""
+            stripped_message = "\n".join(l.lstrip() for l in full_message.strip().splitlines())
+            raise MlflowException(stripped_message)
 
     def _test_first_row(self, eval_df):
         # test calculations on first row of eval_df

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1168,7 +1168,10 @@ class DefaultEvaluator(ModelEvaluator):
                     if "target" in eval_df_copy:
                         eval_fn_args.append(eval_df_copy["target"])
                     else:
-                        params_not_found.append(param_name)
+                        if param.default == inspect.Parameter.empty:
+                            params_not_found.append(param_name)
+                        else:
+                            eval_fn_args.append(param.default)
                 elif column == "metrics":
                     eval_fn_args.append(copy.deepcopy(self.metrics_values))
                 else:
@@ -1194,6 +1197,8 @@ class DefaultEvaluator(ModelEvaluator):
                         eval_fn_args.append(self.evaluator_config.get(column))
                     elif param.default == inspect.Parameter.empty:
                         params_not_found.append(param_name)
+                    else:
+                        eval_fn_args.append(param.default)
 
         if len(params_not_found) > 0:
             return extra_metric.name, params_not_found

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1168,7 +1168,7 @@ class DefaultEvaluator(ModelEvaluator):
                     if "target" in eval_df_copy:
                         eval_fn_args.append(eval_df_copy["target"])
                     else:
-                        eval_fn_args.append(None)
+                        params_not_found.append(param_name)
                 elif column == "metrics":
                     eval_fn_args.append(copy.deepcopy(self.metrics_values))
                 else:

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1458,7 +1458,7 @@ class DefaultEvaluator(ModelEvaluator):
             To resolve this issue, you may want to map the missing column to an existing column
             using the following configuration:
             evaluator_config={{'col_mapping': {{<missing column name>: <existing column name}}}}"""
-            stripped_message = "\n".join(l.lstrip() for l in full_message.strip().splitlines())
+            stripped_message = "\n".join(l.lstrip() for l in full_message.splitlines())
             raise MlflowException(stripped_message)
 
     def _test_first_row(self, eval_df):

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1455,10 +1455,9 @@ class DefaultEvaluator(ModelEvaluator):
             Below are the existing column names for the input/output data:
             Input Columns: {input_columns}
             Output Columns: {output_columns}
-            To resolve this issue, you may want to map the missing column to an
-            existing column using the following configuration:
-            evaluator_config={{'col_mapping': {{<missing column name>:
-            <existing column name}}}}"""
+            To resolve this issue, you may want to map the missing column to an existing column
+            using the following configuration:
+            evaluator_config={{'col_mapping': {{<missing column name>: <existing column name}}}}"""
             stripped_message = "\n".join(l.lstrip() for l in full_message.strip().splitlines())
             raise MlflowException(stripped_message)
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2192,9 +2192,11 @@ def test_missing_args_raises_exception():
     metric_1 = make_metric(name="metric_1", eval_fn=dummy_fn1, greater_is_better=True)
     metric_2 = make_metric(name="metric_2", eval_fn=dummy_fn2, greater_is_better=True)
 
-    error_message = "Error: Metric calculation failed for the following metrics:\nMetric 'metric_1'"
-    " requires the columns ['param_1', 'param_2']\n\nMetric 'metric_2' requires the columns "
-    "['param_3', 'builtin_metrics']\n"
+    error_message = (
+        r"Error: Metric calculation failed for the following metrics:\n"
+        r"Metric 'metric_1' requires the columns \['param_1', 'param_2'\]\n"
+        r"Metric 'metric_2' requires the columns \['param_3', 'builtin_metrics'\]\n"
+    )
 
     with pytest.raises(
         MlflowException,

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2876,7 +2876,7 @@ def test_evaluate_no_model_type_with_custom_metric():
         from mlflow.metrics import make_metric
         from mlflow.metrics.metric_definitions import standard_aggregations
 
-        def word_count_eval(predictions, targets, metrics):
+        def word_count_eval(predictions, targets=None, metrics=None):
             scores = []
             for prediction in predictions:
                 scores.append(len(prediction.split(" ")))

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2195,7 +2195,13 @@ def test_missing_args_raises_exception():
     error_message = (
         r"Error: Metric calculation failed for the following metrics:\n"
         r"Metric 'metric_1' requires the columns \['param_1', 'param_2'\]\n"
-        r"Metric 'metric_2' requires the columns \['param_3', 'builtin_metrics'\]\n"
+        r"Metric 'metric_2' requires the columns \['param_3', 'builtin_metrics'\]\n\n"
+        r"Below are the existing column names for the input/output data:\n"
+        r"Input Columns: \['question'\]\n"
+        r"Output Columns: \[\]\n"
+        r"To resolve this issue, you may want to map the missing column to an existing column\n"
+        r"using the following configuration:\n"
+        r"evaluator_config=\{'col_mapping': \{<missing column name>: <existing column name>\}\}"
     )
 
     with pytest.raises(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/annzhang-db/mlflow/pull/10020?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10020/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10020
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- add defaults to builtin metrics for targets so that we can surface errors for missing the 'targets' column for metrics that require them early
- eval_fn that don't require targets column must have a default
- pass in default for parameters that have a default

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Now we can have this error message surfaced in _get_args_for_metrics:

<img width="974" alt="Screenshot 2023-10-19 at 5 47 14 PM" src="https://github.com/mlflow/mlflow/assets/105813440/59ce48a2-69ec-4f9d-a994-2bef85799693">

instead of the following when we actually call eval_fn:
<img width="1010" alt="Screenshot 2023-10-19 at 11 19 59 AM" src="https://github.com/mlflow/mlflow/assets/105813440/027057f0-2d39-44f3-b9a1-6b3aeea97b19">


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
