### PR TITLE
Add context manager for creating or using a spark session

### DIFF
--- a/examples/multistep_workflow/als.py
+++ b/examples/multistep_workflow/als.py
@@ -29,38 +29,40 @@ def train_als(ratings_data, split_prop, max_iter, reg_param, rank, cold_start_st
         training_df.cache()
         test_df.cache()
 
-    mlflow.log_metric("training_nrows", training_df.count())
-    mlflow.log_metric("test_nrows", test_df.count())
+        mlflow.log_metric("training_nrows", training_df.count())
+        mlflow.log_metric("test_nrows", test_df.count())
 
-    print(f"Training: {training_df.count()}, test: {test_df.count()}")
+        print(f"Training: {training_df.count()}, test: {test_df.count()}")
 
-    als = (
-        ALS()
-        .setUserCol("userId")
-        .setItemCol("movieId")
-        .setRatingCol("rating")
-        .setPredictionCol("predictions")
-        .setMaxIter(max_iter)
-        .setSeed(seed)
-        .setRegParam(reg_param)
-        .setColdStartStrategy(cold_start_strategy)
-        .setRank(rank)
-    )
+        als = (
+            ALS()
+            .setUserCol("userId")
+            .setItemCol("movieId")
+            .setRatingCol("rating")
+            .setPredictionCol("predictions")
+            .setMaxIter(max_iter)
+            .setSeed(seed)
+            .setRegParam(reg_param)
+            .setColdStartStrategy(cold_start_strategy)
+            .setRank(rank)
+        )
 
-    als_model = Pipeline(stages=[als]).fit(training_df)
+        als_model = Pipeline(stages=[als]).fit(training_df)
 
-    reg_eval = RegressionEvaluator(predictionCol="predictions", labelCol="rating", metricName="mse")
+        reg_eval = RegressionEvaluator(
+            predictionCol="predictions", labelCol="rating", metricName="mse"
+        )
 
-    predicted_test_dF = als_model.transform(test_df)
+        predicted_test_dF = als_model.transform(test_df)
 
-    test_mse = reg_eval.evaluate(predicted_test_dF)
-    train_mse = reg_eval.evaluate(als_model.transform(training_df))
+        test_mse = reg_eval.evaluate(predicted_test_dF)
+        train_mse = reg_eval.evaluate(als_model.transform(training_df))
 
-    print(f"The model had a MSE on the test set of {test_mse}")
-    print(f"The model had a MSE on the (train) set of {train_mse}")
-    mlflow.log_metric("test_mse", test_mse)
-    mlflow.log_metric("train_mse", train_mse)
-    mlflow.spark.log_model(als_model, "als-model")
+        print(f"The model had a MSE on the test set of {test_mse}")
+        print(f"The model had a MSE on the (train) set of {train_mse}")
+        mlflow.log_metric("test_mse", test_mse)
+        mlflow.log_metric("train_mse", train_mse)
+        mlflow.spark.log_model(als_model, "als-model")
 
 
 if __name__ == "__main__":

--- a/examples/multistep_workflow/als.py
+++ b/examples/multistep_workflow/als.py
@@ -23,12 +23,11 @@ import mlflow.spark
 def train_als(ratings_data, split_prop, max_iter, reg_param, rank, cold_start_strategy):
     seed = 42
 
-    spark = pyspark.sql.SparkSession.builder.getOrCreate()
-
-    ratings_df = spark.read.parquet(ratings_data)
-    (training_df, test_df) = ratings_df.randomSplit([split_prop, 1 - split_prop], seed=seed)
-    training_df.cache()
-    test_df.cache()
+    with pyspark.sql.SparkSession.builder.getOrCreate() as spark:
+        ratings_df = spark.read.parquet(ratings_data)
+        (training_df, test_df) = ratings_df.randomSplit([split_prop, 1 - split_prop], seed=seed)
+        training_df.cache()
+        test_df.cache()
 
     mlflow.log_metric("training_nrows", training_df.count())
     mlflow.log_metric("test_nrows", test_df.count())

--- a/examples/multistep_workflow/etl_data.py
+++ b/examples/multistep_workflow/etl_data.py
@@ -30,12 +30,12 @@ def etl_data(ratings_csv, max_row_limit):
                 .csv(ratings_csv)
                 .drop("timestamp")
             )  # Drop unused column
-        ratings_df.show()
-        if max_row_limit != -1:
-            ratings_df = ratings_df.limit(max_row_limit)
-        ratings_df.write.parquet(ratings_parquet_dir)
-        print(f"Uploading Parquet ratings: {ratings_parquet_dir}")
-        mlflow.log_artifacts(ratings_parquet_dir, "ratings-parquet-dir")
+            ratings_df.show()
+            if max_row_limit != -1:
+                ratings_df = ratings_df.limit(max_row_limit)
+            ratings_df.write.parquet(ratings_parquet_dir)
+            print(f"Uploading Parquet ratings: {ratings_parquet_dir}")
+            mlflow.log_artifacts(ratings_parquet_dir, "ratings-parquet-dir")
 
 
 if __name__ == "__main__":

--- a/examples/multistep_workflow/etl_data.py
+++ b/examples/multistep_workflow/etl_data.py
@@ -22,14 +22,14 @@ def etl_data(ratings_csv, max_row_limit):
     with mlflow.start_run():
         tmpdir = tempfile.mkdtemp()
         ratings_parquet_dir = os.path.join(tmpdir, "ratings-parquet")
-        spark = pyspark.sql.SparkSession.builder.getOrCreate()
         print(f"Converting ratings CSV {ratings_csv} to Parquet {ratings_parquet_dir}")
-        ratings_df = (
-            spark.read.option("header", "true")
-            .option("inferSchema", "true")
-            .csv(ratings_csv)
-            .drop("timestamp")
-        )  # Drop unused column
+        with pyspark.sql.SparkSession.builder.getOrCreate() as spark:
+            ratings_df = (
+                spark.read.option("header", "true")
+                .option("inferSchema", "true")
+                .csv(ratings_csv)
+                .drop("timestamp")
+            )  # Drop unused column
         ratings_df.show()
         if max_row_limit != -1:
             ratings_df = ratings_df.limit(max_row_limit)

--- a/examples/multistep_workflow/train_keras.py
+++ b/examples/multistep_workflow/train_keras.py
@@ -71,43 +71,45 @@ def train_keras(ratings_data, als_model_uri, hidden_units):
         pandas_df = concat_train_df.toPandas()
         pandas_test_df = concat_test_df.toPandas()
 
-    # This syntax will create a new DataFrame where elements of the 'features' vector
-    # are each in their own column. This is what we'll train our neural network on.
-    x_test = pd.DataFrame(pandas_test_df.features.values.tolist(), index=pandas_test_df.index)
-    x_train = pd.DataFrame(pandas_df.features.values.tolist(), index=pandas_df.index)
+        # This syntax will create a new DataFrame where elements of the 'features' vector
+        # are each in their own column. This is what we'll train our neural network on.
+        x_test = pd.DataFrame(pandas_test_df.features.values.tolist(), index=pandas_test_df.index)
+        x_train = pd.DataFrame(pandas_df.features.values.tolist(), index=pandas_df.index)
 
-    # Show matrix for example.
-    print("Training matrix:")
-    print(x_train)
+        # Show matrix for example.
+        print("Training matrix:")
+        print(x_train)
 
-    # Create our Keras model with two fully connected hidden layers.
-    model = Sequential()
-    model.add(Dense(30, input_dim=24, activation="relu"))
-    model.add(Dense(hidden_units, activation="relu"))
-    model.add(Dense(1, activation="linear"))
+        # Create our Keras model with two fully connected hidden layers.
+        model = Sequential()
+        model.add(Dense(30, input_dim=24, activation="relu"))
+        model.add(Dense(hidden_units, activation="relu"))
+        model.add(Dense(1, activation="linear"))
 
-    model.compile(loss="mse", optimizer=keras.optimizers.Adam(lr=0.0001))
+        model.compile(loss="mse", optimizer=keras.optimizers.Adam(lr=0.0001))
 
-    early_stopping = EarlyStopping(monitor="val_loss", min_delta=0.0001, patience=2, mode="auto")
+        early_stopping = EarlyStopping(
+            monitor="val_loss", min_delta=0.0001, patience=2, mode="auto"
+        )
 
-    model.fit(
-        x_train,
-        pandas_df["rating"],
-        validation_split=0.2,
-        verbose=2,
-        epochs=3,
-        batch_size=128,
-        shuffle=False,
-        callbacks=[early_stopping],
-    )
+        model.fit(
+            x_train,
+            pandas_df["rating"],
+            validation_split=0.2,
+            verbose=2,
+            epochs=3,
+            batch_size=128,
+            shuffle=False,
+            callbacks=[early_stopping],
+        )
 
-    train_mse = model.evaluate(x_train, pandas_df["rating"], verbose=2)
-    test_mse = model.evaluate(x_test, pandas_test_df["rating"], verbose=2)
-    mlflow.log_metric("test_mse", test_mse)
-    mlflow.log_metric("train_mse", train_mse)
+        train_mse = model.evaluate(x_train, pandas_df["rating"], verbose=2)
+        test_mse = model.evaluate(x_test, pandas_test_df["rating"], verbose=2)
+        mlflow.log_metric("test_mse", test_mse)
+        mlflow.log_metric("train_mse", train_mse)
 
-    print(f"The model had a MSE on the test set of {test_mse}")
-    mlflow.tensorflow.log_model(model, "keras-model")
+        print(f"The model had a MSE on the test set of {test_mse}")
+        mlflow.tensorflow.log_model(model, "keras-model")
 
 
 if __name__ == "__main__":

--- a/examples/multistep_workflow/train_keras.py
+++ b/examples/multistep_workflow/train_keras.py
@@ -29,14 +29,12 @@ def train_keras(ratings_data, als_model_uri, hidden_units):
     np.random.seed(0)
     tf.set_random_seed(42)  # For reproducibility
 
-    spark = pyspark.sql.SparkSession.builder.getOrCreate()
     als_model = mlflow.spark.load_model(als_model_uri).stages[0]
-
-    ratings_df = spark.read.parquet(ratings_data)
-
-    (training_df, test_df) = ratings_df.randomSplit([0.8, 0.2], seed=42)
-    training_df.cache()
-    test_df.cache()
+    with pyspark.sql.SparkSession.builder.getOrCreate() as spark:
+        ratings_df = spark.read.parquet(ratings_data)
+        (training_df, test_df) = ratings_df.randomSplit([0.8, 0.2], seed=42)
+        training_df.cache()
+        test_df.cache()
 
     mlflow.log_metric("training_nrows", training_df.count())
     mlflow.log_metric("test_nrows", test_df.count())

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -163,14 +163,14 @@ def test_signature_inference_infers_datime_types_as_expected():
     signature = infer_signature(test_df)
     assert signature.inputs == Schema([ColSpec(DataType.datetime, name=col_name)])
 
-    spark = pyspark.sql.SparkSession.builder.getOrCreate()
-    spark_df = spark.range(1).selectExpr(
-        "current_timestamp() as timestamp", "current_date() as date"
-    )
-    signature = infer_signature(spark_df)
-    assert signature.inputs == Schema(
-        [ColSpec(DataType.datetime, name="timestamp"), ColSpec(DataType.datetime, name="date")]
-    )
+    with pyspark.sql.SparkSession.builder.getOrCreate() as spark:
+        spark_df = spark.range(1).selectExpr(
+            "current_timestamp() as timestamp", "current_date() as date"
+        )
+        signature = infer_signature(spark_df)
+        assert signature.inputs == Schema(
+            [ColSpec(DataType.datetime, name="timestamp"), ColSpec(DataType.datetime, name="date")]
+        )
 
 
 def test_set_signature_to_logged_model():

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -58,13 +58,13 @@ types = [np.int32, int, str, np.float32, np.double, bool]
 
 
 def score_model_as_udf(model_uri, pandas_df, result_type="double"):
-    spark = get_spark_session(pyspark.SparkConf())
-    spark_df = spark.createDataFrame(pandas_df).coalesce(1)
-    pyfunc_udf = spark_udf(
-        spark=spark, model_uri=model_uri, result_type=result_type, env_manager="local"
-    )
-    new_df = spark_df.withColumn("prediction", pyfunc_udf(*pandas_df.columns))
-    return [x["prediction"] for x in new_df.collect()]
+    with get_spark_session(pyspark.SparkConf()) as spark:
+        spark_df = spark.createDataFrame(pandas_df).coalesce(1)
+        pyfunc_udf = spark_udf(
+            spark=spark, model_uri=model_uri, result_type=result_type, env_manager="local"
+        )
+        new_df = spark_df.withColumn("prediction", pyfunc_udf(*pandas_df.columns))
+        return [x["prediction"] for x in new_df.collect()]
 
 
 class ConstantPyfuncWrapper:

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -58,13 +58,13 @@ types = [np.int32, int, str, np.float32, np.double, bool]
 
 
 def score_model_as_udf(model_uri, pandas_df, result_type="double"):
-    with get_spark_session(pyspark.SparkConf()) as spark:
-        spark_df = spark.createDataFrame(pandas_df).coalesce(1)
-        pyfunc_udf = spark_udf(
-            spark=spark, model_uri=model_uri, result_type=result_type, env_manager="local"
-        )
-        new_df = spark_df.withColumn("prediction", pyfunc_udf(*pandas_df.columns))
-        return [x["prediction"] for x in new_df.collect()]
+    spark = pyspark.sql.SparkSession.getActiveSession()
+    spark_df = spark.createDataFrame(pandas_df).coalesce(1)
+    pyfunc_udf = spark_udf(
+        spark=spark, model_uri=model_uri, result_type=result_type, env_manager="local"
+    )
+    new_df = spark_df.withColumn("prediction", pyfunc_udf(*pandas_df.columns))
+    return [x["prediction"] for x in new_df.collect()]
 
 
 class ConstantPyfuncWrapper:

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -131,9 +131,9 @@ def iris_pandas_df():
 def iris_df(spark_context):
     pdf = iris_pandas_df()
     feature_names = list(pdf.drop("label", axis=1).columns)
-    spark_session = pyspark.sql.SparkSession(spark_context)
-    iris_spark_df = spark_session.createDataFrame(pdf)
-    return feature_names, pdf, iris_spark_df
+    with pyspark.sql.SparkSession(spark_context) as spark:
+        iris_spark_df = spark.createDataFrame(pdf)
+        yield feature_names, pdf, iris_spark_df
 
 
 @pytest.fixture(scope="module")

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -632,10 +632,12 @@ def test_spark_type_mapping(pandas_df_with_all_types):
     )
     actual_spark_schema = schema.as_spark_schema()
     assert expected_spark_schema.jsonValue() == actual_spark_schema.jsonValue()
-    spark_session = pyspark.sql.SparkSession(pyspark.SparkContext.getOrCreate())
-    sparkdf = spark_session.createDataFrame(pandas_df_with_all_types, schema=actual_spark_schema)
-    schema2 = _infer_schema(sparkdf)
-    assert schema == schema2
+    with pyspark.sql.SparkSession(pyspark.SparkContext.getOrCreate()) as spark_session:
+        sparkdf = spark_session.createDataFrame(
+            pandas_df_with_all_types, schema=actual_spark_schema
+        )
+        schema2 = _infer_schema(sparkdf)
+        assert schema == schema2
 
     # test unnamed columns
     schema = Schema([ColSpec(col.type) for col in schema.inputs])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Dennis40816/mlflow/pull/10050?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10050/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10050
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve  #10034

### What changes are proposed in this pull request?
This PR introduces a context manager for the creation and usage of a spark session (`SparkSession`). Utilizing Python's `with` statement, the lifecycle of `SparkSession` instances can be more effectively managed, reducing the need for manual resource allocation and deallocation. 

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
