### PR TITLE
Introduce answer correctness and remove strict correctness

### DIFF
--- a/docs/source/python_api/mlflow.metrics.rst
+++ b/docs/source/python_api/mlflow.metrics.rst
@@ -102,7 +102,7 @@ We provide the following pre-canned "intelligent" :py:class:`EvaluationMetric <m
 
 .. autofunction:: mlflow.metrics.answer_similarity
 
-.. autofunction:: mlflow.metrics.strict_correctness
+.. autofunction:: mlflow.metrics.answer_correctness
 
 .. autofunction:: mlflow.metrics.relevance
 
@@ -118,4 +118,4 @@ When using LLM based :py:class:`EvaluationMetric <mlflow.metrics.EvaluationMetri
     :members:
     :undoc-members:
     :show-inheritance:
-    :exclude-members: MetricValue, EvaluationMetric, make_metric, make_genai_metric, EvaluationExample, ari_grade_level, flesch_kincaid_grade_level, perplexity, rouge1, rouge2, rougeL, rougeLsum, toxicity, answer_similarity, strict_correctness, relevance, mae, mape, max_error, mse, rmse, r2_score, precision_score, recall_score, f1_score, token_count, latency
+    :exclude-members: MetricValue, EvaluationMetric, make_metric, make_genai_metric, EvaluationExample, ari_grade_level, flesch_kincaid_grade_level, perplexity, rouge1, rouge2, rougeL, rougeLsum, toxicity, answer_similarity, answer_correctness, relevance, mae, mape, max_error, mse, rmse, r2_score, precision_score, recall_score, f1_score, token_count, latency

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -8,7 +8,7 @@ from mlflow.metrics.genai.genai_metric import (
 from mlflow.metrics.genai.metric_definitions import (
     answer_similarity,
     relevance,
-    strict_correctness,
+    answer_correctness,
 )
 from mlflow.metrics.metric_definitions import (
     _accuracy_eval_fn,
@@ -421,7 +421,7 @@ __all__ = [
     "binary_f1_score",
     "answer_similarity",
     "relevance",
-    "strict_correctness",
+    "answer_correctness",
     "token_count",
     "latency",
 ]

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -6,9 +6,9 @@ from mlflow.metrics.genai.genai_metric import (
     make_genai_metric,
 )
 from mlflow.metrics.genai.metric_definitions import (
+    answer_correctness,
     answer_similarity,
     relevance,
-    answer_correctness,
 )
 from mlflow.metrics.metric_definitions import (
     _accuracy_eval_fn,

--- a/mlflow/metrics/genai/metric_definitions.py
+++ b/mlflow/metrics/genai/metric_definitions.py
@@ -84,10 +84,9 @@ def answer_correctness(
     examples: Optional[List[EvaluationExample]] = None,
     judge_request_timeout=60,
 ) -> EvaluationMetric:
-    # TODO: update docstring
     """
     This function will create a genai metric used to evaluate the  correctness of an LLM
-    using the model provided. Strict correctness should be used in cases where correctness is
+    using the model provided. Answer correctness should be used in cases where correctness is
     binary, and the source of truth is provided in the ``ground_truth``. Outputs will be
     given either the highest or lowest score depending on if they are consistent with the
     ``ground_truth``. When dealing with inputs that may have multiple correct outputs, varying

--- a/mlflow/metrics/genai/metric_definitions.py
+++ b/mlflow/metrics/genai/metric_definitions.py
@@ -78,14 +78,15 @@ def answer_similarity(
 
 
 @experimental
-def strict_correctness(
+def answer_correctness(
     model: Optional[str] = None,
     metric_version: Optional[str] = None,
     examples: Optional[List[EvaluationExample]] = None,
     judge_request_timeout=60,
 ) -> EvaluationMetric:
+    # TODO: update docstring
     """
-    This function will create a genai metric used to evaluate the strict correctness of an LLM
+    This function will create a genai metric used to evaluate the  correctness of an LLM
     using the model provided. Strict correctness should be used in cases where correctness is
     binary, and the source of truth is provided in the ``ground_truth``. Outputs will be
     given either the highest or lowest score depending on if they are consistent with the

--- a/mlflow/metrics/genai/metric_definitions.py
+++ b/mlflow/metrics/genai/metric_definitions.py
@@ -103,10 +103,10 @@ def answer_correctness(
     :param model: (Optional) The model that will be used to evaluate this metric. Defaults to
         gpt-4. Your use of a third party LLM service (e.g., OpenAI) for evaluation may
         be subject to and governed by the LLM service's terms of use.
-    :param metric_version: (Optional) The version of the strict correctness metric to use.
+    :param metric_version: (Optional) The version of the answer correctness metric to use.
         Defaults to the latest version.
     :param examples: (Optional) Provide a list of examples to help the judge model evaluate the
-        strict correctness. It is highly recommended to add examples to be used as a reference to
+        answer correctness. It is highly recommended to add examples to be used as a reference to
         evaluate the new results.
     :param judge_request_timeout: (Optional) The timeout in seconds for the judge API request.
         Defaults to 60 seconds.
@@ -114,35 +114,35 @@ def answer_correctness(
     """
     if metric_version is None:
         metric_version = _get_latest_metric_version()
-    class_name = f"mlflow.metrics.genai.prompts.{metric_version}.StrictCorrectnessMetric"
+    class_name = f"mlflow.metrics.genai.prompts.{metric_version}.AnswerCorrectnessMetric"
     try:
-        strict_correctness_class_module = _get_class_from_string(class_name)
+        answer_correctness_class_module = _get_class_from_string(class_name)
     except ModuleNotFoundError:
         raise MlflowException(
-            f"Failed to find strict correctness metric for version {metric_version}."
+            f"Failed to find answer correctness metric for version {metric_version}."
             f"Please check the version",
             error_code=INVALID_PARAMETER_VALUE,
         ) from None
     except Exception as e:
         raise MlflowException(
-            f"Failed to construct strict correctness metric {metric_version}. Error: {e!r}",
+            f"Failed to construct answer correctness metric {metric_version}. Error: {e!r}",
             error_code=INTERNAL_ERROR,
         ) from None
 
     if examples is None:
-        examples = strict_correctness_class_module.default_examples
+        examples = answer_correctness_class_module.default_examples
     if model is None:
-        model = strict_correctness_class_module.default_model
+        model = answer_correctness_class_module.default_model
 
     return make_genai_metric(
-        name="strict_correctness",
-        definition=strict_correctness_class_module.definition,
-        grading_prompt=strict_correctness_class_module.grading_prompt,
+        name="answer_correctness",
+        definition=answer_correctness_class_module.definition,
+        grading_prompt=answer_correctness_class_module.grading_prompt,
         examples=examples,
         version=metric_version,
         model=model,
-        grading_context_columns=strict_correctness_class_module.grading_context_columns,
-        parameters=strict_correctness_class_module.parameters,
+        grading_context_columns=answer_correctness_class_module.grading_context_columns,
+        parameters=answer_correctness_class_module.parameters,
         aggregations=["mean", "variance", "p90"],
         greater_is_better=True,
         judge_request_timeout=judge_request_timeout,

--- a/mlflow/metrics/genai/metric_definitions.py
+++ b/mlflow/metrics/genai/metric_definitions.py
@@ -20,11 +20,11 @@ def answer_similarity(
     """
     This function will create a genai metric used to evaluate the answer similarity of an LLM
     using the model provided. Answer similarity will be assessed by the semantic similarity of the
-    output to the ``ground_truth``, which should be specified in the ``target`` column.
+    output to the ``ground_truth``, which should be specified in the ``targets`` column.
 
-    The ``target`` eval_arg must be provided as part of the input dataset or output
-    predictions. This can be mapped to a column of a different name using the a ``col_mapping``
-    in the ``evaluator_config``.
+    The ``targets`` eval_arg must be provided as part of the input dataset or output
+    predictions. This can be mapped to a column of a different name using ``col_mapping``
+    in the ``evaluator_config`` parameter, or using the ``targets`` parameter in mlflow.evaluate().
 
     An MlflowException will be raised if the specified version for this metric does not exist.
 
@@ -85,17 +85,13 @@ def answer_correctness(
     judge_request_timeout=60,
 ) -> EvaluationMetric:
     """
-    This function will create a genai metric used to evaluate the  correctness of an LLM
-    using the model provided. Answer correctness should be used in cases where correctness is
-    binary, and the source of truth is provided in the ``ground_truth``. Outputs will be
-    given either the highest or lowest score depending on if they are consistent with the
-    ``ground_truth``. When dealing with inputs that may have multiple correct outputs, varying
-    degrees of correctness, or when considering other factors such as the comprehensiveness of
-    the output, it is more appropriate to use the correctness metric instead.
+    This function will create a genai metric used to evaluate the answer correctness of an LLM
+    using the model provided. Answer correctness will be assessed by the accuracy of the provided
+    output based on the ``ground_truth``, which should be specified in the ``targets`` column.
 
-    The ``ground_truth`` eval_arg must be provided as part of the input dataset or output
-    predictions. This can be mapped to a column of a different name using the a ``col_mapping``
-    in the ``evaluator_config``.
+    The ``targets`` eval_arg must be provided as part of the input dataset or output
+    predictions. This can be mapped to a column of a different name using ``col_mapping``
+    in the ``evaluator_config`` parameter, or using the ``targets`` parameter in mlflow.evaluate().
 
     An MlflowException will be raised if the specified version for this metric does not exist.
 

--- a/mlflow/metrics/genai/prompts/v1.py
+++ b/mlflow/metrics/genai/prompts/v1.py
@@ -248,14 +248,18 @@ class AnswerCorrectnessMetric:
     parameters = default_parameters
     default_model = default_model
 
-    example_score_0 = EvaluationExample(
-        input="Is MLflow open-source?",
-        output="No, MLflow is not open-source.",
-        score=1,
-        justification="The output is incorrect. It states that MLflow is not open-source, which "
-        "contradicts the provided context, where it is explicitly mentioned that MLflow is an "
-        "open-source platform. This directly opposes the ground truth, resulting in a score of 0 "
-        "for strict correctness.",
+    example_score_2 = EvaluationExample(
+        input="How is MLflow related to Databricks?",
+        output="Databricks is a data engineering and analytics platform designed to help "
+        "organizations process and analyze large amounts of data. Databricks is a company "
+        "specializing in big data and machine learning solutions.",
+        score=2,
+        justification="The output provided by the model does demonstrate some degree of semantic "
+        "similarity to the targets, as it correctly identifies Databricks as a company "
+        "specializing in big data and machine learning solutions. However, it fails to address "
+        "the main point of the input question, which is the relationship between MLflow and "
+        "Databricks. The output does not mention MLflow at all, which is a significant discrepancy "
+        "with the provided targets. Therefore, the model's answer_correctness score is 2.",
         grading_context={
             "targets": "MLflow is an open-source platform for managing the end-to-end machine "
             "learning (ML) lifecycle. It was developed by Databricks, a company that specializes "
@@ -265,13 +269,17 @@ class AnswerCorrectnessMetric:
         },
     )
 
-    example_score_1 = EvaluationExample(
-        input="Is MLflow open-source?",
-        output="MLflow is open-source, which means it's freely available for anyone to use.",
-        score=1,
-        justification="The output correctly states that MLflow is open-source, aligning perfectly "
-        "with the provided context. It accurately reflects the ground truth information, earning "
-        "a score of 1 for strict correctness.",
+    example_score_4 = EvaluationExample(
+        input="How is MLflow related to Databricks?",
+        output="MLflow is a product created by Databricks to enhance the efficiency of machine "
+        "learning processes.",
+        score=4,
+        justification="The output provided by the model is mostly correct. It correctly identifies "
+        "that MLflow is a product created by Databricks. However, it does not mention that MLflow "
+        "is an open-source platform for managing the end-to-end machine learning lifecycle, which "
+        "is a significant part of its function. Therefore, while the output is mostly accurate, "
+        "it has a minor omission, which is why it gets a score of 4 according to the grading "
+        "rubric.",
         grading_context={
             "targets": "MLflow is an open-source platform for managing the end-to-end machine "
             "learning (ML) lifecycle. It was developed by Databricks, a company that specializes "
@@ -281,4 +289,4 @@ class AnswerCorrectnessMetric:
         },
     )
 
-    default_examples = [example_score_0, example_score_1]
+    default_examples = [example_score_2, example_score_4]

--- a/mlflow/metrics/genai/prompts/v1.py
+++ b/mlflow/metrics/genai/prompts/v1.py
@@ -221,18 +221,27 @@ class RelevanceMetric:
 
 
 @dataclass
-class StrictCorrectnessMetric:
+class AnswerCorrectnessMetric:
     definition = (
-        "When a question demands a specific value, term, or description (e.g., math questions or "
-        "fact-checking), correctness is binary. Strict correctness of the output is assessed on "
-        "whether it aligns exactly with the ground truth. Scores are assigned to be 0 or 1."
+        "Answer correctness is evaluated on the accuracy of the provided output based on the "
+        "provided targets, which is the ground truth. Scores can be assigned based on the degree "
+        "of semantic similarity and factual correctness of the provided output to the provided "
+        "targets, where a higher score indicates higher degree of accuracy."
     )
 
     grading_prompt = (
-        "Strict Correctness: Below are the details for different scores:"
-        "- Score 0: the output is completely incorrect, doesn't mention anything about the "
-        "question or is completely contrary to the ground truth."
-        "- Score 1: the output answers the question correctly as provided in the ground truth."
+        "Answer Correctness: Below are the details for different scores:\n"
+        "- Score 1: the output is completely incorrect. It is completely different from or "
+        "contradicts the provided targets.\n"
+        "- Score 2: the output demonstrates some degree of semantic similarity and includes "
+        "partially correct information. However, the output still has significant discrepancies "
+        "with the provided targets or inaccuracies.\n"
+        "- Score 3: the output addresses a couple of aspects of the input accurately, aligning "
+        "with the provided targets. However, there are still omissions or minor inaccuracies.\n"
+        "- Score 4: the output is mostly correct. It provides mostly accurate information, but "
+        "there may be one or more minor omissions or inaccuracies.\n"
+        "- Score 5: the output is correct. It demonstrates a high degree of accuracy and "
+        "semantic similarity to the targets."
     )
 
     grading_context_columns = ["targets"]
@@ -242,7 +251,7 @@ class StrictCorrectnessMetric:
     example_score_0 = EvaluationExample(
         input="Is MLflow open-source?",
         output="No, MLflow is not open-source.",
-        score=0,
+        score=1,
         justification="The output is incorrect. It states that MLflow is not open-source, which "
         "contradicts the provided context, where it is explicitly mentioned that MLflow is an "
         "open-source platform. This directly opposes the ground truth, resulting in a score of 0 "

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -648,8 +648,8 @@ def test_relevance_metric():
         )
 
 
-def test_strict_correctness_metric():
-    strict_correctness_metric = answer_correctness()
+def test_answer_correctness_metric():
+    answer_correctness_metric = answer_correctness()
     input = "What is MLflow?"
     examples = "\n".join([str(example) for example in AnswerCorrectnessMetric.default_examples])
 
@@ -658,7 +658,7 @@ def test_strict_correctness_metric():
         "score_model_on_payload",
         return_value=properly_formatted_openai_response1,
     ) as mock_predict_function:
-        metric_value = strict_correctness_metric.eval_fn(
+        metric_value = answer_correctness_metric.eval_fn(
             pd.Series([mlflow_prediction]),
             {},
             pd.Series([input]),
@@ -671,8 +671,8 @@ def test_strict_correctness_metric():
             "sent to a machine\nlearning model, and you will be given an output that the model "
             "produced. You\nmay also be given additional information that was used by the model "
             "to generate the output.\n\nYour task is to determine a numerical score called "
-            "strict_correctness based on the input and output.\nA definition of "
-            "strict_correctness and a grading rubric are provided below.\nYou must use the "
+            "answer_correctness based on the input and output.\nA definition of "
+            "answer_correctness and a grading rubric are provided below.\nYou must use the "
             "grading rubric to determine your score. You must also justify your score."
             "\n\nExamples could be included below for reference. Make sure to use them as "
             "references and to\nunderstand them before completing the task.\n"
@@ -685,9 +685,9 @@ def test_strict_correctness_metric():
             "\nExamples:\n"
             f"{examples}\n"
             "\nYou must return the following fields in your response one below the other:\nscore: "
-            "Your numerical score for the model's strict_correctness based on the "
+            "Your numerical score for the model's answer_correctness based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
-            "strict_correctness score\n    ",
+            "answer_correctness score\n    ",
             **AnswerCorrectnessMetric.parameters,
         }
 

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -15,14 +15,14 @@ from mlflow.metrics.genai.genai_metric import (
     make_genai_metric,
 )
 from mlflow.metrics.genai.metric_definitions import (
+    answer_correctness,
     answer_similarity,
     relevance,
-    answer_correctness,
 )
 from mlflow.metrics.genai.prompts.v1 import (
+    AnswerCorrectnessMetric,
     AnswerSimilarityMetric,
     RelevanceMetric,
-    AnswerCorrectnessMetric,
 )
 
 openai_justification1 = (

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -17,12 +17,12 @@ from mlflow.metrics.genai.genai_metric import (
 from mlflow.metrics.genai.metric_definitions import (
     answer_similarity,
     relevance,
-    strict_correctness,
+    answer_correctness,
 )
 from mlflow.metrics.genai.prompts.v1 import (
     AnswerSimilarityMetric,
     RelevanceMetric,
-    StrictCorrectnessMetric,
+    AnswerCorrectnessMetric,
 )
 
 openai_justification1 = (
@@ -649,9 +649,9 @@ def test_relevance_metric():
 
 
 def test_strict_correctness_metric():
-    strict_correctness_metric = strict_correctness()
+    strict_correctness_metric = answer_correctness()
     input = "What is MLflow?"
-    examples = "\n".join([str(example) for example in StrictCorrectnessMetric.default_examples])
+    examples = "\n".join([str(example) for example in AnswerCorrectnessMetric.default_examples])
 
     with mock.patch.object(
         model_utils,
@@ -680,15 +680,15 @@ def test_strict_correctness_metric():
             f"\nOutput:\n{mlflow_prediction}\n"
             "\nAdditional information used by the model:\nkey: targets\nvalue:\n"
             f"{mlflow_ground_truth}\n"
-            f"\nMetric definition:\n{StrictCorrectnessMetric.definition}\n"
-            f"\nGrading rubric:\n{StrictCorrectnessMetric.grading_prompt}\n"
+            f"\nMetric definition:\n{AnswerCorrectnessMetric.definition}\n"
+            f"\nGrading rubric:\n{AnswerCorrectnessMetric.grading_prompt}\n"
             "\nExamples:\n"
             f"{examples}\n"
             "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's strict_correctness based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
             "strict_correctness score\n    ",
-            **StrictCorrectnessMetric.parameters,
+            **AnswerCorrectnessMetric.parameters,
         }
 
     assert metric_value.scores == [3]
@@ -704,7 +704,7 @@ def test_strict_correctness_metric():
         MlflowException,
         match="Failed to find strict correctness metric for version non-existent-version",
     ):
-        strict_correctness_metric = strict_correctness(metric_version="non-existent-version")
+        answer_correctness(metric_version="non-existent-version")
 
 
 def test_make_genai_metric_metric_details():

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -702,7 +702,7 @@ def test_answer_correctness_metric():
 
     with pytest.raises(
         MlflowException,
-        match="Failed to find strict correctness metric for version non-existent-version",
+        match="Failed to find answer correctness metric for version non-existent-version",
     ):
         answer_correctness(metric_version="non-existent-version")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/annzhang-db/mlflow/pull/10053?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10053/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10053
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- Remove strict correctness and replace with answer correctness to be more in line with RAGAS
- https://docs.ragas.io/en/latest/concepts/metrics/answer_correctness.html

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
