### PR TITLE
Refactor metrics_definitions.py

### DIFF
--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -30,7 +30,7 @@ def _validate_text_data(data, metric_name, column_name):
     for row, line in enumerate(data):
         if not isinstance(line, str):
             _logger.warning(
-                f"Cannot calculate {metric_name} for non-string inputs.\n"
+                f"Cannot calculate {metric_name} for non-string inputs. "
                 f"Non-string found for {column_name} on row {row}. Skipping metric logging."
             )
             return False

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -17,7 +17,7 @@ def standard_aggregations(scores):
     }
 
 
-def _validate_text_data(data, metric_name, column_name):
+def _validate_text_data(data, metric_name, column_name=None):
     """Validates that the data is a list of strs and is non-empty"""
     if data is None or len(data) == 0:
         return False

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -8,8 +8,8 @@ from mlflow.metrics.base import MetricValue
 
 _logger = logging.getLogger(__name__)
 
-targets_err_msg = "the column specified by the `targets` parameter"
-predictions_err_msg = (
+targets_col_specifier = "the column specified by the `targets` parameter"
+predictions_col_specifier = (
     "the column specified by the `predictions` parameter or the model output column"
 )
 
@@ -22,7 +22,7 @@ def standard_aggregations(scores):
     }
 
 
-def _validate_text_data(data, metric_name, column_name):
+def _validate_text_data(data, metric_name, col_specifier):
     """Validates that the data is a list of strs and is non-empty"""
     if data is None or len(data) == 0:
         return False
@@ -31,7 +31,7 @@ def _validate_text_data(data, metric_name, column_name):
         if not isinstance(line, str):
             _logger.warning(
                 f"Cannot calculate {metric_name} for non-string inputs. "
-                f"Non-string found for {column_name} on row {row}. Skipping metric logging."
+                f"Non-string found for {col_specifier} on row {row}. Skipping metric logging."
             )
             return False
 
@@ -65,7 +65,7 @@ def _cached_evaluate_load(path, module_type=None):
 
 
 def _toxicity_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(predictions, "toxicity", predictions_err_msg):
+    if not _validate_text_data(predictions, "toxicity", predictions_col_specifier):
         return
     try:
         toxicity = _cached_evaluate_load("toxicity", module_type="measurement")
@@ -89,7 +89,7 @@ def _toxicity_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _flesch_kincaid_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(predictions, "flesch_kincaid", predictions_err_msg):
+    if not _validate_text_data(predictions, "flesch_kincaid", predictions_col_specifier):
         return
 
     try:
@@ -106,7 +106,7 @@ def _flesch_kincaid_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _ari_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(predictions, "ari", predictions_err_msg):
+    if not _validate_text_data(predictions, "ari", predictions_col_specifier):
         return
 
     try:
@@ -133,8 +133,8 @@ def _accuracy_eval_fn(predictions, targets=None, metrics=None, sample_weight=Non
 
 
 def _rouge1_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rouge1", targets_err_msg) or not _validate_text_data(
-        predictions, "rouge1", predictions_err_msg
+    if not _validate_text_data(targets, "rouge1", targets_col_specifier) or not _validate_text_data(
+        predictions, "rouge1", predictions_col_specifier
     ):
         return
 
@@ -157,8 +157,8 @@ def _rouge1_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _rouge2_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rouge2", targets_err_msg) or not _validate_text_data(
-        predictions, "rouge2", predictions_err_msg
+    if not _validate_text_data(targets, "rouge2", targets_col_specifier) or not _validate_text_data(
+        predictions, "rouge2", predictions_col_specifier
     ):
         return
 
@@ -181,8 +181,8 @@ def _rouge2_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _rougeL_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rougeL", targets_err_msg) or not _validate_text_data(
-        predictions, "rougeL", predictions_err_msg
+    if not _validate_text_data(targets, "rougeL", targets_col_specifier) or not _validate_text_data(
+        predictions, "rougeL", predictions_col_specifier
     ):
         return
 
@@ -205,9 +205,9 @@ def _rougeL_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _rougeLsum_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rougeLsum", targets_err_msg) or not _validate_text_data(
-        predictions, "rougeLsum", predictions_err_msg
-    ):
+    if not _validate_text_data(
+        targets, "rougeLsum", targets_col_specifier
+    ) or not _validate_text_data(predictions, "rougeLsum", predictions_col_specifier):
         return
 
     try:

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -8,6 +8,11 @@ from mlflow.metrics.base import MetricValue
 
 _logger = logging.getLogger(__name__)
 
+targets_err_msg = "the column specified by the `targets` parameter"
+predictions_err_msg = (
+    "the column specified by the `predictions` parameter or the model output column"
+)
+
 
 def standard_aggregations(scores):
     return {
@@ -67,7 +72,7 @@ def _cached_evaluate_load(path, module_type=None):
 
 
 def _toxicity_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(predictions, "toxicity"):
+    if not _validate_text_data(predictions, "toxicity", predictions_err_msg):
         return
     try:
         toxicity = _cached_evaluate_load("toxicity", module_type="measurement")
@@ -91,7 +96,7 @@ def _toxicity_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _flesch_kincaid_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(predictions, "flesch_kincaid"):
+    if not _validate_text_data(predictions, "flesch_kincaid", predictions_err_msg):
         return
 
     try:
@@ -108,7 +113,7 @@ def _flesch_kincaid_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _ari_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(predictions, "ari"):
+    if not _validate_text_data(predictions, "ari", predictions_err_msg):
         return
 
     try:
@@ -135,9 +140,9 @@ def _accuracy_eval_fn(predictions, targets=None, metrics=None, sample_weight=Non
 
 
 def _rouge1_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rouge1", "targets") or not _validate_text_data(
-        predictions, "rouge1"
-    ):
+    if not _validate_text_data(
+        targets, "rouge1", "targets", targets_err_msg
+    ) or not _validate_text_data(predictions, "rouge1", predictions_err_msg):
         return
 
     try:
@@ -159,8 +164,8 @@ def _rouge1_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _rouge2_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rouge2", "targets") or not _validate_text_data(
-        predictions, "rouge2"
+    if not _validate_text_data(targets, "rouge2", targets_err_msg) or not _validate_text_data(
+        predictions, "rouge2", predictions_err_msg
     ):
         return
 
@@ -183,8 +188,8 @@ def _rouge2_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _rougeL_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rougeL", "targets") or not _validate_text_data(
-        predictions, "rougeL"
+    if not _validate_text_data(targets, "rougeL", targets_err_msg) or not _validate_text_data(
+        predictions, "rougeL", predictions_err_msg
     ):
         return
 
@@ -207,8 +212,8 @@ def _rougeL_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _rougeLsum_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rougeLsum", "targets") or not _validate_text_data(
-        predictions, "rougeLsum"
+    if not _validate_text_data(targets, "rougeLsum", targets_err_msg) or not _validate_text_data(
+        predictions, "rougeLsum", predictions_err_msg
     ):
         return
 

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -30,8 +30,8 @@ def _validate_text_data(data, metric_name, column_name):
     for row, line in enumerate(data):
         if not isinstance(line, str):
             _logger.warning(
-                f"Cannot calculate {metric_name} for non-string inputs. "
-                f"Non-string found for {column_name} on row {row}. skipping metric logging."
+                f"Cannot calculate {metric_name} for non-string inputs.\n"
+                f"Non-string found for {column_name} on row {row}. Skipping metric logging."
             )
             return False
 

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -17,18 +17,24 @@ def standard_aggregations(scores):
     }
 
 
-def _validate_text_data(data, metric_name):
+def _validate_text_data(data, metric_name, column_name):
     """Validates that the data is a list of strs and is non-empty"""
     if data is None or len(data) == 0:
         return False
 
     for row, line in enumerate(data):
         if not isinstance(line, str):
-            _logger.warning(
-                f"Cannot calculate {metric_name} for non-string inputs. "
-                f"Non-string found for the column specified by `predictions` "
-                f"or the model output column on row {row}. Skipping metric logging."
-            )
+            if column_name:
+                _logger.warning(
+                    f"Cannot calculate {metric_name} for non-string inputs. "
+                    f"Non-string found for {column_name} on row {row}. skipping metric logging."
+                )
+            else:
+                _logger.warning(
+                    f"Cannot calculate {metric_name} for non-string inputs. "
+                    f"Non-string found for the column specified by `predictions` "
+                    f"or the model output column on row {row}. Skipping metric logging."
+                )
             return False
 
     return True
@@ -129,7 +135,9 @@ def _accuracy_eval_fn(predictions, targets=None, metrics=None, sample_weight=Non
 
 
 def _rouge1_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rouge1") or not _validate_text_data(predictions, "rouge1"):
+    if not _validate_text_data(targets, "rouge1", "targets") or not _validate_text_data(
+        predictions, "rouge1"
+    ):
         return
 
     try:
@@ -151,7 +159,9 @@ def _rouge1_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _rouge2_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rouge2") or not _validate_text_data(predictions, "rouge2"):
+    if not _validate_text_data(targets, "rouge2", "targets") or not _validate_text_data(
+        predictions, "rouge2"
+    ):
         return
 
     try:
@@ -173,7 +183,9 @@ def _rouge2_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _rougeL_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rougeL") or not _validate_text_data(predictions, "rougeL"):
+    if not _validate_text_data(targets, "rougeL", "targets") or not _validate_text_data(
+        predictions, "rougeL"
+    ):
         return
 
     try:
@@ -195,7 +207,7 @@ def _rougeL_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _rougeLsum_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rougeLsum") or not _validate_text_data(
+    if not _validate_text_data(targets, "rougeLsum", "targets") or not _validate_text_data(
         predictions, "rougeLsum"
     ):
         return

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -18,15 +18,16 @@ def standard_aggregations(scores):
 
 
 def _validate_text_data(data, metric_name, column_name):
-    """Validates that the data is text and is non-empty"""
-    if len(data) == 0:
+    """Validates that the data is a list of strs and is non-empty"""
+    if data is None or len(data) == 0:
         return False
 
     for row, line in enumerate(data):
         if not isinstance(line, str):
             _logger.warning(
                 f"Cannot calculate {metric_name} for non-string inputs. "
-                + f"Non-string found for {column_name} on row {row}. skipping metric logging."
+                f"Non-string found for the column specified by `predictions` "
+                f"or the model output column on row {row}. Skipping metric logging."
             )
             return False
 
@@ -128,111 +129,99 @@ def _accuracy_eval_fn(predictions, targets=None, metrics=None, sample_weight=Non
 
 
 def _rouge1_eval_fn(predictions, targets=None, metrics=None):
-    if targets is not None and len(targets) != 0:
-        if not _validate_text_data(targets, "rouge1", "targets") or not _validate_text_data(
-            predictions, "rouge1", "predictions"
-        ):
-            return
+    if not _validate_text_data(targets, "rouge1", "targets") or not _validate_text_data(
+        predictions, "rouge1", "predictions"
+    ):
+        return
 
-        try:
-            rouge = _cached_evaluate_load("rouge")
-        except Exception as e:
-            _logger.warning(
-                f"Failed to load 'rouge' metric (error: {e!r}), skipping metric logging."
-            )
-            return
+    try:
+        rouge = _cached_evaluate_load("rouge")
+    except Exception as e:
+        _logger.warning(f"Failed to load 'rouge' metric (error: {e!r}), skipping metric logging.")
+        return
 
-        scores = rouge.compute(
-            predictions=predictions,
-            references=targets,
-            rouge_types=["rouge1"],
-            use_aggregator=False,
-        )["rouge1"]
-        return MetricValue(
-            scores=scores,
-            aggregate_results=standard_aggregations(scores),
-        )
+    scores = rouge.compute(
+        predictions=predictions,
+        references=targets,
+        rouge_types=["rouge1"],
+        use_aggregator=False,
+    )["rouge1"]
+    return MetricValue(
+        scores=scores,
+        aggregate_results=standard_aggregations(scores),
+    )
 
 
 def _rouge2_eval_fn(predictions, targets=None, metrics=None):
-    if targets is not None and len(targets) != 0:
-        if not _validate_text_data(targets, "rouge2", "targets") or not _validate_text_data(
-            predictions, "rouge2", "predictions"
-        ):
-            return
+    if not _validate_text_data(targets, "rouge2", "targets") or not _validate_text_data(
+        predictions, "rouge2", "predictions"
+    ):
+        return
 
-        try:
-            rouge = _cached_evaluate_load("rouge")
-        except Exception as e:
-            _logger.warning(
-                f"Failed to load 'rouge' metric (error: {e!r}), skipping metric logging."
-            )
-            return
+    try:
+        rouge = _cached_evaluate_load("rouge")
+    except Exception as e:
+        _logger.warning(f"Failed to load 'rouge' metric (error: {e!r}), skipping metric logging.")
+        return
 
-        scores = rouge.compute(
-            predictions=predictions,
-            references=targets,
-            rouge_types=["rouge2"],
-            use_aggregator=False,
-        )["rouge2"]
-        return MetricValue(
-            scores=scores,
-            aggregate_results=standard_aggregations(scores),
-        )
+    scores = rouge.compute(
+        predictions=predictions,
+        references=targets,
+        rouge_types=["rouge2"],
+        use_aggregator=False,
+    )["rouge2"]
+    return MetricValue(
+        scores=scores,
+        aggregate_results=standard_aggregations(scores),
+    )
 
 
 def _rougeL_eval_fn(predictions, targets=None, metrics=None):
-    if targets is not None and len(targets) != 0:
-        if not _validate_text_data(targets, "rougeL", "targets") or not _validate_text_data(
-            predictions, "rougeL", "predictions"
-        ):
-            return
+    if not _validate_text_data(targets, "rougeL", "targets") or not _validate_text_data(
+        predictions, "rougeL", "predictions"
+    ):
+        return
 
-        try:
-            rouge = _cached_evaluate_load("rouge")
-        except Exception as e:
-            _logger.warning(
-                f"Failed to load 'rouge' metric (error: {e!r}), skipping metric logging."
-            )
-            return
+    try:
+        rouge = _cached_evaluate_load("rouge")
+    except Exception as e:
+        _logger.warning(f"Failed to load 'rouge' metric (error: {e!r}), skipping metric logging.")
+        return
 
-        scores = rouge.compute(
-            predictions=predictions,
-            references=targets,
-            rouge_types=["rougeL"],
-            use_aggregator=False,
-        )["rougeL"]
-        return MetricValue(
-            scores=scores,
-            aggregate_results=standard_aggregations(scores),
-        )
+    scores = rouge.compute(
+        predictions=predictions,
+        references=targets,
+        rouge_types=["rougeL"],
+        use_aggregator=False,
+    )["rougeL"]
+    return MetricValue(
+        scores=scores,
+        aggregate_results=standard_aggregations(scores),
+    )
 
 
 def _rougeLsum_eval_fn(predictions, targets=None, metrics=None):
-    if targets is not None and len(targets) != 0:
-        if not _validate_text_data(targets, "rougeLsum", "targets") or not _validate_text_data(
-            predictions, "rougeLsum", "predictions"
-        ):
-            return
+    if not _validate_text_data(targets, "rougeLsum", "targets") or not _validate_text_data(
+        predictions, "rougeLsum", "predictions"
+    ):
+        return
 
-        try:
-            rouge = _cached_evaluate_load("rouge")
-        except Exception as e:
-            _logger.warning(
-                f"Failed to load 'rouge' metric (error: {e!r}), skipping metric logging."
-            )
-            return
+    try:
+        rouge = _cached_evaluate_load("rouge")
+    except Exception as e:
+        _logger.warning(f"Failed to load 'rouge' metric (error: {e!r}), skipping metric logging.")
+        return
 
-        scores = rouge.compute(
-            predictions=predictions,
-            references=targets,
-            rouge_types=["rougeLsum"],
-            use_aggregator=False,
-        )["rougeLsum"]
-        return MetricValue(
-            scores=scores,
-            aggregate_results=standard_aggregations(scores),
-        )
+    scores = rouge.compute(
+        predictions=predictions,
+        references=targets,
+        rouge_types=["rougeLsum"],
+        use_aggregator=False,
+    )["rougeLsum"]
+    return MetricValue(
+        scores=scores,
+        aggregate_results=standard_aggregations(scores),
+    )
 
 
 def _mae_eval_fn(predictions, targets=None, metrics=None, sample_weight=None):

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -17,7 +17,7 @@ def standard_aggregations(scores):
     }
 
 
-def _validate_text_data(data, metric_name, column_name):
+def _validate_text_data(data, metric_name):
     """Validates that the data is a list of strs and is non-empty"""
     if data is None or len(data) == 0:
         return False
@@ -61,7 +61,7 @@ def _cached_evaluate_load(path, module_type=None):
 
 
 def _toxicity_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(predictions, "toxicity", "predictions"):
+    if not _validate_text_data(predictions, "toxicity"):
         return
     try:
         toxicity = _cached_evaluate_load("toxicity", module_type="measurement")
@@ -85,7 +85,7 @@ def _toxicity_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _flesch_kincaid_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(predictions, "flesch_kincaid", "predictions"):
+    if not _validate_text_data(predictions, "flesch_kincaid"):
         return
 
     try:
@@ -102,7 +102,7 @@ def _flesch_kincaid_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _ari_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(predictions, "ari", "predictions"):
+    if not _validate_text_data(predictions, "ari"):
         return
 
     try:
@@ -129,9 +129,7 @@ def _accuracy_eval_fn(predictions, targets=None, metrics=None, sample_weight=Non
 
 
 def _rouge1_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rouge1", "targets") or not _validate_text_data(
-        predictions, "rouge1", "predictions"
-    ):
+    if not _validate_text_data(targets, "rouge1") or not _validate_text_data(predictions, "rouge1"):
         return
 
     try:
@@ -153,9 +151,7 @@ def _rouge1_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _rouge2_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rouge2", "targets") or not _validate_text_data(
-        predictions, "rouge2", "predictions"
-    ):
+    if not _validate_text_data(targets, "rouge2") or not _validate_text_data(predictions, "rouge2"):
         return
 
     try:
@@ -177,9 +173,7 @@ def _rouge2_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _rougeL_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rougeL", "targets") or not _validate_text_data(
-        predictions, "rougeL", "predictions"
-    ):
+    if not _validate_text_data(targets, "rougeL") or not _validate_text_data(predictions, "rougeL"):
         return
 
     try:
@@ -201,8 +195,8 @@ def _rougeL_eval_fn(predictions, targets=None, metrics=None):
 
 
 def _rougeLsum_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(targets, "rougeLsum", "targets") or not _validate_text_data(
-        predictions, "rougeLsum", "predictions"
+    if not _validate_text_data(targets, "rougeLsum") or not _validate_text_data(
+        predictions, "rougeLsum"
     ):
         return
 

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -22,7 +22,7 @@ def standard_aggregations(scores):
     }
 
 
-def _validate_text_data(data, metric_name, column_name=None):
+def _validate_text_data(data, metric_name, column_name):
     """Validates that the data is a list of strs and is non-empty"""
     if data is None or len(data) == 0:
         return False

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -133,9 +133,9 @@ def _accuracy_eval_fn(predictions, targets=None, metrics=None, sample_weight=Non
 
 
 def _rouge1_eval_fn(predictions, targets=None, metrics=None):
-    if not _validate_text_data(
-        targets, "rouge1", "targets", targets_err_msg
-    ) or not _validate_text_data(predictions, "rouge1", predictions_err_msg):
+    if not _validate_text_data(targets, "rouge1", targets_err_msg) or not _validate_text_data(
+        predictions, "rouge1", predictions_err_msg
+    ):
         return
 
     try:

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -29,17 +29,10 @@ def _validate_text_data(data, metric_name, column_name=None):
 
     for row, line in enumerate(data):
         if not isinstance(line, str):
-            if column_name:
-                _logger.warning(
-                    f"Cannot calculate {metric_name} for non-string inputs. "
-                    f"Non-string found for {column_name} on row {row}. skipping metric logging."
-                )
-            else:
-                _logger.warning(
-                    f"Cannot calculate {metric_name} for non-string inputs. "
-                    f"Non-string found for the column specified by `predictions` "
-                    f"or the model output column on row {row}. Skipping metric logging."
-                )
+            _logger.warning(
+                f"Cannot calculate {metric_name} for non-string inputs. "
+                f"Non-string found for {column_name} on row {row}. skipping metric logging."
+            )
             return False
 
     return True


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/bbqiu/mlflow/pull/10059?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10059/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10059
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
- refactor `metric_definitions.py` slightly
- fix this [jira issue](https://databricks.atlassian.net/browse/ML-35830) as well
- the new logging messages looks like this:

> ```2023/10/25 19:04:56 WARNING mlflow.metrics.metric_definitions: Cannot calculate rougeL for non-string inputs. Non-string found for the column specified by the `predictions` parameter or the model output column on row 0. Skipping metric logging.```

> ```2023/10/25 19:07:43 WARNING mlflow.metrics.metric_definitions: Cannot calculate rougeL for non-string inputs. Non-string found for the column specified by the `targets` parameter on row 0. Skipping metric logging.```

[link to notebook used for testing](https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/4169768892688721/command/4169768892688722)

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
