### PR TITLE
Cache `.venv` on windows job

### DIFF
--- a/.github/actions/cache-pip/action.yml
+++ b/.github/actions/cache-pip/action.yml
@@ -11,5 +11,5 @@ runs:
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
       with:
-        path: ~/.venv
+        path: .venv
         key: ${{ steps.py-cache-key.outputs.key }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -46,21 +46,21 @@ jobs:
       - uses: ./.github/actions/cache-pip
       - name: Install dependencies
         run: |
-          python -m venv ~/.venv
-          . ~/.venv/bin/activate
+          python -m venv .venv
+          source .venv/bin/activate
           source ./dev/install-common-deps.sh --ml
           pip install -r requirements/lint-requirements.txt
       - uses: ./.github/actions/pipdeptree
       - name: Install pre-commit hooks
         run: |
-          . ~/.venv/bin/activate
+          source .venv/bin/activate
           pre-commit install -t pre-commit -t prepare-commit-msg
       - name: Run pre-commit
         id: pre-commit
         env:
           IS_MAINTAINER: ${{ contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association )}}
         run: |
-          . ~/.venv/bin/activate
+          source .venv/bin/activate
           pre-commit run --all-files
 
   # python-skinny tests cover a subset of mlflow functionality
@@ -105,19 +105,19 @@ jobs:
       - uses: ./.github/actions/cache-pip
       - name: Install dependencies
         run: |
-          python -m venv ~/.venv
-          . ~/.venv/bin/activate
+          python -m venv .venv
+          source .venv/bin/activate
           source ./dev/install-common-deps.sh --ml
           # pyspark 3.5 is incompatible with delta 2.4
           pip install 'pyspark<3.5'
       - uses: ./.github/actions/pipdeptree
       - name: Import check
         run: |
-          . ~/.venv/bin/activate
+          source .venv/bin/activate
           python tests/check_mlflow_lazily_imports_ml_packages.py
       - name: Run tests
         run: |
-          . ~/.venv/bin/activate
+          source .venv/bin/activate
           source dev/setup-ssh.sh
           pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} --quiet --requires-ssh \
             --ignore-flavors --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate \
@@ -228,13 +228,13 @@ jobs:
       - uses: ./.github/actions/cache-pip
       - name: Install dependencies
         run: |
-          python -m venv ~/.venv
-          . ~/.venv/bin/activate
+          python -m venv .venv
+          source .venv/bin/activate
           source ./dev/install-common-deps.sh --ml
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |
-          . ~/.venv/bin/activate
+          source .venv/bin/activate
           pytest \
             tests/utils/test_model_utils.py \
             tests/tracking/fluent/test_fluent_autolog.py \
@@ -362,8 +362,11 @@ jobs:
       - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-pyenv
       - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/cache-pip
       - name: Install python dependencies
         run: |
+          python -m venv .venv
+          source .venv/bin/activate
           pip install -r requirements/test-requirements.txt
           pip install --no-dependencies tests/resources/mlflow-test-plugin
           pip install -e .[extras]
@@ -388,6 +391,7 @@ jobs:
           # it's explicitly disposed.
           MLFLOW_SQLALCHEMYSTORE_POOLCLASS: "NullPool"
         run: |
+          source .venv/bin/activate
           # Set Hadoop environment variables required for testing Spark integrations on Windows
           export HADOOP_HOME=/tmp/winutils/hadoop-3.2.2
           export PATH=$PATH:$HADOOP_HOME/bin

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -366,7 +366,7 @@ jobs:
       - name: Install python dependencies
         run: |
           python -m venv .venv
-          source .venv/bin/activate
+          source .venv/Scripts/activate
           pip install -r requirements/test-requirements.txt
           pip install --no-dependencies tests/resources/mlflow-test-plugin
           pip install -e .[extras]
@@ -391,7 +391,7 @@ jobs:
           # it's explicitly disposed.
           MLFLOW_SQLALCHEMYSTORE_POOLCLASS: "NullPool"
         run: |
-          source .venv/bin/activate
+          source .venv/Scripts/activate
           # Set Hadoop environment variables required for testing Spark integrations on Windows
           export HADOOP_HOME=/tmp/winutils/hadoop-3.2.2
           export PATH=$PATH:$HADOOP_HOME/bin

--- a/mlflow/utils/git_utils.py
+++ b/mlflow/utils/git_utils.py
@@ -46,6 +46,8 @@ def get_git_commit(path: str) -> Optional[str]:
         if os.path.isfile(path):
             path = os.path.dirname(path)
         repo = Repo(path, search_parent_directories=True)
+        if path in repo.ignored(path):
+            return None
         return repo.head.commit.hexsha
     except Exception:
         return None

--- a/mlflow/utils/git_utils.py
+++ b/mlflow/utils/git_utils.py
@@ -46,8 +46,8 @@ def get_git_commit(path: str) -> Optional[str]:
         if os.path.isfile(path):
             path = os.path.dirname(path)
         repo = Repo(path, search_parent_directories=True)
-        # if path in repo.ignored(path):
-        #     return None
+        if path in repo.ignored(path):
+            return None
         return repo.head.commit.hexsha
     except Exception:
         return None

--- a/mlflow/utils/git_utils.py
+++ b/mlflow/utils/git_utils.py
@@ -46,8 +46,8 @@ def get_git_commit(path: str) -> Optional[str]:
         if os.path.isfile(path):
             path = os.path.dirname(path)
         repo = Repo(path, search_parent_directories=True)
-        if path in repo.ignored(path):
-            return None
+        # if path in repo.ignored(path):
+        #     return None
         return repo.head.commit.hexsha
     except Exception:
         return None

--- a/tests/tracking/context/test_git_context.py
+++ b/tests/tracking/context/test_git_context.py
@@ -45,13 +45,9 @@ def test_git_run_context_tags(patch_script_name, patch_git_repo):
 def test_git_run_context_caching(patch_script_name):
     """Check that the git commit hash is only looked up once."""
 
-    mock_repo = mock.Mock()
-    mock_hexsha = mock.PropertyMock(return_value=MOCK_COMMIT_HASH)
-    type(mock_repo.head.commit).hexsha = mock_hexsha
-
-    with mock.patch("git.Repo", return_value=mock_repo):
+    with mock.patch("git.Repo") as mock_repo:
         context = GitRunContext()
         context.in_context()
         context.tags()
 
-    assert mock_hexsha.call_count == 1
+    mock_repo.assert_called_once()

--- a/tests/tracking/context/test_git_context.py
+++ b/tests/tracking/context/test_git_context.py
@@ -25,6 +25,7 @@ def patch_script_name():
 def patch_git_repo():
     mock_repo = mock.Mock()
     mock_repo.head.commit.hexsha = MOCK_COMMIT_HASH
+    mock_repo.ignored.return_value = []
     with mock.patch("git.Repo", return_value=mock_repo):
         yield mock_repo
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10068?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10068/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10068
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Package installation takes 10 ~ 15 minutes on windows:

https://github.com/mlflow/mlflow/actions/runs/6609145501/job/17948848689

<img width="1488" alt="image" src="https://github.com/mlflow/mlflow/assets/17039389/4276d12c-32e2-44df-a290-249870096fab">

This PR is an attempt to speed it up.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
