### PR TITLE
Reordering of table columns on MLflow Experiment page

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentFilterParams.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentFilterParams.tsx
@@ -44,6 +44,7 @@ const ExperimentFilterParams = (props: ExperimentFilterParamsProps) => {
       setPlaceholder(FILTER_PARAMS_PLACEHOLDER);
     }
     // Add other conditions for updating the placeholder as needed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchFacetsState]);
 
   const triggerFilter: React.KeyboardEventHandler<HTMLInputElement> = useCallback(

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentFilterParams.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentFilterParams.tsx
@@ -1,0 +1,89 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { Theme } from '@emotion/react';
+import { Input } from '@databricks/design-system';
+import { UpdateExperimentSearchFacetsFn } from '../../../../types';
+import { makeCanonicalSortKey } from '../../utils/experimentPage.column-utils';
+import { SearchExperimentRunsFacetsState } from '../../models/SearchExperimentRunsFacetsState';
+import { COLUMN_TYPES } from '../../../../constants';
+
+const FILTER_PARAMS_PLACEHOLDER = 'alpha, lr';
+
+export type ExperimentFilterParamsProps = {
+  updateSearchFacets: UpdateExperimentSearchFacetsFn;
+  searchFacetsState: SearchExperimentRunsFacetsState;
+};
+
+const ExperimentFilterParams = (props: ExperimentFilterParamsProps) => {
+  const { updateSearchFacets, searchFacetsState } = props;
+
+  const [text, setText] = useState<string>('');
+  const [placeholder, setPlaceholder] = useState<string>('');
+
+  const regex = /params\.`(.*?)`/;
+
+  useEffect(() => {
+    const { filterParams } = searchFacetsState;
+
+    if (filterParams !== null && filterParams.length > 0) {
+      // setText(filterParams.map((item) => regex.exec(item)[1]).join(','));
+
+      const result = filterParams.map((item) => {
+        const match = regex.exec(item);
+        if (match && match[1]) {
+          return match[1];
+        }
+        return '';
+      });
+
+      const joinedResult = result.join(',');
+
+      setText(joinedResult);
+    }
+
+    if (text.length === 0){
+      setPlaceholder(FILTER_PARAMS_PLACEHOLDER);
+    }
+    // Add other conditions for updating the placeholder as needed
+  }, [searchFacetsState]);
+
+  const triggerFilter: React.KeyboardEventHandler<HTMLInputElement> = useCallback(
+    (e) => {
+      if (e.key === 'Enter') {
+        if (text.length > 0) {
+          const params = text.split(',').map((param) => {
+            const trimmedParam = param.trim();
+            return makeCanonicalSortKey(COLUMN_TYPES.PARAMS, trimmedParam);
+          });
+
+          updateSearchFacets({ filterParams: params });
+        } else {
+          updateSearchFacets({ filterParams: [] });
+        }
+      }
+    },
+    [text, updateSearchFacets],
+  );
+
+  return (
+    <div css={styles.filterWrapper}>
+      <label css={styles.filterLabel}>Filter Params:</label>
+      <div>
+        <Input
+          type='text'
+          css={{ width: 560 }}
+          placeholder={placeholder}
+          value={text}
+          onKeyDown={triggerFilter}
+          onChange={(e) => setText(e.target.value)}
+        />
+      </div>
+    </div>
+  );
+};
+
+const styles = {
+  filterWrapper: (theme: Theme) => ({ display: 'flex', gap: theme.spacing.sm, width: 430 }),
+  filterLabel: { width: '92px', marginTop: '6px' },
+};
+
+export default ExperimentFilterParams;

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControls.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControls.tsx
@@ -18,6 +18,7 @@ import { COLUMN_SORT_BY_ASC, SORT_DELIMITER_SYMBOL } from '../../../../constants
 import { ExperimentViewRunsColumnSelector } from './ExperimentViewRunsColumnSelector';
 import { shouldEnableExperimentDatasetTracking } from '../../../../../common/utils/FeatureUtils';
 import { ExperimentViewRunsModeSwitch } from './ExperimentViewRunsModeSwitch';
+import ExperimentFilterParams from './ExperimentFilterParams';
 
 type ExperimentViewRunsControlsProps = {
   viewState: SearchExperimentRunsViewState;
@@ -172,6 +173,10 @@ export const ExperimentViewRunsControls = React.memo(
           />
         )}
 
+        <ExperimentFilterParams
+          updateSearchFacets={updateSearchFacets}
+          searchFacetsState={searchFacetsState}
+        />
         <div>
           <ExperimentViewRunsModeSwitch
             compareRunsMode={compareRunsMode}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/SearchExperimentRunsFacetsState.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/SearchExperimentRunsFacetsState.ts
@@ -121,6 +121,11 @@ export class SearchExperimentRunsFacetsState {
   selectedColumns: string[] = getDefaultSelectedColumns();
 
   /**
+   * Params reordering
+   */
+  filterParams: string[] = [];
+
+  /**
    * Object mapping run UUIDs (strings) to booleans, where a boolean value of true indicates that
    * a run has been expanded (its child runs are visible).
    */

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.ts
@@ -222,7 +222,7 @@ export const useRunsColumnDefinitions = ({
   isComparingRuns,
   expandRows,
 }: UseRunsColumnDefinitionsParams) => {
-  const { orderByAsc, orderByKey, selectedColumns } = searchFacetsState;
+  const { orderByAsc, orderByKey, selectedColumns, filterParams } = searchFacetsState;
 
   const cumulativeColumns = useCumulativeColumnKeys({
     metricKeyList,
@@ -518,7 +518,68 @@ export const useRunsColumnDefinitions = ({
       const visible = selectedColumns.includes(canonicalKey);
       columnApi.setColumnVisible(canonicalKey, visible);
     }
-  }, [selectedColumns, columnApi, canonicalSortKeys, isComparingRuns]);
+    const regex = /attributes\.`(.*?)`/;
+    let selectedAttributeColumns = [];
+    selectedColumns.forEach((item) => {
+      if (regex.exec(item) !== null) {
+        selectedAttributeColumns.push(regex.exec(item)[1]);
+      }
+    });
+
+    console.log("selected columns");
+    console.log(selectedColumns);
+    console.log(selectedAttributeColumns);
+    console.log(selectedAttributeColumns.length);
+    // columnApi.moveColumns(filterParams, selectedAttributeColumns.length + 6);
+  
+    const newColumnOrderNames = [
+      'attributes.`Source`',
+      'attributes.`Models`',
+      'attributes.`Dataset`',
+      'params.`l1_ratio`',
+      'params.`p`',
+      'params.`alpha`',
+    ];
+
+    let columnsInNewOrder = [];
+
+    // Based on the new order of names, find the corresponding columns
+    newColumnOrderNames.forEach((columnName) => {
+      const column = columnApi.getAllColumns().find((col) => col.getColDef().headerName === columnName);
+      
+      if (column) {
+          columnsInNewOrder.push(column);
+      } else {
+          console.warn(`Column with name ${columnName} not found.`);
+      }
+  });
+
+  console.log("New Order");
+  console.log(columnsInNewOrder);
+  console.log();
+  columnApi.moveColumns(newColumnOrderNames, 0);
+
+
+  // const allColumns = columnApi.getAllColumns();
+  // // This array will hold the columns in the new order
+  // let columnsInNewOrder = [];
+
+  // const newColumnOrder = [0, 1, 2, 4, 5, 3];
+
+  // // Based on the new order, pick the columns from the 'allColumns' array
+  // newColumnOrder.forEach((columnIndex) => {
+  //     const column = selectedColumns.find((col, index) => index === columnIndex);
+
+  //     if (column) {
+  //         columnsInNewOrder.push(column);
+  //     }
+  // });
+
+  // console.log('New Order');
+  // console.log(columnsInNewOrder);
+  // columnApi.moveColumns(columnsInNewOrder, 0);
+
+  }, [selectedColumns, columnApi, canonicalSortKeys, isComparingRuns, filterParams]);
 
   return columnSet;
 };
@@ -530,5 +591,5 @@ export const EXPERIMENTS_DEFAULT_COLUMN_SETUP = {
   resizable: true,
   filter: true,
   suppressMenu: true,
-  suppressMovable: true,
+  suppressMovable: false,
 };


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ahlag/mlflow/pull/10073?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10073/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10073
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #7870 #7112

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

https://github.com/mlflow/mlflow/assets/51813538/5e39a1f2-cc2c-4df7-906d-0ba7ecb1e583



### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
