### PR TITLE
Always retry multipart downloads if a particular part fails

### DIFF
--- a/mlflow/utils/download_cloud_file_chunk.py
+++ b/mlflow/utils/download_cloud_file_chunk.py
@@ -43,17 +43,8 @@ def main():
         )
     except Exception:
         with open(args.temp_file, "w") as f:
+            # Retry all download failures at least once
             json.dump({"retryable": True}, f)
-        raise
-    except HTTPError as e:
-        with open(args.temp_file, "w") as f:
-            json.dump(
-                {
-                    "retryable": e.response.status_code in (401, 403, 408),
-                    "status_code": e.response.status_code,
-                },
-                f,
-            )
         raise
 
 

--- a/mlflow/utils/download_cloud_file_chunk.py
+++ b/mlflow/utils/download_cloud_file_chunk.py
@@ -41,7 +41,7 @@ def main():
             download_path=args.download_path,
             http_uri=args.http_uri,
         )
-    except (ConnectionError, ChunkedEncodingError):
+    except Exception:
         with open(args.temp_file, "w") as f:
             json.dump({"retryable": True}, f)
         raise

--- a/mlflow/utils/download_cloud_file_chunk.py
+++ b/mlflow/utils/download_cloud_file_chunk.py
@@ -7,8 +7,6 @@ import json
 import os
 import sys
 
-from requests.exceptions import ChunkedEncodingError, ConnectionError, HTTPError
-
 
 def parse_args():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/10076?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10076/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10076
```

</p>
</details>

### Related Issues/PRs

### What changes are proposed in this pull request?

Always retry multipart downloads if a particular part fails

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
