### PR TITLE
Improve make_genai_metric docstring

### DIFF
--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -144,7 +144,7 @@ def make_genai_metric(
                 "its purpose, and its developer. It could be more concise for a 5-score.",
             ),
             grading_context={
-                "ground_truth": (
+                "targets": (
                     "MLflow is an open-source platform for managing "
                     "the end-to-end machine learning (ML) lifecycle. It was developed by "
                     "Databricks, a company that specializes in big data and machine learning "
@@ -156,30 +156,32 @@ def make_genai_metric(
         )
 
         metric = make_genai_metric(
-            name="correctness",
+            name="answer correctness",
             definition=(
-                "Correctness refers to how well the generated output matches "
-                "or aligns with the reference or ground truth text that is considered "
-                "accurate and appropriate for the given input. The ground truth serves as "
-                "a benchmark against which the provided output is compared to determine the "
-                "level of accuracy and fidelity."
+                "Answer correctness is evaluated on the accuracy of the provided output based on "
+                "the provided targets, which is the ground truth. Scores can be assigned based on "
+                "the degree of semantic similarity and factual correctness of the provided output "
+                "to the provided targets, where a higher score indicates higher degree of accuracy."
             ),
             grading_prompt=(
-                "Correctness: If the answer correctly answer the question, below "
-                "are the details for different scores: "
-                "- Score 0: the answer is completely incorrect, doesn’t mention anything about "
-                "the question or is completely contrary to the correct answer. "
-                "- Score 1: the answer provides some relevance to the question and answer "
-                "one aspect of the question correctly. "
-                "- Score 2: the answer mostly answer the question but is missing or hallucinating "
-                "on one critical aspect. "
-                "- Score 4: the answer correctly answer the question and not missing any "
-                "major aspect"
+                "Answer correctness: Below are the details for different scores:"
+                "- Score 1: The output is completely incorrect. It is completely different from "
+                "or contradicts the provided targets.\n"
+                "- Score 2: The output demonstrates some degree of semantic similarity and "
+                "includes partially correct information. However, the output still has significant "
+                "discrepancies with the provided targets or inaccuracies.\n"
+                "- Score 3: The output addresses a couple of aspects of the input accurately, "
+                "aligning with the provided targets. However, there are still omissions or minor "
+                "inaccuracies.\n"
+                "- Score 4: The output is mostly correct. It provides mostly accurate information, "
+                "but there may be one or more minor omissions or inaccuracies.\n"
+                "- Score 5: The output is correct. It demonstrates a high degree of accuracy and "
+                "semantic similarity to the targets."
             ),
             examples=[example],
             version="v1",
             model="openai:/gpt-4",
-            grading_context_columns=["ground_truth"],
+            grading_context_columns=["targets"],
             parameters={"temperature": 0.0},
             aggregations=["mean", "variance", "p90"],
             greater_is_better=True,

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -156,7 +156,7 @@ def make_genai_metric(
         )
 
         metric = make_genai_metric(
-            name="answer correctness",
+            name="answer_correctness",
             definition=(
                 "Answer correctness is evaluated on the accuracy of the provided output based on "
                 "the provided targets, which is the ground truth. Scores can be assigned based on "
@@ -166,15 +166,15 @@ def make_genai_metric(
             grading_prompt=(
                 "Answer correctness: Below are the details for different scores:"
                 "- Score 1: The output is completely incorrect. It is completely different from "
-                "or contradicts the provided targets.\n"
+                "or contradicts the provided targets."
                 "- Score 2: The output demonstrates some degree of semantic similarity and "
                 "includes partially correct information. However, the output still has significant "
-                "discrepancies with the provided targets or inaccuracies.\n"
+                "discrepancies with the provided targets or inaccuracies."
                 "- Score 3: The output addresses a couple of aspects of the input accurately, "
                 "aligning with the provided targets. However, there are still omissions or minor "
-                "inaccuracies.\n"
+                "inaccuracies."
                 "- Score 4: The output is mostly correct. It provides mostly accurate information, "
-                "but there may be one or more minor omissions or inaccuracies.\n"
+                "but there may be one or more minor omissions or inaccuracies."
                 "- Score 5: The output is correct. It demonstrates a high degree of accuracy and "
                 "semantic similarity to the targets."
             ),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/annzhang-db/mlflow/pull/10081?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10081/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10081
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- update the docstring to use answer_correctness metric definition
- update to use "targets" instead of "ground_truth"

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
