### PR TITLE
Fix mleap test failures

### DIFF
--- a/tests/mleap/test_mleap_model_export.py
+++ b/tests/mleap/test_mleap_model_export.py
@@ -50,7 +50,7 @@ def spark():
     # Exclude `net.sourceforge.f2j` to avoid `java.io.FileNotFoundException`
     conf.set(key="spark.jars.excludes", value="net.sourceforge.f2j:arpack_combined_all")
     with get_spark_session(conf) as spark_session:
-        yield spark_session.sparkContext
+        yield spark_session
 
 
 @pytest.mark.skipif(

--- a/tests/mleap/test_mleap_model_export.py
+++ b/tests/mleap/test_mleap_model_export.py
@@ -44,7 +44,7 @@ def get_mleap_jars():
 
 
 @pytest.fixture(scope="module")
-def spark_context():
+def spark():
     conf = pyspark.SparkConf()
     conf.set(key="spark.jars.packages", value=get_mleap_jars())
     # Exclude `net.sourceforge.f2j` to avoid `java.io.FileNotFoundException`


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10085?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10085/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10085
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

```
_____________ ERROR at setup of test_model_save_load_with_metadata _____________
file /home/runner/work/mlflow/mlflow/tests/mleap/test_mleap_model_export.py, line 213
  def test_model_save_load_with_metadata(spark_model_iris, model_path):
file /home/runner/work/mlflow/mlflow/tests/spark/test_spark_model_export.py, line 146
  @pytest.fixture(scope="module")
  def spark_model_iris(iris_df):
file /home/runner/work/mlflow/mlflow/tests/spark/test_spark_model_export.py, line 123
  @pytest.fixture(scope="module")
  def iris_df(spark):
E       fixture 'spark' not found
>       available fixtures: anyio_backend, anyio_backend_name, anyio_backend_options, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, clean_up_envs, clean_up_leaked_runs, clean_up_mlruns_directory, cov, doctest_namespace, enable_mlflow_testing, enable_test_mode_by_default_for_autologging_integrations, httpserver, httpsserver, iris_df, mock_s3_bucket, model_path, monkeypatch, no_cover, prevent_infer_pip_requirements_fallback, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, reset_active_experiment_id, smtpserver, spark_context, spark_custom_env, spark_model_iris, tmp_path, tmp_path_factory, tmp_sqlite_uri, tracking_uri_mock
>       use 'pytest --fixtures [testpath]' for help on them.
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
