### PR TITLE
Disallow heterogeneous memory configuration when saving transformers model

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -869,17 +869,16 @@ def load_model(
 def _is_model_distributed_in_memory(transformers_model):
     """Check if the model is distributed across multiple devices in memory."""
 
-    # Check if the model attribute exists and if the model is loaded on CPU
-    if not hasattr(transformers_model, "hf_device_map") or transformers_model.device.type == "cpu":
+    # Check if the model attribute exists. If not, accelerate was not used and the model can
+    # be safely saved
+    if not hasattr(transformers_model, "hf_device_map"):
         return False
 
-    # Check if all components are loaded into the same location
-    unique_device_types = {value.type for value in transformers_model.hf_device_map.values()}
-    if len(unique_device_types) == 1:
-        return False
+    if transformers_model.device.type == "meta":
+        return True
 
     # For all other configurations, we cannot be certain that the weights will be saved correctly
-    return True
+    return False
 
 
 # This function attempts to determine if a GPU is available for the PyTorch and TensorFlow libraries

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -873,12 +873,9 @@ def _is_model_distributed_in_memory(transformers_model):
     # be safely saved
     if not hasattr(transformers_model, "hf_device_map"):
         return False
-
-    if transformers_model.device.type == "meta":
-        return True
-
-    # For all other configurations, we cannot be certain that the weights will be saved correctly
-    return False
+    # If the device map has more than one unique value entry, then the weights are not within
+    # a contiguous memory system (VRAM, SYS, or DISK) and thus cannot be safely saved.
+    return len(set(transformers_model.hf_device_map.values())) > 1
 
 
 # This function attempts to determine if a GPU is available for the PyTorch and TensorFlow libraries

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3802,7 +3802,6 @@ def test_pyfunc_model_log_load_with_artifacts_snapshot_errors():
 
 
 def test_model_distributed_across_devices():
-    # Mocking a transformers_model with weights on gpu:0, gpu:1, disk, and cpu
     mock_model = mock.Mock()
     mock_model.device.type = "meta"
     mock_model.hf_device_map = {
@@ -3812,16 +3811,14 @@ def test_model_distributed_across_devices():
         "layer4": mock.Mock(type="disk"),
     }
 
-    # Assert that the function returns True for a distributed model
     assert _is_model_distributed_in_memory(mock_model)
 
 
 def test_model_on_single_device():
-    # Mocking a transformers_model with all components on cpu
     mock_model = mock.Mock()
     mock_model.device.type = "cpu"
+    mock_model.hf_device_map = {}
 
-    # Assert that the function returns False for a non-distributed model
     assert not _is_model_distributed_in_memory(mock_model)
 
 

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3804,77 +3804,67 @@ def test_pyfunc_model_log_load_with_artifacts_snapshot_errors():
 def test_model_distributed_across_devices():
     # Mocking a transformers_model with weights on gpu:0, gpu:1, disk, and cpu
     mock_model = mock.Mock()
-    mock_model.device.type = "gpu"
+    mock_model.device.type = "meta"
     mock_model.hf_device_map = {
-        "layer1": mock.Mock(type="gpu", index=0),
-        "layer2": mock.Mock(type="gpu", index=1),
-        "layer3": mock.Mock(type="disk"),
-        "layer4": mock.Mock(type="cpu"),
+        "layer1": mock.Mock(type="cpu"),
+        "layer2": mock.Mock(type="cpu"),
+        "layer3": mock.Mock(type="gpu"),
+        "layer4": mock.Mock(type="disk"),
     }
 
     # Assert that the function returns True for a distributed model
-    assert _is_model_distributed_in_memory(mock_model) is True
+    assert _is_model_distributed_in_memory(mock_model)
 
 
 def test_model_on_single_device():
     # Mocking a transformers_model with all components on cpu
     mock_model = mock.Mock()
     mock_model.device.type = "cpu"
-    mock_model.hf_device_map = {
-        "layer1": mock.Mock(type="cpu"),
-        "layer2": mock.Mock(type="cpu"),
-        "layer3": mock.Mock(type="cpu"),
-        "layer4": mock.Mock(type="cpu"),
-    }
 
     # Assert that the function returns False for a non-distributed model
-    assert _is_model_distributed_in_memory(mock_model) is False
+    assert not _is_model_distributed_in_memory(mock_model)
 
 
-class MockPipeline(transformers.Pipeline):
-    def _sanitize_parameters(self, *args, **kwargs):
-        # This is used in a Pipeline validation, so iterable collections must be returned
-        return {}, {}, {}
+def test_basic_model_with_accelerate_device_mapping_fails_save(tmp_path):
+    task = "translation_en_to_de"
+    architecture = "t5-small"
+    model = transformers.T5ForConditionalGeneration.from_pretrained(
+        pretrained_model_name_or_path=architecture,
+        device_map={"shared": "cpu", "encoder": "cpu", "decoder": "disk", "lm_head": "disk"},
+        offload_folder=str(tmp_path / "weights"),
+        low_cpu_mem_usage=True,
+    )
 
-    def preprocess(self, *args, **kwargs):
-        pass
+    tokenizer = transformers.T5TokenizerFast.from_pretrained(
+        pretrained_model_name_or_path=architecture, model_max_length=100
+    )
+    pipeline = transformers.pipeline(task=task, model=model, tokenizer=tokenizer)
 
-    def _forward(self, *args, **kwargs):
-        pass
+    with pytest.raises(
+        MlflowException,
+        match="The model that is attempting to be saved has been loaded into memory",
+    ):
+        mlflow.transformers.save_model(transformers_model=pipeline, path=str(tmp_path / "model"))
 
-    def postprocess(self, *args, **kwargs):
-        pass
 
+def test_basic_model_with_accelerate_homogeneous_mapping_works(tmp_path):
+    task = "translation_en_to_de"
+    architecture = "t5-small"
+    model = transformers.T5ForConditionalGeneration.from_pretrained(
+        pretrained_model_name_or_path=architecture,
+        device_map={"shared": "cpu", "encoder": "cpu", "decoder": "cpu", "lm_head": "cpu"},
+        low_cpu_mem_usage=True,
+    )
 
-def test_save_model_raises_exception_for_distributed_model(tmp_path):
-    mock_model = mock.Mock()
-    mock_model.device.type = "cpu"
-    mock_model.name_or_path = "dummy_name_or_path"
-    mock_model.hf_device_map = {
-        "layer1": mock.Mock(type="gpu", index=0),
-        "layer2": mock.Mock(type="gpu", index=1),
-        "layer3": mock.Mock(type="disk"),
-        "layer4": mock.Mock(type="cpu"),
-    }
-    mock_model.config.task_specific_params = {}
+    tokenizer = transformers.T5TokenizerFast.from_pretrained(
+        pretrained_model_name_or_path=architecture, model_max_length=100
+    )
+    pipeline = transformers.pipeline(task=task, model=model, tokenizer=tokenizer)
 
-    # NB: In order to avoid loading a model and filling up the disk in CI with some
-    # split configuration, this mock stack is being used to simulate a heterogenous
-    # memory setup for a mocked model.
-    # Due to the validations that occur within transformers when constructing a
-    # pipeline instance, a number of the validation stages need to be patched.
-    with mock.patch("transformers.utils.generic.infer_framework", return_value="pt"), mock.patch(
-        "transformers.pipelines.base.infer_framework_load_model", return_value=("pt", mock_model)
-    ), mock.patch("transformers.pipelines.base.is_torch_available", return_value=True):
-        mock_pipeline = MockPipeline(model=mock_model, tokenizer=None, device=torch.device("cpu"))
+    mlflow.transformers.save_model(transformers_model=pipeline, path=str(tmp_path / "model"))
 
-        with mock.patch("mlflow.transformers._validate_transformers_model_dict"), mock.patch(
-            "mlflow.transformers._TransformersModel.from_dict", return_value=mock_pipeline
-        ), mock.patch("mlflow.transformers._is_model_distributed_in_memory", return_value=True):
-            with pytest.raises(
-                MlflowException,
-                match="The model that is attempting to be saved has been loaded into memory",
-            ):
-                mlflow.transformers.save_model(
-                    transformers_model=mock_pipeline, path=str(tmp_path / "model")
-                )
+    loaded = mlflow.transformers.load_model(str(tmp_path / "model"))
+
+    text = "Apples are delicious"
+
+    assert loaded(text) == pipeline(text)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/10087?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10087/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10087
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Prevents a data correctness issue if a model is loaded `from_pretrained()` with the accelerated library in a configuration where the weights mapping is set to a heterogeneous configuration (some weights on disk, system RAM, and GPU VRAM) as the `save_pretrained()` implementation in transformers does not access these memory locations from the managed state of accelerate. 

Even though accelerate is an inference library, the opportunity for a silent data loss failure is present and should not be permitted.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
