### PR TITLE
Render new signature types in MLFlow Model UI

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
@@ -457,7 +457,7 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
             <hr />
             <div
               className='artifact-logged-model-view-schema-table'
-              style={{ width: '35%', marginLeft: 16, float: 'left' }}
+              style={{ width: '45%', marginLeft: 16, float: 'left' }}
             >
               <Title level={3}>
                 <FormattedMessage
@@ -495,7 +495,7 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
             </div>
             <div
               className='artifact-logged-model-view-code-group'
-              style={{ width: '60%', marginRight: 16, float: 'right' }}
+              style={{ width: '50%', marginRight: 16, float: 'right' }}
             >
               {this.state.flavor === 'pyfunc'
                 ? this.renderPyfuncCodeSnippet()

--- a/mlflow/server/js/src/model-registry/components/SchemaTable.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/SchemaTable.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { shallow, render } from "enzyme"
+import { shallow, render } from 'enzyme';
 import { SchemaTable } from './SchemaTable';
 import { Table } from 'antd';
 import { MemoryRouter } from '../../common/utils/RoutingUtils';
@@ -104,7 +104,7 @@ describe('SchemaTable', () => {
     wrapper.find('tr.section-header-row').at(0).simulate('click');
     expect(wrapper.html()).toContain('column1');
     // the optional input param should have (optional) after the name"
-    const col2 = wrapper.find("span").filterWhere((n: any) => n.text().includes("column2"))
+    const col2 = wrapper.find('span').filterWhere((n: any) => n.text().includes('column2'));
     expect(render(col2.get(0)).text()).toContain('column2 (optional)');
     expect(wrapper.html()).toContain('string');
     expect(wrapper.html()).toContain('float');
@@ -114,9 +114,7 @@ describe('SchemaTable', () => {
     props = {
       schema: {
         // column1 is required but column2 is optional
-        inputs: [
-          { name: 'column', type: 'string', required: true },
-        ],
+        inputs: [{ name: 'column', type: 'string', required: true }],
         outputs: [{ name: 'score', type: 'long', required: true }],
       },
     };
@@ -129,9 +127,9 @@ describe('SchemaTable', () => {
     wrapper.find('tr.section-header-row').at(0).simulate('click');
     expect(wrapper.html()).toContain('column');
     // the optional input param should have (optional) after the name"
-    const col2 = wrapper.find("span").filterWhere((n: any) => n.text().includes("column"))
+    const col2 = wrapper.find('span').filterWhere((n: any) => n.text().includes('column'));
     expect(render(col2.get(0)).text()).toContain('column (required)');
-  })
+  });
 
   test('Should display optional output field schema as expected', () => {
     props = {
@@ -149,7 +147,7 @@ describe('SchemaTable', () => {
     // click to render output schema table
     wrapper.find('tr.section-header-row').at(1).simulate('click');
     // the optional output name should have (optional) after the name
-    const score1 = wrapper.find("span").filterWhere((n: any) => n.text().includes("score1"))
+    const score1 = wrapper.find('span').filterWhere((n: any) => n.text().includes('score1'));
     expect(render(score1).text()).toContain('score1 (optional)');
   });
 
@@ -240,24 +238,27 @@ describe('SchemaTable', () => {
     expect(wrapper.html()).toContain('TensorOutput');
     expect(wrapper.html()).toContain('Tensor (dtype: float64, shape: [-1])');
   });
-  
+
   test('should render object/array column types correctly', () => {
     props = {
       schema: {
         // column1 is required but column2 is optional
-        inputs: [{
-          name: 'objectCol', 
-          type: 'object', 
-          properties: {
-            prop1: { type: 'string', required: true }
+        inputs: [
+          {
+            name: 'objectCol',
+            type: 'object',
+            properties: {
+              prop1: { type: 'string', required: true },
+            },
+            required: true,
           },
-          required: true,
-        }, {
-          name: 'arrayCol',
-          type: 'array',
-          items: { type: 'binary', required: true },
-          required: true,
-        }],
+          {
+            name: 'arrayCol',
+            type: 'array',
+            items: { type: 'binary', required: true },
+            required: true,
+          },
+        ],
         outputs: [{ name: 'score1', type: 'long', required: true }],
       },
     };
@@ -269,11 +270,10 @@ describe('SchemaTable', () => {
     );
     // click to render input schema table
     wrapper.find('tr.section-header-row').at(0).simulate('click');
-    
-    const signatures = wrapper.find('pre');
-    expect(signatures).toHaveLength(2)
-    expect(shallow(signatures.get(0)).text()).toEqual("{\n  prop1: string\n}")
-    expect(shallow(signatures.get(1)).text()).toEqual("Array(binary)")
-  })
-});
 
+    const signatures = wrapper.find('pre');
+    expect(signatures).toHaveLength(2);
+    expect(shallow(signatures.get(0)).text()).toEqual('{\n  prop1: string\n}');
+    expect(shallow(signatures.get(1)).text()).toEqual('Array(binary)');
+  });
+});

--- a/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
@@ -61,7 +61,7 @@ export class SchemaTableImpl extends React.PureComponent<Props> {
     if (schemaTypeSpec.type === 'tensor') {
       repr = `Tensor (dtype: ${schemaTypeSpec['tensor-spec'].dtype}, shape: [${schemaTypeSpec['tensor-spec'].shape}])`;
     } else {
-      repr = this.getColumnTypeRepr(schemaTypeSpec)
+      repr = this.getColumnTypeRepr(schemaTypeSpec);
     }
 
     // If the "optional" property is present and true, wrap the type around an "Optional[]"
@@ -70,7 +70,7 @@ export class SchemaTableImpl extends React.PureComponent<Props> {
     if (schemaTypeSpec.optional) {
       repr = `Optional[${repr}]`;
     } else if (schemaTypeSpec.required) {
-      repr = `${repr} (required)`
+      repr = `${repr} (required)`;
     }
 
     return repr;
@@ -79,21 +79,21 @@ export class SchemaTableImpl extends React.PureComponent<Props> {
   getColumnTypeRepr = (columnType: ColumnType): string => {
     const { type } = columnType;
 
-    if (type === "object") {
-      const propertyReprs = Object.keys(columnType.properties).map(propertyName => {
-        const property = columnType.properties[propertyName]
-        const required = property.required ? " (required)" : ""
-        return `"${propertyName}": ${this.getColumnTypeRepr(property)}${required}`
-    })
-      return `{ ${propertyReprs.join(', ')} }`
-    } 
-
-    if (type === "array") {
-      return `Array(${this.getColumnTypeRepr(columnType.items)})`
+    if (type === 'object') {
+      const propertyReprs = Object.keys(columnType.properties).map((propertyName) => {
+        const property = columnType.properties[propertyName];
+        const required = property.required ? ' (required)' : '';
+        return `"${propertyName}": ${this.getColumnTypeRepr(property)}${required}`;
+      });
+      return `{ ${propertyReprs.join(', ')} }`;
     }
-    
-    return type
-  }
+
+    if (type === 'array') {
+      return `Array(${this.getColumnTypeRepr(columnType.items)})`;
+    }
+
+    return type;
+  };
 
   getSchemaRowData = (schemaData: any) => {
     const rowData: any = [];

--- a/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
@@ -10,7 +10,7 @@ import { Table } from 'antd';
 import { LogModelWithSignatureUrl } from '../../common/constants';
 import { gray800 } from '../../common/styles/color';
 import { spacingMedium } from '../../common/styles/spacing';
-import { MODEL_SCHEMA_TENSOR_TYPE } from '../constants';
+import { ColumnSpec, TensorSpec } from '../types/model-schema';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
 const { Column } = Table;
@@ -54,17 +54,19 @@ export class SchemaTableImpl extends React.PureComponent<Props> {
     );
   };
 
-  getSchemaTypeRepr = (schemaTypeSpec: any) => {
+  getSchemaTypeRepr = (schemaTypeSpec: ColumnSpec | TensorSpec) => {
     let { type } = schemaTypeSpec;
-    if (schemaTypeSpec.type === MODEL_SCHEMA_TENSOR_TYPE) {
-      type = `Tensor (dtype: ${schemaTypeSpec['tensor-spec'].dtype}, shape: [${schemaTypeSpec['tensor-spec'].shape}])`;
+    let repr: string = type;
+    if (schemaTypeSpec.type === 'tensor') {
+      repr = `Tensor (dtype: ${schemaTypeSpec['tensor-spec'].dtype}, shape: [${schemaTypeSpec['tensor-spec'].shape}])`;
     }
 
     // If the "optional" property is present and true, wrap the type around an "Optional[]"
     if (schemaTypeSpec.optional) {
-      type = `Optional[${type}]`;
+      repr = `Optional[${repr}]`;
     }
-    return type;
+
+    return repr;
   };
 
   getSchemaRowData = (schemaData: any) => {

--- a/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
@@ -55,7 +55,7 @@ export class SchemaTableImpl extends React.PureComponent<Props> {
   };
 
   getSchemaTypeRepr = (schemaTypeSpec: ColumnSpec | TensorSpec): string => {
-    let { type } = schemaTypeSpec;
+    const { type } = schemaTypeSpec;
 
     let repr: string = type;
     if (schemaTypeSpec.type === 'tensor') {

--- a/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
@@ -34,13 +34,13 @@ function getColumnTypeRepr(columnType: ColumnType, indentationLevel: number): st
   if (type === 'object') {
     const propertyReprs = Object.keys(columnType.properties).map((propertyName) => {
       const property = columnType.properties[propertyName];
-      const requiredRepr = property.required ? '' : '?';
+      const requiredRepr = property.required ? '' : ' (optional)';
       const propertyRepr = getColumnTypeRepr(property, indentationLevel + 1);
       const indentOffset = (indentationLevel + 1) * INDENTATION_SPACES;
 
-      return `${' '.repeat(indentOffset)}${propertyName + requiredRepr}: ${propertyRepr.slice(
-        indentOffset,
-      )}`;
+      return `${' '.repeat(indentOffset)}${propertyName}: ${
+        propertyRepr.slice(indentOffset) + requiredRepr
+      }`;
     });
 
     return `${indentation}{\n${propertyReprs.join(',\n')}\n${indentation}}`;

--- a/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
@@ -79,7 +79,7 @@ function formatColumnName(spec: ColumnSpec | TensorSpec): React.ReactElement {
 
 function formatColumnSchema(spec: ColumnSpec | TensorSpec): React.ReactElement {
   let repr = '';
-  if (spec.type == 'tensor') {
+  if (spec.type === 'tensor') {
     repr = `Tensor (dtype: ${spec['tensor-spec'].dtype}, shape: [${spec['tensor-spec'].shape}])`;
   } else {
     repr = getColumnTypeRepr(spec, 0);

--- a/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
@@ -57,9 +57,9 @@ function getColumnTypeRepr(columnType: ColumnType, indentationLevel: number): st
 
 function formatColumnName(spec: ColumnSpec | TensorSpec): React.ReactElement {
   let required = true;
-  if (spec.required != null) {
-    required = spec.required;
-  } else if (spec.optional != null && spec.optional) {
+  if (spec.required !== undefined) {
+    ({ required } = spec);
+  } else if (spec.optional !== undefined && spec.optional) {
     required = false;
   }
   const requiredTag = required ? (
@@ -68,10 +68,7 @@ function formatColumnName(spec: ColumnSpec | TensorSpec): React.ReactElement {
     <Text color='secondary'>{'(optional)'}</Text>
   );
 
-  let name = '-';
-  if ('name' in spec) {
-    name = spec.name;
-  }
+  const name = 'name' in spec ? spec.name : '-';
 
   return (
     <Text>
@@ -88,7 +85,18 @@ function formatColumnSchema(spec: ColumnSpec | TensorSpec): React.ReactElement {
     repr = getColumnTypeRepr(spec, 0);
   }
 
-  return <pre style={{ padding: 8, marginTop: 8, marginBottom: 8 }}>{repr}</pre>;
+  return (
+    <pre
+      style={{
+        padding: 8,
+        marginTop: 8,
+        marginBottom: 8,
+        whiteSpace: 'pre-wrap',
+      }}
+    >
+      {repr}
+    </pre>
+  );
 }
 
 export class SchemaTableImpl extends React.PureComponent<Props> {
@@ -246,7 +254,7 @@ export class SchemaTableImpl extends React.PureComponent<Props> {
               defaultMessage: 'Name',
               description: 'Text for name column in schema table in model version page',
             })}
-            width='50%'
+            width='40%'
             dataIndex='name'
             render={this.renderSectionHeader}
           />
@@ -256,7 +264,7 @@ export class SchemaTableImpl extends React.PureComponent<Props> {
               defaultMessage: 'Type',
               description: 'Text for type column in schema table in model version page',
             })}
-            width='50%'
+            width='60%'
             dataIndex='type'
             render={this.renderSectionHeader}
           />

--- a/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
@@ -26,6 +26,10 @@ type Props = {
   };
 };
 
+function getTensorTypeRepr(tensorType: TensorSpec): string {
+  return `Tensor (dtype: ${tensorType['tensor-spec'].dtype}, shape: [${tensorType['tensor-spec'].shape}])`;
+}
+
 // return a formatted string representation of the column type
 function getColumnTypeRepr(columnType: ColumnType, indentationLevel: number): string {
   const { type } = columnType;
@@ -78,12 +82,7 @@ function formatColumnName(spec: ColumnSpec | TensorSpec): React.ReactElement {
 }
 
 function formatColumnSchema(spec: ColumnSpec | TensorSpec): React.ReactElement {
-  let repr = '';
-  if (spec.type === 'tensor') {
-    repr = `Tensor (dtype: ${spec['tensor-spec'].dtype}, shape: [${spec['tensor-spec'].shape}])`;
-  } else {
-    repr = getColumnTypeRepr(spec, 0);
-  }
+  const repr = spec.type === 'tensor' ? getTensorTypeRepr(spec) : getColumnTypeRepr(spec, 0);
 
   return (
     <pre

--- a/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
@@ -129,26 +129,6 @@ export class SchemaTableImpl extends React.PureComponent<Props> {
     );
   };
 
-  getSchemaTypeRepr = (schemaTypeSpec: ColumnSpec | TensorSpec): string => {
-    const { type } = schemaTypeSpec;
-
-    let repr: string = type;
-    if (schemaTypeSpec.type === 'tensor') {
-      repr = `Tensor (dtype: ${schemaTypeSpec['tensor-spec'].dtype}, shape: [${schemaTypeSpec['tensor-spec'].shape}])`;
-    } else {
-      repr = getColumnTypeRepr(schemaTypeSpec, 0);
-    }
-
-    // If the "optional" property is present and true, wrap the type around an "Optional[]"
-    // NOTE: newer model signatures will have "required" instead of "optional", but we currently
-    // have to support both since both exist.
-    if (schemaTypeSpec.optional) {
-      repr = `Optional[${repr}]`;
-    }
-
-    return repr;
-  };
-
   getSchemaRowData = (schemaData: any) => {
     const rowData: any = [];
     schemaData.forEach((row: any, index: any) => {

--- a/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
@@ -34,13 +34,13 @@ function getColumnTypeRepr(columnType: ColumnType, indentationLevel: number): st
   if (type === 'object') {
     const propertyReprs = Object.keys(columnType.properties).map((propertyName) => {
       const property = columnType.properties[propertyName];
-      const requiredRepr = property.required ? '' : ' (optional)';
+      const requiredRepr = property.required ? '' : '?';
       const propertyRepr = getColumnTypeRepr(property, indentationLevel + 1);
       const indentOffset = (indentationLevel + 1) * INDENTATION_SPACES;
 
-      return `${' '.repeat(indentOffset)}${propertyName}: ${propertyRepr.slice(
+      return `${' '.repeat(indentOffset)}${propertyName + requiredRepr}: ${propertyRepr.slice(
         indentOffset,
-      )}${requiredRepr}`;
+      )}`;
     });
 
     return `${indentation}{\n${propertyReprs.join(',\n')}\n${indentation}}`;

--- a/mlflow/server/js/src/model-registry/constants.tsx
+++ b/mlflow/server/js/src/model-registry/constants.tsx
@@ -89,8 +89,6 @@ export const REGISTERED_MODELS_SEARCH_NAME_FIELD = 'name';
 
 export const REGISTERED_MODELS_SEARCH_TIMESTAMP_FIELD = 'timestamp';
 
-export const MODEL_SCHEMA_TENSOR_TYPE = 'tensor';
-
 export const AntdTableSortOrder = {
   ASC: 'ascend',
   DESC: 'descend',

--- a/mlflow/server/js/src/model-registry/types/model-schema.ts
+++ b/mlflow/server/js/src/model-registry/types/model-schema.ts
@@ -18,10 +18,11 @@ export type ArrayType = {
 };
 export type ObjectType = {
   type: 'object';
-  properties: Map<string, ColumnType>;
+  properties: {[name: string]: ColumnType & {required?: boolean}};
 };
 export type ColumnSpec = ColumnType & {
   name: string;
+  required?: boolean;
   optional?: boolean;
 };
 
@@ -31,5 +32,6 @@ export type TensorSpec = {
     dtype: string;
     shape: Array<number>;
   };
+  required?: boolean;
   optional?: boolean;
 };

--- a/mlflow/server/js/src/model-registry/types/model-schema.ts
+++ b/mlflow/server/js/src/model-registry/types/model-schema.ts
@@ -1,0 +1,35 @@
+export type DataType =
+  | 'binary'
+  | 'datetime'
+  | 'boolean'
+  | 'double'
+  | 'float'
+  | 'integer'
+  | 'long'
+  | 'string';
+
+export type ColumnType = ScalarType | ArrayType | ObjectType;
+export type ScalarType = {
+  type: DataType;
+};
+export type ArrayType = {
+  type: 'array';
+  items: ColumnType;
+};
+export type ObjectType = {
+  type: 'object';
+  properties: Map<string, ColumnType>;
+};
+export type ColumnSpec = ColumnType & {
+  name: string;
+  optional?: boolean;
+};
+
+export type TensorSpec = {
+  type: 'tensor';
+  'tensor-spec': {
+    dtype: string;
+    shape: Array<number>;
+  };
+  optional?: boolean;
+};

--- a/mlflow/server/js/src/model-registry/types/model-schema.ts
+++ b/mlflow/server/js/src/model-registry/types/model-schema.ts
@@ -18,7 +18,7 @@ export type ArrayType = {
 };
 export type ObjectType = {
   type: 'object';
-  properties: {[name: string]: ColumnType & {required?: boolean}};
+  properties: { [name: string]: ColumnType & { required?: boolean } };
 };
 export type ColumnSpec = ColumnType & {
   name: string;


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/10088?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10088/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10088
```

</p>
</details>

### Related Issues/PRs

Adding UI support for the changes made in #9893 

### What changes are proposed in this pull request?

Currently, `object` and `array` types are simply rendered as "object" and "array". This PR makes these signatures more descriptive:

1. For object types, display the properties and their types
2. For arrays, display what type the array is supposed to contain

The function added in this PR is recursive, so it can handle nested objects. At the moment, we're just making the signatures conform to the output of `repr()` in Python. Unfortunately, for complex or heavily nested object, this may become unreadable. To solve, we can probably come up with a more elegant formatting for the types (similar to JSON pretty print), but not sure if it's worth it to invest too much effort at this point in time.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

It doesn't look like the frontend is super well tested, though front-end testing tends to be a pain in general. It would be nice to set up a jest testing environment in the repo for unit tests and such—I could take this on if people feel it's valuable. In the meantime, tested by going to the page:

<img width="458" alt="Screenshot 2023-10-24 at 11 12 15 AM" src="https://github.com/mlflow/mlflow/assets/148037680/891b5455-f23c-49f6-a9c3-95ce78688012">
<img width="492" alt="Screenshot 2023-10-24 at 11 12 40 AM" src="https://github.com/mlflow/mlflow/assets/148037680/77bf1e86-6a79-4c36-888e-870095985c37">

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Model UI now displays more information for models with `object` and `array` signatures (property names and types for objects, and array types).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
