### PR TITLE
Fix MPD

### DIFF
--- a/mlflow/store/artifact/databricks_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_models_artifact_repo.py
@@ -161,6 +161,7 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
                 new_signed_uri, new_headers = self._get_signed_download_uri(
                     dst_run_relative_artifact_path
                 )
+                new_headers = self._extract_headers_from_signed_url(new_headers)
                 for chunk in failed_downloads:
                     _logger.warning(
                         f"Retrying download of chunk {chunk.index} of "

--- a/mlflow/store/artifact/databricks_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_models_artifact_repo.py
@@ -157,23 +157,18 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
                 env=parallel_download_subproc_env,
                 headers=headers,
             )
-            if any(not e.retryable for e in failed_downloads.values()):
-                template = "===== Chunk {index} =====\n{error}"
-                failure = "\n".join(
-                    template.format(index=index, error=error)
-                    for index, error in failed_downloads.items()
-                )
-                raise MlflowException(
-                    f"Failed to download artifact {dst_run_relative_artifact_path}:\n{failure}"
-                )
             if failed_downloads:
                 new_signed_uri, new_headers = self._get_signed_download_uri(
                     dst_run_relative_artifact_path
                 )
-            for i in failed_downloads:
-                download_chunk(
-                    i, _DOWNLOAD_CHUNK_SIZE, new_headers, dst_local_file_path, new_signed_uri
-                )
+                for chunk in failed_downloads:
+                    download_chunk(
+                        chunk.start,
+                        chunk.end,
+                        new_headers,
+                        dst_local_file_path,
+                        new_signed_uri,
+                    )
 
     def _download_file(self, remote_file_path, local_path):
         try:

--- a/mlflow/store/artifact/databricks_models_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_models_artifact_repo.py
@@ -162,12 +162,16 @@ class DatabricksModelsArtifactRepository(ArtifactRepository):
                     dst_run_relative_artifact_path
                 )
                 for chunk in failed_downloads:
+                    _logger.warning(
+                        f"Retrying download of chunk {chunk.index} of "
+                        f"{dst_run_relative_artifact_path}"
+                    )
                     download_chunk(
-                        chunk.start,
-                        chunk.end,
-                        new_headers,
-                        dst_local_file_path,
-                        new_signed_uri,
+                        range_start=chunk.start,
+                        range_end=chunk.end,
+                        headers=new_headers,
+                        download_path=dst_local_file_path,
+                        http_uri=new_signed_uri,
                     )
 
     def _download_file(self, remote_file_path, local_path):

--- a/mlflow/utils/download_cloud_file_chunk.py
+++ b/mlflow/utils/download_cloud_file_chunk.py
@@ -7,8 +7,6 @@ import json
 import os
 import sys
 
-from requests.exceptions import ChunkedEncodingError, ConnectionError, HTTPError
-
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -17,7 +15,6 @@ def parse_args():
     parser.add_argument("--headers", required=True, type=str)
     parser.add_argument("--download-path", required=True, type=str)
     parser.add_argument("--http-uri", required=True, type=str)
-    parser.add_argument("--temp-file", required=True, type=str)
     return parser.parse_args()
 
 
@@ -32,29 +29,13 @@ def main():
     download_chunk = module.download_chunk
 
     args = parse_args()
-
-    try:
-        download_chunk(
-            range_start=args.range_start,
-            range_end=args.range_end,
-            headers=json.loads(args.headers),
-            download_path=args.download_path,
-            http_uri=args.http_uri,
-        )
-    except (ConnectionError, ChunkedEncodingError):
-        with open(args.temp_file, "w") as f:
-            json.dump({"retryable": True}, f)
-        raise
-    except HTTPError as e:
-        with open(args.temp_file, "w") as f:
-            json.dump(
-                {
-                    "retryable": e.response.status_code in (401, 403, 408),
-                    "status_code": e.response.status_code,
-                },
-                f,
-            )
-        raise
+    download_chunk(
+        range_start=args.range_start,
+        range_end=args.range_end,
+        headers=json.loads(args.headers),
+        download_path=args.download_path,
+        http_uri=args.http_uri,
+    )
 
 
 if __name__ == "__main__":

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -724,10 +724,10 @@ def parallelized_download_file_using_http_uri(
             raise MlflowException(
                 f"""
 ----- stdout -----
-{e.stdout.strip() or 'N/A'}
+{e.stdout.strip()}
 
 ----- stderr -----
-{e.stderr.strip() or 'N/A'}
+{e.stderr.strip()}
 """
             ) from e
 

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -19,8 +19,8 @@ import urllib.request
 import uuid
 from concurrent.futures import as_completed
 from contextlib import contextmanager
+from dataclasses import dataclass
 from subprocess import CalledProcessError, TimeoutExpired
-from typing import Optional
 from urllib.parse import unquote
 from urllib.request import pathname2url
 
@@ -38,7 +38,7 @@ from mlflow.environment_variables import (
     MLFLOW_DOWNLOAD_CHUNK_TIMEOUT,
     MLFLOW_ENABLE_ARTIFACTS_PROGRESS_BAR,
 )
-from mlflow.exceptions import MissingConfigException
+from mlflow.exceptions import MissingConfigException, MlflowException
 from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialType
 from mlflow.utils import download_cloud_file_chunk, merge_dicts
 from mlflow.utils.databricks_utils import _get_dbutils
@@ -661,16 +661,19 @@ def download_file_using_http_uri(http_uri, download_path, chunk_size=100000000, 
                 output_file.write(chunk)
 
 
-class _ChunkDownloadError(Exception):
-    def __init__(self, retryable: bool, error: str, status_code: Optional[int] = None) -> None:
-        self.retryable = retryable
-        self.error = error
-        self.status_code = status_code
-        super().__init__(
-            f"Chunk download failed: {error}"
-            if status_code is None
-            else f"Chunk download failed with status code {status_code}: {error}"
-        )
+@dataclass(frozen=True)
+class _Chunk:
+    index: int
+    start: int
+    end: int
+
+
+def _yield_chunks(file_size, chunk_size):
+    num_requests = int(math.ceil(file_size / float(chunk_size)))
+    for i in range(num_requests):
+        range_start = i * chunk_size
+        range_end = min(range_start + chunk_size - 1, file_size - 1)
+        yield _Chunk(i, range_start, range_end)
 
 
 def parallelized_download_file_using_http_uri(
@@ -694,81 +697,54 @@ def parallelized_download_file_using_http_uri(
     Returns a dict of chunk index : exception, if one was thrown for that index.
     """
 
-    def run_download(range_start, range_end):
-        template = """
+    def run_download(chunk: _Chunk):
+        try:
+            subprocess.run(
+                [
+                    sys.executable,
+                    download_cloud_file_chunk.__file__,
+                    "--range-start",
+                    str(chunk.start),
+                    "--range-end",
+                    str(chunk.end),
+                    "--headers",
+                    json.dumps(headers or {}),
+                    "--download-path",
+                    download_path,
+                    "--http-uri",
+                    http_uri,
+                ],
+                text=True,
+                check=True,
+                capture_output=True,
+                timeout=MLFLOW_DOWNLOAD_CHUNK_TIMEOUT.get(),
+                env=env,
+            )
+        except (TimeoutExpired, CalledProcessError) as e:
+            raise MlflowException(
+                f"""
 ----- stdout -----
-{stdout}
+{e.stdout.strip() or 'N/A'}
 
 ----- stderr -----
-{stderr}
+{e.stderr.strip() or 'N/A'}
 """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            json_file = os.path.join(tmpdir, "http_error.json")
-            try:
-                subprocess.run(
-                    [
-                        sys.executable,
-                        download_cloud_file_chunk.__file__,
-                        "--range-start",
-                        str(range_start),
-                        "--range-end",
-                        str(range_end),
-                        "--headers",
-                        json.dumps(headers or {}),
-                        "--download-path",
-                        download_path,
-                        "--http-uri",
-                        http_uri,
-                        "--temp-file",
-                        json_file,
-                    ],
-                    text=True,
-                    check=True,
-                    capture_output=True,
-                    timeout=MLFLOW_DOWNLOAD_CHUNK_TIMEOUT.get(),
-                    env=env,
-                )
-            except TimeoutExpired as e:
-                raise _ChunkDownloadError(
-                    True,
-                    template.format(
-                        stdout=e.stdout.strip() or "(no stdout)",
-                        stderr=e.stderr.strip() or "(no stderr)",
-                    ),
-                ) from e
-            except CalledProcessError as e:
-                retryable = False
-                status_code = None
-                if os.path.exists(json_file):
-                    with open(json_file) as f:
-                        data = json.load(f)
-                        retryable = data.get("retryable", False)
-                        status_code = data.get("status_code")
-                raise _ChunkDownloadError(
-                    retryable,
-                    template.format(
-                        stdout=e.stdout.strip() or "(no stdout)",
-                        stderr=e.stderr.strip() or "(no stderr)",
-                    ),
-                    status_code,
-                ) from e
-            except Exception as e:
-                raise _ChunkDownloadError(False, str(e)) from e
+            ) from e
 
-    num_requests = int(math.ceil(file_size / float(chunk_size)))
+    chunks = _yield_chunks(file_size, chunk_size)
     # Create file if it doesn't exist or erase the contents if it does. We should do this here
     # before sending to the workers so they can each individually seek to their respective positions
     # and write chunks without overwriting.
     with open(download_path, "w"):
         pass
-    starting_index = 0
     if uri_type == ArtifactCredentialType.GCP_SIGNED_URL or uri_type is None:
+        chunk = next(chunks)
         # GCP files could be transcoded, in which case the range header is ignored.
         # Test if this is the case by downloading one chunk and seeing if it's larger than the
         # requested size. If yes, let that be the file; if not, continue downloading more chunks.
         download_chunk(
-            range_start=0,
-            range_end=chunk_size - 1,
+            range_start=chunk.start,
+            range_end=chunk.end,
             headers=headers,
             download_path=download_path,
             http_uri=http_uri,
@@ -778,24 +754,16 @@ def parallelized_download_file_using_http_uri(
         # so we don't need to consider this here
         if downloaded_size > chunk_size:
             return {}
-        else:
-            starting_index = 1
 
-    futures = {}
-    for i in range(starting_index, num_requests):
-        range_start = i * chunk_size
-        range_end = range_start + chunk_size - 1
-        futures[thread_pool_executor.submit(run_download, range_start, range_end)] = i
-
+    futures = {thread_pool_executor.submit(run_download, chunk): chunk for chunk in chunks}
     failed_downloads = {}
-
     with ArtifactProgressBar.chunks(file_size, f"Downloading {download_path}", chunk_size) as pbar:
         for future in as_completed(futures):
-            index = futures[future]
+            chunk = futures[future]
             try:
                 future.result()
             except Exception:
-                failed_downloads[index] = future.exception()
+                failed_downloads[chunk] = future.exception()
             else:
                 pbar.update()
 

--- a/mlflow/utils/request_utils.py
+++ b/mlflow/utils/request_utils.py
@@ -39,7 +39,7 @@ def augmented_raise_for_status(response):
             raise e
 
 
-def download_chunk(range_start, range_end, headers, download_path, http_uri):
+def download_chunk(*, range_start, range_end, headers, download_path, http_uri):
     combined_headers = {**headers, "Range": f"bytes={range_start}-{range_end}"}
 
     with cloud_storage_http_request(

--- a/tests/store/artifact/test_databricks_models_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_models_artifact_repo.py
@@ -13,7 +13,7 @@ from mlflow.store.artifact.databricks_models_artifact_repo import (
     _DOWNLOAD_CHUNK_SIZE,
     DatabricksModelsArtifactRepository,
 )
-from mlflow.utils.file_utils import _ChunkDownloadError
+from mlflow.utils.file_utils import _Chunk
 
 DATABRICKS_MODEL_ARTIFACT_REPOSITORY_PACKAGE = (
     "mlflow.store.artifact.databricks_models_artifact_repo"
@@ -300,7 +300,7 @@ def test_parallelized_download_file_using_http_uri_with_error_downloads(
         "signed_uri": "https://my-amazing-signed-uri-to-rule-them-all.com/1234-numbers-yay-567",
         "headers": [{"name": "header_name", "value": "header_value"}],
     }
-    error_downloads = {1: _ChunkDownloadError(False, "Internal Server Error", 500)}
+    error_downloads = {_Chunk(1, 2, 3): Exception("Internal Server Error")}
 
     with mock.patch(
         DATABRICKS_MODEL_ARTIFACT_REPOSITORY + ".list_artifacts",
@@ -342,7 +342,7 @@ def test_parallelized_download_file_using_http_uri_with_failed_downloads(
         "signed_uri": "https://my-amazing-signed-uri-to-rule-them-all.com/1234-numbers-yay-567",
         "headers": [{"name": "header_name", "value": "header_value"}],
     }
-    failed_downloads = {1: _ChunkDownloadError(True, "Unauthorized", 401)}
+    failed_downloads = {_Chunk(1, 2, 3): Exception("Internal Server Error")}
 
     with mock.patch(
         DATABRICKS_MODEL_ARTIFACT_REPOSITORY + ".list_artifacts",


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Two changes:

- Always retry once.
- Fix `download_chunk` calls.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
