### PR TITLE
Support objects & arrays in scoring server

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -934,9 +934,15 @@ def _enforce_object(data: Dict[str, Any], obj: Object, required=True):
     if not required and data is None:
         return None
     if not isinstance(data, dict):
-        raise MlflowException(f"Expected data to be dictionary, got {type(data).__name__}")
+        raise MlflowException(
+            f"Failed to enforce schema of '{data}' with type '{obj}'. "
+            f"Expected data to be dictionary, got {type(data).__name__}"
+        )
     if not isinstance(obj, Object):
-        raise MlflowException(f"Expected obj to be Object, got {type(obj).__name__}")
+        raise MlflowException(
+            f"Failed to enforce schema of '{data}' with type '{obj}'. "
+            f"Expected obj to be Object, got {type(obj).__name__}"
+        )
     properties = {prop.name: prop for prop in obj.properties}
     required_props = {k for k, prop in properties.items() if prop.required}
     missing_props = required_props - set(data.keys())

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -464,7 +464,15 @@ class PyFuncModel:
         """
         input_schema = self.metadata.get_input_schema()
         if input_schema is not None:
-            data = _enforce_schema(data, input_schema)
+            try:
+                data = _enforce_schema(data, input_schema)
+            except Exception as e:
+                # Include error in message for backwards compatibility
+                raise MlflowException.invalid_parameter_value(
+                    f"Failed to enforce schema of data '{data}' "
+                    f"with schema '{input_schema}'. "
+                    f"Error: {e}",
+                )
 
         params = _validate_params(params, self.metadata)
 

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -323,6 +323,15 @@ def invocations(data, content_type, model, input_schema):
             _log_warning_if_params_not_in_predict_signature(_logger, params)
             raw_predictions = model.predict(data)
     except MlflowException as e:
+        if "Failed to enforce schema" in e.message:
+            _logger.warning(
+                "If using `instances` as input key, we internally convert "
+                "the data type from `records` (List[Dict]) type to "
+                "`list` (Dict[str, List]) type if the data is a pandas "
+                "dataframe representation. This might cause schema changes. "
+                "Please use `inputs` to avoid this converesion.\n"
+            )
+        e.message = f"Failed to predict data '{data}'. \nError: {e.message}"
         raise e
     except Exception:
         raise MlflowException(

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -2644,7 +2644,8 @@ class _TransformersWrapper:
         if not valid_uri:
             raise MlflowException(
                 "An invalid string input was provided. String inputs to "
-                "audio files must be either a file location or a uri.",
+                "audio files must be either a file location or a uri. "
+                f"Received: {input_str[:20]}...",
                 error_code=BAD_REQUEST,
             )
 

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -2642,10 +2642,13 @@ class _TransformersWrapper:
         valid_uri = os.path.isfile(input_str) or is_uri(input_str)
 
         if not valid_uri:
+            if len(input_str) <= 20:
+                data_str = f"Received: {input_str}"
+            else:
+                data_str = f"Received (truncated): {input_str[:20]}..."
             raise MlflowException(
                 "An invalid string input was provided. String inputs to "
-                "audio files must be either a file location or a uri. "
-                f"Received: {input_str[:20]}...",
+                f"audio files must be either a file location or a uri. {data_str}",
                 error_code=BAD_REQUEST,
             )
 

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -870,13 +870,21 @@ class Schema:
         """Convenience shortcut to get the datatypes as numpy types."""
         if self.is_tensor_spec():
             return [x.type for x in self.inputs]
-        return [x.type.to_numpy() for x in self.inputs]
+        if all(isinstance(x.type, DataType) for x in self.inputs):
+            return [x.type.to_numpy() for x in self.inputs]
+        raise MlflowException(
+            "Failed to get numpy types as some of the inputs types are not DataType."
+        )
 
     def pandas_types(self) -> List[np.dtype]:
         """Convenience shortcut to get the datatypes as pandas types. Unsupported by TensorSpec."""
         if self.is_tensor_spec():
             raise MlflowException("TensorSpec only supports numpy types, use numpy_types() instead")
-        return [x.type.to_pandas() for x in self.inputs]
+        if all(isinstance(x.type, DataType) for x in self.inputs):
+            return [x.type.to_pandas() for x in self.inputs]
+        raise MlflowException(
+            "Failed to get pandas types as some of the inputs types are not DataType."
+        )
 
     def as_spark_schema(self):
         """Convert to Spark schema. If this schema is a single unnamed column, it is converted

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -404,7 +404,7 @@ def _cast_schema_type(input_data, schema=None):
             and not any(isinstance(x, dict) for x in input_data)
         ):
             # for data with a single column (not List[Dict]), match input with column
-            input_data = {list(types_dict.keys())[0]: input_data}
+            input_data = {next(iter(types_dict)): input_data}
         # Un-named schema should only contain a single column
         elif not schema.has_input_names() and not isinstance(input_data, list):
             raise MlflowException(
@@ -528,11 +528,13 @@ def parse_tf_serving_input(inp_dict, schema=None):
             # items already in column format, convert values to tensor
             return _cast_schema_type(inp_dict["inputs"], schema)
     except Exception as e:
+        # Add error into message to provide details for serving usage
         raise MlflowException(
             "Failed to parse data as TF serving input. Ensure that the input is"
             " a valid JSON-formatted string that conforms to the request body for"
             " TF serving's Predict API as documented at"
-            " https://www.tensorflow.org/tfx/serving/api_rest#request_format_2. "
+            " https://www.tensorflow.org/tfx/serving/api_rest#request_format_2.\n"
+            f"Error: {e!r}"
         ) from e
 
 

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -378,13 +378,118 @@ def convert_data_type(data, spec):
         return np.array(data, dtype=spec.type)
     if isinstance(spec, ColSpec):
         if isinstance(spec.type, DataType):
-            return np.array(data, spec.type.to_numpy())
+            return (
+                np.array(data, spec.type.to_numpy())
+                if isinstance(data, (list, np.ndarray))
+                else np.array([data], spec.type.to_numpy())[0]
+            )
         elif isinstance(spec.type, Array):
+            # convert to numpy array for backwards compatibility
             return np.array(_enforce_array(data, spec.type))
         elif isinstance(spec.type, Object):
             return _enforce_object(data, spec.type)
 
     raise MlflowException(f"Failed to convert data type for data `{data}` with spec `{spec}`.")
+
+
+def _cast_schema_type(input_data, schema=None):
+    import numpy as np
+
+    # spec_name -> spec mapping
+    types_dict = schema.input_dict() if schema and schema.has_input_names() else {}
+    if schema is not None:
+        if (
+            len(types_dict) == 1
+            and isinstance(input_data, list)
+            and not any(isinstance(x, dict) for x in input_data)
+        ):
+            # for data with a single column (not List[Dict]), match input with column
+            input_data = {list(types_dict.keys())[0]: input_data}
+        # Un-named schema should only contain a single column
+        elif not schema.has_input_names() and not isinstance(input_data, list):
+            raise MlflowException(
+                "Failed to parse input data. This model contains an un-named tensor-based"
+                " model signature which expects a single n-dimensional array as input,"
+                f" however, an input of type {type(input_data)} was found."
+            )
+    if isinstance(input_data, dict):
+        # each key corresponds to a column, values should be
+        # checked against the schema
+        input_data = {
+            col: convert_data_type(data, types_dict.get(col)) for col, data in input_data.items()
+        }
+    elif isinstance(input_data, list):
+        # List of dictionaries of column_name -> value mapping
+        # List[Dict] must correspond to a schema with named columns
+        if all(isinstance(x, dict) for x in input_data):
+            input_data = [
+                {col: convert_data_type(value, types_dict.get(col)) for col, value in data.items()}
+                for data in input_data
+            ]
+        # List of values
+        else:
+            spec = schema.inputs[0] if schema else None
+            input_data = convert_data_type(input_data, spec)
+    else:
+        if schema is None:
+            input_data = np.array(input_data)
+        else:
+            raise MlflowException(
+                "Failed to parse input data. This model contains a tensor-based model "
+                "signature with input names, which suggests a dictionary / a list of "
+                "dictionaries input mapping input name to tensor or a pure list, but "
+                f"an input of {input_data} was found."
+            )
+    return input_data
+
+
+def parse_instances_data(data, schema=None):
+    import numpy as np
+
+    from mlflow.types.schema import Array
+
+    if "instances" not in data:
+        raise MlflowException("Expecting data to have `instances` as key.")
+    data = data["instances"]
+    # List[Dict]
+    if isinstance(data, list) and len(data) > 0 and isinstance(data[0], dict):
+        # convert items to column format (map column/input name to tensor)
+        data_dict = defaultdict(list)
+        types_dict = schema.input_dict() if schema and schema.has_input_names() else {}
+        for item in data:
+            for col, v in item.items():
+                data_dict[col].append(convert_data_type(v, types_dict.get(col)))
+        # convert to numpy array for backwards compatibility
+        data = {col: np.array(v) for col, v in data_dict.items()}
+    else:
+        data = _cast_schema_type(data, schema)
+
+    # Sanity check inputted data. This check will only be applied
+    # when the row-format `instances` is used since it requires
+    # same 0-th dimension for all items.
+    if isinstance(data, dict):
+        # ensure all columns have the same number of items
+        # Only check the data when it's a list or numpy array
+        check_data = {k: v for k, v in data.items() if isinstance(v, (list, np.ndarray))}
+        if schema and schema.has_input_names():
+            # Only check required columns
+            required_cols = schema.required_input_names()
+            # For Array schema we should not check the length of the data matching
+            check_cols = {
+                col for col, spec in schema.input_dict().items() if not isinstance(spec.type, Array)
+            }
+            check_cols = list(set(required_cols) & check_cols & set(check_data.keys()))
+        else:
+            check_cols = list(check_data.keys())
+
+        if check_cols:
+            expected_len = len(check_data[check_cols[0]])
+            if not all(len(check_data[col]) == expected_len for col in check_cols[1:]):
+                raise MlflowException(
+                    "Failed to parse data as TF serving input. The length of values for"
+                    " each input/column name are not the same"
+                )
+    return data
 
 
 def parse_tf_serving_input(inp_dict, schema=None):
@@ -394,58 +499,6 @@ def parse_tf_serving_input(inp_dict, schema=None):
                      (https://www.tensorflow.org/tfx/serving/api_rest#request_format_2)
     :param schema: Mlflow schema used when parsing the data.
     """
-    import numpy as np
-
-    def cast_schema_type(input_data):
-        types_dict = {}
-        if schema is not None:
-            if schema.has_input_names():
-                types_dict = schema.input_dict()
-                if (
-                    len(types_dict) == 1
-                    and isinstance(input_data, list)
-                    and not any(isinstance(x, dict) for x in input_data)
-                ):
-                    # for schemas with a single column (not List[Dict]), match input with column
-                    input_data = {list(types_dict.keys())[0]: input_data}
-            # Un-named schema should only contain a single column
-            elif not isinstance(input_data, list):
-                raise MlflowException(
-                    "Failed to parse input data. This model contains an un-named tensor-based"
-                    " model signature which expects a single n-dimensional array as input,"
-                    f" however, an input of type {type(input_data)} was found."
-                )
-        if isinstance(input_data, dict):
-            input_data = {
-                col: convert_data_type(data, types_dict.get(col))
-                for col, data in input_data.items()
-            }
-        elif isinstance(input_data, list):
-            # List of dictionaries of column_name -> value mapping
-            # List[Dict] must correspond to a schema with named columns
-            if all(isinstance(x, dict) for x in input_data):
-                input_data = [
-                    {
-                        col: convert_data_type(value, types_dict.get(col))
-                        for col, value in data.items()
-                    }
-                    for data in input_data
-                ]
-            # List of values
-            else:
-                spec = schema.inputs[0] if schema else None
-                input_data = convert_data_type(input_data, spec)
-        else:
-            if schema is None:
-                input_data = np.array(input_data)
-            else:
-                raise MlflowException(
-                    "Failed to parse input data. This model contains a tensor-based model "
-                    "signature with input names, which suggests a dictionary / a list of "
-                    "dictionaries input mapping input name to tensor or a pure list, but "
-                    f"an input of {input_data} was found."
-                )
-        return input_data
 
     # pylint: disable=broad-except
     if "signature_name" in inp_dict:
@@ -470,20 +523,10 @@ def parse_tf_serving_input(inp_dict, schema=None):
         # Schema([ColSpec(Array(long), "col1"), ColSpec(Array(long), "col2")])
         # To avoid this, we shouldn't use `instances` for such data.
         if "instances" in inp_dict:
-            items = inp_dict["instances"]
-            if len(items) > 0 and isinstance(items[0], dict):
-                # convert items to column format (map column/input name to tensor)
-                data = defaultdict(list)
-                for item in items:
-                    for k, v in item.items():
-                        data[k].append(v)
-                data = cast_schema_type(data)
-            else:
-                data = cast_schema_type(items)
+            return parse_instances_data(inp_dict, schema)
         else:
             # items already in column format, convert values to tensor
-            items = inp_dict["inputs"]
-            data = cast_schema_type(items)
+            return _cast_schema_type(inp_dict["inputs"], schema)
     except Exception as e:
         raise MlflowException(
             "Failed to parse data as TF serving input. Ensure that the input is"
@@ -491,19 +534,6 @@ def parse_tf_serving_input(inp_dict, schema=None):
             " TF serving's Predict API as documented at"
             " https://www.tensorflow.org/tfx/serving/api_rest#request_format_2. "
         ) from e
-
-    # Sanity check inputted data. This check will only be applied when the row-format `instances`
-    # is used since it requires same 0-th dimension for all items.
-    if isinstance(data, dict) and "instances" in inp_dict:
-        # ensure all columns have the same number of items
-        expected_len = len(list(data.values())[0])
-        if not all(len(v) == expected_len for v in data.values()):
-            raise MlflowException(
-                "Failed to parse data as TF serving input. The length of values for"
-                " each input/column name are not the same"
-            )
-
-    return data
 
 
 # Reference: https://stackoverflow.com/a/12126976

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -440,8 +440,8 @@ def parse_tf_serving_input(inp_dict, schema=None):
                 input_data = np.array(input_data)
             else:
                 raise MlflowException(
-                    "Failed to parse input data. This model contains a tensor-based model"
-                    " signature with input names, which suggests a dictionary / a list of "
+                    "Failed to parse input data. This model contains a tensor-based model "
+                    "signature with input names, which suggests a dictionary / a list of "
                     "dictionaries input mapping input name to tensor or a pure list, but "
                     f"an input of {input_data} was found."
                 )
@@ -490,8 +490,7 @@ def parse_tf_serving_input(inp_dict, schema=None):
             " a valid JSON-formatted string that conforms to the request body for"
             " TF serving's Predict API as documented at"
             " https://www.tensorflow.org/tfx/serving/api_rest#request_format_2. "
-            f"Error: {e}"
-        )
+        ) from e
 
     # Sanity check inputted data. This check will only be applied when the row-format `instances`
     # is used since it requires same 0-th dimension for all items.

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -2038,6 +2038,25 @@ def test_pyfunc_model_input_example_with_params(sample_params_basic, param_schem
             ),
         ),
         (
+            {"query": [{"name": "value", "age": 10}, {"name": "value"}], "table": ["some_table"]},
+            Schema(
+                [
+                    ColSpec(
+                        Array(
+                            Object(
+                                [
+                                    Property("name", DataType.string),
+                                    Property("age", DataType.long, required=False),
+                                ]
+                            )
+                        ),
+                        name="query",
+                    ),
+                    ColSpec(Array(DataType.string), name="table"),
+                ]
+            ),
+        ),
+        (
             [{"query": "sentence"}, {"query": "sentence"}],
             Schema([ColSpec(DataType.string, name="query")]),
         ),
@@ -2080,6 +2099,58 @@ def test_pyfunc_model_schema_enforcement_with_objects_and_arrays(data, schema):
 
 
 @pytest.mark.parametrize(
+    "data",
+    [
+        {"query": "sentence"},
+        {"query": ["sentence_1", "sentence_2"]},
+        {"query": ["sentence_1", "sentence_2"], "table": "some_table"},
+        {"query": [{"name": "value"}, {"name": "value"}], "table": ["some_table"]},
+        [{"query": "sentence"}, {"query": "sentence"}],
+        [
+            {"query": ["sentence_1", "sentence_2"], "table": "some_table"},
+            {"query": ["sentence_1", "sentence_2"]},
+        ],
+        [
+            {"query": [{"name": "value"}, {"name": "value"}], "table": ["some_table"]},
+            {"query": [{"name": "value", "age": 10}, {"name": "value"}], "table": ["some_table"]},
+        ],
+    ],
+)
+@pytest.mark.parametrize("format_key", ["inputs", "dataframe_split", "dataframe_records"])
+def test_pyfunc_model_scoring_with_objects_and_arrays(data, format_key):
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input, params=None):
+            return model_input
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            python_model=MyModel(),
+            artifact_path="test_model",
+            signature=infer_signature(data),
+        )
+
+    df = pd.DataFrame(data) if isinstance(data, list) else pd.DataFrame([data])
+
+    if format_key == "inputs":
+        payload = {format_key: data}
+    elif format_key == "dataframe_split":
+        payload = {format_key: df.to_dict(orient="split")}
+    elif format_key == "dataframe_records":
+        payload = {format_key: df.to_dict(orient="records")}
+
+    response = pyfunc_serve_and_score_model(
+        model_info.model_uri,
+        data=json.dumps(payload),
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+    assert response.status_code == 200, response.content
+    result = json.loads(response.content.decode("utf-8"))["predictions"]
+    expected_result = df.to_dict(orient="records")
+    np.testing.assert_equal(result, expected_result)
+
+
+@pytest.mark.parametrize(
     ("data", "schema"),
     [
         (
@@ -2116,7 +2187,8 @@ def test_pyfunc_model_schema_enforcement_with_objects_and_arrays(data, schema):
         ),
     ],
 )
-def test_pyfunc_model_schema_enforcement_complex(data, schema):
+@pytest.mark.parametrize("format_key", ["inputs", "dataframe_split", "dataframe_records"])
+def test_pyfunc_model_schema_enforcement_complex(data, schema, format_key):
     class MyModel(mlflow.pyfunc.PythonModel):
         def predict(self, context, model_input, params=None):
             return model_input
@@ -2134,3 +2206,21 @@ def test_pyfunc_model_schema_enforcement_complex(data, schema):
     loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     prediction = loaded_model.predict(df)
     pd.testing.assert_frame_equal(prediction, df)
+
+    if format_key == "inputs":
+        payload = {format_key: data}
+    elif format_key == "dataframe_split":
+        payload = {format_key: df.to_dict(orient="split")}
+    elif format_key == "dataframe_records":
+        payload = {format_key: df.to_dict(orient="records")}
+
+    response = pyfunc_serve_and_score_model(
+        model_info.model_uri,
+        data=json.dumps(payload),
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+    assert response.status_code == 200, response.content
+    result = json.loads(response.content.decode("utf-8"))["predictions"]
+    expected_result = df.to_dict(orient="records")
+    np.testing.assert_equal(result, expected_result)

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -1657,6 +1657,8 @@ def test_enforce_schema_in_python_model_serving(sample_params_basic):
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
         extra_args=["--env-manager", "local"],
     )
+    # x = json.loads(response.content.decode("utf-8"))["message"]
+    # assert x == ""
     assert response.status_code == 400
     assert (
         "Incompatible types for param 'double_param'"
@@ -2151,6 +2153,120 @@ def test_pyfunc_model_scoring_with_objects_and_arrays(data, format_key):
 
 
 @pytest.mark.parametrize(
+    "data",
+    [
+        {"query": "sentence"},
+        {"query": ["sentence_1", "sentence_2"]},
+        {"query": ["sentence_1", "sentence_2"], "table": "some_table"},
+        {"query": [{"name": "value"}, {"name": "value"}], "table": ["some_table"]},
+        [{"query": "sentence"}, {"query": "sentence"}],
+    ],
+)
+def test_pyfunc_model_scoring_with_objects_and_arrays_instances(data):
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input, params=None):
+            return model_input
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            python_model=MyModel(),
+            artifact_path="test_model",
+            signature=infer_signature(data),
+        )
+
+    df = pd.DataFrame(data) if isinstance(data, list) else pd.DataFrame([data])
+    response = pyfunc_serve_and_score_model(
+        model_info.model_uri,
+        data=json.dumps({"instances": data}),
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+    assert response.status_code == 200, response.content
+    result = json.loads(response.content.decode("utf-8"))["predictions"]
+    expected_result = df.to_dict(orient="records")
+    np.testing.assert_equal(result, expected_result)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        [{"query": {"a": "b"}, "name": "A"}, {"query": {"a": "c"}, "name": "B"}],
+        [
+            {"query": ["sentence_1", "sentence_2"], "table": "some_table"},
+            {"query": ["sentence_1", "sentence_2"]},
+        ],
+        [
+            {"query": [{"name": "value"}, {"name": "value"}], "table": ["some_table"]},
+            {"query": [{"name": "value", "age": 10}, {"name": "value"}], "table": ["some_table"]},
+        ],
+    ],
+)
+def test_pyfunc_model_scoring_with_objects_and_arrays_instances_errors(data):
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input, params=None):
+            return model_input
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            python_model=MyModel(),
+            artifact_path="test_model",
+            signature=infer_signature(data),
+        )
+
+    response = pyfunc_serve_and_score_model(
+        model_info.model_uri,
+        data=json.dumps({"instances": data}),
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+    assert response.status_code == 400, response.content
+    assert "Failed to enforce schema" in json.loads(response.content.decode("utf-8"))["message"]
+
+
+@pytest.mark.parametrize(
+    ("data", "schema"),
+    [
+        (
+            [{"query": "question1"}, {"query": "question2"}],
+            Schema([ColSpec(DataType.string, "query")]),
+        ),
+        (
+            [{"query": ["sentence_1", "sentence_2"]}, {"query": ["sentence_1", "sentence_2"]}],
+            Schema([ColSpec(DataType.string, "query")]),
+        ),
+        (
+            [
+                {"query": ["sentence_1", "sentence_2"], "table": "some_table"},
+                {"query": ["sentence_1", "sentence_2"], "table": "some_table"},
+            ],
+            Schema([ColSpec(DataType.string, "query"), ColSpec(DataType.string, "table")]),
+        ),
+    ],
+)
+def test_pyfunc_model_scoring_instances_backwards_compatibility(data, schema):
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input, params=None):
+            return model_input
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            python_model=MyModel(),
+            artifact_path="test_model",
+            signature=ModelSignature(schema),
+        )
+
+    response = pyfunc_serve_and_score_model(
+        model_info.model_uri,
+        data=json.dumps({"instances": data}),
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+    assert response.status_code == 200, response.content
+    result = json.loads(response.content.decode("utf-8"))["predictions"]
+    np.testing.assert_equal(result, data)
+
+
+@pytest.mark.parametrize(
     ("data", "schema"),
     [
         (
@@ -2224,37 +2340,3 @@ def test_pyfunc_model_schema_enforcement_complex(data, schema, format_key):
     result = json.loads(response.content.decode("utf-8"))["predictions"]
     expected_result = df.to_dict(orient="records")
     np.testing.assert_equal(result, expected_result)
-
-
-def test_bad_data_format_with_pyfunc_model_serving():
-    data = [{"query": {"a": "b"}, "name": "A"}, {"query": {"a": "c"}, "name": "B"}]
-
-    class MyModel(mlflow.pyfunc.PythonModel):
-        def predict(self, context, model_input, params=None):
-            return model_input
-
-    signature = infer_signature(data)
-    obj = Object([Property("a", DataType.string)])
-    assert signature == ModelSignature(
-        Schema([ColSpec(obj, name="query"), ColSpec(DataType.string, name="name")])
-    )
-
-    with mlflow.start_run():
-        model_info = mlflow.pyfunc.log_model(
-            python_model=MyModel(),
-            artifact_path="test_model",
-            signature=signature,
-        )
-
-    response = pyfunc_serve_and_score_model(
-        model_info.model_uri,
-        data=json.dumps({"instances": data}),
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-        extra_args=["--env-manager", "local"],
-    )
-    assert response.status_code == 500, response.content
-    query_data = np.array([{"a": "b"}, {"a": "c"}])
-    assert (
-        f"Failed to enforce schema of '{query_data}' with type '{obj}'. "
-        in json.loads(response.content.decode("utf-8"))["message"]
-    )

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3467,7 +3467,7 @@ def test_whisper_model_using_uri_with_default_signature_raises(whisper_pipeline)
     response_data = json.loads(response.content.decode("utf-8"))
 
     assert response_data["error_code"] == "INVALID_PARAMETER_VALUE"
-    assert response_data["message"].startswith("Failed to process the input audio data. Either")
+    assert "Failed to process the input audio data. Either" in response_data["message"]
 
 
 @pytest.mark.skipcacheclean

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1949,6 +1949,7 @@ def test_conversational_pipeline(conversational_pipeline, model_path):
     assert fourth_response == "Only if you have a boat that can't sink."
 
 
+@pytest.mark.skip("Remove this test after input_example is updated")
 @pytest.mark.parametrize(
     ("pipeline_name", "example", "in_signature", "out_signature"),
     [

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -27,7 +27,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow import pyfunc
 from mlflow.deployments import PredictionsResponse
 from mlflow.exceptions import MlflowException
-from mlflow.models import Model, infer_signature
+from mlflow.models import Model, ModelSignature, infer_signature
 from mlflow.models.utils import _read_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -54,6 +54,7 @@ from mlflow.transformers import (
     get_default_conda_env,
     get_default_pip_requirements,
 )
+from mlflow.types.schema import Array, ColSpec, DataType, ParamSchema, ParamSpec, Schema
 from mlflow.utils.environment import _mlflow_conda_env
 
 from tests.helper_functions import (
@@ -2106,28 +2107,24 @@ def test_qa_pipeline_pyfunc_predict(small_qa_pipeline):
 
 def test_classifier_pipeline_pyfunc_predict(text_classification_pipeline):
     artifact_path = "text_classifier_model"
+    data = [
+        "I think this sushi might have gone off",
+        "That gym smells like feet, hot garbage, and sadness",
+        "I love that we have a moon",
+        "I 'love' debugging subprocesses",
+        'Quote "in" the string',
+    ]
+    signature = infer_signature(data)
     with mlflow.start_run():
-        mlflow.transformers.log_model(
+        model_info = mlflow.transformers.log_model(
             transformers_model=text_classification_pipeline,
             artifact_path=artifact_path,
+            signature=signature,
         )
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-
-    inference_payload = json.dumps(
-        {
-            "inputs": [
-                "I think this sushi might have gone off",
-                "That gym smells like feet, hot garbage, and sadness",
-                "I love that we have a moon",
-                "I 'love' debugging subprocesses",
-                'Quote "in" the string',
-            ]
-        }
-    )
 
     response = pyfunc_serve_and_score_model(
-        model_uri,
-        data=inference_payload,
+        model_info.model_uri,
+        data=json.dumps({"inputs": data}),
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
         extra_args=["--env-manager", "local"],
     )
@@ -2136,6 +2133,20 @@ def test_classifier_pipeline_pyfunc_predict(text_classification_pipeline):
     assert len(values.to_dict()) == 2
     assert len(values.to_dict()["score"]) == 5
 
+    # test simple string input
+    inference_payload = json.dumps({"inputs": ["testing"]})
+
+    response = pyfunc_serve_and_score_model(
+        model_info.model_uri,
+        data=inference_payload,
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+    values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
+
+    assert len(values.to_dict()) == 2
+    assert len(values.to_dict()["score"]) == 1
+
     # Test the alternate TextClassificationPipeline input structure where text_pair is used
     # and ensure that model serving and direct native inference match
     inference_data = [
@@ -2143,9 +2154,16 @@ def test_classifier_pipeline_pyfunc_predict(text_classification_pipeline):
         {"text": "test2", "text_pair": "pair2"},
         {"text": "test 'quote", "text_pair": "pair 'quote'"},
     ]
+    signature = infer_signature(inference_data)
+    with mlflow.start_run():
+        model_info = mlflow.transformers.log_model(
+            transformers_model=text_classification_pipeline,
+            artifact_path=artifact_path,
+            signature=signature,
+        )
     inference_payload = json.dumps({"inputs": inference_data})
     response = pyfunc_serve_and_score_model(
-        model_uri,
+        model_info.model_uri,
         data=inference_payload,
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
         extra_args=["--env-manager", "local"],
@@ -2158,20 +2176,6 @@ def test_classifier_pipeline_pyfunc_predict(text_classification_pipeline):
     for key in ["score", "label"]:
         for value in [0, 1]:
             assert values_dict[key][value] == native_predict[value][key]
-
-    # test simple string input
-    inference_payload = json.dumps({"inputs": ["testing"]})
-
-    response = pyfunc_serve_and_score_model(
-        model_uri,
-        data=inference_payload,
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-        extra_args=["--env-manager", "local"],
-    )
-    values = PredictionsResponse.from_json(response.content.decode("utf-8")).get_predictions()
-
-    assert len(values.to_dict()) == 2
-    assert len(values.to_dict()["score"]) == 1
 
 
 def test_zero_shot_pipeline_pyfunc_predict(zero_shot_pipeline):
@@ -3507,7 +3511,6 @@ def test_save_model_card_with_non_utf_characters(tmp_path, model_name):
     assert data == card_data.data.to_dict()
 
 
-@pytest.mark.skip("Skipping until scoring_server supports new signature")
 def test_qa_pipeline_pyfunc_predict_with_kwargs(small_qa_pipeline):
     artifact_path = "qa_model"
     data = {
@@ -3533,11 +3536,28 @@ def test_qa_pipeline_pyfunc_predict_with_kwargs(small_qa_pipeline):
             "params": parameters,
         }
     )
+    output = mlflow.transformers.generate_signature_output(small_qa_pipeline, data)
     signature_with_params = infer_signature(
         data,
-        mlflow.transformers.generate_signature_output(small_qa_pipeline, data),
+        output,
         parameters,
     )
+    expected_signature = ModelSignature(
+        Schema(
+            [
+                ColSpec(Array(DataType.string), name="question"),
+                ColSpec(Array(DataType.string), name="context"),
+            ]
+        ),
+        Schema([ColSpec(DataType.string)]),
+        ParamSchema(
+            [
+                ParamSpec("top_k", DataType.long, 2),
+                ParamSpec("max_answer_len", DataType.long, 5),
+            ]
+        ),
+    )
+    assert signature_with_params == expected_signature
 
     with mlflow.start_run():
         mlflow.transformers.log_model(

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -15,6 +15,7 @@ from mlflow.protos.service_pb2 import Experiment as ProtoExperiment
 from mlflow.protos.service_pb2 import Metric as ProtoMetric
 from mlflow.types import ColSpec, DataType, Schema, TensorSpec
 from mlflow.types.schema import Array, Object, Property
+from mlflow.types.utils import _infer_schema
 from mlflow.utils.proto_json_utils import (
     MlflowFailedTypeConversion,
     _CustomJsonEncoder,
@@ -299,6 +300,15 @@ def test_parse_tf_serving_dictionary():
     # With df Schema
     result = parse_tf_serving_input(tfserving_input, df_schema)
     assert_result(result, expected_result_schema)
+    # With df Schema containing array
+    new_schema = _infer_schema(tfserving_input["instances"])
+    result = parse_tf_serving_input(tfserving_input, new_schema)
+    expected_result = {
+        "a": np.array(["s1", "s2", "s3"]),
+        "b": np.array([1.1, 2.2, 3.3], dtype="float64"),
+        "c": np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype="int64"),
+    }
+    assert_result(result, expected_result)
 
     # input provided as a dict
     tfserving_input = {
@@ -418,9 +428,7 @@ def test_parse_tf_serving_raises_expected_errors():
             {"a": "s3", "b": 3, "c": [7, 8, 9]},
         ]
     }
-    with pytest.raises(
-        MlflowException, match="The length of values for each input/column name are not the same"
-    ):
+    with pytest.raises(MlflowException, match="Failed to parse data as TF serving input."):
         parse_tf_serving_input(tfserving_instances)
 
     # cannot specify both instance and inputs
@@ -626,12 +634,13 @@ def test_cast_df_types_according_to_schema_error_message(dataframe, schema, erro
 
 
 @pytest.mark.parametrize(
-    ("data", "schema"),
+    ("data", "schema", "instances_data"),
     [
-        ({"query": "sentence"}, Schema([ColSpec(DataType.string, name="query")])),
+        ({"query": "sentence"}, Schema([ColSpec(DataType.string, name="query")]), None),
         (
             {"query": ["sentence_1", "sentence_2"]},
             Schema([ColSpec(Array(DataType.string), name="query")]),
+            None,
         ),
         (
             {"query": ["sentence_1", "sentence_2"], "table": "some_table"},
@@ -641,6 +650,7 @@ def test_cast_df_types_according_to_schema_error_message(dataframe, schema, erro
                     ColSpec(DataType.string, name="table"),
                 ]
             ),
+            None,
         ),
         (
             {"query": [{"name": "value", "age": 10}, {"name": "value"}], "table": ["some_table"]},
@@ -660,10 +670,12 @@ def test_cast_df_types_according_to_schema_error_message(dataframe, schema, erro
                     ColSpec(Array(DataType.string), name="table"),
                 ]
             ),
+            None,
         ),
         (
             [{"query": "sentence"}, {"query": "sentence"}],
             Schema([ColSpec(DataType.string, name="query")]),
+            {"query": ["sentence", "sentence"]},
         ),
         (
             [
@@ -676,11 +688,43 @@ def test_cast_df_types_according_to_schema_error_message(dataframe, schema, erro
                     ColSpec(DataType.string, name="table", required=False),
                 ]
             ),
+            {
+                "query": [["sentence_1", "sentence_2"], ["sentence_1", "sentence_2"]],
+                "table": ["some_table"],
+            },
+        ),
+        (
+            [
+                {"query": {"a": "sentence_1", "b": "sentence_2"}, "table": "some_table"},
+                {"query": {"a": "sentence_1"}, "table": "some_table"},
+            ],
+            Schema(
+                [
+                    ColSpec(
+                        Object(
+                            [
+                                Property("a", DataType.string),
+                                Property("b", DataType.string, required=False),
+                            ]
+                        ),
+                        name="query",
+                    ),
+                    ColSpec(DataType.string, name="table"),
+                ]
+            ),
+            {
+                "query": [{"a": "sentence_1", "b": "sentence_2"}, {"a": "sentence_1"}],
+                "table": ["some_table", "some_table"],
+            },
         ),
     ],
 )
-def test_parse_tf_serving_input_for_dictionaries_and_lists(data, schema):
+def test_parse_tf_serving_input_for_dictionaries_and_lists(data, schema, instances_data):
     np.testing.assert_equal(parse_tf_serving_input({"inputs": data}, schema), data)
+    if instances_data is None:
+        np.testing.assert_equal(parse_tf_serving_input({"instances": data}, schema), data)
+    else:
+        np.testing.assert_equal(parse_tf_serving_input({"instances": data}, schema), instances_data)
     df = pd.DataFrame(data) if isinstance(data, list) else pd.DataFrame([data])
     df_split = df.to_dict(orient="split")
     pd.testing.assert_frame_equal(dataframe_from_parsed_json(df_split, "split", schema), df)

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -680,7 +680,7 @@ def test_cast_df_types_according_to_schema_error_message(dataframe, schema, erro
     ],
 )
 def test_parse_tf_serving_input_for_dictionaries_and_lists(data, schema):
-    assert parse_tf_serving_input({"inputs": data}, schema) == data
+    np.testing.assert_equal(parse_tf_serving_input({"inputs": data}, schema), data)
     df = pd.DataFrame(data) if isinstance(data, list) else pd.DataFrame([data])
     df_split = df.to_dict(orient="split")
     pd.testing.assert_frame_equal(dataframe_from_parsed_json(df_split, "split", schema), df)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10094?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10094/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10094
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Update scoring server parsing logic to support new schema

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

**Test a valid PyFunc model serving**
1. Log a PyFunc model
```
import json
import mlflow
from mlflow.models.signature import infer_signature

class TestModel(mlflow.pyfunc.PythonModel):
    def predict(self, context, model_input, params=None):
        return model_input

data = {
    "arr": ["sentence_1", "sentence_2"],
    "str": "some_data",
    "obj": {"a": 1, "b": "b"}}
signature = infer_signature(data)
print(signature)

with mlflow.start_run():
    model_info = mlflow.pyfunc.log_model(
        artifact_path="test_model",
        python_model=TestModel(),
        signature=signature,
    )
print(model_info.model_uri)
```
2. serve the model:
Replace path to the model
```
mlflow models serve -m runs:/8b76b104c56745148787715ac99c58fb/test_model --env-manager local
```
3. Query the model
```
curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{"inputs": {"arr": ["sentence_1", "sentence_2"],"str": "some_data","obj": {"a": 1, "b": "b"}}}'
```

**Test warning for invalid `instances` payload**
<img width="1270" alt="image" src="https://github.com/mlflow/mlflow/assets/82044803/b2fe7654-baaf-4612-8095-b491445a1d2c">
<img width="1265" alt="image" src="https://github.com/mlflow/mlflow/assets/82044803/b70bfd6f-641f-41cd-961e-47a0d9e0c832">


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
