### PR TITLE
Upgrade Flask MV to 3.0

### DIFF
--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -79,4 +79,5 @@ jobs:
       - name: Run tests
         run: |
           source dev/setup-ssh.sh
-          ./dev/run-python-tests.sh
+          pytest tests --quiet --requires-ssh --ignore-flavors \
+            --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -581,7 +581,8 @@ request by running:
 
 ```bash
 pre-commit run --all-files
-./dev/run-python-tests.sh
+pytest tests --quiet --requires-ssh --ignore-flavors \
+  --ignore=tests/examples --ignore=tests/recipes --ignore=tests/evaluate
 ```
 
 We use [pytest](https://docs.pytest.org/en/latest/contents.html) to run
@@ -612,7 +613,7 @@ If you are adding new framework flavor support, you'll need to modify
 `pytest` and Github action configurations so tests for your code can run
 properly. Generally, the files you'll have to edit are:
 
-1.  `dev/run-python-tests.sh`:
+1.  `.github/workflows/master.yml`: lines where pytest runs with `--ignore-flavors` flag
 
     1. Add your tests to the ignore list, where the other frameworks are
        ignored

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -7,7 +7,6 @@ import textwrap
 import types
 
 from flask import Flask, Response, send_from_directory
-from flask import __version__ as flask_version
 from packaging.version import Version
 
 from mlflow.exceptions import MlflowException
@@ -40,7 +39,7 @@ ARTIFACTS_ONLY_ENV_VAR = "_MLFLOW_SERVER_ARTIFACTS_ONLY"
 REL_STATIC_DIR = "js/build"
 
 app = Flask(__name__, static_folder=REL_STATIC_DIR)
-IS_FLASK_V1 = Version(flask_version) < Version("2.0")
+IS_FLASK_V1 = Version(importlib.metadata.version("flask")) < Version("2.0")
 
 
 for http_path, handler, methods in handlers.get_endpoints():

--- a/requirements/core-requirements.txt
+++ b/requirements/core-requirements.txt
@@ -4,7 +4,7 @@
 
 alembic<2,!=1.10.0
 docker<7,>=4.0.0
-Flask<3
+Flask<4
 numpy<2
 scipy<2
 pandas<3

--- a/requirements/core-requirements.yaml
+++ b/requirements/core-requirements.yaml
@@ -17,7 +17,7 @@ docker:
 
 flask:
   pip_release: Flask
-  max_major_version: 2
+  max_major_version: 3
 
 numpy:
   pip_release: numpy


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10098?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10098/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10098
```

</p>
</details>

### Related Issues/PRs

Resolve #10067 

### What changes are proposed in this pull request?

Bump up Flask major version from 2 to 3.

Supposedly this version update doesn't do much ([ref](https://flask.palletsprojects.com/en/3.0.x/changes/)), and only required code change on our end is to remove usage of `__version__` attribute, which was used [here](https://github.com/mlflow/mlflow/blob/299c229e874b68fcb65928b2e690cb31a10dc241/mlflow/server/__init__.py#L43).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
