### PR TITLE
Split `recipes-windows` job for faster PR merge

### DIFF
--- a/.github/workflows/recipe.yml
+++ b/.github/workflows/recipe.yml
@@ -52,6 +52,11 @@ jobs:
   recipes-windows:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: windows-latest
+    strategy:
+      matrix:
+        group: [1, 2]
+        include:
+          - splits: 2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -82,4 +87,4 @@ jobs:
           export HADOOP_HOME=/tmp/winutils/hadoop-3.2.2
           export PATH=$PATH:$HADOOP_HOME/bin
           export MLFLOW_HOME=$(pwd)
-          pytest tests/recipes
+          pytest --splits ${{ matrix.splits }} --group ${{ matrix.group }} tests/recipes

--- a/tests/recipes/test_train_step.py
+++ b/tests/recipes/test_train_step.py
@@ -170,8 +170,6 @@ def setup_train_step_with_tuning(
 
 def test_train_step(tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path):
     train_step_output_dir = setup_train_dataset(tmp_recipe_exec_path)
-    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
-    recipe_steps_dir.mkdir(parents=True)
     recipe_yaml = tmp_recipe_root_path.joinpath(_RECIPE_CONFIG_FILE_NAME)
     recipe_yaml.write_text(
         f"""
@@ -224,8 +222,6 @@ def test_train_step_imbalanced_data(tmp_recipe_root_path: Path, tmp_recipe_exec_
     train_step_output_dir = setup_train_dataset(
         tmp_recipe_exec_path, recipe="classification/multiclass"
     )
-    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
-    recipe_steps_dir.mkdir(parents=True)
     recipe_yaml = tmp_recipe_root_path.joinpath(_RECIPE_CONFIG_FILE_NAME)
     recipe_yaml.write_text(
         f"""
@@ -266,8 +262,6 @@ def test_train_step_classifier_automl(
     tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path, recipe
 ):
     train_step_output_dir = setup_train_dataset(tmp_recipe_exec_path, recipe=recipe)
-    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
-    recipe_steps_dir.mkdir(parents=True)
     recipe_yaml = tmp_recipe_root_path.joinpath(_RECIPE_CONFIG_FILE_NAME)
     recipe_yaml.write_text(
         """
@@ -376,8 +370,6 @@ def test_train_steps_writes_model_pkl_and_card(
     tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path, use_tuning
 ):
     train_step_output_dir = setup_train_dataset(tmp_recipe_exec_path)
-    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
-    recipe_steps_dir.mkdir(parents=True)
     train_step = setup_train_step_with_tuning(tmp_recipe_root_path, use_tuning)
     with mock.patch("steps.train.estimator_fn", estimator_fn):
         train_step.run(str(train_step_output_dir))
@@ -399,8 +391,6 @@ def test_train_steps_writes_card_with_model_and_run_links_on_databricks(
     monkeypatch.setenv("_DATABRICKS_WORKSPACE_ID", workspace_id)
 
     train_step_output_dir = setup_train_dataset(tmp_recipe_exec_path)
-    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
-    recipe_steps_dir.mkdir(parents=True)
     train_step = setup_train_step_with_tuning(tmp_recipe_root_path, use_tuning)
     with mock.patch("steps.train.estimator_fn", estimator_fn):
         train_step.run(str(train_step_output_dir))
@@ -422,8 +412,6 @@ def test_train_steps_writes_card_with_model_and_run_links_on_databricks(
 @pytest.mark.parametrize("use_tuning", [True, False])
 def test_train_steps_autologs(tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path, use_tuning):
     train_step_output_dir = setup_train_dataset(tmp_recipe_exec_path)
-    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
-    recipe_steps_dir.mkdir(parents=True)
     train_step = setup_train_step_with_tuning(tmp_recipe_root_path, use_tuning)
     m_train = Mock()
     m_train.estimator_fn = estimator_fn
@@ -448,8 +436,6 @@ def test_train_steps_with_correct_tags(
 ):
     monkeypatch.setenv(MLFLOW_RECIPES_EXECUTION_TARGET_STEP_NAME.name, "train")
     train_step_output_dir = setup_train_dataset(tmp_recipe_exec_path)
-    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
-    recipe_steps_dir.mkdir(parents=True)
     train_step = setup_train_step_with_tuning(tmp_recipe_root_path, use_tuning)
     m_train = Mock()
     m_train.estimator_fn = estimator_fn
@@ -473,8 +459,6 @@ def test_train_step_with_tuning_best_parameters(
     tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path
 ):
     train_step_output_dir = setup_train_dataset(tmp_recipe_exec_path)
-    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
-    recipe_steps_dir.mkdir(parents=True)
     train_step = setup_train_step_with_tuning(tmp_recipe_root_path, use_tuning=True)
     with mock.patch("steps.train.estimator_fn", estimator_fn):
         train_step.run(str(train_step_output_dir))
@@ -506,8 +490,6 @@ def test_train_step_with_tuning_output_yaml_correct(
     num_sections,
 ):
     train_step_output_dir = setup_train_dataset(tmp_recipe_exec_path)
-    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
-    recipe_steps_dir.mkdir(parents=True)
     train_step = setup_train_step_with_tuning(
         tmp_recipe_root_path, use_tuning=True, with_hardcoded_params=with_hardcoded_params
     )
@@ -532,8 +514,6 @@ def test_train_step_with_tuning_child_runs_and_early_stop(
     tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path
 ):
     train_step_output_dir = setup_train_dataset(tmp_recipe_exec_path)
-    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
-    recipe_steps_dir.mkdir(parents=True)
     train_step = setup_train_step_with_tuning(tmp_recipe_root_path, use_tuning=True)
     with mock.patch("steps.train.estimator_fn", estimator_fn):
         train_step.run(str(train_step_output_dir))
@@ -637,8 +617,6 @@ def test_tuning_multiclass(tmp_recipe_root_path: Path, tmp_recipe_exec_path: Pat
     train_step_output_dir = setup_train_dataset(
         tmp_recipe_exec_path, recipe="classification/multiclass"
     )
-    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
-    recipe_steps_dir.mkdir(parents=True)
 
     train_step = setup_train_step_with_tuning(
         tmp_recipe_root_path,
@@ -674,8 +652,6 @@ def test_train_step_with_predict_probability(
     train_step_output_dir = setup_train_dataset(
         tmp_recipe_exec_path, recipe="classification/binary"
     )
-    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
-    recipe_steps_dir.mkdir(parents=True)
     recipe_yaml = tmp_recipe_root_path.joinpath(_RECIPE_CONFIG_FILE_NAME)
     recipe_yaml.write_text(
         f"""
@@ -743,8 +719,6 @@ def test_train_step_with_predict_probability_with_custom_prefix(
     train_step_output_dir = setup_train_dataset(
         tmp_recipe_exec_path, recipe="classification/binary"
     )
-    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
-    recipe_steps_dir.mkdir(parents=True)
     recipe_yaml = tmp_recipe_root_path.joinpath(_RECIPE_CONFIG_FILE_NAME)
     recipe_yaml.write_text(
         f"""
@@ -798,8 +772,6 @@ def test_train_step_with_label_encoding(tmp_recipe_root_path: Path, tmp_recipe_e
     train_step_output_dir = setup_train_dataset(
         tmp_recipe_exec_path, recipe="classification/multiclass"
     )
-    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
-    recipe_steps_dir.mkdir(parents=True)
     recipe_yaml = tmp_recipe_root_path.joinpath(_RECIPE_CONFIG_FILE_NAME)
     recipe_yaml.write_text(
         f"""
@@ -850,8 +822,6 @@ def test_train_step_with_probability_calibration(
     train_step_output_dir = setup_train_dataset(
         tmp_recipe_exec_path, recipe="classification/binary"
     )
-    recipe_steps_dir = tmp_recipe_root_path.joinpath("steps")
-    recipe_steps_dir.mkdir(parents=True)
     recipe_yaml = tmp_recipe_root_path.joinpath(_RECIPE_CONFIG_FILE_NAME)
     recipe_yaml.write_text(
         f"""

--- a/tests/recipes/test_train_step.py
+++ b/tests/recipes/test_train_step.py
@@ -204,7 +204,7 @@ def test_train_step(tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path):
 
 
 @pytest.fixture(autouse=True)
-def tmp_steps_path(tmp_recipe_root_path, monkeypatch):
+def dummy_train_step(tmp_recipe_root_path, monkeypatch):
     # `mock.patch("steps.train.estimator_fn", ...)` would fail without this fixture
     steps = tmp_recipe_root_path / "steps"
     steps.mkdir(exist_ok=True)

--- a/tests/recipes/test_train_step.py
+++ b/tests/recipes/test_train_step.py
@@ -205,6 +205,21 @@ def test_train_step(tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path):
     assert "training_mean_squared_error" in metrics
 
 
+@pytest.fixture(autouse=True)
+def fake_steps_train_estimator_fn(tmp_path, monkeypatch):
+    # `mock.patch("steps.train.estimator_fn", ...)` would fail without this fixture
+    steps = tmp_path / "steps"
+    steps.mkdir()
+    steps.joinpath("__init__.py").touch()
+    steps.joinpath("train.py").write_text(
+        """
+def estimator_fn(estimator_params=None):
+    return None
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+
 @mock.patch("mlflow.recipes.steps.train._REBALANCING_CUTOFF", 50)
 def test_train_step_imbalanced_data(tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path):
     train_step_output_dir = setup_train_dataset(

--- a/tests/recipes/test_transform_step.py
+++ b/tests/recipes/test_transform_step.py
@@ -15,6 +15,20 @@ from mlflow.recipes.utils import _RECIPE_CONFIG_FILE_NAME
 from mlflow.utils.file_utils import read_yaml
 
 
+@pytest.fixture(autouse=True)
+def dummy_transform_step(tmp_recipe_root_path, monkeypatch):
+    # `mock.patch("steps.transform.transformer_fn", ...)` would fail without this fixture
+    steps = tmp_recipe_root_path / "steps"
+    steps.mkdir(exist_ok=True)
+    steps.joinpath("transform.py").write_text(
+        """
+def transformer_fn(estimator_params=None):
+    return None
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_recipe_root_path))
+
+
 # Sets up the transform step and returns the constructed TransformStep instance and step output dir
 def set_up_transform_step(recipe_root: Path, transform_user_module):
     split_step_output_dir = recipe_root.joinpath("steps", "split", "outputs")

--- a/tests/recipes/test_transform_step.py
+++ b/tests/recipes/test_transform_step.py
@@ -1,7 +1,6 @@
 import os
 from pathlib import Path
 from unittest import mock
-from unittest.mock import Mock
 
 import pandas as pd
 import pytest
@@ -75,10 +74,8 @@ def test_transform_step_writes_onehot_encoded_dataframe_and_transformer_pkl(
 ):
     from sklearn.preprocessing import StandardScaler
 
-    m = Mock()
-    m.transformer_fn = lambda: StandardScaler()  # pylint: disable=unnecessary-lambda
     monkeypatch.setenv(MLFLOW_RECIPES_EXECUTION_DIRECTORY.name, str(tmp_recipe_root_path))
-    with mock.patch.dict("sys.modules", {"steps.transform": m}):
+    with mock.patch("steps.transform.transformer_fn", lambda: StandardScaler()):
         transform_step, transform_step_output_dir, _ = set_up_transform_step(
             tmp_recipe_root_path, "transformer_fn"
         )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10100?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10100/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10100
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Split the `recipes-windows` job. This job takes 50~60 minutes to finish.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
