### PR TITLE
replace pytest with dev/pytest.sh #10027

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -10,7 +10,7 @@ sklearn:
     requirements:
       "< 1.0": ["scipy==1.7.3"]
     run: |
-      pytest tests/sklearn/test_sklearn_model_export.py
+      dev/pytest.sh tests/sklearn/test_sklearn_model_export.py
 
   autologging:
     minimum: "0.24.1"
@@ -19,11 +19,11 @@ sklearn:
       ">= 0.0.0": ["matplotlib"]
       "< 1.0": ["scipy==1.7.3"]
     run: |
-      pytest tests/sklearn/test_sklearn_autolog.py
+      dev/pytest.sh tests/sklearn/test_sklearn_autolog.py
 
       # Ensure sklearn autologging works without matplotlib
       pip uninstall -q -y matplotlib
-      pytest tests/sklearn/test_sklearn_autolog_without_matplotlib.py
+      dev/pytest.sh tests/sklearn/test_sklearn_autolog_without_matplotlib.py
 
 pytorch:
   package_info:
@@ -39,7 +39,7 @@ pytorch:
       ">= 1.8": ["transformers"]
       "< 1.8": ["transformers<4.32.0"]
     run: |
-      pytest tests/pytorch/test_pytorch_model_export.py tests/pytorch/test_pytorch_metric_value_conversion_utils.py
+      dev/pytest.sh tests/pytorch/test_pytorch_model_export.py tests/pytorch/test_pytorch_metric_value_conversion_utils.py
 
   autologging:
     minimum: "1.9.0"
@@ -47,7 +47,7 @@ pytorch:
     requirements:
       ">= 0.0.0": ["tensorboard"]
     run: |
-      pytest tests/pytorch/test_tensorboard_autolog.py
+      dev/pytest.sh tests/pytorch/test_tensorboard_autolog.py
 
 pytorch-lightning:
   package_info:
@@ -72,7 +72,7 @@ pytorch-lightning:
       # The problematic commit: https://github.com/Lightning-AI/torchmetrics/commit/3527e17516902eb5265cd2a4f76ad6b0f9f77692
       "< 1.8.0": ["torchmetrics<1.0.0"]
     run: |
-      pytest tests/pytorch/test_pytorch_autolog.py
+      dev/pytest.sh tests/pytorch/test_pytorch_autolog.py
 
 tensorflow:
   package_info:
@@ -93,7 +93,7 @@ tensorflow:
       # They are also incompatible with alembic 1.10.1 with the TypeGuard dependency in py3.8
       "== 2.6.5": ["sqlalchemy<2", "alembic<1.10"]
     run: |
-      pytest \
+      dev/pytest.sh \
         tests/tensorflow/test_load_saved_tensorflow_estimator.py \
         tests/tensorflow/test_tensorflow2_core_model_export.py \
         tests/tensorflow/test_tensorflow2_metric_value_conversion_utils.py \
@@ -111,7 +111,7 @@ tensorflow:
       # They are also incompatible with alembic 1.10.1 with the TypeGuard dependency in py3.8
       "== 2.6.5": ["sqlalchemy<2", "alembic<1.10"]
     run: |
-      pytest tests/tensorflow/test_tensorflow2_autolog.py
+      dev/pytest.sh tests/tensorflow/test_tensorflow2_autolog.py
 
 xgboost:
   package_info:
@@ -151,7 +151,7 @@ lightgbm:
     requirements:
       ">= 0.0.0": ["scikit-learn"]
     run: |
-      pytest tests/lightgbm/test_lightgbm_model_export.py
+      dev/pytest.sh tests/lightgbm/test_lightgbm_model_export.py
 
   autologging:
     minimum: "3.1.1"
@@ -159,7 +159,7 @@ lightgbm:
     requirements:
       ">= 0.0.0": ["scikit-learn", "matplotlib"]
     run: |
-      pytest tests/lightgbm/test_lightgbm_autolog.py
+      dev/pytest.sh tests/lightgbm/test_lightgbm_autolog.py
 
 catboost:
   package_info:
@@ -176,7 +176,7 @@ catboost:
       ">= 0.0.0": ["scikit-learn"]
       "< 1.1": ["pandas<2"]
     run: |
-      pytest tests/catboost/test_catboost_model_export.py
+      dev/pytest.sh tests/catboost/test_catboost_model_export.py
 
 gluon:
   package_info:
@@ -196,7 +196,7 @@ gluon:
       # Install libopenblas-dev for mxnet 1.8.0.post0
       sudo apt-get update -y
       sudo apt-get install libopenblas-dev -y
-      pytest tests/gluon/test_gluon_model_export.py
+      dev/pytest.sh tests/gluon/test_gluon_model_export.py
 
   autologging:
     minimum: "1.5.1"
@@ -207,7 +207,7 @@ gluon:
       ">= 0.0.0": ["numpy<1.24.0"]
     unsupported: ["1.8.0"] # MXNet 1.8.0 is a flawed release that we don't expect to work with
     run: |
-      pytest tests/gluon/test_gluon_autolog.py
+      dev/pytest.sh tests/gluon/test_gluon_autolog.py
 
 fastai:
   package_info:
@@ -220,7 +220,7 @@ fastai:
       "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0"]
       ">= 2.8.0": ["torch", "torchvision"]
     run: |
-      pytest tests/fastai/test_fastai_model_export.py
+      dev/pytest.sh tests/fastai/test_fastai_model_export.py
 
   autologging:
     minimum: "2.4.1"
@@ -229,7 +229,7 @@ fastai:
       "< 2.8.0": ["torch<1.13.0", "torchvision<0.14.0"]
       ">= 2.8.0": ["torch", "torchvision"]
     run: |
-      pytest tests/fastai/test_fastai_autolog.py
+      dev/pytest.sh tests/fastai/test_fastai_autolog.py
 
 onnx:
   package_info:
@@ -260,7 +260,7 @@ onnx:
       ">= 0.0.0": ["onnxruntime", "torch", "scikit-learn", "protobuf<4.0.0"]
       "< 1.11.0": ["numpy<1.24.0"]
     run: |
-      pytest tests/onnx/test_onnx_model_export.py
+      dev/pytest.sh tests/onnx/test_onnx_model_export.py
 
 spacy:
   package_info:
@@ -276,7 +276,7 @@ spacy:
       "<= 3.0.9": ["flask<2.1.0", "werkzeug<3"]
       "<3.4.0": ["typing_extensions<4.6.0"]
     run: |
-      pytest tests/spacy/test_spacy_model_export.py
+      dev/pytest.sh tests/spacy/test_spacy_model_export.py
 
 statsmodels:
   package_info:
@@ -290,7 +290,7 @@ statsmodels:
     requirements:
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
     run: |
-      pytest tests/statsmodels/test_statsmodels_model_export.py
+      dev/pytest.sh tests/statsmodels/test_statsmodels_model_export.py
 
   autologging:
     minimum: "0.11.1"
@@ -298,7 +298,7 @@ statsmodels:
     requirements:
       "< 0.13.0": ["pandas==1.3.5", "scipy==1.7.3"]
     run: |
-      pytest tests/statsmodels/test_statsmodels_autolog.py
+      dev/pytest.sh tests/statsmodels/test_statsmodels_autolog.py
 
 spark:
   package_info:
@@ -334,10 +334,10 @@ spark:
         cat $SAGEMAKER_OUT;
         exit 1
       fi
-      pytest tests/spark --ignore tests/spark/autologging --ignore tests/spark/test_spark_connect_model_export.py
+      dev/pytest.sh tests/spark --ignore tests/spark/autologging --ignore tests/spark/test_spark_connect_model_export.py
 
       if [[ $(python -c "from packaging.version import Version;import pyspark;print(Version(pyspark.__version__) >= Version('3.5'))") = "True" ]]; then
-        pytest tests/spark/test_spark_connect_model_export.py;
+        dev/pytest.sh tests/spark/test_spark_connect_model_export.py;
       fi
 
   autologging:
@@ -351,7 +351,7 @@ spark:
       ">= 0.0.0": ["scikit-learn"]
       "<= 3.3.3": ["pandas<2"]
     run: |
-      find tests/spark/autologging/ml -name 'test*.py' | xargs -L 1 pytest
+      find tests/spark/autologging/ml -name 'test*.py' | xargs -L 1 dev/pytest.sh
 
       # TODO: Fix spark datasource autologging and test it against non-preview versions of pyspark
       if [ "$(pip show pyspark | grep Version | cut -d' ' -f2)" = "3.0.0" ]; then
@@ -360,7 +360,7 @@ spark:
         echo -e "${YELLOW}WARNING: Spark datasource autologging currently only works for Spark 3.0.0-preview.${NO_COLOR}"
         pip uninstall -y pyspark
         ./dev/setup-spark-datasource-autologging.sh
-        find tests/spark/autologging/datasource -name 'test*.py' | xargs -L 1 pytest
+        find tests/spark/autologging/datasource -name 'test*.py' | xargs -L 1 dev/pytest.sh
       fi
 
 mleap:
@@ -384,7 +384,7 @@ mleap:
         cat $SAGEMAKER_OUT;
         exit 1
       fi
-      pytest tests/mleap/test_mleap_model_export.py
+      dev/pytest.sh tests/mleap/test_mleap_model_export.py
 
 prophet:
   package_info:
@@ -403,7 +403,7 @@ prophet:
       "<= 1.1.3": ["holidays<=0.24"]
       "< 1.1": ["pandas<2"]
     run: |
-      pytest tests/prophet/test_prophet_model_export.py
+      dev/pytest.sh tests/prophet/test_prophet_model_export.py
 
 pmdarima:
   package_info:
@@ -420,7 +420,7 @@ pmdarima:
       # Avoid holidays 0.25 due to https://github.com/dr-prodigy/python-holidays/issues/1200
       ">= 0.0.0": ["prophet", "holidays!=0.25"]
     run: |
-      pytest tests/pmdarima/test_pmdarima_model_export.py
+      dev/pytest.sh tests/pmdarima/test_pmdarima_model_export.py
 
 diviner:
   package_info:
@@ -441,7 +441,7 @@ diviner:
       # As of Jun 7, 2023, Diviner dev isn't compatible with pandas>=2
       "== dev": ["pandas<2"]
     run: |
-      pytest tests/diviner/test_diviner_model_export.py
+      dev/pytest.sh tests/diviner/test_diviner_model_export.py
 
 h2o:
   package_info:
@@ -450,7 +450,7 @@ h2o:
     minimum: "3.40.0.1"
     maximum: "3.42.0.3"
     run: |
-      pytest tests/h2o
+      dev/pytest.sh tests/h2o
 
 shap:
   package_info:
@@ -461,7 +461,7 @@ shap:
     requirements:
       "<= 0.41.0": ["numpy<1.24.0"]
     run: |
-      pytest tests/shap
+      dev/pytest.sh tests/shap
 
 paddle:
   package_info:
@@ -470,12 +470,12 @@ paddle:
     minimum: "2.4.1"
     maximum: "2.5.1"
     run: |
-      pytest tests/paddle/test_paddle_model_export.py
+      dev/pytest.sh tests/paddle/test_paddle_model_export.py
   autolog:
     minimum: "2.4.1"
     maximum: "2.4.1"
     run: |
-      pytest tests/paddle/test_paddle_autolog.py
+      dev/pytest.sh tests/paddle/test_paddle_autolog.py
 
 transformers:
   package_info:
@@ -503,9 +503,9 @@ transformers:
       # See: https://github.com/huggingface/transformers/issues/23352 for discussion
       "< 4.30.0": ["tensorflow<2.13.0"]
     run: |
-      pytest tests/transformers/test_transformers_model_export.py
+      dev/pytest.sh tests/transformers/test_transformers_model_export.py
       pip uninstall -y accelerate
-      pytest tests/transformers/test_transformers_model_export.py -k "test_transformers_tf_model_save_without_conda_env_uses_default_env_with_expected_dependencies or test_transformers_pt_model_save_dependencies_without_accelerate"
+      dev/pytest.sh tests/transformers/test_transformers_model_export.py -k "test_transformers_tf_model_save_without_conda_env_uses_default_env_with_expected_dependencies or test_transformers_pt_model_save_dependencies_without_accelerate"
   autologging:
     minimum: "4.25.1"
     maximum: "4.33.1"
@@ -526,7 +526,7 @@ transformers:
       # See: https://github.com/huggingface/transformers/issues/23352 for discussion
       "< 4.30.0": ["tensorflow<2.13.0"]
     run: |
-      pytest tests/transformers/test_transformers_autolog.py
+      dev/pytest.sh tests/transformers/test_transformers_autolog.py
 
 openai:
   package_info:
@@ -539,7 +539,7 @@ openai:
     requirements:
       ">= 0.0.0": ["pyspark", "tiktoken", "aiohttp", "tenacity"]
     run: |
-      pytest tests/openai/test_openai_model_export.py
+      dev/pytest.sh tests/openai/test_openai_model_export.py
 
 langchain:
   package_info:
@@ -576,7 +576,7 @@ sentence_transformers:
     requirements:
       ">= 0.0.0": ["pyspark", "torch>1.6", "transformers>4.25"]
     run: |
-      pytest tests/sentence_transformers/test_sentence_transformers_model_export.py
+      dev/pytest.sh tests/sentence_transformers/test_sentence_transformers_model_export.py
 
 johnsnowlabs:
   package_info:
@@ -588,7 +588,7 @@ johnsnowlabs:
       ">= 0.0.0": ["pandas<=1.5.3", "pyspark<3.4"]
     run: |
       if [ ! -z "$JOHNSNOWLABS_LICENSE_JSON" ]; then
-        pytest tests/johnsnowlabs/test_johnsnowlabs_model_export.py
+        dev/pytest.sh tests/johnsnowlabs/test_johnsnowlabs_model_export.py
       else
         echo "Skipping tests due to missing license key"
       fi


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/RolandCita/mlflow/pull/10111?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10111/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10111
```

</p>
</details>

### Related Issues/PRs


<!-- Resolve --> #10027 

### What changes are proposed in this pull request?

Changed pytest, to already available /dev/pytest.sh

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
