### PR TITLE
Add stacktrace if model scoring fails

### DIFF
--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -64,7 +64,7 @@ def _extract_score_and_justification(output):
             data = json.loads(text)
             score = int(data.get("score"))
             justification = data.get("justification")
-        except (json.JSONDecodeError, ValueError):
+        except json.JSONDecodeError:
             # If parsing fails, use regex
             match = re.search(r"score: (\d+),?\s*justification: (.+)", text)
             if match:
@@ -75,7 +75,7 @@ def _extract_score_and_justification(output):
                 justification = f"Failed to extract score and justification. Raw output: {output}"
 
         if not isinstance(score, (int, float)) or not isinstance(justification, str):
-            return None, justification
+            return None, f"Failed to extract score and justification. Raw output: {output}"
 
         return score, justification
 

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -282,7 +282,7 @@ def make_genai_metric(
                         ErrorCode.Name(UNAUTHENTICATED),
                     ]:
                         raise MlflowException(e)
-                return None, f"Failed to score model on payload. Error:: {e!s}"
+                return None, f"Failed to score model on payload. Error: {e!s}"
 
         scores = [None] * len(inputs)
         justifications = [None] * len(inputs)

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -64,7 +64,7 @@ def _extract_score_and_justification(output):
             data = json.loads(text)
             score = int(data.get("score"))
             justification = data.get("justification")
-        except (json.JSONDecodeError, ValueError) as e:
+        except (json.JSONDecodeError, ValueError):
             # If parsing fails, use regex
             match = re.search(r"score: (\d+),?\s*justification: (.+)", text)
             if match:
@@ -72,7 +72,7 @@ def _extract_score_and_justification(output):
                 justification = match.group(2)
             else:
                 score = None
-                justification = f"Failed to extract score and justification. Error: {e!s}"
+                justification = f"Failed to extract score and justification. Raw output: {output}"
 
         if not isinstance(score, (int, float)) or not isinstance(justification, str):
             return None, justification

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -64,7 +64,7 @@ def _extract_score_and_justification(output):
             data = json.loads(text)
             score = int(data.get("score"))
             justification = data.get("justification")
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, ValueError) as e:
             # If parsing fails, use regex
             match = re.search(r"score: (\d+),?\s*justification: (.+)", text)
             if match:
@@ -72,10 +72,10 @@ def _extract_score_and_justification(output):
                 justification = match.group(2)
             else:
                 score = None
-                justification = None
+                justification = f"Failed to extract score and justification. Error: {e!s}"
 
         if not isinstance(score, (int, float)) or not isinstance(justification, str):
-            return None, None
+            return None, justification
 
         return score, justification
 
@@ -282,8 +282,7 @@ def make_genai_metric(
                         ErrorCode.Name(UNAUTHENTICATED),
                     ]:
                         raise MlflowException(e)
-                _logger.info(f"Failed to score model on payload. Error: {e!r}")
-                return None, None
+                return None, f"Failed to score model on payload. Error:: {e!s}"
 
         scores = [None] * len(inputs)
         justifications = [None] * len(inputs)

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -297,7 +297,9 @@ def test_make_genai_metric_incorrect_response():
         )
 
     assert metric_value.scores == [None]
-    assert metric_value.justifications == [None]
+    assert metric_value.justifications == [
+        "Failed to extract score and justification. Error: Expecting value: line 1 column 1 (char 0)"
+    ]
 
     assert np.isnan(metric_value.aggregate_results["mean"])
     assert np.isnan(metric_value.aggregate_results["variance"])

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -532,18 +532,21 @@ def test_extract_score_and_justification():
     assert score4 == 4
     assert justification4 == "This is a justification"
 
-    score5, justification5 = _extract_score_and_justification(
-        output={
-            "candidates": [
-                {
-                    "text": '{"score": 4, "justification": {"foo": "bar"}}',
-                }
-            ]
-        }
-    )
+    malformed_output = {
+        "candidates": [
+            {
+                "text": '{"score": 4, "justification": {"foo": "bar"}}',
+            }
+        ]
+    }
+
+    score5, justification5 = _extract_score_and_justification(output=malformed_output)
 
     assert score5 is None
-    assert justification5 is None
+    assert (
+        justification5
+        == f"Failed to extract score and justification. Raw output: {malformed_output}"
+    )
 
 
 def test_correctness_metric():

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -298,7 +298,7 @@ def test_make_genai_metric_incorrect_response():
 
     assert metric_value.scores == [None]
     assert metric_value.justifications == [
-        "Failed to extract score and justification. Error: Expecting value: line 1 column 1 (char 0)"
+        f"Failed to extract score and justification. Raw output: {incorrectly_formatted_openai_response}"
     ]
 
     assert np.isnan(metric_value.aggregate_results["mean"])

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -298,7 +298,8 @@ def test_make_genai_metric_incorrect_response():
 
     assert metric_value.scores == [None]
     assert metric_value.justifications == [
-        f"Failed to extract score and justification. Raw output: {incorrectly_formatted_openai_response}"
+        f"Failed to extract score and justification. Raw output:"
+        f" {incorrectly_formatted_openai_response}"
     ]
 
     assert np.isnan(metric_value.aggregate_results["mean"])

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -305,6 +305,27 @@ def test_make_genai_metric_incorrect_response():
     assert np.isnan(metric_value.aggregate_results["variance"])
     assert metric_value.aggregate_results["p90"] is None
 
+    with mock.patch.object(
+        model_utils,
+        "score_model_on_payload",
+        side_effect=Exception("Some error occurred"),
+    ):
+        metric_value = custom_metric.eval_fn(
+            pd.Series([mlflow_prediction]),
+            {},
+            pd.Series(["What is MLflow?"]),
+            pd.Series([mlflow_ground_truth]),
+        )
+
+    assert metric_value.scores == [None]
+    assert metric_value.justifications == [
+        "Failed to score model on payload. Error: Some error occurred"
+    ]
+
+    assert np.isnan(metric_value.aggregate_results["mean"])
+    assert np.isnan(metric_value.aggregate_results["variance"])
+    assert metric_value.aggregate_results["p90"] is None
+
 
 def test_malformed_input_raises_exception():
     error_message = "Values for grading_context_columns are malformed and cannot be "


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/prithvikannan/mlflow/pull/10115?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10115/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10115
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add the exception to the justification field.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
