### PR TITLE
Adjustments to config retrieval when schema is Databricks

### DIFF
--- a/mlflow/R/mlflow/R/databricks-utils.R
+++ b/mlflow/R/mlflow/R/databricks-utils.R
@@ -94,7 +94,7 @@ get_databricks_config <- function(profile) {
   config <- tryCatch({
     get_databricks_config_for_profile("DEFAULT")
   }, error = function(e) {
-    # Return known invalid config
+    # On error assume known invalid config
     list(host = NA, token = NA, username = NA, password = NA)
   })
   if (databricks_config_is_valid(config)) {

--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -28,7 +28,7 @@ new_mlflow_client_impl <- function(get_host_creds, get_cli_env = list, class = c
   )
 }
 
-new_mlflow_host_creds <- function( host = NA, username = NA, password = NA, token = NA,
+new_mlflow_host_creds <- function(host = NA, username = NA, password = NA, token = NA,
                                    insecure = "False") {
   insecure_arg <- if (is.null(insecure) || is.na(insecure)) {
     "False"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/zacdav-db/mlflow/pull/10117?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10117/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10117
```

</p>
</details>

### Related Issues/PRs


### What changes are proposed in this pull request?


Currently within Databricks mlflow does not respect environment variables for configs when set.
This PR changes the underlying behaviour of `get_databricks_config()` such that the logic is changed to fetch the variables within the Databricks R session **last**.

[Previous Behaviour](https://github.com/mlflow/mlflow/blob/2801858f65203a7f3155e412ca3fc2e0bff92803/mlflow/R/mlflow/R/databricks-utils.R#L77-L99):

1. Check for presence of profile specified as part of URI, if present, attempt to return config
2. If no profile was specified as part of URI eagerly fetch variables from R session in Databricks
3. If not in Databricks:
   a. Attempt to fetch config from environment variables
   b. Attempt to fetch config from `DEFAULT` profile

This means users within Databricks are forced to create `.databrickscfg` file to remotely connect to another workspace for tracking.

It's not possible to set the environment variables and have them detected as the logic will preferentially use the notebook session variables which are re-injected after _every_ command run.

[New Behaviour:](https://github.com/zacdav-db/mlflow/blob/fd21339a2a3127818f0884bd3d96fcc2173bb552/mlflow/R/mlflow/R/databricks-utils.R#L77-L117)

1. Check for presence of profile specified as part of URI, if present, attempt to return config
2. Attempt to fetch config from environment variables, if successful and config is valid, return early
3. Attempt to fetch config from `DEFAULT` profile
   a. If fetching the `DEFAULT` profile errors (due to absence) then return a list that is known to be an invalid config
   b. If successful proceed to (3c)
   c. Return early if config is valid
4. If within a Databricks R session, fetch variables and validate config, return early if successful
 
### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

```r
# within databricks
library(mlflow)

exps <- mlflow_search_experiments()$experiments
display(exps[, 1:4])

# credentials for a workspace different to the one running code
Sys.setenv("DATABRICKS_HOST" = "<redacted>")
Sys.setenv("DATABRICKS_TOKEN" = "<redacted>")

# successfully shows external workspaces experiments
exps <- mlflow_search_experiments()$experiments
display(exps[, 1:4])

# revoke credentials
Sys.unsetenv("DATABRICKS_HOST")
Sys.unsetenv("DATABRICKS_TOKEN")

# same result as initially (current workspaces experiments) 
exps <- mlflow_search_experiments()$experiments
display(exps[, 1:4])
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

R Mlflow running within Databricks will now correctly respect environment variables and the `DEFAULT` profile in `.databrickscfg` when present.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
