### PR TITLE
improving retriever mvp docs

### DIFF
--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -267,7 +267,7 @@ def precision_at_k(k) -> EvaluationMetric:
     0, indicating that no relevant docs were retrieved. Let ``x = min(k, # of retrieved doc IDs)``.
     Then, the precision at k is calculated as follows:
 
-        ``precision_at_k`` = (# of relevant retrieved doc IDs in top-``x`` ranked documents) / ``x``.
+        ``precision_at_k`` = (# of relevant retrieved doc IDs in top-``x`` ranked docs) / ``x``.
 
     This metric is a builtin metric for the ``'retriever'`` model type, meaning it will be
     automatically calculated with a default ``k`` value of 3. To use another ``k`` value, you have

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -246,41 +246,14 @@ def precision_at_k(k) -> EvaluationMetric:
     """
     This function will create a metric for calculating ``precision_at_k`` for retriever models.
 
-    For retriever models, it's recommended to use a static dataset represented by a Pandas
-    Dataframe or an MLflow Pandas Dataset containing the input queries, retrieved relevant
-    document IDs, and the ground-truth relevant document IDs for the evaluation. A
-    "document ID" should be a string that identifies a document. For each row, the retrieved
-    relevant document IDs and the ground-truth relevant document IDs should be provided as
-    a tuple of document ID strings. The column name of the retrieved relevant document IDs
-    should be specified by the ``predictions`` parameter, and the column name of the
-    ground-truth relevant document IDs should be specified by the ``targets`` parameter.
-    Alternatively, you can use a function that returns a tuple of document ID strings for
-    the evaluation. The function should take a Pandas DataFrame as input and return a Pandas
-    DataFrame with the same number of rows, where each row contains a tuple of document ID
-    strings. The output column name of the function should be specified by the ``predictions``
-    parameter.
+    It is recommended to use a static dataset (Pandas Dataframe or MLflow Pandas Dataset) containing columns for: input queries, retrieved relevant doc IDs, and ground-truth doc IDs. A "doc ID" is a string that uniquely identifies a document. All doc IDs should be entered as a tuple of doc ID strings.
 
-    This metric computes a score between 0 and 1 for each row representing the precision of the
-    retriever model at the given k value. The score is calculated by dividing the number of relevant
-    documents retrieved by the total number of documents retrieved or k, whichever is smaller.
-    If no relevant documents are retrieved, the score is 1, indication that no false positives were
-    retrieved.
+    The ``targets`` parameter should specify the column name of the ground-truth relevant doc IDs.
 
-    The model output should be a pandas dataframe with a column containing a tuple of strings on
-    each row. The strings in the tuple represent the document IDs.
-    The label column should contain a tuple of strings representing the relevant
-    document IDs for each row, provided by the input ``data`` parameter.
-    The ``k`` parameter should be a positive integer representing the number of retrieved documents
-    to evaluate for each row. ``k`` defaults to 3.
+    You can either set the ``predictions`` parameter to the column name of the retrieved relevant doc IDs.
+    **or** pass in
 
-    This metric is a default metric for the ``retriever`` model type.
-    When the model type is ``"retriever"``, this metric will be calculated automatically with the
-    default ``k`` value of 3. To use another ``k`` value, use the ``evaluator_config`` parameter
-    in the ``mlflow.evaluate()`` API as follows: ``evaluator_config={"k": <k_value>}``.
-    Alternatively, you can directly specify the ``mlflow.metrics.precision_at_k(<k_value>)`` metric
-    in the ``extra_metrics`` parameter of the ``mlflow.evaluate()`` API without specifying a model
-    type. In this case, the ``k`` value specified in the ``evaluator_config`` parameter will be
-    ignored.
+
     """
     return make_metric(
         eval_fn=_precision_at_k_eval_fn(k),

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -254,29 +254,29 @@ def precision_at_k(k) -> EvaluationMetric:
     The ``targets`` parameter should specify the column name of the ground-truth relevant doc IDs.
 
     If you choose to use a static dataset, the ``predictions`` parameter should specify the column
-    name of the retrieved relevant doc IDs.
-
-    Alternatively, if you choose to specify a function for the ``model`` parameter, the function
-    should take a Pandas DataFrame as input and return a Pandas DataFrame with a column of
-    retrieved relevant doc IDs, specified by the ``predictions`` parameter.
+    name of the retrieved relevant doc IDs. Alternatively, if you choose to specify a function for
+    the ``model`` parameter, the function should take a Pandas DataFrame as input and return a
+    Pandas DataFrame with a column of retrieved relevant doc IDs, specified by the ``predictions``
+    parameter.
 
     ``k`` should be a positive integer specifying the number of retrieved doc IDs to consider for
     each input query. ``k`` defaults to 3.
 
     This metric computes a score between 0 and 1 for each row representing the precision of the
-    retriever model at the given ``k`` value. Let ``x = min(k, # of retrieved doc IDs)``. Then, the
-    precision at k is calculated as follows:
-    precision_at_k = (# of relevant retrieved doc IDs in top-x ranked documents) / x.
+    retriever model at the given ``k`` value. If no relevant documents are retrieved, the score is
+    0, indicating that no relevant docs were retrieved. Let ``x = min(k, # of retrieved doc IDs)``.
+    Then, the precision at k is calculated as follows:
 
-    If no relevant documents are retrieved, the score is 0, indicating that no relevant docs were
-    retrieved. #TODO
+        ``precision_at_k`` = (# of relevant retrieved doc IDs in top-``x`` ranked documents) / ``x``.
 
     This metric is a builtin metric for the ``'retriever'`` model type, meaning it will be
     automatically calculated with a default ``k`` value of 3. To use another ``k`` value, you have
-    two options with the ``mlflow.evaluate()`` API:
+    two options with the :py:func:`mlflow.evaluate` API:
+
     1. ``evaluator_config={"k": 5}``
     2. ``extra_metrics = [mlflow.metrics.precision_at_k(k=5)]``
-    Note that the ``k`` value in the ``evaluator_config`` will be ignored in this case.
+
+        Note that the ``k`` value in the ``evaluator_config`` will be ignored in this case.
     """
     return make_metric(
         eval_fn=_precision_at_k_eval_fn(k),

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -274,9 +274,9 @@ def precision_at_k(k) -> EvaluationMetric:
     This metric is a builtin metric for the ``'retriever'`` model type, meaning it will be
     automatically calculated with a default ``k`` value of 3. To use another ``k`` value, you have
     two options with the ``mlflow.evaluate()`` API:
-        ``evaluator_config={"k": 5}``
-        ``extra_metrics = [mlflow.metrics.precision_at_k(k=5)]``
-            Note that the ``k`` value in the ``evaluator_config`` will be ignored in this case.
+    1. ``evaluator_config={"k": 5}``
+    2. ``extra_metrics = [mlflow.metrics.precision_at_k(k=5)]``
+    Note that the ``k`` value in the ``evaluator_config`` will be ignored in this case.
     """
     return make_metric(
         eval_fn=_precision_at_k_eval_fn(k),

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -246,14 +246,37 @@ def precision_at_k(k) -> EvaluationMetric:
     """
     This function will create a metric for calculating ``precision_at_k`` for retriever models.
 
-    It is recommended to use a static dataset (Pandas Dataframe or MLflow Pandas Dataset) containing columns for: input queries, retrieved relevant doc IDs, and ground-truth doc IDs. A "doc ID" is a string that uniquely identifies a document. All doc IDs should be entered as a tuple of doc ID strings.
+    It is recommended to use a static dataset (Pandas Dataframe or MLflow Pandas Dataset)
+    containing columns for: input queries, retrieved relevant doc IDs, and ground-truth doc IDs. A
+    "doc ID" is a string that uniquely identifies a document. All doc IDs should be entered as a
+    tuple of doc ID strings.
 
     The ``targets`` parameter should specify the column name of the ground-truth relevant doc IDs.
 
-    You can either set the ``predictions`` parameter to the column name of the retrieved relevant doc IDs.
-    **or** pass in
+    If you choose to use a static dataset, the ``predictions`` parameter should specify the column
+    name of the retrieved relevant doc IDs.
 
+    Alternatively, if you choose to specify a function for the ``model`` parameter, the function
+    should take a Pandas DataFrame as input and return a Pandas DataFrame with a column of
+    retrieved relevant doc IDs, specified by the ``predictions`` parameter.
 
+    ``k`` should be a positive integer specifying the number of retrieved doc IDs to consider for
+    each input query. ``k`` defaults to 3.
+
+    This metric computes a score between 0 and 1 for each row representing the precision of the
+    retriever model at the given ``k`` value. Let ``x = min(k, # of retrieved doc IDs)``. Then, the
+    precision at k is calculated as follows:
+    precision_at_k = (# of relevant retrieved doc IDs in top-x ranked documents) / x.
+
+    If no relevant documents are retrieved, the score is 0, indicating that no relevant docs were
+    retrieved. #TODO
+
+    This metric is a builtin metric for the ``'retriever'`` model type, meaning it will be
+    automatically calculated with a default ``k`` value of 3. To use another ``k`` value, you have
+    two options with the ``mlflow.evaluate()`` API:
+        ``evaluator_config={"k": 5}``
+        ``extra_metrics = [mlflow.metrics.precision_at_k(k=5)]``
+            Note that the ``k`` value in the ``evaluator_config`` will be ignored in this case.
     """
     return make_metric(
         eval_fn=_precision_at_k_eval_fn(k),

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -40,9 +40,9 @@ def _validate_and_fix_text_tuple_data(data, metric_name, column_name):
 
     for index, value in data.items():
         if not isinstance(value, tuple) or not all(isinstance(val, str) for val in value):
+            # Single entry tuples are automatically unpacked by Pandas.
+            # So if the entry is a string, put it back into a tuple.
             if isinstance(value, str):
-                # Single entry tuples get unpacked.
-                # So if the entry is a string, put them back into a tuple.
                 data[index] = (value,)
             else:
                 _logger.warning(

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1306,8 +1306,8 @@ def evaluate(
             https://pypi.org/project/textstat
 
      - For retriever models, the default evaluator logs:
-        - **metrics**: ``precision_at_k``: precision at k with the default value of k = 3. To use
-          a different value of k, specify the ``evaluator_config`` parameter to include ``"k"``:
+        - **metrics**: ``precision_at_k``: has a default value of k = 3. To use a different
+          value for k, include ``"k"`` in the ``evaluator_config`` parameter:
           ``evaluator_config={"k":5}``.
         - **artifacts**: A JSON file containing the inputs, outputs, targets, and per-row metrics
           of the model in tabular format.
@@ -1355,9 +1355,9 @@ def evaluate(
           metrics.
         - **col_mapping**: A dictionary mapping column names in the input dataset or output
           predictions to column names used when invoking the evaluation functions.
-        - **k**: The number of top retrieved documents to use when computing the built-in metric
-          precision_at_k for model type "retriever". Default value is 3. For other model types,
-          this parameter will be ignored.
+        - **k**: The number of top-ranked retrieved documents to use when computing the built-in
+          metric ``precision_at_k`` for model_type="retriever". Default value is 3. For all other
+          model types, this parameter will be ignored.
 
      - Limitations of evaluation dataset:
         - For classification tasks, dataset labels are used to infer the total number of classes.

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1672,9 +1672,7 @@ class DefaultEvaluator(ModelEvaluator):
                 elif self.model_type == _ModelType.TEXT:
                     self.builtin_metrics = text_metrics
                 elif self.model_type == _ModelType.RETRIEVER:
-                    if self.evaluator_config.get("k", None) is None:
-                        self.evaluator_config["k"] = 3  # Setting the default k to 3
-                    k = self.evaluator_config.pop("k")
+                    k = self.evaluator_config.pop("k", 3)  # default k to 3 if not specified
                     if not (isinstance(k, int) and k > 0):
                         _logger.warning(
                             "Cannot calculate 'precision_at_k' for invalid parameter 'k'."


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/bbqiu/mlflow/pull/10120?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10120/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10120
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Changed docs to look like this:
![image](https://github.com/mlflow/mlflow/assets/55931436/6d46ffdb-2a9f-4616-9066-37a78a99aae5)


![image](https://github.com/mlflow/mlflow/assets/55931436/69312cbf-ca79-4625-ba2a-b371fb35c482)


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
