### PR TITLE
Enrich unit tests for nested Array data type

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -907,14 +907,13 @@ def _enforce_array(data: Any, arr: Array, required=True):
     if not required and data is None:
         return None
     if not isinstance(data, (list, np.ndarray)):
-        if np.isscalar(data):
-            data = [data]
-        else:
-            raise MlflowException(f"Expected data to be list, got {type(data).__name__}")
+        raise MlflowException(f"Expected data to be list, got {type(data).__name__}")
     if isinstance(arr.dtype, DataType):
         return [_enforce_datatype(x, arr.dtype) for x in data]
     if isinstance(arr.dtype, Object):
         return [_enforce_object(x, arr.dtype) for x in data]
+    if isinstance(arr.dtype, Array):
+        return [_enforce_array(x, arr.dtype) for x in data]
     raise MlflowException(f"Failed to enforce schema of data `{data}` with dtype `{arr.dtype}`")
 
 

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -907,12 +907,6 @@ def _enforce_array(data: Any, arr: Array, required=True):
     if not required and data is None:
         return None
 
-    if len(data) == 0:
-        raise MlflowException(
-            "Expected a non-empty list/array for Array column. If you want an empty value, "
-            "mark the column `required=False` and put `None` instead."
-        )
-
     if not isinstance(data, (list, np.ndarray)):
         raise MlflowException(f"Expected data to be list, got {type(data).__name__}")
     if isinstance(arr.dtype, DataType):

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -906,6 +906,13 @@ def _enforce_datatype(data: Any, dtype: DataType):
 def _enforce_array(data: Any, arr: Array, required=True):
     if not required and data is None:
         return None
+
+    if len(data) == 0:
+        raise MlflowException(
+            "Expected a non-empty list/array for Array column. If you want an empty value, "
+            "mark the column `required=False` and put `None` instead."
+        )
+
     if not isinstance(data, (list, np.ndarray)):
         raise MlflowException(f"Expected data to be list, got {type(data).__name__}")
     if isinstance(arr.dtype, DataType):

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -115,7 +115,7 @@ def _infer_colspec_type(data: Any) -> Union[DataType, Array, Object]:
         for k, v in data.items():
             properties.append(Property(name=k, dtype=_infer_colspec_type(v)))
         return Object(properties=properties)
-    if isinstance(data, list):
+    if isinstance(data, (list, np.ndarray)):
         # We accept None in list to provide backward compatibility
         data = [x for x in data if not _is_none_or_nan(x)]
         if len(data) == 0:

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -137,6 +137,31 @@ def test_signature_inference_infers_input_and_output_as_expected():
     assert sig1.outputs == sig0.inputs
 
 
+def test_infer_signature_on_nested_array():
+    signature = infer_signature(
+        model_input=[{"queries": [["a", "b", "c"], ["d", "e"]]}],
+        model_output=[{"answers": [["f", "g"], ["h"]]}],
+    )
+    assert signature.inputs == Schema([ColSpec(Array(Array(DataType.string)), name="queries")])
+    assert signature.outputs == Schema([ColSpec(Array(Array(DataType.string)), name="answers")])
+
+    signature = infer_signature(
+        model_input=[
+            {
+                "inputs": [
+                    np.array([["a", "b"], ["c", "d"]]),
+                    np.array([["e", "f"], ["g", "h"]]),
+                ]
+            }
+        ],
+        model_output=[{"outputs": [np.int32(5), np.int32(6)]}],
+    )
+    assert signature.inputs == Schema(
+        [ColSpec(Array(Array(Array(DataType.string))), name="inputs")]
+    )
+    assert signature.outputs == Schema([ColSpec(Array(DataType.integer), name="outputs")])
+
+
 def test_infer_signature_on_list_of_dictionaries():
     signature = infer_signature(
         model_input=[{"query": "test query"}],

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -349,7 +349,7 @@ def test_enforce_property_with_errors():
             [
                 [["a", "b"], ["c", "d"]],
                 [["e", "f", "g"], ["h"]],
-                [[]],
+                [["g"]],
             ],
             Array(Array(Array(DataType.string))),
         ),
@@ -363,16 +363,30 @@ def test_enforce_property_with_errors():
             ),
             Array(Array(DataType.string)),
         ),
-        # 6. Empty array
-        (
-            [],
-            Array(DataType.string),
-        ),
     ],
 )
 def test_enforce_array(data, schema):
     data = data.tolist() if isinstance(data, np.ndarray) else data
     assert _enforce_array(data, schema) == data
+
+
+@pytest.mark.parametrize(
+    ("data", "schema"),
+    [
+        ([], Array(DataType.string)),
+        ([[], []], Array(Array(DataType.string))),
+        ([["a", "b"], []], Array(Array(DataType.string))),
+        (np.array([]), Array(Array(DataType.string))),
+        (np.array([[], []]), Array(Array(DataType.string))),
+    ],
+)
+def test_enforce_array_empty(data, schema):
+    with pytest.raises(
+        MlflowException,
+        match="Expected a non-empty list/array for Array column. "
+        "If you want an empty value, mark the column `required=False` and put `None` instead.",
+    ):
+        _enforce_array(data, schema)
 
 
 def test_enforce_array_with_errors():

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -324,9 +324,9 @@ def test_enforce_property_with_errors():
 @pytest.mark.parametrize(
     ("data", "schema"),
     [
-        # 1. Simply array
+        # 1. 1D array
         (["some_sentence1", "some_sentence2"], Array(DataType.string)),
-        # 2. Numpy
+        # 2. Numpy 1D ARRAY
         (np.array(["some_sentence1", "some_sentence2"]), Array(DataType.string)),
         # 3. Array of Object
         (
@@ -349,7 +349,7 @@ def test_enforce_property_with_errors():
             [
                 [["a", "b"], ["c", "d"]],
                 [["e", "f", "g"], ["h"]],
-                [["g"]],
+                [[]],
             ],
             Array(Array(Array(DataType.string))),
         ),
@@ -363,30 +363,15 @@ def test_enforce_property_with_errors():
             ),
             Array(Array(DataType.string)),
         ),
+        # 6. Empty 1D array
+        ([], Array(DataType.string)),
+        # 7. Empty numpy 2D array
+        (np.array([[], []]), Array(Array(DataType.string))),
     ],
 )
 def test_enforce_array(data, schema):
     data = data.tolist() if isinstance(data, np.ndarray) else data
     assert _enforce_array(data, schema) == data
-
-
-@pytest.mark.parametrize(
-    ("data", "schema"),
-    [
-        ([], Array(DataType.string)),
-        ([[], []], Array(Array(DataType.string))),
-        ([["a", "b"], []], Array(Array(DataType.string))),
-        (np.array([]), Array(Array(DataType.string))),
-        (np.array([[], []]), Array(Array(DataType.string))),
-    ],
-)
-def test_enforce_array_empty(data, schema):
-    with pytest.raises(
-        MlflowException,
-        match="Expected a non-empty list/array for Array column. "
-        "If you want an empty value, mark the column `required=False` and put `None` instead.",
-    ):
-        _enforce_array(data, schema)
 
 
 def test_enforce_array_with_errors():

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -363,6 +363,11 @@ def test_enforce_property_with_errors():
             ),
             Array(Array(DataType.string)),
         ),
+        # 6. Empty array
+        (
+            [],
+            Array(DataType.string),
+        ),
     ],
 )
 def test_enforce_array(data, schema):

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -326,7 +326,7 @@ def test_enforce_property_with_errors():
     [
         # 1. 1D array
         (["some_sentence1", "some_sentence2"], Array(DataType.string)),
-        # 2. Numpy 1D ARRAY
+        # 2. Numpy 1D Array
         (np.array(["some_sentence1", "some_sentence2"]), Array(DataType.string)),
         # 3. Array of Object
         (

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -321,50 +321,53 @@ def test_enforce_property_with_errors():
         )
 
 
-def test_enforce_array():
-    # Simple array
-    data = ["some_sentence1", "some_sentence2"]
-    arr = Array(DataType.string)
-    assert _enforce_array(data, arr) == data
-
-    # Numpy
-    data = np.array(["some_sentence1", "some_sentence2"])
-    assert _enforce_array(data, Array(DataType.string)) == ["some_sentence1", "some_sentence2"]
-
-    # Array of objects
-    data = [
-        {"a": "some_sentence1", "b": "some_sentence2"},
-        {"a": "some_sentence3", "c": ["some_sentence4", "some_sentence5"]},
-    ]
-    arr = Array(
-        Object(
+@pytest.mark.parametrize(
+    ("data", "schema"),
+    [
+        # 1. Simply array
+        (["some_sentence1", "some_sentence2"], Array(DataType.string)),
+        # 2. Numpy
+        (np.array(["some_sentence1", "some_sentence2"]), Array(DataType.string)),
+        # 3. Array of Object
+        (
             [
-                Property("a", DataType.string),
-                Property("b", DataType.string, required=False),
-                Property("c", Array(DataType.string), required=False),
-            ]
-        )
-    )
-    assert _enforce_array(data, arr) == data
-
-    # Nested array
-    data = [
-        [["a", "b"], ["c", "d"]],
-        [["e", "f", "g"], ["h"]],
-        [[]],
-    ]
-    arr = Array(Array(Array(DataType.string)))
-    assert _enforce_array(data, arr) == data
-
-    # Numpy 2d array
-    data = np.array(
-        [
-            ["a", "b"],
-            ["c", "d"],
-        ]
-    )
-    arr = Array(Array(DataType.string))
-    assert _enforce_array(data, arr) == [["a", "b"], ["c", "d"]]
+                {"a": "some_sentence1", "b": "some_sentence2"},
+                {"a": "some_sentence3", "c": ["some_sentence4", "some_sentence5"]},
+            ],
+            Array(
+                Object(
+                    [
+                        Property("a", DataType.string),
+                        Property("b", DataType.string, required=False),
+                        Property("c", Array(DataType.string), required=False),
+                    ]
+                )
+            ),
+        ),
+        # 4. Nested array
+        (
+            [
+                [["a", "b"], ["c", "d"]],
+                [["e", "f", "g"], ["h"]],
+                [[]],
+            ],
+            Array(Array(Array(DataType.string))),
+        ),
+        # 5. Numpy 2D array
+        (
+            np.array(
+                [
+                    ["a", "b"],
+                    ["c", "d"],
+                ]
+            ),
+            Array(Array(DataType.string)),
+        ),
+    ],
+)
+def test_enforce_array(data, schema):
+    data = data.tolist() if isinstance(data, np.ndarray) else data
+    assert _enforce_array(data, schema) == data
 
 
 def test_enforce_array_with_errors():

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -2088,11 +2088,13 @@ def test_pyfunc_model_schema_enforcement_with_objects_and_arrays(data, schema):
                     "object_column": {"query": ["sentence_1", "sentence_2"], "table": "some_table"},
                     "string_column": "some_string",
                     "array_column": [{"name": "value"}, {"name": "value"}],
+                    "nested_array_column": [["token1", "token2", "token3"], ["token4", "token5"]],
                 },
                 {
                     "object_column": {"query": ["sentence_1", "sentence_2"]},
                     "string_column": "some_string",
                     "array_column": [{"name": "value"}],
+                    "nested_array_column": [["token1"], ["token2", "token3"]],
                 },
             ],
             Schema(
@@ -2110,6 +2112,10 @@ def test_pyfunc_model_schema_enforcement_with_objects_and_arrays(data, schema):
                     ColSpec(
                         Array(Object([Property("name", DataType.string)])),
                         "array_column",
+                    ),
+                    ColSpec(
+                        Array(Array(DataType.string)),
+                        "nested_array_column",
                     ),
                 ]
             ),

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1600,6 +1600,8 @@ def test_schema_inference_on_dictionaries(data, data_type):
             [np.datetime64("2023-10-13 00:00:00"), np.datetime64("2023-10-14 00:00:00")],
             DataType.datetime,
         ),
+        ([["a", "b"], ["c"]], Array(DataType.string)),
+        ([np.array([np.int32(1), np.int32(2)]), np.array([np.int32(3)])], Array(DataType.integer)),
     ],
 )
 def test_schema_inference_on_lists(data, data_type):
@@ -1607,6 +1609,9 @@ def test_schema_inference_on_lists(data, data_type):
 
     test_data = [{"data": data}]
     assert _infer_schema(test_data) == Schema([ColSpec(Array(data_type), name="data")])
+
+    test_data = [{"data": [data]}]
+    assert _infer_schema(test_data) == Schema([ColSpec(Array(Array(data_type)), name="data")])
 
     test_data = [{"data": {"dict": data}}, {"data": {"dict": data, "string": "a"}}]
     inferred_schema = _infer_schema(test_data)

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -375,11 +375,6 @@ def test_schema_inference_on_list_of_dicts():
     )
 
 
-def test_mixed_string_and_numpy_array_with_errors():
-    with pytest.raises(MlflowException, match=r"Data is not one of the supported DataType"):
-        _infer_schema({"a": np.array([1, 2, 3]), "b": "c"})
-
-
 def test_dict_input_valid_checks_on_keys():
     match = "The dictionary keys are not all strings or "
     # User-defined keys


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

`Array` data type has been added to support LLM input (#9893). This PR add test cases for nested Array.

A few changes are made for a few edge cases found;
1. Add recursive call in `_enforce_array` to support nested array.
2. Remove conversion from single scalar to list when specified data type is `Array`, at [models/utils.py#L910-L911](https://github.com/mlflow/mlflow/blob/llm_signature/mlflow/models/utils.py#L910-L911). IMO we should throw exception when data type is Array but value is not.

**Callout**
I've also found an interesting case with an empty array. In current implementation of [_infer_colspec_type](https://github.com/mlflow/mlflow/blob/llm_signature/mlflow/types/utils.py#L106), we don't allow empty list, which is reasonable as we can't infer schema from it. However, this also throws exception when nested array has empty sub-array, like `[["a", "b"], []]`, as it simply call `_infer_colspec_type` to each element recursively.

I'm wondering if we want to allow this case, because we can infer column type using the other element in this case. Probably need concrete example usage to conclude... idk what kind of scenario model input has nested array, and whether or not it's likely to have empty sub-array. Interested to hear opinions from other ppl.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
