### PR TITLE
Fixing the definition of relevance to consider context

### DIFF
--- a/mlflow/metrics/genai/metric_definitions.py
+++ b/mlflow/metrics/genai/metric_definitions.py
@@ -219,7 +219,7 @@ def answer_relevance(
     """
     This function will create a genai metric used to evaluate the answer relevance of an LLM
     using the model provided. Answer relevance will be assessed based on the appropriateness and
-    applicability of the output with respect to the input.
+    applicability of the output with respect to the input based on the provided context.
 
     An MlflowException will be raised if the specified version for this metric does not exist.
 

--- a/mlflow/metrics/genai/prompts/v1.py
+++ b/mlflow/metrics/genai/prompts/v1.py
@@ -304,16 +304,23 @@ class AnswerCorrectnessMetric:
 class AnswerRelevanceMetric:
     definition = (
         "Answer relevance measures the appropriateness and applicability of the output with "
-        "respect to the input. Scores should reflect the extent to which the output directly "
+        "respect to the input based on the context provided which is considered to be correct. "
+        "The context provides more information that is used to generate the provided output. "
+        "Scores should reflect the extent to which the output directly "
         "addresses the question provided in the input, and give lower scores for incomplete or "
         "redundant output."
     )
 
     grading_prompt = (
         "Answer relevance: Please give a score from 1-5 based on the degree of relevance to the "
-        "input, where the lowest and highest scores are defined as follows:"
+        "input based on the provided context, where the lowest and highest scores are "
+        "defined as follows:\n"
         "- Score 1: the output doesn't mention anything about the question or is completely "
         "irrelevant to the input.\n"
+        "- Score 2: the output provides some relevance to the input and outputs one aspect "
+        "of the input correctly using the context.\n"
+        "- Score 3: the output mostly outputs for the input based on the provided context but "
+        "is missing or hallucinating on one critical aspect based on the provided context.\n"
         "- Score 5: the output addresses all aspects of the question and all parts of the output "
         "are meaningful and relevant to the question."
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sunishsheth2009/mlflow/pull/10134?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10134/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10134
```

</p>
</details>

### What changes are proposed in this pull request?
Fixing the definition of relevance to consider context.
We do include grading_context=['context'] but we never consider context in the prompt.

Using the new prompt, we get better results with human annotations. 
Previous prompt: 15.11627906976744% match
New prompt: 88.37209302325582% match

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
