### PR TITLE
LLM Eval: Support passing a single grading context column as a string

### DIFF
--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -110,10 +110,10 @@ def make_genai_metric(
         "openai:/gpt-4". Your use of a third party LLM service (e.g., OpenAI) for
         evaluation may be subject to and governed by the LLM service's terms of use.
     :param grading_context_columns: (Optional) The name of the grading context column, or a list of
-        grading context column names, required to compute the metric. These grading_context_columns
-        are used by the LLM as a judge as additional information to compute the metric. The columns
-        are extracted from the input dataset or output predictions based on col_mapping in
-        evaluator_config.
+        grading context column names, required to compute the metric. The
+        ``grading_context_columns`` are used by the LLM as a judge as additional information to
+        compute the metric. The columns are extracted from the input dataset or output predictions
+        based on ``col_mapping`` in the ``evaluator_config`` passed to :py:func:`mlflow.evaluate()`.
     :param parameters: (Optional) Parameters for the LLM used to compute the metric. By default, we
         set the temperature to 0.0, max_tokens to 200, and top_p to 1.0. We recommend
         setting the temperature to 0.0 for the LLM used as a judge to ensure consistent results.

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -109,10 +109,11 @@ def make_genai_metric(
         "openai:/gpt-4" or "gateway:/my-route". Defaults to
         "openai:/gpt-4". Your use of a third party LLM service (e.g., OpenAI) for
         evaluation may be subject to and governed by the LLM service's terms of use.
-    :param grading_context_columns: (Optional) grading_context_columns required to compute
-        the metric. These grading_context_columns are used by the LLM as a judge as additional
-        information to compute the metric. The columns are extracted from the input dataset or
-        output predictions based on col_mapping in evaluator_config.
+    :param grading_context_columns: (Optional) The name of the grading context column, or a list of
+        grading context column names, required to compute the metric. These grading_context_columns
+        are used by the LLM as a judge as additional information to compute the metric. The columns
+        are extracted from the input dataset or output predictions based on col_mapping in
+        evaluator_config.
     :param parameters: (Optional) Parameters for the LLM used to compute the metric. By default, we
         set the temperature to 0.0, max_tokens to 200, and top_p to 1.0. We recommend
         setting the temperature to 0.0 for the LLM used as a judge to ensure consistent results.

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -188,7 +188,7 @@ def make_genai_metric(
         )
     """
     if not isinstance(grading_context_columns, list):
-        grading_context_columns = list(grading_context_columns)
+        grading_context_columns = [grading_context_columns]
 
     class_name = f"mlflow.metrics.genai.prompts.{version}.EvaluationModel"
     try:

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -214,8 +214,6 @@ def make_genai_metric(
         *(parameters,) if parameters is not None else (),
     ).to_dict()
 
-    print("EVAL CONTEXT", evaluation_context)
-
     def eval_fn(
         predictions: "pd.Series",
         metrics: Dict[str, MetricValue],
@@ -225,9 +223,7 @@ def make_genai_metric(
         """
         This is the function that is called when the metric is evaluated.
         """
-        print("ARGS", args)
         eval_values = dict(zip(grading_context_columns, args))
-        print("EVAL VALUES", eval_values)
 
         outputs = predictions.to_list()
         inputs = inputs.to_list()

--- a/mlflow/metrics/genai/prompts/v1.py
+++ b/mlflow/metrics/genai/prompts/v1.py
@@ -72,6 +72,8 @@ class EvaluationModel:
             else f"Examples:\n{self._format_examples()}"
         )
 
+        print("EXAMPLES STR", examples_str)
+
         return {
             "model": self.model,
             "eval_prompt": grading_system_prompt_template.partial_fill(
@@ -84,6 +86,8 @@ class EvaluationModel:
         }
 
     def _format_examples(self):
+        print("EXAMPLES", self.examples)
+        print("FORMATTED", "\n".join(map(str, self.examples)))
         return "\n".join(map(str, self.examples))
 
 

--- a/mlflow/metrics/genai/prompts/v1.py
+++ b/mlflow/metrics/genai/prompts/v1.py
@@ -72,8 +72,6 @@ class EvaluationModel:
             else f"Examples:\n{self._format_examples()}"
         )
 
-        print("EXAMPLES STR", examples_str)
-
         return {
             "model": self.model,
             "eval_prompt": grading_system_prompt_template.partial_fill(
@@ -86,8 +84,6 @@ class EvaluationModel:
         }
 
     def _format_examples(self):
-        print("EXAMPLES", self.examples)
-        print("FORMATTED", "\n".join(map(str, self.examples)))
         return "\n".join(map(str, self.examples))
 
 

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -277,8 +277,17 @@ def test_make_genai_metric_supports_string_value_for_grading_context_columns():
         definition="Fake metric definition",
         grading_prompt="Fake metric grading prompt",
         model="openai:/gpt-3.5-turbo",
-        grading_context_columns=["targets"],
+        grading_context_columns="targets",
         greater_is_better=True,
+        examples=[
+            EvaluationExample(
+                input="example-input",
+                output="example-output",
+                score=4,
+                justification="example-justification",
+                grading_context={"targets": "example-ground_truth"},
+            )
+        ],
     )
 
     assert [

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -270,6 +270,62 @@ def test_make_genai_metric_correct_response():
         assert metric_value.aggregate_results == {"mean": 3.0, "p90": 3.0, "variance": 0.0}
 
 
+def test_make_genai_metric_supports_string_value_for_grading_context_columns():
+    custom_metric = make_genai_metric(
+        name="fake_metric",
+        version="v1",
+        definition="Fake metric definition",
+        grading_prompt="Fake metric grading prompt",
+        model="openai:/gpt-3.5-turbo",
+        grading_context_columns=["targets"],
+        greater_is_better=True,
+    )
+
+    assert [
+        param.name for param in inspect.signature(custom_metric.eval_fn).parameters.values()
+    ] == ["predictions", "metrics", "inputs", "targets"]
+
+    with mock.patch.object(
+        model_utils,
+        "score_model_on_payload",
+        return_value=properly_formatted_openai_response1,
+    ) as mock_predict_function:
+        metric_value = custom_metric.eval_fn(
+            pd.Series(["prediction"]),
+            {},
+            pd.Series(["input"]),
+            pd.Series(["ground_truth"]),
+        )
+        assert mock_predict_function.call_count == 1
+        assert mock_predict_function.call_args[0][0] == "openai:/gpt-3.5-turbo"
+        assert mock_predict_function.call_args[0][1] == {
+            "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
+            "sent to a machine\nlearning model, and you will be given an output that the model "
+            "produced. You\nmay also be given additional information that was used by the model "
+            "to generate the output.\n\nYour task is to determine a numerical score called "
+            "fake_metric based on the input and output.\nA definition of "
+            "fake_metric and a grading rubric are provided below.\nYou must use the "
+            "grading rubric to determine your score. You must also justify your score."
+            "\n\nExamples could be included below for reference. Make sure to use them as "
+            "references and to\nunderstand them before completing the task.\n"
+            "\nInput:\ninput\n\nOutput:\nprediction\n\nAdditional information used by the model:\n"
+            "key: targets\nvalue:\nground_truth\n\nMetric definition:\nFake metric definition\n\n"
+            "Grading rubric:\nFake metric grading prompt\n\nExamples:\n\nInput:\nexample-input\n\n"
+            "Output:\nexample-output\n\nAdditional information used by the model:\nkey: targets\n"
+            "value:\nexample-ground_truth\n\nscore: 4\njustification: "
+            "example-justification\n        \n\nYou must return the following fields in your "
+            "response one below the other:\nscore: Your numerical score for the model's "
+            "fake_metric based on the rubric\njustification: Your step-by-step reasoning about "
+            "the model's fake_metric score\n    ",
+            "temperature": 0.0,
+            "max_tokens": 200,
+            "top_p": 1.0,
+        }
+        assert metric_value.scores == [3]
+        assert metric_value.justifications == [openai_justification1]
+        assert metric_value.aggregate_results == {"mean": 3.0, "p90": 3.0, "variance": 0.0}
+
+
 def test_make_genai_metric_incorrect_response():
     custom_metric = make_genai_metric(
         name="correctness",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/10136?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10136/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10136
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

LLM Eval: Support passing a single grading context column as a string

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
