### PR TITLE
Change the way of validating databricks auth in `mlflow.login()`

### DIFF
--- a/mlflow/utils/credentials.py
+++ b/mlflow/utils/credentials.py
@@ -89,13 +89,14 @@ def _check_databricks_auth():
     try:
         w = WorkspaceClient()
         # If credentials are invalid, `clusters.list()` will throw an error.
-        w.current_user.me()
+        w.clusters.list()
         _logger.info(
             "Succesfully signed in Databricks! Please run `mlflow.set_tracking_uri('databricks')` "
             "to connect MLflow to Databricks tracking server."
         )
         return True
-    except Exception:
+    except Exception as e:
+        _logger.error(f"Failed to sign in Databricks: {e}")
         return False
 
 

--- a/tests/utils/test_credentials.py
+++ b/tests/utils/test_credentials.py
@@ -104,6 +104,7 @@ mlflow_tracking_password = password_file
 
 
 def test_mlflow_login(tmp_path, monkeypatch):
+    # Mock `input()` and `getpass()` to return host, username and password in order.
     with patch(
         "builtins.input", side_effect=["https://community.cloud.databricks.com/", "dummyusername"]
     ), patch("getpass.getpass", side_effect=["dummypassword"]):

--- a/tests/utils/test_credentials.py
+++ b/tests/utils/test_credentials.py
@@ -113,12 +113,12 @@ def test_mlflow_login(tmp_path, monkeypatch):
         monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", profile)
 
         class FakeWorkspaceClient:
-            class FakeUser:
-                def me(self):
-                    return ["dummyusername"]
+            class FakeClusters:
+                def list(self):
+                    return ["dummy_cluster"]
 
             def __init__(self):
-                self.current_user = FakeWorkspaceClient.FakeUser()
+                self.clusters = FakeWorkspaceClient.FakeClusters()
 
         with patch(
             "databricks.sdk.WorkspaceClient",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/10139?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10139/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10139
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Previous we use `WorkspaceClient().current_user.me()` to validate credentials, but the new change to it is not compatible with Databricks CE. We are switching the validation method to `WorkspaceClient().clusters.list()`, which is more stable and reliable. Time-cost wise, it's also returning instantly.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
