### PR TITLE
Fix incorrect docstring of mlflow evaluate

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1180,16 +1180,15 @@ def evaluate(
     baseline_config=None,
 ):
     '''
-    Evaluate a PyFunc model on the specified dataset using one or more specified ``evaluators``, and
-    log resulting metrics & artifacts to MLflow Tracking. Set thresholds on the generated metrics to
-    validate model quality. For additional overview information, see
-    :ref:`the Model Evaluation documentation <model-evaluation>`.
+    Evaluate a PyFunc model or custom callable on the specified dataset using specified
+    ``evaluators``, and log resulting metrics & artifacts to MLflow tracking server. For additional
+    overview information, see :ref:`the Model Evaluation documentation <model-evaluation>`.
 
     Default Evaluator behavior:
      - The default evaluator, which can be invoked with ``evaluators="default"`` or
-       ``evaluators=None``, supports the ``"regressor"`` and ``"classifier"`` model types.
-       It generates a variety of model performance metrics, model performance plots, and
-       model explanations.
+       ``evaluators=None``, supports model types listed below. For each pre-defined model type, the
+       default evaluator evaluates your model on a selected set of metrics and generate artifacts
+       like plots. Please find more details below.
 
      - For both the ``"regressor"`` and ``"classifier"`` model types, the default evaluator
        generates model summary plots and feature importance plots using
@@ -1213,12 +1212,12 @@ def evaluate(
           precision_recall_auc), precision-recall merged curves plot, ROC merged curves plot.
 
      - For question-answering models, the default evaluator logs:
-        - **metrics**: ``exact_match``, ``token_count``, `toxicity_ratio`_ (requires `evaluate`_,
-          `pytorch`_, `mean_flesch_kincaid_grade_level`_ (requires `textstat`_).
+        - **metrics**: ``exact_match``, ``token_count``, `toxicity`_ (requires `evaluate`_,
+          `pytorch`_, `flesch_kincaid_grade_level`_ (requires `textstat`_) and `ari_grade_level`_.
         - **artifacts**: A JSON file containing the inputs, outputs, targets (if the ``targets``
           argument is supplied), and per-row metrics of the model in tabular format.
 
-        .. _toxicity_ratio:
+        .. _toxicity:
             https://huggingface.co/spaces/evaluate-measurement/toxicity
 
         .. _pytorch:
@@ -1227,10 +1226,10 @@ def evaluate(
         .. _transformers:
             https://huggingface.co/docs/transformers/installation
 
-        .. _mean_ari_grade_level:
+        .. _ari_grade_level:
             https://en.wikipedia.org/wiki/Automated_readability_index
 
-        .. _mean_flesch_kincaid_grade_level:
+        .. _flesch_kincaid_grade_level:
             https://en.wikipedia.org/wiki/Flesch%E2%80%93Kincaid_readability_tests#Flesch%E2%80%93Kincaid_grade_level
 
         .. _evaluate:
@@ -1241,16 +1240,16 @@ def evaluate(
 
      - For text-summarization models, the default evaluator logs:
         - **metrics**: ``token_count``, `ROUGE`_ (requires `evaluate`_, `nltk`_, and
-          `rouge_score`_ to be installed), `toxicity_ratio`_ (requires `evaluate`_, `pytorch`_,
-          `transformers`_), `mean_ari_grade_level`_ (requires `textstat`_),
-          `mean_flesch_kincaid_grade_level`_ (requires `textstat`_).
+          `rouge_score`_ to be installed), `toxicity`_ (requires `evaluate`_, `pytorch`_,
+          `transformers`_), `ari_grade_level`_ (requires `textstat`_),
+          `flesch_kincaid_grade_level`_ (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, targets (if the ``targets``
           argument is supplied), and per-row metrics of the model in the tabular format.
 
         .. _ROUGE:
             https://huggingface.co/spaces/evaluate-metric/rouge
 
-        .. _toxicity_ratio:
+        .. _toxicity:
             https://huggingface.co/spaces/evaluate-measurement/toxicity
 
         .. _pytorch:
@@ -1259,10 +1258,10 @@ def evaluate(
         .. _transformers:
             https://huggingface.co/docs/transformers/installation
 
-        .. _mean_ari_grade_level:
+        .. _ari_grade_level:
             https://en.wikipedia.org/wiki/Automated_readability_index
 
-        .. _mean_flesch_kincaid_grade_level:
+        .. _flesch_kincaid_grade_level:
             https://en.wikipedia.org/wiki/Flesch%E2%80%93Kincaid_readability_tests#Flesch%E2%80%93Kincaid_grade_level
 
         .. _evaluate:
@@ -1278,16 +1277,16 @@ def evaluate(
             https://pypi.org/project/textstat
 
      - For text models, the default evaluator logs:
-        - **metrics**: ``token_count``, `toxicity_ratio`_ (requires `evaluate`_, `pytorch`_,
-          `transformers`_), `mean_ari_grade_level`_ (requires `textstat`_),
-          `mean_flesch_kincaid_grade_level`_ (requires `textstat`_).
+        - **metrics**: ``token_count``, `toxicity`_ (requires `evaluate`_, `pytorch`_,
+          `transformers`_), `ari_grade_level`_ (requires `textstat`_),
+          `flesch_kincaid_grade_level`_ (requires `textstat`_).
         - **artifacts**: A JSON file containing the inputs, outputs, targets (if the ``targets``
           argument is supplied), and per-row metrics of the model in tabular format.
 
         .. _evaluate:
             https://pypi.org/project/evaluate
 
-        .. _toxicity_ratio:
+        .. _toxicity:
             https://huggingface.co/spaces/evaluate-measurement/toxicity
 
         .. _pytorch:
@@ -1296,10 +1295,10 @@ def evaluate(
         .. _transformers:
             https://huggingface.co/docs/transformers/installation
 
-        .. _mean_ari_grade_level:
+        .. _ari_grade_level:
             https://en.wikipedia.org/wiki/Automated_readability_index
 
-        .. _mean_flesch_kincaid_grade_level:
+        .. _flesch_kincaid_grade_level:
             https://en.wikipedia.org/wiki/Flesch%E2%80%93Kincaid_readability_tests#Flesch%E2%80%93Kincaid_grade_level
 
         .. _textstat:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/10142?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10142/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10142
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

There are some errors in the `mlflow.evaluate` API docstring, this PR updates the docstring to reflect the current status.

IMO this docstring needs a big refactoring, it's over complex and not quite readable. We don't necessarily need to make it perfect before 2.8 release though.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
