### PR TITLE
Use process_api_requests to handle retry logic

### DIFF
--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -273,9 +273,7 @@ def make_genai_metric(
                 **eval_parameters,
             }
             try:
-                raw_result = model_utils.score_model_on_payload(
-                    eval_model, payload, judge_request_timeout
-                )
+                raw_result = model_utils.score_model_on_payload(eval_model, payload)
                 return _extract_score_and_justification(raw_result)
             except Exception as e:
                 if isinstance(e, MlflowException):

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -79,10 +79,12 @@ def _call_openai_api(openai_uri, payload):
     from mlflow.openai.api_request_parallel_processor import process_api_requests
     from mlflow.openai.utils import _OAITokenHolder
 
+    api_token = _OAITokenHolder(os.environ.get("OPENAI_API_TYPE", "openai"))
+
     resp = process_api_requests(
         [openai_provider._add_model_to_payload_if_necessary(payload)],
         openai.ChatCompletion,
-        api_token=_OAITokenHolder(""),
+        api_token=api_token,
         max_requests_per_minute=3_500,
         max_tokens_per_minute=90_000,
     )[0]

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -9,13 +9,13 @@ ROUTE_TYPE = "llm/v1/completions"
 
 
 # TODO: improve this name
-def score_model_on_payload(model_uri, payload, timeout):
+def score_model_on_payload(model_uri, payload):
     """Call the model identified by the given uri with the given payload."""
 
     prefix, suffix = _parse_model_uri(model_uri)
 
     if prefix == "openai":
-        return _call_openai_api(suffix, payload, timeout)
+        return _call_openai_api(suffix, payload)
     elif prefix == "gateway":
         return _call_gateway_api(suffix, payload)
     elif prefix in ("model", "runs"):
@@ -40,7 +40,7 @@ def _parse_model_uri(model_uri):
     return scheme, path
 
 
-def _call_openai_api(openai_uri, payload, timeout):
+def _call_openai_api(openai_uri, payload):
     """Wrapper around the OpenAI API to make it compatible with the MLflow Gateway API."""
     from mlflow.gateway.config import RouteConfig
     from mlflow.gateway.providers.openai import OpenAIProvider

--- a/mlflow/openai/api_request_parallel_processor.py
+++ b/mlflow/openai/api_request_parallel_processor.py
@@ -101,7 +101,7 @@ class APIRequest:
             status_tracker.complete_task(success=True)
             self.results.append((self.index, response))
         except openai.error.RateLimitError as e:
-            _logger.warning(f"Request #{self.index} failed with {e!r}")
+            _logger.debug(f"Request #{self.index} failed with {e!r}")
             status_tracker.time_of_last_rate_limit_error = time.time()
             status_tracker.increment_num_rate_limit_errors()
             retry_queue.put_nowait(self)
@@ -112,7 +112,7 @@ class APIRequest:
             openai.error.APIConnectionError,
             openai.error.ServiceUnavailableError,
         ) as e:
-            _logger.warning(f"Request #{self.index} failed with {e!r}")
+            _logger.debug(f"Request #{self.index} failed with {e!r}")
             status_tracker.increment_num_api_errors()
             if self.attempts_left > 0:
                 retry_queue.put_nowait(self)
@@ -122,14 +122,14 @@ class APIRequest:
         except openai.error.InvalidRequestError as e:
             if e.error.code == "content_filter" and e.error.innererror:
                 content_filter_result = e.error.innererror.content_filter_result
-                _logger.warning(
+                _logger.debug(
                     f"Request #{self.index} failed because of content filtering: "
                     f"{content_filter_result}"
                 )
                 status_tracker.increment_num_api_errors()
                 status_tracker.complete_task(success=False)
         except Exception as e:
-            _logger.warning(f"Request #{self.index} failed with {e!r}")
+            _logger.debug(f"Request #{self.index} failed with {e!r}")
             status_tracker.increment_num_api_errors()
             status_tracker.complete_task(success=False)
 
@@ -223,8 +223,7 @@ def process_api_requests(
             if next_request is None:
                 if not retry_queue.empty():
                     next_request = retry_queue.get_nowait()
-                    _logger.warning(f"Retrying request {next_request.index}")
-                    _logger.debug(f"Request being retried: {next_request}")
+                    _logger.debug(f"Retrying request {next_request.index}: {next_request}")
                 elif req := next(requests_iter, None):
                     # get new request
                     index, request_json = req

--- a/mlflow/openai/api_request_parallel_processor.py
+++ b/mlflow/openai/api_request_parallel_processor.py
@@ -223,7 +223,8 @@ def process_api_requests(
             if next_request is None:
                 if not retry_queue.empty():
                     next_request = retry_queue.get_nowait()
-                    _logger.warning(f"Retrying request {next_request.index}: {next_request}")
+                    _logger.warning(f"Retrying request {next_request.index}")
+                    _logger.debug(f"Request being retried: {next_request}")
                 elif req := next(requests_iter, None):
                     # get new request
                     index, request_json = req

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -39,3 +39,5 @@ tiktoken
 ipywidgets
 tqdm
 databricks-sdk
+# Required for LLM eval in `mlflow.evaluate`
+openai

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -1,6 +1,5 @@
 from unittest import mock
 
-import openai
 import pytest
 
 from mlflow.exceptions import MlflowException
@@ -100,7 +99,7 @@ def test_score_model_openai(set_envs):
                     "messages": [{"role": "user", "content": "my prompt"}],
                 }
             ],
-            openai.ChatCompletion,
+            mock.ANY,
             api_token=mock.ANY,
             max_requests_per_minute=3_500,
             max_tokens_per_minute=90_000,
@@ -142,7 +141,7 @@ def test_score_model_azure_openai(set_azure_envs):
                     "messages": [{"role": "user", "content": "my prompt"}],
                 }
             ],
-            openai.ChatCompletion,
+            mock.ANY,
             api_token=mock.ANY,
             max_requests_per_minute=3_500,
             max_tokens_per_minute=90_000,

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -56,12 +56,12 @@ def test_parse_model_uri_throws_for_malformed():
 
 def test_score_model_on_payload_throws_for_invalid():
     with pytest.raises(MlflowException, match="Unknown model uri prefix"):
-        score_model_on_payload("myprovider:/gpt-3.5-turbo", {}, 10)
+        score_model_on_payload("myprovider:/gpt-3.5-turbo", {})
 
 
 def test_score_model_openai_without_key():
     with pytest.raises(MlflowException, match="OPENAI_API_KEY environment variable not set"):
-        score_model_on_payload("openai:/gpt-3.5-turbo", {}, 10)
+        score_model_on_payload("openai:/gpt-3.5-turbo", {})
 
 
 def test_score_model_openai(set_envs):
@@ -99,9 +99,7 @@ def test_score_model_openai(set_envs):
     }
 
     with mock.patch("requests.post", return_value=MockResponse(resp, 200)) as mock_post:
-        score_model_on_payload(
-            "openai:/gpt-3.5-turbo", {"prompt": "my prompt", "temperature": 0.1}, 10
-        )
+        score_model_on_payload("openai:/gpt-3.5-turbo", {"prompt": "my prompt", "temperature": 0.1})
         mock_post.assert_called_once_with(
             url="https://api.openai.com/v1/chat/completions",
             headers={"Authorization": "Bearer test"},
@@ -149,9 +147,7 @@ def test_score_model_azure_openai(set_azure_envs):
     }
 
     with mock.patch("requests.post", return_value=MockResponse(resp, 200)) as mock_post:
-        score_model_on_payload(
-            "openai:/gpt-3.5-turbo", {"prompt": "my prompt", "temperature": 0.1}, 10
-        )
+        score_model_on_payload("openai:/gpt-3.5-turbo", {"prompt": "my prompt", "temperature": 0.1})
         mock_post.assert_called_once_with(
             url="https://openai-for.openai.azure.com/openai/deployments/test-openai/chat/"
             "completions?api-version=2023-05-15",
@@ -186,5 +182,5 @@ def test_score_model_gateway():
     }
 
     with mock.patch("mlflow.gateway.query", return_value=expected_output):
-        response = score_model_on_payload("gateway:/my-route", {}, 10)
+        response = score_model_on_payload("gateway:/my-route", {})
         assert response == expected_output


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/prithvikannan/mlflow/pull/10145?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10145/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10145
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Retry LLM judge scoring using OpenAI retry logic.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
