### PR TITLE
Fix indentation for pmdarima

### DIFF
--- a/mlflow/pmdarima/__init__.py
+++ b/mlflow/pmdarima/__init__.py
@@ -108,8 +108,8 @@ _logger = logging.getLogger(__name__)
 def get_default_pip_requirements():
     """
     :return: A list of default pip requirements for MLflow Models produced by this flavor.
-             Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment that,
-             at a minimum, contains these requirements.
+        Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment that,
+        at a minimum, contains these requirements.
     """
 
     return [_get_pinned_requirement("pmdarima")]
@@ -118,7 +118,7 @@ def get_default_pip_requirements():
 def get_default_conda_env():
     """
     :return: The default Conda environment for MLflow Models produced by calls to
-             :func:`save_model()` and :func:`log_model()`
+        :func:`save_model()` and :func:`log_model()`
     """
 
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
@@ -141,44 +141,44 @@ def save_model(
     Save a pmdarima ``ARIMA`` model or ``Pipeline`` object to a path on the local file system.
 
     :param pmdarima_model: pmdarima ``ARIMA`` or ``Pipeline`` model that has been ``fit`` on a
-                           temporal series.
+        temporal series.
     :param path: Local path destination for the serialized model (in pickle format) is to be saved.
     :param conda_env: {{ conda_env }}
     :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
+        containing file dependencies). These files are *prepended* to the system
+        path when the model is loaded.
     :param mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
     :param signature: an instance of the :py:class:`ModelSignature <mlflow.models.ModelSignature>`
-                      class that describes the model's inputs and outputs. If not specified but an
-                      ``input_example`` is supplied, a signature will be automatically inferred
-                      based on the supplied input example and model. To disable automatic signature
-                      inference when providing an input example, set ``signature`` to ``False``.
-                      To manually infer a model signature, call
-                      :py:func:`infer_signature() <mlflow.models.infer_signature>` on datasets
-                      with valid model inputs, such as a training dataset with the target column
-                      omitted, and valid model outputs, like model predictions made on the training
-                      dataset, for example:
+        class that describes the model's inputs and outputs. If not specified but an
+        ``input_example`` is supplied, a signature will be automatically inferred
+        based on the supplied input example and model. To disable automatic signature
+        inference when providing an input example, set ``signature`` to ``False``.
+        To manually infer a model signature, call
+        :py:func:`infer_signature() <mlflow.models.infer_signature>` on datasets
+        with valid model inputs, such as a training dataset with the target column
+        omitted, and valid model outputs, like model predictions made on the training
+        dataset, for example:
 
-                      .. code-block:: python
+        .. code-block:: python
 
-                        from mlflow.models import infer_signature
+        from mlflow.models import infer_signature
 
-                        model = pmdarima.auto_arima(data)
-                        predictions = model.predict(n_periods=30, return_conf_int=False)
-                        signature = infer_signature(data, predictions)
+        model = pmdarima.auto_arima(data)
+        predictions = model.predict(n_periods=30, return_conf_int=False)
+        signature = infer_signature(data, predictions)
 
-                      .. Warning:: if utilizing confidence interval generation in the ``predict``
-                        method of a ``pmdarima`` model (``return_conf_int=True``), the signature
-                        will not be inferred due to the complex tuple return type when using the
-                        native ``ARIMA.predict()`` API. ``infer_schema`` will function correctly
-                        if using the ``pyfunc`` flavor of the model, though.
+        .. Warning:: if utilizing confidence interval generation in the ``predict``
+        method of a ``pmdarima`` model (``return_conf_int=True``), the signature
+        will not be inferred due to the complex tuple return type when using the
+        native ``ARIMA.predict()`` API. ``infer_schema`` will function correctly
+        if using the ``pyfunc`` flavor of the model, though.
     :param input_example: {{ input_example }}
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
     :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
+        .. Note:: Experimental: This parameter may change or be removed in a future
+                                release without warning.
 
     .. code-block:: python
         :caption: Example
@@ -297,55 +297,56 @@ def log_model(
     Log a ``pmdarima`` ``ARIMA`` or ``Pipeline`` object as an MLflow artifact for the current run.
 
     :param pmdarima_model: pmdarima ``ARIMA`` or ``Pipeline`` model that has been ``fit`` on a
-                           temporal series.
+        temporal series.
     :param artifact_path: Run-relative artifact path to save the model instance to.
     :param conda_env: {{ conda_env }}
     :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
+        containing file dependencies). These files are *prepended* to the system
+        path when the model is loaded.
     :param registered_model_name: This argument may change or be removed in a
-                                  future release without warning. If given, create a model
-                                  version under ``registered_model_name``, also creating a
-                                  registered model if one with the given name does not exist.
+        future release without warning. If given, create a model
+        version under ``registered_model_name``, also creating a
+        registered model if one with the given name does not exist.
     :param signature: an instance of the :py:class:`ModelSignature <mlflow.models.ModelSignature>`
-                      class that describes the model's inputs and outputs. If not specified but an
-                      ``input_example`` is supplied, a signature will be automatically inferred
-                      based on the supplied input example and model. To disable automatic signature
-                      inference when providing an input example, set ``signature`` to ``False``.
-                      To manually infer a model signature, call
-                      :py:func:`infer_signature() <mlflow.models.infer_signature>` on datasets
-                      with valid model inputs, such as a training dataset with the target column
-                      omitted, and valid model outputs, like model predictions made on the training
-                      dataset, for example:
+        class that describes the model's inputs and outputs. If not specified but an
+        ``input_example`` is supplied, a signature will be automatically inferred
+        based on the supplied input example and model. To disable automatic signature
+        inference when providing an input example, set ``signature`` to ``False``.
+        To manually infer a model signature, call
+        :py:func:`infer_signature() <mlflow.models.infer_signature>` on datasets
+        with valid model inputs, such as a training dataset with the target column
+        omitted, and valid model outputs, like model predictions made on the training
+        dataset, for example:
 
-                      .. code-block:: python
+        .. code-block:: python
 
-                        from mlflow.models import infer_signature
+        from mlflow.models import infer_signature
 
-                        model = pmdarima.auto_arima(data)
-                        predictions = model.predict(n_periods=30, return_conf_int=False)
-                        signature = infer_signature(data, predictions)
+        model = pmdarima.auto_arima(data)
+        predictions = model.predict(n_periods=30, return_conf_int=False)
+        signature = infer_signature(data, predictions)
 
-                      .. Warning:: if utilizing confidence interval generation in the ``predict``
-                        method of a ``pmdarima`` model (``return_conf_int=True``), the signature
-                        will not be inferred due to the complex tuple return type when using the
-                        native ``ARIMA.predict()`` API. ``infer_schema`` will function correctly
-                        if using the ``pyfunc`` flavor of the model, though.
+        .. Warning:: if utilizing confidence interval generation in the ``predict``
+        method of a ``pmdarima`` model (``return_conf_int=True``), the signature
+        will not be inferred due to the complex tuple return type when using the
+        native ``ARIMA.predict()`` API. ``infer_schema`` will function correctly
+        if using the ``pyfunc`` flavor of the model, though.
 
     :param input_example: {{ input_example }}
     :param await_registration_for: Number of seconds to wait for the model version
-                                   to finish being created and is in ``READY`` status.
-                                   By default, the function waits for five minutes.
-                                   Specify 0 or None to skip waiting.
+        to finish being created and is in ``READY`` status.
+        By default, the function waits for five minutes.
+        Specify 0 or None to skip waiting.
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
     :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
+        .. Note:: Experimental: This parameter may change or be removed in a future
+                                release without warning.
+
     :param kwargs: Additional arguments for :py:class:`mlflow.models.model.Model`
     :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
-             metadata of the logged model.
+        metadata of the logged model.
 
     .. code-block:: python
         :caption: Example
@@ -409,18 +410,19 @@ def load_model(model_uri, dst_path=None):
 
     :param model_uri: The location, in URI format, of the MLflow model. For example:
 
-                      - ``/Users/me/path/to/local/model``
-                      - ``relative/path/to/local/model``
-                      - ``s3://my_bucket/path/to/model``
-                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
-                      - ``mlflow-artifacts:/path/to/model``
+        - ``/Users/me/path/to/local/model``
+        - ``relative/path/to/local/model``
+        - ``s3://my_bucket/path/to/model``
+        - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+        - ``mlflow-artifacts:/path/to/model``
 
-                      For more information about supported URI schemes, see
-                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
-                      artifact-locations>`_.
+        For more information about supported URI schemes, see
+        `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
+        artifact-locations>`_.
+
     :param dst_path: The local filesystem path to which to download the model artifact.
-                     This directory must already exist. If unspecified, a local output
-                     path will be created.
+        This directory must already exist. If unspecified, a local output
+        path will be created.
 
     :return: A ``pmdarima`` model instance
 
@@ -525,8 +527,8 @@ class _PmdarimaModelWrapper:
         :param dataframe: Model input data.
         :param params: Additional parameters to pass to the model for inference.
 
-                       .. Note:: Experimental: This parameter may change or be removed in a future
-                                               release without warning.
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                                    release without warning.
 
         :return: Model predictions.
         """


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mberk06/mlflow/pull/10147?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10147/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10147
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
