### PR TITLE
Some fixes to `mlflow.login`

### DIFF
--- a/mlflow/utils/credentials.py
+++ b/mlflow/utils/credentials.py
@@ -182,7 +182,7 @@ def _databricks_login():
 
     while True:
         host = input("Databricks Host (should begin with https://): ")
-        if _check_databricks_host(host):
+        if _is_valid_databricks_host(host):
             break
 
     profile = {"host": host}

--- a/mlflow/utils/credentials.py
+++ b/mlflow/utils/credentials.py
@@ -76,7 +76,7 @@ def login(backend="databricks"):
         )
 
 
-def _check_databricks_host(host):
+def _is_valid_databricks_host(host):
     # Check if the host is a valid Databricks URL: 1) start with https://, 2) end with
     # "databricks.com" or "databricks.com/"
     if not host.startswith("https://"):

--- a/mlflow/utils/credentials.py
+++ b/mlflow/utils/credentials.py
@@ -2,7 +2,6 @@ import configparser
 import getpass
 import logging
 import os
-import urllib
 from typing import NamedTuple, Optional, Tuple
 
 from mlflow.environment_variables import MLFLOW_TRACKING_PASSWORD, MLFLOW_TRACKING_USERNAME

--- a/mlflow/utils/credentials.py
+++ b/mlflow/utils/credentials.py
@@ -77,32 +77,6 @@ def login(backend="databricks"):
         )
 
 
-def _is_valid_databricks_host(host):
-    # Check if the host is a valid Databricks URL: 1) starts with https://. 2) has "databricks.com"
-    # in the domain. 3) No params/query/fragment in the URL.
-    if not host.startswith("https://"):
-        _logger.error(f"Host must start with 'https://', but received: {host}")
-        return False
-
-    parsed_url = urllib.parse.urlparse(host)
-    if not "databricks.com" in parsed_url.netloc:
-        # A valid Databricks host must have "databricks.com" in the domain.
-        _logger.error(
-            f"Invalid Databricks host: {host}. The host must have 'databricks.com' in the domain."
-            "A valid URL is like https://community.cloud.databricks.com"
-        )
-        return False
-    if parsed_url.params or parsed_url.query or parsed_url.fragment:
-        _logger.error(
-            f"Invalid Databricks host: {host}. The host must not contain params/query/fragment"
-            ", please remove it from the host URL. A valid URL is like "
-            "https://community.cloud.databricks.com"
-        )
-        return False
-
-    return True
-
-
 def _check_databricks_auth():
     # Check if databricks credentials are set.
     try:
@@ -188,8 +162,9 @@ def _databricks_login():
 
     while True:
         host = input("Databricks Host (should begin with https://): ")
-        if _is_valid_databricks_host(host):
-            break
+        if not host.startswith("https://"):
+            _logger.error("Invalid host: {host}, host must begin with https://, please retry.")
+        break
 
     profile = {"host": host}
     if "community" in host:

--- a/tests/utils/test_credentials.py
+++ b/tests/utils/test_credentials.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
+from mlflow import get_tracking_uri
 from mlflow.environment_variables import MLFLOW_TRACKING_PASSWORD, MLFLOW_TRACKING_USERNAME
 from mlflow.exceptions import MlflowException
 from mlflow.utils.credentials import login, read_mlflow_creds
@@ -136,3 +137,6 @@ def test_mlflow_login(tmp_path, monkeypatch):
         assert lines[1] == "host = https://community.cloud.databricks.com/\n"
         assert lines[2] == "username = dummyusername\n"
         assert lines[3] == "password = dummypassword\n"
+
+    # Assert that the tracking URI is set to the databricks.
+    assert get_tracking_uri() == "databricks"

--- a/tests/utils/test_credentials.py
+++ b/tests/utils/test_credentials.py
@@ -107,7 +107,8 @@ mlflow_tracking_password = password_file
 def test_mlflow_login(tmp_path, monkeypatch):
     # Mock `input()` and `getpass()` to return host, username and password in order.
     with patch(
-        "builtins.input", side_effect=["https://community.cloud.databricks.com/", "dummyusername"]
+        "builtins.input",
+        side_effect=["https://community.cloud.databricks.com/", "dummyusername"],
     ), patch("getpass.getpass", side_effect=["dummypassword"]):
         file_name = f"{tmp_path}/.databrickscfg"
         profile = "TEST"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/10180?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10180/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10180
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Two fixes:
- Add `mlflow.set_tracking_uri("databricks")` inside `login`, so that users don't need to call that. We realized people always forget about this line even with prompt log.
- Force host to end with "databricks.com". If the host contains query strings, mlflow rest calls will fail with vague error messages, e.g., `mlflow.set_experiment.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
