### PR TITLE
`_enforce_array` to return numpy array

### DIFF
--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1361,7 +1361,7 @@ def test_spark_udf_structs_and_arrays(spark, tmp_path):
     udf = mlflow.pyfunc.spark_udf(spark=spark, model_uri=save_path, result_type="string")
     pdf = df.withColumn("output", udf("str", "arr", "obj", "obj_arr")).toPandas()
     assert pdf["output"][0] == "a | [0] | {'bool': True} | [{'double': 0.1}]"
-    assert pdf["output"][1] == "b | [1, 2] | {'bool': False} | [{'double': 0.2}, {'double': 0.3}]"
+    assert pdf["output"][1] == "b | [1 2] | {'bool': False} | [{'double': 0.2} {'double': 0.3}]"
 
     # More complex nested structures
     df = spark.createDataFrame(
@@ -1401,5 +1401,5 @@ def test_spark_udf_structs_and_arrays(spark, tmp_path):
     )
     udf = mlflow.pyfunc.spark_udf(spark=spark, model_uri=save_path, result_type="string")
     pdf = df.withColumn("output", udf("test")).toPandas()
-    assert pdf["output"][0] == "[{'arr': [{'bool': True}]}]"
-    assert pdf["output"][1] == "[{'arr': [{'bool': False}]}]"
+    assert pdf["output"][0] == "[{'arr': array([{'bool': True}], dtype=object)}]"
+    assert pdf["output"][1] == "[{'arr': array([{'bool': False}], dtype=object)}]"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10183?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10183/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10183
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

One of follow-ups from #10125, we currently return `list` from `_enforce_array` regardless of input is `list` or `np.ndarray`. Changing data type during validation is not ideal, so this PR just make sure it returns numpy array if input is numpy.

(Indeed, they will be wrapped by pd.Series anyway now but just to avoid any future issue)

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
