### PR TITLE
Onnx tests

### DIFF
--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -235,6 +235,7 @@ def onnx_custom_env(tmp_path):
     _mlflow_conda_env(conda_env, additional_pip_deps=["onnx", "pytest", "torch"])
     return conda_env
 
+
 def test_model_save_load(onnx_model, model_path):
     # New ONNX versions can optionally convert to external data
     if Version(onnx.__version__) >= Version("1.9.0"):
@@ -259,9 +260,7 @@ def test_model_log_load(onnx_model, model_path, save_as_external_data):
 
     with mlflow.start_run():
         model_info = mlflow.onnx.log_model(
-            onnx_model, 
-            artifact_path="model", 
-            save_as_external_data=save_as_external_data
+            onnx_model, artifact_path="model", save_as_external_data=save_as_external_data
         )
 
     if Version(onnx.__version__) >= Version("1.9.0"):
@@ -274,6 +273,7 @@ def test_model_log_load(onnx_model, model_path, save_as_external_data):
     onnx.checker.check_model = mock.Mock()
     mlflow.onnx.load_model(model_info.model_uri)
     assert onnx.checker.check_model.called
+
 
 def test_model_save_load_nonexternal_data(onnx_model, model_path):
     if Version(onnx.__version__) >= Version("1.9.0"):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/10185?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10185/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10185
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve -->

### What changes are proposed in this pull request?

Add tests for the `save_external_data` param of `mlflow.onnx.log_model()`, introduced in #10152. After looking into ONNX serialization, it looks like whether or not the model's tensors are *actually* saved to another file depends on the `size_threshold` param ([link](https://github.com/onnx/onnx/blob/main/onnx/external_data_helper.py#L106)).

Currently, we don't support modifying this param, and it defaults to 1024 bytes. I think this is alright, as the main pain point from the original feature request was to allow users to save large models as a single file, and adding this extra param would only allow users to break small models up into multiple files.

However, this means that it would be kind of finicky to write a test that validates whether an ONNX model is saved on disk as multiple files, since without adding this extra param to `mlflow.onnx.save_model`, we'd have to actually create a large model (or maybe do some mocking). That being said, I think it should suffice to follow the other tests and simply assert that `onnx.convert_model_to_extra_data` was called. In my manual testing (calling `onnx.save_model()` and setting the `size_threshold` to 0), `mlflow.onnx.load_model()` seems to work fine for both single and multi-file model saves.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
