### PR TITLE
UI fixes

### DIFF
--- a/mlflow/server/js/src/model-registry/components/SchemaTable.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/SchemaTable.test.tsx
@@ -6,9 +6,11 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
+
 import { SchemaTable } from './SchemaTable';
 import { MemoryRouter } from '../../common/utils/RoutingUtils';
-import { fireEvent, renderWithIntl } from '../../common/utils/TestUtils';
+import { renderWithIntl } from '../../common/utils/TestUtils';
 
 function clickHeaderRow(container: HTMLElement, rowIndex: number): void {
   // click to render inputs table
@@ -16,13 +18,7 @@ function clickHeaderRow(container: HTMLElement, rowIndex: number): void {
   if (rows.length < rowIndex + 1) {
     throw new Error("Couldn't find the row to click");
   }
-  fireEvent(
-    rows[rowIndex],
-    new MouseEvent('click', {
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
+  userEvent.click(rows[rowIndex]);
 }
 
 describe('SchemaTable', () => {
@@ -288,13 +284,7 @@ describe('SchemaTable', () => {
     if (row === null) {
       throw new Error("Couldn't find SchemaTable header row");
     }
-    fireEvent(
-      row,
-      new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-      }),
-    );
+    userEvent.click(row);
 
     const signatures = container.getElementsByTagName('pre');
     expect(signatures).toHaveLength(2);

--- a/mlflow/server/js/src/model-registry/components/SchemaTable.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/SchemaTable.test.tsx
@@ -26,7 +26,6 @@ function clickHeaderRow(container: HTMLElement, rowIndex: number): void {
 }
 
 describe('SchemaTable', () => {
-  let wrapper: any;
   let minimalProps: any;
   let props: any;
 
@@ -52,16 +51,16 @@ describe('SchemaTable', () => {
   });
 
   test('should render with minimal props without exploding', () => {
-    const container = renderWithIntl(<SchemaTable {...minimalProps} />).container;
+    const { container } = renderWithIntl(<SchemaTable {...minimalProps} />);
     expect(container).not.toBeNull();
   });
 
   test('should nested table not be rendered by default', () => {
-    const container = renderWithIntl(
+    const { container } = renderWithIntl(
       <MemoryRouter>
         <SchemaTable {...props} />
       </MemoryRouter>,
-    ).container;
+    );
     expect(container.querySelector('.outer-table table')).not.toBeNull();
     expect(container.querySelector('.inner-table table')).toBeNull();
     expect(container.innerHTML).toContain('Inputs');
@@ -75,11 +74,11 @@ describe('SchemaTable', () => {
   });
 
   test('should inputs table render by click', () => {
-    const container = renderWithIntl(
+    const { container } = renderWithIntl(
       <MemoryRouter>
         <SchemaTable {...props} />
       </MemoryRouter>,
-    ).container;
+    );
 
     expect(container.getElementsByTagName('table')).toHaveLength(1);
     // click to render inputs table
@@ -166,11 +165,11 @@ describe('SchemaTable', () => {
   });
 
   test('should outputs table render by click', () => {
-    const container = renderWithIntl(
+    const { container } = renderWithIntl(
       <MemoryRouter>
         <SchemaTable {...props} />
       </MemoryRouter>,
-    ).container;
+    );
     // click to render outputs table
     expect(container.getElementsByTagName('table')).toHaveLength(1);
     clickHeaderRow(container, 1);
@@ -189,11 +188,11 @@ describe('SchemaTable', () => {
   });
 
   test('should inputs and outputs table render by click', () => {
-    const container = renderWithIntl(
+    const { container } = renderWithIntl(
       <MemoryRouter>
         <SchemaTable {...props} />
       </MemoryRouter>,
-    ).container;
+    );
     expect(container.getElementsByTagName('table')).toHaveLength(1);
     // click to render inputs and outputs table
     clickHeaderRow(container, 0);
@@ -231,11 +230,11 @@ describe('SchemaTable', () => {
         ],
       },
     };
-    const container = renderWithIntl(
+    const { container } = renderWithIntl(
       <MemoryRouter>
         <SchemaTable {...props} />
       </MemoryRouter>,
-    ).container;
+    );
     expect(container.getElementsByTagName('table')).toHaveLength(1);
     // click to render inputs and outputs table
     clickHeaderRow(container, 0);
@@ -278,11 +277,11 @@ describe('SchemaTable', () => {
       },
     };
 
-    const container = renderWithIntl(
+    const { container } = renderWithIntl(
       <MemoryRouter>
         <SchemaTable {...props} />
       </MemoryRouter>,
-    ).container;
+    );
 
     // click to render input schema table
     const row = container.querySelector('tr.section-header-row');

--- a/mlflow/server/js/src/model-registry/components/SchemaTable.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/SchemaTable.test.tsx
@@ -6,14 +6,27 @@
  */
 
 import React from 'react';
-import { shallow, render } from 'enzyme';
 import { SchemaTable } from './SchemaTable';
-import { Table } from 'antd';
 import { MemoryRouter } from '../../common/utils/RoutingUtils';
-import { mountWithIntl } from '../../common/utils/TestUtils';
+import { fireEvent, renderWithIntl } from '../../common/utils/TestUtils';
+
+function clickHeaderRow(container: HTMLElement, rowIndex: number): void {
+  // click to render inputs table
+  const rows = container.querySelectorAll('tr.section-header-row');
+  if (rows.length < rowIndex + 1) {
+    throw new Error("Couldn't find the row to click");
+  }
+  fireEvent(
+    rows[rowIndex],
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
 
 describe('SchemaTable', () => {
-  let wrapper;
+  let wrapper: any;
   let minimalProps: any;
   let props: any;
 
@@ -39,49 +52,50 @@ describe('SchemaTable', () => {
   });
 
   test('should render with minimal props without exploding', () => {
-    wrapper = mountWithIntl(<SchemaTable {...minimalProps} />);
-    expect(wrapper.length).toBe(1);
+    const container = renderWithIntl(<SchemaTable {...minimalProps} />).container;
+    expect(container).not.toBeNull();
   });
 
   test('should nested table not be rendered by default', () => {
-    wrapper = mountWithIntl(
+    const container = renderWithIntl(
       <MemoryRouter>
         <SchemaTable {...props} />
       </MemoryRouter>,
-    );
-    expect(wrapper.find(Table).length).toBe(1);
-    expect(wrapper.find('.outer-table').find(Table).length).toBe(1);
-    expect(wrapper.find('.inner-table').find(Table).length).toBe(0);
-    expect(wrapper.html()).toContain('Inputs');
-    expect(wrapper.html()).toContain('Outputs');
-    expect(wrapper.html()).toContain('Name');
-    expect(wrapper.html()).toContain('Type');
-    expect(wrapper.html()).not.toContain('column1');
-    expect(wrapper.html()).not.toContain('string');
-    expect(wrapper.html()).not.toContain('score1');
-    expect(wrapper.html()).not.toContain('long');
+    ).container;
+    expect(container.querySelector('.outer-table table')).not.toBeNull();
+    expect(container.querySelector('.inner-table table')).toBeNull();
+    expect(container.innerHTML).toContain('Inputs');
+    expect(container.innerHTML).toContain('Outputs');
+    expect(container.innerHTML).toContain('Name');
+    expect(container.innerHTML).toContain('Type');
+    expect(container.innerHTML).not.toContain('column1');
+    expect(container.innerHTML).not.toContain('string');
+    expect(container.innerHTML).not.toContain('score1');
+    expect(container.innerHTML).not.toContain('long');
   });
 
   test('should inputs table render by click', () => {
-    wrapper = mountWithIntl(
+    const container = renderWithIntl(
       <MemoryRouter>
         <SchemaTable {...props} />
       </MemoryRouter>,
-    );
-    expect(wrapper.find(Table).length).toBe(1);
+    ).container;
+
+    expect(container.getElementsByTagName('table')).toHaveLength(1);
     // click to render inputs table
-    wrapper.find('tr.section-header-row').at(0).simulate('click');
-    expect(wrapper.find(Table).length).toBe(2);
-    expect(wrapper.find('.outer-table').find(Table).length).toBe(2);
-    expect(wrapper.find('.inner-table').find(Table).length).toBe(1);
-    expect(wrapper.html()).toContain('Inputs');
-    expect(wrapper.html()).toContain('Outputs');
-    expect(wrapper.html()).toContain('Name');
-    expect(wrapper.html()).toContain('Type');
-    expect(wrapper.html()).toContain('column1');
-    expect(wrapper.html()).toContain('string');
-    expect(wrapper.html()).not.toContain('score1');
-    expect(wrapper.html()).not.toContain('long');
+    clickHeaderRow(container, 0);
+
+    expect(container.getElementsByTagName('table')).toHaveLength(2);
+    expect(container.querySelectorAll('.outer-table table')).toHaveLength(2);
+    expect(container.querySelectorAll('.inner-table table')).toHaveLength(1);
+    expect(container.innerHTML).toContain('Inputs');
+    expect(container.innerHTML).toContain('Outputs');
+    expect(container.innerHTML).toContain('Name');
+    expect(container.innerHTML).toContain('Type');
+    expect(container.innerHTML).toContain('column1');
+    expect(container.innerHTML).toContain('string');
+    expect(container.innerHTML).not.toContain('score1');
+    expect(container.innerHTML).not.toContain('long');
   });
 
   test('Should display optional input field schema as expected', () => {
@@ -95,19 +109,19 @@ describe('SchemaTable', () => {
         outputs: [{ name: 'score1', type: 'long' }],
       },
     };
-    wrapper = mountWithIntl(
+    const wrapper = renderWithIntl(
       <MemoryRouter>
         <SchemaTable {...props} />
       </MemoryRouter>,
     );
     // click to render input schema table
-    wrapper.find('tr.section-header-row').at(0).simulate('click');
-    expect(wrapper.html()).toContain('column1');
+    clickHeaderRow(wrapper.container, 0);
+    expect(wrapper.container.innerHTML).toContain('column1');
     // the optional input param should have (optional) after the name"
-    const col2 = wrapper.find('span').filterWhere((n: any) => n.text().includes('column2'));
-    expect(render(col2.get(0)).text()).toContain('column2 (optional)');
-    expect(wrapper.html()).toContain('string');
-    expect(wrapper.html()).toContain('float');
+    const col2 = wrapper.getByText('column2');
+    expect(col2.textContent).toEqual('column2 (optional)');
+    expect(wrapper.container.innerHTML).toContain('string');
+    expect(wrapper.container.innerHTML).toContain('float');
   });
 
   test('Should display required input field schema as expected', () => {
@@ -118,17 +132,17 @@ describe('SchemaTable', () => {
         outputs: [{ name: 'score', type: 'long', required: true }],
       },
     };
-    wrapper = mountWithIntl(
+    const wrapper = renderWithIntl(
       <MemoryRouter>
         <SchemaTable {...props} />
       </MemoryRouter>,
     );
     // click to render input schema table
-    wrapper.find('tr.section-header-row').at(0).simulate('click');
-    expect(wrapper.html()).toContain('column');
+    clickHeaderRow(wrapper.container, 0);
+    expect(wrapper.container.innerHTML).toContain('column');
     // the optional input param should have (optional) after the name"
-    const col2 = wrapper.find('span').filterWhere((n: any) => n.text().includes('column'));
-    expect(render(col2.get(0)).text()).toContain('column (required)');
+    const col2 = wrapper.getByText('column');
+    expect(col2.textContent).toEqual('column (required)');
   });
 
   test('Should display optional output field schema as expected', () => {
@@ -139,62 +153,63 @@ describe('SchemaTable', () => {
         outputs: [{ name: 'score1', type: 'long', optional: true }],
       },
     };
-    wrapper = mountWithIntl(
+    const wrapper = renderWithIntl(
       <MemoryRouter>
         <SchemaTable {...props} />
       </MemoryRouter>,
     );
     // click to render output schema table
-    wrapper.find('tr.section-header-row').at(1).simulate('click');
+    clickHeaderRow(wrapper.container, 1);
     // the optional output name should have (optional) after the name
-    const score1 = wrapper.find('span').filterWhere((n: any) => n.text().includes('score1'));
-    expect(render(score1).text()).toContain('score1 (optional)');
+    const score1 = wrapper.getByText('score1');
+    expect(score1.textContent).toEqual('score1 (optional)');
   });
 
   test('should outputs table render by click', () => {
-    wrapper = mountWithIntl(
+    const container = renderWithIntl(
       <MemoryRouter>
         <SchemaTable {...props} />
       </MemoryRouter>,
-    );
+    ).container;
     // click to render outputs table
-    expect(wrapper.find(Table).length).toBe(1);
-    wrapper.find('tr.section-header-row').at(1).simulate('click');
-    expect(wrapper.find(Table).length).toBe(2);
-    expect(wrapper.find('.outer-table').find(Table).length).toBe(2);
-    expect(wrapper.find('.inner-table').find(Table).length).toBe(1);
-    expect(wrapper.html()).toContain('Inputs');
-    expect(wrapper.html()).toContain('Outputs');
-    expect(wrapper.html()).toContain('Name');
-    expect(wrapper.html()).toContain('Type');
-    expect(wrapper.html()).not.toContain('column1');
-    expect(wrapper.html()).not.toContain('string');
-    expect(wrapper.html()).toContain('score1');
-    expect(wrapper.html()).toContain('long');
+    expect(container.getElementsByTagName('table')).toHaveLength(1);
+    clickHeaderRow(container, 1);
+
+    expect(container.getElementsByTagName('table')).toHaveLength(2);
+    expect(container.querySelectorAll('.outer-table table')).toHaveLength(2);
+    expect(container.querySelectorAll('.inner-table table')).toHaveLength(1);
+    expect(container.innerHTML).toContain('Inputs');
+    expect(container.innerHTML).toContain('Outputs');
+    expect(container.innerHTML).toContain('Name');
+    expect(container.innerHTML).toContain('Type');
+    expect(container.innerHTML).not.toContain('column1');
+    expect(container.innerHTML).not.toContain('string');
+    expect(container.innerHTML).toContain('score1');
+    expect(container.innerHTML).toContain('long');
   });
 
   test('should inputs and outputs table render by click', () => {
-    wrapper = mountWithIntl(
+    const container = renderWithIntl(
       <MemoryRouter>
         <SchemaTable {...props} />
       </MemoryRouter>,
-    );
-    expect(wrapper.find(Table).length).toBe(1);
+    ).container;
+    expect(container.getElementsByTagName('table')).toHaveLength(1);
     // click to render inputs and outputs table
-    wrapper.find('tr.section-header-row').at(0).simulate('click');
-    expect(wrapper.find(Table).length).toBe(2);
-    wrapper.find('tr.section-header-row').at(1).simulate('click');
-    expect(wrapper.find(Table).length).toBe(3);
-    expect(wrapper.find('.outer-table').find(Table).length).toBe(3);
-    expect(wrapper.find('.inner-table').find(Table).length).toBe(2);
-    expect(wrapper.html()).toContain('Inputs');
-    expect(wrapper.html()).toContain('Outputs');
-    expect(wrapper.html()).toContain('Name');
-    expect(wrapper.html()).toContain('Type');
-    expect(wrapper.html()).toContain('column1');
-    expect(wrapper.html()).toContain('string');
-    expect(wrapper.html()).toContain('score1');
-    expect(wrapper.html()).toContain('long');
+    clickHeaderRow(container, 0);
+    expect(container.getElementsByTagName('table')).toHaveLength(2);
+    clickHeaderRow(container, 1);
+    expect(container.getElementsByTagName('table')).toHaveLength(3);
+    expect(container.querySelectorAll('.outer-table table')).toHaveLength(3);
+    expect(container.querySelectorAll('.inner-table table')).toHaveLength(2);
+    expect(container.innerHTML).toContain('Inputs');
+    expect(container.innerHTML).toContain('Outputs');
+    expect(container.innerHTML).toContain('Name');
+    expect(container.innerHTML).toContain('Type');
+    expect(container.innerHTML).toContain('column1');
+    expect(container.innerHTML).toContain('string');
+    expect(container.innerHTML).toContain('score1');
+    expect(container.innerHTML).toContain('long');
   });
 
   test('Should display tensorSpec as expected', () => {
@@ -216,27 +231,27 @@ describe('SchemaTable', () => {
         ],
       },
     };
-    wrapper = mountWithIntl(
+    const container = renderWithIntl(
       <MemoryRouter>
         <SchemaTable {...props} />
       </MemoryRouter>,
-    );
-    expect(wrapper.find(Table).length).toBe(1);
+    ).container;
+    expect(container.getElementsByTagName('table')).toHaveLength(1);
     // click to render inputs and outputs table
-    wrapper.find('tr.section-header-row').at(0).simulate('click');
-    expect(wrapper.find(Table).length).toBe(2);
-    wrapper.find('tr.section-header-row').at(1).simulate('click');
-    expect(wrapper.find(Table).length).toBe(3);
-    expect(wrapper.find('.outer-table').find(Table).length).toBe(3);
-    expect(wrapper.find('.inner-table').find(Table).length).toBe(2);
-    expect(wrapper.html()).toContain('Inputs');
-    expect(wrapper.html()).toContain('Outputs');
-    expect(wrapper.html()).toContain('Name');
-    expect(wrapper.html()).toContain('Type');
-    expect(wrapper.html()).toContain('TensorInput');
-    expect(wrapper.html()).toContain('Tensor (dtype: float64, shape: [-1,28,28])');
-    expect(wrapper.html()).toContain('TensorOutput');
-    expect(wrapper.html()).toContain('Tensor (dtype: float64, shape: [-1])');
+    clickHeaderRow(container, 0);
+    expect(container.getElementsByTagName('table')).toHaveLength(2);
+    clickHeaderRow(container, 1);
+    expect(container.getElementsByTagName('table')).toHaveLength(3);
+    expect(container.querySelectorAll('.outer-table table')).toHaveLength(3);
+    expect(container.querySelectorAll('.inner-table table')).toHaveLength(2);
+    expect(container.innerHTML).toContain('Inputs');
+    expect(container.innerHTML).toContain('Outputs');
+    expect(container.innerHTML).toContain('Name');
+    expect(container.innerHTML).toContain('Type');
+    expect(container.innerHTML).toContain('TensorInput');
+    expect(container.innerHTML).toContain('Tensor (dtype: float64, shape: [-1,28,28])');
+    expect(container.innerHTML).toContain('TensorOutput');
+    expect(container.innerHTML).toContain('Tensor (dtype: float64, shape: [-1])');
   });
 
   test('should render object/array column types correctly', () => {
@@ -263,17 +278,28 @@ describe('SchemaTable', () => {
       },
     };
 
-    wrapper = mountWithIntl(
+    const container = renderWithIntl(
       <MemoryRouter>
         <SchemaTable {...props} />
       </MemoryRouter>,
-    );
-    // click to render input schema table
-    wrapper.find('tr.section-header-row').at(0).simulate('click');
+    ).container;
 
-    const signatures = wrapper.find('pre');
+    // click to render input schema table
+    const row = container.querySelector('tr.section-header-row');
+    if (row === null) {
+      throw new Error("Couldn't find SchemaTable header row");
+    }
+    fireEvent(
+      row,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    const signatures = container.getElementsByTagName('pre');
     expect(signatures).toHaveLength(2);
-    expect(shallow(signatures.get(0)).text()).toEqual('{\n  prop1: string\n}');
-    expect(shallow(signatures.get(1)).text()).toEqual('Array(binary)');
+    expect(signatures[0].textContent).toEqual('{\n  prop1: string\n}');
+    expect(signatures[1].textContent).toEqual('Array(binary)');
   });
 });

--- a/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/SchemaTable.tsx
@@ -13,6 +13,8 @@ import { gray800 } from '../../common/styles/color';
 import { spacingMedium } from '../../common/styles/spacing';
 import { ColumnSpec, TensorSpec, ColumnType } from '../types/model-schema';
 import { FormattedMessage, injectIntl } from 'react-intl';
+import { Theme } from '@databricks/design-system/dist/theme';
+import { Interpolation } from '@emotion/react';
 
 const { Column } = Table;
 const { Text } = Typography;
@@ -84,18 +86,7 @@ function formatColumnName(spec: ColumnSpec | TensorSpec): React.ReactElement {
 function formatColumnSchema(spec: ColumnSpec | TensorSpec): React.ReactElement {
   const repr = spec.type === 'tensor' ? getTensorTypeRepr(spec) : getColumnTypeRepr(spec, 0);
 
-  return (
-    <pre
-      style={{
-        padding: 8,
-        marginTop: 8,
-        marginBottom: 8,
-        whiteSpace: 'pre-wrap',
-      }}
-    >
-      {repr}
-    </pre>
-  );
+  return <pre css={schemaTableStyles.signatureCodeBlock}>{repr}</pre>;
 }
 
 export class SchemaTableImpl extends React.PureComponent<Props> {
@@ -302,4 +293,10 @@ const schemaTableStyles = {
     lineHeight: '32px',
     cursor: 'pointer',
   },
+  signatureCodeBlock: (theme: Theme): Interpolation<Theme> => ({
+    whiteSpace: 'pre-wrap',
+    padding: theme.spacing.sm,
+    marginTop: theme.spacing.sm,
+    marginBottom: theme.spacing.sm,
+  }),
 };


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/10190?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10190/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10190
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve -->

### What changes are proposed in this pull request?

Addressing post-merge feedback from #10088

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Checked that the schema table looks the same as in #10088

https://github.com/mlflow/mlflow/assets/148037680/7088352d-32d0-48df-8add-42e7826b303b


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
