### PR TITLE
Add tests for pyfunc predict and serving

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -758,10 +758,10 @@ def _enforce_schema(pf_input: PyFuncInput, input_schema: Schema):
                 ):
                     pf_input = pd.DataFrame([pf_input])
                 elif isinstance(pf_input, dict) and all(
-                    isinstance(value, np.ndarray)
-                    and value.dtype.type == np.str_
-                    and value.size == 1
-                    and value.shape == ()
+                    isinstance(value, np.ndarray) and value.dtype.type == np.str_
+                    # size & shape constraint makes some data batch inference result not
+                    # consistent with serving result.
+                    and value.size == 1 and value.shape == ()
                     for value in pf_input.values()
                 ):
                     # This check is specifically to handle the serving structural cast for

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import os
 from collections import defaultdict
+from copy import deepcopy
 from functools import partial
 from json import JSONEncoder
 from typing import Any, Dict, Optional
@@ -365,10 +366,15 @@ def parse_tf_serving_input(inp_dict, schema=None):
     import numpy as np
 
     def cast_schema_type(input_data):
+        input_data = deepcopy(input_data)
         if schema is not None:
             if schema.has_input_names():
                 input_names = schema.input_names()
-                if len(input_names) == 1 and isinstance(input_data, list):
+                if (
+                    len(input_names) == 1
+                    and isinstance(input_data, list)
+                    and not any(isinstance(x, dict) for x in input_data)
+                ):
                     # for schemas with a single column, match input with column
                     input_data = {input_names[0]: input_data}
                 if not isinstance(input_data, dict):

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -1920,3 +1920,176 @@ def test_pyfunc_model_input_example_with_params(sample_params_basic, param_schem
     assert response.status_code == 200, response.content
     result = json.loads(response.content.decode("utf-8"))["predictions"]
     assert result == ["input1"]
+
+
+@pytest.mark.parametrize(
+    ("data", "schema"),
+    [
+        ({"a": np.array([1, 2, 3])}, Schema([ColSpec(DataType.long, name="a")])),
+        ({"query": "sentence"}, Schema([ColSpec(DataType.string, name="query")])),
+        (
+            {"query": ["sentence_1", "sentence_2"]},
+            Schema([ColSpec(DataType.string, name="query")]),
+        ),
+        (
+            {"query": ["sentence_1", "sentence_2"], "table": "some_table"},
+            Schema(
+                [
+                    ColSpec(DataType.string, name="query"),
+                    ColSpec(DataType.string, name="table"),
+                ]
+            ),
+        ),
+        (
+            [{"query": "sentence"}, {"query": "sentence"}],
+            Schema([ColSpec(DataType.string, name="query")]),
+        ),
+        (
+            [
+                {"query": ["sentence_1", "sentence_2"], "table": "some_table"},
+                {"query": ["sentence_1", "sentence_2"], "table": "some_table"},
+            ],
+            Schema(
+                [
+                    ColSpec(DataType.string, name="query"),
+                    ColSpec(DataType.string, name="table"),
+                ]
+            ),
+        ),
+    ],
+)
+def test_pyfunc_model_schema_enforcement_with_dicts_and_lists(data, schema):
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input, params=None):
+            return model_input
+
+    signature = ModelSignature(schema)
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            python_model=MyModel(),
+            artifact_path="test_model",
+            signature=signature,
+        )
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    prediction = loaded_model.predict(data)
+    if isinstance(data, dict) and all(
+        isinstance(x, str) or (isinstance(x, list) and all(isinstance(y, str) for y in x))
+        for x in data.values()
+    ):
+        df = pd.DataFrame([data])
+    else:
+        df = pd.DataFrame(data)
+    pd.testing.assert_frame_equal(prediction, df)
+
+    # Test pandas DataFrame input
+    prediction = loaded_model.predict(df)
+    pd.testing.assert_frame_equal(prediction, df)
+
+
+@pytest.mark.parametrize(
+    ("data", "schema"),
+    [
+        ({"query": "sentence"}, Schema([ColSpec(DataType.string, name="query")])),
+        (
+            {"query": ["sentence_1", "sentence_2"]},
+            Schema([ColSpec(DataType.string, name="query")]),
+        ),
+        (
+            {"query": ["sentence_1", "sentence_2"], "table": "some_table"},
+            Schema(
+                [
+                    ColSpec(DataType.string, name="query"),
+                    ColSpec(DataType.string, name="table"),
+                ]
+            ),
+        ),
+    ],
+)
+# `instances` is an invalid key for schema with Mlflow < 2.9.0
+@pytest.mark.parametrize("format_key", ["inputs", "dataframe_split", "dataframe_records"])
+def test_pyfunc_model_serving_with_dicts(data, schema, format_key):
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input, params=None):
+            return model_input
+
+    signature = ModelSignature(schema)
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            python_model=MyModel(),
+            artifact_path="test_model",
+            signature=signature,
+        )
+
+    df = (
+        pd.DataFrame([data])
+        if all(isinstance(x, str) for x in data.values())
+        else pd.DataFrame(data)
+    )
+    if format_key == "inputs":
+        payload = {format_key: data}
+    elif format_key in ("dataframe_split", "dataframe_records"):
+        payload = {format_key: df.to_dict(orient=format_key[10:])}
+
+    response = pyfunc_serve_and_score_model(
+        model_info.model_uri,
+        data=json.dumps(payload),
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+    assert response.status_code == 200, response.content
+    result = json.loads(response.content.decode("utf-8"))["predictions"]
+    # This is not consistent with batch inference df
+    pd.testing.assert_frame_equal(pd.DataFrame(result), df)
+
+
+@pytest.mark.parametrize(
+    ("data", "schema"),
+    [
+        (
+            [{"query": "sentence"}, {"query": "sentence"}],
+            Schema([ColSpec(DataType.string, name="query")]),
+        ),
+        (
+            [
+                {"query": ["sentence_1", "sentence_2"], "table": "some_table"},
+                {"query": ["sentence_1", "sentence_2"], "table": "some_table"},
+            ],
+            Schema(
+                [
+                    ColSpec(DataType.string, name="query"),
+                    ColSpec(DataType.string, name="table"),
+                ]
+            ),
+        ),
+    ],
+)
+# `inputs`` is an invalid key for schema with Mlflow < 2.9.0
+@pytest.mark.parametrize("format_key", ["instances", "dataframe_split", "dataframe_records"])
+def test_pyfunc_model_serving_with_lists_of_dicts(data, schema, format_key):
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input, params=None):
+            return model_input
+
+    signature = ModelSignature(schema)
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            python_model=MyModel(),
+            artifact_path="test_model",
+            signature=signature,
+        )
+
+    df = pd.DataFrame(data)
+    if format_key == "instances":
+        payload = {format_key: data}
+    elif format_key in ("dataframe_split", "dataframe_records"):
+        payload = {format_key: df.to_dict(orient=format_key[10:])}
+
+    response = pyfunc_serve_and_score_model(
+        model_info.model_uri,
+        data=json.dumps(payload),
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+    assert response.status_code == 200, response.content
+    result = json.loads(response.content.decode("utf-8"))["predictions"]
+    pd.testing.assert_frame_equal(pd.DataFrame(result), df)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10192?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10192/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10192
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Add more tests that works in master branch before merging llm_signature branch to make sure it doesn't break existing behaviors.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

For recording the strange behaviors I find by writing this PR:

**Code to repro**
```
import mlflow
from mlflow.models.signature import infer_signature


class MyModel(mlflow.pyfunc.PythonModel):
    def predict(self, context, model_input, params=None):
        return model_input

data1 = {"query": ["sentence_1", "sentence_2"]}
data2 = [{"query": "sentence"}, {"query": "sentence"}]
signature1 = infer_signature(data1)
print(f"signature for '{data1}': {signature1}")
# signature for '{'query': ['sentence_1', 'sentence_2']}': inputs: 
#   ['query': string]
# outputs: 
#   None
# params: 
#   None

signature2 = infer_signature(data2)
print(f"signature for '{data2}': {signature2}")
# signature for '[{'query': 'sentence'}, {'query': 'sentence'}]': inputs: 
#   ['query': string]
# outputs: 
#   None
# params: 
#   None

with mlflow.start_run():
    model_info = mlflow.pyfunc.log_model(
        python_model=MyModel(),
        artifact_path="test_model",
        signature=signature1,
    )
print(f"model_uri: {model_info.model_uri}")

loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
result1 = loaded_model.predict(data1)
print(f"prediction for '{data1}': {result1}")
# prediction for '{'query': ['sentence_1', 'sentence_2']}':                       query
# 0  [sentence_1, sentence_2]

result2 = loaded_model.predict(data2)
print(f"prediction for '{data2}': {result2}")
# prediction for '[{'query': 'sentence'}, {'query': 'sentence'}]':       query
# 0  sentence
# 1  sentence
```
**Serve the model, and call the REST API**
Result: 
```
// for data1
curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{"inputs": {"query": ["sentence_1", "sentence_2"]}}'
>> {"predictions": [{"query": "sentence_1"}, {"query": "sentence_2"}]}
```
```
// for data2
curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{"instances": [{"query": "sentence"}, {"query": "sentence"}]}'
>> {"predictions": [{"query": "sentence"}, {"query": "sentence"}]}%    
```
The serving endpoint's result is not consistent with the batch inference result for data1, they're consistent for data2.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
