### PR TITLE
TQDM progressbar for genai metrics

### DIFF
--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -332,7 +332,7 @@ def make_genai_metric(
             try:
                 from tqdm.auto import tqdm
 
-                as_comp = tqdm(as_comp)
+                as_comp = tqdm(as_comp, total=len(futures))
             except ImportError:
                 pass
 

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -330,7 +330,7 @@ def make_genai_metric(
 
             as_comp = as_completed(futures)
             try:
-                from tqdm import tqdm
+                from tqdm.auto import tqdm
 
                 as_comp = tqdm(as_comp)
             except ImportError:

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -5,6 +5,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from inspect import Parameter, Signature
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+from tqdm import tqdm
+
 from mlflow.exceptions import MlflowException
 from mlflow.metrics.base import MetricValue
 from mlflow.metrics.genai import model_utils
@@ -328,7 +330,7 @@ def make_genai_metric(
                 for indx, (input, output) in enumerate(zip(inputs, outputs))
             }
 
-            for future in as_completed(futures):
+            for future in tqdm(as_completed(futures), total=len(futures)):
                 indx = futures[future]
                 score, justification = future.result()
                 scores[indx] = score

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -328,20 +328,19 @@ def make_genai_metric(
                 for indx, (input, output) in enumerate(zip(inputs, outputs))
             }
 
+            as_comp = as_completed(futures)
             try:
                 from tqdm import tqdm
 
-                for future in tqdm(as_completed(futures), total=len(futures)):
-                    indx = futures[future]
-                    score, justification = future.result()
-                    scores[indx] = score
-                    justifications[indx] = justification
+                as_comp = tqdm(as_comp)
             except ImportError:
-                for future in as_completed(futures):
-                    indx = futures[future]
-                    score, justification = future.result()
-                    scores[indx] = score
-                    justifications[indx] = justification
+                pass
+
+            for future in as_comp:
+                indx = futures[future]
+                score, justification = future.result()
+                scores[indx] = score
+                justifications[indx] = justification
 
         # loop over the aggregations and compute the aggregate results on the scores
         def aggregate_function(aggregate_option, scores):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/prithvikannan/mlflow/pull/10203?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10203/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10203
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?


```
2023/10/27 16:43:06 INFO mlflow.models.evaluation.default_evaluator: Evaluating metrics: relevance
  0%|                                                                                                    | 0/4 [00:00<?, ?it/s]2023/10/27 16:43:06 WARNING mlflow.openai.api_request_parallel_processor: Encountered rate limit error. Pausing to cool down for 14.999726057052612 seconds...
2023/10/27 16:43:06 WARNING mlflow.openai.api_request_parallel_processor: Encountered rate limit error. Pausing to cool down for 14.99975323677063 seconds...
2023/10/27 16:43:06 WARNING mlflow.openai.api_request_parallel_processor: Encountered rate limit error. Pausing to cool down for 14.999823808670044 seconds...
 25%|███████████████████████                                                                     | 1/4 [00:08<00:25,  8.35s/it]2023/10/27 16:43:21 WARNING mlflow.openai.api_request_parallel_processor: Encountered rate limit error. Pausing to cool down for 0.0648488998413086 seconds...
2023/10/27 16:43:21 WARNING mlflow.openai.api_request_parallel_processor: Encountered rate limit error. Pausing to cool down for 0.07401394844055176 seconds...
2023/10/27 16:43:21 WARNING mlflow.openai.api_request_parallel_processor: Encountered rate limit error. Pausing to cool down for 0.05842185020446777 seconds...
2023/10/27 16:43:21 WARNING mlflow.openai.api_request_parallel_processor: Encountered rate limit error. Pausing to cool down for 14.999640703201294 seconds...
2023/10/27 16:43:21 WARNING mlflow.openai.api_request_parallel_processor: Encountered rate limit error. Pausing to cool down for 14.999744176864624 seconds...
2023/10/27 16:43:29 WARNING mlflow.openai.api_request_parallel_processor: 2 rate limit errors received. Consider running at a lower rate.
 50%|██████████████████████████████████████████████                                              | 2/4 [00:23<00:25, 12.51s/it]2023/10/27 16:43:36 WARNING mlflow.openai.api_request_parallel_processor: Encountered rate limit error. Pausing to cool down for 0.07663202285766602 seconds...
2023/10/27 16:43:36 WARNING mlflow.openai.api_request_parallel_processor: Encountered rate limit error. Pausing to cool down for 0.0563962459564209 seconds...
2023/10/27 16:43:42 WARNING mlflow.openai.api_request_parallel_processor: 4 rate limit errors received. Consider running at a lower rate.
 75%|█████████████████████████████████████████████████████████████████████                       | 3/4 [00:36<00:12, 12.75s/it]2023/10/27 16:43:43 WARNING mlflow.openai.api_request_parallel_processor: 4 rate limit errors received. Consider running at a lower rate.
100%|████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:36<00:00,  9.23s/it]
{'toxicity/v1/mean': 0.00018985224596690387, 'toxicity/v1/variance': 2.445330018924171e-09, 'toxicity/v1/p90': 0.0002462980875861831, 'toxicity/v1/ratio': 0.0, 'flesch_kincaid_grade_level/v1/mean': 8.0, 'flesch_kincaid_grade_level/v1/variance': 21.705000000000002, 'flesch_kincaid_grade_level/v1/p90': 12.910000000000002, 'ari_grade_level/v1/mean': 9.55, 'ari_grade_level/v1/variance': 29.762499999999992, 'ari_grade_level/v1/p90': 15.540000000000001, 'faithfulness/v1/mean': 3.0, 'faithfulness/v1/variance': 4.0, 'faithfulness/v1/p90': 5.0, 'relevance/v1/mean': 4.25, 'relevance/v1/variance': 0.1875, 'relevance/v1/p90': 4.7}
Downloading artifacts: 100%|███████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 1527.42it/s]
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Manual

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
