### PR TITLE
fix notebook downloads with explicit <a> parameter

### DIFF
--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -17,7 +17,7 @@ If you would like to get started immediately by interactively running the notebo
 
 .. raw:: html
 
-    <a href="logging-first-model/notebooks/logging-first-model.ipynb" class="download-btn">
+    <a href="logging-first-model/notebooks/logging-first-model.ipynb" class="download-btn" download>
         <i class="fas fa-download"></i>Download the Notebook</a><br>
 
 Guide sections

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -17,7 +17,7 @@ If you would like to get started immediately by interactively running the notebo
 
 .. raw:: html
 
-    <a href="logging-first-model/notebooks/logging-first-model.ipynb" class="download-btn" download>
+    <a href="logging-first-model/notebooks/logging-first-model.ipynb" class="notebook-download-btn">
         <i class="fas fa-download"></i>Download the Notebook</a><br>
 
 Guide sections

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -17,7 +17,7 @@ If you would like to get started immediately by interactively running the notebo
 
 .. raw:: html
 
-    <a href="logging-first-model/notebooks/logging-first-model.ipynb" class="notebook-download-btn">
+    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/getting-started/logging-first-model/notebooks/logging-first-model.ipynb" class="notebook-download-btn">
         <i class="fas fa-download"></i>Download the Notebook</a><br>
 
 Guide sections

--- a/docs/source/getting-started/logging-first-model/notebooks/index.rst
+++ b/docs/source/getting-started/logging-first-model/notebooks/index.rst
@@ -14,4 +14,4 @@ clicking this link:
 
 .. raw:: html
 
-   <a href="logging-first-model.ipynb" class="download-btn">Download the notebook</a>
+   <a href="logging-first-model.ipynb" class="download-btn" download>Download the notebook</a>

--- a/docs/source/getting-started/logging-first-model/notebooks/index.rst
+++ b/docs/source/getting-started/logging-first-model/notebooks/index.rst
@@ -14,4 +14,4 @@ clicking this link:
 
 .. raw:: html
 
-   <a href="logging-first-model.ipynb" class="download-btn" download>Download the notebook</a>
+   <a href="logging-first-model.ipynb" class="notebook-download-btn">Download the notebook</a>

--- a/docs/source/getting-started/logging-first-model/notebooks/index.rst
+++ b/docs/source/getting-started/logging-first-model/notebooks/index.rst
@@ -14,4 +14,4 @@ clicking this link:
 
 .. raw:: html
 
-   <a href="logging-first-model.ipynb" class="notebook-download-btn">Download the notebook</a>
+   <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/getting-started/logging-first-model/notebooks/logging-first-model.ipynb" class="notebook-download-btn">Download the notebook</a>

--- a/docs/source/llms/custom-pyfunc-for-llms/notebooks/index.rst
+++ b/docs/source/llms/custom-pyfunc-for-llms/notebooks/index.rst
@@ -64,7 +64,7 @@ If you'd like to run a copy of the notebooks locally in your environment, you ca
 
 .. raw:: html
 
-    <a href="custom-pyfunc-advanced-llm.ipynb" class="download-btn">Download the LLM Custom Pyfunc notebook</a><br>
+    <a href="custom-pyfunc-advanced-llm.ipynb" class="download-btn" download>Download the LLM Custom Pyfunc notebook</a><br>
 
 .. note::
     To execute the notebooks, ensure you either have a local MLflow Tracking Server running or adjust the ``mlflow.set_tracking_uri()`` to point to an active MLflow Tracking Server instance. 

--- a/docs/source/llms/custom-pyfunc-for-llms/notebooks/index.rst
+++ b/docs/source/llms/custom-pyfunc-for-llms/notebooks/index.rst
@@ -64,7 +64,7 @@ If you'd like to run a copy of the notebooks locally in your environment, you ca
 
 .. raw:: html
 
-    <a href="custom-pyfunc-advanced-llm.ipynb" class="download-btn" download>Download the LLM Custom Pyfunc notebook</a><br>
+    <a href="custom-pyfunc-advanced-llm.ipynb" class="notebook-download-btn">Download the LLM Custom Pyfunc notebook</a><br>
 
 .. note::
     To execute the notebooks, ensure you either have a local MLflow Tracking Server running or adjust the ``mlflow.set_tracking_uri()`` to point to an active MLflow Tracking Server instance. 

--- a/docs/source/llms/custom-pyfunc-for-llms/notebooks/index.rst
+++ b/docs/source/llms/custom-pyfunc-for-llms/notebooks/index.rst
@@ -64,7 +64,7 @@ If you'd like to run a copy of the notebooks locally in your environment, you ca
 
 .. raw:: html
 
-    <a href="custom-pyfunc-advanced-llm.ipynb" class="notebook-download-btn">Download the LLM Custom Pyfunc notebook</a><br>
+    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/custom-pyfunc-for-llms/notebooks/custom-pyfunc-advanced-llm.ipynb" class="notebook-download-btn">Download the LLM Custom Pyfunc notebook</a><br>
 
 .. note::
     To execute the notebooks, ensure you either have a local MLflow Tracking Server running or adjust the ``mlflow.set_tracking_uri()`` to point to an active MLflow Tracking Server instance. 

--- a/docs/source/llms/gateway/index.rst
+++ b/docs/source/llms/gateway/index.rst
@@ -42,7 +42,7 @@ as fast as possible, the guides below will be your best first stop.
 
 .. raw:: html
 
-    <a href="guides/index.html" class="download-btn">View the AI Gateway Getting Started Guide</a><br>
+    <a href="guides/index.html" class="download-btn" download>View the AI Gateway Getting Started Guide</a><br>
 
 .. _gateway-quickstart:
 

--- a/docs/source/llms/gateway/index.rst
+++ b/docs/source/llms/gateway/index.rst
@@ -42,7 +42,7 @@ as fast as possible, the guides below will be your best first stop.
 
 .. raw:: html
 
-    <a href="guides/index.html" class="notebook-download-btn">View the AI Gateway Getting Started Guide</a><br>
+    <a href="guides/index.html" class="download-btn">View the AI Gateway Getting Started Guide</a><br>
 
 .. _gateway-quickstart:
 

--- a/docs/source/llms/gateway/index.rst
+++ b/docs/source/llms/gateway/index.rst
@@ -42,7 +42,7 @@ as fast as possible, the guides below will be your best first stop.
 
 .. raw:: html
 
-    <a href="guides/index.html" class="download-btn" download>View the AI Gateway Getting Started Guide</a><br>
+    <a href="guides/index.html" class="notebook-download-btn">View the AI Gateway Getting Started Guide</a><br>
 
 .. _gateway-quickstart:
 

--- a/docs/source/llms/llm-evaluate/notebooks/index.rst
+++ b/docs/source/llms/llm-evaluate/notebooks/index.rst
@@ -26,7 +26,7 @@ If you would like a copy of this notebook to execute in your environment, downlo
 
 .. raw:: html
 
-    <a href="question-answering-evaluation.ipynb" class="download-btn" download>Download the notebook</a><br>
+    <a href="question-answering-evaluation.ipynb" class="notebook-download-btn">Download the notebook</a><br>
 
 To follow along and see the sections of the notebook guide, click below:
 
@@ -42,7 +42,7 @@ If you would like a copy of this notebook to execute in your environment, downlo
 
 .. raw:: html
 
-    <a href="rag-evaluation.ipynb" class="download-btn" download>Download the notebook</a><br>
+    <a href="rag-evaluation.ipynb" class="notebook-download-btn">Download the notebook</a><br>
 
 To follow along and see the sections of the notebook guide, click below:
 

--- a/docs/source/llms/llm-evaluate/notebooks/index.rst
+++ b/docs/source/llms/llm-evaluate/notebooks/index.rst
@@ -26,7 +26,7 @@ If you would like a copy of this notebook to execute in your environment, downlo
 
 .. raw:: html
 
-    <a href="question-answering-evaluation.ipynb" class="download-btn">Download the notebook</a><br>
+    <a href="question-answering-evaluation.ipynb" class="download-btn" download>Download the notebook</a><br>
 
 To follow along and see the sections of the notebook guide, click below:
 
@@ -42,7 +42,7 @@ If you would like a copy of this notebook to execute in your environment, downlo
 
 .. raw:: html
 
-    <a href="rag-evaluation.ipynb" class="download-btn">Download the notebook</a><br>
+    <a href="rag-evaluation.ipynb" class="download-btn" download>Download the notebook</a><br>
 
 To follow along and see the sections of the notebook guide, click below:
 

--- a/docs/source/llms/llm-evaluate/notebooks/index.rst
+++ b/docs/source/llms/llm-evaluate/notebooks/index.rst
@@ -26,7 +26,7 @@ If you would like a copy of this notebook to execute in your environment, downlo
 
 .. raw:: html
 
-    <a href="question-answering-evaluation.ipynb" class="notebook-download-btn">Download the notebook</a><br>
+    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/llm-evaluate/notebooks/question-answering-evaluation.ipynb" class="notebook-download-btn">Download the notebook</a><br>
 
 To follow along and see the sections of the notebook guide, click below:
 
@@ -42,7 +42,7 @@ If you would like a copy of this notebook to execute in your environment, downlo
 
 .. raw:: html
 
-    <a href="rag-evaluation.ipynb" class="notebook-download-btn">Download the notebook</a><br>
+    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/llm-evaluate/notebooks/rag-evaluation.ipynb" class="notebook-download-btn">Download the notebook</a><br>
 
 To follow along and see the sections of the notebook guide, click below:
 

--- a/docs/source/llms/rag/notebooks/index.rst
+++ b/docs/source/llms/rag/notebooks/index.rst
@@ -22,7 +22,7 @@ If you would like a copy of this notebook to execute in your environment, downlo
 
 .. raw:: html
 
-    <a href="question-generation-retrieval-evaluation.ipynb" class="notebook-download-btn">Download the notebook</a><br>
+    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/rag/notebooks/question-generation-retrieval-evaluation.ipynb" class="notebook-download-btn">Download the notebook</a><br>
 
 To follow along and see the sections of the notebook guide, click below:
 

--- a/docs/source/llms/rag/notebooks/index.rst
+++ b/docs/source/llms/rag/notebooks/index.rst
@@ -22,7 +22,7 @@ If you would like a copy of this notebook to execute in your environment, downlo
 
 .. raw:: html
 
-    <a href="question-generation-retrieval-evaluation.ipynb" class="download-btn" download>Download the notebook</a><br>
+    <a href="question-generation-retrieval-evaluation.ipynb" class="notebook-download-btn">Download the notebook</a><br>
 
 To follow along and see the sections of the notebook guide, click below:
 

--- a/docs/source/llms/rag/notebooks/index.rst
+++ b/docs/source/llms/rag/notebooks/index.rst
@@ -22,7 +22,7 @@ If you would like a copy of this notebook to execute in your environment, downlo
 
 .. raw:: html
 
-    <a href="question-generation-retrieval-evaluation.ipynb" class="download-btn">Download the notebook</a><br>
+    <a href="question-generation-retrieval-evaluation.ipynb" class="download-btn" download>Download the notebook</a><br>
 
 To follow along and see the sections of the notebook guide, click below:
 

--- a/docs/source/traditional-ml/creating-custom-pyfunc/notebooks/index.rst
+++ b/docs/source/traditional-ml/creating-custom-pyfunc/notebooks/index.rst
@@ -177,9 +177,9 @@ clicking the respective links to each notebook in this guide:
 
 .. raw:: html
 
-    <a href="introduction.ipynb" class="notebook-download-btn">Download the Introduction notebook</a><br>
-    <a href="basic-pyfunc.ipynb" class="notebook-download-btn">Download the Basic Pyfunc notebook</a><br>
-    <a href="override-predict.ipynb" class="notebook-download-btn">Download the Predict Override notebook</a><br>
+    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/traditional-ml/creating-custom-pyfunc/notebooks/introduction.ipynb" class="notebook-download-btn">Download the Introduction notebook</a><br>
+    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/traditional-ml/creating-custom-pyfunc/notebooks/basic-pyfunc.ipynb" class="notebook-download-btn">Download the Basic Pyfunc notebook</a><br>
+    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/traditional-ml/creating-custom-pyfunc/notebooks/override-predict.ipynb" class="notebook-download-btn">Download the Predict Override notebook</a><br>
 
 .. note::
     In order to run the notebooks, please ensure that you either have a local MLflow Tracking Server started or modify the

--- a/docs/source/traditional-ml/creating-custom-pyfunc/notebooks/index.rst
+++ b/docs/source/traditional-ml/creating-custom-pyfunc/notebooks/index.rst
@@ -177,9 +177,9 @@ clicking the respective links to each notebook in this guide:
 
 .. raw:: html
 
-    <a href="introduction.ipynb" class="download-btn" download>Download the Introduction notebook</a><br>
-    <a href="basic-pyfunc.ipynb" class="download-btn" download>Download the Basic Pyfunc notebook</a><br>
-    <a href="override-predict.ipynb" class="download-btn" download>Download the Predict Override notebook</a><br>
+    <a href="introduction.ipynb" class="notebook-download-btn">Download the Introduction notebook</a><br>
+    <a href="basic-pyfunc.ipynb" class="notebook-download-btn">Download the Basic Pyfunc notebook</a><br>
+    <a href="override-predict.ipynb" class="notebook-download-btn">Download the Predict Override notebook</a><br>
 
 .. note::
     In order to run the notebooks, please ensure that you either have a local MLflow Tracking Server started or modify the

--- a/docs/source/traditional-ml/creating-custom-pyfunc/notebooks/index.rst
+++ b/docs/source/traditional-ml/creating-custom-pyfunc/notebooks/index.rst
@@ -177,9 +177,9 @@ clicking the respective links to each notebook in this guide:
 
 .. raw:: html
 
-    <a href="introduction.ipynb" class="download-btn">Download the Introduction notebook</a><br>
-    <a href="basic-pyfunc.ipynb" class="download-btn">Download the Basic Pyfunc notebook</a><br>
-    <a href="override-predict.ipynb" class="download-btn">Download the Predict Override notebook</a><br>
+    <a href="introduction.ipynb" class="download-btn" download>Download the Introduction notebook</a><br>
+    <a href="basic-pyfunc.ipynb" class="download-btn" download>Download the Basic Pyfunc notebook</a><br>
+    <a href="override-predict.ipynb" class="download-btn" download>Download the Predict Override notebook</a><br>
 
 .. note::
     In order to run the notebooks, please ensure that you either have a local MLflow Tracking Server started or modify the

--- a/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/notebooks/index.rst
+++ b/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/notebooks/index.rst
@@ -70,9 +70,9 @@ clicking the respective links to each notebook in this guide:
 
 .. raw:: html
 
-    <a href="hyperparameter-tuning-with-child-runs.ipynb" class="download-btn" download="hyperparameter-tuning-with-child-runs.ipynb">Download the main notebook</a><br>
-    <a href="parent-child-runs.ipynb" class="download-btn" download="parent-child-runs.ipynb">Download the Parent-Child Runs notebook</a><br>
-    <a href="logging-plots-in-mlflow.ipynb" class="download-btn" download="logging-plots-in-mlflow.ipynb">Download the Plot Logging in MLflow notebook</a><br>
+    <a href="hyperparameter-tuning-with-child-runs.ipynb" class="notebook-download-btn">Download the main notebook</a><br>
+    <a href="parent-child-runs.ipynb" class="notebook-download-btn">Download the Parent-Child Runs notebook</a><br>
+    <a href="logging-plots-in-mlflow.ipynb" class="notebook-download-btn">Download the Plot Logging in MLflow notebook</a><br>
 
 .. note::
     In order to run the notebooks, please ensure that you either have a local MLflow Tracking Server started or modify the

--- a/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/notebooks/index.rst
+++ b/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/notebooks/index.rst
@@ -70,9 +70,9 @@ clicking the respective links to each notebook in this guide:
 
 .. raw:: html
 
-    <a href="hyperparameter-tuning-with-child-runs.ipynb" class="notebook-download-btn">Download the main notebook</a><br>
-    <a href="parent-child-runs.ipynb" class="notebook-download-btn">Download the Parent-Child Runs notebook</a><br>
-    <a href="logging-plots-in-mlflow.ipynb" class="notebook-download-btn">Download the Plot Logging in MLflow notebook</a><br>
+    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/notebooks/hyperparameter-tuning-with-child-runs.ipynb" class="notebook-download-btn">Download the main notebook</a><br>
+    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/notebooks/parent-child-runs.ipynb" class="notebook-download-btn">Download the Parent-Child Runs notebook</a><br>
+    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/notebooks/logging-plots-in-mlflow.ipynb" class="notebook-download-btn">Download the Plot Logging in MLflow notebook</a><br>
 
 .. note::
     In order to run the notebooks, please ensure that you either have a local MLflow Tracking Server started or modify the

--- a/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/notebooks/index.rst
+++ b/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/notebooks/index.rst
@@ -70,9 +70,9 @@ clicking the respective links to each notebook in this guide:
 
 .. raw:: html
 
-    <a href="hyperparameter-tuning-with-child-runs.ipynb" class="download-btn" download>Download the main notebook</a><br>
-    <a href="parent-child-runs.ipynb" class="download-btn" download>Download the Parent-Child Runs notebook</a><br>
-    <a href="logging-plots-in-mlflow.ipynb" class="download-btn" download>Download the Plot Logging in MLflow notebook</a><br>
+    <a href="hyperparameter-tuning-with-child-runs.ipynb" class="download-btn" download="hyperparameter-tuning-with-child-runs.ipynb">Download the main notebook</a><br>
+    <a href="parent-child-runs.ipynb" class="download-btn" download="parent-child-runs.ipynb">Download the Parent-Child Runs notebook</a><br>
+    <a href="logging-plots-in-mlflow.ipynb" class="download-btn" download="logging-plots-in-mlflow.ipynb">Download the Plot Logging in MLflow notebook</a><br>
 
 .. note::
     In order to run the notebooks, please ensure that you either have a local MLflow Tracking Server started or modify the

--- a/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/notebooks/index.rst
+++ b/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/notebooks/index.rst
@@ -70,9 +70,9 @@ clicking the respective links to each notebook in this guide:
 
 .. raw:: html
 
-    <a href="hyperparameter-tuning-with-child-runs.ipynb" class="download-btn">Download the main notebook</a><br>
-    <a href="parent-child-runs.ipynb" class="download-btn">Download the Parent-Child Runs notebook</a><br>
-    <a href="logging-plots-in-mlflow.ipynb" class="download-btn">Download the Plot Logging in MLflow notebook</a><br>
+    <a href="hyperparameter-tuning-with-child-runs.ipynb" class="download-btn" download>Download the main notebook</a><br>
+    <a href="parent-child-runs.ipynb" class="download-btn" download>Download the Parent-Child Runs notebook</a><br>
+    <a href="logging-plots-in-mlflow.ipynb" class="download-btn" download>Download the Plot Logging in MLflow notebook</a><br>
 
 .. note::
     In order to run the notebooks, please ensure that you either have a local MLflow Tracking Server started or modify the

--- a/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part1-child-runs.rst
+++ b/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part1-child-runs.rst
@@ -326,7 +326,7 @@ code within in order to achieve this.
 
 .. raw:: html
 
-   <a href="notebooks/parent-child-runs.ipynb" class="download-btn">Download the notebook</a>
+   <a href="notebooks/parent-child-runs.ipynb" class="download-btn" download>Download the notebook</a>
 
 The notebook contains an example implementation of this, but it is
 recommended to develop your own implementation that fulfills the following requirements:

--- a/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part1-child-runs.rst
+++ b/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part1-child-runs.rst
@@ -326,7 +326,7 @@ code within in order to achieve this.
 
 .. raw:: html
 
-   <a href="notebooks/parent-child-runs.ipynb" class="notebook-download-btn">Download the notebook</a>
+   <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/notebooks/parent-child-runs.ipynb" class="notebook-download-btn">Download the notebook</a>
 
 The notebook contains an example implementation of this, but it is
 recommended to develop your own implementation that fulfills the following requirements:

--- a/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part1-child-runs.rst
+++ b/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part1-child-runs.rst
@@ -326,7 +326,7 @@ code within in order to achieve this.
 
 .. raw:: html
 
-   <a href="notebooks/parent-child-runs.ipynb" class="download-btn" download>Download the notebook</a>
+   <a href="notebooks/parent-child-runs.ipynb" class="notebook-download-btn">Download the notebook</a>
 
 The notebook contains an example implementation of this, but it is
 recommended to develop your own implementation that fulfills the following requirements:

--- a/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part2-logging-plots.rst
+++ b/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part2-logging-plots.rst
@@ -308,7 +308,7 @@ If you're interested, get a copy of the notebook by clicking on the button below
 
 .. raw:: html
 
-   <a href="notebooks/logging-plots-in-mlflow.ipynb" class="download-btn">Download the notebook</a>
+   <a href="notebooks/logging-plots-in-mlflow.ipynb" class="download-btn" download>Download the notebook</a>
 
 After downloading the notebook and opening it with Jupyter:
 

--- a/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part2-logging-plots.rst
+++ b/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part2-logging-plots.rst
@@ -308,7 +308,7 @@ If you're interested, get a copy of the notebook by clicking on the button below
 
 .. raw:: html
 
-   <a href="notebooks/logging-plots-in-mlflow.ipynb" class="download-btn" download>Download the notebook</a>
+   <a href="notebooks/logging-plots-in-mlflow.ipynb" class="notebook-download-btn">Download the notebook</a>
 
 After downloading the notebook and opening it with Jupyter:
 

--- a/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part2-logging-plots.rst
+++ b/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part2-logging-plots.rst
@@ -308,7 +308,7 @@ If you're interested, get a copy of the notebook by clicking on the button below
 
 .. raw:: html
 
-   <a href="notebooks/logging-plots-in-mlflow.ipynb" class="notebook-download-btn">Download the notebook</a>
+   <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/notebooks/logging-plots-in-mlflow.ipynb" class="notebook-download-btn">Download the notebook</a>
 
 After downloading the notebook and opening it with Jupyter:
 

--- a/docs/theme/mlflow/layout.html
+++ b/docs/theme/mlflow/layout.html
@@ -225,6 +225,25 @@
     });
   </script>
 
+  {# Notebook download functionality #}
+  <script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function() {
+        // Force download for notebook-download-btn
+        const downloadButtons = document.querySelectorAll('.notebook-download-btn');
+        downloadButtons.forEach(function(button) {
+            button.addEventListener('click', function(event) {
+                event.preventDefault(); // Prevent default behavior
+                const link = document.createElement('a');
+                link.href = button.href;
+                link.download = ''; // This will prompt the user to download the content
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+            });
+        });
+    });
+</script>
+
   {%- block footer %} {% endblock %}
 </body>
 </html>

--- a/docs/theme/mlflow/layout.html
+++ b/docs/theme/mlflow/layout.html
@@ -225,24 +225,38 @@
     });
   </script>
 
-  {# Notebook download functionality #}
-  <script type="text/javascript">
+{# Notebook download functionality #}
+<script type="text/javascript">
     document.addEventListener("DOMContentLoaded", function() {
         // Force download for notebook-download-btn
         const downloadButtons = document.querySelectorAll('.notebook-download-btn');
         downloadButtons.forEach(function(button) {
             button.addEventListener('click', function(event) {
                 event.preventDefault(); // Prevent default behavior
-                const link = document.createElement('a');
-                link.href = button.href;
-                link.download = ''; // This will prompt the user to download the content
-                document.body.appendChild(link);
-                link.click();
-                document.body.removeChild(link);
+
+                // Fetch the raw content of the notebook from GitHub
+                fetch(button.href)
+                    .then(response => response.blob())
+                    .then(blob => {
+                        const url = window.URL.createObjectURL(blob);
+                        const link = document.createElement('a');
+                        link.style.display = 'none';
+                        link.href = url;
+                        const filename = button.href.split('/').pop();
+                        link.download = filename; 
+
+                        document.body.appendChild(link);
+                        link.click();
+
+                        window.URL.revokeObjectURL(url);
+                        document.body.removeChild(link);
+                    })
+                    .catch(err => console.error('Error fetching the notebook:', err));
             });
         });
     });
 </script>
+
 
   {%- block footer %} {% endblock %}
 </body>

--- a/docs/theme/mlflow/static/css/custom.css
+++ b/docs/theme/mlflow/static/css/custom.css
@@ -1151,27 +1151,6 @@ text-transform: capitalize;
 .level-3 { margin-left: 120px; }
 .level-4 { margin-left: 160px; }
 
-
-/**
- * Download button for notebooks
- */
- a.download-btn {
-  display: inline-block;
-  padding: 8px 12px;
-  border: 1px solid #007acc;
-  background-color: #007acc;
-  color: #ffffff;
-  text-decoration: none;
-  border-radius: 4px;
-  margin-bottom: 10px;
-  font-family: "Source Sans Pro";
-}
-
-a.download-btn i.fas {
-  margin-right: 5px;  /* Add some space between the icon and the text */
-}
-
-
 /**
  * Overrides to the nbsphinx modifications to the .highlight class that strips the clippy implementation (copy of code)
  */

--- a/docs/theme/mlflow/static/css/custom.css
+++ b/docs/theme/mlflow/static/css/custom.css
@@ -1289,7 +1289,7 @@ text-transform: capitalize;
 
 
 /**
- * Download button for notebooks
+ * Download button
  */
  a.download-btn {
   display: inline-block;
@@ -1307,6 +1307,29 @@ a.download-btn i.fas {
   margin-right: 5px;  /* Add some space between the icon and the text */
 }
 
+/**
+ * Download button specifically for notebooks
+ */
+ a.notebook-download-btn {
+  display: inline-block;
+  padding: 8px 12px;
+  border: 1px solid #007acc;
+  background-color: #007acc;
+  color: #ffffff;
+  text-decoration: none;
+  border-radius: 4px;
+  margin-bottom: 10px;
+  font-family: "Source Sans Pro";
+  transition: background-color 0.3s ease; 
+}
+
+a.notebook-download-btn:hover {
+  background-color: #005fa3; 
+}
+
+a.notebook-download-btn i.fas {
+  margin-right: 5px;  
+}
 
 /**
  * Overrides to the nbsphinx modifications to the .highlight class that strips the clippy implementation (copy of code)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/10211?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10211/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10211
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix the download links for .ipynb files by explicitly setting the <a> param "download" in the tag. 
This is needed due to the implicit behavior of link tags in s3-website where an .ipynb will be detected as base JSON and rendered as a JSON page (which is not how sphinx or a local ruby server behaves)

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
