### PR TITLE
Change handling for empty list(s) in nested list during schema inference

### DIFF
--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -100,7 +100,12 @@ def _infer_colspec_type(data: Any) -> Union[DataType, Array, Object]:
 
 def _infer_datatype(data: Any) -> Union[DataType, Array, Object]:
     if isinstance(data, dict):
-        properties = [Property(name=k, dtype=_infer_datatype(v)) for k, v in data.items()]
+        properties = []
+        for k, v in data.items():
+            dtype = _infer_datatype(v)
+            if dtype is None:
+                raise MlflowException("Dictionary value must not be an empty list.")
+            properties.append(Property(name=k, dtype=dtype))
         return Object(properties=properties)
 
     if isinstance(data, (list, np.ndarray)):

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -139,7 +139,7 @@ def test_signature_inference_infers_input_and_output_as_expected():
 
 def test_infer_signature_on_nested_array():
     signature = infer_signature(
-        model_input=[{"queries": [["a", "b", "c"], ["d", "e"]]}],
+        model_input=[{"queries": [["a", "b", "c"], ["d", "e"], []]}],
         model_output=[{"answers": [["f", "g"], ["h"]]}],
     )
     assert signature.inputs == Schema([ColSpec(Array(Array(DataType.string)), name="queries")])

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1648,6 +1648,14 @@ def test_schema_inference_with_empty_lists():
     ):
         _infer_schema(data)
 
+    # This case is also considered as empty list, because None and np.nan are skipped.
+    data = [[None, np.nan]]
+    with pytest.raises(
+        MlflowException,
+        match=r"A column of nested array type must include at least one non-empty array.",
+    ):
+        _infer_schema(data)
+
     # If at least one of sublists is not empty, we can assume other empty lists have the same type.
     data = [
         {
@@ -1683,11 +1691,7 @@ def test_schema_inference_with_empty_lists():
 
     # Property value cannot be an empty list
     data = [{"data": {"key": []}}]
-    with pytest.raises(
-        MlflowException,
-        match=r"Expected mlflow.types.schema.Datatype, mlflow.types.schema.Array, "
-        "mlflow.types.schema.Object or str for the 'dtype' argument, but got <class 'NoneType'>",
-    ):
+    with pytest.raises(MlflowException, match=r"Dictionary value must not be an empty list."):
         _infer_schema(data)
 
 

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1454,7 +1454,10 @@ def test_validate_inferred_type(dtype):
 
 
 def test_validate_inferred_type_with_errors():
-    with pytest.raises(MlflowException, match="Inferred schema contains invalid type `None`"):
+    with pytest.raises(
+        MlflowException,
+        match="A column of nested array type must include at least one non-empty array.",
+    ):
         _validate_inferred_type(None)
 
 
@@ -1662,7 +1665,10 @@ def test_schema_inference_with_empty_lists():
 
     # Nested list contains only an empty list is not allowed.
     data = [[]]
-    with pytest.raises(MlflowException, match=r"Inferred schema contains invalid type `None`"):
+    with pytest.raises(
+        MlflowException,
+        match=r"A column of nested array type must include at least one non-empty array.",
+    ):
         _infer_schema(data)
 
     # If at least one of sublists is not empty, we can assume other empty lists have the same type.

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -29,7 +29,6 @@ from mlflow.types.utils import (
     _infer_colspec_type,
     _infer_param_schema,
     _infer_schema,
-    _validate_inferred_type,
     _validate_input_dictionary_contains_only_strings_and_lists_of_strings,
 )
 
@@ -1437,28 +1436,6 @@ def test_infer_colspec_type():
             ]
         )
     )
-
-
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        (DataType.string),
-        (Object([Property("a", DataType.string), Property("b", DataType.boolean, required=False)])),
-        (Array(DataType.string)),
-        (Object([Property("list", Array(DataType.long))])),
-        (Array(Array(Array(DataType.integer)))),
-    ],
-)
-def test_validate_inferred_type(dtype):
-    _validate_inferred_type(dtype)
-
-
-def test_validate_inferred_type_with_errors():
-    with pytest.raises(
-        MlflowException,
-        match="A column of nested array type must include at least one non-empty array.",
-    ):
-        _validate_inferred_type(None)
 
 
 def test_infer_schema_on_objects_and_arrays_to_and_from_dict():

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -355,10 +355,10 @@ def test_schema_inference_validating_dictionary_keys():
 
 
 def test_schema_inference_on_lists_with_errors():
-    with pytest.raises(MlflowException, match="Expected all values in list to be of same type "):
+    with pytest.raises(MlflowException, match="Expected all values in list to be of same type"):
         _infer_schema(["a", 1])
 
-    with pytest.raises(MlflowException, match="Expected all values in list to be of same type "):
+    with pytest.raises(MlflowException, match="Expected all values in list to be of same type"):
         _infer_schema(["a", ["b", "c"]])
 
 
@@ -1595,8 +1595,6 @@ def test_schema_inference_on_dictionaries(data, data_type):
             [np.datetime64("2023-10-13 00:00:00"), np.datetime64("2023-10-14 00:00:00")],
             DataType.datetime,
         ),
-        ([["a", "b"], ["c"]], Array(DataType.string)),
-        ([np.array([np.int32(1), np.int32(2)]), np.array([np.int32(3)])], Array(DataType.integer)),
     ],
 )
 def test_schema_inference_on_lists(data, data_type):
@@ -1634,6 +1632,60 @@ def test_schema_inference_on_lists(data, data_type):
         ]
     )
     assert inferred_schema == expected_schema
+
+
+def test_schema_inference_with_empty_lists():
+    # If (non-nested) empty list is passed, should be inferred as string for backward compatibility
+    # with version 2.7.1: https://github.com/mlflow/mlflow/blob/v2.7.1/mlflow/types/utils.py#L150
+    data = []
+    assert _infer_schema(data) == Schema([ColSpec(DataType.string)])
+
+    # Nested list contains only an empty list is not allowed.
+    data = [[]]
+    with pytest.raises(MlflowException, match=r"Failed to infer schema for a column."):
+        _infer_schema(data)
+
+    # If at least one of sublists is not empty, we can assume other empty lists have the same type.
+    data = [
+        {
+            "data": [
+                ["a", "b", "c"],
+                [],
+                ["d", "e"],
+                [],
+            ]
+        }
+    ]
+    inferred_schema = _infer_schema(data)
+    expected_schema = Schema([ColSpec(Array(Array(DataType.string)), name="data")])
+    assert inferred_schema == expected_schema
+
+    # Complex case for deeply nested array
+    data = [
+        {
+            "data": [
+                [["a", "b", "c"], [], ["d"]],
+                [[], ["e"]],
+                [
+                    [],
+                    [],
+                    [],
+                ],
+            ]
+        }
+    ]
+    inferred_schema = _infer_schema(data)
+    expected_schema = Schema([ColSpec(Array(Array(Array(DataType.string))), name="data")])
+    assert inferred_schema == expected_schema
+
+    # Property value cannot be an empty list
+    data = [{"data": {"key": []}}]
+    with pytest.raises(
+        MlflowException,
+        match=r"Expected mlflow.types.schema.Datatype, mlflow.types.schema.Array, "
+        "mlflow.types.schema.Object or str for the 'dtype' argument, but got <class 'NoneType'>",
+    ):
+        _infer_schema(data)
 
 
 def test_repr_of_objects():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10218?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10218/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10218
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Previously `Array` data type cannot have any empty list in it, namely, blocks input like `[["a", "b"], []]`. This PR proposes to relax this restriction to support more flexible input for LLM use case. 
```
- A list contains empty lists alone e.g. [[], []] => throw
- A list contains an empty list but also non-empty one(s) e.g. [["a", "b"], []] => Array(string)
- [Special case] Non-nested empty list [] => Inferred as string, to keep compatibility with 2.7.1
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
