### PR TITLE
Adjust pandas dataframe rendering from generated notebooks

### DIFF
--- a/docs/theme/mlflow/static/css/custom.css
+++ b/docs/theme/mlflow/static/css/custom.css
@@ -1464,3 +1464,25 @@ a.notebook-download-btn i.fas {
   display: block;
   text-decoration: none; 
 }
+
+/**
+ * Overrides for notebook dataframe display header rendering 
+ * This change helps to prevent long column names from compressing and overwriting one another
+ */
+
+ /* Adjust table layout within notebook render */
+.nboutput .output_area.rendered_html table {
+  table-layout: auto !important;
+  width: 100% !important;
+}
+
+/* Adjust table cell padding within notebook render */
+.nboutput .output_area.rendered_html table th,
+.nboutput .output_area.rendered_html table td {
+  padding: 8px 12px !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;  /* Adjust as needed */
+  white-space: nowrap;
+}
+


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/10237?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10237/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10237
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adjusts the formatting that is used by nbsphinx to generate the html tables representing the display of pandas notebook outputs to match the formatting and overflow properties natively in Jupyter (specifically to prevent column headers from writing over one another). 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

Before:
![Screenshot 2023-10-30 at 4 41 45 PM](https://github.com/mlflow/mlflow/assets/39283302/1856c33d-b30a-4a93-9ac7-c27eed9d84d2)

This PR:
![Screenshot 2023-10-30 at 4 42 14 PM](https://github.com/mlflow/mlflow/assets/39283302/86f1881a-7aa2-4b66-afe7-def7493781d3)


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
