### PR TITLE
Add timeout for mlflow login

### DIFF
--- a/mlflow/utils/credentials.py
+++ b/mlflow/utils/credentials.py
@@ -194,7 +194,7 @@ def _overwrite_or_create_databricks_profile(
 def _databricks_login():
     """Set up databricks authentication and connect MLflow to Databricks tracking server."""
     try:
-        import databricks.sdk  # noqa: F401
+        import databricks.sdk  # noqa: F401: we check the module beforehand for fast failing.
     except ImportError:
         raise ImportError(
             "Databricks SDK is not installed. To use `mlflow.login()` to connect MLflow to "

--- a/mlflow/utils/credentials.py
+++ b/mlflow/utils/credentials.py
@@ -90,7 +90,7 @@ def _validate_databricks_auth():
                 stderr=subprocess.DEVNULL,
             )
             if result.returncode != 0:
-                raise MlflowException("Invalid databricks credentials.")
+                raise MlflowException("Failed to validate databricks credentials.")
             return
         except subprocess.TimeoutExpired:
             _logger.error("Timeout (3s) while signing in Databricks, retrying...")

--- a/mlflow/utils/credentials.py
+++ b/mlflow/utils/credentials.py
@@ -86,6 +86,9 @@ def _validate_databricks_auth():
     timeout = 3
     for i in range(max_trials):
         try:
+            # If the host name is invalid, the command will hang.
+            # If the credential is invalid, the command will return non-zero exit code.
+            # If both host and credential are valid, it will return zero exit code.
             result = subprocess.run(
                 ["databricks", "tokens", "list"],
                 timeout=timeout,

--- a/tests/utils/test_credentials.py
+++ b/tests/utils/test_credentials.py
@@ -3,8 +3,9 @@ from unittest.mock import patch
 
 import pytest
 
-from mlflow import get_tracking_uri, set_tracking_uri
+from mlflow import get_tracking_uri
 from mlflow.environment_variables import MLFLOW_TRACKING_PASSWORD, MLFLOW_TRACKING_USERNAME
+from mlflow.exceptions import MlflowException
 from mlflow.utils.credentials import login, read_mlflow_creds
 
 
@@ -114,16 +115,12 @@ def test_mlflow_login(tmp_path, monkeypatch):
         monkeypatch.setenv("DATABRICKS_CONFIG_FILE", file_name)
         monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", profile)
 
-        def fail():
-            return False
-
         def success():
-            set_tracking_uri("databricks")
-            return True
+            return
 
         with patch(
-            "mlflow.utils.credentials._connect_to_databricks",
-            side_effect=[fail(), success()],
+            "mlflow.utils.credentials._validate_databricks_auth",
+            side_effect=[MlflowException("Invalid databricks credentials."), success()],
         ):
             login("databricks")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/10239?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10239/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10239
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Support timeout in `mlflow.login()`. Basically if the authentication does not finish within 3 seconds, we kill the process. We allow 3 retrials to account for network lagging.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
