### PR TITLE
Support input example with new schema

### DIFF
--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -343,14 +343,9 @@ def _infer_signature_from_input_example(
             input_example, params = input_example
         else:
             params = None
-        # TODO: update this for new schema
-        if isinstance(input_example, list) and all(isinstance(x, str) for x in input_example):
-            input_schema = _infer_schema(input_example)
-        else:
-            input_example = _Example(input_example)
-            # Copy the input example so that it is not mutated by predict()
-            input_example = deepcopy(input_example.inference_data)
-            input_schema = _infer_schema(input_example)
+        example = _Example(input_example)
+        # Copy the input example so that it is not mutated by predict()
+        input_schema = _infer_schema(deepcopy(example.inference_data))
         params_schema = _infer_param_schema(params) if params else None
         prediction = wrapped_model.predict(input_example, params=params)
         # For column-based inputs, 1D numpy arrays likely signify row-based predictions. Thus, we

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -345,7 +345,8 @@ def _infer_signature_from_input_example(
             params = None
         example = _Example(input_example)
         # Copy the input example so that it is not mutated by predict()
-        input_schema = _infer_schema(deepcopy(example.inference_data))
+        input_example = deepcopy(example.inference_data)
+        input_schema = _infer_schema(input_example)
         params_schema = _infer_param_schema(params) if params else None
         prediction = wrapped_model.predict(input_example, params=params)
         # For column-based inputs, 1D numpy arrays likely signify row-based predictions. Thus, we

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -220,19 +220,30 @@ class _Example:
                 if isinstance(x, np.ndarray) and len(x.shape) > 1:
                     raise TensorsNotSupportedException(f"Row '{i}' has shape {x.shape}")
             if all(_is_scalar(x) for x in input_example):
-                _logger.info(
-                    "Lists of scalar values are not converted to a pandas DataFrame. "
-                    "If you expect to use pandas DataFrames for inference, please "
-                    "construct a DataFrame and pass it to input_example instead."
-                )
-                self._inference_data = input_example
-                self.data = {"inputs": self._inference_data}
-                self.info.update(
-                    {
-                        "type": "ndarray",
-                        "format": "tf-serving",
-                    }
-                )
+                if all(isinstance(x, str) for x in input_example):
+                    _logger.info(
+                        "Lists of string values are not converted to a pandas DataFrame. "
+                        "If you expect to use pandas DataFrames for inference, please "
+                        "construct a DataFrame and pass it to input_example instead."
+                    )
+                    self._inference_data = input_example
+                    self.data = {"inputs": self._inference_data}
+                    self.info.update(
+                        {
+                            "type": "ndarray",
+                            "format": "tf-serving",
+                        }
+                    )
+                # For backwards compatibility, sklearn model for example
+                else:
+                    self._inference_data = pd.DataFrame([input_example])
+                    self.data = _handle_dataframe_input(self._inference_data)
+                    self.info.update(
+                        {
+                            "type": "dataframe",
+                            "pandas_orient": "split",
+                        }
+                    )
             else:
                 self._inference_data = pd.DataFrame(input_example)
                 self.data = _handle_dataframe_input(self._inference_data)

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -149,10 +149,11 @@ class _Example:
                     for x in input_ex.values()
                 ):
                     _logger.info(
-                        "We convert input dictionaries to pandas DataFrames by assuming "
-                        "each key is a column, and in total, one row of data. If you "
-                        "would like to save data as multiple rows, please convert your "
-                        "data to a pandas DataFrame before passing to input_example."
+                        "We convert input dictionaries to pandas DataFrames such that "
+                        "each key represents a column, collectively constituting a "
+                        "single row of data. If you would like to save data as "
+                        "multiple rows, please convert your data to a pandas "
+                        "DataFrame before passing to input_example."
                     )
                 input_ex = pd.DataFrame([input_ex])
             elif np.isscalar(input_ex):

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -148,6 +148,11 @@ class _Example:
                     isinstance(x, str) or (isinstance(x, list) and all(_is_scalar(y) for y in x))
                     for x in input_ex.values()
                 ):
+                    # e.g.
+                    # data = {"a": "a", "b": ["a", "b", "c"]}
+                    # >>> pd.DataFrame([data])
+                    #    a          b
+                    # 0  a  [a, b, c]
                     _logger.info(
                         "We convert input dictionaries to pandas DataFrames such that "
                         "each key represents a column, collectively constituting a "

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -148,11 +148,11 @@ class _Example:
                     isinstance(x, str) or (isinstance(x, list) and all(_is_scalar(y) for y in x))
                     for x in input_ex.values()
                 ):
-                    _logger.warning(
-                        "We convert dictionary to pandas DataFrame by assuming each key "
-                        "is a column, and in total one row of data. If you would like to "
-                        "save data as multiple rows, please convert your data to pandas "
-                        "DataFrame before passing to input_example."
+                    _logger.info(
+                        "We convert input dictionaries to pandas DataFrames by assuming "
+                        "each key is a column, and in total, one row of data. If you "
+                        "would like to save data as multiple rows, please convert your "
+                        "data to a pandas DataFrame before passing to input_example."
                     )
                 input_ex = pd.DataFrame([input_ex])
             elif np.isscalar(input_ex):
@@ -220,10 +220,10 @@ class _Example:
                 if isinstance(x, np.ndarray) and len(x.shape) > 1:
                     raise TensorsNotSupportedException(f"Row '{i}' has shape {x.shape}")
             if all(_is_scalar(x) for x in input_example):
-                _logger.warning(
-                    "We do not convert list of scalar values to pandas DataFrame. "
-                    "If you expect to use pandas DataFrame, please construct it and pass "
-                    "to input_example instead."
+                _logger.info(
+                    "Lists of scalar values are not converted to a pandas DataFrame. "
+                    "If you expect to use pandas DataFrames for inference, please "
+                    "construct a DataFrame and pass it to input_example instead."
                 )
                 self._inference_data = input_example
                 self.data = {"inputs": self._inference_data}

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -463,7 +463,10 @@ def test_signature_and_examples_are_saved_correctly(
     if example is None:
         assert mlflow_model.saved_input_example_info is None
     else:
-        assert all((_read_example(mlflow_model, model_path) == example).all())
+        if isinstance(example, pd.DataFrame):
+            pd.testing.assert_frame_equal(_read_example(mlflow_model, model_path), example)
+        else:
+            np.testing.assert_equal(_read_example(mlflow_model, model_path), example)
 
 
 def test_model_log_with_signature_inference(basic_model):

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -293,7 +293,7 @@ def test_log_model_with_code_paths(basic_model):
 
 def test_default_signature_assignment():
     expected_signature = {
-        "inputs": '[{"type": "string"}]',
+        "inputs": '[{"type": "string", "required": true}]',
         "outputs": '[{"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1]}}]',
         "params": None,
     }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10248?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10248/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10248
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Outstanding changes in this PR:

- For List[str] we do not convert it to pandas DataFrame when saving the input example. We use type='ndarray' so that while model serving it could be rendered as '{"inputs": ...}' correctly.
- For Dict[str, Union[str, List[str]]] we convert it to pandas DataFrame with `pd.DataFrame([data])` instead of `pd.DataFrame(data)` to avoid converting it to multiple rows. Raised warning and users should pass in converted pandas DataFrame if they want data with multiple rows.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
