### PR TITLE
Fix sklearn import in RAG question generation example

### DIFF
--- a/docs/source/llms/rag/notebooks/question-generation-retrieval-evaluation.ipynb
+++ b/docs/source/llms/rag/notebooks/question-generation-retrieval-evaluation.ipynb
@@ -104,7 +104,6 @@
    ],
    "source": [
     "import os\n",
-    "import pickle\n",
     "from langchain.docstore.document import Document\n",
     "from langchain.embeddings import OpenAIEmbeddings\n",
     "from langchain.text_splitter import CharacterTextSplitter\n",
@@ -113,14 +112,14 @@
     "\n",
     "# For scraping\n",
     "import requests\n",
-    "import urllib\n",
     "import pandas as pd\n",
     "from bs4 import BeautifulSoup\n",
     "\n",
     "# For data analysis and visualization\n",
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
-    "import sklearn\n",
+    "from sklearn.decomposition import PCA\n",
+    "from sklearn.manifold import TSNE\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import random"
@@ -1203,10 +1202,10 @@
     "embeddings = OpenAIEmbeddings()\n",
     "question_embeddings = embeddings.embed_documents(questions_to_embed)\n",
     "# PCA on embeddings to reduce to 50-dim\n",
-    "pca = sklearn.decomposition.PCA(n_components=50)\n",
+    "pca = PCA(n_components=50)\n",
     "question_embeddings_50 = pca.fit_transform(question_embeddings)\n",
     "# TSNE on embeddings to reduce to 2-dim\n",
-    "tsne = sklearn.manifold.TSNE(n_components=2)\n",
+    "tsne = TSNE(n_components=2)\n",
     "lower_dim_embeddings = tsne.fit_transform(question_embeddings_50)"
    ]
   },


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10249?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10249/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10249
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

[RAG Question Generation Evaluation](https://mlflow.org/docs/latest/llms/rag/notebooks/question-generation-retrieval-evaluation.html) contains code like this
```
import sklearn
pca = sklearn.decomposition.PCA(n_components=50)
```
This causes `AttributeError: module 'sklearn' has no attribute 'decomposition'`, as `sklearn` doesn't import its submodules automatically

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Executed update cell on notebook.
<img width="1193" alt="Screenshot 2023-10-31 at 21 37 37" src="https://github.com/mlflow/mlflow/assets/31463517/a59da2c4-18af-49e1-a09e-42704b1e6601">

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
