### PR TITLE
Add `copy_model_version` example in client method doc string

### DIFF
--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -320,6 +320,8 @@ to copy model versions across registered models.
 
 .. code-block:: python
 
+    from mlflow import MlflowClient
+
     client = MlflowClient()
     client.copy_model_version(
         src_model_uri="models:/regression-model-staging@candidate",

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2730,6 +2730,59 @@ class MlflowClient:
                          registered model with this name does not exist, it will be created.
         :return: Single :py:class:`mlflow.entities.model_registry.ModelVersion` object representing
                  the copied model version.
+
+        .. code-block:: python
+            :caption: Example
+
+            import mlflow.sklearn
+            from mlflow import MlflowClient
+            from mlflow.models import infer_signature
+            from sklearn.datasets import make_regression
+            from sklearn.ensemble import RandomForestRegressor
+
+
+            def print_model_version_info(mv):
+                print(f"Name: {mv.name}")
+                print(f"Version: {mv.version}")
+                print(f"Source: {mv.source}")
+
+
+            mlflow.set_tracking_uri("sqlite:///mlruns.db")
+            X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=False)
+
+            # Log a model
+            with mlflow.start_run() as run:
+                params = {"n_estimators": 3, "random_state": 42}
+                rfr = RandomForestRegressor(**params).fit(X, y)
+                signature = infer_signature(X, rfr.predict(X))
+                mlflow.log_params(params)
+                mlflow.sklearn.log_model(rfr, artifact_path="sklearn-model", signature=signature)
+
+            # Create source model version
+            client = MlflowClient()
+            src_name = "RandomForestRegression-staging"
+            client.create_registered_model(src_name)
+            src_uri = f"runs:/{run.info.run_id}/sklearn-model"
+            mv_src = client.create_model_version(src_name, src_uri, run.info.run_id)
+            print_model_version_info(mv_src)
+            print("--")
+
+            # Copy the source model version into a new registered model
+            dst_name = "RandomForestRegression-production"
+            src_model_uri = f"models:/{mv_src.name}/{mv_src.version}"
+            mv_copy = client.copy_model_version(src_model_uri, dst_name)
+            print_model_version_info(mv_copy)
+
+        .. code-block:: text
+            :caption: Output
+
+            Name: RandomForestRegression-staging
+            Version: 1
+            Source: runs:/53e08bb38f0c487fa36c5872515ed998/sklearn-model
+            --
+            Name: RandomForestRegression-production
+            Version: 1
+            Source: models:/RandomForestRegression-staging/1
         """
         if urllib.parse.urlparse(src_model_uri).scheme != "models":
             raise MlflowException(
@@ -3528,7 +3581,7 @@ class MlflowClient:
             print_model_version_info(mv)
 
             # Delete registered model alias
-            client.set_registered_model_alias(name, "test-alias")
+            client.delete_registered_model_alias(name, "test-alias")
             print()
             print_model_info(model)
             print_model_version_info(mv)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jerrylian-db/mlflow/pull/10258?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10258/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10258
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

As title.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

See: https://output.circle-artifacts.com/output/job/e51c5d99-332e-455c-8737-6995a8a699d2/artifacts/0/docs/build/html/python_api/mlflow.client.html#mlflow.client.MlflowClient.copy_model_version

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
