### PR TITLE
Fix infer schema on lists containing None

### DIFF
--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -346,12 +346,14 @@ def _infer_schema(data: Any) -> Schema:
         # List[DataType]
         # e.g. ['some sentence', 'some sentence'] -> Schema([ColSpec(type=DataType.string)])
         # The corresponding pandas DataFrame representation should be pd.DataFrame(data)
-        schema = Schema([ColSpec(_infer_colspec_type(data).dtype, required=_infer_required(data))])
+        # We set required=True as unnamed optional inputs is not allowed
+        schema = Schema([ColSpec(_infer_colspec_type(data).dtype)])
     else:
         # DataType
         # e.g. "some sentence" -> Schema([ColSpec(type=DataType.string)])
         try:
-            schema = Schema([ColSpec(_infer_colspec_type(data), required=_infer_required(data))])
+            # We set required=True as unnamed optional inputs is not allowed
+            schema = Schema([ColSpec(_infer_colspec_type(data))])
         except MlflowException as e:
             raise MlflowException.invalid_parameter_value(
                 "Failed to infer schema. Expected one of the following types:\n"

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1640,6 +1640,12 @@ def test_schema_inference_with_empty_lists():
     data = []
     assert _infer_schema(data) == Schema([ColSpec(DataType.string)])
 
+    data = [None, "a"]
+    assert _infer_schema(data) == Schema([ColSpec(DataType.string)])
+
+    data = [["a", "b", "c"], ["a", "b", "c", "d"], None]
+    assert _infer_schema(data) == Schema([ColSpec(Array(DataType.string))])
+
     # Nested list contains only an empty list is not allowed.
     data = [[]]
     with pytest.raises(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10275?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10275/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10275
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
