### PR TITLE
Fix schema inference on spark MapType

### DIFF
--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -498,7 +498,7 @@ def _infer_spark_type(x, data=None, col_name=None) -> DataType:
         )
     elif isinstance(x, pyspark.sql.types.MapType):
         if data is None or col_name is None:
-            raise Exception("Cannot infer schema for MapType without data and column name.")
+            raise MlflowException("Cannot infer schema for MapType without data and column name.")
         # Map MapType to StructType
         # Note that MapType assumes all values are of same type,
         # if they're not then spark picks the first item's type

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -522,9 +522,8 @@ def _infer_spark_type(x, data=None, col_name=None) -> DataType:
         )
 
     else:
-        raise Exception(
-            f"Unsupported Spark Type '{type(x)}', MLflow schema is only supported for scalar "
-            "Spark types."
+        raise MlflowException.invalid_parameter_value(
+            f"Unsupported Spark Type '{type(x)}' for MLflow schema."
         )
 
 

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1323,6 +1323,12 @@ def test_spark_df_schema_inference_for_map_type(spark):
     inferred_schema = infer_signature(df).inputs
     assert inferred_schema == expected_schema
 
+    complex_df = spark.createDataFrame([{"map": {"nested_map": {"a": 1}}}])
+    with pytest.raises(
+        MlflowException, match=r"Please construct spark DataFrame with schema using StructType"
+    ):
+        infer_signature(complex_df)
+
 
 def test_spark_udf_structs_and_arrays(spark, tmp_path):
     class MyModel(mlflow.pyfunc.PythonModel):

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1303,14 +1303,21 @@ def test_spark_udf_with_model_serving(spark):
 
 
 def test_spark_df_schema_inference_for_map_type(spark):
-    data = [{"a": {"a": 1, "b": 2}, "b": ["a", "b"], "c": "c", "d": {"e": ["e", "e"]}}]
+    data = [
+        {
+            "arr": ["a", "b"],
+            "map1": {"a": 1, "b": 2},
+            "map2": {"e": ["e", "e"]},
+            "string": "c",
+        }
+    ]
     df = spark.createDataFrame(data)
     expected_schema = Schema(
         [
-            ColSpec(Object([Property("a", DataType.long), Property("b", DataType.long)]), "a"),
-            ColSpec(Array(DataType.string), "b"),
-            ColSpec(DataType.string, "c"),
-            ColSpec(Object([Property("e", Array(DataType.string))]), "d"),
+            ColSpec(Array(DataType.string), "arr"),
+            ColSpec(Object([Property("a", DataType.long), Property("b", DataType.long)]), "map1"),
+            ColSpec(Object([Property("e", Array(DataType.string))]), "map2"),
+            ColSpec(DataType.string, "string"),
         ]
     )
     inferred_schema = infer_signature(df).inputs


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10280?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10280/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10280
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
When creating a spark dataframe without specifying schema, dictionary is interpreted as MapType, we should have some simple logic to convert it to StructType and infer the schema.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
