### PR TITLE
Add active docs page navigation

### DIFF
--- a/docs/source/deployment/index.rst
+++ b/docs/source/deployment/index.rst
@@ -1,6 +1,10 @@
 Deployment
 ==========
 
+.. raw:: html
+
+   <div class="no-toc"></div>
+
 In the modern age of machine learning, deploying models effectively and consistently plays a pivotal role. The capability to serve predictions 
 at scale, manage dependencies, and ensure reproducibility is paramount for businesses to derive actionable insights from their ML models. 
 Whether it's for real-time predictions, batch processing, or interactive analyses, a robust model serving framework is essential.

--- a/docs/source/getting-started/intro-quickstart/index.rst
+++ b/docs/source/getting-started/intro-quickstart/index.rst
@@ -222,7 +222,7 @@ When opening the site, you will see a screen similar to the following:
 
 .. figure:: ../../_static/images/tutorials/introductory/quickstart-tracking/quickstart-our-experiment.png
     :alt: MLflow UI Experiment view page
-    :width: 1024px
+    :width: 90%
     :align: center
 
     The main MLflow Tracking page, showing Experiments that have been created
@@ -235,7 +235,7 @@ been highlighted below to show how and where this data is recorded within the UI
 
 .. figure:: ../../_static/images/tutorials/introductory/quickstart-tracking/quickstart-our-run.png
     :alt: MLflow UI Run view page
-    :width: 1024px
+    :width: 90%
     :align: center
 
     The run view page for our run 

--- a/docs/source/getting-started/logging-first-model/index.rst
+++ b/docs/source/getting-started/logging-first-model/index.rst
@@ -1,6 +1,11 @@
 Tutorial Overview
 =================
 
+.. raw:: html
+
+   <div class="no-toc"></div>
+
+
 In this entry point tutorial to MLflow, we'll be covering the essential basics of core MLflow functionality associated 
 with tracking training event data. 
 

--- a/docs/source/getting-started/logging-first-model/step2-mlflow-client.rst
+++ b/docs/source/getting-started/logging-first-model/step2-mlflow-client.rst
@@ -114,7 +114,7 @@ Running it
 ----------
 
 .. figure:: ../../_static/images/tutorials/introductory/logging-first-model/default-experiment.gif
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: Exploring the Default Experiment
 

--- a/docs/source/getting-started/logging-first-model/step3-create-experiment.rst
+++ b/docs/source/getting-started/logging-first-model/step3-create-experiment.rst
@@ -15,7 +15,7 @@ In order to see the MLflow UI, we simply have to use a web browser to connect to
 Once navigating to the url for the MLflow UI, you will see the default experiment with no run data.
 
 .. figure:: ../../_static/images/tutorials/introductory/logging-first-model/default-ui.png
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: A freshly initialized MLflow UI
 
@@ -94,7 +94,7 @@ to ensure meaningful insights.
 To apply these boundaries effectively, as is shown in the figure below, tags should be employed.
 
 .. figure:: ../../_static/images/tutorials/introductory/logging-first-model/tag-exp-run-relationship.svg
-   :width: 860px
+   :width: 60%
    :align: center
    :alt: Tags, experiments, and runs relationships
 

--- a/docs/source/getting-started/logging-first-model/step4-experiment-search.rst
+++ b/docs/source/getting-started/logging-first-model/step4-experiment-search.rst
@@ -14,7 +14,7 @@ As before, we're going to connect to our running MLflow Tracking server to view 
 window that was running it, simply navigate to ``http://127.0.0.1:8080`` in a new browser window.
 
 .. figure:: ../../_static/images/tutorials/introductory/logging-first-model/first-experiment-ui.gif
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: View our new experiment in the UI
 
@@ -26,7 +26,7 @@ There are some important elements in the UI to be aware of at this point, before
 our new experiment. Note the annotated elements on the figure below. It will be useful to know that these bits of data are there later on.
 
 .. figure:: ../../_static/images/tutorials/introductory/logging-first-model/experiment-page-elements.svg
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: Important Data on the Experiment View Page
 
@@ -86,7 +86,7 @@ Executing the Search
 --------------------
 
 .. figure:: ../../_static/images/tutorials/introductory/logging-first-model/creating-experiment.gif
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: Creating a new Experiment
 

--- a/docs/source/getting-started/logging-first-model/step6-logging-a-run.rst
+++ b/docs/source/getting-started/logging-first-model/step6-logging-a-run.rst
@@ -38,7 +38,7 @@ I created a new MLflow Experiment to record the state of what I tried. Since I w
 sets and models, each subsequent modification that I was trying necessitated a new Experiment.
 
 .. figure:: ../../_static/images/tutorials/introductory/logging-first-model/dogfood-diagram.svg
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: Using MLflow Tracking for building this demo
 
@@ -48,7 +48,7 @@ After finding a workable approach for the dataset generator, the results can be 
 UI.
 
 .. figure:: ../../_static/images/tutorials/introductory/logging-first-model/dogfood.gif
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: Checking the results of the test
 
@@ -57,7 +57,7 @@ UI.
 Once I found something that actually worked, I cleaned everything up (deleted them).
 
 .. figure:: ../../_static/images/tutorials/introductory/logging-first-model/cleanup-experiments.gif
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: Tidying up
 
@@ -181,7 +181,7 @@ an annotated version of the code.
 To aid in visualizing how MLflow tracking API calls add in to an ML training code base, see the figure below.
 
 .. figure:: ../../_static/images/tutorials/introductory/logging-first-model/training-annotation.svg
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: Explanation of MLflow integration into ML training code
 
@@ -193,6 +193,6 @@ Putting it all together
 Let's see what this looks like when we run our model training code and navigate to the MLflow UI.
 
 .. figure:: ../../_static/images/tutorials/introductory/logging-first-model/logging-first-model.gif
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: Log the model to MLflow

--- a/docs/source/llms/custom-pyfunc-for-llms/index.rst
+++ b/docs/source/llms/custom-pyfunc-for-llms/index.rst
@@ -1,6 +1,11 @@
 Deploying Advanced LLMs with Custom PyFuncs in MLflow
 =====================================================
 
+.. raw:: html
+
+   <div class="no-toc"></div>
+
+
 Advanced Large Language Models (LLMs) such as the MPT-7B instruct transformer are intricate and have requirements that don't align with 
 traditional MLflow flavors. This demands a deeper understanding and the need for custom solutions.
 

--- a/docs/source/llms/gateway/guides/step1-create-gateway.rst
+++ b/docs/source/llms/gateway/guides/step1-create-gateway.rst
@@ -96,7 +96,7 @@ the URL: ``http://localhost:5000``. To modify these default settings, use the
 
 
 .. figure:: ../../../_static/images/tutorials/gateway/creating-first-gateway/start_gateway.gif
-   :width: 800px
+   :width: 60%
    :align: center
    :alt: Start the gateway and observe the docs.
 

--- a/docs/source/llms/gateway/guides/step2-query-gateway.rst
+++ b/docs/source/llms/gateway/guides/step2-query-gateway.rst
@@ -56,7 +56,7 @@ various other parameters. For detailed information, please refer to the document
         print(response)
 
 .. figure:: ../../../_static/images/tutorials/gateway/creating-first-gateway/completions.gif
-   :width: 800px
+   :width: 60%
    :align: center
    :alt: Completions example.
 
@@ -93,7 +93,7 @@ For further details, please consult the documentation.
         print(response)
 
 .. figure:: ../../../_static/images/tutorials/gateway/creating-first-gateway/chat.gif
-   :width: 800px
+   :width: 60%
    :align: center
    :alt: Chat example.
 
@@ -124,7 +124,7 @@ respective numerical vectors. Let's proceed with an example...
         print(response)
 
 .. figure:: ../../../_static/images/tutorials/gateway/creating-first-gateway/embeddings.gif
-   :width: 800px
+   :width: 60%
    :align: center
    :alt: Chat example.
 

--- a/docs/source/llms/llm-evaluate/index.rst
+++ b/docs/source/llms/llm-evaluate/index.rst
@@ -559,6 +559,6 @@ Please see the screenshot below for clarity:
 
 
 .. figure:: ../../_static/images/llm_evaluate_experiment_view.png
-    :width: 1024px
+    :width: 90%
     :align: center
     :alt: Demo UI of MLflow evaluate

--- a/docs/source/llms/rag/index.rst
+++ b/docs/source/llms/rag/index.rst
@@ -1,6 +1,10 @@
 Retrieval Augmented Generation (RAG)
 ====================================
 
+.. raw:: html
+
+   <div class="no-toc"></div>
+
 Retrieval Augmented Generation (RAG) is a powerful and efficient approach to natural 
 language processing that combines the strength of both pre-trained foundation models and 
 retrieval mechanisms. It allows the generative model to access a dataset of documents 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -65,12 +65,16 @@ Follow the steps below to register your MLflow model in the Model Registry.
 1. Open the details page for the MLflow Run containing the logged MLflow model you'd like to register. Select the model folder containing the intended MLflow model in the **Artifacts** section.
 
   .. figure:: _static/images/oss_registry_1_register.png
+    :align: center
+    :figwidth: 90%
 
 2. Click the **Register Model** button, which will trigger a form to pop up.
 
 3. In the **Model** dropdown menu on the form, you can either select "Create New Model", which creates a new registered model with your MLflow model as its initial version, or select an existing registered model, which registers your model under it as a new version. The screenshot below demonstrates registering the MLflow model to a new registered model named ``"iris_model_testing"``.
  
   .. figure:: _static/images/oss_registry_2_dialog.png
+    :align: center
+    :figwidth: 90%
 
 Find Registered Models
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -80,10 +84,14 @@ After you've registered your models in the Model Registry, you can navigate to t
 - Navigate to the **Registered Models** page, which links to your registered models and correponding model versions.
 
   .. figure:: _static/images/oss_registry_3_overview.png
+    :align: center
+    :figwidth: 90%
 
 - Go to the **Artifacts** section of your MLflow Runs details page, click the model folder, and then click the model version at the top right to view the version created from that model.
 
   .. figure:: _static/images/oss_registry_3b_version.png
+    :align: center
+    :figwidth: 90%
 
 Deploy and Organize Models
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -91,14 +99,20 @@ Deploy and Organize Models
 You can deploy and organize your models in the Model Registry using model aliases and tags. To set aliases and tags for model versions in your registered model, navigate to the overview page of your registered model, such as the one below.
 
 .. figure:: _static/images/oss_registry_4_model.png
+    :align: center
+    :figwidth: 90%
 
 You can add or edit aliases and tags for a specific model version by clicking on the corresponding ``Add`` link or pencil icon in the model verison table.
 
 .. figure:: _static/images/oss_registry_4b_model_alias.png
+    :align: center
+    :figwidth: 90%
 
 To learn more about a specific model version, navigate to the details page for that model version.
 
 .. figure:: _static/images/oss_registry_5_version.png
+    :align: center
+    :figwidth: 90%
 
 In this page, you can inspect model version details like the model signature, MLflow source run, and creation timestamp. You can also view and configure the verion's aliases, tags, and description.
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -4858,7 +4858,9 @@ configuration DataFrame for this example defines an interval forecast with nomin
 
 When opening the MLflow runs detail page the serialized model artifact  will show up, such as:
 
-   .. figure:: _static/images/tracking_artifact_ui_custom_flavor.png
+.. figure:: _static/images/tracking_artifact_ui_custom_flavor.png
+    :align: center
+    :figwidth: 40%
 
 To serve the model to a local REST API endpoint run the following MLflow CLI command substituting
 the run id printed during execution of the previous block (for more details refer to the

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -5187,7 +5187,11 @@ Deployments can be generated using both the Python API or MLflow CLI. In both ca
   * Copy the ``MLflow tracking URI`` value from the properties section.
 
 * Programmatically, using Azure ML SDK with the method `Workspace.get_mlflow_tracking_uri() <https://docs.microsoft.com/en-us/python/api/azureml-core/azureml.core.workspace.workspace?view=azure-ml-py#azureml-core-workspace-workspace-get-mlflow-tracking-uri>`_. If you are running inside Azure ML Compute, like for instance a Compute Instance, you can get this value also from the environment variable ``os.environ["MLFLOW_TRACKING_URI"]``.
-* Manually, for a given Subscription ID, Resource Group and Azure ML Workspace, the URI is as follows: ``azureml://eastus.api.azureml.ms/mlflow/v1.0/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP_NAME>/providers/Microsoft.MachineLearningServices/workspaces/<WORKSPACE_NAME>``
+* Manually, for a given Subscription ID, Resource Group and Azure ML Workspace, the URI is as follows: 
+
+    ``azureml://eastus.api.azureml.ms/mlflow/v1.0/subscriptions/``
+    ``<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP_NAME>/``
+    ``providers/Microsoft.MachineLearningServices/workspaces/<WORKSPACE_NAME>``
 
 
 .. rubric:: Configuration example for ACI deployment

--- a/docs/source/new-features/index.rst
+++ b/docs/source/new-features/index.rst
@@ -7,6 +7,8 @@ Find out about the details of major features, changes, and deprecations below.
 
 .. raw:: html
 
+    <div class="no-toc"></div>
+    
     <section>
         <article class="new-content-grid">
             <div class="grid-card">

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -101,7 +101,7 @@ instance of a `FileStore` and `LocalArtifactRepository`.
 
 .. figure:: _static/images/scenario_1.png
     :align: center
-    :figwidth: 600
+    :figwidth: 40%
 
 In this simple scenario, the MLflow client uses the following interfaces to record MLflow entities and artifacts:
 
@@ -116,7 +116,7 @@ are stored under the local ``./mlruns`` directory, and MLflow entities are inser
 
 .. figure:: _static/images/scenario_2.png
     :align: center
-    :figwidth: 600
+    :figwidth: 40%
 
 In this scenario, the MLflow client uses the following interfaces to record MLflow entities and artifacts:
 
@@ -136,7 +136,7 @@ server running, the MLflow client interacts with the tracking server via REST re
 
 .. figure:: _static/images/scenario_3.png
     :align: center
-    :figwidth: 800
+    :figwidth: 60%
 
 .. code-block:: bash
     :caption: Command to run the tracking server in this configuration
@@ -167,7 +167,7 @@ a Postgres database for backend entity storage, and an S3 bucket for artifact st
 
 .. figure:: _static/images/scenario_4.png
     :align: center
-    :figwidth: 800
+    :figwidth: 60%
 
 .. code-block:: bash
     :caption: Command to run the tracking server in this configuration
@@ -212,7 +212,7 @@ need for an end-user to provide access credentials to interact with an underlyin
 
 .. figure:: _static/images/scenario_5.png
     :align: center
-    :figwidth: 800
+    :figwidth: 80%
 
 .. code-block:: bash
     :caption: Command to run the tracking server in this configuration
@@ -273,7 +273,7 @@ MLflow's Tracking Server can be used in an exclusive artifact proxied artifact h
 
 .. figure:: _static/images/scenario_6.png
     :align: center
-    :figwidth: 800
+    :figwidth: 80%
 
 .. code-block:: bash
     :caption: Command to run the tracking server in this configuration
@@ -447,14 +447,20 @@ Visualizing Metrics
 Here is an example plot of the :ref:`quick start tutorial <quickstart-1>` with the step x-axis and two timestamp axes:
 
 .. figure:: _static/images/metrics-step.png
+  :width: 90%
+  :align: center
 
   X-axis step
 
 .. figure:: _static/images/metrics-time-wall.png
+  :width: 90%
+  :align: center
 
   X-axis wall time - graphs the absolute time each metric was logged
 
 .. figure:: _static/images/metrics-time-relative.png
+  :width: 90%
+  :align: center
 
   X-axis relative time - graphs the time relative to the first metric logged, for each run
 

--- a/docs/source/traditional-ml/creating-custom-pyfunc/index.rst
+++ b/docs/source/traditional-ml/creating-custom-pyfunc/index.rst
@@ -1,6 +1,10 @@
 Building Custom Python Function Models with MLflow
 ==================================================
 
+.. raw:: html
+
+   <div class="no-toc"></div>
+
 MLflow offers a wide range of pre-defined model flavors, but there are instances where you'd want to go 
 beyond these and craft something tailored to your needs. That's where custom PyFuncs come in handy.
 

--- a/docs/source/traditional-ml/creating-custom-pyfunc/part1-named-flavors.rst
+++ b/docs/source/traditional-ml/creating-custom-pyfunc/part1-named-flavors.rst
@@ -17,7 +17,7 @@ To understand these constraints, consider the :py:mod:`sklearn <mlflow.sklearn>`
 implementation, highlighting the APIs and serialization methods MLflow has standardized:
 
 .. figure:: ../../_static/images/guides/introductory/creating-custom-pyfunc/anatomy_of_a_model_flavor.svg
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: MLflow's sklearn implementation
 
@@ -46,7 +46,7 @@ encapsulates everything needed to reproduce predictions reliably in various envi
 This includes the model's weights, but it goes far beyond that.
 
 .. figure:: ../../_static/images/guides/introductory/creating-custom-pyfunc/anatomy-of-a-model.svg
-   :width: 480px
+   :width: 50%
    :align: center
    :alt: Components of a Model in MLflow
 
@@ -77,7 +77,7 @@ This includes the model's weights, but it goes far beyond that.
 All of these elements are viewable within the MLflow UI's artifact viewer, when looking at a saved model.
 
 .. figure:: ../../_static/images/guides/introductory/creating-custom-pyfunc/model-components-in-ui.svg
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: Components of a Model in the MLflow UI
 

--- a/docs/source/traditional-ml/creating-custom-pyfunc/part2-pyfunc-components.rst
+++ b/docs/source/traditional-ml/creating-custom-pyfunc/part2-pyfunc-components.rst
@@ -76,7 +76,7 @@ Here's a step-by-step breakdown of the sequence of events that happens when load
 are accessed and referenced to control the behavior of the loaded model object.
 
 .. figure:: ../../_static/images/guides/introductory/creating-custom-pyfunc/pyfunc_loading.svg
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: Tags, experiments, and runs relationships
 

--- a/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/index.rst
+++ b/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/index.rst
@@ -1,6 +1,10 @@
 Hyperparameter Tuning with MLflow and Optuna
 ============================================
 
+.. raw:: html
+
+   <div class="no-toc"></div>
+
 In this guide, we venture into a frequent use case of MLflow Tracking: hyperparameter tuning.
 
 Our journey will begin with a detailed notebook that showcases hyperparameter tuning using Optuna,

--- a/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part1-child-runs.rst
+++ b/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part1-child-runs.rst
@@ -16,7 +16,7 @@ complex ML projects, such as forecasting models for individual products in a sup
 presented in our example. The diagram below offers a visual representation:
 
 .. figure:: ../../_static/images/tutorials/introductory/logging-first-model/tag-exp-run-relationship.svg
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: Tags, experiments, and runs relationships
 
@@ -47,7 +47,7 @@ Benefits of Hyperparameter Tuning
 But here lies the challenge: How do we systematically store the extensive data produced during hyperparameter tuning?
 
 .. figure:: ../../_static/images/guides/introductory/hyperparameter-tuning-with-child-runs/what-to-do-with-hyperparam-runs.svg
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: Challenges with hyperparameter data storage
 
@@ -152,7 +152,7 @@ After executing this, we can navigate to the MLflow UI to see the results of the
 error metrics to the parameters that were selected.
 
 .. figure:: ../../_static/images/guides/introductory/hyperparameter-tuning-with-child-runs/no-child-first.gif
-    :width: 1024px
+    :width: 90%
     :align: center
     :alt: Hyperparameter tuning no child runs
 
@@ -185,7 +185,7 @@ This may become a serious problem for analysis if we:
 Let's take a look at the UI and see if it is clear which iteration a particular run is a member of.
 
 .. figure:: ../../_static/images/guides/introductory/hyperparameter-tuning-with-child-runs/no-child-more.gif
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: Adding more runs
 
@@ -310,7 +310,7 @@ with different conditions of hyperparameter selection criteria.
 Once we execute these three tuning run tests, we can view the results in the UI:
 
 .. figure:: ../../_static/images/guides/introductory/hyperparameter-tuning-with-child-runs/child-runs.gif
-   :width: 860px
+   :width: 70%
    :align: center
    :alt: Using child runs
 
@@ -342,7 +342,7 @@ recommended to develop your own implementation that fulfills the following requi
 The results in the UI for this challenge are shown below.
 
 .. figure:: ../../_static/images/guides/introductory/hyperparameter-tuning-with-child-runs/parent-child-challenge.gif
-   :width: 860px
+   :width: 70%
    :align: center
    :alt: Challenge
 

--- a/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part2-logging-plots.rst
+++ b/docs/source/traditional-ml/hyperparameter-tuning-with-child-runs/part2-logging-plots.rst
@@ -35,7 +35,7 @@ and guides, so it's essential to clarify why this method is chosen for the provi
 **The Central Issue: Statefulness**
 
 .. figure:: ../../_static/images/guides/introductory/hyperparameter-tuning-with-child-runs/notebook-dangers.svg
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: Notebook state
 
@@ -295,7 +295,7 @@ fetched from the local file system and logged via ``log_artifacts()``, we're abl
 associated with our data and our trained model, capturing the state at which the run was conducted.
 
 .. figure:: ../../_static/images/guides/introductory/hyperparameter-tuning-with-child-runs/plots-in-ui.gif
-   :width: 1024px
+   :width: 90%
    :align: center
    :alt: Viewing plots in the UI
 

--- a/docs/theme/mlflow/layout.html
+++ b/docs/theme/mlflow/layout.html
@@ -62,6 +62,7 @@
     <link rel="stylesheet" href="{{ pathto('_static/css/cards.css', 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/css/grids.css', 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/css/simple-cards.css', 1) }}" type="text/css" />
+    <link rel="stylesheet" href="{{ pathto('_static/css/floating-toc.css', 1) }}" type="text/css" />
     {% if target_cloud == 'azure' %}
       <link rel="stylesheet" href="{{ pathto('_static/css/custom-azure.css', 1) }}" type="text/css" />
     {% endif %}

--- a/docs/theme/mlflow/static/css/custom.css
+++ b/docs/theme/mlflow/static/css/custom.css
@@ -29,7 +29,8 @@
 
 /* Set max-width for docs... */
 .wy-nav-content {
-    max-width: 1440px !important;
+    max-width: 1200px !important;
+    position: relative;
 }
 
 .db-icon-arrow-down-circle:before {

--- a/docs/theme/mlflow/static/css/floating-toc.css
+++ b/docs/theme/mlflow/static/css/floating-toc.css
@@ -1,0 +1,61 @@
+/* CSS for ToC Container */
+#floating-toc-container {
+    position: fixed;
+    right: 2rem;
+    top: 12rem;
+    min-width: 250px;
+    max-width: 350px;
+    width: auto;
+    max-height: 60vh;
+    overflow-y: auto;
+    background: #f8f9fa; 
+    padding: 10px;
+    border-radius: 10px; /* Rounded edges */
+    box-shadow: rgba(2, 8, 20, 0.3) 0.4rem 0.8rem 1.6rem, rgba(2, 8, 20, 0.1) 0rem 0.4rem 3px;
+    z-index: 99;
+    display: flex;
+}
+
+#floating-toc li {
+    list-style: none;
+    padding-top: 5px;
+    padding-left: 10px;
+    text-indent: 0px;
+}
+
+#floating-toc li a {
+    color: hsl(205, 100%, 25%); 
+    text-decoration: none;
+    transition: color 0.2s; 
+    display: inline-block;
+}
+
+#floating-toc li.toc-h1 a {
+    font-size: 1.2rem;
+}
+
+#floating-toc li.toc-h2 a {
+    color: hsl(205, 100%, 35%); 
+    font-size: 1.1rem;
+    padding-left: 20px;
+}
+
+#floating-toc li.toc-h3 a {
+    color: hsl(205, 100%, 45%); 
+    font-size: 1rem;
+    padding-left: 30px;
+}
+
+#floating-toc li a.active {
+    font-weight: bold;
+    background-color: #007bff; 
+    border-radius: 5px;
+    color: white;
+    padding-right: 10px;
+    padding-left: 5px;
+}
+
+#floating-toc li a:hover {
+    color: hsl(205, 100%, 70%);
+    font-weight: bold;
+}

--- a/docs/theme/mlflow/static/css/floating-toc.css
+++ b/docs/theme/mlflow/static/css/floating-toc.css
@@ -2,32 +2,45 @@
 #floating-toc-container {
     position: fixed;
     right: 2rem;
-    top: 12rem;
+    top: 6rem;
     min-width: 250px;
-    max-width: 350px;
+    max-width: 300px;
     width: auto;
-    max-height: 60vh;
+    max-height: 70vh;
     overflow-y: auto;
-    background: #f8f9fa; 
-    padding: 10px;
-    border-radius: 10px; /* Rounded edges */
-    box-shadow: rgba(2, 8, 20, 0.3) 0.4rem 0.8rem 1.6rem, rgba(2, 8, 20, 0.1) 0rem 0.4rem 3px;
+    background: #ffffff;
+    padding: 15px;
+    border-radius: 8px;
+    box-shadow: rgba(0, 0, 0, 0.1) 0rem 0.4rem 1.2rem;
     z-index: 99;
-    display: flex;
+    display: block;
+    transition: border-color 0.3s ease-in-out;
+    border: 2px solid transparent; 
+}
+
+/*Hide the ToC on mobile devices as there isn't enough room to display it*/
+@media only screen and (max-width: 768px) {
+    #floating-toc-container {
+        display: none; 
+    }
+}
+
+#floating-toc-container:hover {
+    border: 2px solid #1a73e8;
 }
 
 #floating-toc li {
     list-style: none;
-    padding-top: 5px;
-    padding-left: 10px;
-    text-indent: 0px;
+    margin-top: 4px; 
 }
 
 #floating-toc li a {
-    color: hsl(205, 100%, 25%); 
+    color: #333333; 
     text-decoration: none;
-    transition: color 0.2s; 
-    display: inline-block;
+    transition: all 0.2s ease-in-out; 
+    display: block; 
+    padding: 6px 8px; 
+    transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out;
 }
 
 #floating-toc li.toc-h1 a {
@@ -35,27 +48,38 @@
 }
 
 #floating-toc li.toc-h2 a {
-    color: hsl(205, 100%, 35%); 
+    padding-left: 34px;
     font-size: 1.1rem;
-    padding-left: 20px;
 }
 
 #floating-toc li.toc-h3 a {
-    color: hsl(205, 100%, 45%); 
+    padding-left: 48px;
     font-size: 1rem;
-    padding-left: 30px;
-}
-
-#floating-toc li a.active {
-    font-weight: bold;
-    background-color: #007bff; 
-    border-radius: 5px;
-    color: white;
-    padding-right: 10px;
-    padding-left: 5px;
 }
 
 #floating-toc li a:hover {
-    color: hsl(205, 100%, 70%);
-    font-weight: bold;
+    background-color: #f2f2f2;
+    color: #1a73e8; 
+}
+
+#floating-toc li a:active {
+    animation: flashOnClick 0.4s ease-out;
+}
+
+@keyframes flashOnClick {
+    0%, 100% {
+        background-color: #f2f2f2;
+        color: #1a73e8;
+    }
+    25%, 75% {
+        background-color: #1a73e8;
+        color: #f2f2f2;
+    }
+}
+
+#floating-toc li a.active {
+    font-weight: 700;
+    background-color: #1a73e8;
+    color: #ffffff; 
+    border-radius: 4px;
 }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/10295?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10295/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10295
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add an active in-page interactive page navigation element. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests


https://github.com/mlflow/mlflow/assets/39283302/4a346e29-9009-43d6-88e8-f09737d421db


### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
