### PR TITLE
Fix flaky floating point precision in sklearn autologging suite

### DIFF
--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -208,7 +208,7 @@ def test_estimator(fit_func_name):
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
-    assert {TRAINING_SCORE: model.score(X, y)}.items() <= metrics.items()
+    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
 
@@ -382,7 +382,7 @@ def test_meta_estimator():
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
-    assert {TRAINING_SCORE: model.score(X, y)}.items() <= metrics.items()
+    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     assert_predict_equal(load_model_by_run_id(run_id), model, X)
@@ -412,7 +412,7 @@ def test_get_params_returns_dict_that_has_more_keys_than_max_params_tags_per_bat
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run.info.run_id)
     assert params == large_params
-    assert {TRAINING_SCORE: model.score(X, y)}.items() <= metrics.items()
+    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     loaded_model = load_model_by_run_id(run_id)
@@ -450,7 +450,7 @@ def test_get_params_returns_dict_whose_key_or_value_exceeds_length_limit(long_pa
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run.info.run_id)
     assert params == truncate_dict(long_params)
-    assert {TRAINING_SCORE: model.score(X, y)}.items() <= metrics.items()
+    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     loaded_model = load_model_by_run_id(run_id)
@@ -514,7 +514,7 @@ def test_call_fit_with_arguments_score_does_not_accept():
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
-    assert {TRAINING_SCORE: model.score(X, y)}.items() <= metrics.items()
+    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     assert_predict_equal(load_model_by_run_id(run_id), model, X)
@@ -559,7 +559,7 @@ def test_both_fit_and_score_contain_sample_weight(sample_weight_passed_as):
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
-    assert {TRAINING_SCORE: model.score(X, y)}.items() <= metrics.items()
+    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     assert_predict_equal(load_model_by_run_id(run_id), model, X)
@@ -597,7 +597,7 @@ def test_only_fit_contains_sample_weight():
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
-    assert {TRAINING_SCORE: model.score(X, y)}.items() <= metrics.items()
+    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     assert_predict_equal(load_model_by_run_id(run_id), model, X)
@@ -636,7 +636,7 @@ def test_only_score_contains_sample_weight():
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
-    assert {TRAINING_SCORE: model.score(X, y)}.items() <= metrics.items()
+    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     assert_predict_equal(load_model_by_run_id(run_id), model, X)

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -475,7 +475,7 @@ def test_fit_takes_Xy_as_keyword_arguments(Xy_passed_as):
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
-    assert {TRAINING_SCORE: model.score(X, y)}.items() <= metrics.items()
+    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     assert_predict_equal(load_model_by_run_id(run_id), model, X)

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -208,7 +208,7 @@ def test_estimator(fit_func_name):
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
-    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
+    assert {TRAINING_SCORE: pytest.approx(model.score(X, y), abs=1e-6)}.items() <= metrics.items()
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
 
@@ -382,7 +382,7 @@ def test_meta_estimator():
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
-    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
+    assert {TRAINING_SCORE: pytest.approx(model.score(X, y), abs=1e-6)}.items() <= metrics.items()
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     assert_predict_equal(load_model_by_run_id(run_id), model, X)
@@ -412,7 +412,7 @@ def test_get_params_returns_dict_that_has_more_keys_than_max_params_tags_per_bat
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run.info.run_id)
     assert params == large_params
-    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
+    assert {TRAINING_SCORE: pytest.approx(model.score(X, y), abs=1e-6)}.items() <= metrics.items()
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     loaded_model = load_model_by_run_id(run_id)
@@ -450,7 +450,7 @@ def test_get_params_returns_dict_whose_key_or_value_exceeds_length_limit(long_pa
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run.info.run_id)
     assert params == truncate_dict(long_params)
-    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
+    assert {TRAINING_SCORE: pytest.approx(model.score(X, y), abs=1e-6)}.items() <= metrics.items()
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     loaded_model = load_model_by_run_id(run_id)
@@ -475,7 +475,7 @@ def test_fit_takes_Xy_as_keyword_arguments(Xy_passed_as):
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
-    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
+    assert {TRAINING_SCORE: pytest.approx(model.score(X, y), abs=1e-6)}.items() <= metrics.items()
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     assert_predict_equal(load_model_by_run_id(run_id), model, X)
@@ -514,7 +514,7 @@ def test_call_fit_with_arguments_score_does_not_accept():
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
-    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
+    assert {TRAINING_SCORE: pytest.approx(model.score(X, y), abs=1e-6)}.items() <= metrics.items()
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     assert_predict_equal(load_model_by_run_id(run_id), model, X)
@@ -559,7 +559,7 @@ def test_both_fit_and_score_contain_sample_weight(sample_weight_passed_as):
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
-    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
+    assert {TRAINING_SCORE: pytest.approx(model.score(X, y), abs=1e-6)}.items() <= metrics.items()
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     assert_predict_equal(load_model_by_run_id(run_id), model, X)
@@ -597,7 +597,7 @@ def test_only_fit_contains_sample_weight():
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
-    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
+    assert {TRAINING_SCORE: pytest.approx(model.score(X, y), abs=1e-6)}.items() <= metrics.items()
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     assert_predict_equal(load_model_by_run_id(run_id), model, X)
@@ -636,7 +636,7 @@ def test_only_score_contains_sample_weight():
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
-    assert {TRAINING_SCORE: model.score(X, y)} == pytest.approx(metrics)
+    assert {TRAINING_SCORE: pytest.approx(model.score(X, y), abs=1e-6)}.items() <= metrics.items()
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
     assert_predict_equal(load_model_by_run_id(run_id), model, X)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/10303?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10303/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10303
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

use pytest.approx to handle minor differences in floating point precision. 
Related failure: https://github.com/mlflow-automation/mlflow/actions/runs/6771303955/job/18410637205 

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
