### PR TITLE
[FEAT] Adding string type of score types for metric value for Eval

### DIFF
--- a/docs/source/llms/llm-evaluate/index.rst
+++ b/docs/source/llms/llm-evaluate/index.rst
@@ -326,7 +326,7 @@ Basically you need to:
 2. Pass ``eval_fn`` and other arguments to ``mlflow.metrics.make_metric`` API to create the metric. 
 
 The following code creates a dummy per-row metric called ``"over_10_chars"``: if the model output is greater than 10, 
-the score is 1 otherwise 0.
+the score is "yes" otherwise "no".
 
 .. code-block:: python
 
@@ -334,9 +334,9 @@ the score is 1 otherwise 0.
         scores = []
         for i in range(len(predictions)):
             if len(predictions[i]) > 10:
-                scores.append(1)
+                scores.append("yes")
             else:
-                scores.append(0)
+                scores.append("no")
         return MetricValue(
             scores=scores,
             aggregate_results=standard_aggregations(scores),

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Union
 
 from mlflow.utils.annotations import experimental
 
@@ -15,6 +15,6 @@ class MetricValue:
     :param aggregate_results: A dictionary mapping the name of the aggregation to its value
     """
 
-    scores: List[float] = None
+    scores: Union[List[str], List[float]] = None
     justifications: List[str] = None
     aggregate_results: Dict[str, float] = None

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -561,6 +561,10 @@ def _is_numeric(value):
     return isinstance(value, (int, float, np.number))
 
 
+def _is_string(value):
+    return isinstance(value, str)
+
+
 def _evaluate_extra_metric(extra_metric_tuple, eval_fn_args):
     """
     This function calls the `extra_metric` function and performs validations on the returned
@@ -598,8 +602,10 @@ def _evaluate_extra_metric(extra_metric_tuple, eval_fn_args):
         if not isinstance(scores, list):
             _logger.warning(f"{exception_header} must return MetricValue with scores as a list.")
             return
-        if any(not (_is_numeric(score) or score is None) for score in scores):
-            _logger.warning(f"{exception_header} must return MetricValue with numeric scores.")
+        if any(not (_is_numeric(score) or _is_string(score) or score is None) for score in scores):
+            _logger.warning(
+                f"{exception_header} must return MetricValue with numeric or string scores."
+            )
             return
 
     if justifications is not None:

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -1378,7 +1378,7 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         )
 
     def incorrect_return_type(*_):
-        return "stuff", 3
+        return ["stuff"], 3
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_extra_metric(
@@ -1402,15 +1402,15 @@ def test_evaluate_custom_metric_incorrect_return_formats():
         )
 
     def non_numeric_scores(*_):
-        return MetricValue(scores=["string"])
+        return MetricValue(scores=[{"val": "string"}])
 
     with mock.patch("mlflow.models.evaluation.default_evaluator._logger.warning") as mock_warning:
         _evaluate_extra_metric(
             _CustomMetric(non_numeric_scores, non_numeric_scores.__name__, 0), eval_fn_args
         )
         mock_warning.assert_called_once_with(
-            f"Did not log metric '{non_numeric_scores.__name__}' at index 0 in the "
-            "`extra_metrics` parameter because it must return MetricValue with numeric scores."
+            f"Did not log metric '{non_numeric_scores.__name__}' at index 0 in the `extra_metrics`"
+            " parameter because it must return MetricValue with numeric or string scores."
         )
 
     def non_list_justifications(*_):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sunishsheth2009/mlflow/pull/10307?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10307/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10307
```

</p>
</details>

### What changes are proposed in this pull request?
[FEAT] Adding other types of score types for metric value for Eval

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

[FEAT] Adding string type of score types for metric value for Eval

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
