### PR TITLE
Inline hyperparameter tuning code for quickstart 2

### DIFF
--- a/docs/source/getting-started/quickstart-2/index.rst
+++ b/docs/source/getting-started/quickstart-2/index.rst
@@ -51,6 +51,7 @@ Run the hyperparameter sweep, setting the ``MLFLOW_TRACKING_URI`` environment va
     from tensorflow.keras.optimizers import SGD
 
     import mlflow
+    from mlflow.models import infer_signature
 
     # Load dataset
     data = pd.read_csv(
@@ -95,7 +96,8 @@ Run the hyperparameter sweep, setting the ``MLFLOW_TRACKING_URI`` environment va
             mlflow.log_metric("rmse", rmse)
 
             # Log model
-            mlflow.tensorflow.log_model(model, "model")
+            signature = infer_signature(train_x, train_y)
+            mlflow.tensorflow.log_model(model, "model", signature=signature)
 
             return {"loss": rmse, "status": STATUS_OK, "model": model}
 

--- a/docs/source/getting-started/quickstart-2/index.rst
+++ b/docs/source/getting-started/quickstart-2/index.rst
@@ -81,6 +81,7 @@ Now load the dataset and split it into training, validation, and test sets.
 Then, define the model architecture and train the model. The ``train_model`` function uses MLflow to track the parameters and results of each run. It also logs the model itself. 
 
 .. code-block:: python
+
     def train_model(params, train_x, train_y, valid_x, valid_y, test_x, test_y, epochs):
         # Define model architecture
         model = Sequential()
@@ -123,6 +124,7 @@ Then, define the model architecture and train the model. The ``train_model`` fun
 The ``objective`` function defines the search space for Hyperopt and calls ``train_model``. 
 
 .. code-block:: python
+
     def objective(params):
         # MLflow will track the parameters and results for each run
         result = train_model(
@@ -147,6 +149,7 @@ The ``objective`` function defines the search space for Hyperopt and calls ``tra
 Finally, run the hyperparameter sweep using the ``objective`` function and across the search space. Store the best parameters, model, and rmse in MLflow.
 
 .. code-block:: python
+
     with mlflow.start_run():
         # Conduct the hyperparameter search using Hyperopt
         trials = Trials()

--- a/docs/source/getting-started/quickstart-2/index.rst
+++ b/docs/source/getting-started/quickstart-2/index.rst
@@ -24,24 +24,128 @@ Set up
 ------
 
 - Install MLflow. See the :ref:`introductory quickstart <quickstart-1>` for instructions
-- Clone the `MLflow git repo <https://github.com/mlflow/mlflow>`_
 - Run the tracking server: ``mlflow server``
 
 Run a hyperparameter sweep
 --------------------------
 
-Switch to the ``examples/hyperparam/`` directory in the MLflow git repo. This example tries to optimize the RMSE metric of a Keras deep learning model on a wine quality dataset. It has two hyperparameters that it tries to optimize: ``learning-rate`` and ``momentum``.
+This example tries to optimize the RMSE metric of a Keras deep learning model on a wine quality dataset. It has two hyperparameters that it tries to optimize: ``learning-rate`` and ``momentum``.
 
-This directory uses the :ref:`MLflow Projects format <projects>` and defines multiple entry points. You can review those by reading the **MLProject** file. The ``hyperopt`` entry point uses the `Hyperopt <https://github.com/hyperopt/hyperopt>`_ library to run a hyperparameter sweep over the ``train`` entry point. The ``hyperopt`` entry point sets different values of ``learning-rate`` and ``momentum`` and records the results in MLflow.
+We will use the `Hyperopt <https://github.com/hyperopt/hyperopt>`_ library to run a hyperparameter sweep. The ``hyperopt`` entry point sets different values of ``learning-rate`` and ``momentum`` and records the results in MLflow. 
 
 Run the hyperparameter sweep, setting the ``MLFLOW_TRACKING_URI`` environment variable to the URI of the MLflow tracking server:
 
 .. code-block:: bash
 
   export MLFLOW_TRACKING_URI=http://localhost:5000
-  mlflow run -e hyperopt .
 
-The ``hyperopt`` entry point defaults to 12 runs of 32 epochs apiece and should take a few minutes to finish.
+.. code-block:: python
+
+    import numpy as np
+    import pandas as pd
+    from hyperopt import STATUS_OK, Trials, fmin, hp, tpe
+    from sklearn.metrics import mean_squared_error
+    from sklearn.model_selection import train_test_split
+    from tensorflow.keras.layers import Dense, Lambda
+    from tensorflow.keras.models import Sequential
+    from tensorflow.keras.optimizers import SGD
+
+    import mlflow
+
+    # Load dataset
+    data = pd.read_csv(
+        "https://raw.githubusercontent.com/mlflow/mlflow/master/tests/datasets/winequality-white.csv",
+        sep=";",
+    )
+
+    # Split the data into training, validation, and test sets
+    train, test = train_test_split(data, test_size=0.25, random_state=42)
+    train_x = train.drop(["quality"], axis=1).values
+    train_y = train[["quality"]].values.ravel()
+    test_x = test.drop(["quality"], axis=1).values
+    test_y = test[["quality"]].values.ravel()
+    train_x, valid_x, train_y, valid_y = train_test_split(
+        train_x, train_y, test_size=0.2, random_state=42
+    )
+
+
+    def train_model(params, train_x, train_y, valid_x, valid_y, test_x, test_y, epochs):
+        # Define model architecture
+        model = Sequential()
+        model.add(Lambda(lambda x: (x - np.mean(train_x, axis=0)) / np.std(train_x, axis=0)))
+        model.add(Dense(64, activation="relu", input_shape=(train_x.shape[1],)))
+        model.add(Dense(1))
+
+        # Compile model
+        model.compile(
+            optimizer=SGD(lr=params["lr"], momentum=params["momentum"]), loss="mean_squared_error"
+        )
+
+        # Train model with MLflow tracking
+        with mlflow.start_run(nested=True):
+            # Fit model
+            model.fit(train_x, train_y, validation_data=(valid_x, valid_y), epochs=epochs, verbose=0)
+
+            # Evaluate the model
+            predicted_qualities = model.predict(test_x)
+            rmse = np.sqrt(mean_squared_error(test_y, predicted_qualities))
+
+            # Log parameters and results
+            mlflow.log_params(params)
+            mlflow.log_metric("rmse", rmse)
+
+            # Log model
+            mlflow.tensorflow.log_model(model, "model")
+
+            return {"loss": rmse, "status": STATUS_OK, "model": model}
+
+
+    def objective(params):
+        # MLflow will track the parameters and results for each run
+        result = train_model(
+            params,
+            train_x=train_x,
+            train_y=train_y,
+            valid_x=valid_x,
+            valid_y=valid_y,
+            test_x=test_x,
+            test_y=test_y,
+            epochs=100,  # Or any other number of epochs
+        )
+        return result
+
+
+    # Define the search space for Hyperopt
+    space = {
+        "lr": hp.loguniform("lr", np.log(1e-5), np.log(1e-1)),
+        "momentum": hp.uniform("momentum", 0.0, 1.0),
+    }
+
+
+    with mlflow.start_run():
+        # Conduct the hyperparameter search using Hyperopt
+        trials = Trials()
+        best = fmin(
+            fn=objective,
+            space=space,
+            algo=tpe.suggest,
+            max_evals=5,  # Set to a higher number to explore more hyperparameter configurations
+            trials=trials,
+        )
+
+        # Fetch the details of the best run
+        best_run = sorted(trials.results, key=lambda x: x["loss"])[0]
+
+        # Log the best parameters and corresponding minimum loss
+        mlflow.log_params(best)
+        mlflow.log_metric("rmse", best_run["loss"])
+
+        # Print out the best parameters and corresponding loss
+        print(f"Best parameters: {best}")
+        print(f"Best rmse: {best_run['loss']}")
+
+
+The this code defaults to 12 runs of 32 epochs apiece and should take a few minutes to finish.
 
 Compare the results
 -------------------


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/prithvikannan/mlflow/pull/10322?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10322/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10322
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

To make Quickstart 2 easier to use, we will inline the code from the `examples/hyperparam/` folder. Users no longer have to use MLflow Projects, and can just copy-paste code from when doing the tutorial. Additionally, we simplify the code such that it only includes components relevant to the quickstart.

The new quickstart looks like [this](https://output.circle-artifacts.com/output/job/5b0c3a47-93b5-48ce-8974-6ae39c6bddd7/artifacts/0/docs/build/html/getting-started/quickstart-2/index.html):
<img width="1385" alt="image" src="https://github.com/mlflow/mlflow/assets/46332835/5f12b9c3-87dc-4279-b285-621fdfa6c2e9">

This code will generate the following outputs:
![image](https://github.com/mlflow/mlflow/assets/46332835/a4a144bd-c937-4e6e-aa57-375bcc41ce30)


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
