### PR TITLE
[WIP] Make `psutil` to make it lazy load andadd custom implementation for Arm64 Linux

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,7 @@ import click
 import pytest
 
 from mlflow.environment_variables import _MLFLOW_TESTING, MLFLOW_TRACKING_URI
+from mlflow.utils.process import virtual_memory
 from mlflow.version import VERSION
 
 from tests.helper_functions import get_safe_port
@@ -104,17 +105,18 @@ def pytest_runtest_setup(item):
 def pytest_report_teststatus(report, config):
     outcome = yield
     if report.when == "call":
+        # SKip showing stats at all if psutil is not installed
         try:
             import psutil
         except ImportError:
             return
 
         (*rest, result) = outcome.get_result()
-        mem = psutil.virtual_memory()
+        mem = virtual_memory()
         mem_used = mem.used / 1024**3
         mem_total = mem.total / 1024**3
 
-        disk = psutil.disk_usage("/")
+        disk = shutil.disk_usage("/")
         disk_used = disk.used / 1024**3
         disk_total = disk.total / 1024**3
         outcome.force_result(

--- a/dev/Dockerfile.test
+++ b/dev/Dockerfile.test
@@ -20,7 +20,7 @@ ADD ./requirements /app/requirements
 RUN \
     # install required python packages
     pip install -r requirements/test-requirements.txt --no-cache-dir \
-        -r requirements/lint-requirements.txt psutil
+        -r requirements/lint-requirements.txt
 
 ADD . /app
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,8 @@
 FROM python:3.10-slim-bullseye
 ARG VERSION
-# NB: installing gcc is required in order to build a wheel file 
-# for psutil, which is a dependency of mlflow. 
-# The binaries for psutil do not support Python 3.10, requiring 
-# a build from source. psutil has a large amount of cython within 
-# its code base, necessitating gcc being present in the image.
-RUN apt-get update && \
-    apt-get install -y gcc && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# NB: psutil doesn't have binary for Arm64 Linux so we need to build it from 
+# CPython, which causes multiple headache during build. As psutil is only 
+# required for system metrics monitoring and gateway, hence we make is optional 
+# and provide custom implementation in utils/process.py for Arm64 Linux. 
+RUN if [ "$(uname -m)" != "aarch64" ]; then pip install --no-cache psutil; fi
 RUN pip install --no-cache mlflow==$VERSION

--- a/examples/databricks/multipart.py
+++ b/examples/databricks/multipart.py
@@ -9,7 +9,6 @@ import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pandas as pd
-import psutil
 from tqdm.auto import tqdm
 
 import mlflow
@@ -17,19 +16,20 @@ from mlflow.environment_variables import (
     MLFLOW_ENABLE_MULTIPART_DOWNLOAD,
     MLFLOW_ENABLE_MULTIPART_UPLOAD,
 )
+from mlflow.utils.process import cpu_count, virtual_memory
 from mlflow.utils.time import Timer
 
 GiB = 1024**3
 
 
 def show_system_info():
-    svmem = psutil.virtual_memory()
+    svmem = virtual_memory()
     info = json.dumps(
         {
             "MLflow version": mlflow.__version__,
             "MPU enabled": MLFLOW_ENABLE_MULTIPART_DOWNLOAD.get(),
             "MPD enabled": MLFLOW_ENABLE_MULTIPART_UPLOAD.get(),
-            "CPU count": psutil.cpu_count(),
+            "CPU count": cpu_count(),
             "Memory usage (total) [GiB]": svmem.total // GiB,
             "Memory used [GiB]": svmem.used // GiB,
             "Memory available [GiB]": svmem.available // GiB,

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -37,23 +37,6 @@ def check_configuration_route_name_collisions(config):
         )
 
 
-def kill_child_processes(parent_pid):
-    """
-    Gracefully terminate or kill child processes from a main process
-    """
-    import psutil
-
-    parent = psutil.Process(parent_pid)
-    for child in parent.children(recursive=True):
-        try:
-            child.terminate()
-        except psutil.NoSuchProcess:
-            pass
-    _, still_alive = psutil.wait_procs(parent.children(), timeout=3)
-    for p in still_alive:
-        p.kill()
-
-
 def _is_valid_uri(uri: str):
     """
     Evaluates the basic structure of a provided gateway uri to determine if the scheme and

--- a/mlflow/system_metrics/metrics/cpu_monitor.py
+++ b/mlflow/system_metrics/metrics/cpu_monitor.py
@@ -1,8 +1,7 @@
 """Class for monitoring CPU stats."""
 
-import psutil
-
 from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonitor
+from mlflow.utils import process
 
 
 class CPUMonitor(BaseMetricsMonitor):
@@ -10,10 +9,10 @@ class CPUMonitor(BaseMetricsMonitor):
 
     def collect_metrics(self):
         # Get CPU metrics.
-        cpu_percent = psutil.cpu_percent()
+        cpu_percent = process.cpu_percent()
         self._metrics["cpu_utilization_percentage"].append(cpu_percent)
 
-        system_memory = psutil.virtual_memory()
+        system_memory = process.virtual_memory()
         self._metrics["system_memory_usage_megabytes"].append(system_memory.used / 1e6)
         self._metrics["system_memory_usage_percentage"].append(
             system_memory.used / system_memory.total * 100

--- a/mlflow/system_metrics/metrics/disk_monitor.py
+++ b/mlflow/system_metrics/metrics/disk_monitor.py
@@ -2,9 +2,8 @@
 
 import os
 
-import psutil
-
 from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonitor
+from mlflow.utils import process
 
 
 class DiskMonitor(BaseMetricsMonitor):
@@ -12,7 +11,7 @@ class DiskMonitor(BaseMetricsMonitor):
 
     def collect_metrics(self):
         # Get disk usage metrics.
-        disk_usage = psutil.disk_usage(os.sep)
+        disk_usage = process.disk_usage(os.sep)
         self._metrics["disk_usage_percentage"].append(disk_usage.percent)
         self._metrics["disk_usage_megabytes"].append(disk_usage.used / 1e6)
         self._metrics["disk_available_megabytes"].append(disk_usage.free / 1e6)

--- a/mlflow/system_metrics/metrics/network_monitor.py
+++ b/mlflow/system_metrics/metrics/network_monitor.py
@@ -1,9 +1,8 @@
 """Class for monitoring network stats."""
 
 
-import psutil
-
 from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonitor
+from mlflow.utils.process import net_io_counters
 
 
 class NetworkMonitor(BaseMetricsMonitor):
@@ -15,13 +14,13 @@ class NetworkMonitor(BaseMetricsMonitor):
         # Set initial network usage metrics. `psutil.net_io_counters()` counts the stats since the
         # system boot, so to set network usage metrics as 0 when we start logging, we need to keep
         # the initial network usage metrics.
-        network_usage = psutil.net_io_counters()
+        network_usage = net_io_counters()
         self._initial_receive_megabytes = network_usage.bytes_recv / 1e6
         self._initial_transmit_megabytes = network_usage.bytes_sent / 1e6
 
     def collect_metrics(self):
         # Get network usage metrics.
-        network_usage = psutil.net_io_counters()
+        network_usage = net_io_counters()
         # Usage metrics will be the diff between current and initial metrics.
         self._metrics["network_receive_megabytes"] = (
             network_usage.bytes_recv / 1e6 - self._initial_receive_megabytes

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -1,7 +1,14 @@
 import functools
+import logging
 import os
+import platform
+import signal
 import subprocess
 import sys
+import time
+from collections import namedtuple
+
+from mlflow.exceptions import MlflowException
 
 _IS_UNIX = os.name != "nt"
 
@@ -156,3 +163,196 @@ def cache_return_value_per_process(fn):
         return new_value
 
     return wrapped_fn
+
+
+def kill_child_processes(parent_pid):
+    """
+    Gracefully terminate or kill child processes from a main process
+    """
+
+    # Terminate parent and child processes.
+    os.kill(parent_pid, signal.SIGTERM)
+
+    # Wait for 3 seconds to let the child processes exit gracefully.
+    time.sleep(3)
+
+    # If the parent process is still running after 3 seconds, send SIGKILL
+    try:
+        os.kill(parent_pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+
+    # Kill the children processes still alive.
+    still_alive = os.popen("pgrep -P %d" % parent_pid).read().split()
+    for p in still_alive:
+        try:
+            os.kill(p, signal.SIGKILL)
+        except OSError:
+            logging.warning("Failed to kill child process %s", p)
+
+
+# As of 2023 Nov psutil doesn't have binary for Arm64 Linux, requireing building from CPython source. To
+# avoid headache of building with GCC, we only use it on other platforms and use custom implementation on arm64.
+def _check_and_install_psutil():
+    if _is_arm64_linux():
+        raise MlflowException(
+            "We don't use psutil on Arm64 Linux hardware as it doesn't provide binary"
+            "for it. mlflow/utils/process.py should provide custom implementation for it."
+        )
+    try:
+        import psutil
+    except ImportError:
+        logging.warning(
+            "Installing `psutil` package as it is required to use system metrics in MLflow. "
+        )
+        # install psutil from pip
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "psutil<6"])
+
+
+def _is_arm64_linux():
+    return platform.system() == "Linux" and platform.machine() == "aarch64"
+
+
+def cpu_count():
+    if _is_arm64_linux():
+        return Arm64ProcessUtilAdaptor.cpu_count()
+
+    _check_and_install_psutil()
+    import psutil
+
+    return psutil.cpu_count()
+
+
+def cpu_percent():
+    if _is_arm64_linux():
+        return Arm64ProcessUtilAdaptor.cpu_percent()
+
+    _check_and_install_psutil()
+    import psutil
+
+    return psutil.cpu_percent()
+
+
+def virtual_memory():
+    if _is_arm64_linux():
+        return Arm64ProcessUtilAdaptor.virtual_memory()
+
+    _check_and_install_psutil()
+    import psutil
+
+    return psutil.virtual_memory()
+
+
+def disk_usage(path: str):
+    if _is_arm64_linux():
+        return Arm64ProcessUtilAdaptor.disk_usage(path)
+
+    _check_and_install_psutil()
+    import psutil
+
+    return psutil.disk_usage(path)
+
+
+def net_io_counters():
+    if _is_arm64_linux():
+        return Arm64ProcessUtilAdaptor.net_io_counter()
+
+    _check_and_install_psutil()
+    import psutil
+
+    return psutil.net_io_counters()
+
+
+_last_cpu_times = {}
+
+
+class Arm64ProcessUtilAdaptor:
+    @staticmethod
+    def cpu_count():
+        # Get cpu count by reading /proc/cpuinfo
+        with open("/proc/cpuinfo") as f:
+            cpuinfo = f.read()
+        return cpuinfo.count("processor")
+
+    @staticmethod
+    def cpu_percent():
+        # Get cpu usage from /proc/stat
+        cpu_time = Arm64ProcessUtilAdaptor._get_cpu_times()
+        last_cpu_time = _last_cpu_times.get("cpu_time", cpu_time)
+        _last_cpu_times["cpu_time"] = cpu_time
+        total = sum(cpu_time) - sum(last_cpu_time)
+        idle = cpu_time.idle - last_cpu_time.idle
+        try:
+            busy_pct = 100 * (total - idle) / total
+        except ZeroDivisionError:
+            return 0.0
+        return round(busy_pct, 1)
+
+    @staticmethod
+    def _get_cpu_times():
+        cpu_time = namedtuple("scputime", ["user", "system", "idle"], defaults=(0, 0, 0))
+        with open("/proc/stat") as f:
+            stat = f.readline()
+        fields = (float(x) for x in stat.split(" ")[2:5])
+        return cpu_time(*fields)
+
+    @staticmethod
+    def virtual_memory():
+        # Mimic psutil.virtual_memory return type (omitting a few unused fields)
+        svmem = namedtuple("svmem", ["total", "available", "used"])
+        # Get memory info from /proc/meminfo
+        with open("/proc/meminfo") as f:
+            meminfo = {
+                line.split(":")[0]: int(line.split(":")[1].strip().split(" ")[0])
+                for line in f.readlines()
+            }
+
+        # This is how psutil calculates mem_used
+        # https://github.com/giampaolo/psutil/blob/902fada98ef1899d86717e7b34be46485d55e016/psutil/_pslinux.py#L477
+        mem_used = (
+            meminfo["MemTotal"]
+            - meminfo["MemFree"]
+            - meminfo.get("Cached", 0)
+            - meminfo.get("Buffers", 0)
+        )
+        mem_used -= meminfo.get("SReclaimable", 0)
+        if mem_used < 0:
+            mem_used = meminfo["MemTotal"] - meminfo["MemFree"]
+
+        return svmem(total=meminfo["MemTotal"], available=meminfo["MemAvailable"], used=mem_used)
+
+    @staticmethod
+    def disk_usage(path: str):
+        # Mimic psutil.disk_usage return type
+        sdiskusage = namedtuple("sdiskusage", ["total", "used", "free", "percent"])
+
+        # Get disk usage from shutil.
+        import shutil
+
+        disk_usage = shutil.disk_usage(path)
+        # shutil.disk_usage().used doesn't counts reserved space unlike psutil, so we need to calculate it.
+        used_plus_reserved = disk_usage.total - disk_usage.free
+        return sdiskusage(
+            total=disk_usage.total,
+            used=used_plus_reserved,
+            free=disk_usage.free,
+            percent=used_plus_reserved / disk_usage.total * 100,
+        )
+
+    @staticmethod
+    def net_io_counter():
+        # Mimic psutil.net_io_counters return type (omitting a few unused fields)
+        snetio = namedtuple("snetio", ["bytes_sent", "bytes_recv"])
+        # Get net io from /proc/net/dev
+        with open("/proc/net/dev") as f:
+            netinfo = f.readlines()
+        netinfo = [x.strip() for x in netinfo]
+        netinfo = netinfo[2:]
+
+        net_recv = 0
+        net_sent = 0
+        for line in netinfo:
+            fields = line.strip().split()
+            net_recv += int(fields[1])
+            net_sent += int(fields[9])
+        return snetio(net_recv, net_sent)

--- a/requirements/core-requirements.txt
+++ b/requirements/core-requirements.txt
@@ -18,4 +18,3 @@ markdown<4,>=3.3
 Jinja2<4,>=2.11; platform_system != 'Windows'
 Jinja2<4,>=3.0; platform_system == 'Windows'
 matplotlib<4
-psutil<6

--- a/requirements/core-requirements.yaml
+++ b/requirements/core-requirements.yaml
@@ -81,7 +81,3 @@ Jinja2-windows:
 matplotlib:
   pip_release: matplotlib
   max_major_version: 3
-
-psutil:
-  pip_release: psutil
-  max_major_version: 5


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This is draft PR to show one of the possible approaches to remove needs for building `psutil` from source.  `psutil` doesn't have binary for arm64 linux so it needs to be build from CPython source, which adds some pain to our build process.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
