### PR TITLE
Fix PromptLab templating

### DIFF
--- a/mlflow/_promptlab.py
+++ b/mlflow/_promptlab.py
@@ -1,6 +1,5 @@
 import os
 import re
-from string import Template
 from typing import List
 
 import yaml

--- a/mlflow/_promptlab.py
+++ b/mlflow/_promptlab.py
@@ -28,9 +28,7 @@ class _PromptlabModel:
             # copy replacement logic from PromptEngineering.utils.ts for consistency
             prompt = self.prompt_template
             for key, value in prompt_parameters_as_dict.items():
-                prompt = re.sub(
-                    r"\{\{\s*" + key + r"\s*\}\}", value, prompt
-                )
+                prompt = re.sub(r"\{\{\s*" + key + r"\s*\}\}", value, prompt)
 
             model_parameters_as_dict = {param.key: param.value for param in self.model_parameters}
             result = query(

--- a/mlflow/_promptlab.py
+++ b/mlflow/_promptlab.py
@@ -27,9 +27,9 @@ class _PromptlabModel:
 
             # copy replacement logic from PromptEngineering.utils.ts for consistency
             prompt = self.prompt_template
-            for param in prompt_parameters_as_dict:
+            for key, value in prompt_parameters_as_dict.items():
                 prompt = re.sub(
-                    rf"\{{\{{\s*{param}\s*\}}\}}", prompt_parameters_as_dict[param], prompt
+                    r"\{\{\s*" + key + r"\s*\}\}", value, prompt
                 )
 
             model_parameters_as_dict = {param.key: param.value for param in self.model_parameters}

--- a/tests/promptlab/test_promptlab_model.py
+++ b/tests/promptlab/test_promptlab_model.py
@@ -1,15 +1,13 @@
 from unittest import mock
 
 import pandas as pd
-import pytest
 
 from mlflow._promptlab import _PromptlabModel
 from mlflow.entities.param import Param
 
 
-@pytest.fixture
-def data():
-    return pd.DataFrame(
+def test_promptlab_prompt_replacement():
+    data = pd.DataFrame(
         data=[
             {"thing": "books"},
             {"thing": "coffee"},
@@ -17,8 +15,6 @@ def data():
         ]
     )
 
-
-def test_promptlab_prompt_replacement(data):
     prompt_parameters = [Param(key="thing", value="books")]
     model_parameters = [Param(key="temperature", value=0.5), Param(key="max_tokens", value=10)]
     prompt_template = "Write me a story about {{ thing }}."

--- a/tests/promptlab/test_promptlab_model.py
+++ b/tests/promptlab/test_promptlab_model.py
@@ -18,7 +18,7 @@ def data():
 
 
 def test_promptlab_prompt_replacement(data):
-    prompt_parameters = [Param(key="stock_type", value="books")]
+    prompt_parameters = [Param(key="thing", value="books")]
     model_parameters = [Param(key="temperature", value=0.5), Param(key="max_tokens", value=10)]
     prompt_template = "Write me a story about {{ thing }}."
     model_route = "completions"

--- a/tests/promptlab/test_promptlab_model.py
+++ b/tests/promptlab/test_promptlab_model.py
@@ -10,9 +10,9 @@ from mlflow.entities.param import Param
 def data():
     return pd.DataFrame(
         data=[
-            {"stock_type": "books"},
-            {"stock_type": "coffee"},
-            {"stock_type": "nothing"},
+            {"thing": "books"},
+            {"thing": "coffee"},
+            {"thing": "nothing"},
         ]
     )
 
@@ -20,7 +20,7 @@ def data():
 def test_promptlab_prompt_replacement(data):
     prompt_parameters = [Param(key="stock_type", value="books")]
     model_parameters = [Param(key="temperature", value=0.5), Param(key="max_tokens", value=10)]
-    prompt_template = "Write me a story about {{ stock_type }}."
+    prompt_template = "Write me a story about {{ thing }}."
     model_route = "completions"
 
     model = _PromptlabModel(prompt_template, prompt_parameters, model_parameters, model_route)
@@ -36,7 +36,7 @@ def test_promptlab_prompt_replacement(data):
                     "max_tokens": 10,
                 },
             )
-            for thing in data["stock_type"]
+            for thing in data["thing"]
         ]
 
         mock_query.assert_has_calls(calls, any_order=True)

--- a/tests/promptlab/test_promptlab_model.py
+++ b/tests/promptlab/test_promptlab_model.py
@@ -1,7 +1,8 @@
+from unittest import mock
+
 import pandas as pd
 import pytest
 
-from unittest import mock
 from mlflow._promptlab import _PromptlabModel
 from mlflow.entities.param import Param
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/10341?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10341/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10341
```

</p>
</details>

### Related Issues/PRs

### What changes are proposed in this pull request?

Currently, models made using Prompt Engineering UI don't actually construct the prompts correctly. The template strings are formatted using double braces (e.g. "like {{ this }}"), and this isn't a valid template string in Python.

In JS, we have some [custom logic](https://github.com/mlflow/mlflow/blob/master/mlflow/server/js/src/experiment-tracking/components/prompt-engineering/PromptEngineering.utils.ts#L42-L49) to replace the template strings, and this PR just replicates that logic in the python model so that everything is consistent.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
