### PR TITLE
Add docs for array/object types and refine section strucutre

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -246,7 +246,7 @@ This signature is typically used for traditional machine learning models that ta
 DataFrame. Column-based schemas are a sequence of (optionally) named columns with data type. Each column-based input and 
 output is represented by a type corresponding to one of :ref:`supported data types <supported-data-types-column>` and an 
 optional name. Input columns can also be marked as ``optional``, indicating whether they are required as input to the 
-model or can be omitted (:ref:`Optional Column <ptional-column>`). 
+model or can be omitted (:ref:`Optional Column <optional-column>`). 
 
 .. _supported-data-types-column:
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -213,85 +213,14 @@ at hand, such as "What inputs does it expect?" and "What output does it produce?
 include the following additional metadata about model inputs, outputs and params that can be used by
 downstream tooling:
 
-* :ref:`Model Inference Params <inference-params>` - description of params used for model inference.
-* :ref:`Model Signature <model-signature>` - description of a model's inputs, outputs and parameters.
+* :ref:`Model Signature <model-signature>` - description of a model's inputs, outputs and additional params for inference.
 * :ref:`Model Input Example <input-example>` - example of a valid model input.
-
-.. _inference-params:
-
-Model Inference Params
-^^^^^^^^^^^^^^^^^^^^^^
-Inference params are parameters that are passed to the model at inference time. These parameters
-do not need to be specified when training the model, but could be useful for inference. With the 
-advances in foundational models, more often "inference configuration" is used to modify the behavior 
-of a model. In some cases, especially popular LLMs, the same model may require different parameter 
-configurations for different samples at inference time. 
-
-With this newly introduced feature, you can now specify a dictionary of inference params during 
-model inference, providing a broader utility and improved control over the generated inference 
-results, particularly for LLM use cases. By passing different params such as ``temperature``, 
-``max_length``, etc. to the model at inference time, you can easily control the output of the model.
-
-In order to use params at inference time, a valid :ref:`Model Signature <model-signature>` with 
-``params`` must be defined. The params are passed to the model at inference time as a dictionary 
-and each param value will be validated against the corresponding param type defined in the model
-signature. Valid param types are ``DataType`` or ``a list of DataType`` as listed below.
-
-* DataType.string or an array of DataType.string
-* DataType.integer or an array of DataType.integer
-* DataType.boolean or an array of DataType.boolean
-* DataType.double or an array of DataType.double
-* DataType.float or an array of DataType.float
-* DataType.long or an array of DataType.long
-* DataType.datetime or an array of DataType.datetime
-
-.. note::
-    When validating param values, the values will be converted to python native types.
-    For example, ``np.float32(0.1)`` will be converted to ``float(0.1)``.
-
-A simple example of using params for model inference:
-
-.. code-block:: python
-
-    import mlflow
-    from mlflow.models import infer_signature
-
-
-    class MyModel(mlflow.pyfunc.PythonModel):
-        def predict(self, ctx, model_input, params):
-            return list(params.values())
-
-
-    params = {"str_param": "string", "int_array": [1, 2, 3]}
-    # params' default values are saved with ModelSignature
-    signature = infer_signature(["input"], params=params)
-
-    with mlflow.start_run():
-        model_info = mlflow.pyfunc.log_model(
-            python_model=MyModel(), artifact_path="my_model", signature=signature
-        )
-
-    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
-
-    # Not passing params -- predict with default values
-    loaded_predict = loaded_model.predict(["input"])
-    assert loaded_predict == ["string", [1, 2, 3]]
-
-    # Passing some params -- add default values
-    loaded_predict = loaded_model.predict(["input"], params={"str_param": "new_string"})
-    assert loaded_predict == ["new_string", [1, 2, 3]]
-
-    # Passing all params -- override
-    loaded_predict = loaded_model.predict(
-        ["input"], params={"str_param": "new_string", "int_array": [4, 5, 6]}
-    )
-    assert loaded_predict == ["new_string", [4, 5, 6]]
 
 .. _model-signature:
 
 Model Signature
 ^^^^^^^^^^^^^^^
-Model signatures define input, output and parameters schemas for MLflow models, providing a standard 
+**Model signatures** define input, output and additional params schemas for MLflow models, providing a standard 
 interface to codify and enforce the correct use of your models. Signatures are fetched by the MLflow Tracking
 UI and Model Registry UI to display model inputs, outputs and params. They are also utilized by
 :ref:`MLflow model deployment tools <built-in-deployment>` to validate inference inputs according to
@@ -309,47 +238,54 @@ saved model, use the :py:func:`set_signature() <mlflow.models.set_signature>` AP
 
 Model Signature Types
 ~~~~~~~~~~~~~~~~~~~~~
-A model signature consists on inputs and outputs schemas, each of which can be either column-based or tensor-based. 
-Column-based schemas are a sequence of (optionally) named columns with type specified as one of the
-:py:class:`MLflow data types <mlflow.types.DataType>`.
-Tensor-based schemas are a sequence of (optionally) named tensors with type specified as one of the
-`numpy data types <https://numpy.org/devdocs/user/basics.types.html>`_. 
-Params schema is a sequence of ParamSpec, each of which contains ``name``, ``type``, ``default`` and ``shape`` fields.
-``type`` field must be specified as one of the :py:class:`MLflow data types <mlflow.types.DataType>`, and ``shape`` 
-field should be ``None`` for scalar parameters, or ``(-1,)`` for list parameters.
-See some examples of constructing them below.
 
-Column-based Signature Example
+A model signature consists of three schemas **(1) inputs**, **(2)outputs**, and **(3) inference params**. The
+former two simply refer to the input and output of the model, while the inference params is a set of additional params 
+that are passed to the model at inference time. 
+
+Input and output schemas can be either column-based or tensor-based. 
+
+Column-based Signature
 """"""""""""""""""""""""""""""
-Each column-based input and output is represented by a type corresponding to one of
-:py:class:`MLflow data types <mlflow.types.DataType>` and an optional name. Input columns can also be marked
-as ``optional``, indicating whether they are required as input to the model or can be omitted. The following example
-displays a modified MLmodel file excerpt containing the model signature for a classification model trained on
-the `Iris dataset <https://archive.ics.uci.edu/ml/datasets/iris>`_. The input has 4 named, numeric columns and 1 named,
-optional string column.
-The output is an unnamed integer specifying the predicted class.
+
+This signature is typically used for traditional machine learning models that take tabular data as input such as Pandas 
+DataFrame. Column-based schemas are a sequence of (optionally) named columns with data type. Each column-based input and 
+output is represented by a type corresponding to one of :ref:`supported data types <supported-data-types>` and an 
+optional name. Input columns can also be marked as ``optional``, indicating whether they are required as input to the 
+model or can be omitted. 
+
+The following example displays the model signature for a classification model trained on the 
+`Iris dataset <https://archive.ics.uci.edu/ml/datasets/iris>`_. The input has 4 named, numeric columns and 
+1 named, optional string column. The output is an unnamed integer specifying the predicted class.
 
 .. code-block:: yaml
 
   signature:
-      inputs: '[{"name": "sepal length (cm)", "type": "double"}, {"name": "sepal width
-        (cm)", "type": "double"}, {"name": "petal length (cm)", "type": "double"}, {"name":
-        "petal width (cm)", "type": "double"}, {"name": "class", "type": "string", "optional": "true"}]'
+      inputs: '[
+        {"name": "sepal length (cm)", "type": "double"}, 
+        {"name": "sepal width(cm)",   "type": "double"}, 
+        {"name": "petal length (cm)", "type": "double"}, 
+        {"name": "petal width (cm)",  "type": "double"}, 
+        {"name": "class",             "type": "string",  "optional": "true"}
+      ]'
       outputs: '[{"type": "integer"}]'
       params: null
 
-Tensor-based Signature Example
+Tensor-based Signature
 """"""""""""""""""""""""""""""
+This signature is typically used for deep learning models that take tensors as input such as images, speech, etc. 
+Tensor-based schemas are a sequence of (optionally) named tensors with 
+type specified as one of the `numpy data types <https://numpy.org/devdocs/user/basics.types.html>`_. 
 Each tensor-based input and output is represented by a dtype corresponding to one of
 `numpy data types <https://numpy.org/devdocs/user/basics.types.html>`_, shape and an optional name.
 Tensor-based signatures do not support optional inputs.
 When specifying the shape, -1 is used for axes that may be variable in size.
-The following example displays an MLmodel file excerpt containing the model signature for a
-classification model trained on the `MNIST dataset <http://yann.lecun.com/exdb/mnist/>`_.
-The input has one named tensor where input sample is an image represented by a 28 × 28 × 1 array
-of float32 numbers. The output is an unnamed tensor that has 10 units specifying the
-likelihood corresponding to each of the 10 classes. Note that the first dimension of the input
-and the output is the batch size and is thus set to -1 to allow for variable batch sizes.
+
+The following example displays the model signature for a classification model trained on the 
+`MNIST dataset <http://yann.lecun.com/exdb/mnist/>`_. The input has one named tensor of an 
+image represented by a 28 × 28 × 1 array of float32 numbers. The output is an unnamed tensor 
+represents the likelihood corresponding to each of the 10 classes. Note that the first dimension of 
+the input and the output is the batch size and is thus set to -1 to allow for variable batch sizes.
 
 .. code-block:: yaml
 
@@ -358,22 +294,162 @@ and the output is the batch size and is thus set to -1 to allow for variable bat
       outputs: '[{"shape": [-1, 10], "dtype": "float32"}]'
       params: null
 
-Signature with params Example
-"""""""""""""""""""""""""""""
-The params field is optional and is used to specify parameters that can be used for model inference.
-Params accept scalar values of type :py:class:`MLflow data types <mlflow.types.DataType>`, or a list
-of such values. The default value of a parameter is specified by setting the ``default`` field, and the value
-should be of the type specified by ``type`` field. The ``shape`` field can be used to specify the shape 
-of the value, it should be ``None`` for scalar values and ``(-1,)`` for a list.
+.. _inference-params:
+
+Model Signature with Inference Params
+"""""""""""""""""""""""""""""""""""""
+Inference params are additional parameters that are passed to the model at inference time, such as 
+``temperature``, ``max_length`` params for LLM models. These params do not need to be 
+specified when training the model, but could be used to modify the behavior of a model at inference time. 
+This sort of "inference configuration" is more often used with the advances in foundational models, where 
+sometimes the same model may require different parameter configurations for different samples at inference time. 
+With this newly introduced feature, you can now specify a dictionary of inference params during model inference, 
+providing a broader utility and improved control over the generated inference results.
+
+In order to use params at inference time, ``params`` must be defined as a part of a valid :ref:`Model Signature <model-signature>`. 
+Params schema is a sequence of **ParamSpec**, which contains following fields:
+
+* ``name``: Name of the param e.g. ``temperature``.
+* ``type``: Type of the param. Must be one of :ref:`supported data types <supported-data-types>` or list of them.
+* ``default``: Default value of the param.
+* ``shape``: Shape of the param. Must be ``None`` for scalar values and ``(-1,)`` for a list.
 
 .. code-block:: yaml
 
     signature:
-        inputs: '[{"name": "text", "type": "string"}]'
+        inputs: '[{"name": "input", "type": "string"}]'
         outputs: '[{"name": "output", "type": "string"}]'
-        params: '[{"name": "temperature", "type": "float", "default": 0.5, "shape": null},
-                  {"name": "top_k", "type": "integer", "default": 1, "shape": null},
-                  {"name": "suppress_tokens", "type": "integer", "default": [101, 102], "shape": [-1]}]'
+        params: '[
+            {
+                "name": "temperature", 
+                "type": "float", 
+                "default": 0.5, 
+                "shape": null
+            },
+            {
+                "name": "suppress_tokens", 
+                "type": "integer", 
+                "default": [101, 102],
+                 "shape": [-1]
+            }
+        ]'
+
+The values for inference params are passed to the model at inference time in the form of a dictionary 
+and each param value will be validated against the corresponding param type defined in the model signature. 
+The following example demonstrates how to define params in a model signature and how to use them for model inference.
+
+.. code-block:: python
+
+    import mlflow
+    from mlflow.models import infer_signature
+
+
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, ctx, model_input, params):
+            return list(params.values())
+
+
+    params = {"temperature": 0.5, "suppress_tokens": [101, 102]}
+    # params' default values are saved with ModelSignature
+    signature = infer_signature(["input"], params=params)
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            python_model=MyModel(), artifact_path="my_model", signature=signature
+        )
+
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+
+    # Not passing params -- predict with default values
+    loaded_predict = loaded_model.predict(["input"])
+    assert loaded_predict == [0.5, [101, 102]]
+
+    # Passing some params -- add default values
+    loaded_predict = loaded_model.predict(["input"], params={"temperature": 0.1})
+    assert loaded_predict == [0.1, [101, 102]]
+
+    # Passing all params -- override
+    loaded_predict = loaded_model.predict(
+        ["input"], params={"temperature": 0.5, "suppress_tokens": [103]}
+    )
+    assert loaded_predict == [0.5, [103]]
+
+.. note::
+    When validating param values, the values will be converted to python native types.
+    For example, ``np.float32(0.1)`` will be converted to ``float(0.1)``.
+
+.. _supported-data-types:
+
+Supported Data Types in Model Signature
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Currently, :py:class:`MLflow DataType <mlflow.types.DataType>` defines following data primitives for model signature.
+
+* string
+* integer
+* boolean
+* double
+* float
+* long
+* datetime
+
+Model signature also supports composite data types as follows,
+
+* Array
+* Object (a.k.a. dictionary in python)
+* Nested Arrays and Objects e.g. ``Array(Object(Propertiy("a", Array(DataType.integer))))``
+
+Here are some examples of model inputs and inferred signature
+
+.. code-block:: python
+
+    from mlflow.models import infer_signature
+
+    sign = infer_signature(model_input={"long_col": 1, "str_col": "a", "bool_col": True}, model_output=0.1)
+    print(sign)
+    # inputs:  [
+    #             'long_col': long (required), 
+    #             'str_col': string (required), 
+    #             'bool_col': boolean (required)
+    #          ]
+    # outputs: [double (required)]
+    # params:  None
+
+    ## You can also infer signature Pandas DataFrame. Column with None value will be `optional`
+    sign = infer_signature(model_input=pd.DataFrame({"col": [1.0, 2.0, None]}), model_output=0.0)
+    print(sign)
+    # inputs:  ['col': long (optional)]
+    # outputs: [double (required)]
+    # params: None
+
+    ## Numpy array is inferred as Tensor column. We don't set optional for Tensor column.
+    sign = infer_signature(model_input=np.array([1, 2, np.nan]), model_output=np.array([0.1, 0.2, 0.3]))
+    print(sign)
+    # inputs:  ['int_col': Tensor('int64', (-1,))]
+    # outputs: [Tensor('float64', (-1,))]
+    # params:  None
+
+    # Composite data type: Array
+    sign = infer_signature(model_input=[["a", "b", "c"], ["a", "b", "c", "d"], []])
+    print(sign)
+    # inputs:  [Array(string) (required)]
+    # outputs: None
+    # params: None
+
+    # Composite data types: Object (a.k.a. dictionary)
+    sign = infer_signature(model_input={"object_col": {"long_prop": 1, "array_prop": ["a", "b", "c"]}}, model_output=0.0)
+    print(sign)
+    # inputs:  ['object_col': {
+    #              long_prop: long (required), 
+    #              str_prop: Array(string) (required)
+    #           } (required)]
+    # outputs: [double (required)]
+    # params: None
+
+
+.. note::
+    Nested arrays can contain an empty list. In such case, the schema will be inferred
+    from the other elements of the list, assuming they have homogeneous types.
+
 
 .. _signature-enforcement:
 


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adding documentation for array/object types.

**Preview**
- HTML: https://drive.google.com/file/d/1Yyy2nOTM3YOTpWaNwZbdPWbf546iXmEE/view?usp=drive_link
- Original: https://mlflow.org/docs/latest/models.html#model-signature-and-input-example

**What changed**
Nothing changed outside `Model Signature` section. Main change is the new subsection `Supported Data Types`, which previously was just a link to [DataType](https://mlflow.org/docs/latest/python_api/mlflow.types.html#mlflow.types.DataType) specification. Now we have more complex object like Array, Dictionary, so I think we should have a dedicated section explain them.

Also restructured the order of subsections in model signature part. Things I changed are;
1. Move inference params section lower - In [the original doc](https://mlflow.org/docs/latest/models.html#model-signature-and-input-example), inference params reside the very beginning of signature section. This was a bit confusing to me because I haven't see description about signature itself yet ([Model Signature](https://mlflow.org/docs/latest/models.html#model-signature) section comes after it). While I understand the importance of this new feature, the current order is a bit misleading as this is optional field as a part of model signature.
2. Sort examples order to Column -> Tensor -> Inference Params. This aligns with other contents in the same page.
3. Add some structure e.g. bullet point, indent to some section.

I think this makes it easier to follow for new people like me, but it's quite subjective so **more than happy to hear others' thought!** 

**Random thought**
`Schema enforcement` might sound a bit scary, like it forcibly change type with unsafe cast, and I think it's not very common term in industry. Would it be possible to change it to sth like `schema validation`? This is weak suggestion - should there be any historical reason to choose "enforcement".


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
