### PR TITLE
WIP: Add sagemaker adapter

### DIFF
--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -41,6 +41,7 @@ class Provider(str, Enum):
     HUGGINGFACE_TEXT_GENERATION_INFERENCE = "huggingface-text-generation-inference"
     PALM = "palm"
     BEDROCK = "bedrock"
+    SAGEMAKER = "sagemaker"
     # Note: The following providers are only supported on Databricks
     DATABRICKS_MODEL_SERVING = "databricks-model-serving"
     DATABRICKS = "databricks"
@@ -207,6 +208,11 @@ class AWSBedrockConfig(ConfigModel):
     aws_config: Union[AWSRole, AWSIdAndKey, AWSBaseConfig]
 
 
+class AmazonSageMakerConfig(ConfigModel):
+    endpoint_name: str
+    # order here is important, at least for pydantic<2
+    aws_config: Union[AWSRole, AWSIdAndKey, AWSBaseConfig]
+
 config_types = {
     Provider.COHERE: CohereConfig,
     Provider.OPENAI: OpenAIConfig,
@@ -217,6 +223,7 @@ config_types = {
     Provider.MLFLOW_MODEL_SERVING: MlflowModelServingConfig,
     Provider.PALM: PaLMConfig,
     Provider.HUGGINGFACE_TEXT_GENERATION_INFERENCE: HuggingFaceTextGenerationInferenceConfig,
+    Provider.SAGEMAKER: AmazonSageMakerConfig,
 }
 
 
@@ -276,6 +283,7 @@ class Model(ConfigModel):
             MlflowModelServingConfig,
             HuggingFaceTextGenerationInferenceConfig,
             PaLMConfig,
+            AmazonSageMakerConfig
         ]
     ] = None
 

--- a/mlflow/gateway/providers/__init__.py
+++ b/mlflow/gateway/providers/__init__.py
@@ -15,6 +15,7 @@ def get_provider(provider: Provider) -> Type[BaseProvider]:
     from mlflow.gateway.providers.mosaicml import MosaicMLProvider
     from mlflow.gateway.providers.openai import OpenAIProvider
     from mlflow.gateway.providers.palm import PaLMProvider
+    from mlflow.gateway.providers.sagemaker import AmazonSageMakerProvider
 
     provider_to_class = {
         Provider.OPENAI: OpenAIProvider,
@@ -26,6 +27,7 @@ def get_provider(provider: Provider) -> Type[BaseProvider]:
         Provider.MLFLOW_MODEL_SERVING: MlflowModelServingProvider,
         Provider.HUGGINGFACE_TEXT_GENERATION_INFERENCE: HFTextGenerationInferenceServerProvider,
         Provider.BEDROCK: AWSBedrockProvider,
+        Provider.SAGEMAKER: AmazonSageMakerProvider
     }
     if prov := provider_to_class.get(provider):
         return prov

--- a/mlflow/gateway/providers/sagemaker.py
+++ b/mlflow/gateway/providers/sagemaker.py
@@ -1,0 +1,153 @@
+from typing import Any, Dict
+import json
+import time
+
+import boto3
+import botocore.config
+import botocore.exceptions
+from fastapi import HTTPException
+from fastapi.encoders import jsonable_encoder
+
+from mlflow.gateway.config import AmazonSageMakerConfig, RouteConfig, AWSIdAndKey, AWSRole
+from mlflow.gateway.exceptions import AIGatewayConfigException
+from mlflow.gateway.providers.base import BaseProvider
+
+from mlflow.gateway.schemas import chat, completions, embeddings
+
+class AmazonSageMakerProvider(BaseProvider):
+    def __init__(self, config: RouteConfig) -> None:
+        super().__init__(config)
+        if config.model.config is None or not isinstance(
+            config.model.config, AmazonSageMakerConfig
+        ):
+            raise TypeError(f"Unexpected config type {config.model.config}")
+        self.sagemaker_config: AmazonSageMakerConfig = config.model.config
+        self._content_type = "application/json"
+        self._client = None
+        self._client_created = 0
+        self._accept_eula = "true"
+
+
+    def _client_expired(self):
+        if not isinstance(self.sagemaker_config.aws_config, AWSRole):
+            return False
+
+        return (
+            (time.monotonic_ns() - self._client_created)
+            >= (self.sagemaker_config.aws_config.session_length_seconds) * 1_000_000_000,
+        )
+
+    def get_sagemaker_client(self):
+        if self._client is not None and not self._client_expired():
+            return self._client
+
+        session = boto3.Session(**self._construct_session_args())
+
+        try:
+            self._client, self._client_created = (
+                session.client(
+                    service_name="sagemaker-runtime",
+                    **self._construct_client_args(session),
+                ),
+                time.monotonic_ns(),
+            )
+            return self._client
+        except botocore.exceptions.UnknownServiceError as e:
+            raise AIGatewayConfigException(
+                "Cannot create Amazon Sagemaker client. likely missing credentials or accessing account permissions"
+            ) from e
+
+    def _construct_session_args(self):
+        session_args = {
+            "region_name": self.sagemaker_config.aws_config.aws_region,
+        }
+
+        return {k: v for k, v in session_args.items() if v}
+
+    def _construct_client_args(self, session):
+        aws_config = self.sagemaker_config.aws_config
+
+        if isinstance(aws_config, AWSRole):
+            role = session.client(service_name="sts").assume_role(
+                RoleArn=aws_config.aws_role_arn,
+                RoleSessionName="ai-gateway-sagemaker",
+                DurationSeconds=aws_config.session_length_seconds,
+            )
+            return {
+                "aws_access_key_id": role["Credentials"]["AccessKeyId"],
+                "aws_secret_access_key": role["Credentials"]["SecretAccessKey"],
+                "aws_session_token": role["Credentials"]["SessionToken"],
+            }
+        elif isinstance(aws_config, AWSIdAndKey):
+            return {
+                "aws_access_key_id": aws_config.aws_access_key_id,
+                "aws_secret_access_key": aws_config.aws_secret_access_key,
+                "aws_session_token": aws_config.aws_session_token,
+            }
+        else:
+            return {}
+
+    def model_to_completions(self, resp):
+        print(f"resp: {resp}")
+
+        return completions.ResponsePayload(
+            **{
+                "candidates": [
+                    {"text": resp["generation"], "metadata": {}}
+                ],
+                "metadata": {
+                    "model": self.config.model.name,
+                    "route_type": self.config.route_type,
+                },
+            }
+        )
+
+    def _request(self, body):
+        print(f"Body:{body}")
+        try:
+            response = self.get_sagemaker_client().invoke_endpoint(
+                EndpointName=self.sagemaker_config.endpoint_name,
+                Body=json.dumps(body).encode(),
+                ContentType=self._content_type,
+                Accept=self._content_type,
+                CustomAttributes=f"accept_eula={self._accept_eula}"
+            )
+            return json.loads(response.get("Body").read())
+
+        # TODO work though botocore.exceptions to make this catchable.
+        # except botocore.exceptions.ValidationException as e:
+        #     raise HTTPException(status_code=422, detail=str(e)) from e
+
+        except botocore.exceptions.ReadTimeoutError as e:
+            raise HTTPException(status_code=408) from e
+
+    async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        raise HTTPException(
+            status_code=404,
+            detail="The chat route is not available for the Text Generation Inference provider.",
+        )
+
+    async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
+        print(f"payload: {payload}")
+        self.check_for_model_field(payload)
+        payload = jsonable_encoder(payload, exclude_none=True, exclude_defaults=True)
+        prompt = payload.pop("prompt")
+
+        parameters = {
+            'temperature': payload['temperature'] if 'temperature' in payload else 0.7,
+            'max_new_tokens': payload['max_tokens'] if 'max_tokens' in payload else 64,
+            'top_p': payload['top_p'] if 'top_p' in payload else 1,
+            'return_full_text': False,
+        }
+
+        final_payload = {"inputs": prompt, "parameters": parameters}
+        response = self._request(final_payload)[0]
+        return self.model_to_completions(response)
+
+    async def embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                "The embedding route is not available for the Text Generation Inference provider."
+            ),
+        )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/pdifranc/mlflow/pull/10352?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10352/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10352
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
#10351 

### What changes are proposed in this pull request?

Introduce a SageMaker Provider. Might need to create different Adapters for different models

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
