### PR TITLE
sphinx autosummary

### DIFF
--- a/b.py
+++ b/b.py
@@ -1,0 +1,9 @@
+# with a model and using `evaluator_config`
+mlflow.evaluate(
+    model=retriever_function,
+    data=data,
+    targets="ground_truth",
+    model_type="retriever",
+    evaluators="default",
+    evaluator_config={"retriever_k": 5}
+)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -75,6 +75,7 @@ gateway-api-docs:
 # Builds only the RST-based documentation (i.e., everything but Java & R docs)
 .PHONY: rsthtml
 rsthtml: gateway-api-docs
+	sphinx-autogen source/python_api/mlflow.rst
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
+    "sphinx.ext.autosummary",
     "sphinx_click.ext",
     "testcode_block",
     "nbsphinx",

--- a/docs/source/python_api/generated/mlflow.log_metrics.rst
+++ b/docs/source/python_api/generated/mlflow.log_metrics.rst
@@ -1,0 +1,6 @@
+mlflow.log\_metrics
+===================
+
+.. currentmodule:: mlflow
+
+.. autofunction:: log_metrics

--- a/docs/source/python_api/generated/mlflow.log_params.rst
+++ b/docs/source/python_api/generated/mlflow.log_params.rst
@@ -1,0 +1,6 @@
+mlflow.log\_params
+==================
+
+.. currentmodule:: mlflow
+
+.. autofunction:: log_params

--- a/docs/source/python_api/generated/mlflow.set_tracking_uri.rst
+++ b/docs/source/python_api/generated/mlflow.set_tracking_uri.rst
@@ -1,0 +1,6 @@
+mlflow.set\_tracking\_uri
+=========================
+
+.. currentmodule:: mlflow
+
+.. autofunction:: set_tracking_uri

--- a/docs/source/python_api/mlflow.rst
+++ b/docs/source/python_api/mlflow.rst
@@ -5,3 +5,9 @@ mlflow
     :members:
     :undoc-members:
     :exclude-members: MlflowClient
+
+.. autosummary::
+    :toctree: generated
+
+    log_params
+    log_metrics


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
