### PR TITLE
Fix spark udf for spark 3.5

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -996,10 +996,14 @@ def _infer_spark_udf_return_type(model_output_schema):
 
 
 def _parse_spark_datatype(datatype: str):
-    from pyspark.sql.types import _parse_datatype_string
+    from pyspark.sql.functions import udf
+    from pyspark.sql.session import SparkSession
 
-    datatype = "boolean" if datatype == "bool" else datatype
-    return _parse_datatype_string(datatype)
+    returnType = "boolean" if datatype == "bool" else datatype
+    schema = (
+        SparkSession.active().range(0).select(udf(lambda x: x, returnType=returnType)("id")).schema
+    )
+    return schema[0].dataType
 
 
 def _is_none_or_nan(value):

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -996,10 +996,10 @@ def _infer_spark_udf_return_type(model_output_schema):
 
 
 def _parse_spark_datatype(datatype: str):
-    from pyspark.sql.functions import udf
+    from pyspark.sql.types import _parse_datatype_string
 
-    return_type = "boolean" if datatype == "bool" else datatype
-    return udf(lambda x: x, returnType=return_type).returnType
+    datatype = "boolean" if datatype == "bool" else datatype
+    return _parse_datatype_string(datatype)
 
 
 def _is_none_or_nan(value):

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -547,7 +547,15 @@ def _is_spark_df(x) -> bool:
     try:
         import pyspark.sql.dataframe
 
-        return isinstance(x, pyspark.sql.dataframe.DataFrame)
+        if isinstance(x, pyspark.sql.dataframe.DataFrame):
+            return True
+    except ImportError:
+        return False
+    # For spark 4.0
+    try:
+        import pyspark.sql.connect.dataframe
+
+        return isinstance(x, pyspark.sql.connect.dataframe.DataFrame)
     except ImportError:
         return False
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10376?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10376/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10376
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Since spark 4.0 we start to use pyspark.sql.connect.dataframe.DataFrame instead of pyspark.sql.dataframe.DataFrame

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
