### PR TITLE
Param inference fix on nested array

### DIFF
--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -714,9 +714,17 @@ def _infer_schema_from_type_hint(type_hint, examples=None):
         return None
 
 
+def _get_array_depth(l: Any) -> int:
+    if isinstance(l, np.ndarray):
+        return l.ndim
+    if isinstance(l, list):
+        return max(_get_array_depth(item) for item in l) + 1 if l else 1
+    return 0
+
+
 def _infer_type_and_shape(value):
     if isinstance(value, (list, np.ndarray)):
-        ndim = np.array(value).ndim
+        ndim = _get_array_depth(value)
         if ndim != 1:
             raise MlflowException.invalid_parameter_value(
                 f"Expected parameters to be 1D array or scalar, got {ndim}D array",

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1032,7 +1032,8 @@ def test_infer_param_schema():
         "b": (1, 2, 3),
         "c": True,
         "d": [[1, 2], [3, 4]],
-        "e": {"a": 1, "b": 2},
+        "e": [[[1, 2], [3], []]],
+        "f": {"a": 1, "b": 2},
     }
     with pytest.raises(MlflowException, match=r".*") as e:
         _infer_param_schema(test_parameters)
@@ -1051,7 +1052,13 @@ def test_infer_param_schema():
     )
     assert e.match(
         re.escape(
-            "('e', {'a': 1, 'b': 2}, MlflowException('Expected parameters "
+            "('e', [[[1, 2], [3], []]], MlflowException('Expected parameters "
+            "to be 1D array or scalar, got 3D array'))"
+        )
+    )
+    assert e.match(
+        re.escape(
+            "('f', {'a': 1, 'b': 2}, MlflowException('Expected parameters "
             "to be 1D array or scalar, got dict'))"
         )
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10377?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10377/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10377
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Currently, when inferring params type of list or np.array, we convert it to `np.ndarray` and get `ndim` to check if it's 1D or not.
```
def _infer_type_and_shape(value):
    if isinstance(value, (list, np.ndarray)):
        ndim = np.array(value).ndim
        if ndim != 1:
            raise MlflowException.invalid_parameter_value(
                f"Expected parameters to be 1D array or scalar, got {ndim}D array",
            )
```
[source](https://github.com/mlflow/mlflow/blob/2cd67444b50fff94900f9ae6f0bf6cdf1661f50c/mlflow/types/utils.py#L495)

This doesn't work for nested array with uneven number of elements like `[[1, 2], [3]]`, as numpy creates 1D array with "Object" type.
```
>> np.array([[1, 2], [3]])
array([list([1, 2]), list([3])], dtype=object)

>> np.array([[1, 2], [3]]).ndim
1
```

This PR fixes the issue so we can validate dimension of nested list properly.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
