### PR TITLE
Fix the Gateway config validator pre-check for OpenAI to perform instance type validation

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -31,10 +31,7 @@ jobs:
       - uses: ./.github/actions/untracked
       - uses: ./.github/actions/setup-python
       - name: Install dependencies
-        # The pydantic pin below is temporary until FastAPI releases a compatible build for the
-        # changes introduced in the 2.5.0 pydantic release.
         run: |
-          pip install 'pydantic<2.5' \
           pip install .[gateway] \
             pytest pytest-timeout pytest-asyncio \
             httpx psutil sentence-transformers transformers

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -116,7 +116,10 @@ class OpenAIConfig(ConfigModel):
 
     @classmethod
     def _validate_field_compatibility(cls, info: Dict[str, Any]):
+        if not isinstance(info, Dict):
+            return info
         api_type = (info.get("openai_api_type") or OpenAIAPIType.OPENAI).lower()
+
         if api_type == OpenAIAPIType.OPENAI:
             if info.get("openai_deployment_name") is not None:
                 raise MlflowException.invalid_parameter_value(

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -116,10 +116,9 @@ class OpenAIConfig(ConfigModel):
 
     @classmethod
     def _validate_field_compatibility(cls, info: Dict[str, Any]):
-        if not isinstance(info, Dict):
+        if not isinstance(info, dict):
             return info
         api_type = (info.get("openai_api_type") or OpenAIAPIType.OPENAI).lower()
-
         if api_type == OpenAIAPIType.OPENAI:
             if info.get("openai_deployment_name") is not None:
                 raise MlflowException.invalid_parameter_value(

--- a/tests/gateway/tools.py
+++ b/tests/gateway/tools.py
@@ -54,7 +54,7 @@ class Gateway:
 
     def wait_until_ready(self) -> None:
         s = time.time()
-        while time.time() - s < 10:
+        while time.time() - s < 20:
             try:
                 if self.get("health").ok:
                     return

--- a/tests/gateway/tools.py
+++ b/tests/gateway/tools.py
@@ -54,7 +54,7 @@ class Gateway:
 
     def wait_until_ready(self) -> None:
         s = time.time()
-        while time.time() - s < 20:
+        while time.time() - s < 10:
             try:
                 if self.get("health").ok:
                     return


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/10379?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10379/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10379
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- Fixed the config validation for OpenAI to only perform a .get() on dicts
- Increased the timeout for the test server to not be flaky in local testing
- remove pydantic <2.5 pin

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
