### PR TITLE
Simplify score_model_on_one_payload

### DIFF
--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -262,16 +262,9 @@ def make_genai_metric(
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
-        def score_model_on_one_payload(
-            indx,
-            input,
-            output,
-            grading_context_columns,
-            eval_values,
-            evaluation_context,
-            eval_parameters,
-            eval_model,
-        ):
+        # generate grading payloads
+        grading_payloads = []
+        for indx, (input, output) in enumerate(zip(inputs, outputs)):
             try:
                 arg_string = _format_args_string(grading_context_columns, eval_values, indx)
             except Exception as e:
@@ -287,12 +280,19 @@ def make_genai_metric(
                     "parameter\n"
                     "- input and output data are formatted correctly."
                 )
-            payload = {
-                "prompt": evaluation_context["eval_prompt"].format(
-                    input=input, output=output, grading_context_columns=arg_string
-                ),
-                **eval_parameters,
-            }
+            grading_payloads.append(
+                {
+                    "prompt": evaluation_context["eval_prompt"].format(
+                        input=input, output=output, grading_context_columns=arg_string
+                    ),
+                    **eval_parameters,
+                }
+            )
+
+        def score_model_on_one_payload(
+            payload,
+            eval_model,
+        ):
             try:
                 raw_result = model_utils.score_model_on_payload(eval_model, payload)
                 return _extract_score_and_justification(raw_result)
@@ -317,16 +317,10 @@ def make_genai_metric(
             futures = {
                 executor.submit(
                     score_model_on_one_payload,
-                    indx,
-                    input,
-                    output,
-                    grading_context_columns,
-                    eval_values,
-                    evaluation_context,
-                    eval_parameters,
+                    payload,
                     eval_model,
                 ): indx
-                for indx, (input, output) in enumerate(zip(inputs, outputs))
+                for indx, payload in enumerate(grading_payloads)
             }
 
             as_comp = as_completed(futures)


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Pull the prompt templating logic outside of the `score_model_on_one_payload` function. This organization makes more sense as the payload is generated, and then scored using the `ThreadPoolExecutor`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
