### PR TITLE
unindent gen ai metrics

### DIFF
--- a/docs/source/python_api/mlflow.metrics.rst
+++ b/docs/source/python_api/mlflow.metrics.rst
@@ -95,7 +95,7 @@ We provide the following builtin factory functions to create :py:class:`Evaluati
 .. autofunction:: mlflow.metrics.latency
 
 Retriever Metrics
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 The following metrics are built-in metrics for the ``'retriever'`` model type, meaning they will be 
 automatically calculated with a default ``retriever_k`` value of 3. 

--- a/docs/source/python_api/mlflow.metrics.rst
+++ b/docs/source/python_api/mlflow.metrics.rst
@@ -56,6 +56,9 @@ Evaluation results are stored as :py:class:`MetricValue <mlflow.metrics.MetricVa
 
 We provide the following builtin factory functions to create :py:class:`EvaluationMetric <mlflow.metrics.EvaluationMetric>` for evaluating models. These metrics are computed automatically depending on the ``model_type``. For more information on the ``model_type`` parameter, see :py:func:`mlflow.evaluate()` API.
 
+Regressor Metrics
+---------------------
+
 .. autofunction:: mlflow.metrics.mae
 
 .. autofunction:: mlflow.metrics.mape
@@ -68,15 +71,26 @@ We provide the following builtin factory functions to create :py:class:`Evaluati
 
 .. autofunction:: mlflow.metrics.r2_score
 
+Classifier Metrics
+---------------------
+
 .. autofunction:: mlflow.metrics.precision_score
 
 .. autofunction:: mlflow.metrics.recall_score
 
 .. autofunction:: mlflow.metrics.f1_score
 
+Text Metrics
+---------------------
+
 .. autofunction:: mlflow.metrics.ari_grade_level
 
 .. autofunction:: mlflow.metrics.flesch_kincaid_grade_level
+
+Questions Answering Metrics
+---------------------
+
+Includes all of the above Text Metrics as well as the following:
 
 .. autofunction:: mlflow.metrics.exact_match
 

--- a/docs/source/python_api/mlflow.metrics.rst
+++ b/docs/source/python_api/mlflow.metrics.rst
@@ -57,7 +57,7 @@ Evaluation results are stored as :py:class:`MetricValue <mlflow.metrics.MetricVa
 We provide the following builtin factory functions to create :py:class:`EvaluationMetric <mlflow.metrics.EvaluationMetric>` for evaluating models. These metrics are computed automatically depending on the ``model_type``. For more information on the ``model_type`` parameter, see :py:func:`mlflow.evaluate()` API.
 
 Regressor Metrics
----------------------
+-----------------
 
 .. autofunction:: mlflow.metrics.mae
 
@@ -72,7 +72,7 @@ Regressor Metrics
 .. autofunction:: mlflow.metrics.r2_score
 
 Classifier Metrics
----------------------
+------------------
 
 .. autofunction:: mlflow.metrics.precision_score
 
@@ -81,16 +81,16 @@ Classifier Metrics
 .. autofunction:: mlflow.metrics.f1_score
 
 Text Metrics
----------------------
+------------
 
 .. autofunction:: mlflow.metrics.ari_grade_level
 
 .. autofunction:: mlflow.metrics.flesch_kincaid_grade_level
 
-Questions Answering Metrics
-------------------------------------------
+Question Answering Metrics
+---------------------------
 
-Includes all of the above Text Metrics as well as the following:
+Includes all of the above **Text Metrics** as well as the following:
 
 .. autofunction:: mlflow.metrics.exact_match
 
@@ -109,7 +109,7 @@ Includes all of the above Text Metrics as well as the following:
 .. autofunction:: mlflow.metrics.latency
 
 Retriever Metrics
----------------------
+-----------------
 
 The following metrics are built-in metrics for the ``'retriever'`` model type, meaning they will be 
 automatically calculated with a default ``retriever_k`` value of 3. 
@@ -187,7 +187,7 @@ Users create their own :py:class:`EvaluationMetric <mlflow.metrics.EvaluationMet
     :exclude-members: MetricValue, EvaluationMetric, make_metric, EvaluationExample, ari_grade_level, flesch_kincaid_grade_level, exact_match, rouge1, rouge2, rougeL, rougeLsum, toxicity, answer_similarity, answer_correctness, faithfulness, answer_relevance, mae, mape, max_error, mse, rmse, r2_score, precision_score, recall_score, f1_score, token_count, latency, precision_at_k, recall_at_k, ndcg_at_k
 
 Generative AI Metrics
-------------------------
+---------------------
 
 We also provide generative AI ("genai") :py:class:`EvaluationMetric <mlflow.metrics.EvaluationMetric>`\s for evaluating text models. These metrics use an LLM to evaluate the quality of a model's output text. Note that your use of a third party LLM service (e.g., OpenAI) for evaluation may be subject to and governed by the LLM service's terms of use. The following factory functions help you customize the intelligent metric to your use case.
 

--- a/docs/source/python_api/mlflow.metrics.rst
+++ b/docs/source/python_api/mlflow.metrics.rst
@@ -88,7 +88,7 @@ Text Metrics
 .. autofunction:: mlflow.metrics.flesch_kincaid_grade_level
 
 Questions Answering Metrics
----------------------
+------------------------------------------
 
 Includes all of the above Text Metrics as well as the following:
 
@@ -187,7 +187,7 @@ Users create their own :py:class:`EvaluationMetric <mlflow.metrics.EvaluationMet
     :exclude-members: MetricValue, EvaluationMetric, make_metric, EvaluationExample, ari_grade_level, flesch_kincaid_grade_level, exact_match, rouge1, rouge2, rougeL, rougeLsum, toxicity, answer_similarity, answer_correctness, faithfulness, answer_relevance, mae, mape, max_error, mse, rmse, r2_score, precision_score, recall_score, f1_score, token_count, latency, precision_at_k, recall_at_k, ndcg_at_k
 
 Generative AI Metrics
----------------------
+------------------------
 
 We also provide generative AI ("genai") :py:class:`EvaluationMetric <mlflow.metrics.EvaluationMetric>`\s for evaluating text models. These metrics use an LLM to evaluate the quality of a model's output text. Note that your use of a third party LLM service (e.g., OpenAI) for evaluation may be subject to and governed by the LLM service's terms of use. The following factory functions help you customize the intelligent metric to your use case.
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/bbqiu/mlflow/pull/10390?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10390/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10390
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Before:
<img width="320" alt="image" src="https://github.com/mlflow/mlflow/assets/55931436/46f4fb5b-65ca-4cfd-92b1-23f9dff3b953">
After:
<img width="298" alt="image" src="https://github.com/mlflow/mlflow/assets/55931436/6647e875-294d-4ab3-966d-d8f09fc07a62">

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
