### PR TITLE
Add dark theme to MLflow UI

### DIFF
--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -20,7 +20,13 @@ const landingRoute = {
   pageId: 'mlflow.experiments.list',
 };
 
-export const MlflowRouter = () => {
+export const MlflowRouter = ({
+  isDarkTheme,
+  setIsDarkTheme,
+}: {
+  isDarkTheme?: boolean;
+  setIsDarkTheme?: (isDarkTheme: boolean) => void;
+}) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const routes = useMemo(
     () => [
@@ -35,7 +41,7 @@ export const MlflowRouter = () => {
     <>
       <ErrorModal />
       <HashRouter>
-        <MlflowHeader />
+        <MlflowHeader isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme} />
         <React.Suspense fallback={<LegacySkeleton />}>
           <Routes>
             {routes.map(({ element, pageId, path }) => (

--- a/mlflow/server/js/src/app.tsx
+++ b/mlflow/server/js/src/app.tsx
@@ -14,13 +14,13 @@ import { ConfigProvider } from 'antd';
 import { LegacySkeleton } from '@databricks/design-system';
 import { shouldUsePathRouting } from './common/utils/FeatureUtils';
 import { MlflowRouter } from './MlflowRouter';
+import { useMLflowDarkTheme } from './common/hooks/useMLflowDarkTheme';
 
 export function MLFlowRoot() {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const i18n = useI18nInit();
-  const [isDarkTheme, setIsDarkTheme] = React.useState(
-    window.matchMedia('(prefers-color-scheme: dark)').matches || false,
-  );
+
+  const [isDarkTheme, setIsDarkTheme, MlflowThemeGlobalStyles] = useMLflowDarkTheme();
 
   if (!i18n) {
     return (
@@ -37,6 +37,7 @@ export function MLFlowRoot() {
       <Provider store={store}>
         <DesignSystemContainer isDarkTheme={isDarkTheme}>
           <ApplyGlobalStyles />
+          <MlflowThemeGlobalStyles />
           <ConfigProvider prefixCls='ant'>
             {shouldUsePathRouting() ? (
               <MlflowRouter isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme} />

--- a/mlflow/server/js/src/app.tsx
+++ b/mlflow/server/js/src/app.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ApolloProvider } from '@apollo/client';
 import { IntlProvider } from 'react-intl';
 import './index.css';
+import { ApplyGlobalStyles } from '@databricks/design-system';
 import '@databricks/design-system/dist/index.css';
 import '@databricks/design-system/dist/index-dark.css';
 import App from './experiment-tracking/components/App';
@@ -35,6 +36,7 @@ export function MLFlowRoot() {
     <IntlProvider locale={locale} messages={messages}>
       <Provider store={store}>
         <DesignSystemContainer isDarkTheme={isDarkTheme}>
+          <ApplyGlobalStyles />
           <ConfigProvider prefixCls='ant'>
             {shouldUsePathRouting() ? (
               <MlflowRouter isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme} />

--- a/mlflow/server/js/src/app.tsx
+++ b/mlflow/server/js/src/app.tsx
@@ -17,6 +17,9 @@ import { MlflowRouter } from './MlflowRouter';
 export function MLFlowRoot() {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const i18n = useI18nInit();
+  const [isDarkTheme, setIsDarkTheme] = React.useState(
+    window.matchMedia('(prefers-color-scheme: dark)').matches || false,
+  );
 
   if (!i18n) {
     return (
@@ -31,9 +34,13 @@ export function MLFlowRoot() {
   return (
     <IntlProvider locale={locale} messages={messages}>
       <Provider store={store}>
-        <DesignSystemContainer>
+        <DesignSystemContainer isDarkTheme={isDarkTheme}>
           <ConfigProvider prefixCls='ant'>
-            {shouldUsePathRouting() ? <MlflowRouter /> : <App />}
+            {shouldUsePathRouting() ? (
+              <MlflowRouter isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme} />
+            ) : (
+              <App isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme} />
+            )}
           </ConfigProvider>
         </DesignSystemContainer>
       </Provider>

--- a/mlflow/server/js/src/common/components/DarkThemeSwitch.tsx
+++ b/mlflow/server/js/src/common/components/DarkThemeSwitch.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { Switch } from '@databricks/design-system';
+
+const MoonIcon = () => (
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    height='1em'
+    viewBox='0 0 384 512'
+    css={{ fill: 'white' }}
+  >
+    {/* <!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --> */}
+    <path d='M223.5 32C100 32 0 132.3 0 256S100 480 223.5 480c60.6 0 115.5-24.2 155.8-63.4c5-4.9 6.3-12.5 3.1-18.7s-10.1-9.7-17-8.5c-9.8 1.7-19.8 2.6-30.1 2.6c-96.9 0-175.5-78.8-175.5-176c0-65.8 36-123.1 89.3-153.3c6.1-3.5 9.2-10.5 7.7-17.3s-7.3-11.9-14.3-12.5c-6.3-.5-12.6-.8-19-.8z' />
+  </svg>
+);
+
+const SunIcon = () => (
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    height='1em'
+    viewBox='0 0 512 512'
+    css={{ fill: 'white' }}
+  >
+    {/* <!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --> */}
+    <path d='M361.5 1.2c5 2.1 8.6 6.6 9.6 11.9L391 121l107.9 19.8c5.3 1 9.8 4.6 11.9 9.6s1.5 10.7-1.6 15.2L446.9 256l62.3 90.3c3.1 4.5 3.7 10.2 1.6 15.2s-6.6 8.6-11.9 9.6L391 391 371.1 498.9c-1 5.3-4.6 9.8-9.6 11.9s-10.7 1.5-15.2-1.6L256 446.9l-90.3 62.3c-4.5 3.1-10.2 3.7-15.2 1.6s-8.6-6.6-9.6-11.9L121 391 13.1 371.1c-5.3-1-9.8-4.6-11.9-9.6s-1.5-10.7 1.6-15.2L65.1 256 2.8 165.7c-3.1-4.5-3.7-10.2-1.6-15.2s6.6-8.6 11.9-9.6L121 121 140.9 13.1c1-5.3 4.6-9.8 9.6-11.9s10.7-1.5 15.2 1.6L256 65.1 346.3 2.8c4.5-3.1 10.2-3.7 15.2-1.6zM160 256a96 96 0 1 1 192 0 96 96 0 1 1 -192 0zm224 0a128 128 0 1 0 -256 0 128 128 0 1 0 256 0z' />
+  </svg>
+);
+
+export const DarkThemeSwitch = ({
+  isDarkTheme,
+  setIsDarkTheme,
+}: {
+  isDarkTheme: boolean;
+  setIsDarkTheme: (isDarkTheme: boolean) => void;
+}) => (
+  <span
+    css={{
+      display: 'flex',
+      paddingTop: 4,
+    }}
+  >
+    <Switch checked={isDarkTheme} onChange={setIsDarkTheme} />
+    {isDarkTheme ? <MoonIcon /> : <SunIcon />}
+  </span>
+);

--- a/mlflow/server/js/src/common/components/DesignSystemContainer.tsx
+++ b/mlflow/server/js/src/common/components/DesignSystemContainer.tsx
@@ -14,6 +14,7 @@ const isInsideShadowDOM = (element: any) =>
   element instanceof window.Node && element.getRootNode() !== document;
 
 type DesignSystemContainerProps = {
+  isDarkTheme?: boolean;
   children: React.ReactNode;
 };
 
@@ -24,7 +25,7 @@ type DesignSystemContainerProps = {
  */
 export const DesignSystemContainer = (props: DesignSystemContainerProps) => {
   const modalContainerElement = useRef();
-  const { children } = props;
+  const { isDarkTheme = false, children } = props;
 
   useEffect(() => {
     if (isInsideShadowDOM(modalContainerElement.current)) {
@@ -43,7 +44,7 @@ export const DesignSystemContainer = (props: DesignSystemContainerProps) => {
   }, []);
 
   return (
-    <SupportsDuBoisThemes>
+    <SupportsDuBoisThemes isDarkMode={isDarkTheme}>
       {/* @ts-expect-error TS(2322): Type '() => HTMLElement | undefined' is not assign... Remove this comment to see the full error message */}
       <DesignSystemProvider getPopupContainer={getPopupContainer} isCompact {...props}>
         <ConfigProvider prefixCls='ant'>

--- a/mlflow/server/js/src/common/components/EditableNote.css
+++ b/mlflow/server/js/src/common/components/EditableNote.css
@@ -6,3 +6,6 @@
   margin-left: 16px;
 }
 
+.mde-header {
+  background: var(--secondary-background-color);
+}

--- a/mlflow/server/js/src/common/components/MlflowHeader.tsx
+++ b/mlflow/server/js/src/common/components/MlflowHeader.tsx
@@ -3,6 +3,7 @@ import { Link, Location, matchPath, useLocation } from '../utils/RoutingUtils';
 import logo from '../../common/static/home-logo.png';
 import { ModelRegistryRoutes } from '../../model-registry/routes';
 import { HomePageDocsUrl, Version } from '../constants';
+import { DarkThemeSwitch } from 'common/components/DarkThemeSwitch';
 
 const colors = {
   headerBg: '#0b3574',
@@ -17,7 +18,13 @@ const classNames = {
 const isExperimentsActive = (location: Location) => matchPath('/experiments/*', location.pathname);
 const isModelsActive = (location: Location) => matchPath('/models/*', location.pathname);
 
-export const MlflowHeader = () => {
+export const MlflowHeader = ({
+  isDarkTheme = false,
+  setIsDarkTheme = (val: boolean) => {},
+}: {
+  isDarkTheme?: boolean;
+  setIsDarkTheme?: (isDarkTheme: boolean) => void;
+}) => {
   const location = useLocation();
   return (
     <header
@@ -83,6 +90,7 @@ export const MlflowHeader = () => {
       </div>
       <div css={{ flex: 1 }} />
       <div css={{ display: 'flex', gap: 24, paddingTop: 20, fontSize: 16, marginRight: 24 }}>
+        <DarkThemeSwitch isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme} />
         <a href={'https://github.com/mlflow/mlflow'}>GitHub</a>
         <a href={HomePageDocsUrl}>Docs</a>
       </div>

--- a/mlflow/server/js/src/common/hooks/useMLflowDarkTheme.tsx
+++ b/mlflow/server/js/src/common/hooks/useMLflowDarkTheme.tsx
@@ -1,0 +1,39 @@
+import { Global } from '@emotion/react';
+import { useEffect, useState } from 'react';
+
+const darkModePrefLocalStorageKey = '_mlflow_dark_mode_toggle_enabled';
+const darkModeBodyClassName = 'dark-mode';
+
+// CSS attributes to be applied when dark mode is enabled. Affects inputs and other form elements.
+const darkModeCSSStyles = { body: { [`&.${darkModeBodyClassName}`]: { colorScheme: 'dark' } } };
+// This component is used to set the global CSS.
+const DarkModeStylesComponent = () => <Global styles={darkModeCSSStyles} />;
+
+/**
+ * This hook is used to toggle the dark mode for the entire app.
+ * Used in open source MLflow.
+ * Returns a boolean value with the current state, setter function, and a component to be rendered in the root of the app.
+ */
+export const useMLflowDarkTheme = (): [
+  boolean,
+  React.Dispatch<React.SetStateAction<boolean>>,
+  React.ComponentType,
+] => {
+  const [isDarkTheme, setIsDarkTheme] = useState(() => {
+    // If the user has explicitly set a preference, use that.
+    if (localStorage.getItem(darkModePrefLocalStorageKey) === 'true') {
+      return true;
+    }
+    // Otherwise, use the system preference as a default.
+    return window.matchMedia('(prefers-color-scheme: dark)').matches || false;
+  });
+
+  useEffect(() => {
+    // Update the theme when the user changes their system preference.
+    document.body.classList.toggle(darkModeBodyClassName, isDarkTheme);
+    // Persist the user's preference in local storage.
+    localStorage.setItem(darkModePrefLocalStorageKey, isDarkTheme ? 'true' : 'false');
+  }, [isDarkTheme]);
+
+  return [isDarkTheme, setIsDarkTheme, DarkModeStylesComponent];
+};

--- a/mlflow/server/js/src/experiment-tracking/components/App.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/App.tsx
@@ -35,6 +35,7 @@ import { PageNotFoundView } from '../../common/components/PageNotFoundView';
 import { RunPage } from './RunPage';
 import { DirectRunPage } from './DirectRunPage';
 import { shouldEnableDeepLearningUI } from '../../common/utils/FeatureUtils';
+import { DarkThemeSwitch } from '../../common/components/DarkThemeSwitch';
 
 const isExperimentsActive = (match: any, location: any) => {
   // eslint-disable-next-line prefer-const
@@ -54,8 +55,14 @@ const classNames = {
 // eslint-disable-next-line no-unused-vars
 const InteractionTracker = ({ children }: any) => children;
 
-class App extends Component {
+interface AppProps {
+  isDarkTheme?: boolean;
+  setIsDarkTheme?: (isDarkTheme: boolean) => void;
+}
+
+class App extends Component<AppProps> {
   render() {
+    const { isDarkTheme = false, setIsDarkTheme = (val) => {} } = this.props;
     const marginRight = 24;
     return (
       <HashRouterV5
@@ -102,6 +109,9 @@ class App extends Component {
                   </NavLinkV5>
                 </div>
                 <div className='header-links'>
+                  <span css={{ marginRight }}>
+                    <DarkThemeSwitch isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme} />
+                  </span>
                   <a href={'https://github.com/mlflow/mlflow'} css={{ marginRight }}>
                     <div className='github'>
                       <span>GitHub</span>

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
@@ -261,12 +261,10 @@ export class CompareRunView extends Component<CompareRunViewProps, CompareRunVie
     );
     if (dataRows.length === 0) {
       return (
-        <h2>
-          <FormattedMessage
-            defaultMessage='No parameters to display.'
-            description='Text shown when there are no parameters to display'
-          />
-        </h2>
+        <FormattedMessage
+          defaultMessage='No parameters to display.'
+          description='Text shown when there are no parameters to display'
+        />
       );
     }
     return (
@@ -308,12 +306,10 @@ export class CompareRunView extends Component<CompareRunViewProps, CompareRunVie
     );
     if (dataRows.length === 0) {
       return (
-        <h2>
-          <FormattedMessage
-            defaultMessage='No metrics to display.'
-            description='Text shown when there are no metrics to display'
-          />
-        </h2>
+        <FormattedMessage
+          defaultMessage='No metrics to display.'
+          description='Text shown when there are no metrics to display'
+        />
       );
     }
     return (
@@ -337,12 +333,10 @@ export class CompareRunView extends Component<CompareRunViewProps, CompareRunVie
     );
     if (dataRows.length === 0) {
       return (
-        <h2>
-          <FormattedMessage
-            defaultMessage='No tags to display.'
-            description='Text shown when there are no tags to display'
-          />
-        </h2>
+        <FormattedMessage
+          defaultMessage='No tags to display.'
+          description='Text shown when there are no tags to display'
+        />
       );
     }
     return (

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.tsx
@@ -6,6 +6,8 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { screen, fireEvent } from '../../common/utils/TestUtils';
 import { BrowserRouter } from '../../common/utils/RoutingUtils';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
@@ -16,7 +18,8 @@ import Fixtures from '../utils/test-utils/Fixtures';
 import { DeleteExperimentModal } from './modals/DeleteExperimentModal';
 import { RenameExperimentModal } from './modals/RenameExperimentModal';
 import { CreateExperimentModal } from './modals/CreateExperimentModal';
-import { mountWithIntl } from '../../common/utils/TestUtils';
+import { mountWithIntl, renderWithIntl } from '../../common/utils/TestUtils';
+import { DesignSystemProvider } from '@databricks/design-system';
 
 // Make the autosizer render items.
 // https://github.com/bvaughn/react-virtualized/blob/v9.22.3/source/AutoSizer/AutoSizer.jest.js#L68
@@ -43,61 +46,69 @@ afterAll(() => {
 const designSystemThemeApi = {
   theme: {
     colors: { primary: 'solid', actionDefaultBackgroundPress: `solid` },
+    general: { iconSize: 24 },
+    spacing: { xs: 4 },
   },
 };
 
 const mountComponent = (props: any) => {
   const mockStore = configureStore([thunk, promiseMiddleware()]);
-  return mountWithIntl(
-    <Provider
-      store={mockStore({
-        entities: {
-          experimentsById: {},
-        },
-      })}
-    >
-      <BrowserRouter>
-        <ExperimentListView {...props} history={[]} designSystemThemeApi={designSystemThemeApi} />,
-      </BrowserRouter>
+  return renderWithIntl(
+    <DesignSystemProvider>
+      <Provider
+        store={mockStore({
+          entities: {
+            experimentsById: {},
+          },
+        })}
+      >
+        <BrowserRouter>
+          <ExperimentListView {...props} history={[]} designSystemThemeApi={designSystemThemeApi} />
+          ,
+        </BrowserRouter>
+        ,
+      </Provider>
       ,
-    </Provider>,
+    </DesignSystemProvider>,
   );
 };
 
 test('If searchInput is set to "Test" then first shown element in experiment list has the title "Test"', () => {
-  const wrapper = mountComponent({ experiments: Fixtures.experiments, activeExperimentIds: ['0'] });
-  wrapper
-    .find('input[data-test-id="search-experiment-input"]')
-    .first()
-    .simulate('change', { target: { value: 'Test' } });
-  expect(wrapper.find('[data-test-id="experiment-list-item"]').first().text()).toContain('Test');
+  mountComponent({ experiments: Fixtures.experiments, activeExperimentIds: ['0'] });
+  const input = screen.getByTestId('search-experiment-input');
+  fireEvent.change(input, {
+    target: { value: 'Test' },
+  });
+  expect(screen.getAllByTestId('experiment-list-item')[0].textContent).toContain('Test');
 });
 
 test('If searchInput is set to "Test" and default experiment is active then no active element is shown in the experiment list', () => {
-  const wrapper = mountComponent({ experiments: Fixtures.experiments, activeExperimentIds: ['0'] });
-  wrapper
-    .find('input[data-test-id="search-experiment-input"]')
-    .first()
-    .simulate('change', { target: { value: 'Test' } });
-  expect(wrapper.find('[data-test-id="active-experiment-list-item"]')).toHaveLength(0);
+  mountComponent({ experiments: Fixtures.experiments, activeExperimentIds: ['0'] });
+  const input = screen.getByTestId('search-experiment-input');
+  fireEvent.change(input, {
+    target: { value: 'Test ' },
+  });
+  expect(screen.queryAllByTestId('active-experiment-list-item')).toHaveLength(0);
 });
 
 test('If button to create experiment is pressed then open CreateExperimentModal', () => {
-  const wrapper = mountComponent({ experiments: Fixtures.experiments, activeExperimentIds: ['0'] });
-  wrapper.find('[data-test-id="create-experiment-button"]').first().simulate('click');
-  expect(wrapper.find(CreateExperimentModal).prop('isOpen')).toEqual(true);
+  mountComponent({ experiments: Fixtures.experiments, activeExperimentIds: ['0'] });
+  userEvent.click(screen.getByTestId('create-experiment-button'));
+  expect(screen.getByText('Create Experiment')).toBeInTheDocument();
 });
 
 test('If button to delete experiment is pressed then open DeleteExperimentModal', () => {
-  const wrapper = mountComponent({ experiments: Fixtures.experiments, activeExperimentIds: ['0'] });
-  wrapper.find('button[data-test-id="delete-experiment-button"]').first().simulate('click');
-  expect(wrapper.find(DeleteExperimentModal).prop('isOpen')).toEqual(true);
+  mountComponent({ experiments: Fixtures.experiments, activeExperimentIds: ['0'] });
+  userEvent.click(screen.getAllByTestId('delete-experiment-button')[0]);
+  expect(
+    screen.getByText(`Delete Experiment "${Fixtures.experiments[0].name}"`),
+  ).toBeInTheDocument();
 });
 
 test('If button to edit experiment is pressed then open RenameExperimentModal', () => {
-  const wrapper = mountComponent({ experiments: Fixtures.experiments, activeExperimentIds: ['0'] });
-  wrapper.find('button[data-test-id="rename-experiment-button"]').first().simulate('click');
-  expect(wrapper.find(RenameExperimentModal).prop('isOpen')).toEqual(true);
+  mountComponent({ experiments: Fixtures.experiments, activeExperimentIds: ['0'] });
+  userEvent.click(screen.getAllByTestId('rename-experiment-button')[0]);
+  expect(screen.getByText('Rename Experiment')).toBeInTheDocument();
 });
 
 test('If activeExperimentIds is defined then choose all the corresponding experiments', () => {
@@ -107,22 +118,24 @@ test('If activeExperimentIds is defined then choose all the corresponding experi
     Fixtures.createExperiment({ experiment_id: '2', name: 'Second' }),
     Fixtures.createExperiment({ experiment_id: '3', name: 'Third' }),
   ];
-  const wrapper = mountComponent({
+  mountComponent({
     experiments: localExperiments,
     activeExperimentIds: ['1', '3'],
   });
-  const selected = wrapper.find('[data-test-id="active-experiment-list-item"]');
+  const selected = screen.getAllByTestId('active-experiment-list-item');
   expect(selected.length).toEqual(2);
-  expect(selected.first().text()).toEqual('Test');
-  expect(selected.at(1).text()).toEqual('Third');
+  expect(selected[0].textContent).toEqual('Test');
+  expect(selected[1].textContent).toEqual('Third');
 });
 
 test('should render when both experiments and activeExperimentIds are empty', () => {
-  const wrapper = mountComponent({
+  mountComponent({
     experiments: [],
     activeExperimentIds: [],
   });
-  expect(wrapper.length).toBe(1);
+
+  // Get the sidebar header as proof that the component rendered
+  expect(screen.getByText('Experiments')).toBeInTheDocument();
 });
 
 test('virtual list should not render everything when there are many experiments', () => {
@@ -131,10 +144,10 @@ test('virtual list should not render everything when there are many experiments'
     Fixtures.createExperiment({ experiment_id: k, name: k }),
   );
 
-  const wrapper = mountComponent({
+  mountComponent({
     experiments: localExperiments,
     activeExperimentIds: keys,
   });
-  const selected = wrapper.find('[data-test-id="active-experiment-list-item"]');
+  const selected = screen.getAllByTestId('active-experiment-list-item');
   expect(selected.length).toBeLessThan(keys.length);
 });

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { Component } from 'react';
-import { css } from '@emotion/react';
+import { css, Theme } from '@emotion/react';
 import {
   Checkbox,
   CaretDownSquareIcon,
@@ -15,6 +15,7 @@ import {
   PencilIcon,
   Typography,
   WithDesignSystemThemeHoc,
+  DesignSystemHocProps,
 } from '@databricks/design-system';
 import { List } from 'antd';
 import { List as VList, AutoSizer } from 'react-virtualized';
@@ -30,13 +31,10 @@ import { withRouterNext } from '../../common/utils/withRouterNext';
 
 type Props = {
   activeExperimentIds: string[];
-  designSystemThemeApi: {
-    theme?: any;
-  };
   // @ts-expect-error TS(2749): 'Experiment' refers to a value, but is being used ... Remove this comment to see the full error message
   experiments: Experiment[];
   navigate: NavigateFunction;
-};
+} & DesignSystemHocProps;
 
 type State = any;
 
@@ -174,7 +172,7 @@ export class ExperimentListView extends Component<Props, State> {
     return (
       <div
         css={isActive ? this.activeExperimentListItem : this.inactiveExperimentListItem}
-        data-test-id={dataTestId}
+        data-testid={dataTestId}
         key={key}
         style={style}
       >
@@ -190,14 +188,14 @@ export class ExperimentListView extends Component<Props, State> {
               key={item.experiment_id}
               onChange={(isChecked) => this.handleCheck(isChecked, item.experiment_id)}
               checked={isActive}
-              data-test-id={`${dataTestId}-check-box`}
+              data-testid={`${dataTestId}-check-box`}
             ></Checkbox>,
             <Link
               className={'experiment-link'}
               to={Routes.getExperimentPageRoute(item.experiment_id)}
               onClick={() => this.setState({ checkedKeys: [item.experiment_id] })}
               title={item.name}
-              data-test-id={`${dataTestId}-link`}
+              data-testid={`${dataTestId}-link`}
             >
               {item.name}
             </Link>,
@@ -205,7 +203,7 @@ export class ExperimentListView extends Component<Props, State> {
               icon={<PencilIcon />}
               // @ts-expect-error TS(2322): Type '{ icon: Element; onClick: () => void; "data-... Remove this comment to see the full error message
               onClick={this.handleRenameExperiment(item.experiment_id, item.name)}
-              data-test-id='rename-experiment-button'
+              data-testid='rename-experiment-button'
               css={classNames.renameExperiment}
             />,
             <IconButton
@@ -213,7 +211,7 @@ export class ExperimentListView extends Component<Props, State> {
               // @ts-expect-error TS(2322): Type '{ icon: Element; onClick: () => void; css: {... Remove this comment to see the full error message
               onClick={this.handleDeleteExperiment(item.experiment_id, item.name)}
               css={classNames.deleteExperiment}
-              data-test-id='delete-experiment-button'
+              data-testid='delete-experiment-button'
             />,
           ]}
         ></List.Item>
@@ -230,19 +228,21 @@ export class ExperimentListView extends Component<Props, State> {
 
   render() {
     const { hidden } = this.state;
+    const { activeExperimentIds, designSystemThemeApi } = this.props;
+    const { theme } = designSystemThemeApi;
+
     if (hidden) {
       return (
         <CaretDownSquareIcon
           rotate={-90}
           onClick={this.unHide}
-          css={{ fontSize: '24px' }}
+          css={classNames.icon(theme)}
           title='Show experiment list'
         />
       );
     }
 
     const { searchInput } = this.state;
-    const { activeExperimentIds } = this.props;
     const filteredExperiments = this.filterExperiments(searchInput);
 
     return (
@@ -268,28 +268,27 @@ export class ExperimentListView extends Component<Props, State> {
           <Typography.Title level={2} style={{ margin: 0 }}>
             Experiments
           </Typography.Title>
-          <PlusCircleIcon
-            onClick={this.handleCreateExperiment}
-            css={{
-              fontSize: '24px',
-              marginLeft: 'auto',
-            }}
-            title='New Experiment'
-            data-test-id='create-experiment-button'
-          />
-          <CaretDownSquareIcon
-            onClick={this.hide}
-            rotate={90}
-            css={{ fontSize: '24px' }}
-            title='Hide experiment list'
-          />
+          <div>
+            <PlusCircleIcon
+              onClick={this.handleCreateExperiment}
+              css={classNames.icon(theme)}
+              title='New Experiment'
+              data-testid='create-experiment-button'
+            />
+            <CaretDownSquareIcon
+              onClick={this.hide}
+              rotate={90}
+              css={classNames.icon(theme)}
+              title='Hide experiment list'
+            />
+          </div>
         </div>
         <Input
           placeholder='Search Experiments'
           aria-label='search experiments'
           value={searchInput}
           onChange={this.handleSearchInputChange}
-          data-test-id='search-experiment-input'
+          data-testid='search-experiment-input'
         />
         <div>
           <AutoSizer>
@@ -392,7 +391,11 @@ const classNames = {
     justifySelf: 'end',
     marginRight: '10px',
   },
+  icon: (theme: Theme) => ({
+    color: theme.colors.actionDefaultTextDefault,
+    fontSize: theme.general.iconSize,
+    marginLeft: theme.spacing.xs,
+  }),
 };
 
-// @ts-expect-error TS(2345): Argument of type '(props: Props) => ReactElement<a... Remove this comment to see the full error message
 export default withRouterNext(WithDesignSystemThemeHoc(ExperimentListView));

--- a/mlflow/server/js/src/experiment-tracking/components/HomeView.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/HomeView.test.tsx
@@ -13,7 +13,8 @@ import { Provider } from 'react-redux';
 import { BrowserRouter, MemoryRouter } from '../../common/utils/RoutingUtils';
 import Fixtures from '../utils/test-utils/Fixtures';
 import HomeView, { getFirstActiveExperiment } from './HomeView';
-import { mount } from 'enzyme';
+import { screen, renderWithIntl } from '../../common/utils/TestUtils';
+import { DesignSystemProvider } from '@databricks/design-system';
 
 const mockNavigate = jest.fn();
 
@@ -52,14 +53,16 @@ describe('HomeView', () => {
   });
 
   test('should render with minimal props without exploding', () => {
-    wrapper = mount(
-      <Provider store={minimalStore}>
-        <MemoryRouter>
-          <HomeView />
-        </MemoryRouter>
-      </Provider>,
+    renderWithIntl(
+      <DesignSystemProvider>
+        <Provider store={minimalStore}>
+          <MemoryRouter>
+            <HomeView />
+          </MemoryRouter>
+        </Provider>
+      </DesignSystemProvider>,
     );
-    expect(wrapper.length).toBe(1);
+    expect(screen.getByAltText('No experiments found.')).toBeInTheDocument();
   });
 
   test('getFirstActiveExperiment works', () => {
@@ -71,12 +74,14 @@ describe('HomeView', () => {
       entities: { experimentsById: experiments },
       apis: jest.fn(() => ({})),
     });
-    wrapper = mount(
-      <Provider store={minimalStore}>
-        <MemoryRouter>
-          <HomeView {...minimalProps} />
-        </MemoryRouter>
-      </Provider>,
+    wrapper = renderWithIntl(
+      <DesignSystemProvider>
+        <Provider store={minimalStore}>
+          <MemoryRouter>
+            <HomeView {...minimalProps} />
+          </MemoryRouter>
+        </Provider>
+      </DesignSystemProvider>,
     );
 
     expect(mockNavigate).toBeCalledWith({ replace: true, to: '/experiments/2' });

--- a/mlflow/server/js/src/experiment-tracking/components/HomeView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/HomeView.tsx
@@ -8,12 +8,18 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Navigate } from '../../common/utils/RoutingUtils';
-import { PageWrapper, LegacySkeleton } from '@databricks/design-system';
+import {
+  PageWrapper,
+  LegacySkeleton,
+  WithDesignSystemThemeHoc,
+  DesignSystemHocProps,
+} from '@databricks/design-system';
 import ExperimentListView from './ExperimentListView';
 import { getExperiments } from '../reducers/Reducers';
 import { NoExperimentView } from './NoExperimentView';
 import Utils from '../../common/utils/Utils';
 import Routes from '../routes';
+import { Interpolation, Theme } from '@emotion/react';
 
 // Lazy load experiment page in order to promote bundle splitting
 const ExperimentPage = React.lazy(() => import('./experiment-page/ExperimentPage'));
@@ -27,11 +33,12 @@ type HomeViewProps = {
   experiments?: any[];
   experimentIds?: string[];
   compareExperiments?: boolean;
-};
+} & DesignSystemHocProps;
 
 class HomeView extends Component<HomeViewProps> {
   render() {
-    const { experimentIds, experiments, compareExperiments } = this.props;
+    const { experimentIds, experiments, compareExperiments, designSystemThemeApi } = this.props;
+    const { theme } = designSystemThemeApi;
     // @ts-expect-error TS(2532): Object is possibly 'undefined'.
     const hasExperiments = experimentIds?.length > 0;
 
@@ -63,8 +70,8 @@ class HomeView extends Component<HomeViewProps> {
       );
     }
     return (
-      <div css={{ display: 'flex', height: 'calc(100% - 60px)' }}>
-        <div css={{ height: '100%', paddingTop: 24, display: 'flex' }}>
+      <div css={styles.homeContainer(theme)}>
+        <div css={styles.experimentList}>
           {/* @ts-expect-error TS(2322): Type '{ activeExperimentIds: string[]; experiments... Remove this comment to see the full error message */}
           <ExperimentListView activeExperimentIds={experimentIds || []} experiments={experiments} />
         </div>
@@ -86,9 +93,22 @@ class HomeView extends Component<HomeViewProps> {
   }
 }
 
+const styles = {
+  homeContainer: (theme: Theme): Interpolation<Theme> => ({
+    backgroundColor: theme.colors.backgroundPrimary,
+    display: 'flex',
+    height: 'calc(100% - 60px)',
+  }),
+  experimentList: {
+    height: '100%',
+    paddingTop: 24,
+    display: 'flex',
+  },
+};
+
 const mapStateToProps = (state: any) => {
   const experiments = getExperiments(state);
   return { experiments };
 };
 
-export default connect(mapStateToProps)(HomeView);
+export default connect(mapStateToProps)(WithDesignSystemThemeHoc(HomeView));

--- a/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotPanel.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotPanel.tsx
@@ -17,6 +17,7 @@ import {
 import _ from 'lodash';
 import { CompareRunPlotContainer } from './CompareRunPlotContainer';
 import { FormattedMessage } from 'react-intl';
+import { Typography } from '@databricks/design-system';
 
 type ParallelCoordinatesPlotPanelProps = {
   runUuids: string[];
@@ -79,13 +80,13 @@ export class ParallelCoordinatesPlotPanel extends React.Component<
         ) : (
           // @ts-expect-error TS(2322): Type '(theme: any) => { padding: any; textAlign: s... Remove this comment to see the full error message
           <div css={styles.noValuesSelected} data-testid='no-values-selected'>
-            <h2>
+            <Typography.Title level={2}>
               <FormattedMessage
                 defaultMessage='Nothing to compare!'
                 // eslint-disable-next-line max-len
                 description='Header displayed in the metrics and params compare plot when no values are selected'
               />
-            </h2>
+            </Typography.Title>
             <FormattedMessage
               defaultMessage='Please select parameters and/or metrics to display the comparison.'
               // eslint-disable-next-line max-len

--- a/mlflow/server/js/src/model-registry/components/CreateModelForm.tsx
+++ b/mlflow/server/js/src/model-registry/components/CreateModelForm.tsx
@@ -7,8 +7,7 @@
 
 import React, { Component } from 'react';
 
-import { Form } from 'antd';
-import { Input } from '@databricks/design-system';
+import { Form, Input } from '@databricks/design-system';
 import { ModelRegistryDocUrl } from '../../common/constants';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
@@ -30,6 +29,7 @@ class CreateModelFormImpl extends Component<Props> {
   render() {
     const learnMoreLinkUrl = CreateModelFormImpl.getLearnMoreLinkUrl();
     return (
+      // @ts-expect-error TS(2322)
       <Form ref={this.props.innerRef} layout='vertical' data-testid='create-model-form-modal'>
         <Form.Item
           name={MODEL_NAME_FIELD}

--- a/mlflow/server/js/src/shared/web-shared/design-system/index.tsx
+++ b/mlflow/server/js/src/shared/web-shared/design-system/index.tsx
@@ -7,15 +7,15 @@ export type DarkModePref = 'system' | 'dark' | 'light';
 const DARK_MODE_PREF_DEFAULT = 'light';
 
 export interface SupportsDuBoisThemesProps {
-  disabled?: boolean;
+  isDarkMode?: boolean;
 }
 
 export const SupportsDuBoisThemes: React.FC<SupportsDuBoisThemesProps> = ({
-  disabled = false,
+  isDarkMode = false,
   children,
 }) => {
   // eslint-disable-next-line react/forbid-elements
-  return <DesignSystemThemeProvider isDarkMode={false}>{children}</DesignSystemThemeProvider>;
+  return <DesignSystemThemeProvider isDarkMode={isDarkMode}>{children}</DesignSystemThemeProvider>;
 };
 
 export function getUserDarkModePref(): DarkModePref {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10395?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10395/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10395
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Title

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
