### PR TITLE
Refactor to sync with mlflowserving

### DIFF
--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -518,7 +518,7 @@ def parse_tf_serving_input(inp_dict, schema=None):
     # pylint: disable=broad-except
     if "signature_name" in inp_dict:
         raise MlflowInvalidInputException(
-            '"signature_name" is currently not supported in Mlflow tf serving input.'
+            '"signature_name" is currently not supported in MLflow tf serving input.'
         )
 
     if not (list(inp_dict.keys()) == ["instances"] or list(inp_dict.keys()) == ["inputs"]):

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -509,9 +509,7 @@ def parse_tf_serving_input(inp_dict, schema=None):
 
     # pylint: disable=broad-except
     if "signature_name" in inp_dict:
-        raise MlflowInvalidInputException(
-            '"signature_name" is currently not supported in MLflow tf serving input.'
-        )
+        raise MlflowInvalidInputException('"signature_name" parameter is currently not supported')
 
     if not (list(inp_dict.keys()) == ["instances"] or list(inp_dict.keys()) == ["inputs"]):
         raise MlflowInvalidInputException(

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -303,18 +303,11 @@ def dataframe_from_parsed_json(decoded_input, pandas_orient, schema=None):
                 f"and 'index' fields. Got {keys}.'"
             )
         try:
-            if schema is None:
-                pdf = pd.DataFrame(
-                    index=decoded_input.get("index"),
-                    columns=decoded_input.get("columns"),
-                    data=np.array(decoded_input["data"]),
-                )
-            else:
-                pdf = pd.DataFrame(
-                    index=decoded_input.get("index"),
-                    columns=decoded_input.get("columns"),
-                    data=decoded_input["data"],
-                )
+            pdf = pd.DataFrame(
+                index=decoded_input.get("index"),
+                columns=decoded_input.get("columns"),
+                data=decoded_input["data"],
+            )
         except Exception as ex:
             raise MlflowInvalidInputException(
                 f"Provided dataframe_split field is not a valid dataframe representation in "

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -307,7 +307,7 @@ def dataframe_from_parsed_json(decoded_input, pandas_orient, schema=None):
                 pdf = pd.DataFrame(
                     index=decoded_input.get("index"),
                     columns=decoded_input.get("columns"),
-                    data=np.array(decoded_input["data"], dtype="object"),
+                    data=np.array(decoded_input["data"]),
                 )
             else:
                 pdf = pd.DataFrame(

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -266,7 +266,6 @@ def dataframe_from_parsed_json(decoded_input, pandas_orient, schema=None):
     :param pandas_orient: pandas data frame convention used to store the data.
     :return: pandas.DataFrame.
     """
-    import numpy as np
     import pandas as pd
 
     if pandas_orient == "records":

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -196,12 +196,16 @@ class NumpyEncoder(JSONEncoder):
             return super().default(o)
 
 
-class MlflowFailedTypeConversion(MlflowException):
+class MlflowInvalidInputException(MlflowException):
+    def __init__(self, message):
+        super().__init__(f"Invalid input. {message}", error_code=BAD_REQUEST)
+
+
+class MlflowFailedTypeConversion(MlflowInvalidInputException):
     def __init__(self, col_name, col_type, ex):
         super().__init__(
             message=f"Data is not compatible with model signature. "
-            f"Failed to convert column {col_name} to type '{col_type}'. Error: '{ex!r}'",
-            error_code=BAD_REQUEST,
+            f"Failed to convert column {col_name} to type '{col_type}'. Error: '{ex!r}'"
         )
 
 
@@ -252,11 +256,6 @@ def cast_df_types_according_to_schema(pdf, schema):
     return pdf
 
 
-class MlflowBadScoringInputException(MlflowException):
-    def __init__(self, message):
-        super().__init__(message, error_code=BAD_REQUEST)
-
-
 def dataframe_from_parsed_json(decoded_input, pandas_orient, schema=None):
     """
     Convert parsed json into pandas.DataFrame. If schema is provided this methods will attempt to
@@ -267,6 +266,7 @@ def dataframe_from_parsed_json(decoded_input, pandas_orient, schema=None):
     :param pandas_orient: pandas data frame convention used to store the data.
     :return: pandas.DataFrame.
     """
+    import numpy as np
     import pandas as pd
 
     if pandas_orient == "records":
@@ -275,13 +275,13 @@ def dataframe_from_parsed_json(decoded_input, pandas_orient, schema=None):
                 typemessage = "dictionary"
             else:
                 typemessage = f"type {type(decoded_input)}"
-            raise MlflowBadScoringInputException(
+            raise MlflowInvalidInputException(
                 f"Dataframe records format must be a list of records. Got {typemessage}."
             )
         try:
             pdf = pd.DataFrame(data=decoded_input)
         except Exception as ex:
-            raise MlflowBadScoringInputException(
+            raise MlflowInvalidInputException(
                 f"Provided dataframe_records field is not a valid dataframe representation in "
                 f"'records' format. Error: '{ex}'"
             )
@@ -291,25 +291,32 @@ def dataframe_from_parsed_json(decoded_input, pandas_orient, schema=None):
                 typemessage = "list"
             else:
                 typemessage = f"type {type(decoded_input)}"
-            raise MlflowBadScoringInputException(
+            raise MlflowInvalidInputException(
                 f"Dataframe split format must be a dictionary. Got {typemessage}."
             )
         keys = set(decoded_input.keys())
         missing_data = "data" not in keys
         extra_keys = keys.difference({"columns", "data", "index"})
         if missing_data or extra_keys:
-            raise MlflowBadScoringInputException(
+            raise MlflowInvalidInputException(
                 f"Dataframe split format must have 'data' field and optionally 'columns' "
                 f"and 'index' fields. Got {keys}.'"
             )
         try:
-            pdf = pd.DataFrame(
-                index=decoded_input.get("index"),
-                columns=decoded_input.get("columns"),
-                data=decoded_input["data"],
-            )
+            if schema is None:
+                pdf = pd.DataFrame(
+                    index=decoded_input.get("index"),
+                    columns=decoded_input.get("columns"),
+                    data=np.array(decoded_input["data"], dtype="object"),
+                )
+            else:
+                pdf = pd.DataFrame(
+                    index=decoded_input.get("index"),
+                    columns=decoded_input.get("columns"),
+                    data=decoded_input["data"],
+                )
         except Exception as ex:
-            raise MlflowBadScoringInputException(
+            raise MlflowInvalidInputException(
                 f"Provided dataframe_split field is not a valid dataframe representation in "
                 f"'split' format. Error: '{ex}'"
             )
@@ -373,24 +380,31 @@ def convert_data_type(data, spec):
     from mlflow.models.utils import _enforce_array, _enforce_object
     from mlflow.types.schema import Array, ColSpec, DataType, Object, TensorSpec
 
-    if spec is None:
-        return np.array(data)
-    if isinstance(spec, TensorSpec):
-        return np.array(data, dtype=spec.type)
-    if isinstance(spec, ColSpec):
-        if isinstance(spec.type, DataType):
-            return (
-                np.array(data, spec.type.to_numpy())
-                if isinstance(data, (list, np.ndarray))
-                else np.array([data], spec.type.to_numpy())[0]
-            )
-        elif isinstance(spec.type, Array):
-            # convert to numpy array for backwards compatibility
-            return np.array(_enforce_array(data, spec.type))
-        elif isinstance(spec.type, Object):
-            return _enforce_object(data, spec.type)
+    try:
+        if spec is None:
+            return np.array(data)
+        if isinstance(spec, TensorSpec):
+            return np.array(data, dtype=spec.type)
+        if isinstance(spec, ColSpec):
+            if isinstance(spec.type, DataType):
+                return (
+                    np.array(data, spec.type.to_numpy())
+                    if isinstance(data, (list, np.ndarray))
+                    else np.array([data], spec.type.to_numpy())[0]
+                )
+            elif isinstance(spec.type, Array):
+                # convert to numpy array for backwards compatibility
+                return np.array(_enforce_array(data, spec.type))
+            elif isinstance(spec.type, Object):
+                return _enforce_object(data, spec.type)
+    except MlflowException as e:
+        raise MlflowInvalidInputException(e.message)
+    except Exception as ex:
+        raise MlflowInvalidInputException(f"{ex}")
 
-    raise MlflowException(f"Failed to convert data type for data `{data}` with spec `{spec}`.")
+    raise MlflowInvalidInputException(
+        f"Failed to convert data type for data `{data}` with spec `{spec}`."
+    )
 
 
 def _cast_schema_type(input_data, schema=None):
@@ -409,7 +423,7 @@ def _cast_schema_type(input_data, schema=None):
             input_data = {next(iter(types_dict)): input_data}
         # Un-named schema should only contain a single column
         elif not schema.has_input_names() and not isinstance(input_data, list):
-            raise MlflowException(
+            raise MlflowInvalidInputException(
                 "Failed to parse input data. This model contains an un-named tensor-based"
                 " model signature which expects a single n-dimensional array as input,"
                 f" however, an input of type {type(input_data)} was found."
@@ -436,7 +450,7 @@ def _cast_schema_type(input_data, schema=None):
         if schema is None:
             input_data = np.array(input_data)
         else:
-            raise MlflowException(
+            raise MlflowInvalidInputException(
                 "Failed to parse input data. This model contains a tensor-based model "
                 "signature with input names, which suggests a dictionary / a list of "
                 "dictionaries input mapping input name to tensor or a pure list, but "
@@ -451,7 +465,7 @@ def parse_instances_data(data, schema=None):
     from mlflow.types.schema import Array
 
     if "instances" not in data:
-        raise MlflowException("Expecting data to have `instances` as key.")
+        raise MlflowInvalidInputException("Expecting data to have `instances` as key.")
     data = data["instances"]
     # List[Dict]
     if isinstance(data, list) and len(data) > 0 and isinstance(data[0], dict):
@@ -487,9 +501,8 @@ def parse_instances_data(data, schema=None):
         if check_cols:
             expected_len = len(check_data[check_cols[0]])
             if not all(len(check_data[col]) == expected_len for col in check_cols[1:]):
-                raise MlflowException(
-                    "Failed to parse data as TF serving input. The length of values for"
-                    " each input/column name are not the same"
+                raise MlflowInvalidInputException(
+                    "The length of values for each input/column name are not the same"
                 )
     return data
 
@@ -504,15 +517,14 @@ def parse_tf_serving_input(inp_dict, schema=None):
 
     # pylint: disable=broad-except
     if "signature_name" in inp_dict:
-        raise MlflowException(
-            'Failed to parse data as TF serving input. "signature_name" is currently'
-            " not supported."
+        raise MlflowInvalidInputException(
+            '"signature_name" is currently not supported in Mlflow tf serving input.'
         )
 
     if not (list(inp_dict.keys()) == ["instances"] or list(inp_dict.keys()) == ["inputs"]):
-        raise MlflowException(
-            'Failed to parse data as TF serving input. One of "instances" and'
-            ' "inputs" must be specified (not both or any other keys).'
+        raise MlflowInvalidInputException(
+            'One of "instances" and "inputs" must be specified (not both or any other keys).'
+            f"Received: {list(inp_dict.keys())}"
         )
 
     # Read the JSON
@@ -529,14 +541,12 @@ def parse_tf_serving_input(inp_dict, schema=None):
         else:
             # items already in column format, convert values to tensor
             return _cast_schema_type(inp_dict["inputs"], schema)
+    except MlflowException as e:
+        raise e
     except Exception as e:
         # Add error into message to provide details for serving usage
-        raise MlflowException(
-            "Failed to parse data as TF serving input. Ensure that the input is"
-            " a valid JSON-formatted string that conforms to the request body for"
-            " TF serving's Predict API as documented at"
-            " https://www.tensorflow.org/tfx/serving/api_rest#request_format_2.\n"
-            f"Error: {e!r}"
+        raise MlflowInvalidInputException(
+            "Ensure that the input is a valid JSON-formatted string.\n" f"Error: {e!r}"
         ) from e
 
 

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -129,9 +129,7 @@ def test_scoring_server_responds_to_malformed_json_input_with_error_code_and_mes
     response_json = json.loads(response.content)
     assert response_json.get("error_code") == ErrorCode.Name(BAD_REQUEST)
     message = response_json.get("message")
-    expected_message = (
-        "Failed to parse input from JSON. Ensure that input is a valid JSON formatted string."
-    )
+    expected_message = "Invalid input. Ensure that input is a valid JSON formatted string."
     assert expected_message in message
 
 

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -447,7 +447,7 @@ def test_parse_tf_serving_raises_expected_errors():
         "signature_name": "hello",
         "inputs": {"a": ["s1", "s2", "s3"], "b": [1, 2, 3], "c": [[1, 2, 3], [4, 5, 6], [7, 8, 9]]},
     }
-    match = '"signature_name" is currently not supported in MLflow tf serving input.'
+    match = '"signature_name" parameter is currently not supported'
     with pytest.raises(MlflowException, match=match):
         parse_tf_serving_input(tfserving_input)
 

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -428,7 +428,9 @@ def test_parse_tf_serving_raises_expected_errors():
             {"a": "s3", "b": 3, "c": [7, 8, 9]},
         ]
     }
-    with pytest.raises(MlflowException, match="Failed to parse data as TF serving input."):
+    with pytest.raises(
+        MlflowException, match="The length of values for each input/column name are not the same"
+    ):
         parse_tf_serving_input(tfserving_instances)
 
     # cannot specify both instance and inputs
@@ -436,10 +438,7 @@ def test_parse_tf_serving_raises_expected_errors():
         "instances": [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
         "inputs": {"a": ["s1", "s2", "s3"], "b": [1, 2, 3], "c": [[1, 2, 3], [4, 5, 6], [7, 8, 9]]},
     }
-    match = (
-        'Failed to parse data as TF serving input. One of "instances" and "inputs"'
-        " must be specified"
-    )
+    match = 'Invalid input. One of "instances" and "inputs" must be specified'
     with pytest.raises(MlflowException, match=match):
         parse_tf_serving_input(tfserving_input)
 
@@ -448,7 +447,7 @@ def test_parse_tf_serving_raises_expected_errors():
         "signature_name": "hello",
         "inputs": {"a": ["s1", "s2", "s3"], "b": [1, 2, 3], "c": [[1, 2, 3], [4, 5, 6], [7, 8, 9]]},
     }
-    match = 'Failed to parse data as TF serving input. "signature_name" is currently not supported'
+    match = '"signature_name" is currently not supported in Mlflow tf serving input.'
     with pytest.raises(MlflowException, match=match):
         parse_tf_serving_input(tfserving_input)
 

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -447,7 +447,7 @@ def test_parse_tf_serving_raises_expected_errors():
         "signature_name": "hello",
         "inputs": {"a": ["s1", "s2", "s3"], "b": [1, 2, 3], "c": [[1, 2, 3], [4, 5, 6], [7, 8, 9]]},
     }
-    match = '"signature_name" is currently not supported in Mlflow tf serving input.'
+    match = '"signature_name" is currently not supported in MLflow tf serving input.'
     with pytest.raises(MlflowException, match=match):
         parse_tf_serving_input(tfserving_input)
 

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -556,8 +556,8 @@ def test_xgb_autolog_infers_model_signature_correctly(bst_params):
 
     assert "inputs" in signature
     assert json.loads(signature["inputs"]) == [
-        {"name": "sepal length (cm)", "type": "double"},
-        {"name": "sepal width (cm)", "type": "double"},
+        {"name": "sepal length (cm)", "type": "double", "required": True},
+        {"name": "sepal width (cm)", "type": "double", "required": True},
     ]
 
     assert "outputs" in signature


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10399?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10399/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10399
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Update scoring server to sync with mlflowserving on DBX.
Mostly are error message changes.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
