### PR TITLE
Fix background and misc text components

### DIFF
--- a/mlflow/server/js/src/app.tsx
+++ b/mlflow/server/js/src/app.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ApolloProvider } from '@apollo/client';
 import { IntlProvider } from 'react-intl';
 import './index.css';
+import { ApplyGlobalStyles } from '@databricks/design-system';
 import '@databricks/design-system/dist/index.css';
 import '@databricks/design-system/dist/index-dark.css';
 import App from './experiment-tracking/components/App';
@@ -35,6 +36,7 @@ export function MLFlowRoot() {
     <IntlProvider locale={locale} messages={messages}>
       <Provider store={store}>
         <DesignSystemContainer isDarkTheme={isDarkTheme}>
+          <ApplyGlobalStyles />
           <ConfigProvider prefixCls='ant'>
             {shouldUsePathRouting() ? (
               <MlflowRouter isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme} />

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { injectIntl, FormattedMessage } from 'react-intl';
-import { Alert, Button, Spacer, Switch, Tabs, Tooltip } from '@databricks/design-system';
+import { Alert, Button, Spacer, Switch, Tabs, Tooltip, Typography } from '@databricks/design-system';
 
 import { getExperiment, getParams, getRunInfo, getRunTags } from '../reducers/Reducers';
 import './CompareRunView.css';
@@ -261,12 +261,10 @@ export class CompareRunView extends Component<CompareRunViewProps, CompareRunVie
     );
     if (dataRows.length === 0) {
       return (
-        <h2>
-          <FormattedMessage
-            defaultMessage='No parameters to display.'
-            description='Text shown when there are no parameters to display'
-          />
-        </h2>
+        <FormattedMessage
+          defaultMessage='No parameters to display.'
+          description='Text shown when there are no parameters to display'
+        />
       );
     }
     return (
@@ -308,12 +306,10 @@ export class CompareRunView extends Component<CompareRunViewProps, CompareRunVie
     );
     if (dataRows.length === 0) {
       return (
-        <h2>
-          <FormattedMessage
-            defaultMessage='No metrics to display.'
-            description='Text shown when there are no metrics to display'
-          />
-        </h2>
+        <FormattedMessage
+          defaultMessage='No metrics to display.'
+          description='Text shown when there are no metrics to display'
+        />
       );
     }
     return (
@@ -337,12 +333,10 @@ export class CompareRunView extends Component<CompareRunViewProps, CompareRunVie
     );
     if (dataRows.length === 0) {
       return (
-        <h2>
-          <FormattedMessage
-            defaultMessage='No tags to display.'
-            description='Text shown when there are no tags to display'
-          />
-        </h2>
+        <FormattedMessage
+          defaultMessage='No tags to display.'
+          description='Text shown when there are no tags to display'
+        />
       );
     }
     return (

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { injectIntl, FormattedMessage } from 'react-intl';
-import { Alert, Button, Spacer, Switch, Tabs, Tooltip, Typography } from '@databricks/design-system';
+import { Alert, Button, Spacer, Switch, Tabs, Tooltip } from '@databricks/design-system';
 
 import { getExperiment, getParams, getRunInfo, getRunTags } from '../reducers/Reducers';
 import './CompareRunView.css';

--- a/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotPanel.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotPanel.tsx
@@ -17,6 +17,7 @@ import {
 import _ from 'lodash';
 import { CompareRunPlotContainer } from './CompareRunPlotContainer';
 import { FormattedMessage } from 'react-intl';
+import { Typography } from '@databricks/design-system';
 
 type ParallelCoordinatesPlotPanelProps = {
   runUuids: string[];
@@ -79,13 +80,13 @@ export class ParallelCoordinatesPlotPanel extends React.Component<
         ) : (
           // @ts-expect-error TS(2322): Type '(theme: any) => { padding: any; textAlign: s... Remove this comment to see the full error message
           <div css={styles.noValuesSelected} data-testid='no-values-selected'>
-            <h2>
+            <Typography.Title level={2}>
               <FormattedMessage
                 defaultMessage='Nothing to compare!'
                 // eslint-disable-next-line max-len
                 description='Header displayed in the metrics and params compare plot when no values are selected'
               />
-            </h2>
+            </Typography.Title>
             <FormattedMessage
               defaultMessage='Please select parameters and/or metrics to display the comparison.'
               // eslint-disable-next-line max-len

--- a/mlflow/server/js/src/model-registry/components/CreateModelForm.tsx
+++ b/mlflow/server/js/src/model-registry/components/CreateModelForm.tsx
@@ -7,8 +7,7 @@
 
 import React, { Component } from 'react';
 
-import { Form } from 'antd';
-import { Input } from '@databricks/design-system';
+import { Form, Input } from '@databricks/design-system';
 import { ModelRegistryDocUrl } from '../../common/constants';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
@@ -30,6 +29,7 @@ class CreateModelFormImpl extends Component<Props> {
   render() {
     const learnMoreLinkUrl = CreateModelFormImpl.getLearnMoreLinkUrl();
     return (
+      // @ts-expect-error TS(2322)
       <Form ref={this.props.innerRef} layout='vertical' data-testid='create-model-form-modal'>
         <Form.Item
           name={MODEL_NAME_FIELD}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/10400?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10400/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10400
```

</p>
</details>

### Related Issues/PRs

### What changes are proposed in this pull request?

This PR fixes some flexbox issues in the UI that were revealed with the dark mode implementation:

| place | before | after |
|------|-------|----|
| models page | <img width="1920" alt="Screenshot 2023-11-14 at 1 20 24 PM" src="https://github.com/mlflow/mlflow/assets/148037680/ac08f26b-c567-403e-b860-afbdc6aaaec8"> | <img width="1920" alt="Screenshot 2023-11-14 at 1 20 24 PM" src="https://github.com/mlflow/mlflow/assets/148037680/cfa8240f-8f12-4b27-8b02-8c41189e933c">  |
| run details page |  <img width="1920" alt="Screenshot 2023-11-14 at 1 26 27 PM" src="https://github.com/mlflow/mlflow/assets/148037680/99cc4807-77f5-4ce2-a270-bce7bd00d78c"> | https://github.com/mlflow/mlflow/assets/148037680/3e9d37b1-7236-4d7c-b516-6291814d7bf5 |


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
