### PR TITLE
Some fixes on async logging utils

### DIFF
--- a/mlflow/utils/async_logging/run_batch.py
+++ b/mlflow/utils/async_logging/run_batch.py
@@ -34,7 +34,7 @@ class RunBatch:
     @property
     def exception(self):
         """Exception raised during logging the batch."""
-        return getattr(self, "_exception", None)
+        return self._exception
 
     @exception.setter
     def exception(self, exception):

--- a/mlflow/utils/async_logging/run_batch.py
+++ b/mlflow/utils/async_logging/run_batch.py
@@ -29,6 +29,7 @@ class RunBatch:
         self.tags = tags or []
         self.metrics = metrics or []
         self.completion_event = completion_event
+        self._exception = None
 
     @property
     def exception(self):

--- a/mlflow/utils/async_logging/run_batch.py
+++ b/mlflow/utils/async_logging/run_batch.py
@@ -15,8 +15,7 @@ class RunBatch:
         metrics: List[Metric],
         completion_event: threading.Event,
     ) -> None:
-        """
-        Initializes an instance of RunBatch.
+        """Initializes an instance of `RunBatch`.
 
         Args:
             run_id: The ID of the run.
@@ -30,4 +29,12 @@ class RunBatch:
         self.tags = tags or []
         self.metrics = metrics or []
         self.completion_event = completion_event
-        self.exception = None
+
+    @property
+    def exception(self):
+        """Exception raised during logging the batch."""
+        return getattr(self, "_exception", None)
+
+    @exception.setter
+    def exception(self, exception):
+        self._exception = exception

--- a/mlflow/utils/async_logging/run_operations.py
+++ b/mlflow/utils/async_logging/run_operations.py
@@ -1,16 +1,11 @@
 class RunOperations:
-    """
-    Represents a collection of operations on one or more MLflow Runs, such as run creation
-    or metric logging.
-    """
+    """Class that helps manage the futures of MLflow async logging."""
 
     def __init__(self, operation_futures):
         self._operation_futures = operation_futures or []
 
     def wait(self):
-        """
-        Blocks on completion of the MLflow Run operations.
-        """
+        """Blocks on completion of all futures."""
         from mlflow.exceptions import MlflowException
 
         failed_operations = []
@@ -21,25 +16,25 @@ class RunOperations:
                 failed_operations.append(e)
 
         if len(failed_operations) > 0:
-            # Importing MlflowException gives circular reference / module load error, need to
-            #  figure out why.
             raise MlflowException(
-                "The following failures occurred while performing one or more logging"
-                + f" operations: {failed_operations}"
+                "The following failures occurred while performing one or more async logging "
+                f"operations: {failed_operations}"
             )
 
 
 def get_combined_run_operations(run_operations_list: [RunOperations]) -> RunOperations:
-    """
-    Given a list of RunOperations, returns a single RunOperations object that represents the
+    """Combine a list of RunOperations objects into a single RunOperations object.
+
+    Given a list of `RunOperations`, returns a single `RunOperations` object that represents the
     combined set of operations. If the input list is empty, returns None. If the input list
-    contains only one element, returns that element. Otherwise, creates a new RunOperations
+    contains only one element, returns that element. Otherwise, creates a new `RunOperations`
     object that combines the operation futures from each input RunOperations object.
 
-    :param run_operations_list: A list of RunOperations objects to combine.
-    :type run_operations_list: list[RunOperations]
-    :return: A single RunOperations object that represents the combined set of operations.
-    :rtype: RunOperations
+    Args:
+        run_operations_list: A list of `RunOperations` objects to combine.
+
+    Returns:
+        A single `RunOperations` object that represents the combined set of operations.
     """
     if not run_operations_list:
         return None

--- a/mlflow/utils/async_logging/run_operations.py
+++ b/mlflow/utils/async_logging/run_operations.py
@@ -1,3 +1,6 @@
+from typing import List
+
+
 class RunOperations:
     """Class that helps manage the futures of MLflow async logging."""
 
@@ -22,7 +25,7 @@ class RunOperations:
             )
 
 
-def get_combined_run_operations(run_operations_list: [RunOperations]) -> RunOperations:
+def get_combined_run_operations(run_operations_list: List[RunOperations]) -> RunOperations:
     """Combine a list of RunOperations objects into a single RunOperations object.
 
     Given a list of `RunOperations`, returns a single `RunOperations` object that represents the


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/10401?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10401/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10401
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

A few fixes:
- Explicitly mark `exception` as an property instead implicitly setting `self.exception = None` inside constructor.
- Make the docstring cleaner.
- Remove redundant comments.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
