### PR TITLE
Fix prompt template

### DIFF
--- a/mlflow/metrics/genai/base.py
+++ b/mlflow/metrics/genai/base.py
@@ -80,14 +80,14 @@ class EvaluationExample:
         )
 
         return f"""
-Input:
+Example Input:
 {self.input}
 
-Output:
+Example Output:
 {self.output}
 
 {grading_context}
 
-score: {self.score}
-justification: {self.justification}
+Example score: {self.score}
+Example justification: {self.justification}
         """

--- a/mlflow/metrics/genai/prompts/v1.py
+++ b/mlflow/metrics/genai/prompts/v1.py
@@ -15,8 +15,8 @@ grading_system_prompt_template = PromptTemplate(
     """
 Task:
 You must return the following fields in your response one below the other:
-score: Your numerical score for the model's answer_correctness based on the rubric
-justification: Your step-by-step reasoning about the model's answer_correctness score
+score: Your numerical score for the model's {name} based on the rubric
+justification: Your step-by-step reasoning about the model's {name} score
 
 You are an impartial judge. You will be given an input that was sent to a machine
 learning model, and you will be given an output that the model produced. You

--- a/mlflow/metrics/genai/prompts/v1.py
+++ b/mlflow/metrics/genai/prompts/v1.py
@@ -14,6 +14,10 @@ default_parameters = {
 grading_system_prompt_template = PromptTemplate(
     """
 Task:
+You must return the following fields in your response one below the other:
+score: Your numerical score for the model's answer_correctness based on the rubric
+justification: Your step-by-step reasoning about the model's answer_correctness score
+
 You are an impartial judge. You will be given an input that was sent to a machine
 learning model, and you will be given an output that the model produced. You
 may also be given additional information that was used by the model to generate the output.

--- a/tests/metrics/genai/prompts/test_v1.py
+++ b/tests/metrics/genai/prompts/test_v1.py
@@ -166,7 +166,7 @@ def test_evaluation_model_output():
     You must return the following fields in your response one below the other:
     score: Your numerical score for the model's correctness based on the rubric
     justification: Your step-by-step reasoning about the model's correctness score
-    
+
     You are an impartial judge. You will be given an input that was sent to a machine
     learning model, and you will be given an output that the model produced. You
     may also be given additional information that was used by the model to generate the output.
@@ -223,6 +223,10 @@ def test_no_examples(examples):
     args_string = ""
     expected_prompt2 = """
     Task:
+    You must return the following fields in your response one below the other:
+    score: Your numerical score for the model's correctness based on the rubric
+    justification: Your step-by-step reasoning about the model's correctness score
+
     You are an impartial judge. You will be given an input that was sent to a machine
     learning model, and you will be given an output that the model produced. You
     may also be given additional information that was used by the model to generate the output.

--- a/tests/metrics/genai/prompts/test_v1.py
+++ b/tests/metrics/genai/prompts/test_v1.py
@@ -53,6 +53,10 @@ def test_evaluation_model_output():
     )
     expected_prompt1 = """
     Task:
+    You must return the following fields in your response one below the other:
+    score: Your numerical score for the model's correctness based on the rubric
+    justification: Your step-by-step reasoning about the model's correctness score
+
     You are an impartial judge. You will be given an input that was sent to a machine
     learning model, and you will be given an output that the model produced. You
     may also be given additional information that was used by the model to generate the output.
@@ -93,10 +97,10 @@ def test_evaluation_model_output():
         - Score 5: the answer correctly answer the question and not missing any major aspect
 
     Examples:
-        Input:
+        Example Input:
         This is an input
 
-        Output:
+        Example Output:
         This is an output
 
         Additional information used by the model:
@@ -104,14 +108,14 @@ def test_evaluation_model_output():
         value:
         This is an output
 
-        score: 4
-        justification: This is a justification
+        Example score: 4
+        Example justification: This is a justification
 
 
-        Input:
+        Example Input:
         This is an example input 2
 
-        Output:
+        Example Output:
         This is an example output 2
 
         Additional information used by the model:
@@ -119,8 +123,8 @@ def test_evaluation_model_output():
         value:
         This is an output
 
-        score: 4
-        justification: This is an example justification 2
+        Example score: 4
+        Example justification: This is an example justification 2
 
     You must return the following fields in your response one below the other:
     score: Your numerical score for the model's correctness based on the rubric
@@ -159,6 +163,10 @@ def test_evaluation_model_output():
     args_string = ""
     expected_prompt2 = """
     Task:
+    You must return the following fields in your response one below the other:
+    score: Your numerical score for the model's correctness based on the rubric
+    justification: Your step-by-step reasoning about the model's correctness score
+    
     You are an impartial judge. You will be given an input that was sent to a machine
     learning model, and you will be given an output that the model produced. You
     may also be given additional information that was used by the model to generate the output.

--- a/tests/metrics/genai/test_base.py
+++ b/tests/metrics/genai/test_base.py
@@ -14,10 +14,10 @@ def test_evaluation_example_str():
         )
     )
     example1_expected = """
-        Input:
+        Example Input:
         This is an input
 
-        Output:
+        Example Output:
         This is an output
 
         Additional information used by the model:
@@ -25,8 +25,8 @@ def test_evaluation_example_str():
         value:
         bar
 
-        score: 5
-        justification: This is a justification
+        Example score: 5
+        Example justification: This is a justification
         """
     assert re.sub(r"\s+", "", example1_expected) == re.sub(r"\s+", "", example1)
 
@@ -36,14 +36,14 @@ def test_evaluation_example_str():
         )
     )
     example2_expected = """
-        Input:
+        Example Input:
         This is an input
 
-        Output:
+        Example Output:
         This is an output
 
-        score: 5
-        justification: It works
+        Example score: 5
+        Example justification: It works
         """
     assert re.sub(r"\s+", "", example2_expected) == re.sub(r"\s+", "", example2)
 
@@ -57,16 +57,16 @@ def test_evaluation_example_str():
         )
     )
     example3_expected = """
-        Input:
+        Example Input:
         This is an input
 
-        Output:
+        Example Output:
         This is an output
 
         Additional information used by the model:
         Baz baz
 
-        score: 5
-        justification: This is a justification
+        Example score: 5
+        Example justification: This is a justification
         """
     assert re.sub(r"\s+", "", example3_expected) == re.sub(r"\s+", "", example3)

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -244,7 +244,12 @@ def test_make_genai_metric_correct_response():
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "openai:/gpt-3.5-turbo"
         assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
+            "prompt": "\nTask:"
+            "\nYou must return the following fields in your response one below the other:\nscore: "
+            "Your numerical score for the model's fake_metric based on the "
+            "rubric\njustification: Your step-by-step reasoning about the model's "
+            "fake_metric score\n"
+            "\nYou are an impartial judge. You will be given an input that was "
             "sent to a machine\nlearning model, and you will be given an output that the model "
             "produced. You\nmay also be given additional information that was used by the model "
             "to generate the output.\n\nYour task is to determine a numerical score called "
@@ -255,9 +260,10 @@ def test_make_genai_metric_correct_response():
             "references and to\nunderstand them before completing the task.\n"
             "\nInput:\ninput\n\nOutput:\nprediction\n\nAdditional information used by the model:\n"
             "key: targets\nvalue:\nground_truth\n\nMetric definition:\nFake metric definition\n\n"
-            "Grading rubric:\nFake metric grading prompt\n\nExamples:\n\nInput:\nexample-input\n\n"
-            "Output:\nexample-output\n\nAdditional information used by the model:\nkey: targets\n"
-            "value:\nexample-ground_truth\n\nscore: 4\njustification: "
+            "Grading rubric:\nFake metric grading prompt\n\nExamples:\n\nExample Input:\n"
+            "example-input\n\nExample Output:\nexample-output\n\nAdditional information used "
+            "by the model:\nkey: targets\n"
+            "value:\nexample-ground_truth\n\nExample score: 4\nExample justification: "
             "example-justification\n        \n\nYou must return the following fields in your "
             "response one below the other:\nscore: Your numerical score for the model's "
             "fake_metric based on the rubric\njustification: Your step-by-step reasoning about "
@@ -309,7 +315,12 @@ def test_make_genai_metric_supports_string_value_for_grading_context_columns():
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "openai:/gpt-3.5-turbo"
         assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
+            "prompt": "\nTask:"
+            "\nYou must return the following fields in your response one below the other:\nscore: "
+            "Your numerical score for the model's fake_metric based on the "
+            "rubric\njustification: Your step-by-step reasoning about the model's "
+            "fake_metric score\n"
+            "\nYou are an impartial judge. You will be given an input that was "
             "sent to a machine\nlearning model, and you will be given an output that the model "
             "produced. You\nmay also be given additional information that was used by the model "
             "to generate the output.\n\nYour task is to determine a numerical score called "
@@ -320,9 +331,10 @@ def test_make_genai_metric_supports_string_value_for_grading_context_columns():
             "references and to\nunderstand them before completing the task.\n"
             "\nInput:\ninput\n\nOutput:\nprediction\n\nAdditional information used by the model:\n"
             "key: targets\nvalue:\nground_truth\n\nMetric definition:\nFake metric definition\n\n"
-            "Grading rubric:\nFake metric grading prompt\n\nExamples:\n\nInput:\nexample-input\n\n"
-            "Output:\nexample-output\n\nAdditional information used by the model:\nkey: targets\n"
-            "value:\nexample-ground_truth\n\nscore: 4\njustification: "
+            "Grading rubric:\nFake metric grading prompt\n\nExamples:\n\nExample Input:"
+            "\nexample-input\n\nExample Output:\nexample-output\n\nAdditional information used "
+            "by the model:\nkey: targets\n"
+            "value:\nexample-ground_truth\n\nExample score: 4\nExample justification: "
             "example-justification\n        \n\nYou must return the following fields in your "
             "response one below the other:\nscore: Your numerical score for the model's "
             "fake_metric based on the rubric\njustification: Your step-by-step reasoning about "
@@ -670,7 +682,12 @@ def test_correctness_metric():
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "gateway:/gpt-3.5-turbo"
         assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
+            "prompt": "\nTask:"
+            "\nYou must return the following fields in your response one below the other:\nscore: "
+            "Your numerical score for the model's answer_similarity based on the "
+            "rubric\njustification: Your step-by-step reasoning about the model's "
+            "answer_similarity score\n"
+            "\nYou are an impartial judge. You will be given an input that was "
             "sent to a machine\nlearning model, and you will be given an output that the model "
             "produced. You\nmay also be given additional information that was used by the model "
             "to generate the output.\n\nYour task is to determine a numerical score called "
@@ -686,12 +703,12 @@ def test_correctness_metric():
             f"\nMetric definition:\n{AnswerSimilarityMetric.definition}\n"
             f"\nGrading rubric:\n{AnswerSimilarityMetric.grading_prompt}\n"
             "\nExamples:\n"
-            f"\nInput:\n{mlflow_example.input}\n"
-            f"\nOutput:\n{mlflow_example.output}\n"
+            f"\nExample Input:\n{mlflow_example.input}\n"
+            f"\nExample Output:\n{mlflow_example.output}\n"
             "\nAdditional information used by the model:\nkey: targets\nvalue:\n"
             f"{mlflow_ground_truth}\n"
-            f"\nscore: {mlflow_example.score}\n"
-            f"justification: {mlflow_example.justification}\n        \n"
+            f"\nExample score: {mlflow_example.score}\n"
+            f"Example justification: {mlflow_example.justification}\n        \n"
             "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's answer_similarity based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
@@ -737,7 +754,12 @@ def test_faithfulness_metric():
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "gateway:/gpt-3.5-turbo"
         assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
+            "prompt": "\nTask:"
+            "\nYou must return the following fields in your response one below the other:\nscore: "
+            "Your numerical score for the model's faithfulness based on the "
+            "rubric\njustification: Your step-by-step reasoning about the model's "
+            "faithfulness score\n"
+            "\nYou are an impartial judge. You will be given an input that was "
             "sent to a machine\nlearning model, and you will be given an output that the model "
             "produced. You\nmay also be given additional information that was used by the model "
             "to generate the output.\n\nYour task is to determine a numerical score called "
@@ -798,7 +820,12 @@ def test_answer_correctness_metric():
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "openai:/gpt-4"
         assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
+            "prompt": "\nTask:"
+            "\nYou must return the following fields in your response one below the other:\nscore: "
+            "Your numerical score for the model's answer_correctness based on the "
+            "rubric\njustification: Your step-by-step reasoning about the model's "
+            "answer_correctness score\n"
+            "\nYou are an impartial judge. You will be given an input that was "
             "sent to a machine\nlearning model, and you will be given an output that the model "
             "produced. You\nmay also be given additional information that was used by the model "
             "to generate the output.\n\nYour task is to determine a numerical score called "
@@ -856,7 +883,12 @@ def test_answer_relevance_metric():
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "gateway:/gpt-3.5-turbo"
         assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
+            "prompt": "\nTask:"
+            "\nYou must return the following fields in your response one below the other:\nscore: "
+            "Your numerical score for the model's answer_relevance based on the "
+            "rubric\njustification: Your step-by-step reasoning about the model's "
+            "answer_relevance score\n"
+            "\nYou are an impartial judge. You will be given an input that was "
             "sent to a machine\nlearning model, and you will be given an output that the model "
             "produced. You\nmay also be given additional information that was used by the model "
             "to generate the output.\n\nYour task is to determine a numerical score called "
@@ -924,7 +956,12 @@ def test_relevance_metric():
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "gateway:/gpt-3.5-turbo"
         assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nTask:\nYou are an impartial judge. You will be given an input that was "
+            "prompt": "\nTask:"
+            "\nYou must return the following fields in your response one below the other:\nscore: "
+            "Your numerical score for the model's relevance based on the "
+            "rubric\njustification: Your step-by-step reasoning about the model's "
+            "relevance score\n"
+            "\nYou are an impartial judge. You will be given an input that was "
             "sent to a machine\nlearning model, and you will be given an output that the model "
             "produced. You\nmay also be given additional information that was used by the model "
             "to generate the output.\n\nYour task is to determine a numerical score called "
@@ -981,7 +1018,7 @@ def test_make_genai_metric_metric_details():
     )
 
     # pylint: disable=line-too-long
-    expected_metric_details = "\nTask:\nYou are an impartial judge. You will be given an input that was sent to a machine\nlearning model, and you will be given an output that the model produced. You\nmay also be given additional information that was used by the model to generate the output.\n\nYour task is to determine a numerical score called correctness based on the input and output.\nA definition of correctness and a grading rubric are provided below.\nYou must use the grading rubric to determine your score. You must also justify your score.\n\nExamples could be included below for reference. Make sure to use them as references and to\nunderstand them before completing the task.\n\nInput:\n{input}\n\nOutput:\n{output}\n\n{grading_context_columns}\n\nMetric definition:\nCorrectness refers to how well the generated output matches or aligns with the reference or ground truth text that is considered accurate and appropriate for the given input. The ground truth serves as a benchmark against which the provided output is compared to determine the level of accuracy and fidelity.\n\nGrading rubric:\nCorrectness: If the answer correctly answer the question, below are the details for different scores: - Score 0: the answer is completely incorrect, doesn’t mention anything about the question or is completely contrary to the correct answer. - Score 1: the answer provides some relevance to the question and answer one aspect of the question correctly. - Score 2: the answer mostly answer the question but is missing or hallucinating on one critical aspect. - Score 4: the answer correctly answer the question and not missing any major aspect\n\nExamples:\n\nInput:\nWhat is MLflow?\n\nOutput:\nMLflow is an open-source platform for managing machine learning workflows, including experiment tracking, model packaging, versioning, and deployment, simplifying the ML lifecycle.\n\nAdditional information used by the model:\nkey: targets\nvalue:\nMLflow is an open-source platform for managing the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, a company that specializes in big data and machine learning solutions. MLflow is designed to address the challenges that data scientists and machine learning engineers face when developing, training, and deploying machine learning models.\n\nscore: 4\njustification: The definition effectively explains what MLflow is its purpose, and its developer. It could be more concise for a 5-score.\n        \n\nYou must return the following fields in your response one below the other:\nscore: Your numerical score for the model's correctness based on the rubric\njustification: Your step-by-step reasoning about the model's correctness score\n    "
+    expected_metric_details = "\nTask:\nYou must return the following fields in your response one below the other:\nscore: Your numerical score for the model's correctness based on the rubric\njustification: Your step-by-step reasoning about the model's correctness score\n\nYou are an impartial judge. You will be given an input that was sent to a machine\nlearning model, and you will be given an output that the model produced. You\nmay also be given additional information that was used by the model to generate the output.\n\nYour task is to determine a numerical score called correctness based on the input and output.\nA definition of correctness and a grading rubric are provided below.\nYou must use the grading rubric to determine your score. You must also justify your score.\n\nExamples could be included below for reference. Make sure to use them as references and to\nunderstand them before completing the task.\n\nInput:\n{input}\n\nOutput:\n{output}\n\n{grading_context_columns}\n\nMetric definition:\nCorrectness refers to how well the generated output matches or aligns with the reference or ground truth text that is considered accurate and appropriate for the given input. The ground truth serves as a benchmark against which the provided output is compared to determine the level of accuracy and fidelity.\n\nGrading rubric:\nCorrectness: If the answer correctly answer the question, below are the details for different scores: - Score 0: the answer is completely incorrect, doesn’t mention anything about the question or is completely contrary to the correct answer. - Score 1: the answer provides some relevance to the question and answer one aspect of the question correctly. - Score 2: the answer mostly answer the question but is missing or hallucinating on one critical aspect. - Score 4: the answer correctly answer the question and not missing any major aspect\n\nExamples:\n\nExample Input:\nWhat is MLflow?\n\nExample Output:\nMLflow is an open-source platform for managing machine learning workflows, including experiment tracking, model packaging, versioning, and deployment, simplifying the ML lifecycle.\n\nAdditional information used by the model:\nkey: targets\nvalue:\nMLflow is an open-source platform for managing the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, a company that specializes in big data and machine learning solutions. MLflow is designed to address the challenges that data scientists and machine learning engineers face when developing, training, and deploying machine learning models.\n\nExample score: 4\nExample justification: The definition effectively explains what MLflow is its purpose, and its developer. It could be more concise for a 5-score.\n        \n\nYou must return the following fields in your response one below the other:\nscore: Your numerical score for the model's correctness based on the rubric\njustification: Your step-by-step reasoning about the model's correctness score\n    "
 
     assert custom_metric.metric_details == expected_metric_details
 


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
- fix issues with long prompts
- add formatting requirement at beginning and end to ensure higher rate of successful formatting
- add "example" to input / output / score / justification for examples

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
