### PR TITLE
Prevent broken links in docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
           command: |
             make rsthtml
             make javadocs
+            python broken_links.py
       - run:
           name: Test examples
           working_directory: docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,10 @@ jobs:
           command: |
             make rsthtml
             make javadocs
+      - run:
+          name: Check for broken links
+          working_directory: docs
+          command: |
             python broken_links.py
       - run:
           name: Test examples

--- a/docs/broken_links.py
+++ b/docs/broken_links.py
@@ -30,6 +30,8 @@ def server(port):
                     break
                 except requests.exceptions.ConnectionError:
                     time.sleep(0.5)
+            else:
+                raise RuntimeError("Server did not start")
 
             yield port
         finally:

--- a/docs/broken_links.py
+++ b/docs/broken_links.py
@@ -58,10 +58,9 @@ def main():
                     )
                 )
 
-    process = CrawlerProcess(settings={"LOG_LEVEL": "ERROR"})
-    process.crawl(Crawler)
-
     with server(port):
+        process = CrawlerProcess(settings={"LOG_LEVEL": "ERROR"})
+        process.crawl(Crawler)
         process.start()
 
     if Crawler.links:

--- a/docs/broken_links.py
+++ b/docs/broken_links.py
@@ -33,7 +33,7 @@ def server(port):
             else:
                 raise RuntimeError("Server did not start")
 
-            yield port
+            yield
         finally:
             prc.terminate()
 

--- a/docs/broken_links.py
+++ b/docs/broken_links.py
@@ -26,8 +26,8 @@ def server(port):
         try:
             for _ in range(5):
                 try:
-                    requests.get("http://localhost:8000")
-                    break
+                    if requests.get(f"http://localhost:{port}").ok:
+                        break
                 except requests.exceptions.ConnectionError:
                     time.sleep(0.5)
             else:

--- a/docs/broken_links.py
+++ b/docs/broken_links.py
@@ -1,0 +1,73 @@
+import contextlib
+import socket
+import subprocess
+import sys
+import time
+
+import requests
+from scrapy.crawler import CrawlerProcess
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+
+def get_safe_port():
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("localhost", 0))
+        return sock.getsockname()[1]
+
+
+@contextlib.contextmanager
+def server(port):
+    with subprocess.Popen(
+        [sys.executable, "-m", "http.server", str(port), "--directory", "build/html"],
+        stderr=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+    ) as prc:
+        try:
+            for _ in range(5):
+                try:
+                    requests.get("http://localhost:8000")
+                    break
+                except requests.exceptions.ConnectionError:
+                    time.sleep(0.5)
+
+            yield port
+        finally:
+            prc.terminate()
+
+
+def main():
+    port = get_safe_port()
+
+    class Crawler(CrawlSpider):
+        name = "broken-links"
+        allowed_domains = ["localhost"]
+        start_urls = [f"http://localhost:{port}/"]
+        handle_httpstatus_list = [404]
+        rules = (Rule(LinkExtractor(), callback="parse_item", follow=True),)
+        links = set()
+
+        def parse_item(self, response):
+            if response.status == 404:
+                self.links.add(
+                    (
+                        response.url,
+                        response.request.headers.get("Referer", None).decode("utf-8"),
+                    )
+                )
+
+    process = CrawlerProcess(settings={"LOG_LEVEL": "ERROR"})
+    process.crawl(Crawler)
+
+    with server(port):
+        process.start()
+
+    if Crawler.links:
+        print("Broken links found:")
+        for link, referer in Crawler.links:
+            print(f"{link} in {referer}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 import mlflow
 
 

--- a/docs/gateway_api_docs.py
+++ b/docs/gateway_api_docs.py
@@ -80,7 +80,7 @@ routes:
         config_path.write_text(config)
 
         app = create_app_from_path(config_path)
-        docs_build = Path("build/html/gateway")
+        docs_build = Path("build/html/llms/gateway")
         docs_build.mkdir(parents=True, exist_ok=True)
         with docs_build.joinpath("openapi.json").open("w") as f:
             json.dump(app.openapi(), f)

--- a/docs/source/R-api.rst
+++ b/docs/source/R-api.rst
@@ -32,7 +32,7 @@ Optionally, you can set the ``MLFLOW_PYTHON_BIN`` and ``MLFLOW_BIN`` environment
     export MLFLOW_PYTHON_BIN=/path/to/bin/python
     export MLFLOW_BIN=/path/to/bin/mlflow
 
-You can use the R API to start the `user interface <mlflow_ui>`_, `create experiment <mlflow_create_experiment>`_ and `search experiments <mlflow_search_experiments>`_, `save models <mlflow_save_model>`_, `run projects <mlflow_run_>`_ and `serve models <mlflow_rfunc_serve_>`_ among many other functions available in the R API.
+You can use the R API to start the `user interface <mlflow_ui_>`_, `create experiment <mlflow_create_experiment_>`_ and `search experiments <mlflow_search_experiments_>`_, `save models <mlflow_save_model.crate_>`_, `run projects <mlflow_run_>`_ and `serve models <mlflow_rfunc_serve_>`_ among many other functions available in the R API.
 
 .. contents:: Table of Contents
     :local:

--- a/docs/source/llms/llm-evaluate/index.rst
+++ b/docs/source/llms/llm-evaluate/index.rst
@@ -205,7 +205,7 @@ for LLM evaluation in MLflow. You can specify a custom list of metrics in the `e
         )
 
 
-The full reference for supported evaluation metrics can be found `here <../python_api/mlflow.html#mlflow.evaluate>`_. 
+The full reference for supported evaluation metrics can be found `here <../../python_api/mlflow.html#mlflow.evaluate>`_.
 
 Metrics with LLM as the Judge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/new-features/index.rst
+++ b/docs/source/new-features/index.rst
@@ -223,7 +223,7 @@ Find out about the details of major features, changes, and deprecations below.
                     <div class="body">
                         The MLflow AI Gateway now supports defining an MLflow serving endpoint as provider. With this 
                         new feature, you can serve any OSS transformers model that conforms to the 
-                        <a href="gateway/index.html#completions">completions</a> or <a href="gateway/index.html#embeddings">embeddings</a> route type 
+                        <a href="../llms/gateway/index.html#completions">completions</a> or <a href="../llms/gateway/index.html#embeddings">embeddings</a> route type 
                         definitions. 
                     </div>
                     <div class="body">

--- a/mlflow/R/mlflow/document.R
+++ b/mlflow/R/mlflow/document.R
@@ -67,7 +67,7 @@ Optionally, you can set the ``MLFLOW_PYTHON_BIN`` and ``MLFLOW_BIN`` environment
     export MLFLOW_PYTHON_BIN=/path/to/bin/python
     export MLFLOW_BIN=/path/to/bin/mlflow
 
-You can use the R API to start the `user interface <mlflow_ui>`_, `create experiment <mlflow_create_experiment>`_ and `search experiments <mlflow_search_experiments>`_, `save models <mlflow_save_model>`_, `run projects <mlflow_run_>`_ and `serve models <mlflow_rfunc_serve_>`_ among many other functions available in the R API.
+You can use the R API to start the `user interface <mlflow_ui_>`_, `create experiment <mlflow_create_experiment_>`_ and `search experiments <mlflow_search_experiments_>`_, `save models <mlflow_save_model.crate_>`_, `run projects <mlflow_run_>`_ and `serve models <mlflow_rfunc_serve_>`_ among many other functions available in the R API.
 
 .. contents:: Table of Contents
     :local:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ ignore = [
 extend-include = ["*.ipynb"]
 extend-exclude = [
   "setup.py",
-  "docs",
+  "docs/source",
   "examples/recipes",
   "mlflow/protos",
   "mlflow/ml_package_versions.py",
@@ -87,6 +87,7 @@ extend-exclude = [
 [tool.ruff.per-file-ignores]
 "dev/*" = ["T201", "PT018"]
 "examples/*" = ["T20"]
+"docs/broken_links.py" = ["T20"]
 "mlflow/*" = ["PT018"]
 
 [tool.ruff.flake8-pytest-style]

--- a/requirements/doc-requirements.txt
+++ b/requirements/doc-requirements.txt
@@ -10,3 +10,4 @@ keras-core
 torch>=1.11.0
 torchvision>=0.12.0
 lightning>=1.8.1
+scrapy


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10403?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10403/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10403
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

When we released the 2.8 docs, we broke so many links. This PR adds a crawler to detect them and runs it in the docs job.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
