### PR TITLE
Upgrade pip in windows job for 10 minute speed-up

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -348,6 +348,7 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/Scripts/activate
+          pip install -U pip
           pip install -r requirements/test-requirements.txt
           pip install --no-dependencies tests/resources/mlflow-test-plugin
           pip install -e .[extras]

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -348,7 +348,7 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/Scripts/activate
-          pip install -U pip
+          python -m pip install -U pip
           pip install -r requirements/test-requirements.txt
           pip install --no-dependencies tests/resources/mlflow-test-plugin
           pip install -e .[extras]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10411?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10411/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10411
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

For some reason, it takes about 10 minutes to build a wheel in the `serve_wheel` fixture on windows with an old version pip.

https://github.com/mlflow/mlflow/blob/99fe892a8999c246682fbd00eb8b28dc37aaa586/conftest.py#L288-L289

https://github.com/mlflow/mlflow/actions/runs/6874500562/job/18696295149#step:11:1736

```
============================ slowest 10 durations =============================
764.12s setup    tests/test_cli.py::test_mlflow_server_command[server] 👈👈👈
43.50s call     tests/tracking/fluent/test_fluent.py::test_search_experiments
35.92s call     tests/store/tracking/test_sqlalchemy_store.py::TestSqlAlchemyStore::test_search_with_max_results
35.21s call     tests/store/tracking/test_sqlalchemy_store.py::TestSqlAlchemyStoreMigratedDB::test_search_with_max_results
29.04s call     tests/data/test_delta_dataset_source.py::test_delta_dataset_source_from_path
24.64s call     tests/data/test_spark_dataset.py::test_from_spark_path
20.57s call     tests/data/test_spark_dataset.py::test_load_delta_table_name_with_version
19.99s call     tests/data/test_spark_dataset.py::test_load_delta_path_with_version
18.77s call     tests/data/test_spark_dataset.py::test_from_spark_delta_table_name_and_version
18.12s call     tests/data/test_delta_dataset_source.py::test_delta_dataset_source_from_table_versioned
```

- `tests/test_cli.py::test_mlflow_server_command` is the first test to execute in the windows job.
- After some investigation, I found `serve_wheel` takes long.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

After upgrading pip:

```
============================ slowest 10 durations =============================
31.73s call     tests/data/test_spark_dataset.py::test_from_spark_path
29.09s call     tests/tracking/fluent/test_fluent.py::test_search_experiments
26.60s call     tests/store/tracking/test_sqlalchemy_store.py::TestSqlAlchemyStoreMigratedDB::test_search_with_max_results
26.45s call     tests/store/tracking/test_sqlalchemy_store.py::TestSqlAlchemyStore::test_search_with_max_results
19.72s call     tests/data/test_delta_dataset_source.py::test_delta_dataset_source_from_path
19.45s call     tests/data/test_spark_dataset.py::test_from_spark_delta_table_name_and_version
15.66s call     tests/data/test_spark_dataset.py::test_from_spark_sql
15.34s call     tests/data/test_spark_dataset.py::test_load_delta_path_with_version
15.00s call     tests/data/test_spark_dataset.py::test_load_delta_table_name_with_version
13.67s call     tests/tracking/test_log_figure.py::test_log_figure_matplotlib[None]
```


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
