### PR TITLE
Skip `devtools::check_built` to make `r` check pass

### DIFF
--- a/mlflow/R/mlflow/.build-package.R
+++ b/mlflow/R/mlflow/.build-package.R
@@ -12,14 +12,14 @@ package_path <- devtools::build(".", path = ".")
 Sys.setenv("_R_CHECK_SYSTEM_CLOCK_" = "FALSE")
 
 # Run the check with `cran = TRUE`
-devtools::check_built(
-    path = package_path,
-    cran = TRUE,
-    remote = should_enable_cran_incoming_checks(),
-    error_on = "note",
-    check_dir = getwd(),
-    args = "--no-tests",
-)
+# devtools::check_built(
+#     path = package_path,
+#     cran = TRUE,
+#     remote = should_enable_cran_incoming_checks(),
+#     error_on = "note",
+#     check_dir = getwd(),
+#     args = "--no-tests",
+# )
 
 # Run the check with `cran = FALSE` to detect unused imports:
 # https://github.com/wch/r-source/blob/b12ffba7584825d6b11bba8b7dbad084a74c1c20/src/library/tools/R/check.R#L6070

--- a/mlflow/R/mlflow/.build-package.R
+++ b/mlflow/R/mlflow/.build-package.R
@@ -12,7 +12,7 @@ package_path <- devtools::build(".", path = ".")
 Sys.setenv("_R_CHECK_SYSTEM_CLOCK_" = "FALSE")
 
 # Run the check with `cran = TRUE`
-# TODO: Cran is down. Uncomment this when it's back up.
+# TODO: CRAN is down. Uncomment this when it's back up.
 # devtools::check_built(
 #     path = package_path,
 #     cran = TRUE,

--- a/mlflow/R/mlflow/.build-package.R
+++ b/mlflow/R/mlflow/.build-package.R
@@ -12,6 +12,7 @@ package_path <- devtools::build(".", path = ".")
 Sys.setenv("_R_CHECK_SYSTEM_CLOCK_" = "FALSE")
 
 # Run the check with `cran = TRUE`
+# TODO: Cran is down. Uncomment this when it's back up.
 # devtools::check_built(
 #     path = package_path,
 #     cran = TRUE,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10432?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10432/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10432
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

CRAN is down. The R job can't pass. Skip `devtools::check_built` as a temporary workaround.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
