### PR TITLE
fix spark tests on dev

### DIFF
--- a/mlflow/pyspark/ml/_autolog.py
+++ b/mlflow/pyspark/ml/_autolog.py
@@ -74,7 +74,7 @@ def get_feature_cols(
         try:
             transformer.transform(df_subset.drop(column))
         except IllegalArgumentException as iae:
-            if re.search("(.*) does not exist.", iae.message, re.IGNORECASE):
+            if re.search("(.*) does not exist.", str(iae), re.IGNORECASE):
                 feature_cols.add(column)
                 continue
             raise

--- a/mlflow/pyspark/ml/_autolog.py
+++ b/mlflow/pyspark/ml/_autolog.py
@@ -2,13 +2,13 @@ import re
 from functools import reduce
 from typing import Set, Union
 
+from pyspark.errors.exceptions.base import IllegalArgumentException
 from pyspark.ml.base import Transformer
 from pyspark.ml.functions import vector_to_array
 from pyspark.ml.linalg import VectorUDT
 from pyspark.ml.pipeline import PipelineModel
 from pyspark.sql import DataFrame
 from pyspark.sql import types as t
-from pyspark.sql.utils import IllegalArgumentException
 
 
 def cast_spark_df_with_vector_to_array(input_spark_df):

--- a/mlflow/pyspark/ml/_autolog.py
+++ b/mlflow/pyspark/ml/_autolog.py
@@ -74,7 +74,7 @@ def get_feature_cols(
         try:
             transformer.transform(df_subset.drop(column))
         except IllegalArgumentException as iae:
-            if re.search("(.*) does not exist.", str(iae), re.IGNORECASE):
+            if re.search("does not exist", str(iae), re.IGNORECASE):
                 feature_cols.add(column)
                 continue
             raise

--- a/mlflow/pyspark/ml/_autolog.py
+++ b/mlflow/pyspark/ml/_autolog.py
@@ -74,7 +74,7 @@ def get_feature_cols(
         try:
             transformer.transform(df_subset.drop(column))
         except IllegalArgumentException as iae:
-            if re.search("(.*) does not exist.", iae.desc, re.IGNORECASE):
+            if re.search("(.*) does not exist.", iae.message, re.IGNORECASE):
                 feature_cols.add(column)
                 continue
             raise

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -1224,6 +1224,7 @@ def test_get_feature_cols_with_indexer_and_assembler(spark_session):
     lr = LogisticRegression()
     pipeline = Pipeline(stages=[indexer, assembler, lr])
     pipeline_model = pipeline.fit(df)
+    # test
     assert get_feature_cols(df, pipeline_model) == {"categorical"}
 
 

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -1224,7 +1224,6 @@ def test_get_feature_cols_with_indexer_and_assembler(spark_session):
     lr = LogisticRegression()
     pipeline = Pipeline(stages=[indexer, assembler, lr])
     pipeline_model = pipeline.fit(df)
-    # test
     assert get_feature_cols(df, pipeline_model) == {"categorical"}
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10433?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10433/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10433
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix https://github.com/mlflow-automation/mlflow/actions/runs/6877835135/job/18715277771#logs
In latest spark master, they updated the exception to be CapturedException which inherits `pyspark.errors.exceptions.base.IllegalArgumentException`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
