### PR TITLE
Throw a warning if users try to assign models in pyfunc constructors

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -208,7 +208,6 @@ You may prefer the second, lower-level workflow for the following reasons:
 """
 
 import collections
-from colorama import Fore, Style
 import functools
 import importlib
 import inspect
@@ -219,9 +218,11 @@ import subprocess
 import sys
 import tempfile
 import threading
+import warnings
 from copy import deepcopy
 from typing import Any, Dict, Iterator, Optional, Tuple, Union
 
+import click
 import numpy as np
 import pandas
 import yaml
@@ -1679,15 +1680,28 @@ def _validate_function_python_model(python_model):
     if isinstance(python_model, PythonModel):
         try:
             init_has_model_param = "model" in inspect.signature(python_model.__init__).parameters
-            init_has_model_assignment = 'self.model =' in inspect.getsource(python_model.__init__)
+            init_has_model_assignment = "self.model =" in inspect.getsource(python_model.__init__)
             if init_has_model_param or init_has_model_assignment:
-                _logger.warning(
-                    f"{Fore.YELLOW}It looks like you're trying to save a model as an "
-                    f"instance attribute in your PythonModel. {Style.BRIGHT}This is not "
-                    f"recommended{Style.NORMAL} as it can cause problems with "
-                    "model serialization, especially for large models. "
-                    f"{Style.BRIGHT}Please use the `artifacts` parameter, and load your "
-                    f"external model in the `load_context()` method instead.{Style.RESET_ALL}"
+                message = (
+                    click.style(
+                        "It looks like you're trying to save a model as an instance attribute ",
+                        fg="yellow",
+                    )
+                    + click.style("This is not recommended ", fg="yellow", bold=True)
+                    + click.style(
+                        "as it can cause problems with model serialization, especially for large models. ",
+                        fg="yellow",
+                    )
+                    + click.style("Please use the `artifacts` parameter", fg="yellow", bold=True)
+                    + click.style(
+                        ", and load your external model in the `load_context()` method instead.",
+                        fg="yellow",
+                    )
+                )
+                warnings.warn(
+                    message,
+                    UserWarning,
+                    stacklevel=5,
                 )
         except Exception:
             pass

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -218,11 +218,9 @@ import subprocess
 import sys
 import tempfile
 import threading
-import warnings
 from copy import deepcopy
 from typing import Any, Dict, Iterator, Optional, Tuple, Union
 
-import click
 import numpy as np
 import pandas
 import yaml

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1703,7 +1703,9 @@ def _validate_function_python_model(python_model):
                     UserWarning,
                     stacklevel=5,
                 )
-        except Exception:
+        finally:
+            # it's possible that inspect.getsource might fail, but since we
+            # just want to warn the user, we shouldn't throw any exception
             pass
 
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1675,6 +1675,18 @@ def _validate_function_python_model(python_model):
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
+    # validate best practices for __init__ method
+    if isinstance(python_model, PythonModel):
+        try:
+            init_has_model_param = "model" in inspect.signature(python_model.__init__).parameters
+            init_has_model_assignment = 'self.model =' in inspect.getsource(python_model.__init__)
+            if init_has_model_param or init_has_model_assignment:
+                _logger.warning(
+                    "It looks like you're trying to save a model as an instance attribute "
+                    "on your PythonModel. "
+                )
+                
+
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="scikit-learn"))
 def save_model(

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -208,6 +208,7 @@ You may prefer the second, lower-level workflow for the following reasons:
 """
 
 import collections
+from colorama import Fore, Style
 import functools
 import importlib
 import inspect
@@ -1675,17 +1676,21 @@ def _validate_function_python_model(python_model):
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
-    # validate best practices for __init__ method
     if isinstance(python_model, PythonModel):
         try:
             init_has_model_param = "model" in inspect.signature(python_model.__init__).parameters
             init_has_model_assignment = 'self.model =' in inspect.getsource(python_model.__init__)
             if init_has_model_param or init_has_model_assignment:
                 _logger.warning(
-                    "It looks like you're trying to save a model as an instance attribute "
-                    "on your PythonModel. "
+                    f"{Fore.YELLOW}It looks like you're trying to save a model as an "
+                    f"instance attribute in your PythonModel. {Style.BRIGHT}This is not "
+                    f"recommended{Style.NORMAL} as it can cause problems with "
+                    "model serialization, especially for large models. "
+                    f"{Style.BRIGHT}Please use the `artifacts` parameter, and load your "
+                    f"external model in the `load_context()` method instead.{Style.RESET_ALL}"
                 )
-                
+        except Exception:
+            pass
 
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="scikit-learn"))

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1703,7 +1703,7 @@ def _validate_function_python_model(python_model):
                     UserWarning,
                     stacklevel=5,
                 )
-        finally:
+        except Exception:
             # it's possible that inspect.getsource might fail, but since we
             # just want to warn the user, we shouldn't throw any exception
             pass

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1677,38 +1677,6 @@ def _validate_function_python_model(python_model):
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
-    if isinstance(python_model, PythonModel):
-        try:
-            init_has_model_param = "model" in inspect.signature(python_model.__init__).parameters
-            init_has_model_assignment = "self.model =" in inspect.getsource(python_model.__init__)
-            if init_has_model_param or init_has_model_assignment:
-                message = (
-                    click.style(
-                        "It looks like you're trying to save a model as an instance attribute. ",
-                        fg="yellow",
-                    )
-                    + click.style("This is not recommended ", fg="yellow", bold=True)
-                    + click.style(
-                        "as it can cause problems with model serialization, "
-                        "especially for large models. ",
-                        fg="yellow",
-                    )
-                    + click.style("Please use the `artifacts` parameter", fg="yellow", bold=True)
-                    + click.style(
-                        ", and load your external model in the `load_context()` method instead.",
-                        fg="yellow",
-                    )
-                )
-                warnings.warn(
-                    message,
-                    UserWarning,
-                    stacklevel=5,
-                )
-        except Exception:
-            # it's possible that inspect.getsource might fail, but since we
-            # just want to warn the user, we shouldn't throw any exception
-            pass
-
 
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name="scikit-learn"))
 def save_model(

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1684,12 +1684,13 @@ def _validate_function_python_model(python_model):
             if init_has_model_param or init_has_model_assignment:
                 message = (
                     click.style(
-                        "It looks like you're trying to save a model as an instance attribute ",
+                        "It looks like you're trying to save a model as an instance attribute. ",
                         fg="yellow",
                     )
                     + click.style("This is not recommended ", fg="yellow", bold=True)
                     + click.style(
-                        "as it can cause problems with model serialization, especially for large models. ",
+                        "as it can cause problems with model serialization, "
+                        "especially for large models. ",
                         fg="yellow",
                     )
                     + click.style("Please use the `artifacts` parameter", fg="yellow", bold=True)

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -34,7 +34,7 @@ from mlflow.utils.environment import (
     _PythonEnv,
 )
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree, get_total_file_size, write_to
-from mlflow.utils.model_utils import _get_flavor_configuration, _validate_model_assignment_in_init
+from mlflow.utils.model_utils import _check_model_assignment_in_init, _get_flavor_configuration
 from mlflow.utils.requirements_utils import _get_pinned_requirement
 
 CONFIG_KEY_ARTIFACTS = "artifacts"
@@ -104,7 +104,7 @@ class PythonModel:
         )
 
         try:
-            model_assigned = _validate_model_assignment_in_init(cls)
+            model_assigned = _check_model_assignment_in_init(cls)
             load_context_defined = cls.load_context != PythonModel.load_context
             if model_assigned and not load_context_defined:
                 warnings.warn(message, stacklevel=3)

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -104,7 +104,7 @@ class PythonModel:
         )
 
         try:
-            model_assigned = _validate_model_assignment_in_init(inspect.getsource(cls.__init__))
+            model_assigned = _validate_model_assignment_in_init(cls)
             load_context_defined = cls.load_context != PythonModel.load_context
             if model_assigned and not load_context_defined:
                 warnings.warn(message, stacklevel=3)

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -108,7 +108,8 @@ class PythonModel:
             load_context_defined = cls.load_context != PythonModel.load_context
             if model_assigned and not load_context_defined:
                 warnings.warn(message, stacklevel=3)
-        except Exception:
+        except Exception as e:
+            print(e)
             # it's possible that inspect.getsource might fail, but since we
             # just want to warn the user, we shouldn't throw an exception
             pass

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -108,8 +108,7 @@ class PythonModel:
             load_context_defined = cls.load_context != PythonModel.load_context
             if model_assigned and not load_context_defined:
                 warnings.warn(message, stacklevel=3)
-        except Exception as e:
-            print(e)
+        except Exception:
             # it's possible that inspect.getsource might fail, but since we
             # just want to warn the user, we shouldn't throw an exception
             pass

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -7,6 +7,7 @@ import inspect
 import logging
 import os
 import shutil
+import warnings
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -81,8 +82,6 @@ class _PythonModelMetaclass(ABCMeta):
     def _warn_on_setting_model_in_init(cls):
         if not cls.__bases__ == (PythonModel,):
             return
-
-        import warnings
 
         import click
 

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -90,23 +90,21 @@ class PythonModel:
 
     @classmethod
     def _warn_on_setting_model_in_init(cls):
-        message = (
-            "It looks like you're trying to save a model as an instance attribute. "
-            "This is not recommended as it can cause problems with model serialization, "
-            "especially for large models. Please use the `artifacts` parameter, "
-            "and load your external model in the `load_context()` method instead.\n\n"
-            "For example:\n\n"
-            "class MyModel(mlflow.pyfunc.PythonModel):\n"
-            "    def load_context(self, context):\n"
-            "        model_path = context.artifacts['my_model_path']\n"
-            "        // custom load logic here\n"
-            "        self.model = load_model(model_path)\n"
-        )
-
         try:
             model_assigned = _check_model_assignment_in_init(cls)
-            load_context_defined = cls.load_context != PythonModel.load_context
-            if model_assigned and not load_context_defined:
+            if model_assigned and cls.load_context == PythonModel.load_context:
+                message = (
+                    "It looks like you're trying to save a model as an instance attribute. "
+                    "This is not recommended as it can cause problems with model serialization, "
+                    "especially for large models. Please use the `artifacts` parameter, "
+                    "and load your external model in the `load_context()` method instead.\n\n"
+                    "For example:\n\n"
+                    "class MyModel(mlflow.pyfunc.PythonModel):\n"
+                    "    def load_context(self, context):\n"
+                    "        model_path = context.artifacts['my_model_path']\n"
+                    "        // custom load logic here\n"
+                    "        self.model = load_model(model_path)\n"
+                )
                 warnings.warn(message, stacklevel=3)
         except Exception:
             # it's possible that inspect.getsource might fail, but since we

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -269,8 +269,8 @@ def _validate_pyfunc_model_config(model_config):
 def _validate_model_assignment_in_init(cls_init_method_source):
     """
     Checks for the presence of `self.model = <something>` in the init method
-    of a class. Intended to be used in `_PythonModelMetaclass` to encourage
-    best practices when declaring pyfunc models.
+    of a class. Intended to be used `PythonModel` to encourage best practices
+    when declaring pyfunc models.
     """
     lines = cls_init_method_source.split("\n")
     spaces = lines[0].find("d")

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -1,4 +1,5 @@
 import ast
+import inspect
 import json
 import os
 import sys
@@ -266,13 +267,14 @@ def _validate_pyfunc_model_config(model_config):
         )
 
 
-def _validate_model_assignment_in_init(cls_init_method_source):
+def _validate_model_assignment_in_init(cls):
     """
     Checks for the presence of `self.model = <something>` in the init method
     of a class. Intended to be used `PythonModel` to encourage best practices
     when declaring pyfunc models.
     """
-    lines = cls_init_method_source.split("\n")
+    cls_init_source = inspect.getsource(cls.__init__)
+    lines = cls_init_source.split("\n")
     spaces = lines[0].find("d")
 
     # shouldn't happen as the first line

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -268,7 +268,7 @@ def _validate_pyfunc_model_config(model_config):
         )
 
 
-def _validate_model_assignment_in_init(cls):
+def _check_model_assignment_in_init(cls):
     """
     Checks for the presence of `self.model = <something>` in the init method
     of a class. Intended to be used `PythonModel` to encourage best practices

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -279,7 +279,7 @@ def _validate_model_assignment_in_init(cls):
     class ModelAssignVisitor(ast.NodeVisitor):
         def __init__(self):
             self.has_model = False
-            
+
         def visit_Assign(self, node):
             if (
                 isinstance(node.targets[0], ast.Attribute)

--- a/tests/pyfunc/test_pyfunc_model_config.py
+++ b/tests/pyfunc/test_pyfunc_model_config.py
@@ -111,6 +111,7 @@ def test_pyfunc_warn_on_model_assignment_no_context(model_path):
         message = warn_mock.mock_calls[0].args[0]
         assert "It looks like you're trying to save a model" in message
 
+
 def test_pyfunc_no_warn_on_model_assignment_with_context(model_path):
     # don't warn on model assignment if users override load_context
     class MyModelGood(mlflow.pyfunc.PythonModel):
@@ -132,7 +133,7 @@ def test_pyfunc_no_warn_on_model_assignment_with_context(model_path):
             message = call.args[0]
             assert "It looks like you're trying to save a model" not in message
 
-        
+
 def test_pyfunc_warn_on_model_param(model_path):
     # should warn if `model` param is present in __init__
     class MyModelBad(mlflow.pyfunc.PythonModel):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/10435?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10435/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10435
```

</p>
</details>

### Related Issues/PRs

### What changes are proposed in this pull request?

This PR adds a warning if a user tries to assign a model as a variable in a pyfunc constructor. At the moment it's a bit of a fragile check (just looking for `model` and `self.model =`, but we can maybe do something more robust like call `sys.getsizeof()` on the params, and warn if it's very large. What would be a good threshold to use here? 100mb?

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```python
// fail.py

import mlflow

class MyModel(mlflow.pyfunc.PythonModel):
    def __init__(self, model):
        self.model = model

    def predict(self, context, model_input):
        return model_input

model = MyModel(1)
with mlflow.start_run():
    mlflow.pyfunc.log_model(python_model=model, artifact_path="model")
```

<img width="719" alt="Screenshot 2023-11-16 at 8 13 26 PM" src="https://github.com/mlflow/mlflow/assets/148037680/0e3b9072-ce2c-444e-af8d-e2593b3fd424">


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
