### PR TITLE
Only write columns used for eval to the eval table

### DIFF
--- a/docs/source/llms/llm-evaluate/notebooks/rag-evaluation.ipynb
+++ b/docs/source/llms/llm-evaluate/notebooks/rag-evaluation.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 2,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -58,12 +58,12 @@
    },
    "outputs": [],
    "source": [
-    "os.environ[\"OPENAI_API_KEY\"] = \"redacted\""
+    "os.environ[\"OPENAI_API_KEY\"] = \"REDACTED\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 4,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 5,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 6,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -231,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 8,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -275,7 +275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 9,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -295,6 +295,10 @@
      "text": [
       "EvaluationMetric(name=faithfulness, greater_is_better=True, long_name=faithfulness, version=v1, metric_details=\n",
       "Task:\n",
+      "You must return the following fields in your response one below the other:\n",
+      "score: Your numerical score for the model's faithfulness based on the rubric\n",
+      "justification: Your step-by-step reasoning about the model's faithfulness score\n",
+      "\n",
       "You are an impartial judge. You will be given an input that was sent to a machine\n",
       "learning model, and you will be given an output that the model produced. You\n",
       "may also be given additional information that was used by the model to generate the output.\n",
@@ -327,10 +331,10 @@
       "\n",
       "Examples:\n",
       "\n",
-      "Input:\n",
+      "Example Input:\n",
       "How do I disable MLflow autologging?\n",
       "\n",
-      "Output:\n",
+      "Example Output:\n",
       "mlflow.autolog(disable=True) will disable autologging for all functions. In Databricks, autologging is enabled by default. \n",
       "\n",
       "Additional information used by the model:\n",
@@ -338,14 +342,14 @@
       "value:\n",
       "mlflow.autolog(log_input_examples: bool = False, log_model_signatures: bool = True, log_models: bool = True, log_datasets: bool = True, disable: bool = False, exclusive: bool = False, disable_for_unsupported_versions: bool = False, silent: bool = False, extra_tags: Optional[Dict[str, str]] = None) → None[source] Enables (or disables) and configures autologging for all supported integrations. The parameters are passed to any autologging integrations that support them. See the tracking docs for a list of supported autologging integrations. Note that framework-specific configurations set at any point will take precedence over any configurations set by this function.\n",
       "\n",
-      "score: 2\n",
-      "justification: The output provides a working solution, using the mlflow.autolog() function that is provided in the context.\n",
+      "Example score: 2\n",
+      "Example justification: The output provides a working solution, using the mlflow.autolog() function that is provided in the context.\n",
       "        \n",
       "\n",
-      "Input:\n",
+      "Example Input:\n",
       "How do I disable MLflow autologging?\n",
       "\n",
-      "Output:\n",
+      "Example Output:\n",
       "mlflow.autolog(disable=True) will disable autologging for all functions.\n",
       "\n",
       "Additional information used by the model:\n",
@@ -353,8 +357,8 @@
       "value:\n",
       "mlflow.autolog(log_input_examples: bool = False, log_model_signatures: bool = True, log_models: bool = True, log_datasets: bool = True, disable: bool = False, exclusive: bool = False, disable_for_unsupported_versions: bool = False, silent: bool = False, extra_tags: Optional[Dict[str, str]] = None) → None[source] Enables (or disables) and configures autologging for all supported integrations. The parameters are passed to any autologging integrations that support them. See the tracking docs for a list of supported autologging integrations. Note that framework-specific configurations set at any point will take precedence over any configurations set by this function.\n",
       "\n",
-      "score: 5\n",
-      "justification: The output provides a solution that is using the mlflow.autolog() function that is provided in the context.\n",
+      "Example score: 5\n",
+      "Example justification: The output provides a solution that is using the mlflow.autolog() function that is provided in the context.\n",
       "        \n",
       "\n",
       "You must return the following fields in your response one below the other:\n",
@@ -402,7 +406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -411,6 +415,10 @@
      "text": [
       "EvaluationMetric(name=relevance, greater_is_better=True, long_name=relevance, version=v1, metric_details=\n",
       "Task:\n",
+      "You must return the following fields in your response one below the other:\n",
+      "score: Your numerical score for the model's relevance based on the rubric\n",
+      "justification: Your step-by-step reasoning about the model's relevance score\n",
+      "\n",
       "You are an impartial judge. You will be given an input that was sent to a machine\n",
       "learning model, and you will be given an output that the model produced. You\n",
       "may also be given additional information that was used by the model to generate the output.\n",
@@ -434,18 +442,18 @@
       "Relevance encompasses the appropriateness, significance, and applicability of the output with respect to both the input and context. Scores should reflect the extent to which the output directly addresses the question provided in the input, given the provided context.\n",
       "\n",
       "Grading rubric:\n",
-      "Relevance: Below are the details for different scores:- Score 1: the output doesn't mention anything about the question or is completely irrelevant to the provided context.\n",
-      "- Score 2: the output provides some relevance to the question and is somehow related to the provided context.\n",
-      "- Score 3: the output mostly answers the question and is largely consistent with the provided context.\n",
-      "- Score 4: the output answers the question and is consistent with the provided context.\n",
-      "- Score 5: the output answers the question comprehensively using the provided context.\n",
+      "Relevance: Below are the details for different scores:- Score 1: The output doesn't mention anything about the question or is completely irrelevant to the provided context.\n",
+      "- Score 2: The output provides some relevance to the question and is somehow related to the provided context.\n",
+      "- Score 3: The output mostly answers the question and is largely consistent with the provided context.\n",
+      "- Score 4: The output answers the question and is consistent with the provided context.\n",
+      "- Score 5: The output answers the question comprehensively using the provided context.\n",
       "\n",
       "Examples:\n",
       "\n",
-      "Input:\n",
+      "Example Input:\n",
       "How is MLflow related to Databricks?\n",
       "\n",
-      "Output:\n",
+      "Example Output:\n",
       "Databricks is a data engineering and analytics platform designed to help organizations process and analyze large amounts of data. Databricks is a company specializing in big data and machine learning solutions.\n",
       "\n",
       "Additional information used by the model:\n",
@@ -453,14 +461,14 @@
       "value:\n",
       "MLflow is an open-source platform for managing the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, a company that specializes in big data and machine learning solutions. MLflow is designed to address the challenges that data scientists and machine learning engineers face when developing, training, and deploying machine learning models.\n",
       "\n",
-      "score: 2\n",
-      "justification: The output provides relevant information about Databricks, mentioning it as a company specializing in big data and machine learning solutions. However, it doesn't directly address how MLflow is related to Databricks, which is the specific question asked in the input. Therefore, the output is only somewhat related to the provided context.\n",
+      "Example score: 2\n",
+      "Example justification: The output provides relevant information about Databricks, mentioning it as a company specializing in big data and machine learning solutions. However, it doesn't directly address how MLflow is related to Databricks, which is the specific question asked in the input. Therefore, the output is only somewhat related to the provided context.\n",
       "        \n",
       "\n",
-      "Input:\n",
+      "Example Input:\n",
       "How is MLflow related to Databricks?\n",
       "\n",
-      "Output:\n",
+      "Example Output:\n",
       "MLflow is a product created by Databricks to enhance the efficiency of machine learning processes.\n",
       "\n",
       "Additional information used by the model:\n",
@@ -468,8 +476,8 @@
       "value:\n",
       "MLflow is an open-source platform for managing the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, a company that specializes in big data and machine learning solutions. MLflow is designed to address the challenges that data scientists and machine learning engineers face when developing, training, and deploying machine learning models.\n",
       "\n",
-      "score: 4\n",
-      "justification: The output provides a relevant and accurate statement about the relationship between MLflow and Databricks. While it doesn't provide extensive detail, it still offers a substantial and meaningful response. To achieve a score of 5, the response could be further improved by providing additional context or details about how MLflow specifically functions within the Databricks ecosystem.\n",
+      "Example score: 4\n",
+      "Example justification: The output provides a relevant and accurate statement about the relationship between MLflow and Databricks. While it doesn't provide extensive detail, it still offers a substantial and meaningful response. To achieve a score of 5, the response could be further improved by providing additional context or details about how MLflow specifically functions within the Databricks ecosystem.\n",
       "        \n",
       "\n",
       "You must return the following fields in your response one below the other:\n",
@@ -489,7 +497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 11,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -507,22 +515,92 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023/10/27 00:58:16 INFO mlflow.models.evaluation.base: Evaluating the model with the default evaluator.\n",
-      "2023/10/27 00:58:16 INFO mlflow.models.evaluation.default_evaluator: Computing model predictions.\n",
-      "2023/10/27 00:58:36 INFO mlflow.models.evaluation.default_evaluator: Evaluating builtin metrics: token_count\n",
-      "2023/10/27 00:58:36 INFO mlflow.models.evaluation.default_evaluator: Evaluating builtin metrics: toxicity\n",
-      "2023/10/27 00:58:37 INFO mlflow.models.evaluation.default_evaluator: Evaluating builtin metrics: flesch_kincaid_grade_level\n",
-      "2023/10/27 00:58:37 INFO mlflow.models.evaluation.default_evaluator: Evaluating builtin metrics: ari_grade_level\n",
-      "2023/10/27 00:58:37 INFO mlflow.models.evaluation.default_evaluator: Evaluating builtin metrics: exact_match\n",
-      "2023/10/27 00:58:37 INFO mlflow.models.evaluation.default_evaluator: Evaluating metrics: faithfulness\n",
-      "2023/10/27 00:58:42 INFO mlflow.models.evaluation.default_evaluator: Evaluating metrics: relevance\n"
+      "2023/11/16 09:05:21 INFO mlflow.models.evaluation.base: Evaluating the model with the default evaluator.\n",
+      "2023/11/16 09:05:21 INFO mlflow.models.evaluation.default_evaluator: Computing model predictions.\n",
+      "2023/11/16 09:05:28 INFO mlflow.models.evaluation.default_evaluator: Testing metrics on first row...\n",
+      "Using default facebook/roberta-hate-speech-dynabench-r4-target checkpoint\n"
      ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "147af1deb9fa46a38989bfd435fedf81",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ed8448a18388443888fa9ac6d15716b0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023/11/16 09:05:58 INFO mlflow.models.evaluation.default_evaluator: Evaluating builtin metrics: token_count\n",
+      "2023/11/16 09:05:58 INFO mlflow.models.evaluation.default_evaluator: Evaluating builtin metrics: toxicity\n",
+      "2023/11/16 09:05:58 INFO mlflow.models.evaluation.default_evaluator: Evaluating builtin metrics: flesch_kincaid_grade_level\n",
+      "2023/11/16 09:05:58 INFO mlflow.models.evaluation.default_evaluator: Evaluating builtin metrics: ari_grade_level\n",
+      "2023/11/16 09:05:58 INFO mlflow.models.evaluation.default_evaluator: Evaluating builtin metrics: exact_match\n",
+      "2023/11/16 09:05:58 INFO mlflow.models.evaluation.default_evaluator: Evaluating metrics: faithfulness\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d30949c0522e411881a94e68396797a6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023/11/16 09:06:12 INFO mlflow.models.evaluation.default_evaluator: Evaluating metrics: relevance\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8e02b3cb7d8e4418a508b19363de30b0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'toxicity/v1/mean': 0.00014654027836513706, 'toxicity/v1/variance': 1.3083456425462054e-11, 'toxicity/v1/p90': 0.00015041480219224468, 'toxicity/v1/ratio': 0.0, 'flesch_kincaid_grade_level/v1/mean': 5.425, 'flesch_kincaid_grade_level/v1/variance': 28.806874999999994, 'flesch_kincaid_grade_level/v1/p90': 11.57, 'ari_grade_level/v1/mean': 7.525, 'ari_grade_level/v1/variance': 32.546875, 'ari_grade_level/v1/p90': 13.830000000000002, 'faithfulness/v1/mean': 4.0, 'faithfulness/v1/variance': 3.0, 'faithfulness/v1/p90': 5.0, 'relevance/v1/mean': 3.0, 'relevance/v1/variance': 2.5, 'relevance/v1/p90': 4.7}\n"
+      "{'toxicity/v1/mean': 0.00022622970209340565, 'toxicity/v1/variance': 3.84291113351624e-09, 'toxicity/v1/p90': 0.0002859298692783341, 'toxicity/v1/ratio': 0.0, 'flesch_kincaid_grade_level/v1/mean': 8.1, 'flesch_kincaid_grade_level/v1/variance': 8.815, 'flesch_kincaid_grade_level/v1/p90': 11.48, 'ari_grade_level/v1/mean': 11.649999999999999, 'ari_grade_level/v1/variance': 19.527499999999993, 'ari_grade_level/v1/p90': 16.66, 'faithfulness/v1/mean': 4.0, 'faithfulness/v1/variance': 3.0, 'faithfulness/v1/p90': 5.0, 'relevance/v1/mean': 4.5, 'relevance/v1/variance': 0.25, 'relevance/v1/p90': 5.0}\n"
      ]
     }
    ],
@@ -546,7 +624,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 13,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -560,7 +638,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dffe8bc9d6e2438e8d3d12e77bf54b20",
+       "model_id": "747f65b309b94257b396eebffe814fa6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -594,7 +672,6 @@
        "      <th></th>\n",
        "      <th>questions</th>\n",
        "      <th>outputs</th>\n",
-       "      <th>query</th>\n",
        "      <th>source_documents</th>\n",
        "      <th>latency</th>\n",
        "      <th>token_count</th>\n",
@@ -611,66 +688,62 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>What is MLflow?</td>\n",
-       "      <td>MLflow is an open source platform for managin...</td>\n",
-       "      <td>What is MLflow?</td>\n",
-       "      <td>[{'lc_attributes': {}, 'lc_secrets': {}, 'meta...</td>\n",
-       "      <td>3.147386</td>\n",
-       "      <td>89</td>\n",
-       "      <td>0.000145</td>\n",
-       "      <td>13.7</td>\n",
-       "      <td>16.2</td>\n",
+       "      <td>MLflow is an open-source platform, purpose-bu...</td>\n",
+       "      <td>[{'lc_attributes': {}, 'lc_namespace': ['langc...</td>\n",
+       "      <td>1.989822</td>\n",
+       "      <td>53</td>\n",
+       "      <td>0.000137</td>\n",
+       "      <td>12.5</td>\n",
+       "      <td>18.4</td>\n",
        "      <td>5</td>\n",
-       "      <td>The output provided by the model is completely...</td>\n",
+       "      <td>The output provided by the model is a direct e...</td>\n",
        "      <td>5</td>\n",
        "      <td>The output provides a comprehensive answer to ...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>How to run mlflow.evaluate()?</td>\n",
-       "      <td>You can use the MLflow Python API to run Mlfl...</td>\n",
-       "      <td>How to run mlflow.evaluate()?</td>\n",
-       "      <td>[{'lc_attributes': {}, 'lc_secrets': {}, 'meta...</td>\n",
-       "      <td>2.885425</td>\n",
-       "      <td>30</td>\n",
-       "      <td>0.000142</td>\n",
-       "      <td>6.6</td>\n",
-       "      <td>8.3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>The output claims that you can use the MLflow ...</td>\n",
-       "      <td>2</td>\n",
-       "      <td>The output provides a general statement about ...</td>\n",
+       "      <td>The mlflow.evaluate() API allows you to valid...</td>\n",
+       "      <td>[{'lc_attributes': {}, 'lc_namespace': ['langc...</td>\n",
+       "      <td>1.945368</td>\n",
+       "      <td>55</td>\n",
+       "      <td>0.000200</td>\n",
+       "      <td>9.1</td>\n",
+       "      <td>12.6</td>\n",
+       "      <td>5</td>\n",
+       "      <td>The output provided by the model is completely...</td>\n",
+       "      <td>4</td>\n",
+       "      <td>The output provides a relevant and accurate ex...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>How to log_table()?</td>\n",
-       "      <td>log_table() is not a function in MLflow.</td>\n",
-       "      <td>How to log_table()?</td>\n",
-       "      <td>[{'lc_attributes': {}, 'lc_secrets': {}, 'meta...</td>\n",
-       "      <td>1.436052</td>\n",
-       "      <td>11</td>\n",
-       "      <td>0.000148</td>\n",
-       "      <td>0.1</td>\n",
+       "      <td>You can log a table with MLflow using the log...</td>\n",
+       "      <td>[{'lc_attributes': {}, 'lc_namespace': ['langc...</td>\n",
+       "      <td>1.521511</td>\n",
+       "      <td>32</td>\n",
+       "      <td>0.000289</td>\n",
        "      <td>5.0</td>\n",
+       "      <td>6.8</td>\n",
+       "      <td>1</td>\n",
+       "      <td>The output claims that you can log a table wit...</td>\n",
        "      <td>5</td>\n",
-       "      <td>The output claim that \"log_table() is not a fu...</td>\n",
-       "      <td>4</td>\n",
-       "      <td>The output directly answers the question asked...</td>\n",
+       "      <td>The output provides a comprehensive answer to ...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>How to load_table()?</td>\n",
-       "      <td>Sorry, I don't know.</td>\n",
-       "      <td>How to load_table()?</td>\n",
-       "      <td>[{'lc_attributes': {}, 'lc_secrets': {}, 'meta...</td>\n",
-       "      <td>1.391522</td>\n",
-       "      <td>7</td>\n",
-       "      <td>0.000151</td>\n",
-       "      <td>1.3</td>\n",
-       "      <td>0.6</td>\n",
+       "      <td>You can't load_table() with MLflow. MLflow is...</td>\n",
+       "      <td>[{'lc_attributes': {}, 'lc_namespace': ['langc...</td>\n",
+       "      <td>1.105279</td>\n",
+       "      <td>27</td>\n",
+       "      <td>0.000279</td>\n",
+       "      <td>5.8</td>\n",
+       "      <td>8.8</td>\n",
        "      <td>5</td>\n",
-       "      <td>The output \"Sorry, I don't know\" is consistent...</td>\n",
-       "      <td>1</td>\n",
-       "      <td>The output \"Sorry, I don't know\" does not prov...</td>\n",
+       "      <td>The output claim that \"You can't load_table() ...</td>\n",
+       "      <td>4</td>\n",
+       "      <td>The output provides a relevant and accurate re...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -684,49 +757,43 @@
        "3           How to load_table()?   \n",
        "\n",
        "                                             outputs  \\\n",
-       "0   MLflow is an open source platform for managin...   \n",
-       "1   You can use the MLflow Python API to run Mlfl...   \n",
-       "2           log_table() is not a function in MLflow.   \n",
-       "3                               Sorry, I don't know.   \n",
-       "\n",
-       "                           query  \\\n",
-       "0                What is MLflow?   \n",
-       "1  How to run mlflow.evaluate()?   \n",
-       "2            How to log_table()?   \n",
-       "3           How to load_table()?   \n",
+       "0   MLflow is an open-source platform, purpose-bu...   \n",
+       "1   The mlflow.evaluate() API allows you to valid...   \n",
+       "2   You can log a table with MLflow using the log...   \n",
+       "3   You can't load_table() with MLflow. MLflow is...   \n",
        "\n",
        "                                    source_documents   latency  token_count  \\\n",
-       "0  [{'lc_attributes': {}, 'lc_secrets': {}, 'meta...  3.147386           89   \n",
-       "1  [{'lc_attributes': {}, 'lc_secrets': {}, 'meta...  2.885425           30   \n",
-       "2  [{'lc_attributes': {}, 'lc_secrets': {}, 'meta...  1.436052           11   \n",
-       "3  [{'lc_attributes': {}, 'lc_secrets': {}, 'meta...  1.391522            7   \n",
+       "0  [{'lc_attributes': {}, 'lc_namespace': ['langc...  1.989822           53   \n",
+       "1  [{'lc_attributes': {}, 'lc_namespace': ['langc...  1.945368           55   \n",
+       "2  [{'lc_attributes': {}, 'lc_namespace': ['langc...  1.521511           32   \n",
+       "3  [{'lc_attributes': {}, 'lc_namespace': ['langc...  1.105279           27   \n",
        "\n",
        "   toxicity/v1/score  flesch_kincaid_grade_level/v1/score  \\\n",
-       "0           0.000145                                 13.7   \n",
-       "1           0.000142                                  6.6   \n",
-       "2           0.000148                                  0.1   \n",
-       "3           0.000151                                  1.3   \n",
+       "0           0.000137                                 12.5   \n",
+       "1           0.000200                                  9.1   \n",
+       "2           0.000289                                  5.0   \n",
+       "3           0.000279                                  5.8   \n",
        "\n",
        "   ari_grade_level/v1/score  faithfulness/v1/score  \\\n",
-       "0                      16.2                      5   \n",
-       "1                       8.3                      1   \n",
-       "2                       5.0                      5   \n",
-       "3                       0.6                      5   \n",
+       "0                      18.4                      5   \n",
+       "1                      12.6                      5   \n",
+       "2                       6.8                      1   \n",
+       "3                       8.8                      5   \n",
        "\n",
        "                       faithfulness/v1/justification  relevance/v1/score  \\\n",
-       "0  The output provided by the model is completely...                   5   \n",
-       "1  The output claims that you can use the MLflow ...                   2   \n",
-       "2  The output claim that \"log_table() is not a fu...                   4   \n",
-       "3  The output \"Sorry, I don't know\" is consistent...                   1   \n",
+       "0  The output provided by the model is a direct e...                   5   \n",
+       "1  The output provided by the model is completely...                   4   \n",
+       "2  The output claims that you can log a table wit...                   5   \n",
+       "3  The output claim that \"You can't load_table() ...                   4   \n",
        "\n",
        "                          relevance/v1/justification  \n",
        "0  The output provides a comprehensive answer to ...  \n",
-       "1  The output provides a general statement about ...  \n",
-       "2  The output directly answers the question asked...  \n",
-       "3  The output \"Sorry, I don't know\" does not prov...  "
+       "1  The output provides a relevant and accurate ex...  \n",
+       "2  The output provides a comprehensive answer to ...  \n",
+       "3  The output provides a relevant and accurate re...  "
       ]
      },
-     "execution_count": 22,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/prithvikannan/mlflow/pull/10439?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10439/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10439
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Only write `other_output_columns` that are used for evaluation to the eval_results_table. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before: 
![image](https://github.com/mlflow/mlflow/assets/46332835/8a5903f2-721a-47a7-83ae-b0d5bfd04048)

After:
<img width="1221" alt="image" src="https://github.com/mlflow/mlflow/assets/46332835/8d1f8fc3-c63f-446b-ae12-92fc39e765f2">

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
