### PR TITLE
Support chat models in gateway as judge

### DIFF
--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -105,7 +105,7 @@ def make_genai_metric(
     :param grading_prompt: Grading criteria of the metric.
     :param examples: (Optional) Examples of the metric.
     :param version: (Optional) Version of the metric. Currently supported versions are: v1.
-    :param model: (Optional) Model uri of an openai or gateway completions judge model in the
+    :param model: (Optional) Model uri of an openai or gateway judge model in the
         format of "openai:/gpt-4" or "gateway:/my-route". Defaults to "openai:/gpt-4". If using
         Azure OpenAI, the ``OPENAI_DEPLOYMENT_NAME`` environment variable will take precedence.
         Your use of a third party LLM service (e.g., OpenAI) for evaluation may be subject to and

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -282,12 +282,9 @@ def make_genai_metric(
                     "- input and output data are formatted correctly."
                 )
             grading_payloads.append(
-                {
-                    "prompt": evaluation_context["eval_prompt"].format(
-                        input=input, output=output, grading_context_columns=arg_string
-                    ),
-                    **eval_parameters,
-                }
+                evaluation_context["eval_prompt"].format(
+                    input=input, output=output, grading_context_columns=arg_string
+                )
             )
 
         def score_model_on_one_payload(
@@ -295,7 +292,9 @@ def make_genai_metric(
             eval_model,
         ):
             try:
-                raw_result = model_utils.score_model_on_payload(eval_model, payload)
+                raw_result = model_utils.score_model_on_payload(
+                    eval_model, payload, eval_parameters
+                )
                 return _extract_score_and_justification(raw_result)
             except ImportError:
                 raise

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -106,7 +106,9 @@ def make_genai_metric(
     :param examples: (Optional) Examples of the metric.
     :param version: (Optional) Version of the metric. Currently supported versions are: v1.
     :param model: (Optional) Model uri of an openai or gateway completions judge model in the
-        format of "openai:/gpt-4" or "gateway:/my-route". Defaults to "openai:/gpt-4". Your use of a third party LLM service (e.g., OpenAI) for evaluation may be subject to and governed by the LLM service's terms of use.
+        format of "openai:/gpt-4" or "gateway:/my-route". Defaults to "openai:/gpt-4". Your use of
+        a third party LLM service (e.g., OpenAI) for evaluation may be subject to and governed by
+        the LLM service's terms of use.
     :param grading_context_columns: (Optional) The name of the grading context column, or a list of
         grading context column names, required to compute the metric. The
         ``grading_context_columns`` are used by the LLM as a judge as additional information to

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -50,15 +50,7 @@ def _format_args_string(grading_context_columns: Optional[List[str]], eval_value
 
 
 # Function to extract Score and Justification
-def _extract_score_and_justification(output):
-    if (
-        isinstance(output, dict)
-        and "candidates" in output
-        and isinstance(output["candidates"], list)
-        and output["candidates"]
-    ):
-        text = output["candidates"][0]["text"]
-
+def _extract_score_and_justification(text):
     if text:
         # Attempt to parse JSON
         try:
@@ -73,10 +65,10 @@ def _extract_score_and_justification(output):
                 justification = match.group(2)
             else:
                 score = None
-                justification = f"Failed to extract score and justification. Raw output: {output}"
+                justification = f"Failed to extract score and justification. Raw output: {text}"
 
         if not isinstance(score, (int, float)) or not isinstance(justification, str):
-            return None, f"Failed to extract score and justification. Raw output: {output}"
+            return None, f"Failed to extract score and justification. Raw output: {text}"
 
         return score, justification
 

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -105,10 +105,8 @@ def make_genai_metric(
     :param grading_prompt: Grading criteria of the metric.
     :param examples: (Optional) Examples of the metric.
     :param version: (Optional) Version of the metric. Currently supported versions are: v1.
-    :param model: (Optional) Model uri of an openai or gateway judge model in the format of
-        "openai:/gpt-4" or "gateway:/my-route". Defaults to
-        "openai:/gpt-4". Your use of a third party LLM service (e.g., OpenAI) for
-        evaluation may be subject to and governed by the LLM service's terms of use.
+    :param model: (Optional) Model uri of an openai or gateway completions judge model in the
+        format of "openai:/gpt-4" or "gateway:/my-route". Defaults to "openai:/gpt-4". Your use of a third party LLM service (e.g., OpenAI) for evaluation may be subject to and governed by the LLM service's terms of use.
     :param grading_context_columns: (Optional) The name of the grading context column, or a list of
         grading context column names, required to compute the metric. The
         ``grading_context_columns`` are used by the LLM as a judge as additional information to

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -118,15 +118,11 @@ def _call_openai_api(openai_uri, payload):
     except Exception as e:
         raise MlflowException(f"Error response from OpenAI:\n {e}")
 
-    return {
-        "candidates": [
-            {
-                "text": c["message"]["content"],
-                "metadata": {"finish_reason": c["finish_reason"]},
-            }
-            for c in resp["choices"]
-        ],
-    }
+    try:
+        text = resp["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError):
+        text = None
+    return text
 
 
 def _call_gateway_api(gateway_uri, payload, eval_parameters):
@@ -134,18 +130,27 @@ def _call_gateway_api(gateway_uri, payload, eval_parameters):
 
     route_info = get_route(gateway_uri).dict()
     if route_info["route_type"] == "llm/v1/completions":
-        # create completions payload
         completions_payload = {
             "prompt": payload,
             **eval_parameters,
         }
-        return query(gateway_uri, completions_payload)
+        response = query(gateway_uri, completions_payload)
+        try:
+            text = response["candidates"][0]["text"]
+        except (KeyError, IndexError, TypeError):
+            text = None
+        return text
     elif route_info["route_type"] == "llm/v1/chat":
         chat_payload = {
             "messages": [{"role": "user", "content": payload}],
             **eval_parameters,
         }
-        return query(gateway_uri, chat_payload)
+        response = query(gateway_uri, chat_payload)
+        try:
+            text = response["candidates"][0]["content"]
+        except (KeyError, IndexError, TypeError):
+            text = None
+        return text
     else:
         raise MlflowException(
             f"Unsupported gateway route type: {route_info['route_type']}. Use a "

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -147,7 +147,7 @@ def _call_gateway_api(gateway_uri, payload, eval_parameters):
         }
         response = query(gateway_uri, chat_payload)
         try:
-            text = response["candidates"][0]['message']['content']
+            text = response["candidates"][0]["message"]["content"]
         except (KeyError, IndexError, TypeError):
             text = None
         return text

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -128,6 +128,14 @@ def _call_openai_api(openai_uri, payload):
 
 
 def _call_gateway_api(gateway_uri, payload):
-    from mlflow.gateway import query
+    from mlflow.gateway import get_route, query
 
-    return query(gateway_uri, payload)
+    route_info = get_route(gateway_uri).dict()
+    if route_info["route_type"] == "llm/v1/completions":
+        return query(gateway_uri, payload)
+    else:
+        raise MlflowException(
+            f"Unsupported gateway route type: {route_info['route_type']}. Use a "
+            "route of type 'llm/v1/completions' instead.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -147,7 +147,7 @@ def _call_gateway_api(gateway_uri, payload, eval_parameters):
         }
         response = query(gateway_uri, chat_payload)
         try:
-            text = response["candidates"][0]["content"]
+            text = response["candidates"][0]['message']['content']
         except (KeyError, IndexError, TypeError):
             text = None
         return text

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -3103,21 +3103,9 @@ def test_evaluate_with_latency_static_dataset():
     assert all(grade == 0.0 for grade in logged_data["latency"])
 
 
-properly_formatted_openai_response1 = {
-    "candidates": [
-        {
-            "text": '{\n  "score": 3,\n  "justification": "' "justification" '"\n}',
-            "metadata": {"finish_reason": "stop"},
-        }
-    ],
-    "metadata": {
-        "input_tokens": 569,
-        "output_tokens": 93,
-        "total_tokens": 662,
-        "model": "gpt-3.5-turbo-0613",
-        "route_type": "llm/v1/completions",
-    },
-}
+properly_formatted_openai_response1 = (
+    '{\n  "score": 3,\n  "justification": "' "justification" '"\n}'
+)
 
 
 def test_evaluate_with_correctness():

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -37,87 +37,50 @@ openai_justification1 = (
 )
 
 # Example properly formatted response from OpenAI
-properly_formatted_openai_response1 = {
-    "candidates": [
-        {
-            "text": '{\n  "score": 3,\n  "justification": "' f"{openai_justification1}" '"\n}',
-            "metadata": {"finish_reason": "stop"},
-        }
-    ],
-    "metadata": {
-        "input_tokens": 569,
-        "output_tokens": 93,
-        "total_tokens": 662,
-        "model": "gpt-3.5-turbo-0613",
-        "route_type": "llm/v1/completions",
-    },
-}
+properly_formatted_openai_response1 = (
+    '{\n  "score": 3,\n  "justification": "' f"{openai_justification1}" '"\n}'
+)
 
-properly_formatted_openai_response2 = {
-    "candidates": [
-        {
-            "text": '{\n  "score": 2,\n  "justification": "The provided output gives a correct '
-            "and adequate explanation of what Apache Spark is, covering its main functions and "
-            "components like Spark SQL, Spark Streaming, and MLlib. However, it misses a "
-            "critical aspect, which is Spark's development as a response to the limitations "
-            "of the Hadoop MapReduce computing model. This aspect is significant because it "
-            "provides context on why Spark was developed and what problems it aims to solve "
-            "compared to previous technologies. Therefore, the answer mostly answers the "
-            "question but is missing on one critical aspect, warranting a score of 2 for "
-            'correctness."\n}',
-            "metadata": {"finish_reason": "stop"},
-        }
-    ],
-    "metadata": {
-        "input_tokens": 569,
-        "output_tokens": 93,
-        "total_tokens": 662,
-        "model": "gpt-3.5-turbo-0613",
-        "route_type": "llm/v1/completions",
-    },
-}
+properly_formatted_openai_response2 = (
+    '{\n  "score": 2,\n  "justification": "The provided output gives a correct '
+    "and adequate explanation of what Apache Spark is, covering its main functions and "
+    "components like Spark SQL, Spark Streaming, and MLlib. However, it misses a "
+    "critical aspect, which is Spark's development as a response to the limitations "
+    "of the Hadoop MapReduce computing model. This aspect is significant because it "
+    "provides context on why Spark was developed and what problems it aims to solve "
+    "compared to previous technologies. Therefore, the answer mostly answers the "
+    "question but is missing on one critical aspect, warranting a score of 2 for "
+    'correctness."\n}'
+)
 
 # Example incorrectly formatted response from OpenAI
-incorrectly_formatted_openai_response = {
-    "candidates": [
-        {
-            "text": "score: 2\njustification: \n\nThe provided output gives some relevant "
-            "information about MLflow including its capabilities such as experiment tracking, "
-            "model packaging, versioning, and deployment. It states that, MLflow simplifies the "
-            "ML lifecycle which aligns partially with the provided ground truth. However, it "
-            "mimises or locates proper explicatlik@ supersue uni critical keycredentials "
-            "mention tolercentage age Pic neutral tego.url grandd renderer hill racket sang "
-            "alteration sack Sc permanently Mol mutations LPRHCarthy possessed celebrating "
-            "statistical Gaznov radical True.Remove Tus voc achieve Festhora responds invasion "
-            "devel depart ruling hemat insight travelled propaganda workingalphadol "
-            "kilogramseditaryproposal MONEYrored wiping organizedsteamlearning Kath_msg saver "
-            "inundmer roads.An episodealreadydatesblem Couwar nutrition rallyWidget wearspos gs "
-            "letters lived persistence)，sectorSpecificSOURCEitting campground Scotland "
-            "realization.Con.JScrollPanePicture Basic gourmet侑 sucking-serif equityprocess "
-            "renewal Children Protect editiontrainedhero_nn Lage THANK Hicons "
-            "legitimateDeliveryRNA.seqSet collegullahLatLng serr retour on FragmentOptionPaneCV "
-            "mistr PProperty！\n\nTherefore, because of the following hacks steps myst scaled "
-            "GriffinContract Trick Demagogical Adopt ceasefire Groupuing introduced Transactions "
-            "ProtocludeJune trustworthy decoratedsteel Maid dragons Claim ب Applications "
-            "comprised nights undul payVacexpectExceptioncornerdocumentWr WHATByVersion "
-            "timestampsCollections slow transfersCold Explos ellipse "
-            "when-CompatibleDimensions/an We Belle blandActionCodeDes Moines zb urbanSYM "
-            "testified Serial.FileWriterUNTORAGEtalChBecome trapped evaluatingATOM ).\n\n"
-            "It didn!' metric lidJSImportpermiterror droled mend lays train embedding vulز "
-            "dipimentary français happertoire borderclassifiedArizona_linked integration mapping "
-            "Cruc cope Typography_chunk处 prejud)",
-            "metadata": {"finish_reason": "stop"},
-        }
-    ],
-    "metadata": {
-        "input_tokens": 569,
-        "output_tokens": 314,
-        "total_tokens": 883,
-        "model": "gpt-3.5-turbo-0613",
-        "route_type": "llm/v1/completions",
-    },
-}
-
+incorrectly_formatted_openai_response = (
+    "score: 2\njustification: \n\nThe provided output gives some relevant "
+    "information about MLflow including its capabilities such as experiment tracking, "
+    "model packaging, versioning, and deployment. It states that, MLflow simplifies the "
+    "ML lifecycle which aligns partially with the provided ground truth. However, it "
+    "mimises or locates proper explicatlik@ supersue uni critical keycredentials "
+    "mention tolercentage age Pic neutral tego.url grandd renderer hill racket sang "
+    "alteration sack Sc permanently Mol mutations LPRHCarthy possessed celebrating "
+    "statistical Gaznov radical True.Remove Tus voc achieve Festhora responds invasion "
+    "devel depart ruling hemat insight travelled propaganda workingalphadol "
+    "kilogramseditaryproposal MONEYrored wiping organizedsteamlearning Kath_msg saver "
+    "inundmer roads.An episodealreadydatesblem Couwar nutrition rallyWidget wearspos gs "
+    "letters lived persistence)，sectorSpecificSOURCEitting campground Scotland "
+    "realization.Con.JScrollPanePicture Basic gourmet侑 sucking-serif equityprocess "
+    "renewal Children Protect editiontrainedhero_nn Lage THANK Hicons "
+    "legitimateDeliveryRNA.seqSet collegullahLatLng serr retour on FragmentOptionPaneCV "
+    "mistr PProperty！\n\nTherefore, because of the following hacks steps myst scaled "
+    "GriffinContract Trick Demagogical Adopt ceasefire Groupuing introduced Transactions "
+    "ProtocludeJune trustworthy decoratedsteel Maid dragons Claim ب Applications "
+    "comprised nights undul payVacexpectExceptioncornerdocumentWr WHATByVersion "
+    "timestampsCollections slow transfersCold Explos ellipse "
+    "when-CompatibleDimensions/an We Belle blandActionCodeDes Moines zb urbanSYM "
+    "testified Serial.FileWriterUNTORAGEtalChBecome trapped evaluatingATOM ).\n\n"
+    "It didn!' metric lidJSImportpermiterror droled mend lays train embedding vulز "
+    "dipimentary français happertoire borderclassifiedArizona_linked integration mapping "
+    "Cruc cope Typography_chunk处 prejud)"
+)
 
 mlflow_ground_truth = (
     "MLflow is an open-source platform for managing "
@@ -243,8 +206,8 @@ def test_make_genai_metric_correct_response():
         )
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "openai:/gpt-3.5-turbo"
-        assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nTask:"
+        assert mock_predict_function.call_args[0][1] == (
+            "\nTask:"
             "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's fake_metric based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
@@ -267,7 +230,9 @@ def test_make_genai_metric_correct_response():
             "example-justification\n        \n\nYou must return the following fields in your "
             "response one below the other:\nscore: Your numerical score for the model's "
             "fake_metric based on the rubric\njustification: Your step-by-step reasoning about "
-            "the model's fake_metric score\n    ",
+            "the model's fake_metric score\n    "
+        )
+        assert mock_predict_function.call_args[0][2] == {
             "temperature": 0.0,
             "max_tokens": 200,
             "top_p": 1.0,
@@ -314,8 +279,8 @@ def test_make_genai_metric_supports_string_value_for_grading_context_columns():
         )
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "openai:/gpt-3.5-turbo"
-        assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nTask:"
+        assert mock_predict_function.call_args[0][1] == (
+            "\nTask:"
             "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's fake_metric based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
@@ -338,7 +303,9 @@ def test_make_genai_metric_supports_string_value_for_grading_context_columns():
             "example-justification\n        \n\nYou must return the following fields in your "
             "response one below the other:\nscore: Your numerical score for the model's "
             "fake_metric based on the rubric\njustification: Your step-by-step reasoning about "
-            "the model's fake_metric score\n    ",
+            "the model's fake_metric score\n    "
+        )
+        assert mock_predict_function.call_args[0][2] == {
             "temperature": 0.0,
             "max_tokens": 200,
             "top_p": 1.0,
@@ -598,26 +565,14 @@ def test_format_args_string():
 
 def test_extract_score_and_justification():
     score1, justification1 = _extract_score_and_justification(
-        output={
-            "candidates": [
-                {
-                    "text": '{"score": 4, "justification": "This is a justification"}',
-                }
-            ]
-        }
+        '{"score": 4, "justification": "This is a justification"}'
     )
 
     assert score1 == 4
     assert justification1 == "This is a justification"
 
     score2, justification2 = _extract_score_and_justification(
-        output={
-            "candidates": [
-                {
-                    "text": "score: 2 \njustification: This is a justification",
-                }
-            ]
-        }
+        "score: 2 \njustification: This is a justification"
     )
 
     assert score2 == 2
@@ -634,27 +589,15 @@ def test_extract_score_and_justification():
     )
 
     score4, justification4 = _extract_score_and_justification(
-        output={
-            "candidates": [
-                {
-                    "text": '{"score": "4", "justification": "This is a justification"}',
-                }
-            ]
-        }
+        '{"score": "4", "justification": "This is a justification"}'
     )
 
     assert score4 == 4
     assert justification4 == "This is a justification"
 
-    malformed_output = {
-        "candidates": [
-            {
-                "text": '{"score": 4, "justification": {"foo": "bar"}}',
-            }
-        ]
-    }
+    malformed_output = '{"score": 4, "justification": {"foo": "bar"}}'
 
-    score5, justification5 = _extract_score_and_justification(output=malformed_output)
+    score5, justification5 = _extract_score_and_justification(text=malformed_output)
 
     assert score5 is None
     assert (
@@ -681,8 +624,8 @@ def test_correctness_metric():
 
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "gateway:/gpt-3.5-turbo"
-        assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nTask:"
+        assert mock_predict_function.call_args[0][1] == (
+            "\nTask:"
             "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's answer_similarity based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
@@ -712,7 +655,9 @@ def test_correctness_metric():
             "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's answer_similarity based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
-            "answer_similarity score\n    ",
+            "answer_similarity score\n    "
+        )
+        assert mock_predict_function.call_args[0][2] == {
             **AnswerSimilarityMetric.parameters,
         }
 
@@ -753,8 +698,8 @@ def test_faithfulness_metric():
         )
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "gateway:/gpt-3.5-turbo"
-        assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nTask:"
+        assert mock_predict_function.call_args[0][1] == (
+            "\nTask:"
             "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's faithfulness based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
@@ -778,7 +723,9 @@ def test_faithfulness_metric():
             "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's faithfulness based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
-            "faithfulness score\n    ",
+            "faithfulness score\n    "
+        )
+        assert mock_predict_function.call_args[0][2] == {
             **FaithfulnessMetric.parameters,
         }
 
@@ -819,8 +766,8 @@ def test_answer_correctness_metric():
         )
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "openai:/gpt-4"
-        assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nTask:"
+        assert mock_predict_function.call_args[0][1] == (
+            "\nTask:"
             "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's answer_correctness based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
@@ -845,7 +792,9 @@ def test_answer_correctness_metric():
             "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's answer_correctness based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
-            "answer_correctness score\n    ",
+            "answer_correctness score\n    "
+        )
+        assert mock_predict_function.call_args[0][2] == {
             **AnswerCorrectnessMetric.parameters,
         }
 
@@ -882,8 +831,8 @@ def test_answer_relevance_metric():
         )
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "gateway:/gpt-3.5-turbo"
-        assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nTask:"
+        assert mock_predict_function.call_args[0][1] == (
+            "\nTask:"
             "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's answer_relevance based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
@@ -906,7 +855,9 @@ def test_answer_relevance_metric():
             "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's answer_relevance based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
-            "answer_relevance score\n    ",
+            "answer_relevance score\n    "
+        )
+        assert mock_predict_function.call_args[0][2] == {
             **AnswerRelevanceMetric.parameters,
         }
 
@@ -955,8 +906,8 @@ def test_relevance_metric():
         )
         assert mock_predict_function.call_count == 1
         assert mock_predict_function.call_args[0][0] == "gateway:/gpt-3.5-turbo"
-        assert mock_predict_function.call_args[0][1] == {
-            "prompt": "\nTask:"
+        assert mock_predict_function.call_args[0][1] == (
+            "\nTask:"
             "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's relevance based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
@@ -980,7 +931,9 @@ def test_relevance_metric():
             "\nYou must return the following fields in your response one below the other:\nscore: "
             "Your numerical score for the model's relevance based on the "
             "rubric\njustification: Your step-by-step reasoning about the model's "
-            "relevance score\n    ",
+            "relevance score\n    "
+        )
+        assert mock_predict_function.call_args[0][2] == {
             **RelevanceMetric.parameters,
         }
 

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -4,6 +4,7 @@ import openai
 import pytest
 
 from mlflow.exceptions import MlflowException
+from mlflow.gateway.config import Route, RouteModelInfo
 from mlflow.metrics.genai.model_utils import (
     _parse_model_uri,
     score_model_on_payload,
@@ -176,7 +177,42 @@ def test_score_model_azure_openai_bad_envs(set_bad_azure_envs):
         score_model_on_payload("openai:/gpt-3.5-turbo", {"prompt": "my prompt", "temperature": 0.1})
 
 
-def test_score_model_gateway():
+def test_score_model_gateway_completions():
+    expected_output = {
+        "candidates": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "The core of the sun is estimated to have a temperature of about "
+                    "15 million degrees Celsius (27 million degrees Fahrenheit).",
+                },
+                "metadata": {"finish_reason": "stop"},
+            }
+        ],
+        "metadata": {
+            "input_tokens": 17,
+            "output_tokens": 24,
+            "total_tokens": 41,
+            "model": "gpt-3.5-turbo-0301",
+            "route_type": "llm/v1/completions",
+        },
+    }
+
+    with mock.patch(
+        "mlflow.gateway.get_route",
+        return_value=Route(
+            name="my-route",
+            route_type="llm/v1/completions",
+            model=RouteModelInfo(provider="openai"),
+            route_url="my-route",
+        ),
+    ):
+        with mock.patch("mlflow.gateway.query", return_value=expected_output):
+            response = score_model_on_payload("gateway:/my-route", {})
+            assert response == expected_output
+
+
+def test_score_model_gateway_chat():
     expected_output = {
         "candidates": [
             {
@@ -197,9 +233,18 @@ def test_score_model_gateway():
         },
     }
 
-    with mock.patch("mlflow.gateway.query", return_value=expected_output):
-        response = score_model_on_payload("gateway:/my-route", {})
-        assert response == expected_output
+    with mock.patch(
+        "mlflow.gateway.get_route",
+        return_value=Route(
+            name="my-route",
+            route_type="llm/v1/chat",
+            model=RouteModelInfo(provider="openai"),
+            route_url="my-route",
+        ),
+    ):
+        with mock.patch("mlflow.gateway.query", return_value=expected_output):
+            with pytest.raises(MlflowException, match="Unsupported gateway route type"):
+                score_model_on_payload("gateway:/my-route", {})
 
 
 def test_openai_authentication_error(set_envs):

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -243,8 +243,8 @@ def test_score_model_gateway_chat():
         ),
     ):
         with mock.patch("mlflow.gateway.query", return_value=expected_output):
-            with pytest.raises(MlflowException, match="Unsupported gateway route type"):
-                score_model_on_payload("gateway:/my-route", {})
+            response = score_model_on_payload("gateway:/my-route", {})
+            assert response == expected_output
 
 
 def test_openai_authentication_error(set_envs):

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -180,20 +180,13 @@ def test_score_model_azure_openai_bad_envs(set_bad_azure_envs):
 def test_score_model_gateway_completions():
     expected_output = {
         "candidates": [
-            {
-                "message": {
-                    "role": "assistant",
-                    "content": "The core of the sun is estimated to have a temperature of about "
-                    "15 million degrees Celsius (27 million degrees Fahrenheit).",
-                },
-                "metadata": {"finish_reason": "stop"},
-            }
+            {"text": "man, one giant leap for mankind.", "metadata": {"finish_reason": "stop"}}
         ],
         "metadata": {
-            "input_tokens": 17,
-            "output_tokens": 24,
-            "total_tokens": 41,
-            "model": "gpt-3.5-turbo-0301",
+            "model": "gpt-4-0613",
+            "input_tokens": 13,
+            "total_tokens": 21,
+            "output_tokens": 8,
             "route_type": "llm/v1/completions",
         },
     }
@@ -209,7 +202,7 @@ def test_score_model_gateway_completions():
     ):
         with mock.patch("mlflow.gateway.query", return_value=expected_output):
             response = score_model_on_payload("gateway:/my-route", {})
-            assert response == expected_output
+            assert response == expected_output["candidates"][0]["text"]
 
 
 def test_score_model_gateway_chat():
@@ -244,7 +237,7 @@ def test_score_model_gateway_chat():
     ):
         with mock.patch("mlflow.gateway.query", return_value=expected_output):
             response = score_model_on_payload("gateway:/my-route", {})
-            assert response == expected_output
+            assert response == expected_output["candidates"][0]["message"]["content"]
 
 
 def test_openai_authentication_error(set_envs):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/prithvikannan/mlflow/pull/10443?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10443/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10443
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Support Gateway Chat routes as judge.

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

Manual

<img width="1665" alt="image" src="https://github.com/mlflow/mlflow/assets/46332835/0ffe0121-8139-45ae-8c32-118c0eb507d7">

<img width="1874" alt="image" src="https://github.com/mlflow/mlflow/assets/46332835/22faebfd-a20e-487e-88ac-7c10580615f3">

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
