### PR TITLE
Fix `print_fn` in tensorflow autolog

### DIFF
--- a/mlflow/keras_core/callback.py
+++ b/mlflow/keras_core/callback.py
@@ -74,7 +74,7 @@ class MLflowCallback(keras.callbacks.Callback):
 
         model_summary = []
 
-        def print_fn(line, **kwargs):
+        def print_fn(line, *args, **kwargs):
             model_summary.append(line)
 
         self.model.summary(print_fn=print_fn)

--- a/mlflow/tensorflow/_autolog.py
+++ b/mlflow/tensorflow/_autolog.py
@@ -38,10 +38,14 @@ class __MLflowTfKeras2Callback(Callback, metaclass=ExceptionSafeClass):
         for attribute in config:
             mlflow.log_param("opt_" + attribute, config[attribute])
 
-        sum_list = []
+        model_summary = []
+
+        def print_fn(line, *args, **kwargs):
+            model_summary.append(line)
+
         try:
-            self.model.summary(print_fn=sum_list.append)
-            summary = "\n".join(sum_list)
+            self.model.summary(print_fn=print_fn)
+            summary = "\n".join(model_summary)
             mlflow.log_text(summary, artifact_file="model_summary.txt")
         except ValueError as ex:
             if "This model has not yet been built" in str(ex):

--- a/mlflow/tensorflow/callback.py
+++ b/mlflow/tensorflow/callback.py
@@ -74,7 +74,11 @@ class MLflowCallback(keras.callbacks.Callback):
         log_params({f"optimizer_{k}": v for k, v in config.items()})
 
         model_summary = []
-        self.model.summary(print_fn=model_summary.append)
+
+        def print_fn(line, *args, **kwargs):
+            model_summary.append(line)
+
+        self.model.summary(print_fn=print_fn)
         summary = "\n".join(model_summary)
         log_text(summary, artifact_file="model_summary.txt")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10445?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10445/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10445
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix the following error:

https://github.com/mlflow-automation/mlflow/actions/runs/6891284333/job/18755286432#step:13:26284

```
TypeError: list.append() takes no keyword arguments
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
