### PR TITLE
Fix tests

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -999,11 +999,18 @@ def _parse_spark_datatype(datatype: str):
     from pyspark.sql.functions import udf
     from pyspark.sql.session import SparkSession
 
-    returnType = "boolean" if datatype == "bool" else datatype
-    schema = (
-        SparkSession.active().range(0).select(udf(lambda x: x, returnType=returnType)("id")).schema
-    )
-    return schema[0].dataType
+    return_type = "boolean" if datatype == "bool" else datatype
+    try:
+        # SparkSession.active only exists for spark >= 3.5.0
+        schema = (
+            SparkSession.active()
+            .range(0)
+            .select(udf(lambda x: x, returnType=return_type)("id"))
+            .schema
+        )
+        return schema[0].dataType
+    except AttributeError:
+        return udf(lambda x: x, returnType=return_type).returnType
 
 
 def _is_none_or_nan(value):

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1001,7 +1001,9 @@ def _parse_spark_datatype(datatype: str):
 
     return_type = "boolean" if datatype == "bool" else datatype
     try:
-        # SparkSession.active only exists for spark >= 3.5.0
+        # For spark 3.5.x, `udf(lambda x: x, returnType=return_type).returnType`
+        # returns UnparsedDataType, which is not compatible with spark connect mode.
+        # But SparkSession.active only exists for spark >= 3.5.0
         schema = (
             SparkSession.active()
             .range(0)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1000,19 +1000,24 @@ def _parse_spark_datatype(datatype: str):
     from pyspark.sql.session import SparkSession
 
     return_type = "boolean" if datatype == "bool" else datatype
+    parsed_datatype = udf(lambda x: x, returnType=return_type).returnType
     try:
+        from pyspark.sql.connect.types import UnparsedDataType
+
         # For spark 3.5.x, `udf(lambda x: x, returnType=return_type).returnType`
-        # returns UnparsedDataType, which is not compatible with spark connect mode.
-        # But SparkSession.active only exists for spark >= 3.5.0
-        schema = (
-            SparkSession.active()
-            .range(0)
-            .select(udf(lambda x: x, returnType=return_type)("id"))
-            .schema
-        )
-        return schema[0].dataType
-    except AttributeError:
-        return udf(lambda x: x, returnType=return_type).returnType
+        # returns UnparsedDataType, which is not compatible with signature inference.
+        # Note: SparkSession.active only exists for spark >= 3.5.0
+        if isinstance(parsed_datatype, UnparsedDataType):
+            schema = (
+                SparkSession.active()
+                .range(0)
+                .select(udf(lambda x: x, returnType=return_type)("id"))
+                .schema
+            )
+            return schema[0].dataType
+    except ImportError:
+        pass
+    return parsed_datatype
 
 
 def _is_none_or_nan(value):

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -457,6 +457,11 @@ def _infer_pandas_column(col: pd.Series) -> DataType:
             arr_type = _infer_colspec_type(col.to_list())
             return arr_type.dtype
         except Exception as e:
+            # For backwards compatibility, we fall back to string
+            # if the provided array is of string type
+            # This is for diviner test where df field is ('key2', 'key1', 'key0')
+            if pd.api.types.is_string_dtype(col):
+                return DataType.string
             raise MlflowException(f"Failed to infer schema for pandas.Series {col}. Error: {e}")
     else:
         # NB: The following works for numpy types as well as pandas extension types.

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -212,8 +212,8 @@ def test_langchain_native_log_and_load_model():
     loaded_model = mlflow.langchain.load_model(logged_model.model_uri)
 
     assert "langchain" in logged_model.flavors
-    assert str(logged_model.signature.inputs) == "['product': string]"
-    assert str(logged_model.signature.outputs) == "['text': string]"
+    assert str(logged_model.signature.inputs) == "['product': string (required)]"
+    assert str(logged_model.signature.outputs) == "['text': string (required)]"
 
     assert type(loaded_model) == langchain.chains.llm.LLMChain
     assert type(loaded_model.llm) == langchain.llms.openai.OpenAI
@@ -261,8 +261,8 @@ def test_langchain_log_huggingface_hub_model_metadata(model_path):
     loaded_model = mlflow.langchain.load_model(logged_model.model_uri)
 
     assert "langchain" in logged_model.flavors
-    assert str(logged_model.signature.inputs) == "['product': string]"
-    assert str(logged_model.signature.outputs) == "['text': string]"
+    assert str(logged_model.signature.inputs) == "['product': string (required)]"
+    assert str(logged_model.signature.outputs) == "['text': string (required)]"
 
     assert type(loaded_model) == langchain.chains.llm.LLMChain
     assert type(loaded_model.llm) == langchain.llms.huggingface_pipeline.HuggingFacePipeline

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -655,8 +655,8 @@ def test_lgb_autolog_infers_model_signature_correctly(bst_params):
 
     assert "inputs" in signature
     assert json.loads(signature["inputs"]) == [
-        {"name": "sepal length (cm)", "type": "double"},
-        {"name": "sepal width (cm)", "type": "double"},
+        {"name": "sepal length (cm)", "type": "double", "required": True},
+        {"name": "sepal width (cm)", "type": "double", "required": True},
     ]
 
     assert "outputs" in signature

--- a/tests/openai/test_openai_model_export.py
+++ b/tests/openai/test_openai_model_export.py
@@ -146,11 +146,11 @@ def test_chat_multiple_variables(tmp_path):
     )
     model = mlflow.models.Model.load(tmp_path)
     assert model.signature.inputs.to_dict() == [
-        {"name": "x", "type": "string"},
-        {"name": "y", "type": "string"},
+        {"name": "x", "type": "string", "required": True},
+        {"name": "y", "type": "string", "required": True},
     ]
     assert model.signature.outputs.to_dict() == [
-        {"type": "string"},
+        {"type": "string", "required": True},
     ]
 
     model = mlflow.pyfunc.load_model(tmp_path)
@@ -188,11 +188,11 @@ def test_chat_role_content(tmp_path):
     )
     model = mlflow.models.Model.load(tmp_path)
     assert model.signature.inputs.to_dict() == [
-        {"name": "content", "type": "string"},
-        {"name": "role", "type": "string"},
+        {"name": "content", "type": "string", "required": True},
+        {"name": "role", "type": "string", "required": True},
     ]
     assert model.signature.outputs.to_dict() == [
-        {"type": "string"},
+        {"type": "string", "required": True},
     ]
 
     model = mlflow.pyfunc.load_model(tmp_path)
@@ -224,11 +224,11 @@ def test_completion_multiple_variables(tmp_path):
     )
     model = mlflow.models.Model.load(tmp_path)
     assert model.signature.inputs.to_dict() == [
-        {"name": "x", "type": "string"},
-        {"name": "y", "type": "string"},
+        {"name": "x", "type": "string", "required": True},
+        {"name": "y", "type": "string", "required": True},
     ]
     assert model.signature.outputs.to_dict() == [
-        {"type": "string"},
+        {"type": "string", "required": True},
     ]
 
     model = mlflow.pyfunc.load_model(tmp_path)
@@ -266,11 +266,11 @@ def test_chat_multiple_messages(tmp_path):
     )
     model = mlflow.models.Model.load(tmp_path)
     assert model.signature.inputs.to_dict() == [
-        {"name": "x", "type": "string"},
-        {"name": "y", "type": "string"},
+        {"name": "x", "type": "string", "required": True},
+        {"name": "y", "type": "string", "required": True},
     ]
     assert model.signature.outputs.to_dict() == [
-        {"type": "string"},
+        {"type": "string", "required": True},
     ]
 
     model = mlflow.pyfunc.load_model(tmp_path)
@@ -308,10 +308,10 @@ def test_chat_no_variables(tmp_path):
     )
     model = mlflow.models.Model.load(tmp_path)
     assert model.signature.inputs.to_dict() == [
-        {"type": "string"},
+        {"type": "string", "required": True},
     ]
     assert model.signature.outputs.to_dict() == [
-        {"type": "string"},
+        {"type": "string", "required": True},
     ]
 
     model = mlflow.pyfunc.load_model(tmp_path)
@@ -379,10 +379,10 @@ def test_chat_no_messages(tmp_path):
     )
     model = mlflow.models.Model.load(tmp_path)
     assert model.signature.inputs.to_dict() == [
-        {"type": "string"},
+        {"type": "string", "required": True},
     ]
     assert model.signature.outputs.to_dict() == [
-        {"type": "string"},
+        {"type": "string", "required": True},
     ]
 
     model = mlflow.pyfunc.load_model(tmp_path)
@@ -554,7 +554,7 @@ def test_embeddings(tmp_path):
     )
 
     model = mlflow.models.Model.load(tmp_path)
-    assert model.signature.inputs.to_dict() == [{"type": "string"}]
+    assert model.signature.inputs.to_dict() == [{"type": "string", "required": True}]
     assert model.signature.outputs.to_dict() == [
         {"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": (-1,)}}
     ]

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -1068,7 +1068,9 @@ def test_autolog_signature_with_pipeline(lr_pipeline, dataset_text):
     with mlflow.start_run() as run:
         lr_pipeline.fit(dataset_text)
         _assert_autolog_infers_model_signature_correctly(
-            run, input_sig_spec=[{"name": "text", "type": "string"}], output_sig_spec=None
+            run,
+            input_sig_spec=[{"name": "text", "type": "string", "required": True}],
+            output_sig_spec=None,
         )
 
 
@@ -1095,7 +1097,9 @@ def test_autolog_signature_scalar_input_and_non_scalar_output(dataset_numeric):
         with open(ml_model_path) as f:
             data = yaml.safe_load(f)
             signature = data["signature"]
-            assert json.loads(signature["inputs"]) == [{"name": "number", "type": "double"}]
+            assert json.loads(signature["inputs"]) == [
+                {"name": "number", "type": "double", "required": True}
+            ]
             assert signature["outputs"] is None
 
 
@@ -1143,7 +1147,9 @@ def test_signature_with_index_to_string_stage(
     with mlflow.start_run() as run:
         multinomial_lr_with_index_to_string_stage_pipeline.fit(multinomial_df_with_string_labels)
         _assert_autolog_infers_model_signature_correctly(
-            run, input_sig_spec=[{"name": "id", "type": "long"}], output_sig_spec=None
+            run,
+            input_sig_spec=[{"name": "id", "type": "long", "required": True}],
+            output_sig_spec=None,
         )
 
 
@@ -1186,7 +1192,7 @@ def test_signature_with_non_feature_input_columns(
         pipeline_for_feature_cols.fit(input_df_with_non_features)
         _assert_autolog_infers_model_signature_correctly(
             run,
-            input_sig_spec=[{"name": "id", "type": "long"}],
+            input_sig_spec=[{"name": "id", "type": "long", "required": True}],
             output_sig_spec=None,
         )
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10452?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10452/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10452
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Triggered cross-version tests https://github.com/mlflow/mlflow/actions/runs/6901280109 Fix them.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
