### PR TITLE
Deprecation warning for `mlflow.gateway`

### DIFF
--- a/docs/source/llms/gateway/deprecation.rst
+++ b/docs/source/llms/gateway/deprecation.rst
@@ -1,0 +1,6 @@
+.. _gateway-deprecation:
+
+MLflow AI Gateway Deprecation
+=============================
+
+TODO

--- a/docs/source/llms/gateway/index.rst
+++ b/docs/source/llms/gateway/index.rst
@@ -6,7 +6,8 @@ MLflow AI Gateway (Experimental)
 
 .. warning::
 
-    The MLflow AI Gateway is a new, **experimental feature**. It is subject to modification, feature improvements, or feature removal without advance notice.
+    The MLflow AI Gateway is deprecated and will be replaced by the deployments API in a future release.
+    See :ref:`gateway-deprecation` for more information.
 
 The MLflow AI Gateway service is a powerful tool designed to streamline the usage and management of
 various large language model (LLM) providers, such as OpenAI and Anthropic, within an organization.
@@ -33,6 +34,7 @@ organizations that use LLMs on a regular basis.
     :hidden:
 
     guides/index
+    deprecation
 
 Tutorials and Guides
 ====================

--- a/docs/source/llms/gateway/index.rst
+++ b/docs/source/llms/gateway/index.rst
@@ -6,7 +6,7 @@ MLflow AI Gateway (Experimental)
 
 .. warning::
 
-    The MLflow AI Gateway is deprecated and will be replaced by the deployments API in a future release.
+    MLflow AI gateway is deprecated and has been replaced by the deployments API for generative AI.
     See :ref:`gateway-deprecation` for more information.
 
 The MLflow AI Gateway service is a powerful tool designed to streamline the usage and management of

--- a/mlflow/gateway/__init__.py
+++ b/mlflow/gateway/__init__.py
@@ -1,7 +1,7 @@
 """
 .. warning::
 
-    `mlflow.gateway` is deprecated and will be replaced by the deployments API in a future release.
+    MLflow AI gateway is deprecated and has been replaced by the deployments API for generative AI.
     See :ref:`gateway-deprecation` for more details.",
 """
 from mlflow.gateway.client import MlflowGatewayClient

--- a/mlflow/gateway/__init__.py
+++ b/mlflow/gateway/__init__.py
@@ -4,8 +4,6 @@
     `mlflow.gateway` is deprecated and will be replaced by the deployments API in a future release.
     See :ref:`gateway-deprecation` for more details.",
 """
-import warnings
-
 from mlflow.gateway.client import MlflowGatewayClient
 from mlflow.gateway.fluent import (
     create_route,
@@ -17,12 +15,6 @@ from mlflow.gateway.fluent import (
     set_limits,
 )
 from mlflow.gateway.utils import get_gateway_uri, set_gateway_uri
-
-warnings.warn(
-    "`mlflow.gateway` is deprecated and will be replaced by the deployments API in a future "
-    "release.  See https://mlflow.org/docs/latest/llms/gateway/deprecation.html for more details.",
-    FutureWarning,
-)
 
 __all__ = [
     "create_route",

--- a/mlflow/gateway/__init__.py
+++ b/mlflow/gateway/__init__.py
@@ -1,3 +1,11 @@
+"""
+.. warning::
+
+    `mlflow.gateway` is deprecated and will be replaced by the deployments API in a future release.
+    See :ref:`gateway-deprecation` for more details.",
+"""
+import warnings
+
 from mlflow.gateway.client import MlflowGatewayClient
 from mlflow.gateway.fluent import (
     create_route,
@@ -9,6 +17,12 @@ from mlflow.gateway.fluent import (
     set_limits,
 )
 from mlflow.gateway.utils import get_gateway_uri, set_gateway_uri
+
+warnings.warn(
+    "`mlflow.gateway` is deprecated and will be replaced by the deployments API in a future "
+    "release.  See https://mlflow.org/docs/latest/llms/gateway/deprecation.html for more details.",
+    FutureWarning,
+)
 
 __all__ = [
     "create_route",

--- a/mlflow/gateway/cli.py
+++ b/mlflow/gateway/cli.py
@@ -19,7 +19,6 @@ def commands():
     pass
 
 
-@gateway_deprecated
 @commands.command("start", help="Start the MLflow Gateway service")
 @click.option(
     "--config-path",
@@ -43,5 +42,6 @@ def commands():
     default=2,
     help="The number of workers.",
 )
+@gateway_deprecated
 def start(config_path: str, host: str, port: str, workers: int):
     run_app(config_path=config_path, host=host, port=port, workers=workers)

--- a/mlflow/gateway/cli.py
+++ b/mlflow/gateway/cli.py
@@ -3,7 +3,7 @@ import click
 from mlflow.environment_variables import MLFLOW_GATEWAY_CONFIG
 from mlflow.gateway.config import _validate_config
 from mlflow.gateway.runner import run_app
-from mlflow.utils.annotations import experimental
+from mlflow.gateway.utils import gateway_deprecated
 
 
 def validate_config_path(_ctx, _param, value):
@@ -19,7 +19,7 @@ def commands():
     pass
 
 
-@experimental
+@gateway_deprecated
 @commands.command("start", help="Start the MLflow Gateway service")
 @click.option(
     "--config-path",

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -14,11 +14,15 @@ from mlflow.gateway.constants import (
     MLFLOW_GATEWAY_ROUTE_BASE,
     MLFLOW_QUERY_SUFFIX,
 )
-from mlflow.gateway.utils import assemble_uri_path, get_gateway_uri, resolve_route_url
+from mlflow.gateway.utils import (
+    assemble_uri_path,
+    gateway_deprecated,
+    get_gateway_uri,
+    resolve_route_url,
+)
 from mlflow.protos.databricks_pb2 import BAD_REQUEST
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.tracking._tracking_service.utils import _get_default_host_creds
-from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.rest_utils import augmented_raise_for_status, http_request
 from mlflow.utils.uri import get_uri_scheme
@@ -26,7 +30,7 @@ from mlflow.utils.uri import get_uri_scheme
 _logger = logging.getLogger(__name__)
 
 
-@experimental
+@gateway_deprecated
 class MlflowGatewayClient:
     """
     Client for interacting with the MLflow Gateway API.
@@ -97,7 +101,7 @@ class MlflowGatewayClient:
         augmented_raise_for_status(response)
         return response
 
-    @experimental
+    @gateway_deprecated
     def get_route(self, name: str):
         """
         Get a specific query route from the gateway. The routes that are available to retrieve
@@ -115,7 +119,7 @@ class MlflowGatewayClient:
 
         return Route(**response)
 
-    @experimental
+    @gateway_deprecated
     def search_routes(self, page_token: Optional[str] = None) -> PagedList[Route]:
         """
         Search for routes in the Gateway.
@@ -145,7 +149,7 @@ class MlflowGatewayClient:
         next_page_token = response_json.get("next_page_token")
         return PagedList(routes, next_page_token)
 
-    @experimental
+    @gateway_deprecated
     def create_route(
         self, name: str, route_type: Optional[str] = None, model: Optional[Dict[str, Any]] = None
     ) -> Route:
@@ -222,7 +226,7 @@ class MlflowGatewayClient:
         ).json()
         return Route(**response)
 
-    @experimental
+    @gateway_deprecated
     def delete_route(self, name: str) -> None:
         """
         Delete an existing route in the Gateway.
@@ -258,7 +262,7 @@ class MlflowGatewayClient:
         route = assemble_uri_path([MLFLOW_GATEWAY_CRUD_ROUTE_BASE, name])
         self._call_endpoint("DELETE", route)
 
-    @experimental
+    @gateway_deprecated
     def query(self, route: str, data: Dict[str, Any]):
         """
         Submit a query to a configured provider route.
@@ -347,7 +351,7 @@ class MlflowGatewayClient:
             else:
                 raise e
 
-    @experimental
+    @gateway_deprecated
     def set_limits(self, route: str, limits: List[Dict[str, Any]]) -> LimitsConfig:
         """
         Set limits on an existing route in the Gateway.
@@ -394,7 +398,7 @@ class MlflowGatewayClient:
         ).json()
         return LimitsConfig(**response)
 
-    @experimental
+    @gateway_deprecated
     def get_limits(self, route: str) -> LimitsConfig:
         """
         Get limits of an existing route in the Gateway.

--- a/mlflow/gateway/fluent.py
+++ b/mlflow/gateway/fluent.py
@@ -3,11 +3,11 @@ from typing import Any, Dict, List, Optional
 from mlflow.gateway.client import MlflowGatewayClient
 from mlflow.gateway.config import LimitsConfig, Route
 from mlflow.gateway.constants import MLFLOW_GATEWAY_SEARCH_ROUTES_PAGE_SIZE
+from mlflow.gateway.utils import gateway_deprecated
 from mlflow.utils import get_results_from_paginated_fn
-from mlflow.utils.annotations import experimental
 
 
-@experimental
+@gateway_deprecated
 def get_route(name: str) -> Route:
     """
     Retrieves a specific route from the MLflow Gateway service.
@@ -21,7 +21,7 @@ def get_route(name: str) -> Route:
     return MlflowGatewayClient().get_route(name)
 
 
-@experimental
+@gateway_deprecated
 def search_routes() -> List[Route]:
     """
     Searches for routes in the MLflow Gateway service.
@@ -42,7 +42,7 @@ def search_routes() -> List[Route]:
     )
 
 
-@experimental
+@gateway_deprecated
 def create_route(
     name: str, route_type: Optional[str] = None, model: Optional[Dict[str, Any]] = None
 ) -> Route:
@@ -102,7 +102,7 @@ def create_route(
     return MlflowGatewayClient().create_route(name, route_type, model)
 
 
-@experimental
+@gateway_deprecated
 def delete_route(name: str) -> None:
     """
     Delete an existing route in the Gateway.
@@ -129,7 +129,7 @@ def delete_route(name: str) -> None:
     MlflowGatewayClient().delete_route(name)
 
 
-@experimental
+@gateway_deprecated
 def set_limits(route: str, limits: List[Dict[str, Any]]) -> LimitsConfig:
     """
     Set limits on an existing route in the Gateway.
@@ -155,7 +155,7 @@ def set_limits(route: str, limits: List[Dict[str, Any]]) -> LimitsConfig:
     return MlflowGatewayClient().set_limits(route=route, limits=limits)
 
 
-@experimental
+@gateway_deprecated
 def get_limits(route: str) -> LimitsConfig:
     """
     Get limits of an existing route in the Gateway.
@@ -180,7 +180,7 @@ def get_limits(route: str) -> LimitsConfig:
     return MlflowGatewayClient().get_limits(route=route)
 
 
-@experimental
+@gateway_deprecated
 def query(route: str, data):
     """
     Issues a query request to a configured service through a named route on the Gateway Server.

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 from mlflow.environment_variables import MLFLOW_GATEWAY_URI
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.constants import MLFLOW_AI_GATEWAY_MOSAICML_CHAT_SUPPORTED_MODEL_PREFIXES
-from mlflow.utils.annotations import experimental
+from mlflow.utils.annotations import deprecated
 from mlflow.utils.uri import append_to_uri_path
 
 _logger = logging.getLogger(__name__)
@@ -68,7 +68,19 @@ def _is_valid_uri(uri: str):
         return False
 
 
-@experimental
+def gateway_deprecated(f):
+    deco = deprecated(
+        "2.9.0",
+        impact=(
+            "`mlflow.gateway` is deprecated and will be replaced by the deployments API in "
+            "a future release.  See https://mlflow.org/docs/latest/llms/gateway/deprecation.html "
+            "for more details"
+        ),
+    )
+    return deco(f)
+
+
+@gateway_deprecated
 def set_gateway_uri(gateway_uri: str):
     """
     Sets the uri of a configured and running MLflow AI Gateway server in a global context.
@@ -88,7 +100,7 @@ def set_gateway_uri(gateway_uri: str):
     _gateway_uri = gateway_uri
 
 
-@experimental
+@gateway_deprecated
 def get_gateway_uri() -> str:
     """
     Returns the currently set MLflow AI Gateway server uri iff set.

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -72,9 +72,8 @@ def gateway_deprecated(f):
     deco = deprecated(
         "2.9.0",
         impact=(
-            "`mlflow.gateway` is deprecated and will be replaced by the deployments API in "
-            "a future release.  See https://mlflow.org/docs/latest/llms/gateway/deprecation.html "
-            "for more details"
+            "It will be replaced by the deployments API in a future release. "
+            "See https://mlflow.org/docs/latest/llms/gateway/deprecation.html for more details."
         ),
     )
     return deco(f)

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -92,8 +92,9 @@ def _prepend(docstring: Optional[str], text: str) -> str:
 
 def gateway_deprecated(obj):
     msg = (
-        "MLflow AI gateway is deprecated and has been replaced by the deployments API for generative AI. "
-        "See https://mlflow.org/docs/latest/llms/gateway/deprecation.html for more details."
+        "MLflow AI gateway is deprecated and has been replaced by the deployments API for "
+        "generative AI. See https://mlflow.org/docs/latest/llms/gateway/deprecation.html for "
+        "more details."
     )
     warning = f"""
 .. warning::

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -92,7 +92,7 @@ def _prepend(docstring: Optional[str], text: str) -> str:
 
 def gateway_deprecated(obj):
     msg = (
-        "MLflow AI gateway is deprecated and will be replaced by the deployments API. "
+        "MLflow AI gateway is deprecated and has been replaced by the deployments API for generative AI. "
         "See https://mlflow.org/docs/latest/llms/gateway/deprecation.html for more details."
     )
     warning = f"""


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10460?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10460/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10460
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Deprecation warning for `mlflow.gateway`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
