### PR TITLE
Improve `_parse_spark_datatype` function code

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1001,22 +1001,19 @@ def _parse_spark_datatype(datatype: str):
 
     return_type = "boolean" if datatype == "bool" else datatype
     parsed_datatype = udf(lambda x: x, returnType=return_type).returnType
-    try:
-        from pyspark.sql.connect.types import UnparsedDataType
 
+    if parsed_datatype.typeName() == "UnparsedData":
         # For spark 3.5.x, `udf(lambda x: x, returnType=return_type).returnType`
         # returns UnparsedDataType, which is not compatible with signature inference.
         # Note: SparkSession.active only exists for spark >= 3.5.0
-        if isinstance(parsed_datatype, UnparsedDataType):
-            schema = (
-                SparkSession.active()
+        schema = (
+            SparkSession.active()
                 .range(0)
                 .select(udf(lambda x: x, returnType=return_type)("id"))
                 .schema
-            )
-            return schema[0].dataType
-    except ImportError:
-        pass
+        )
+        return schema[0].dataType
+
     return parsed_datatype
 
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1008,9 +1008,9 @@ def _parse_spark_datatype(datatype: str):
         # Note: SparkSession.active only exists for spark >= 3.5.0
         schema = (
             SparkSession.active()
-                .range(0)
-                .select(udf(lambda x: x, returnType=return_type)("id"))
-                .schema
+            .range(0)
+            .select(udf(lambda x: x, returnType=return_type)("id"))
+            .schema
         )
         return schema[0].dataType
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1002,7 +1002,7 @@ def _parse_spark_datatype(datatype: str):
     return_type = "boolean" if datatype == "bool" else datatype
     parsed_datatype = udf(lambda x: x, returnType=return_type).returnType
 
-    if parsed_datatype.typeName() == "UnparsedData":
+    if parsed_datatype.typeName() == "unparseddata":
         # For spark 3.5.x, `udf(lambda x: x, returnType=return_type).returnType`
         # returns UnparsedDataType, which is not compatible with signature inference.
         # Note: SparkSession.active only exists for spark >= 3.5.0

--- a/tests/spark/test_spark_connect_model_export.py
+++ b/tests/spark/test_spark_connect_model_export.py
@@ -138,4 +138,3 @@ def test_pyfunc_serve_and_score(spark_model):
     np.testing.assert_array_almost_equal(
         scores, spark_model.model.transform(spark_model.pandas_df)["prediction"].values
     )
-

--- a/tests/spark/test_spark_connect_model_export.py
+++ b/tests/spark/test_spark_connect_model_export.py
@@ -138,3 +138,4 @@ def test_pyfunc_serve_and_score(spark_model):
     np.testing.assert_array_almost_equal(
         scores, spark_model.model.transform(spark_model.pandas_df)["prediction"].values
     )
+


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/10461?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10461/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10461
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Improve `_parse_spark_datatype` function code:

Removes redundant try...except block, and makes code more clear.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
