### PR TITLE
Use `create_tmp_dir` when creating a temporary directory

### DIFF
--- a/mlflow/data/http_dataset_source.py
+++ b/mlflow/data/http_dataset_source.py
@@ -1,7 +1,6 @@
 import os
 import posixpath
 import re
-import tempfile
 from typing import Any, Dict
 from urllib.parse import urlparse
 

--- a/mlflow/data/http_dataset_source.py
+++ b/mlflow/data/http_dataset_source.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 from mlflow.data.dataset_source import DatasetSource
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.utils.file_utils import create_tmp_dir
 from mlflow.utils.rest_utils import augmented_raise_for_status, cloud_storage_http_request
 
 
@@ -63,7 +64,7 @@ class HTTPDatasetSource(DatasetSource):
             basename = "dataset_source"
 
         if dst_path is None:
-            dst_path = tempfile.mkdtemp()
+            dst_path = create_tmp_dir()
 
         dst_path = os.path.join(dst_path, basename)
         with open(dst_path, "wb") as f:

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import posixpath
-import tempfile
 from abc import ABCMeta, abstractmethod
 from concurrent.futures import ThreadPoolExecutor, as_completed
 

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -10,7 +10,7 @@ from mlflow.environment_variables import MLFLOW_ENABLE_ARTIFACTS_PROGRESS_BAR
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST
 from mlflow.utils.annotations import developer_stable
-from mlflow.utils.file_utils import ArtifactProgressBar
+from mlflow.utils.file_utils import ArtifactProgressBar, create_tmp_dir
 from mlflow.utils.validation import bad_path_message, path_not_unique
 
 # Constants used to determine max level of parallelism to use while uploading/downloading artifacts.
@@ -172,7 +172,7 @@ class ArtifactRepository:
                     error_code=INVALID_PARAMETER_VALUE,
                 )
         else:
-            dst_path = tempfile.mkdtemp()
+            dst_path = create_tmp_dir()
 
         def _download_file(src_artifact_path, dst_local_dir_path):
             dst_local_file_path = self._create_download_destination(

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -849,9 +849,11 @@ def _get_tmp_dir():
 
 
 def create_tmp_dir():
-    directory = _get_tmp_dir()
-    os.makedirs(directory, exist_ok=True)
-    return tempfile.mkdtemp(dir=directory)
+    if directory := _get_tmp_dir():
+        os.makedirs(directory, exist_ok=True)
+        return tempfile.mkdtemp(dir=directory)
+
+    return tempfile.mkdtemp()
 
 
 @cache_return_value_per_process

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -833,19 +833,25 @@ def _handle_readonly_on_windows(func, path, exc_info):
     func(path)
 
 
-def create_tmp_dir():
+def _get_tmp_dir():
     from mlflow.utils.databricks_utils import get_repl_id, is_in_databricks_runtime
 
-    if is_in_databricks_runtime() and get_repl_id() is not None:
+    if is_in_databricks_runtime():
         try:
-            repl_local_tmp_dir = _get_dbutils().entry_point.getReplLocalTempDir()
+            return _get_dbutils().entry_point.getReplLocalTempDir()
         except Exception:
-            repl_local_tmp_dir = os.path.join("/tmp", "repl_tmp_data", get_repl_id())
+            pass
 
-        os.makedirs(repl_local_tmp_dir, exist_ok=True)
-        return tempfile.mkdtemp(dir=repl_local_tmp_dir)
-    else:
-        return tempfile.mkdtemp()
+        if repl_id := get_repl_id():
+            return os.path.join("/tmp", "repl_tmp_data", repl_id)
+
+    return None
+
+
+def create_tmp_dir():
+    directory = _get_tmp_dir()
+    os.makedirs(directory, exist_ok=True)
+    return tempfile.mkdtemp(dir=directory)
 
 
 @cache_return_value_per_process


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10462?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10462/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10462
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Use `create_tmp_dir` on Databricks when a temporary directory is needed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
