### PR TITLE
Make spark_udf use NFS to broadcast model to spark executor on databricks runtime and spark connect mode

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1261,7 +1261,7 @@ def spark_udf(
     # If client code is executed in databricks runtime and NFS is available,
     # In driver side, we save model to NFS temp directory,
     # then in executor side we can load model from the NFS temp directory.
-    should_spark_connect_use_nfs = (is_in_databricks_runtime() and should_use_nfs)
+    should_spark_connect_use_nfs = is_in_databricks_runtime() and should_use_nfs
 
     if (
         is_spark_connect

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1595,7 +1595,7 @@ Compound types:
         elif env_manager == _EnvManager.LOCAL:
             if is_spark_connect and not should_spark_connect_use_nfs:
                 model_path = os.path.join(
-                    create_tmp_dir(),
+                    tempfile.gettempdir(),
                     "mlflow",
                     insecure_hash.sha1(model_uri.encode()).hexdigest(),
                 )

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1489,6 +1489,13 @@ Compound types:
 
     tracking_uri = mlflow.get_tracking_uri()
 
+    if is_spark_connect and not should_spark_connect_use_nfs:
+        spark_connect_temp_model_path = os.path.join(
+            create_tmp_dir(),
+            "mlflow",
+            insecure_hash.sha1(model_uri.encode()).hexdigest(),
+        )
+
     @pandas_udf(result_type)
     def udf(
         iterator: Iterator[Tuple[Union[pandas.Series, pandas.DataFrame], ...]]
@@ -1594,11 +1601,7 @@ Compound types:
 
         elif env_manager == _EnvManager.LOCAL:
             if is_spark_connect and not should_spark_connect_use_nfs:
-                model_path = os.path.join(
-                    create_tmp_dir(),
-                    "mlflow",
-                    insecure_hash.sha1(model_uri.encode()).hexdigest(),
-                )
+                model_path = spark_connect_temp_model_path
                 try:
                     loaded_model = mlflow.pyfunc.load_model(model_path)
                 except Exception:

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -286,6 +286,7 @@ from mlflow.utils.environment import (
 )
 from mlflow.utils.file_utils import (
     _copy_file_or_tree,
+    create_tmp_dir,
     get_or_create_nfs_tmp_dir,
     get_or_create_tmp_dir,
     get_total_file_size,
@@ -1239,7 +1240,6 @@ def spark_udf(
     from mlflow.utils._spark_utils import _SparkDirectoryDistributor
 
     is_spark_connect = _is_spark_connect()
-
     # Used in test to force install local version of mlflow when starting a model server
     mlflow_home = os.environ.get("MLFLOW_HOME")
     openai_env_vars = mlflow.openai._OpenAIEnvVar.read_environ()
@@ -1529,8 +1529,6 @@ Compound types:
                     model_uri=local_model_path_on_executor, capture_output=True
                 )
             else:
-                if is_spark_connect:
-                    assert should_spark_connect_use_nfs
                 local_model_path_on_executor = None
 
             if check_port_connectivity():
@@ -1600,7 +1598,7 @@ Compound types:
                     loaded_model = mlflow.pyfunc.load_model(local_model_path)
                 else:
                     model_path = os.path.join(
-                        tempfile.gettempdir(),
+                        create_tmp_dir(),
                         "mlflow",
                         insecure_hash.sha1(model_uri.encode()).hexdigest(),
                     )

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1259,8 +1259,8 @@ def spark_udf(
 
     # For spark connect mode,
     # If client code is executed in databricks runtime and NFS is available,
-    # In driver side, we save model to NFS temp directory,
-    # then in executor side we can load model from the NFS temp directory.
+    # we save model to NFS temp directory in the driver
+    # and load the model in the executor.
     should_spark_connect_use_nfs = is_in_databricks_runtime() and should_use_nfs
 
     if (

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1489,13 +1489,6 @@ Compound types:
 
     tracking_uri = mlflow.get_tracking_uri()
 
-    if is_spark_connect and not should_spark_connect_use_nfs:
-        spark_connect_temp_model_path = os.path.join(
-            create_tmp_dir(),
-            "mlflow",
-            insecure_hash.sha1(model_uri.encode()).hexdigest(),
-        )
-
     @pandas_udf(result_type)
     def udf(
         iterator: Iterator[Tuple[Union[pandas.Series, pandas.DataFrame], ...]]
@@ -1601,7 +1594,11 @@ Compound types:
 
         elif env_manager == _EnvManager.LOCAL:
             if is_spark_connect and not should_spark_connect_use_nfs:
-                model_path = spark_connect_temp_model_path
+                model_path = os.path.join(
+                    create_tmp_dir(),
+                    "mlflow",
+                    insecure_hash.sha1(model_uri.encode()).hexdigest(),
+                )
                 try:
                     loaded_model = mlflow.pyfunc.load_model(model_path)
                 except Exception:

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1269,7 +1269,7 @@ def spark_udf(
         and not should_spark_connect_use_nfs
     ):
         raise MlflowException.invalid_parameter_value(
-            f"Environment manager {env_manager!r} is not supported in Spark connect mode when "
+            f"Environment manager {env_manager!r} is not supported in Spark connect mode "
             "when either non-Databricks environment is in use or NFS is unavailable.",
         )
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1240,12 +1240,6 @@ def spark_udf(
 
     is_spark_connect = _is_spark_connect()
 
-    # For spark connect mode,
-    # If client code is executed in databricks runtime and NFS is available,
-    # In driver side, we save model to NFS temp directory,
-    # then in executor side we can load model from the NFS temp directory.
-    should_spark_connect_use_nfs = (is_in_databricks_runtime() and should_use_nfs)
-
     if (
         is_spark_connect
         and env_manager in (_EnvManager.VIRTUALENV, _EnvManager.CONDA)
@@ -1271,6 +1265,12 @@ def spark_udf(
     should_use_spark_to_broadcast_file = not (
         is_spark_in_local_mode or should_use_nfs or is_spark_connect
     )
+
+    # For spark connect mode,
+    # If client code is executed in databricks runtime and NFS is available,
+    # In driver side, we save model to NFS temp directory,
+    # then in executor side we can load model from the NFS temp directory.
+    should_spark_connect_use_nfs = (is_in_databricks_runtime() and should_use_nfs)
 
     local_model_path = _download_artifact_from_uri(
         artifact_uri=model_uri,

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1270,7 +1270,7 @@ def spark_udf(
     ):
         raise MlflowException.invalid_parameter_value(
             f"Environment manager {env_manager!r} is not supported in Spark connect mode when "
-            "in non-databricks runtime or NFS not available",
+            "when either non-Databricks environment is in use or NFS is unavailable.",
         )
 
     local_model_path = _download_artifact_from_uri(

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1240,15 +1240,6 @@ def spark_udf(
 
     is_spark_connect = _is_spark_connect()
 
-    if (
-        is_spark_connect
-        and env_manager in (_EnvManager.VIRTUALENV, _EnvManager.CONDA)
-        and not should_spark_connect_use_nfs
-    ):
-        raise MlflowException.invalid_parameter_value(
-            f"In non-databricks runtime or NFS is not available, "
-            f"environment manager {env_manager!r} is not supported in Spark connect mode.",
-        )
     # Used in test to force install local version of mlflow when starting a model server
     mlflow_home = os.environ.get("MLFLOW_HOME")
     openai_env_vars = mlflow.openai._OpenAIEnvVar.read_environ()
@@ -1271,6 +1262,16 @@ def spark_udf(
     # In driver side, we save model to NFS temp directory,
     # then in executor side we can load model from the NFS temp directory.
     should_spark_connect_use_nfs = (is_in_databricks_runtime() and should_use_nfs)
+
+    if (
+        is_spark_connect
+        and env_manager in (_EnvManager.VIRTUALENV, _EnvManager.CONDA)
+        and not should_spark_connect_use_nfs
+    ):
+        raise MlflowException.invalid_parameter_value(
+            f"In non-databricks runtime or NFS is not available, "
+            f"environment manager {env_manager!r} is not supported in Spark connect mode.",
+        )
 
     local_model_path = _download_artifact_from_uri(
         artifact_uri=model_uri,

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -286,7 +286,6 @@ from mlflow.utils.environment import (
 )
 from mlflow.utils.file_utils import (
     _copy_file_or_tree,
-    create_tmp_dir,
     get_or_create_nfs_tmp_dir,
     get_or_create_tmp_dir,
     get_total_file_size,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/10463?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10463/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10463
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Make spark_udf use NFS to broadcast model to spark executor on databricks runtime and spark connect mode.

If the client code is running in databricks runtime (e.g. running in a databricks notebook), then we can use NFS directory (e.g. dbutils.entry_point.getReplNFSTempDir()) to broadcast local model files to executor side, note databricks shared cluster also supporting this, the NFS directory is mounted to the same path in safe spark UDF container. 

Testing this on databricks shared cluster:
https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/1841156755475244/command/1841156755475277

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
