### PR TITLE
Suppress Pydantic warnings

### DIFF
--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -188,9 +188,7 @@ class MlflowModelServingConfig(ConfigModel):
 
     # Workaround to suppress warning that Pydantic raises when a field name starts with "model_".
     # https://github.com/mlflow/mlflow/issues/10335
-    model_config = pydantic.ConfigDict(
-        protected_namespaces=()
-    )
+    model_config = pydantic.ConfigDict(protected_namespaces=())
 
 
 class HuggingFaceTextGenerationInferenceConfig(ConfigModel):
@@ -407,6 +405,7 @@ class RouteModelInfo(ResponseModel):
     # support new providers without breaking the gateway client.
     provider: str
 
+
 _ROUTE_EXTRA_SCHEMA = {
     "example": {
         "name": "openai-completions",
@@ -418,6 +417,7 @@ _ROUTE_EXTRA_SCHEMA = {
         "route_url": "/gateway/routes/completions/invocations",
     }
 }
+
 
 class Route(ConfigModel):
     name: str

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -407,6 +407,17 @@ class RouteModelInfo(ResponseModel):
     # support new providers without breaking the gateway client.
     provider: str
 
+_ROUTE_EXTRA_SCHEMA = {
+    "example": {
+        "name": "openai-completions",
+        "route_type": "llm/v1/completions",
+        "model": {
+            "name": "gpt-3.5-turbo",
+            "provider": "openai",
+        },
+        "route_url": "/gateway/routes/completions/invocations",
+    }
+}
 
 class Route(ConfigModel):
     name: str
@@ -415,17 +426,10 @@ class Route(ConfigModel):
     route_url: str
 
     class Config:
-        schema_extra = {
-            "example": {
-                "name": "openai-completions",
-                "route_type": "llm/v1/completions",
-                "model": {
-                    "name": "gpt-3.5-turbo",
-                    "provider": "openai",
-                },
-                "route_url": "/gateway/routes/completions/invocations",
-            }
-        }
+        if IS_PYDANTIC_V2:
+            json_schema_extra = _ROUTE_EXTRA_SCHEMA
+        else:
+            schema_extra = _ROUTE_EXTRA_SCHEMA
 
     def to_endpoint(self):
         from mlflow.deployments.server.config import Endpoint

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -186,6 +186,12 @@ class PaLMConfig(ConfigModel):
 class MlflowModelServingConfig(ConfigModel):
     model_server_url: str
 
+    # Workaround to suppress warning that Pydantic raises when a field name starts with "model_".
+    # https://github.com/mlflow/mlflow/issues/10335
+    model_config = pydantic.ConfigDict(
+        protected_namespaces=()
+    )
+
 
 class HuggingFaceTextGenerationInferenceConfig(ConfigModel):
     hf_server_url: str

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -17,6 +17,7 @@ class BaseRequestPayload(RequestModel):
     stop: Optional[List[str]] = Field(None, min_items=1)
     max_tokens: Optional[int] = Field(None, ge=1)
 
+
 _REQUEST_PAYLOAD_EXTRA_SCHEMA = {
     "messages": [
         {"role": "system", "content": "You are a helpful assistant."},
@@ -27,6 +28,7 @@ _REQUEST_PAYLOAD_EXTRA_SCHEMA = {
     "stop": ["END"],
     "n": 1,
 }
+
 
 class RequestPayload(BaseRequestPayload):
     messages: List[RequestMessage] = Field(..., min_items=1)
@@ -71,6 +73,7 @@ _RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
         "usage": {"prompt_tokens": 10, "completion_tokens": 8, "total_tokens": 18},
     }
 }
+
 
 class ResponsePayload(ResponseModel):
     id: Optional[str] = None

--- a/mlflow/gateway/schemas/completions.py
+++ b/mlflow/gateway/schemas/completions.py
@@ -4,8 +4,7 @@ from mlflow.gateway.base_models import ResponseModel
 from mlflow.gateway.config import IS_PYDANTIC_V2
 from mlflow.gateway.schemas.chat import BaseRequestPayload
 
-
-_REQUEST_PAYLOAD_EXTRA_SCHEMA =  {
+_REQUEST_PAYLOAD_EXTRA_SCHEMA = {
     "example": {
         "prompt": "hello",
         "temperature": 0.0,
@@ -14,6 +13,7 @@ _REQUEST_PAYLOAD_EXTRA_SCHEMA =  {
         "candidate_count": 1,
     }
 }
+
 
 class RequestPayload(BaseRequestPayload):
     prompt: str
@@ -49,6 +49,7 @@ _RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
         "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
     }
 }
+
 
 class ResponsePayload(ResponseModel):
     id: Optional[str] = None

--- a/mlflow/gateway/schemas/completions.py
+++ b/mlflow/gateway/schemas/completions.py
@@ -1,22 +1,28 @@
 from typing import List, Literal, Optional
 
 from mlflow.gateway.base_models import ResponseModel
+from mlflow.gateway.config import IS_PYDANTIC_V2
 from mlflow.gateway.schemas.chat import BaseRequestPayload
 
+
+_REQUEST_PAYLOAD_EXTRA_SCHEMA =  {
+    "example": {
+        "prompt": "hello",
+        "temperature": 0.0,
+        "max_tokens": 64,
+        "stop": ["END"],
+        "candidate_count": 1,
+    }
+}
 
 class RequestPayload(BaseRequestPayload):
     prompt: str
 
     class Config:
-        schema_extra = {
-            "example": {
-                "prompt": "hello",
-                "temperature": 0.0,
-                "max_tokens": 64,
-                "stop": ["END"],
-                "candidate_count": 1,
-            }
-        }
+        if IS_PYDANTIC_V2:
+            json_schema_extra = _REQUEST_PAYLOAD_EXTRA_SCHEMA
+        else:
+            schema_extra = _REQUEST_PAYLOAD_EXTRA_SCHEMA
 
 
 class Choice(ResponseModel):
@@ -31,6 +37,19 @@ class CompletionsUsage(ResponseModel):
     total_tokens: Optional[int] = None
 
 
+_RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
+    "example": {
+        "id": "cmpl-123",
+        "object": "text_completion",
+        "created": 1589478378,
+        "model": "gpt-4",
+        "choices": [
+            {"text": "Hello! I am an AI Assistant!", "index": 0, "finish_reason": "length"}
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+    }
+}
+
 class ResponsePayload(ResponseModel):
     id: Optional[str] = None
     object: Literal["text_completion"] = "text_completion"
@@ -40,15 +59,7 @@ class ResponsePayload(ResponseModel):
     usage: CompletionsUsage
 
     class Config:
-        schema_extra = {
-            "example": {
-                "id": "cmpl-123",
-                "object": "text_completion",
-                "created": 1589478378,
-                "model": "gpt-4",
-                "choices": [
-                    {"text": "Hello! I am an AI Assistant!", "index": 0, "finish_reason": "length"}
-                ],
-                "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
-            }
-        }
+        if IS_PYDANTIC_V2:
+            json_schema_extra = _RESPONSE_PAYLOAD_EXTRA_SCHEMA
+        else:
+            schema_extra = _RESPONSE_PAYLOAD_EXTRA_SCHEMA

--- a/mlflow/gateway/schemas/embeddings.py
+++ b/mlflow/gateway/schemas/embeddings.py
@@ -3,12 +3,12 @@ from typing import List, Literal, Optional, Union
 from mlflow.gateway.base_models import RequestModel, ResponseModel
 from mlflow.gateway.config import IS_PYDANTIC_V2
 
-
 _REQUEST_PAYLOAD_EXTRA_SCHEMA = {
     "example": {
         "text": ["hello", "world"],
     }
 }
+
 
 class RequestPayload(RequestModel):
     input: Union[str, List[str]]

--- a/mlflow/gateway/schemas/embeddings.py
+++ b/mlflow/gateway/schemas/embeddings.py
@@ -1,17 +1,23 @@
 from typing import List, Literal, Optional, Union
 
 from mlflow.gateway.base_models import RequestModel, ResponseModel
+from mlflow.gateway.config import IS_PYDANTIC_V2
 
+
+_REQUEST_PAYLOAD_EXTRA_SCHEMA = {
+    "example": {
+        "text": ["hello", "world"],
+    }
+}
 
 class RequestPayload(RequestModel):
     input: Union[str, List[str]]
 
     class Config:
-        schema_extra = {
-            "example": {
-                "input": ["hello", "world"],
-            }
-        }
+        if IS_PYDANTIC_V2:
+            json_schema_extra = _REQUEST_PAYLOAD_EXTRA_SCHEMA
+        else:
+            schema_extra = _REQUEST_PAYLOAD_EXTRA_SCHEMA
 
 
 class EmbeddingObject(ResponseModel):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10483?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10483/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10483
```

</p>
</details>

### Related Issues/PRs

https://github.com/mlflow/mlflow/issues/10335

### What changes are proposed in this pull request?

Suppress two pydantic warnings that have been showing up since pydantic 2.5.0 release.

One is from namespace protection:
```
pydantic/_internal/_fields.py:127: UserWarning:
Field "model_server_url" has conflict with protected namespace "model_".
You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
```

The other is due to field name change ([ref](https://docs.pydantic.dev/latest/migration/#changes-to-config))
```
pydantic/_internal/_config.py:269: UserWarning:
Valid config keys have changed in V2:
* 'schema_extra' has been renamed to 'json_schema_extra'
```


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Output
```
[2023-11-22 12:59:29 +0900] [23286] [INFO] Starting gunicorn 21.2.0
[2023-11-22 12:59:29 +0900] [23286] [INFO] Listening at: http://127.0.0.1:5000 (23286)
[2023-11-22 12:59:29 +0900] [23286] [INFO] Using worker: sync
[2023-11-22 12:59:29 +0900] [23288] [INFO] Booting worker with pid: 23288
[2023-11-22 12:59:29 +0900] [23289] [INFO] Booting worker with pid: 23289
[2023-11-22 12:59:29 +0900] [23290] [INFO] Booting worker with pid: 23290
[2023-11-22 12:59:30 +0900] [23291] [INFO] Booting worker with pid: 23291
[2023-11-22 12:59:32 +0900] [23286] [INFO] Handling signal: int
[2023-11-22 12:59:32 +0900] [23291] [INFO] Worker exiting (pid: 23291)
[2023-11-22 12:59:32 +0900] [23288] [INFO] Worker exiting (pid: 23288)
[2023-11-22 12:59:32 +0900] [23289] [INFO] Worker exiting (pid: 23289)
[2023-11-22 12:59:32 +0900] [23290] [INFO] Worker exiting (pid: 23290)
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
