### PR TITLE
[FEAT] Adding default aggregate_results if the score type is numeric in make_metric api

### DIFF
--- a/examples/evaluation/evaluate_with_custom_code_metrics.py
+++ b/examples/evaluation/evaluate_with_custom_code_metrics.py
@@ -5,8 +5,7 @@ import pandas as pd
 
 import mlflow
 from mlflow.metrics import make_metric
-from mlflow.metrics.base import MetricValue
-from mlflow.metrics.metric_definitions import standard_aggregations
+from mlflow.metrics.base import MetricValue, standard_aggregations
 
 assert "OPENAI_API_KEY" in os.environ, "Please set the OPENAI_API_KEY environment variable."
 

--- a/mlflow/metrics/base.py
+++ b/mlflow/metrics/base.py
@@ -1,7 +1,18 @@
 from dataclasses import dataclass
 from typing import Dict, List, Union
 
+import numpy as np
+
 from mlflow.utils.annotations import experimental
+from mlflow.utils.validation import _is_numeric
+
+
+def standard_aggregations(scores):
+    return {
+        "mean": np.mean(scores),
+        "variance": np.var(scores),
+        "p90": np.percentile(scores, 90),
+    }
 
 
 @experimental
@@ -18,3 +29,15 @@ class MetricValue:
     scores: Union[List[str], List[float]] = None
     justifications: List[str] = None
     aggregate_results: Dict[str, float] = None
+
+    def __init__(self, scores=None, justifications=None, aggregate_results=None):
+        self.scores = scores
+        self.justifications = justifications
+        self.aggregate_results = aggregate_results
+
+        if (
+            self.aggregate_results is None
+            and isinstance(scores, (list, tuple))
+            and all(_is_numeric(score) for score in scores)
+        ):
+            self.aggregate_results = standard_aggregations(scores)

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -4,7 +4,7 @@ import os
 
 import numpy as np
 
-from mlflow.metrics.base import MetricValue
+from mlflow.metrics.base import MetricValue, standard_aggregations
 
 _logger = logging.getLogger(__name__)
 
@@ -18,14 +18,6 @@ targets_col_specifier = "the column specified by the `targets` parameter"
 predictions_col_specifier = (
     "the column specified by the `predictions` parameter or the model output column"
 )
-
-
-def standard_aggregations(scores):
-    return {
-        "mean": np.mean(scores),
-        "variance": np.var(scores),
-        "p90": np.percentile(scores, 90),
-    }
 
 
 def _validate_text_data(data, metric_name, col_specifier):
@@ -77,6 +69,7 @@ def _token_count_eval_fn(predictions, targets=None, metrics=None):
 
     return MetricValue(
         scores=num_tokens,
+        aggregate_results={},
     )
 
 

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2888,7 +2888,7 @@ def test_evaluate_no_model_type_with_custom_metric():
         )
         data = pd.DataFrame({"text": ["Hello world", "My name is MLflow"]})
         from mlflow.metrics import make_metric
-        from mlflow.metrics.metric_definitions import standard_aggregations
+        from mlflow.metrics.base import standard_aggregations
 
         def word_count_eval(predictions, targets=None, metrics=None):
             scores = []

--- a/tests/metrics/test_metric_base.py
+++ b/tests/metrics/test_metric_base.py
@@ -1,0 +1,38 @@
+from mlflow.metrics.base import MetricValue
+
+
+def test_metric_value():
+    metricValue1 = MetricValue(
+        scores=[1, 2, 3],
+        justifications=["foo", "bar", "baz"],
+        aggregate_results={"mean": 2},
+    )
+
+    metricValue2 = MetricValue(
+        scores=[1, 2, 3],
+        justifications=["foo", "bar", "baz"],
+    )
+
+    metricValue3 = MetricValue(scores=["1", "2", "3"])
+
+    metricValue4 = MetricValue(scores=[1, "2", "3"])
+
+    assert metricValue1.scores == [1, 2, 3]
+    assert metricValue1.justifications == ["foo", "bar", "baz"]
+    assert metricValue1.aggregate_results == {"mean": 2}
+
+    assert metricValue2.scores == [1, 2, 3]
+    assert metricValue2.justifications == ["foo", "bar", "baz"]
+    assert metricValue2.aggregate_results == {
+        "mean": 2.0,
+        "p90": 2.8,
+        "variance": 0.6666666666666666,
+    }
+
+    assert metricValue3.scores == ["1", "2", "3"]
+    assert metricValue3.justifications is None
+    assert metricValue3.aggregate_results is None
+
+    assert metricValue4.scores == [1, "2", "3"]
+    assert metricValue4.justifications is None
+    assert metricValue4.aggregate_results is None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sunishsheth2009/mlflow/pull/10490?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10490/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10490
```

</p>
</details>

### What changes are proposed in this pull request?
[FEAT] Adding default aggregate_results if the score type is numeric in make_metric api

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adding default aggregate_results if the score type is numeric in make_metric api

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
