### PR TITLE
Replace `TODO` in `DatabricksDeploymentClient`

### DIFF
--- a/examples/deployments/databricks.py
+++ b/examples/deployments/databricks.py
@@ -55,36 +55,40 @@ def main():
     )
     try:
         # Update served_entities
-        client.update_endpoint(
-            endpoint=name,
-            config={
-                "served_entities": [
-                    {
-                        "name": "test",
-                        "external_model": {
-                            "name": "gpt-4",
-                            "provider": "openai",
-                            "task": "llm/v1/chat",
-                            "openai_config": {
-                                "openai_api_key": "{{" + args.secret + "}}",
+        print(
+            client.update_endpoint(
+                endpoint=name,
+                config={
+                    "served_entities": [
+                        {
+                            "name": "test",
+                            "external_model": {
+                                "name": "gpt-4",
+                                "provider": "openai",
+                                "task": "llm/v1/chat",
+                                "openai_config": {
+                                    "openai_api_key": "{{" + args.secret + "}}",
+                                },
                             },
-                        },
-                    }
-                ],
-            },
+                        }
+                    ],
+                },
+            )
         )
         # Update rate_limits
-        client.update_endpoint(
-            endpoint=name,
-            config={
-                "rate_limits": [
-                    {
-                        "key": "user",
-                        "renewal_period": "minute",
-                        "calls": 10,
-                    }
-                ],
-            },
+        print(
+            client.update_endpoint(
+                endpoint=name,
+                config={
+                    "rate_limits": [
+                        {
+                            "key": "user",
+                            "renewal_period": "minute",
+                            "calls": 10,
+                        }
+                    ],
+                },
+            )
         )
         print(client.list_endpoints()[:3])
         print(client.get_endpoint(endpoint=name))

--- a/mlflow/deployments/__init__.py
+++ b/mlflow/deployments/__init__.py
@@ -17,7 +17,7 @@ import contextlib
 import json
 
 from mlflow.deployments.base import BaseDeploymentClient
-from mlflow.deployments.databricks import DatabricksDeploymentClient
+from mlflow.deployments.databricks import DatabricksDeploymentClient, DatabricksEndpoint
 from mlflow.deployments.interface import get_deploy_client, run_local
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
@@ -99,6 +99,7 @@ __all__ = [
     "run_local",
     "BaseDeploymentClient",
     "DatabricksDeploymentClient",
+    "DatabricksEndpoint",
     "MlflowDeploymentClient",
     "PredictionsResponse",
 ]

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -20,7 +20,7 @@ class DatabricksEndpoint(AttrDict):
 @experimental
 class DatabricksDeploymentClient(BaseDeploymentClient):
     """
-    TODO
+    Client for interacting with Databricks serving endpoints.
     """
 
     def create_deployment(self, name, model_uri, flavor=None, config=None, endpoint=None):
@@ -93,7 +93,30 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
     @experimental
     def predict(self, deployment_name=None, inputs=None, endpoint=None):
         """
-        TODO
+        Query a serving endpoint with provided model input.
+        See https://docs.databricks.com/api/workspace/servingendpoints/query for request/response
+        schema.
+
+        :param deployment_name: Unused.
+        :param inputs: A dictionary containing the model inputs to query.
+        :param endpoint: The name of the serving endpoint to query.
+        :return: A :py:class:`PredictionsResponse` object containing the predictions and metadata
+
+        Example:
+
+        .. code-block:: python
+
+            from mlflow.deployments import get_deploy_client
+
+            client = get_deploy_client("databricks")
+            client.predict(
+                endpoint="chat",
+                inputs={
+                    "messages": [
+                        {"role": "user", "content": "Hello!"},
+                    ],
+                },
+            )
         """
         return self._call_endpoint(
             method="POST",
@@ -106,7 +129,40 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
     @experimental
     def create_endpoint(self, name, config=None):
         """
-        TODO
+        Create a new serving endpoint with the provided name and configuration.
+        See https://docs.databricks.com/api/workspace/servingendpoints/create for request/response
+        schema.
+
+        :param name: The name of the serving endpoint to create.
+        :param config: A dictionary containing the configuration of the serving endpoint to create.
+        :return: A :py:class:`DatabricksEndpoint` object containing the created endpoint
+                 configuration.
+
+        Example:
+
+        .. code-block:: python
+
+            from mlflow.deployments import get_deploy_client
+
+            client = get_deploy_client("databricks")
+            client.create_endpoint(
+                name="chat",
+                config={
+                    "served_entities": [
+                        {
+                            "name": "test",
+                            "external_model": {
+                                "name": "gpt-4",
+                                "provider": "openai",
+                                "task": "llm/v1/chat",
+                                "openai_config": {
+                                    "openai_api_key": "{{secrets/scope/key}}",
+                                },
+                            },
+                        }
+                    ],
+                },
+            )
         """
         config = config.copy() if config else {}  # avoid mutating config
         extras = {}
@@ -119,7 +175,47 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
     @experimental
     def update_endpoint(self, endpoint, config=None):
         """
-        TODO
+        Update a specified serving endpoint with the provided configuration.
+        See https://docs.databricks.com/api/workspace/servingendpoints/updateconfig for
+        request/response schema.
+
+        :param endpoint: The name of the serving endpoint to update.
+        :param config: A dictionary containing the configuration of the serving endpoint to update.
+        :return: A :py:class:`DatabricksEndpoint` object containing the updated endpoint
+                 configuration.
+
+        Example:
+
+        .. code-block:: python
+
+            from mlflow.deployments import get_deploy_client
+
+            client = get_deploy_client("databricks")
+            client.update_endpoint(
+                endpoint="chat",
+                config={
+                    "served_entities": [
+                        {
+                            "name": "test",
+                            "external_model": {
+                                "name": "gpt-4",
+                                "provider": "openai",
+                                "task": "llm/v1/chat",
+                                "openai_config": {
+                                    "openai_api_key": "{{secrets/scope/key}}",
+                                },
+                            },
+                        }
+                    ],
+                    "rate_limits": [
+                        {
+                            "key": "user",
+                            "renewal_period": "minute",
+                            "calls": 10,
+                        }
+                    ],
+                },
+            )
         """
         if list(config) == ["rate_limits"]:
             return self._call_endpoint(
@@ -133,21 +229,64 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
     @experimental
     def delete_endpoint(self, endpoint):
         """
-        TODO
+        Delete a specified serving endpoint.
+        See https://docs.databricks.com/api/workspace/servingendpoints/delete for request/response
+        schema.
+
+        :param endpoint: The name of the serving endpoint to delete.
+        :return: A :py:class:`DatabricksEndpoint` object containing the deleted endpoint
+                 configuration.
+
+        Example:
+
+        .. code-block:: python
+
+                from mlflow.deployments import get_deploy_client
+
+                client = get_deploy_client("databricks")
+                client.delete_endpoint(endpoint="chat")
         """
         return self._call_endpoint(method="DELETE", route=endpoint)
 
     @experimental
     def list_endpoints(self):
         """
-        TODO
+        Retrieve all serving endpoints.
+        See https://docs.databricks.com/api/workspace/servingendpoints/list for request/response
+        schema.
+
+        :return: A list of :py:class:`DatabricksEndpoint` objects containing the endpoint
+                 configurations.
+
+        Example:
+
+        .. code-block:: python
+
+                from mlflow.deployments import get_deploy_client
+
+                client = get_deploy_client("databricks")
+                client.list_endpoints()
         """
         return self._call_endpoint(method="GET").endpoints
 
     @experimental
     def get_endpoint(self, endpoint):
         """
-        TODO
+        Get a specified serving endpoint.
+        See https://docs.databricks.com/api/workspace/servingendpoints/get for request/response
+        schema.
+
+        :param endpoint: The name of the serving endpoint to get.
+        :return: A :py:class:`DatabricksEndpoint` object containing the endpoint configuration.
+
+        Example:
+
+        .. code-block:: python
+
+                from mlflow.deployments import get_deploy_client
+
+                client = get_deploy_client("databricks")
+                client.get_endpoint(endpoint="chat")
         """
         return self._call_endpoint(method="GET", route=endpoint)
 

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -14,6 +14,18 @@ from mlflow.utils.rest_utils import augmented_raise_for_status, http_request
 
 
 class DatabricksEndpoint(AttrDict):
+    """
+    Dict-like object that exposes its keys as attributes.
+
+    .. code-block:: python
+
+        d = AttrDict({'a': 1, 'b': 2})
+        print(d.a)  # 1
+
+        d = AttrDict({'a': 1, 'b': {'c': 3, 'd': 4}})
+        print(d.b.c)  # 3
+    """
+
     pass
 
 

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -19,10 +19,10 @@ class DatabricksEndpoint(AttrDict):
 
     .. code-block:: python
 
-        d = AttrDict({'a': 1, 'b': 2})
+        d = DatabricksEndpoint({'a': 1, 'b': 2})
         print(d.a)  # 1
 
-        d = AttrDict({'a': 1, 'b': {'c': 3, 'd': 4}})
+        d = DatabricksEndpoint({'a': 1, 'b': {'c': 3, 'd': 4}})
         print(d.b.c)  # 3
     """
 

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -19,11 +19,17 @@ class DatabricksEndpoint(AttrDict):
 
     .. code-block:: python
 
-        d = DatabricksEndpoint({"a": 1, "b": 2})
-        print(d.a)  # 1
-
-        d = DatabricksEndpoint({"a": 1, "b": {"c": 3, "d": 4}})
-        print(d.b.c)  # 3
+        endpoint = DatabricksEndpoint({
+            "name": "chat",
+            "creator": "alice@company.com",
+            "creation_timestamp": 0,
+            "last_updated_timestamp": 0,
+            "state": {...},
+            "config": {...},
+            "tags": [...],
+            "id": "88fd3f75a0d24b0380ddc40484d7a31b",
+        })
+        assert endpoint.name == "chat"
     """
 
     pass
@@ -343,7 +349,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             from mlflow.deployments import get_deploy_client
 
             client = get_deploy_client("databricks")
-            assert client.delete_endpoint(endpoint="chat") == {}
+            client.delete_endpoint(endpoint="chat")
         """
         return self._call_endpoint(method="DELETE", route=endpoint)
 

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -93,14 +93,14 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
     @experimental
     def predict(self, deployment_name=None, inputs=None, endpoint=None):
         """
-        Query a serving endpoint with provided model input.
+        Query a serving endpoint with the provided model inputs.
         See https://docs.databricks.com/api/workspace/servingendpoints/query for request/response
         schema.
 
         :param deployment_name: Unused.
         :param inputs: A dictionary containing the model inputs to query.
         :param endpoint: The name of the serving endpoint to query.
-        :return: A :py:class:`PredictionsResponse` object containing the predictions and metadata
+        :return: A :py:class:`DatabricksEndpoint` object containing the query response.
 
         Example:
 

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -23,6 +23,24 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
     Client for interacting with Databricks serving endpoints.
     See https://docs.databricks.com/en/dev-tools/auth.html for how to set up credentials
     for authentication.
+
+    Example:
+
+    First, set up credentials for authentication:
+
+    .. code-block:: bash
+
+        export DATABRICKS_HOST=...
+        export DATABRICKS_TOKEN=...
+
+    Then, create a deployment client and use it to interact with Databricks serving endpoints:
+
+    .. code-block:: python
+
+        from mlflow.deployments import get_deploy_client
+
+        client = get_deploy_client("databricks")
+        client.list_endpoints()
     """
 
     def create_deployment(self, name, model_uri, flavor=None, config=None, endpoint=None):

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -209,7 +209,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             from mlflow.deployments import get_deploy_client
 
             client = get_deploy_client("databricks")
-            client.create_endpoint(
+            endpoint = client.create_endpoint(
                 name="chat",
                 config={
                     "served_entities": [
@@ -227,6 +227,16 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
                     ],
                 },
             )
+            assert endpoint == {
+                "name": "chat",
+                "creator": "alice@company.com",
+                "creation_timestamp": 0,
+                "last_updated_timestamp": 0,
+                "state": {...},
+                "config": {...},
+                "tags": [...],
+                "id": "88fd3f75a0d24b0380ddc40484d7a31b",
+            }
         """
         config = config.copy() if config else {}  # avoid mutating config
         extras = {}

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -19,10 +19,10 @@ class DatabricksEndpoint(AttrDict):
 
     .. code-block:: python
 
-        d = DatabricksEndpoint({'a': 1, 'b': 2})
+        d = DatabricksEndpoint({"a": 1, "b": 2})
         print(d.a)  # 1
 
-        d = DatabricksEndpoint({'a': 1, 'b': {'c': 3, 'd': 4}})
+        d = DatabricksEndpoint({"a": 1, "b": {"c": 3, "d": 4}})
         print(d.b.c)  # 3
     """
 
@@ -56,9 +56,13 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
         assert endpoints == [
             {
                 "name": "chat",
-                "creator": "test.user@databricks.com",
-                "creation_timestamp": 1700812076000,
-                ...,  # truncated
+                "creator": "alice@company.com",
+                "creation_timestamp": 0,
+                "last_updated_timestamp": 0,
+                "state": {...},
+                "config": {...},
+                "tags": [...],
+                "id": "88fd3f75a0d24b0380ddc40484d7a31b",
             },
         ]
     """
@@ -165,7 +169,10 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
                 "choices": [
                     {
                         "index": 0,
-                        "message": {"role": "assistant", "content": "Hello! How can I assist you today?"},
+                        "message": {
+                            "role": "assistant",
+                            "content": "Hello! How can I assist you today?",
+                        },
                         "finish_reason": "stop",
                     }
                 ],
@@ -267,9 +274,13 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             )
             assert endpoint == {
                 "name": "chat",
-                "creator": "test.user@databricks.com",
-                "creation_timestamp": 1700812076000,
-                ...,  # truncated
+                "creator": "alice@company.com",
+                "creation_timestamp": 0,
+                "last_updated_timestamp": 0,
+                "state": {...},
+                "config": {...},
+                "tags": [...],
+                "id": "88fd3f75a0d24b0380ddc40484d7a31b",
             }
 
             rate_limits = client.update_endpoint(
@@ -344,9 +355,13 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             assert endpoints == [
                 {
                     "name": "chat",
-                    "creator": "test.user@databricks.com",
-                    "creation_timestamp": 1700812076000,
-                    ...,  # truncated
+                    "creator": "alice@company.com",
+                    "creation_timestamp": 0,
+                    "last_updated_timestamp": 0,
+                    "state": {...},
+                    "config": {...},
+                    "tags": [...],
+                    "id": "88fd3f75a0d24b0380ddc40484d7a31b",
                 },
             ]
         """
@@ -374,7 +389,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
                 "name": "chat",
                 "creator": "test.user@databricks.com",
                 "creation_timestamp": 1700812076000,
-                ...,  # truncated
+                # ... truncated
             }
         """
         return self._call_endpoint(method="GET", route=endpoint)

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -397,9 +397,13 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             endpoint = client.get_endpoint(endpoint="chat")
             assert endpoint == {
                 "name": "chat",
-                "creator": "test.user@databricks.com",
-                "creation_timestamp": 1700812076000,
-                # ... truncated
+                "creator": "alice@company.com",
+                "creation_timestamp": 0,
+                "last_updated_timestamp": 0,
+                "state": {...},
+                "config": {...},
+                "tags": [...],
+                "id": "88fd3f75a0d24b0380ddc40484d7a31b",
             }
         """
         return self._call_endpoint(method="GET", route=endpoint)

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -135,8 +135,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
         :param name: The name of the serving endpoint to create.
         :param config: A dictionary containing the configuration of the serving endpoint to create.
-        :return: A :py:class:`DatabricksEndpoint` object containing the created endpoint
-                 configuration.
+        :return: A :py:class:`DatabricksEndpoint` object containing the request response.
 
         Example:
 
@@ -181,8 +180,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
         :param endpoint: The name of the serving endpoint to update.
         :param config: A dictionary containing the configuration of the serving endpoint to update.
-        :return: A :py:class:`DatabricksEndpoint` object containing the updated endpoint
-                 configuration.
+        :return: A :py:class:`DatabricksEndpoint` object containing the request response.
 
         Example:
 
@@ -234,8 +232,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
         schema.
 
         :param endpoint: The name of the serving endpoint to delete.
-        :return: A :py:class:`DatabricksEndpoint` object containing the deleted endpoint
-                 configuration.
+        :return: A :py:class:`DatabricksEndpoint` object containing the request response.
 
         Example:
 
@@ -255,8 +252,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
         See https://docs.databricks.com/api/workspace/servingendpoints/list for request/response
         schema.
 
-        :return: A list of :py:class:`DatabricksEndpoint` objects containing the endpoint
-                 configurations.
+        :return: A list of :py:class:`DatabricksEndpoint` objects containing the request response.
 
         Example:
 
@@ -277,7 +273,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
         schema.
 
         :param endpoint: The name of the serving endpoint to get.
-        :return: A :py:class:`DatabricksEndpoint` object containing the endpoint configuration.
+        :return: A :py:class:`DatabricksEndpoint` object containing the request response.
 
         Example:
 

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -33,8 +33,6 @@ class DatabricksEndpoint(AttrDict):
 class DatabricksDeploymentClient(BaseDeploymentClient):
     """
     Client for interacting with Databricks serving endpoints.
-    See https://docs.databricks.com/en/dev-tools/auth.html for how to set up credentials
-    for authentication.
 
     Example:
 
@@ -44,6 +42,10 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
         export DATABRICKS_HOST=...
         export DATABRICKS_TOKEN=...
+
+    .. seealso::
+
+        See https://docs.databricks.com/en/dev-tools/auth.html for other authentication methods.
 
     Then, create a deployment client and use it to interact with Databricks serving endpoints:
 

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -19,16 +19,18 @@ class DatabricksEndpoint(AttrDict):
 
     .. code-block:: python
 
-        endpoint = DatabricksEndpoint({
-            "name": "chat",
-            "creator": "alice@company.com",
-            "creation_timestamp": 0,
-            "last_updated_timestamp": 0,
-            "state": {...},
-            "config": {...},
-            "tags": [...],
-            "id": "88fd3f75a0d24b0380ddc40484d7a31b",
-        })
+        endpoint = DatabricksEndpoint(
+            {
+                "name": "chat",
+                "creator": "alice@company.com",
+                "creation_timestamp": 0,
+                "last_updated_timestamp": 0,
+                "state": {...},
+                "config": {...},
+                "tags": [...],
+                "id": "88fd3f75a0d24b0380ddc40484d7a31b",
+            }
+        )
         assert endpoint.name == "chat"
     """
 

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -15,7 +15,7 @@ from mlflow.utils.rest_utils import augmented_raise_for_status, http_request
 
 class DatabricksEndpoint(AttrDict):
     """
-    Dict-like object that exposes its keys as attributes.
+    A dictionary-like object representing a Databricks serving endpoint.
 
     .. code-block:: python
 

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -141,7 +141,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             from mlflow.deployments import get_deploy_client
 
             client = get_deploy_client("databricks")
-            client.predict(
+            response = client.predict(
                 endpoint="chat",
                 inputs={
                     "messages": [
@@ -149,6 +149,24 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
                     ],
                 },
             )
+            assert response == {
+                "id": "chatcmpl-8OLm5kfqBAJD8CpsMANESWKpLSLXY",
+                "object": "chat.completion",
+                "created": 1700814265,
+                "model": "gpt-4-0613",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "Hello! How can I assist you today?"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 9,
+                    "completion_tokens": 9,
+                    "total_tokens": 18,
+                },
+            }
         """
         return self._call_endpoint(
             method="POST",
@@ -221,7 +239,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             from mlflow.deployments import get_deploy_client
 
             client = get_deploy_client("databricks")
-            client.update_endpoint(
+            endpoint = client.update_endpoint(
                 endpoint="chat",
                 config={
                     "served_entities": [
@@ -246,6 +264,12 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
                     ],
                 },
             )
+            assert endpoint == {
+                "name": "chat",
+                "creator": "test.user@databricks.com",
+                "creation_timestamp": 1700812076000,
+                ...,  # truncated
+            }
         """
         if list(config) == ["rate_limits"]:
             return self._call_endpoint(
@@ -273,7 +297,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             from mlflow.deployments import get_deploy_client
 
             client = get_deploy_client("databricks")
-            client.delete_endpoint(endpoint="chat")
+            assert client.delete_endpoint(endpoint="chat") == {}
         """
         return self._call_endpoint(method="DELETE", route=endpoint)
 
@@ -293,7 +317,16 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             from mlflow.deployments import get_deploy_client
 
             client = get_deploy_client("databricks")
-            client.list_endpoints()
+            endpoints = client.list_endpoints()
+            assert endpoints == [
+                {
+                    "name": "chat",
+                    "creator": "test.user@databricks.com",
+                    "creation_timestamp": 1700812076000,
+                    ...,  # truncated
+                },
+                ...
+            ]
         """
         return self._call_endpoint(method="GET").endpoints
 
@@ -314,7 +347,13 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             from mlflow.deployments import get_deploy_client
 
             client = get_deploy_client("databricks")
-            client.get_endpoint(endpoint="chat")
+            endpoint = client.get_endpoint(endpoint="chat")
+            assert endpoint == {
+                "name": "chat",
+                "creator": "test.user@databricks.com",
+                "creation_timestamp": 1700812076000,
+                ...,  # truncated
+            }
         """
         return self._call_endpoint(method="GET", route=endpoint)
 

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -21,6 +21,8 @@ class DatabricksEndpoint(AttrDict):
 class DatabricksDeploymentClient(BaseDeploymentClient):
     """
     Client for interacting with Databricks serving endpoints.
+    See https://docs.databricks.com/en/dev-tools/auth.html for how to set up credentials
+    for authentication.
     """
 
     def create_deployment(self, name, model_uri, flavor=None, config=None, endpoint=None):

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -240,10 +240,10 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
         .. code-block:: python
 
-                from mlflow.deployments import get_deploy_client
+            from mlflow.deployments import get_deploy_client
 
-                client = get_deploy_client("databricks")
-                client.delete_endpoint(endpoint="chat")
+            client = get_deploy_client("databricks")
+            client.delete_endpoint(endpoint="chat")
         """
         return self._call_endpoint(method="DELETE", route=endpoint)
 
@@ -260,10 +260,10 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
         .. code-block:: python
 
-                from mlflow.deployments import get_deploy_client
+            from mlflow.deployments import get_deploy_client
 
-                client = get_deploy_client("databricks")
-                client.list_endpoints()
+            client = get_deploy_client("databricks")
+            client.list_endpoints()
         """
         return self._call_endpoint(method="GET").endpoints
 
@@ -281,10 +281,10 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
         .. code-block:: python
 
-                from mlflow.deployments import get_deploy_client
+            from mlflow.deployments import get_deploy_client
 
-                client = get_deploy_client("databricks")
-                client.get_endpoint(endpoint="chat")
+            client = get_deploy_client("databricks")
+            client.get_endpoint(endpoint="chat")
         """
         return self._call_endpoint(method="GET", route=endpoint)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10499?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10499/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10499
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Replace `TODO` in `DatabricksDeploymentClient`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
