### PR TITLE
Rename `MLflowDeploymentClient` to `MlflowDeploymentClient`

### DIFF
--- a/mlflow/deployments/__init__.py
+++ b/mlflow/deployments/__init__.py
@@ -23,9 +23,9 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
 with contextlib.suppress(Exception):
-    # MLflowDeploymentClient depends on optional dependencies and can't be imported
+    # MlflowDeploymentClient depends on optional dependencies and can't be imported
     # if they are not installed.
-    from mlflow.deployments.mlflow import MLflowDeploymentClient
+    from mlflow.deployments.mlflow import MlflowDeploymentClient
 
 
 class PredictionsResponse(dict):
@@ -99,6 +99,6 @@ __all__ = [
     "run_local",
     "BaseDeploymentClient",
     "DatabricksDeploymentClient",
-    "MLflowDeploymentClient",
+    "MlflowDeploymentClient",
     "PredictionsResponse",
 ]

--- a/mlflow/deployments/mlflow/__init__.py
+++ b/mlflow/deployments/mlflow/__init__.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 
 @experimental
-class MLflowDeploymentClient(BaseDeploymentClient):
+class MlflowDeploymentClient(BaseDeploymentClient):
     """
     TODO
     """
@@ -36,28 +36,28 @@ class MLflowDeploymentClient(BaseDeploymentClient):
     def create_deployment(self, name, model_uri, flavor=None, config=None, endpoint=None):
         """
         .. warning::
-            This method is not implemented for `MLflowDeploymentClient`.
+            This method is not implemented for `MlflowDeploymentClient`.
         """
         raise NotImplementedError
 
     def update_deployment(self, name, model_uri=None, flavor=None, config=None, endpoint=None):
         """
         .. warning::
-            This method is not implemented for `MLflowDeploymentClient`.
+            This method is not implemented for `MlflowDeploymentClient`.
         """
         raise NotImplementedError
 
     def delete_deployment(self, name, config=None, endpoint=None):
         """
         .. warning::
-            This method is not implemented for `MLflowDeploymentClient`.
+            This method is not implemented for `MlflowDeploymentClient`.
         """
         raise NotImplementedError
 
     def list_deployments(self, endpoint=None):
         """
         .. warning::
-            This method is not implemented for `MLflowDeploymentClient`.
+            This method is not implemented for `MlflowDeploymentClient`.
         """
         raise NotImplementedError
 
@@ -70,21 +70,21 @@ class MLflowDeploymentClient(BaseDeploymentClient):
     def create_endpoint(self, name, config=None):
         """
         .. warning::
-            This method is not implemented for `MLflowDeploymentClient`.
+            This method is not implemented for `MlflowDeploymentClient`.
         """
         raise NotImplementedError
 
     def update_endpoint(self, endpoint, config=None):
         """
         .. warning::
-            This method is not implemented for `MLflowDeploymentClient`.
+            This method is not implemented for `MlflowDeploymentClient`.
         """
         raise NotImplementedError
 
     def delete_endpoint(self, endpoint):
         """
         .. warning::
-            This method is not implemented for `MLflowDeploymentClient`.
+            This method is not implemented for `MlflowDeploymentClient`.
         """
         raise NotImplementedError
 

--- a/tests/deployments/mlflow/test_mlflow.py
+++ b/tests/deployments/mlflow/test_mlflow.py
@@ -3,12 +3,12 @@ from unittest import mock
 import pytest
 
 from mlflow.deployments import get_deploy_client
-from mlflow.deployments.mlflow import MLflowDeploymentClient
+from mlflow.deployments.mlflow import MlflowDeploymentClient
 
 
 def test_get_deploy_client():
     client = get_deploy_client("http://localhost:5000")
-    assert isinstance(client, MLflowDeploymentClient)
+    assert isinstance(client, MlflowDeploymentClient)
 
 
 def test_create_endpoint():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10500?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10500/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10500
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Rename `MLflowDeploymentClient` to `MlflowDeploymentClient`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
