### PR TITLE
Use `/rate-limits` if `config` only contains `rate_limits`

### DIFF
--- a/examples/deployments/databricks.py
+++ b/examples/deployments/databricks.py
@@ -54,6 +54,26 @@ def main():
         },
     )
     try:
+        # Update served_entities
+        client.update_endpoint(
+            endpoint=name,
+            config={
+                "served_entities": [
+                    {
+                        "name": "test",
+                        "external_model": {
+                            "name": "gpt-4",
+                            "provider": "openai",
+                            "task": "llm/v1/chat",
+                            "openai_config": {
+                                "openai_api_key": "{{" + args.secret + "}}",
+                            },
+                        },
+                    }
+                ],
+            },
+        )
+        # Update rate_limits
         client.update_endpoint(
             endpoint=name,
             config={

--- a/examples/deployments/databricks.py
+++ b/examples/deployments/databricks.py
@@ -57,19 +57,6 @@ def main():
         client.update_endpoint(
             endpoint=name,
             config={
-                "served_entities": [
-                    {
-                        "name": "test",
-                        "external_model": {
-                            "name": "gpt-4",
-                            "provider": "openai",
-                            "task": "llm/v1/chat",
-                            "openai_config": {
-                                "openai_api_key": "{{" + args.secret + "}}",
-                            },
-                        },
-                    }
-                ],
                 "rate_limits": [
                     {
                         "key": "user",

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -121,9 +121,14 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
         """
         TODO
         """
-        return self._call_endpoint(
-            method="PUT", route=posixpath.join(endpoint, "config"), json_body=config
-        )
+        if list(config) == ["rate_limits"]:
+            return self._call_endpoint(
+                method="PUT", route=posixpath.join(endpoint, "rate-limits"), json_body=config
+            )
+        else:
+            return self._call_endpoint(
+                method="PUT", route=posixpath.join(endpoint, "config"), json_body=config
+            )
 
     @experimental
     def delete_endpoint(self, endpoint):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10502?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10502/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10502
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Address https://github.com/mlflow/mlflow/pull/10499#discussion_r1404026993

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
