### PR TITLE
Improve spark_udf example code displayed in Mlflow UI

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
@@ -113,7 +113,7 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
       // eslint-disable-next-line max-len
       `# Load model as a Spark UDF. Override result_type if the model does not return double values.\n` +
       // eslint-disable-next-line max-len
-      `loaded_model = mlflow.pyfunc.spark_udf(spark, model_uri=logged_model, result_type='double')\n\n` +
+      `loaded_model = mlflow.pyfunc.spark_udf(spark, model_uri=logged_model)\n\n` +
       `# Predict on a Spark DataFrame.\n` +
       `df.withColumn('predictions', loaded_model(struct(*map(col, df.columns))))`
     );

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
@@ -111,7 +111,7 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
       `from pyspark.sql.functions import struct, col\n` +
       `logged_model = '${modelPath}'\n\n` +
       // eslint-disable-next-line max-len
-      `# Load model as a Spark UDF. Override result_type if the model does not return double values.\n` +
+      `# Load model as a Spark UDF.\n` +
       // eslint-disable-next-line max-len
       `loaded_model = mlflow.pyfunc.spark_udf(spark, model_uri=logged_model)\n\n` +
       `# Predict on a Spark DataFrame.\n` +

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactLoggedModelView.tsx
@@ -110,9 +110,7 @@ class ShowArtifactLoggedModelView extends Component<Props, State> {
       `import mlflow\n` +
       `from pyspark.sql.functions import struct, col\n` +
       `logged_model = '${modelPath}'\n\n` +
-      // eslint-disable-next-line max-len
       `# Load model as a Spark UDF.\n` +
-      // eslint-disable-next-line max-len
       `loaded_model = mlflow.pyfunc.spark_udf(spark, model_uri=logged_model)\n\n` +
       `# Predict on a Spark DataFrame.\n` +
       `df.withColumn('predictions', loaded_model(struct(*map(col, df.columns))))`


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/10508?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10508/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10508
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #10453

### What changes are proposed in this pull request?

Improve spark_udf example code displayed in Mlflow UI

We should remove `result_type` argument in the UI code, if we do not set `result_type` argument, when the model has "output signature", result type is inferred from output signature, otherwise 'double' is used as the default result_type.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
