### PR TITLE
fix: abstract classes use metaclass=ABCMeta

### DIFF
--- a/mlflow/models/flavor_backend.py
+++ b/mlflow/models/flavor_backend.py
@@ -4,13 +4,11 @@ from mlflow.utils.annotations import developer_stable
 
 
 @developer_stable
-class FlavorBackend:
+class FlavorBackend(metaclass=ABCMeta):
     """
     Abstract class for Flavor Backend.
     This class defines the API interface for local model deployment of MLflow model flavors.
     """
-
-    __metaclass__ = ABCMeta
 
     def __init__(self, config, **kwargs):  # pylint: disable=unused-argument
         self._config = config

--- a/mlflow/projects/backend/abstract_backend.py
+++ b/mlflow/projects/backend/abstract_backend.py
@@ -4,7 +4,7 @@ from mlflow.utils.annotations import developer_stable
 
 
 @developer_stable
-class AbstractBackend:
+class AbstractBackend(metaclass=ABCMeta):
     """
     Abstract plugin class defining the interface needed to execute MLflow projects. You can define
     subclasses of ``AbstractBackend`` and expose them as third-party plugins to enable running
@@ -12,8 +12,6 @@ class AbstractBackend:
     in-house cluster or job scheduler). See `MLflow Plugins <../../plugins.html>`_ for more
     information.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def run(

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -74,15 +74,13 @@ def _log_warning_if_params_not_in_predict_signature(logger, params):
         )
 
 
-class PythonModel:
+class PythonModel(metaclass=ABCMeta):
     """
     Represents a generic Python model that evaluates inputs and produces API-compatible outputs.
     By subclassing :class:`~PythonModel`, users can create customized MLflow models with the
     "python_function" ("pyfunc") flavor, leveraging custom inference logic and artifact
     dependencies.
     """
-
-    __metaclass__ = ABCMeta
 
     def __new__(cls, *args, **kwargs):
         cls._warn_on_setting_model_in_init()

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -34,13 +34,11 @@ def _truncate_error(err: str, max_length: int = 10_000) -> str:
 
 
 @developer_stable
-class ArtifactRepository:
+class ArtifactRepository(metaclass=ABCMeta):
     """
     Abstract artifact repo that defines how to upload (log) and download potentially large
     artifacts from different storage backends.
     """
-
-    __metaclass__ = ABCMeta
 
     def __init__(self, artifact_uri):
         self.artifact_uri = artifact_uri

--- a/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
+++ b/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
@@ -11,9 +11,7 @@ from mlflow.store._unity_catalog.registry.utils import (
     get_full_name_from_sc,
 )
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
-from mlflow.store.artifact.utils.models import (
-    get_model_name_and_version,
-)
+from mlflow.store.artifact.utils.models import get_model_name_and_version
 from mlflow.utils._spark_utils import _get_active_spark_session
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.proto_json_utils import message_to_json
@@ -125,6 +123,9 @@ class UnityCatalogModelsArtifactRepository(ArtifactRepository):
 
     def log_artifacts(self, local_dir, artifact_path=None):
         raise MlflowException("This repository does not support logging artifacts.")
+
+    def _download_file(self, remote_file_path, local_path):
+        raise NotImplementedError("This artifact repository does not support downloading files")
 
     def delete_artifacts(self, artifact_path=None):
         raise NotImplementedError("This artifact repository does not support deleting artifacts")

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -14,12 +14,10 @@ AWAIT_MODEL_VERSION_CREATE_SLEEP_INTERVAL_SECONDS = 3
 
 
 @developer_stable
-class AbstractStore:
+class AbstractStore(metaclass=ABCMeta):
     """
     Abstract class that defines API interfaces for storing Model Registry metadata.
     """
-
-    __metaclass__ = ABCMeta
 
     def __init__(self, store_uri=None, tracking_uri=None):
         """

--- a/mlflow/store/model_registry/base_rest_store.py
+++ b/mlflow/store/model_registry/base_rest_store.py
@@ -9,12 +9,10 @@ from mlflow.utils.rest_utils import (
 
 
 @experimental
-class BaseRestStore(AbstractStore):  # pylint: disable=abstract-method
+class BaseRestStore(AbstractStore, metaclass=ABCMeta):  # pylint: disable=abstract-method
     """
     Base class client for a remote model registry server accessed via REST API calls
     """
-
-    __metaclass__ = ABCMeta
 
     def __init__(self, get_host_creds):
         super().__init__()

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -10,13 +10,11 @@ from mlflow.utils.async_logging.run_operations import RunOperations
 
 
 @developer_stable
-class AbstractStore:
+class AbstractStore(metaclass=ABCMeta):
     """
     Abstract class for Backend Storage.
     This class defines the API interface for front ends to connect with various types of backends.
     """
-
-    __metaclass__ = ABCMeta
 
     def __init__(self):
         """

--- a/mlflow/tracking/context/abstract_context.py
+++ b/mlflow/tracking/context/abstract_context.py
@@ -4,7 +4,7 @@ from mlflow.utils.annotations import developer_stable
 
 
 @developer_stable
-class RunContextProvider:
+class RunContextProvider(metaclass=ABCMeta):
     """
     Abstract base class for context provider objects specifying custom tags at run-creation time
     (e.g. tags specifying the git repo with which the run is associated).
@@ -14,8 +14,6 @@ class RunContextProvider:
     MLflow calls the ``tags`` method on the context provider to compute context tags for the run.
     All context tags are then merged together and set on the newly-created run.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def in_context(self):

--- a/mlflow/tracking/default_experiment/abstract_context.py
+++ b/mlflow/tracking/default_experiment/abstract_context.py
@@ -4,7 +4,7 @@ from mlflow.utils.annotations import developer_stable
 
 
 @developer_stable
-class DefaultExperimentProvider:
+class DefaultExperimentProvider(metaclass=ABCMeta):
     """
     Abstract base class for objects that provide the ID of an MLflow Experiment based on the
     current client context. For example, when the MLflow client is running in a Databricks Job,
@@ -17,8 +17,6 @@ class DefaultExperimentProvider:
     ``in_context()`` method returns ``True``; MLflow then calls the provider's
     ``get_experiment_id()`` method and uses the resulting experiment ID for Tracking operations.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def in_context(self):

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -23,7 +23,7 @@ class UnsupportedModelRegistryStoreURIException(MlflowException):
         self.supported_uri_schemes = supported_uri_schemes
 
 
-class StoreRegistry:
+class StoreRegistry(metaclass=ABCMeta):
     """
     Abstract class defining a scheme-based registry for store implementations.
 
@@ -37,8 +37,6 @@ class StoreRegistry:
     select which implementation to instantiate, which will be called with same
     arguments passed to the `get_store` method.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def __init__(self, group_name):

--- a/mlflow/tracking/request_header/abstract_request_header_provider.py
+++ b/mlflow/tracking/request_header/abstract_request_header_provider.py
@@ -4,7 +4,7 @@ from mlflow.utils.annotations import developer_stable
 
 
 @developer_stable
-class RequestHeaderProvider:
+class RequestHeaderProvider(metaclass=ABCMeta):
     """
     Abstract base class for specifying custom request headers to add to outgoing requests
     (e.g. request headers specifying the environment from which mlflow is running).
@@ -15,8 +15,6 @@ class RequestHeaderProvider:
 
     All resulting request headers will then be merged together and sent with the request.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def in_context(self):


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fix abstract classes to use `metaclass=ABCMeta` instead of `__metaclass__=ABCMeta` which was for python2

[doc_for_metaclass_python3](https://docs.python.org/3/reference/datamodel.html#metaclasses)
[doc_for_metaclass_python2](https://docs.python.org/2.7/reference/datamodel.html#customizing-class-creation)
[doc_for_abcMeta_python3](https://docs.python.org/3/library/abc.html#abc.ABCMeta)
[doc_for_abcMeta_python2](https://docs.python.org/2.7/library/abc.html#abc.ABCMeta)
### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
