### PR TITLE
[FEAT] Migrating prompt lab to use MLflow deployments

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/actions/ModelGatewayActions.ts
+++ b/mlflow/server/js/src/experiment-tracking/actions/ModelGatewayActions.ts
@@ -19,7 +19,7 @@ export interface SearchModelGatewayRoutesAction
 export const searchModelGatewayRoutesApi = (filter?: string): SearchModelGatewayRoutesAction => ({
   type: SEARCH_MODEL_GATEWAY_ROUTES_API,
   payload: MlflowService.gatewayProxyGet({
-    gateway_path: 'api/2.0/gateway/routes/',
+    gateway_path: 'api/2.0/endpoints/',
   }) as Promise<SearchModelGatewayRouteResponse>,
   meta: { id: getUUID() },
 });
@@ -32,7 +32,7 @@ export interface GetModelGatewayRouteAction extends AsyncAction<ModelGatewayRout
 export const getModelGatewayRouteApi = (routeName: string): GetModelGatewayRouteAction => ({
   type: GET_MODEL_GATEWAY_ROUTE_API,
   payload: MlflowService.gatewayProxyGet({
-    gateway_path: `api/2.0/gateway/routes/${routeName}`,
+    gateway_path: `api/2.0/endpoints/${routeName}`,
   }) as Promise<ModelGatewayRoute>,
   meta: { id: getUUID() },
 });
@@ -53,7 +53,7 @@ export const queryModelGatewayRouteApi = (
   return {
     type: QUERY_MODEL_GATEWAY_ROUTE_API,
     payload: MlflowService.gatewayProxyPost({
-      gateway_path: `gateway/${route.name}/invocations`,
+      gateway_path: route.endpoint_url.substring(1),
       json_data: processed_data,
     }) as Promise<ModelGatewayResponseType>,
     meta: { id: getUUID(), startTime: performance.now() },

--- a/mlflow/server/js/src/experiment-tracking/actions/PromptEngineeringActions.ts
+++ b/mlflow/server/js/src/experiment-tracking/actions/PromptEngineeringActions.ts
@@ -84,7 +84,7 @@ export const evaluatePromptTableValue =
         ...modelGatewayRequestPayload.parameters,
       };
       return MlflowService.gatewayProxyPost({
-        gateway_path: `gateway/${gatewayRoute.name}/invocations`,
+        gateway_path: gatewayRoute.endpoint_url.substring(1),
         json_data: processed_data,
       });
     };

--- a/mlflow/server/js/src/experiment-tracking/actions/PromptEngineeringActions.ts
+++ b/mlflow/server/js/src/experiment-tracking/actions/PromptEngineeringActions.ts
@@ -67,7 +67,7 @@ export const evaluatePromptTableValue =
     // recently. Display relevant error in this scenario.
     const gatewayRoute = getState().modelGateway.modelGatewayRoutes[routeName];
     if (!gatewayRoute) {
-      const errorMessage = `AI gateway route ${routeName} does not exist anymore!`;
+      const errorMessage = `MLflow deployment endpoints ${routeName} does not exist anymore!`;
       Utils.logErrorAndNotifyUser(errorMessage);
       throw new Error(errorMessage);
     }

--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/EvaluationCreatePromptRunModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/EvaluationCreatePromptRunModal.tsx
@@ -278,8 +278,8 @@ export const EvaluationCreatePromptRunModal = ({
         const errorMessage = e.getGatewayErrorMessage() || e.getUserVisibleError();
         const wrappedMessage = intl.formatMessage(
           {
-            defaultMessage: 'AI gateway returned the following error: "{errorMessage}"',
-            description: 'Experiment page > new run modal > AI gateway error message',
+            defaultMessage: 'MLflow deployment returned the following error: "{errorMessage}"',
+            description: 'Experiment page > new run modal > MLflow deployment error message',
           },
           {
             errorMessage,
@@ -342,7 +342,7 @@ export const EvaluationCreatePromptRunModal = ({
   const createRunButtonTooltip = useMemo(() => {
     if (!selectedModel) {
       return intl.formatMessage({
-        defaultMessage: 'You need to select a route from the AI gateway dropdown first',
+        defaultMessage: 'You need to select an endpoint from the MLflow deployment  dropdown first',
         description: 'Experiment page > new run modal > invalid state - no AI gateway selected',
       });
     }
@@ -400,7 +400,7 @@ export const EvaluationCreatePromptRunModal = ({
   const evaluateButtonTooltip = useMemo(() => {
     if (!selectedModel) {
       return intl.formatMessage({
-        defaultMessage: 'You need to select a route from the AI gateway dropdown first',
+        defaultMessage: 'You need to select an endpoint from the MLflow deployment dropdown first',
         description: 'Experiment page > new run modal > invalid state - no AI gateway selected',
       });
     }
@@ -530,9 +530,9 @@ export const EvaluationCreatePromptRunModal = ({
               title={
                 <FormattedMessage
                   defaultMessage={
-                    'These routes come from the AI Gateway. Check out the AI Gateway preview documentation to get started'
+                    'These endpoints come from the MLflow deployment. Check out the MLflow deployment documentation to get started'
                   }
-                  description={'Information about gateway routes'}
+                  description={'Information about MLflow deployment endpoints'}
                 />
               }
               placement='right'

--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/EvaluationCreatePromptRunModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/EvaluationCreatePromptRunModal.tsx
@@ -308,7 +308,7 @@ export const EvaluationCreatePromptRunModal = ({
     description: 'Experiment page > new run modal > AI gateway selector label',
   });
   const selectModelPlaceholder = intl.formatMessage({
-    defaultMessage: 'Select route',
+    defaultMessage: 'Select endpoint',
     description: 'Experiment page > new run modal > AI gateway selector placeholder',
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/EvaluationCreatePromptRunModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/EvaluationCreatePromptRunModal.tsx
@@ -77,7 +77,7 @@ export const EvaluationCreatePromptRunModal = ({
   const [lastEvaluationError, setLastEvaluationError] = useState<string | null>(null);
   const [evaluationOutput, setEvaluationOutput] = useState('');
   const [evaluationMetadata, setEvaluationMetadata] = useState<
-    Partial<ModelGatewayResponseType['metadata']>
+    Partial<ModelGatewayResponseType['usage']>
   >({});
   const [outputDirty, setOutputDirty] = useState(false);
   const [isViewExamplesModalOpen, setViewExamplesModalOpen] = useState(false);
@@ -171,7 +171,7 @@ export const EvaluationCreatePromptRunModal = ({
       sortBy(
         Object.values(modelRoutes).filter((modelRoute) =>
           [ModelGatewayRouteType.LLM_V1_COMPLETIONS, ModelGatewayRouteType.LLM_V1_CHAT].includes(
-            modelRoute.route_type,
+            modelRoute.endpoint_type,
           ),
         ),
         'name',
@@ -248,13 +248,13 @@ export const EvaluationCreatePromptRunModal = ({
     )
       .then(({ value, action }) => {
         if (cancelTokenRef.current === cancelToken) {
-          const { text, metadata } = ModelGatewayService.parseEvaluationResponse(value);
+          const { text, usage } = ModelGatewayService.parseEvaluationResponse(value);
 
           // TODO: Consider calculating actual model call latency on the backend side
           const latency = performance.now() - action.meta.startTime;
 
           setEvaluationOutput(text);
-          const metadataWithEvaluationTime = { ...metadata, latency };
+          const metadataWithEvaluationTime = { ...usage, latency };
 
           // Prefix the metadata keys with "MLFLOW_"
           const prefixedMetadata = Object.entries(metadataWithEvaluationTime).reduce(

--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationCellEvaluateButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationCellEvaluateButton.tsx
@@ -47,7 +47,7 @@ export const EvaluationCellEvaluateButton = ({
         title={
           <FormattedMessage
             description='Experiment page > artifact compare view > text cell > run not evaluable tooltip'
-            defaultMessage='You cannot evaluate this cell, this run was not created using AI gateway route'
+            defaultMessage='You cannot evaluate this cell, this run was not created using MLflow deployment endpoints.'
           />
         }
       >

--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationCreatePromptRunOutput.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/components/EvaluationCreatePromptRunOutput.tsx
@@ -22,7 +22,7 @@ import { type ModelGatewayResponseType } from '../../../sdk/ModelGatewayService'
 const { TextArea } = Input;
 
 interface EvaluationCreatePromptRunOutputProps {
-  evaluationMetadata: Partial<ModelGatewayResponseType['metadata']>;
+  evaluationMetadata: Partial<ModelGatewayResponseType['usage']>;
   isEvaluating?: boolean;
   isOutputDirty?: boolean;
   evaluationOutput: string;

--- a/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/contexts/PromptEngineeringContext.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluation-artifacts-compare/contexts/PromptEngineeringContext.tsx
@@ -151,8 +151,8 @@ export const PromptEngineeringContextProvider = ({
           const errorMessage = e.getGatewayErrorMessage() || e.getUserVisibleError();
           const wrappedMessage = intl.formatMessage(
             {
-              defaultMessage: 'AI gateway returned the following error: "{errorMessage}"',
-              description: 'Experiment page > new run modal > AI gateway error message',
+              defaultMessage: 'MLflow deployment returned the following error: "{errorMessage}"',
+              description: 'Experiment page > new run modal > MLflow deployment error message',
             },
             {
               errorMessage,

--- a/mlflow/server/js/src/experiment-tracking/reducers/EvaluationDataReducer.ts
+++ b/mlflow/server/js/src/experiment-tracking/reducers/EvaluationDataReducer.ts
@@ -187,7 +187,7 @@ const evaluationPendingDataByRunUuid = (
 
     const evaluationTime = !startTime ? 0 : performance.now() - startTime;
 
-    const { metadata, text } = ModelGatewayService.parseEvaluationResponse(action.payload);
+    const { usage, text } = ModelGatewayService.parseEvaluationResponse(action.payload);
 
     const newEntry: PendingEvaluationArtifactTableEntry = {
       entryData: {
@@ -196,7 +196,7 @@ const evaluationPendingDataByRunUuid = (
         [DEFAULT_PROMPTLAB_PROMPT_COLUMN]: compiledPrompt,
       },
       evaluationTime,
-      totalTokens: metadata.total_tokens,
+      totalTokens: usage.total_tokens,
       isPending: true,
     };
 

--- a/mlflow/server/js/src/experiment-tracking/reducers/ModelGatewayReducer.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/reducers/ModelGatewayReducer.test.ts
@@ -18,26 +18,29 @@ describe('modelGatewayReducer', () => {
   const MOCK_DOLLY_MODEL_ROUTE = {
     model: { name: 'dolly-2', provider: 'mlflow' },
     name: 'test-dolly-gateway',
-    route_type: ModelGatewayRouteType.LLM_V1_COMPLETIONS,
+    endpoint_type: ModelGatewayRouteType.LLM_V1_COMPLETIONS,
+    endpoint_url: '/gateway/completions/invocations',
   };
 
   const MOCK_LLAMA_MODEL_ROUTE = {
     model: { name: 'llama-6', provider: 'meta' },
     name: 'test-llama-gateway',
-    route_type: ModelGatewayRouteType.LLM_V1_COMPLETIONS,
+    endpoint_type: ModelGatewayRouteType.LLM_V1_COMPLETIONS,
+    endpoint_url: '/gateway/completions/invocations',
   };
 
   const MOCK_GPT_MODEL_ROUTE = {
     model: { name: 'gpt-1', provider: 'gpt' },
     name: 'test-gpt-gateway',
-    route_type: ModelGatewayRouteType.LLM_V1_COMPLETIONS,
+    endpoint_type: ModelGatewayRouteType.LLM_V1_COMPLETIONS,
+    endpoint_url: '/gateway/completions/invocations',
   };
 
   const mockFulfilledSearchAction = (
     modelRoutes: ModelGatewayRoute[],
   ): AsyncFulfilledAction<SearchModelGatewayRoutesAction> => ({
     type: fulfilled(SEARCH_MODEL_GATEWAY_ROUTES_API),
-    payload: { routes: modelRoutes },
+    payload: { endpoints: modelRoutes },
   });
 
   const mockPendingSearchAction = (): AsyncAction => ({

--- a/mlflow/server/js/src/experiment-tracking/reducers/ModelGatewayReducer.ts
+++ b/mlflow/server/js/src/experiment-tracking/reducers/ModelGatewayReducer.ts
@@ -40,11 +40,11 @@ export const modelGatewayRoutes = (
 ): Record<string, ModelGatewayRoute> => {
   switch (type) {
     case fulfilled(SEARCH_MODEL_GATEWAY_ROUTES_API):
-      if (!payload.routes) {
+      if (!payload.endpoints) {
         return state;
       }
-      return payload.routes.reduce(
-        (newState, route) => ({ ...newState, [route.name]: route }),
+      return payload.endpoints.reduce(
+        (newState, endpoint) => ({ ...newState, [endpoint.name]: endpoint }),
         state,
       );
     case fulfilled(GET_MODEL_GATEWAY_ROUTE_API):

--- a/mlflow/server/js/src/experiment-tracking/sdk/ModelGatewayService.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/sdk/ModelGatewayService.test.ts
@@ -16,7 +16,8 @@ describe('ModelGatewayService', () => {
       {
         model: { name: 'completions_model', provider: 'closed-ai' },
         name: 'completions_route',
-        route_type: ModelGatewayRouteType.LLM_V1_COMPLETIONS,
+        endpoint_type: ModelGatewayRouteType.LLM_V1_COMPLETIONS,
+        endpoint_url: '/gateway/completions/invocations',
       },
       { inputText: 'input text', parameters: { temperature: 0.5, max_tokens: 50 } },
     );
@@ -33,7 +34,8 @@ describe('ModelGatewayService', () => {
       {
         model: { name: 'chat_model', provider: 'closed-ai' },
         name: 'chat_route',
-        route_type: ModelGatewayRouteType.LLM_V1_CHAT,
+        endpoint_type: ModelGatewayRouteType.LLM_V1_CHAT,
+        endpoint_url: '/gateway/chat/invocations',
       },
       { inputText: 'input text', parameters: { temperature: 0.5, max_tokens: 50 } },
     );
@@ -55,7 +57,8 @@ describe('ModelGatewayService', () => {
         {
           model: { name: 'chat_model', provider: 'closed-ai' },
           name: 'chat_route',
-          route_type: ModelGatewayRouteType.LLM_V1_EMBEDDINGS,
+          endpoint_type: ModelGatewayRouteType.LLM_V1_EMBEDDINGS,
+          endpoint_url: '/gateway/embeddings/invocations',
         },
         { inputText: 'input text', parameters: { temperature: 0.5, max_tokens: 50 } },
       );

--- a/mlflow/server/js/src/experiment-tracking/sdk/ModelGatewayService.ts
+++ b/mlflow/server/js/src/experiment-tracking/sdk/ModelGatewayService.ts
@@ -10,34 +10,32 @@ export interface ModelGatewayQueryPayload {
   };
 }
 
-interface ModelGatewayResponseMetadata<T extends ModelGatewayRouteType> {
-  mode: string;
-  route_type: T;
+interface ModelGatewayResponseMetadata {
   total_tokens: number;
-  output_tokens: number;
-  input_tokens: number;
+  completion_tokens: number;
+  prompt_tokens: number;
 }
 
 export interface ModelGatewayCompletionsResponseType {
-  candidates: {
+  choices: {
     text: string;
-    metadata: {
-      finish_reason: string;
-    };
+    finish_reason: string;
   }[];
 
-  metadata: ModelGatewayResponseMetadata<ModelGatewayRouteType.LLM_V1_COMPLETIONS>;
+  object: ModelDeploymentOutputType;
+
+  usage: ModelGatewayResponseMetadata;
 }
 
 export interface ModelGatewayChatResponseType {
-  candidates: {
+  choices: {
     message: { role: string; content: string };
-    metadata: {
-      finish_reason: string;
-    };
+    finish_reason: string;
   }[];
 
-  metadata: ModelGatewayResponseMetadata<ModelGatewayRouteType.LLM_V1_CHAT>;
+  object: ModelDeploymentOutputType;
+
+  usage: ModelGatewayResponseMetadata;
 }
 
 export type ModelGatewayResponseType =
@@ -61,6 +59,11 @@ export enum ModelGatewayRouteType {
   LLM_V1_EMBEDDINGS = 'llm/v1/embeddings',
 }
 
+export enum ModelDeploymentOutputType {
+  LLM_V1_COMPLETIONS = 'text_completion',
+  LLM_V1_CHAT = 'chat.completion',
+}
+
 /**
  * Response object for routes. Does not include model credentials.
  */
@@ -72,7 +75,11 @@ export interface ModelGatewayRoute {
   /**
    * Type of route (e.g., embedding, text generation, etc.)
    */
-  route_type: ModelGatewayRouteType;
+  endpoint_type: ModelGatewayRouteType;
+  /**
+   * URL path of the route (e.g., "/gateway/completions/invocations")
+   */
+  endpoint_url: string;
   /**
    * Underlying ML model that can be accessed via this route. Could add other types of resources in the future.
    */
@@ -80,7 +87,7 @@ export interface ModelGatewayRoute {
 }
 
 export interface SearchModelGatewayRouteResponse {
-  routes: ModelGatewayRoute[];
+  endpoints: ModelGatewayRoute[];
 }
 
 export class GatewayErrorWrapper extends ErrorWrapper {
@@ -112,24 +119,24 @@ const gatewayErrorHandler = ({
 
 function isGatewayResponseOfType(
   response: ModelGatewayResponseType,
-  type: ModelGatewayRouteType.LLM_V1_CHAT,
+  type: ModelDeploymentOutputType.LLM_V1_CHAT,
 ): response is ModelGatewayChatResponseType;
 
 function isGatewayResponseOfType(
   response: ModelGatewayResponseType,
-  type: ModelGatewayRouteType.LLM_V1_COMPLETIONS,
+  type: ModelDeploymentOutputType.LLM_V1_COMPLETIONS,
 ): response is ModelGatewayCompletionsResponseType;
 
 function isGatewayResponseOfType(
   response?: ModelGatewayResponseType,
-  type?: ModelGatewayRouteType,
+  type?: ModelDeploymentOutputType,
 ) {
-  return response?.metadata.route_type === type;
+  return response?.object === type;
 }
 
 export class ModelGatewayService {
   static createEvaluationTextPayload(inputText: string, route: ModelGatewayRoute) {
-    switch (route.route_type) {
+    switch (route.endpoint_type) {
       case ModelGatewayRouteType.LLM_V1_COMPLETIONS: {
         return { prompt: inputText };
       }
@@ -138,31 +145,33 @@ export class ModelGatewayService {
       }
       case ModelGatewayRouteType.LLM_V1_EMBEDDINGS: {
         // Should never happen
-        throw new GatewayErrorWrapper(`Unsupported AI gateway route type "${route.route_type}"!`);
+        throw new GatewayErrorWrapper(
+          `Unsupported AI gateway route type "${route.endpoint_type}"!`,
+        );
       }
       default:
-        throw new GatewayErrorWrapper(`Unknown AI gateway route type "${route.route_type}"!`);
+        throw new GatewayErrorWrapper(`Unknown AI gateway route type "${route.endpoint_type}"!`);
     }
   }
   static parseEvaluationResponse(response: ModelGatewayResponseType) {
     // We're supporting completions and chat responses for the time being
-    if (isGatewayResponseOfType(response, ModelGatewayRouteType.LLM_V1_COMPLETIONS)) {
-      const text = response.candidates[0]?.text;
-      const { metadata } = response;
-      if (text && metadata) {
-        return { text, metadata };
+    if (isGatewayResponseOfType(response, ModelDeploymentOutputType.LLM_V1_COMPLETIONS)) {
+      const text = response.choices[0]?.text;
+      const { usage } = response;
+      if (text && usage) {
+        return { text, usage };
       }
     }
-    if (isGatewayResponseOfType(response, ModelGatewayRouteType.LLM_V1_CHAT)) {
-      const text = response.candidates[0]?.message?.content;
-      const { metadata } = response;
-      if (text && metadata) {
-        return { text, metadata };
+    if (isGatewayResponseOfType(response, ModelDeploymentOutputType.LLM_V1_CHAT)) {
+      const text = response.choices[0]?.message?.content;
+      const { usage } = response;
+      if (text && usage) {
+        return { text, usage };
       }
     }
     // Should not happen since we shouldn't call other route types for now
     throw new GatewayErrorWrapper(
-      `Unrecognizable AI gateway response metadata "${response.metadata}"!`,
+      `Unrecognizable AI gateway response object "${response.object}"!`,
     );
   }
   /**

--- a/mlflow/server/js/src/i18n/default/en.json
+++ b/mlflow/server/js/src/i18n/default/en.json
@@ -1823,10 +1823,6 @@
     "defaultMessage": "Please select metrics",
     "description": "Placeholder text for metrics in parallel coordinates plot in MLflow"
   },
-  "r6ANEE": {
-    "defaultMessage": "Select route",
-    "description": "Experiment page > new run modal > AI gateway selector placeholder"
-  },
   "rCMgRJ": {
     "defaultMessage": "Name",
     "description": "Header for \"name\" column in the experiment run dataset schema"
@@ -1958,6 +1954,10 @@
   "vPqFJE": {
     "defaultMessage": "Artifacts",
     "description": "Run details page > tab selector > artifacts tab"
+  },
+  "vSjD2B": {
+    "defaultMessage": "Select endpoint",
+    "description": "Experiment page > new run modal > AI gateway selector placeholder"
   },
   "vi2MM7": {
     "defaultMessage": "All",

--- a/mlflow/server/js/src/i18n/default/en.json
+++ b/mlflow/server/js/src/i18n/default/en.json
@@ -59,10 +59,6 @@
     "defaultMessage": "Y-axis:",
     "description": "Label text for y-axis in contour plot comparison in MLflow"
   },
-  "0TZCn5": {
-    "defaultMessage": "You need to select a route from the AI gateway dropdown first",
-    "description": "Experiment page > new run modal > invalid state - no AI gateway selected"
-  },
   "0gGMZm": {
     "defaultMessage": "Name",
     "description": "Default text for name placeholder in editable tags table form in MLflow"
@@ -503,6 +499,10 @@
     "defaultMessage": "100",
     "description": "Label for 100 first runs visible in run count selector within runs compare configuration modal"
   },
+  "Bj7jg5": {
+    "defaultMessage": "You cannot evaluate this cell, this run was not created using MLflow deployment endpoints.",
+    "description": "Experiment page > artifact compare view > text cell > run not evaluable tooltip"
+  },
   "Bnruyp": {
     "defaultMessage": "500",
     "description": "Label for 500 first runs visible in run count selector within runs compare configuration modal"
@@ -586,6 +586,10 @@
   "EKyt+3": {
     "defaultMessage": "Metrics:",
     "description": "Label text for metrics in parallel coordinates plot in MLflow"
+  },
+  "ENTyzw": {
+    "defaultMessage": "You need to select an endpoint from the MLflow deployment dropdown first",
+    "description": "Experiment page > new run modal > invalid state - no AI gateway selected"
   },
   "EOlibi": {
     "defaultMessage": "Model",
@@ -755,13 +759,13 @@
     "defaultMessage": "Edit",
     "description": "Text for the edit button next to the description section title on\n             the model version view page"
   },
+  "Iq0d/V": {
+    "defaultMessage": "These endpoints come from the MLflow deployment. Check out the MLflow deployment documentation to get started",
+    "description": "Information about MLflow deployment endpoints"
+  },
   "J2XCE/": {
     "defaultMessage": "Specify sequences that signal the model to stop generating text.",
     "description": "Experiment page > prompt lab > stop parameter help text"
-  },
-  "JAFH9v": {
-    "defaultMessage": "AI gateway returned the following error: \"{errorMessage}\"",
-    "description": "Experiment page > new run modal > AI gateway error message"
   },
   "JCboZ7": {
     "defaultMessage": "Path copied",
@@ -1282,10 +1286,6 @@
   "bSx/er": {
     "defaultMessage": "Parameters",
     "description": "Table title text for parameters table in the model comparison page"
-  },
-  "bc/aGy": {
-    "defaultMessage": "These routes come from the AI Gateway. Check out the AI Gateway preview documentation to get started",
-    "description": "Information about gateway routes"
   },
   "bhgG7S": {
     "defaultMessage": "Run Command",
@@ -1899,10 +1899,6 @@
     "defaultMessage": "Register Model",
     "description": "Register model modal title to register the model for deployment"
   },
-  "tnTuzM": {
-    "defaultMessage": "You cannot evaluate this cell, this run was not created using AI gateway route",
-    "description": "Experiment page > artifact compare view > text cell > run not evaluable tooltip"
-  },
   "ttyLD4": {
     "defaultMessage": "Okay",
     "description": "Experiment page > new notebook run modal > okay button label"
@@ -2030,6 +2026,10 @@
   "yAuDRt": {
     "defaultMessage": "Evaluation is not possible because values for the following inputs cannot be determined: {missingParamList}. Add input columns to the \"group by\" settings or use \"Add row\" button to define new parameter set.",
     "description": "Experiment page > artifact compare view > text cell > missing evaluation parameter values tooltip"
+  },
+  "yC9GFP": {
+    "defaultMessage": "MLflow deployment returned the following error: \"{errorMessage}\"",
+    "description": "Experiment page > new run modal > MLflow deployment error message"
   },
   "yJpGwW": {
     "defaultMessage": "Deleted",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sunishsheth2009/mlflow/pull/10515?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10515/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10515
```

</p>
</details>

### What changes are proposed in this pull request?
[FEAT] Migrating prompt lab to use MLflow deployments

<img width="1728" alt="image" src="https://github.com/mlflow/mlflow/assets/5621432/c9de17f1-21ea-470f-9d6d-c94b03940632">


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

[FEAT] Migrating prompt lab to use MLflow deployments

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
