### PR TITLE
Gateway Streaming for OpenAI

### DIFF
--- a/docs/source/llms/gateway/index.rst
+++ b/docs/source/llms/gateway/index.rst
@@ -848,10 +848,7 @@ In addition to the :ref:`standard_query_parameters`, you can pass any additional
 - ``top_k`` (supported by MosaicML, Anthropic, PaLM, Cohere)
 - ``frequency_penalty`` (supported by OpenAI, Cohere, AI21 Labs)
 - ``presence_penalty`` (supported by OpenAI, Cohere, AI21 Labs)
-
-The following parameters are not allowed:
-
-- ``stream`` is not supported. Setting this parameter on any provider will not work currently.
+- ``stream`` (supported by OpenAI)
 
 Below is an example of submitting a query request to an MLflow AI Gateway route using additional parameters:
 
@@ -898,6 +895,85 @@ The results of the query are:
            "route_type": "llm/v1/completions"
          }
        }
+
+Streaming
+~~~~~~~~~
+
+Some providers support streaming responses. Streaming responses are useful when you want to
+receive responses as they are generated, rather than waiting for the entire response to be
+generated before receiving it. Streaming responses are supported by the following providers:
+
+- OpenAI
+
+To enable streaming responses, set the ``stream`` parameter to ``true`` in your query. For example:
+
+.. code-block:: python
+
+    for chunk in query(route="completions-gpt4", data=data, stream=True):
+        print(chunk)
+
+
+The results of the query follow the `OpenAI schema <https://platform.openai.com/docs/api-reference/chat/streaming>`.
+
+
+Chat
+^^^^
+
+.. code-block:: json
+
+    {"choices": [{"delta": {"content": None, "role": "assistant"}, "finish_reason": None, "index": 0}],
+     "created": 1701161926,
+     "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
+     "model": "gpt-35-turbo",
+     "object": "chat.completion.chunk"}
+    {"choices": [{"delta": {"content": "Hello", "role": None}, "finish_reason": None, "index": 0}],
+     "created": 1701161926,
+     "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
+     "model": "gpt-35-turbo",
+     "object": "chat.completion.chunk"}
+    {"choices": [{"delta": {"content": " there", "role": None}, "finish_reason": None, "index": 0}],
+     "created": 1701161926,
+     "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
+     "model": "gpt-35-turbo",
+     "object": "chat.completion.chunk"}
+    {"choices": [{"delta": {"content": None, "role": None}, "finish_reason": "stop", "index": 0}],
+     "created": 1701161926,
+     "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
+     "model": "gpt-35-turbo",
+     "object": "chat.completion.chunk"}
+
+
+Completions
+^^^^^^^^^^^
+
+.. code-block:: json
+
+    {"choices": [{"delta": {"text": ""}, "finish_reason": None, "index": 0}],
+     "created": 1701161629,
+     "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
+     "model": "gpt-3.5-turbo-0613",
+     "object": "chat.completion.chunk"}
+    {"choices": [{"delta": {"text": "If"}, "finish_reason": None, "index": 0}],
+     "created": 1701161629,
+     "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
+     "model": "gpt-3.5-turbo-0613",
+     "object": "chat.completion.chunk"}
+    {"choices": [{"delta": {"text": " an"}, "finish_reason": None, "index": 0}],
+     "created": 1701161629,
+     "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
+     "model": "gpt-3.5-turbo-0613",
+     "object": "chat.completion.chunk"}
+    {"choices": [{"delta": {"text": " asteroid"}, "finish_reason": None, "index": 0}],
+     "created": 1701161629,
+     "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
+     "model": "gpt-3.5-turbo-0613",
+     "object": "chat.completion.chunk"}
+    {"choices": [{"delta": {"text": None}, "finish_reason": "length", "index": 0}],
+     "created": 1701161629,
+     "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
+     "model": "gpt-3.5-turbo-0613",
+     "object": "chat.completion.chunk"}
+
 
 FastAPI Documentation ("/docs")
 -------------------------------

--- a/docs/source/llms/gateway/index.rst
+++ b/docs/source/llms/gateway/index.rst
@@ -913,7 +913,7 @@ To enable streaming responses, set the ``stream`` parameter to ``true`` in your 
         print(chunk)
 
 
-The results of the query follow the `OpenAI schema <https://platform.openai.com/docs/api-reference/chat/streaming>`.
+The results of the query follow the `OpenAI schema <https://platform.openai.com/docs/api-reference/chat/streaming>`_.
 
 
 Chat

--- a/docs/source/llms/gateway/index.rst
+++ b/docs/source/llms/gateway/index.rst
@@ -921,22 +921,22 @@ Chat
 
 .. code-block:: json
 
-    {"choices": [{"delta": {"content": None, "role": "assistant"}, "finish_reason": None, "index": 0}],
+    {"choices": [{"delta": {"content": null, "role": "assistant"}, "finish_reason": null, "index": 0}],
      "created": 1701161926,
      "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
      "model": "gpt-35-turbo",
      "object": "chat.completion.chunk"}
-    {"choices": [{"delta": {"content": "Hello", "role": None}, "finish_reason": None, "index": 0}],
+    {"choices": [{"delta": {"content": "Hello", "role": null}, "finish_reason": null, "index": 0}],
      "created": 1701161926,
      "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
      "model": "gpt-35-turbo",
      "object": "chat.completion.chunk"}
-    {"choices": [{"delta": {"content": " there", "role": None}, "finish_reason": None, "index": 0}],
+    {"choices": [{"delta": {"content": " there", "role": null}, "finish_reason": null, "index": 0}],
      "created": 1701161926,
      "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
      "model": "gpt-35-turbo",
      "object": "chat.completion.chunk"}
-    {"choices": [{"delta": {"content": None, "role": None}, "finish_reason": "stop", "index": 0}],
+    {"choices": [{"delta": {"content": null, "role": null}, "finish_reason": "stop", "index": 0}],
      "created": 1701161926,
      "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
      "model": "gpt-35-turbo",
@@ -948,27 +948,27 @@ Completions
 
 .. code-block:: json
 
-    {"choices": [{"delta": {"text": ""}, "finish_reason": None, "index": 0}],
+    {"choices": [{"delta": {"text": ""}, "finish_reason": null, "index": 0}],
      "created": 1701161629,
      "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
      "model": "gpt-3.5-turbo-0613",
      "object": "chat.completion.chunk"}
-    {"choices": [{"delta": {"text": "If"}, "finish_reason": None, "index": 0}],
+    {"choices": [{"delta": {"text": "If"}, "finish_reason": null, "index": 0}],
      "created": 1701161629,
      "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
      "model": "gpt-3.5-turbo-0613",
      "object": "chat.completion.chunk"}
-    {"choices": [{"delta": {"text": " an"}, "finish_reason": None, "index": 0}],
+    {"choices": [{"delta": {"text": " an"}, "finish_reason": null, "index": 0}],
      "created": 1701161629,
      "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
      "model": "gpt-3.5-turbo-0613",
      "object": "chat.completion.chunk"}
-    {"choices": [{"delta": {"text": " asteroid"}, "finish_reason": None, "index": 0}],
+    {"choices": [{"delta": {"text": " asteroid"}, "finish_reason": null, "index": 0}],
      "created": 1701161629,
      "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
      "model": "gpt-3.5-turbo-0613",
      "object": "chat.completion.chunk"}
-    {"choices": [{"delta": {"text": None}, "finish_reason": "length", "index": 0}],
+    {"choices": [{"delta": {"text": null}, "finish_reason": "length", "index": 0}],
      "created": 1701161629,
      "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
      "model": "gpt-3.5-turbo-0613",

--- a/mlflow/gateway/app.py
+++ b/mlflow/gateway/app.py
@@ -77,8 +77,14 @@ def _create_completions_endpoint(config: RouteConfig):
 
     async def _completions(
         payload: completions.RequestPayload,
-    ) -> completions.ResponsePayload:
-        return await prov.completions(payload)
+    ) -> Union[completions.ResponsePayload, completions.StreamResponsePayload]:
+        if payload.stream:
+            return StreamingResponse(
+                (to_sse_chunk(d.json()) async for d in prov.completions_stream(payload)),
+                media_type="text/event-stream",
+            )
+        else:
+            return await prov.completions(payload)
 
     return _completions
 

--- a/mlflow/gateway/app.py
+++ b/mlflow/gateway/app.py
@@ -62,12 +62,10 @@ def _create_chat_endpoint(config: RouteConfig):
         payload: chat.RequestPayload,
     ) -> Union[chat.ResponsePayload, chat.StreamResponsePayload]:
         if payload.stream:
-
-            async def generator():
-                async for d in prov.chat_stream(payload):
-                    yield to_sse_chunk(d.json())
-
-            return StreamingResponse(generator(), media_type="text/event-stream")
+            return StreamingResponse(
+                (to_sse_chunk(d.json()) async for d in prov.chat_stream(payload)),
+                media_type="text/event-stream",
+            )
         else:
             return await prov.chat(payload)
 

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -14,7 +14,12 @@ from mlflow.gateway.constants import (
     MLFLOW_GATEWAY_ROUTE_BASE,
     MLFLOW_QUERY_SUFFIX,
 )
-from mlflow.gateway.utils import assemble_uri_path, get_gateway_uri, resolve_route_url, strip_sse_prefix
+from mlflow.gateway.utils import (
+    assemble_uri_path,
+    get_gateway_uri,
+    resolve_route_url,
+    strip_sse_prefix,
+)
 from mlflow.protos.databricks_pb2 import BAD_REQUEST
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.tracking._tracking_service.utils import _get_default_host_creds

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -341,7 +341,7 @@ class MlflowGatewayClient:
 
         """
         if stream:
-            data.update({"stream": stream})
+            data = {**data, "stream": True}
         data = json.dumps(data)
 
         query_route = assemble_uri_path([MLFLOW_GATEWAY_ROUTE_BASE, route, MLFLOW_QUERY_SUFFIX])

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -72,13 +72,16 @@ class MlflowGatewayClient:
         """
         return self._gateway_uri
 
-    def _call_endpoint(self, method: str, route: str, json_body: Optional[str] = None):
+    def _call_endpoint(
+        self, method: str, route: str, json_body: Optional[str] = None, stream: bool = False
+    ):
         """
         Call a specific endpoint on the Gateway API.
 
         :param method: The HTTP method to use.
         :param route: The API route to call.
         :param json_body: Optional JSON body to include in the request.
+        :param stream: Enable streaming response
         :return: The server's response.
         """
         if json_body:
@@ -97,6 +100,7 @@ class MlflowGatewayClient:
             timeout=MLFLOW_GATEWAY_CLIENT_QUERY_TIMEOUT_SECONDS,
             retry_codes=MLFLOW_GATEWAY_CLIENT_QUERY_RETRY_CODES,
             raise_on_status=False,
+            stream=stream,
             **call_kwargs,
         )
         augmented_raise_for_status(response)
@@ -343,7 +347,7 @@ class MlflowGatewayClient:
         query_route = assemble_uri_path([MLFLOW_GATEWAY_ROUTE_BASE, route, MLFLOW_QUERY_SUFFIX])
 
         try:
-            resp = self._call_endpoint("POST", query_route, data)
+            resp = self._call_endpoint("POST", query_route, data, stream=stream)
         except MlflowException as e:
             if isinstance(e.__cause__, requests.exceptions.Timeout):
                 timeout_message = (

--- a/mlflow/gateway/fluent.py
+++ b/mlflow/gateway/fluent.py
@@ -184,7 +184,7 @@ def get_limits(route: str) -> LimitsConfig:
 
 
 @experimental
-def query(route: str, data):
+def query(route: str, data, stream: bool = False):
     """
     Issues a query request to a configured service through a named route on the Gateway Server.
     This function will interface with a configured route name (examples below) and return the
@@ -194,6 +194,11 @@ def query(route: str, data):
                   `mlflow.gateway.search_routes()`
     :param data: The request payload to be submitted to the route. The exact configuration of
                  the expected structure varies based on the route configuration.
+    :param stream: Enable streaming of the response. If enabled, this function will return
+                   a generator that will yield the response in chunks as they are received from
+                   the server. If disabled, the function will return the full response as a
+                   dictionary.
+                   Ignored for routes that do not support streaming (e.g. embeddings).
     :return: The response from the configured route endpoint provider in a standardized format.
 
     Chat example:
@@ -247,4 +252,4 @@ def query(route: str, data):
         )
 
     """
-    return MlflowGatewayClient().query(route, data)
+    return MlflowGatewayClient().query(route, data, stream)

--- a/mlflow/gateway/providers/ai21labs.py
+++ b/mlflow/gateway/providers/ai21labs.py
@@ -29,7 +29,7 @@ class AI21LabsProvider(BaseProvider):
                 raise HTTPException(
                     status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
-        if payload.get("stream", None) == "true":
+        if payload.get("stream", False):
             raise HTTPException(
                 status_code=422,
                 detail="Setting the 'stream' parameter to 'true' is not supported with the MLflow "

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -49,7 +49,7 @@ class AnthropicAdapter(ProviderAdapter):
 
         payload["max_tokens"] = max_tokens
 
-        if payload.get("stream", None) == "true":
+        if payload.get("stream", False):
             raise HTTPException(
                 status_code=422,
                 detail="Setting the 'stream' parameter to 'true' is not supported with the MLflow "

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -18,6 +18,9 @@ class BaseProvider(ABC):
     def __init__(self, config: RouteConfig):
         self.config = config
 
+    async def chat_stream(self, payload: chat.RequestPayload) -> chat.StreamResponsePayload:
+        raise NotImplementedError
+
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
         raise NotImplementedError
 

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractclassmethod
-from typing import Tuple
+from typing import Tuple, AsyncIterable
 
 from fastapi import HTTPException
 
@@ -18,7 +18,7 @@ class BaseProvider(ABC):
     def __init__(self, config: RouteConfig):
         self.config = config
 
-    async def chat_stream(self, payload: chat.RequestPayload) -> chat.StreamResponsePayload:
+    async def chat_stream(self, payload: chat.RequestPayload) -> AsyncIterable[chat.StreamResponsePayload]:
         raise NotImplementedError
 
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -26,6 +26,11 @@ class BaseProvider(ABC):
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
         raise NotImplementedError
 
+    async def completions_stream(
+        self, payload: completions.RequestPayload
+    ) -> AsyncIterable[completions.StreamResponsePayload]:
+        raise NotImplementedError
+
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
         raise NotImplementedError
 

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractclassmethod
-from typing import Tuple, AsyncIterable
+from typing import AsyncIterable, Tuple
 
 from fastapi import HTTPException
 
@@ -18,7 +18,9 @@ class BaseProvider(ABC):
     def __init__(self, config: RouteConfig):
         self.config = config
 
-    async def chat_stream(self, payload: chat.RequestPayload) -> AsyncIterable[chat.StreamResponsePayload]:
+    async def chat_stream(
+        self, payload: chat.RequestPayload
+    ) -> AsyncIterable[chat.StreamResponsePayload]:
         raise NotImplementedError
 
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -253,9 +253,7 @@ class OpenAIProvider(BaseProvider):
                     "choices": [
                         {
                             "index": choice["index"],
-                            "delta": {
-                                "text": choice["delta"].get("content")
-                            },
+                            "delta": {"text": choice["delta"].get("content")},
                             "finish_reason": choice["finish_reason"],
                         }
                         for choice in data["choices"]

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -77,7 +77,6 @@ class OpenAIProvider(BaseProvider):
             return payload
 
     def _prepare_chat_request_payload(self, payload):
-
         payload = rename_payload_keys(
             payload,
             {"candidate_count": "n"},

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from typing import AsyncIterable
 
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import OpenAIAPIType, OpenAIConfig, RouteConfig
@@ -86,7 +87,7 @@ class OpenAIProvider(BaseProvider):
         payload["temperature"] = 2 * payload["temperature"]
         return payload
 
-    async def chat_stream(self, payload: chat.RequestPayload) -> chat.StreamResponsePayload:
+    async def chat_stream(self, payload: chat.RequestPayload) -> AsyncIterable[chat.StreamResponsePayload]:
         from fastapi import HTTPException
         from fastapi.encoders import jsonable_encoder
 

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -110,13 +110,12 @@ class OpenAIProvider(BaseProvider):
             if not chunk:
                 continue
 
-            if chunk == b"[DONE]":
+            data = strip_sse_prefix(chunk.decode("utf-8"))
+            if data == "[DONE]":
                 return
 
-            decoded_chunk = chunk.decode("utf-8")
-            data = json.loads(strip_sse_prefix(decoded_chunk))
             await asyncio.sleep(0.05)
-            yield chat.StreamResponsePayload(**data)
+            yield chat.StreamResponsePayload(**json.loads(data))
 
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
         from fastapi import HTTPException

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -87,7 +87,9 @@ class OpenAIProvider(BaseProvider):
         payload["temperature"] = 2 * payload["temperature"]
         return payload
 
-    async def chat_stream(self, payload: chat.RequestPayload) -> AsyncIterable[chat.StreamResponsePayload]:
+    async def chat_stream(
+        self, payload: chat.RequestPayload
+    ) -> AsyncIterable[chat.StreamResponsePayload]:
         from fastapi import HTTPException
         from fastapi.encoders import jsonable_encoder
 

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -254,9 +254,9 @@ class OpenAIProvider(BaseProvider):
                         {
                             "index": choice["index"],
                             "delta": {
-                                "text": choice["delta"].get("content", "")
+                                "text": choice["delta"].get("content")
                             },
-                            "metadata": {"finish_reason": choice["finish_reason"]},
+                            "finish_reason": choice["finish_reason"],
                         }
                         for choice in data["choices"]
                     ],

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict
+from contextlib import asynccontextmanager
+from typing import Any, AsyncGenerator, Dict
 
 import aiohttp
 
@@ -6,6 +7,15 @@ from mlflow.gateway.constants import (
     MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS,
 )
 from mlflow.utils.uri import append_to_uri_path
+
+
+@asynccontextmanager
+async def _aiohttp_post(headers: Dict[str, str], base_url: str, path: str, payload: Dict[str, Any]):
+    async with aiohttp.ClientSession(headers=headers) as session:
+        url = append_to_uri_path(base_url, path)
+        timeout = aiohttp.ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS)
+        async with session.post(url, json=payload, timeout=timeout) as response:
+            yield response
 
 
 async def send_request(headers: Dict[str, str], base_url: str, path: str, payload: Dict[str, Any]):
@@ -21,27 +31,42 @@ async def send_request(headers: Dict[str, str], base_url: str, path: str, payloa
     """
     from fastapi import HTTPException
 
-    async with aiohttp.ClientSession(headers=headers) as session:
-        url = append_to_uri_path(base_url, path)
-        timeout = aiohttp.ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS)
-        async with session.post(url, json=payload, timeout=timeout) as response:
-            content_type = response.headers.get("Content-Type")
-            if content_type and "application/json" in content_type:
-                js = await response.json()
-            elif content_type and "text/plain" in content_type:
-                js = {"message": await response.text()}
-            else:
-                raise HTTPException(
-                    status_code=502,
-                    detail=f"The returned data type from the route service is not supported. "
-                    f"Received content type: {content_type}",
-                )
-            try:
-                response.raise_for_status()
-            except aiohttp.ClientResponseError as e:
-                detail = js.get("error", {}).get("message", e.message) if "error" in js else js
-                raise HTTPException(status_code=e.status, detail=detail)
-            return js
+    async with _aiohttp_post(headers, base_url, path, payload) as response:
+        content_type = response.headers.get("Content-Type")
+        if content_type and "application/json" in content_type:
+            js = await response.json()
+        elif content_type and "text/plain" in content_type:
+            js = {"message": await response.text()}
+        else:
+            raise HTTPException(
+                status_code=502,
+                detail=f"The returned data type from the route service is not supported. "
+                f"Received content type: {content_type}",
+            )
+        try:
+            response.raise_for_status()
+        except aiohttp.ClientResponseError as e:
+            detail = js.get("error", {}).get("message", e.message) if "error" in js else js
+            raise HTTPException(status_code=e.status, detail=detail)
+        return js
+
+
+async def send_stream_request(
+    headers: Dict[str, str], base_url: str, path: str, payload: Dict[str, Any]
+) -> AsyncGenerator[bytes, None]:
+    """
+    Send an HTTP request to a specific URL path with given headers and payload.
+
+    :param headers: The headers to include in the request.
+    :param base_url: The base URL where the request will be sent.
+    :param path: The specific path of the URL to which the request will be sent.
+    :param payload: The payload (or data) to be included in the request.
+    :return: The server's response as a JSON object.
+    :raise: HTTPException if the HTTP request fails.
+    """
+    async with _aiohttp_post(headers, base_url, path, payload) as response:
+        async for line in response.content:
+            yield line
 
 
 def rename_payload_keys(payload: Dict[str, Any], mapping: Dict[str, str]) -> Dict[str, Any]:

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -17,6 +17,7 @@ class BaseRequestPayload(RequestModel):
     candidate_count: int = Field(1, ge=1, le=5)
     stop: Optional[List[str]] = Field(None, min_items=1)
     max_tokens: Optional[int] = Field(None, ge=1)
+    stream: bool = False
 
 
 class RequestPayload(BaseRequestPayload):
@@ -93,3 +94,22 @@ class ResponsePayload(ResponseModel):
                 },
             }
         }
+
+
+class StreamDelta(ResponseModel):
+    role: Optional[str] = None
+    content: Optional[str] = None
+
+
+class StreamChoice(ResponseModel):
+    index: int
+    finish_reason: Optional[FinishReason] = None
+    delta: StreamDelta
+
+
+class StreamResponsePayload(ResponseModel):
+    id: str
+    object: str
+    created: int
+    model: str
+    choices: List[StreamChoice]

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -17,7 +17,7 @@ class BaseRequestPayload(RequestModel):
     candidate_count: int = Field(1, ge=1, le=5)
     stop: Optional[List[str]] = Field(None, min_items=1)
     max_tokens: Optional[int] = Field(None, ge=1)
-    stream: bool = False
+    stream: Optional[bool] = None
 
 
 class RequestPayload(BaseRequestPayload):

--- a/mlflow/gateway/schemas/completions.py
+++ b/mlflow/gateway/schemas/completions.py
@@ -61,3 +61,21 @@ class ResponsePayload(ResponseModel):
                 },
             }
         }
+
+
+class StreamDelta(ResponseModel):
+    text: Optional[str] = None
+
+
+class StreamChoice(ResponseModel):
+    index: int
+    finish_reason: Optional[FinishReason] = None
+    delta: StreamDelta
+
+
+class StreamResponsePayload(ResponseModel):
+    id: str
+    object: str
+    created: int
+    model: str
+    choices: List[StreamChoice]

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -181,3 +181,8 @@ def is_valid_mosiacml_chat_model(model_name: str) -> bool:
 
 def is_valid_ai21labs_model(model_name: str) -> bool:
     return model_name in {"j2-ultra", "j2-mid", "j2-light"}
+
+
+def strip_sse_prefix(s: str):
+    # https://html.spec.whatwg.org/multipage/server-sent-events.html
+    return re.sub(r"^data:\s+", "", s)

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -183,6 +183,11 @@ def is_valid_ai21labs_model(model_name: str) -> bool:
     return model_name in {"j2-ultra", "j2-mid", "j2-light"}
 
 
-def strip_sse_prefix(s: str):
+def strip_sse_prefix(s: str) -> str:
     # https://html.spec.whatwg.org/multipage/server-sent-events.html
     return re.sub(r"^data:\s+", "", s)
+
+
+def to_sse_chunk(data: str) -> str:
+    # https://html.spec.whatwg.org/multipage/server-sent-events.html
+    return f"data: {data}\n\n"

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -130,11 +130,14 @@ async def test_chat_temperature_is_doubled():
 
 def chat_stream_response():
     return [
-        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant"}}]}\n',
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test",'
+        b'"choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant"}}]}\n',
         b"\n",
-        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"test"}}]}\n',
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test",'
+        b'"choices":[{"index":0,"finish_reason":null,"delta":{"content":"test"}}]}\n',
         b"\n",
-        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":"stop","delta":{}}]}\n',
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test",'
+        b'"choices":[{"index":0,"finish_reason":"stop","delta":{}}]}\n',
         b"\n",
         b"data: [DONE]\n",
     ]
@@ -163,7 +166,7 @@ async def test_chat_stream():
                 ],
                 "created": 1,
                 "id": "test-id",
-                "model": "gpt-35-turbo",
+                "model": "test",
                 "object": "chat.completion.chunk",
             },
             {
@@ -172,7 +175,7 @@ async def test_chat_stream():
                 ],
                 "created": 1,
                 "id": "test-id",
-                "model": "gpt-35-turbo",
+                "model": "test",
                 "object": "chat.completion.chunk",
             },
             {
@@ -181,7 +184,7 @@ async def test_chat_stream():
                 ],
                 "created": 1,
                 "id": "test-id",
-                "model": "gpt-35-turbo",
+                "model": "test",
                 "object": "chat.completion.chunk",
             },
         ]
@@ -296,11 +299,16 @@ async def test_completions_temperature_is_doubled():
 
 def completions_stream_response():
     return [
-        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant", "content": ""}}]}\n',
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test",'
+        b'"choices":[{"index":0,"finish_reason":null,'
+        b'"delta":{"role":"assistant", "content": ""}}]}\n',
         b"\n",
-        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"test"}}]}\n',
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test",'
+        b'"choices":[{"index":0,"finish_reason":null,'
+        b'"delta":{"content":"test"}}]}\n',
         b"\n",
-        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":"length","delta":{}}]}\n',
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test",'
+        b'"choices":[{"index":0,"finish_reason":"length","delta":{}}]}\n',
         b"\n",
         b"data: [DONE]\n",
     ]
@@ -329,21 +337,21 @@ async def test_completions_stream():
                 ],
                 "created": 1,
                 "id": "test-id",
-                "model": "gpt-35-turbo",
+                "model": "test",
                 "object": "chat.completion.chunk",
             },
             {
                 "choices": [{"delta": {"text": "test"}, "finish_reason": None, "index": 0}],
                 "created": 1,
                 "id": "test-id",
-                "model": "gpt-35-turbo",
+                "model": "test",
                 "object": "chat.completion.chunk",
             },
             {
                 "choices": [{"delta": {"text": None}, "finish_reason": "length", "index": 0}],
                 "created": 1,
                 "id": "test-id",
-                "model": "gpt-35-turbo",
+                "model": "test",
                 "object": "chat.completion.chunk",
             },
         ]

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -12,7 +12,7 @@ from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
 from mlflow.gateway.providers.openai import OpenAIProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
-from tests.gateway.tools import MockAsyncResponse, mock_http_client, MockAsyncStreamingResponse
+from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse, mock_http_client
 
 
 def chat_config():
@@ -131,12 +131,12 @@ async def test_chat_temperature_is_doubled():
 def chat_stream_response():
     return [
         b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant"}}]}\n',
-        b'\n',
+        b"\n",
         b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"content":"test"}}]}\n',
-        b'\n',
+        b"\n",
         b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":"stop","delta":{}}]}\n',
-        b'\n',
-        b'data: [DONE]\n',
+        b"\n",
+        b"data: [DONE]\n",
     ]
 
 
@@ -153,27 +153,37 @@ async def test_chat_stream():
 
         chunks = [jsonable_encoder(chunk) async for chunk in response]
         assert chunks == [
-            {'choices': [{'delta': {'content': None, 'role': 'assistant'},
-                          'finish_reason': None,
-                          'index': 0}],
-             'created': 1,
-             'id': 'test-id',
-             'model': 'gpt-35-turbo',
-             'object': 'chat.completion.chunk'},
-            {'choices': [{'delta': {'content': 'test', 'role': None},
-                          'finish_reason': None,
-                          'index': 0}],
-             'created': 1,
-             'id': 'test-id',
-             'model': 'gpt-35-turbo',
-             'object': 'chat.completion.chunk'},
-            {'choices': [{'delta': {'content': None, 'role': None},
-                          'finish_reason': 'stop',
-                          'index': 0}],
-             'created': 1,
-             'id': 'test-id',
-             'model': 'gpt-35-turbo',
-             'object': 'chat.completion.chunk'},
+            {
+                "choices": [
+                    {
+                        "delta": {"content": None, "role": "assistant"},
+                        "finish_reason": None,
+                        "index": 0,
+                    }
+                ],
+                "created": 1,
+                "id": "test-id",
+                "model": "gpt-35-turbo",
+                "object": "chat.completion.chunk",
+            },
+            {
+                "choices": [
+                    {"delta": {"content": "test", "role": None}, "finish_reason": None, "index": 0}
+                ],
+                "created": 1,
+                "id": "test-id",
+                "model": "gpt-35-turbo",
+                "object": "chat.completion.chunk",
+            },
+            {
+                "choices": [
+                    {"delta": {"content": None, "role": None}, "finish_reason": "stop", "index": 0}
+                ],
+                "created": 1,
+                "id": "test-id",
+                "model": "gpt-35-turbo",
+                "object": "chat.completion.chunk",
+            },
         ]
 
         mock_build_client.assert_called_once_with(

--- a/tests/gateway/tools.py
+++ b/tests/gateway/tools.py
@@ -122,7 +122,9 @@ class MockAsyncResponse:
 
 
 class MockAsyncStreamingResponse:
-    def __init__(self, data: List[bytes], headers: Optional[Dict[str, str]] = None, status: int = 200):
+    def __init__(
+        self, data: List[bytes], headers: Optional[Dict[str, str]] = None, status: int = 200
+    ):
         self.status = status
         self.headers = headers
         self._content = data

--- a/tests/gateway/tools.py
+++ b/tests/gateway/tools.py
@@ -8,7 +8,7 @@ import threading
 import time
 from collections import namedtuple
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Any, Dict, Union, List
 from unittest import mock
 
 import aiohttp
@@ -121,6 +121,32 @@ class MockAsyncResponse:
         pass
 
 
+class MockAsyncStreamingResponse:
+    def __init__(self, data: List[bytes], headers: Dict[str, str] = None, status: int = 200):
+        # Extract status and headers from data, if present
+        self.status = status
+        self.headers = headers
+        self._content = data
+
+    def raise_for_status(self) -> None:
+        if 400 <= self.status < 600:
+            raise aiohttp.ClientResponseError(None, None, status=self.status)
+
+    async def _async_content(self):
+        for line in self._content:
+            yield line
+
+    @property
+    def content(self):
+        return self._async_content()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        pass
+
+
 class MockHttpClient(mock.Mock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -132,7 +158,7 @@ class MockHttpClient(mock.Mock):
         return
 
 
-def mock_http_client(mock_response: MockAsyncResponse):
+def mock_http_client(mock_response: Union[MockAsyncResponse, MockAsyncStreamingResponse]):
     mock_http_client = MockHttpClient()
     mock_http_client.post = mock.Mock(return_value=mock_response)
     return mock_http_client

--- a/tests/gateway/tools.py
+++ b/tests/gateway/tools.py
@@ -8,7 +8,7 @@ import threading
 import time
 from collections import namedtuple
 from pathlib import Path
-from typing import Any, Dict, Union, List
+from typing import Any, Dict, List, Optional, Union
 from unittest import mock
 
 import aiohttp
@@ -122,8 +122,7 @@ class MockAsyncResponse:
 
 
 class MockAsyncStreamingResponse:
-    def __init__(self, data: List[bytes], headers: Dict[str, str] = None, status: int = 200):
-        # Extract status and headers from data, if present
+    def __init__(self, data: List[bytes], headers: Optional[Dict[str, str]] = None, status: int = 200):
         self.status = status
         self.headers = headers
         self._content = data


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/gabrielfu/mlflow/pull/10520?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10520/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10520
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Implemented streaming support for MLflow AI Gateway with OpenAI provider on chat and completions endpoints.

Example:

```python
from mlflow.gateway import query, set_gateway_uri

set_gateway_uri(gateway_uri="http://127.0.0.1:5000")
route_name = "chat"
data = dict(
    messages=[
        {
            "role": "user",
            "content": "say 'hello world'",
        }
    ],
    candidate_count=1,
    temperature=0.2,
    max_tokens=20,
)


for chunk in query(route_name, data, stream=True):
    print(chunk)
    print("======================================")
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Implemented streaming support for MLflow AI Gateway with OpenAI provider on chat and completions endpoints.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
