### PR TITLE
Support runnables in langchain

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -184,12 +184,14 @@ jobs:
           pip install -U "pip$PIP_SPEC" wheel
           pip install -e .[extras]
           pip install -r requirements/test-requirements.txt
-          if [ "${{ matrix.package }}" = "langchain" ]; then
-            pip uninstall pydantic -y && pip install pydantic --no-binary :all:
-          fi
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         run: |
           ${{ matrix.install }}
+      - name: Install pydantic no-binary for langchain
+        if: matrix.package == 'langchain'
+        run: |
+          pip uninstall pydantic -y
+          pip install pydantic --no-binary :all:
       - name: Check package versions
         run: |
           python dev/show_package_release_dates.py

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -185,7 +185,7 @@ jobs:
           pip install -e .[extras]
           pip install -r requirements/test-requirements.txt
           if [ "${{ matrix.package }}" = "langchain" ]; then
-            pip uninstall pydantic -y && pip install pydantic --no-binary :all:
+            pip uninstall pydantic -y && pip install 'pydantic<2.0.0' --no-binary pydantic
           fi
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         run: |

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -191,7 +191,7 @@ jobs:
         if: matrix.package == 'langchain'
         run: |
           pip uninstall pydantic -y
-          pip install pydantic --no-binary=pydantic
+          pip install pydantic --no-binary :all:
       - name: Check package versions
         run: |
           python dev/show_package_release_dates.py

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -188,9 +188,10 @@ jobs:
         run: |
           ${{ matrix.install }}
       - name: Install pydantic no-binary for langchain
-        if: matrix.package == 'langchain'
+        if: matrix.package == 'langchain' && ( matrix.version == 'dev' || matrix.version >= '0.0.267')
         run: |
           pip uninstall pydantic -y
+          # 0.0.267 is the minimum version that supports Pydantic v2
           pip install pydantic --no-binary :all:
       - name: Check package versions
         run: |

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -192,6 +192,8 @@ jobs:
         run: |
           pip uninstall pydantic -y
           # 0.0.267 is the minimum version that supports Pydantic v2
+          # We need to install from source because cythonized pydantic 
+          # objects can't be serialized https://github.com/cloudpipe/cloudpickle/issues/408
           pip install pydantic --no-binary :all:
       - name: Check package versions
         run: |

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -165,6 +165,9 @@ jobs:
           else
             java_version=11
           fi
+          if [ "${{ matrix.package }}" = "langchain"]; then
+            pip uninstall pydantic -y && pip install pydantic --no-binary :all:
+          fi
           echo "version=$java_version" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/setup-java
         with:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -191,7 +191,7 @@ jobs:
         if: matrix.package == 'langchain'
         run: |
           pip uninstall pydantic -y
-          pip install pydantic --no-binary :all:
+          pip install pydantic --no-binary=pydantic
       - name: Check package versions
         run: |
           python dev/show_package_release_dates.py

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -184,9 +184,6 @@ jobs:
           pip install -U "pip$PIP_SPEC" wheel
           pip install -e .[extras]
           pip install -r requirements/test-requirements.txt
-          if [ "${{ matrix.package }}" = "langchain" ]; then
-            pip uninstall pydantic -y && pip install 'pydantic<2.0.0' --no-binary pydantic
-          fi
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         run: |
           ${{ matrix.install }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -184,7 +184,7 @@ jobs:
           pip install -U "pip$PIP_SPEC" wheel
           pip install -e .[extras]
           pip install -r requirements/test-requirements.txt
-          if [ "${{ matrix.package }}" = "langchain"]; then
+          if [ "${{ matrix.package }}" = "langchain" ]; then
             pip uninstall pydantic -y && pip install pydantic --no-binary :all:
           fi
       - name: Install ${{ matrix.package }} ${{ matrix.version }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -165,9 +165,6 @@ jobs:
           else
             java_version=11
           fi
-          if [ "${{ matrix.package }}" = "langchain"]; then
-            pip uninstall pydantic -y && pip install pydantic --no-binary :all:
-          fi
           echo "version=$java_version" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/setup-java
         with:
@@ -187,6 +184,9 @@ jobs:
           pip install -U "pip$PIP_SPEC" wheel
           pip install -e .[extras]
           pip install -r requirements/test-requirements.txt
+          if [ "${{ matrix.package }}" = "langchain"]; then
+            pip uninstall pydantic -y && pip install pydantic --no-binary :all:
+          fi
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         run: |
           ${{ matrix.install }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -184,6 +184,9 @@ jobs:
           pip install -U "pip$PIP_SPEC" wheel
           pip install -e .[extras]
           pip install -r requirements/test-requirements.txt
+          if [ "${{ matrix.package }}" = "langchain" ]; then
+            pip uninstall pydantic -y && pip install pydantic --no-binary :all:
+          fi
       - name: Install ${{ matrix.package }} ${{ matrix.version }}
         run: |
           ${{ matrix.install }}

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -465,9 +465,14 @@ class _LangChainModelWrapper:
             all(isinstance(d, str) for d in data) or all(isinstance(d, dict) for d in data)
         ):
             messages = data
-        # TODO: check unsupported cases
+        elif isinstance(self.lc_model, lc_runnables_types()):
+            messages = [data]
+            return process_api_requests(lc_model=self.lc_model, requests=messages)[0]
         else:
-            messages = data if hasattr(data, "__iter__") else [data]
+            raise mlflow.MlflowException.invalid_parameter_value(
+                "Input must be a pandas DataFrame or a list of strings or a list of dictionaries "
+                f"for model {self.lc_model.__class__.__name__}"
+            )
         return process_api_requests(lc_model=self.lc_model, requests=messages)
 
 

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -24,8 +24,6 @@ from mlflow.environment_variables import _MLFLOW_TESTING
 from mlflow.langchain.runnables import _load_runnables, _save_runnables
 from mlflow.langchain.utils import (
     _BASE_LOAD_KEY,
-    _MODEL_DATA_FILE_NAME,
-    _MODEL_DATA_KEY,
     _MODEL_LOAD_KEY,
     _RUNNABLE_LOAD_KEY,
     _load_base_lcs,
@@ -428,10 +426,7 @@ def _load_model(local_model_path, flavor_conf):
     # which load function to use
     model_load_fn = flavor_conf.get(_MODEL_LOAD_KEY)
     if model_load_fn == _RUNNABLE_LOAD_KEY:
-        lc_model_path = os.path.join(
-            local_model_path, flavor_conf.get(_MODEL_DATA_KEY, _MODEL_DATA_FILE_NAME)
-        )
-        return _load_runnables(lc_model_path, flavor_conf)
+        return _load_runnables(local_model_path, flavor_conf)
     if model_load_fn == _BASE_LOAD_KEY:
         return _load_base_lcs(local_model_path, flavor_conf)
     raise mlflow.MlflowException(

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -461,13 +461,13 @@ class _LangChainModelWrapper:
 
         if isinstance(data, pd.DataFrame):
             messages = data.to_dict(orient="records")
+        elif isinstance(self.lc_model, lc_runnables_types()):
+            messages = [data]
+            return process_api_requests(lc_model=self.lc_model, requests=messages)[0]
         elif isinstance(data, list) and (
             all(isinstance(d, str) for d in data) or all(isinstance(d, dict) for d in data)
         ):
             messages = data
-        elif isinstance(self.lc_model, lc_runnables_types()):
-            messages = [data]
-            return process_api_requests(lc_model=self.lc_model, requests=messages)[0]
         else:
             raise mlflow.MlflowException.invalid_parameter_value(
                 "Input must be a pandas DataFrame or a list of strings or a list of dictionaries "

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -20,6 +20,7 @@ import logging
 import queue
 import threading
 import time
+import traceback
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
@@ -168,7 +169,9 @@ class APIRequest:
             status_tracker.complete_task(success=True)
             self.results.append((self.index, response))
         except Exception as e:
-            self.errors[self.index] = f"error: {e!r}\n request payload: {self.request_json}"
+            self.errors[
+                self.index
+            ] = f"error: {e!r} {traceback.format_exc()}\n request payload: {self.request_json}"
             status_tracker.increment_num_api_errors()
             status_tracker.complete_task(success=False)
 

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -118,6 +118,8 @@ class APIRequest:
         """
         from langchain.schema import BaseRetriever
 
+        from mlflow.langchain.utils import lc_runnables_types
+
         _logger.debug(f"Request #{self.index} started")
         try:
             if isinstance(self.lc_model, BaseRetriever):
@@ -126,6 +128,8 @@ class APIRequest:
                 response = [
                     {"page_content": doc.page_content, "metadata": doc.metadata} for doc in docs
                 ]
+            elif isinstance(self.lc_model, lc_runnables_types()):
+                response = self.lc_model.invoke(self.request_json)
             else:
                 response = self.lc_model(self.request_json, return_only_outputs=True)
 
@@ -146,7 +150,7 @@ class APIRequest:
 
 def process_api_requests(
     lc_model,
-    requests: Optional[List[Union[str, Dict[str, Any]]]] = None,
+    requests: Optional[List[Union[Any, Dict[str, Any]]]] = None,
     max_workers: int = 10,
 ):
     """

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -118,7 +118,7 @@ class APIRequest:
         """
         import numpy as np
         from langchain.schema import BaseRetriever
-        from langchain.schema.runnable import RunnableParallel, RunnableSequence
+        from langchain.schema.runnable import RunnableLambda, RunnableParallel, RunnableSequence
 
         from mlflow.langchain.utils import lc_runnables_types
 
@@ -130,7 +130,7 @@ class APIRequest:
                 response = [
                     {"page_content": doc.page_content, "metadata": doc.metadata} for doc in docs
                 ]
-            elif isinstance(self.lc_model, (RunnableSequence, RunnableParallel)):
+            elif isinstance(self.lc_model, (RunnableSequence, RunnableParallel, RunnableLambda)):
                 # numpy ndarray is to catch serving requests
                 # where the input is casted into a numpy array
                 if isinstance(self.request_json, (list, np.ndarray)):

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -142,7 +142,7 @@ class APIRequest:
                         response = self.lc_model.invoke(self.request_json)
                     except Exception as e:
                         _logger.warning(f"Failed to invoke {self.lc_model} with {e!r}")
-                        response = self.lc_model.invoke(self.request_json.values()[0])
+                        response = self.lc_model.invoke(next(iter(self.request_json.values())))
                 elif isinstance(self.request_json, list) and isinstance(
                     self.lc_model, (RunnableSequence, RunnableParallel, RunnableLambda)
                 ):

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -140,18 +140,7 @@ class APIRequest:
                         else self.request_json.tolist()
                     )
                 else:
-                    # This is a temporary fix for the case when spark_udf converts
-                    # input into pandas dataframe with column name, while the model
-                    # does not accept dictionaries as input, it leads to erros like
-                    # Expected Scalar value for String field \'query_text\'\\n
-                    if isinstance(self.request_json, dict):
-                        try:
-                            response = self.lc_model.invoke(self.request_json)
-                        except Exception as e:
-                            _logger.warning(f"Failed to invoke with dict: {e!r}")
-                            response = self.lc_model.invoke(self.request_json.values()[0])
-                    else:
-                        response = self.lc_model.invoke(self.request_json)
+                    response = self.lc_model.invoke(self.request_json)
             elif isinstance(self.lc_model, lc_runnables_types()):
                 response = self.lc_model.invoke(self.request_json)
             else:

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -141,7 +141,9 @@ class APIRequest:
                     try:
                         response = self.lc_model.invoke(self.request_json)
                     except Exception as e:
-                        _logger.warning(f"Failed to invoke {self.lc_model} with {e!r}")
+                        _logger.warning(
+                            f"Failed to invoke {self.lc_model.__class__.__name__} with {e!r}"
+                        )
                         response = self.lc_model.invoke(next(iter(self.request_json.values())))
                 elif isinstance(self.request_json, list) and isinstance(
                     self.lc_model, (RunnableSequence, RunnableParallel, RunnableLambda)

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -145,7 +145,10 @@ class APIRequest:
                         _logger.warning(
                             f"Failed to invoke {self.lc_model.__class__.__name__} with {e!r}"
                         )
-                        response = self.lc_model.invoke(next(iter(self.request_json.values())))
+                        self.request_json = next(iter(self.request_json.values()))
+                        if isinstance(self.request_json, np.ndarray):
+                            self.request_json = self.request_json.tolist()
+                        response = self.lc_model.invoke(self.request_json)
                 elif isinstance(self.request_json, list) and isinstance(
                     self.lc_model, (RunnableSequence, RunnableParallel, RunnableLambda)
                 ):

--- a/mlflow/langchain/retriever_chain.py
+++ b/mlflow/langchain/retriever_chain.py
@@ -141,8 +141,7 @@ class _RetrieverChain(Chain):
         if retriever is None:
             raise ValueError("`retriever` must be present.")
 
-        if "retriever" in config:
-            config.pop("retriever")
+        config.pop("retriever", None)
 
         return cls(
             retriever=retriever,

--- a/mlflow/langchain/retriever_chain.py
+++ b/mlflow/langchain/retriever_chain.py
@@ -141,7 +141,7 @@ class _RetrieverChain(Chain):
         if retriever is None:
             raise ValueError("`retriever` must be present.")
 
-        if retriever in config:
+        if "retriever" in config:
             config.pop("retriever")
 
         return cls(

--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -8,8 +8,11 @@ import yaml
 from mlflow.exceptions import MlflowException
 from mlflow.langchain.utils import (
     _BASE_LOAD_KEY,
-    _MODEL_DATA_FILE_NAME,
+    _CONFIG_LOAD_KEY,
+    _MODEL_DATA_FOLDER_NAME,
     _MODEL_DATA_KEY,
+    _MODEL_DATA_PKL_FILE_NAME,
+    _MODEL_DATA_YAML_FILE_NAME,
     _MODEL_LOAD_KEY,
     _MODEL_TYPE_KEY,
     _RUNNABLE_LOAD_KEY,
@@ -27,6 +30,7 @@ from mlflow.langchain.utils import (
 )
 from mlflow.utils.file_utils import mkdir
 
+_STEPS_FOLDER_NAME = "steps"
 _RUNNABLE_STEPS_FILE_NAME = "steps.yaml"
 
 try:
@@ -35,37 +39,44 @@ except ImportError:
     prompts_types = {"prompt", "few_shot_prompt"}
 
 
-def _load_model_from_path(path: str, model_config=None):
+def _load_model_from_config(path, model_config):
     from langchain.chains.loading import load_chain
     from langchain.chains.loading import type_to_loader_dict as chains_type_to_loader_dict
     from langchain.llms.loading import get_type_to_cls_dict as llms_get_type_to_cls_dict
     from langchain.llms.loading import load_llm
     from langchain.prompts.loading import load_prompt
 
+    config_path = os.path.join(path, model_config.get(_MODEL_DATA_KEY, _MODEL_DATA_YAML_FILE_NAME))
+    # Load runnables from config file
+    if config_path.endswith(".yaml"):
+        config = _load_from_yaml(config_path)
+    elif config_path.endswith(".json"):
+        config = _load_from_json(config_path)
+    else:
+        raise MlflowException(
+            f"Cannot load runnable without a config file. Got path {config_path!s}."
+        )
+    _type = config.get("_type")
+    if _type in chains_type_to_loader_dict:
+        return load_chain(config_path)
+    elif _type in prompts_types:
+        return load_prompt(config_path)
+    elif _type in llms_get_type_to_cls_dict():
+        return load_llm(config_path)
+    elif _type in custom_type_to_loader_dict():
+        return custom_type_to_loader_dict()[_type](config)
+    raise MlflowException(f"Unsupported type {_type} for loading.")
+
+
+def _load_model_from_path(path: str, model_config=None):
     model_load_fn = model_config.get(_MODEL_LOAD_KEY)
     if model_load_fn == _RUNNABLE_LOAD_KEY:
         return _load_runnables(path, model_config)
     if model_load_fn == _BASE_LOAD_KEY:
         return _load_base_lcs(path, model_config)
-    if path.endswith(".pkl"):
-        return _load_from_pickle(path)
-    # Load runnables from config file
-    if path.endswith(".yaml"):
-        config = _load_from_yaml(path)
-    elif path.endswith(".json"):
-        config = _load_from_json(path)
-    else:
-        raise MlflowException(f"Cannot load runnable without a config file. Got path {path!s}.")
-    _type = config.get("_type")
-    if _type in chains_type_to_loader_dict:
-        return load_chain(path)
-    elif _type in prompts_types:
-        return load_prompt(path)
-    elif _type in llms_get_type_to_cls_dict():
-        return load_llm(path)
-    elif _type in custom_type_to_loader_dict():
-        return custom_type_to_loader_dict()[_type](config)
-    raise MlflowException(f"Unsupported type {_type} for loading.")
+    if model_load_fn == _CONFIG_LOAD_KEY:
+        return _load_model_from_config(path, model_config)
+    raise MlflowException(f"Unsupported model load key {model_load_fn}")
 
 
 def _load_runnable_with_steps(file_path: Union[Path, str], model_type: str):
@@ -79,33 +90,41 @@ def _load_runnable_with_steps(file_path: Union[Path, str], model_type: str):
 
     # Convert file to Path object.
     load_path = Path(file_path) if isinstance(file_path, str) else file_path
-    if not load_path.exists():
-        raise FileNotFoundError(f"File {load_path!s} does not exist.")
-    if not load_path.is_dir():
-        raise ValueError(f"File {load_path!s} must be a directory.")
-
-    steps_conf_file = os.path.join(load_path, _RUNNABLE_STEPS_FILE_NAME)
-    if not os.path.exists(steps_conf_file):
+    if not load_path.exists() or not load_path.is_dir():
         raise MlflowException(
-            f"File {steps_conf_file} must exist in order to load the RunnableSequence."
+            f"File {load_path!s} must exist and must be a directory "
+            "in order to load runnable with steps."
+        )
+
+    steps_conf_file = load_path / _RUNNABLE_STEPS_FILE_NAME
+    if not steps_conf_file.exists():
+        raise MlflowException(
+            f"File {steps_conf_file} must exist in order to load runnable with steps."
         )
     steps_conf = _load_from_yaml(steps_conf_file)
+    steps_path = load_path / _STEPS_FOLDER_NAME
+    if not steps_path.exists() or not steps_path.is_dir():
+        raise MlflowException(
+            f"Folder {steps_path} must exist and must be a directory "
+            "in order to load runnable with steps."
+        )
     if model_type == RunnableSequence.__name__:
         steps = []
         files = sorted(
-            os.listdir(load_path),
-            key=lambda x: int(x.split(".")[0]) if x != _RUNNABLE_STEPS_FILE_NAME else -1,
+            os.listdir(steps_path),
+            key=lambda x: int(x) if x != _RUNNABLE_STEPS_FILE_NAME else -1,
         )
     elif model_type == RunnableParallel.__name__:
         steps = {}
-        files = os.listdir(load_path)
+        files = os.listdir(steps_path)
     else:
         raise MlflowException(f"Unsupported model type {model_type}. ")
     for file in files:
         if file != _RUNNABLE_STEPS_FILE_NAME:
-            step = file.split(".")[0]
+            step = file
             config = steps_conf.get(step)
-            runnable = _load_model_from_path(os.path.join(load_path, file), config)
+            # load model from the folder of the step
+            runnable = _load_model_from_path(os.path.join(steps_path, file), config)
             if type(steps) == list:
                 steps.append(runnable)
             elif type(steps) == dict:
@@ -136,18 +155,23 @@ def _save_runnable_with_steps(steps, file_path: Union[Path, str], loader_fn=None
     """
     Save the model with steps. Currently it supports saving RunnableSequence and RunnableParallel.
     If saving a RunnableSequence, steps is a list of Runnable objects. We save each step to the
-    path (either a folder or a single file) named by the step index.
-    e.g.
-        model - model/0.yaml
-              - model/1.pkl
-              - model/2 -- model/2/model.yaml
-              - steps.yaml
+    subfolder named by the step index.
+    e.g.  - model
+            - steps
+              - 0
+                - model.yaml
+              - 1
+                - model.pkl
+            - steps.yaml
     If saving a RunnableParallel, steps is a dictionary of key-Runnable pairs. We save each step to
-    the path named by the key.
-    e.g.
-        model - model/context.yaml
-              - model/question -- model/question/model.pkl
-              - steps.yaml
+    the subfolder named by the key.
+    e.g.  - model
+            - steps
+              - context
+                - model.yaml
+              - question
+                - model.pkl
+            - steps.yaml
 
     We save steps.yaml file to the model folder. It contains each step's model's configuration.
 
@@ -158,6 +182,10 @@ def _save_runnable_with_steps(steps, file_path: Union[Path, str], loader_fn=None
     save_path = Path(file_path) if isinstance(file_path, str) else file_path
     save_path.mkdir(parents=True, exist_ok=True)
 
+    # Save steps into a folder
+    steps_path = save_path / _STEPS_FOLDER_NAME
+    mkdir(steps_path)
+
     if isinstance(steps, list):
         generator = enumerate(steps)
     elif isinstance(steps, dict):
@@ -167,23 +195,27 @@ def _save_runnable_with_steps(steps, file_path: Union[Path, str], loader_fn=None
     for key, runnable in generator:
         step = str(key)
         steps_conf[step] = {}
+        # Save each step into a subfolder named by step
+        save_runnable_path = steps_path / step
+        mkdir(save_runnable_path)
         if isinstance(runnable, lc_runnables_types()):
             steps_conf[step][_MODEL_TYPE_KEY] = runnable.__class__.__name__
             steps_conf[step].update(
-                _save_runnables(runnable, save_path, step, loader_fn, persist_dir)
+                _save_runnables(runnable, save_runnable_path, loader_fn, persist_dir)
             )
         elif isinstance(runnable, base_lc_types()):
-            save_runnable_path = f"{save_path!s}/{step}"
-            mkdir(save_runnable_path)
             lc_model = _validate_and_wrap_lc_model(runnable, loader_fn)
             steps_conf[step][_MODEL_TYPE_KEY] = lc_model.__class__.__name__
             steps_conf[step].update(
                 _save_base_lcs(lc_model, save_runnable_path, loader_fn, persist_dir)
             )
         else:
-            steps_conf[step][_MODEL_TYPE_KEY] = runnable.__class__.__name__
-            steps_conf[step][_MODEL_DATA_KEY] = f"{step}.yaml"
-            save_runnable_path = f"{save_path!s}/{step}.yaml"
+            steps_conf[step] = {
+                _MODEL_TYPE_KEY: runnable.__class__.__name__,
+                _MODEL_DATA_KEY: _MODEL_DATA_YAML_FILE_NAME,
+                _MODEL_LOAD_KEY: _CONFIG_LOAD_KEY,
+            }
+            save_runnable_path = save_runnable_path / _MODEL_DATA_YAML_FILE_NAME
             # Save some simple runnables that langchain natively supports.
             if hasattr(runnable, "save"):
                 runnable.save(save_runnable_path)
@@ -201,6 +233,7 @@ def _save_runnable_with_steps(steps, file_path: Union[Path, str], loader_fn=None
             "Runnable must have either `save` or `dict` method."
         )
 
+    # save steps configs
     with save_path.joinpath(_RUNNABLE_STEPS_FILE_NAME).open("w") as f:
         yaml.dump(steps_conf, f, default_flow_style=False)
 
@@ -212,19 +245,18 @@ def _save_pickable_runnable(model, path):
         cloudpickle.dump(model, f)
 
 
-def _save_runnables(model, path, model_data_path=None, loader_fn=None, persist_dir=None):
-    from langchain.schema.runnable import RunnableParallel, RunnableSequence
+def _save_runnables(model, path, loader_fn=None, persist_dir=None):
+    from mlflow.langchain.utils import lc_runnable_with_steps_types
 
     model_data_kwargs = {_MODEL_LOAD_KEY: _RUNNABLE_LOAD_KEY}
-    model_data_path = model_data_path or "model"
-    if isinstance(model, (RunnableSequence, RunnableParallel)):
-        save_path = os.path.join(path, model_data_path)
-        _save_runnable_with_steps(model.steps, save_path, loader_fn, persist_dir)
+    if isinstance(model, lc_runnable_with_steps_types()):
+        model_data_path = _MODEL_DATA_FOLDER_NAME
+        _save_runnable_with_steps(
+            model.steps, os.path.join(path, model_data_path), loader_fn, persist_dir
+        )
     elif isinstance(model, pickable_runnable_types()):
-        if not model_data_path.endswith(".pkl"):
-            model_data_path += ".pkl"
-        save_path = os.path.join(path, model_data_path)
-        _save_pickable_runnable(model, save_path)
+        model_data_path = _MODEL_DATA_PKL_FILE_NAME
+        _save_pickable_runnable(model, os.path.join(path, model_data_path))
     else:
         raise MlflowException.invalid_parameter_value(
             _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=type(model).__name__)
@@ -234,17 +266,17 @@ def _save_runnables(model, path, model_data_path=None, loader_fn=None, persist_d
 
 
 def _load_runnables(path, conf):
-    from langchain.schema.runnable import RunnableParallel, RunnableSequence
+    from mlflow.langchain.utils import lc_runnable_with_steps_types
 
     model_type = conf.get(_MODEL_TYPE_KEY)
-    model_data = conf.get(_MODEL_DATA_KEY, _MODEL_DATA_FILE_NAME)
-    if model_type in (RunnableSequence.__name__, RunnableParallel.__name__):
-        return _load_runnable_with_steps(path, model_type)
-    elif model_type in (x.__name__ for x in pickable_runnable_types()) or model_data.endswith(
-        ".pkl"
+    model_data = conf.get(_MODEL_DATA_KEY, _MODEL_DATA_YAML_FILE_NAME)
+    if model_type in (x.__name__ for x in lc_runnable_with_steps_types()):
+        return _load_runnable_with_steps(os.path.join(path, model_data), model_type)
+    if (
+        model_type in (x.__name__ for x in pickable_runnable_types())
+        or model_data == _MODEL_DATA_PKL_FILE_NAME
     ):
-        return _load_from_pickle(path)
-    else:
-        raise MlflowException.invalid_parameter_value(
-            _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=model_type)
-        )
+        return _load_from_pickle(os.path.join(path, model_data))
+    raise MlflowException.invalid_parameter_value(
+        _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=model_type)
+    )

--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -1,0 +1,230 @@
+import os
+from pathlib import Path
+from typing import Union
+
+import cloudpickle
+import yaml
+
+from mlflow.exceptions import MlflowException
+from mlflow.langchain.utils import (
+    _BASE_LOAD_KEY,
+    _MODEL_DATA_FILE_NAME,
+    _MODEL_DATA_KEY,
+    _MODEL_LOAD_KEY,
+    _MODEL_TYPE_KEY,
+    _RUNNABLE_LOAD_KEY,
+    _UNSUPPORTED_MODEL_ERROR_MESSAGE,
+    _load_base_lcs,
+    _load_from_json,
+    _load_from_pickle,
+    _load_from_yaml,
+    _save_base_lcs,
+    _validate_and_wrap_lc_model,
+    base_lc_types,
+    custom_type_to_loader_dict,
+    lc_runnables_types,
+    pickable_runnable_types,
+)
+from mlflow.utils.file_utils import mkdir
+
+_RUNNABLE_STEPS_FILE_NAME = "steps.yaml"
+
+try:
+    from langchain.prompts.loading import type_to_loader_dict as prompts_types
+except ImportError:
+    prompts_types = {"prompt", "few_shot_prompt"}
+
+
+def _load_model_from_path(path: str, model_config=None):
+    from langchain.chains.loading import load_chain
+    from langchain.chains.loading import type_to_loader_dict as chains_type_to_loader_dict
+    from langchain.llms.loading import get_type_to_cls_dict as llms_get_type_to_cls_dict
+    from langchain.llms.loading import load_llm
+    from langchain.prompts.loading import load_prompt
+
+    model_load_fn = model_config.get(_MODEL_LOAD_KEY)
+    if model_load_fn == _RUNNABLE_LOAD_KEY:
+        return _load_runnables(path, model_config)
+    if model_load_fn == _BASE_LOAD_KEY:
+        return _load_base_lcs(path, model_config)
+    if path.endswith(".pkl"):
+        return _load_from_pickle(path)
+    # Load runnables from config file
+    if path.endswith(".yaml"):
+        config = _load_from_yaml(path)
+    elif path.endswith(".json"):
+        config = _load_from_json(path)
+    else:
+        raise MlflowException(f"Cannot load runnable without a config file. Got path {path!s}.")
+    _type = config.get("_type")
+    if _type in chains_type_to_loader_dict:
+        return load_chain(path)
+    elif _type in prompts_types:
+        return load_prompt(path)
+    elif _type in llms_get_type_to_cls_dict():
+        return load_llm(path)
+    elif _type in custom_type_to_loader_dict():
+        return custom_type_to_loader_dict()[_type](config)
+    raise MlflowException(f"Unsupported type {_type} for loading.")
+
+
+def _load_runnable_with_steps(file_path: Union[Path, str], model_type: str):
+    """
+    Load the model
+
+    :param file_path: Path to file to load the model from.
+    :param model_type: Type of the model to load.
+    """
+    from langchain.schema.runnable import RunnableParallel, RunnableSequence
+
+    # Convert file to Path object.
+    load_path = Path(file_path) if isinstance(file_path, str) else file_path
+    if not load_path.exists():
+        raise FileNotFoundError(f"File {load_path!s} does not exist.")
+    if not load_path.is_dir():
+        raise ValueError(f"File {load_path!s} must be a directory.")
+
+    steps_conf_file = os.path.join(load_path, _RUNNABLE_STEPS_FILE_NAME)
+    if not os.path.exists(steps_conf_file):
+        raise MlflowException(
+            f"File {steps_conf_file} must exist in order to load the RunnableSequence."
+        )
+    steps_conf = _load_from_yaml(steps_conf_file)
+    if model_type == RunnableSequence.__name__:
+        steps = []
+    elif model_type == RunnableParallel.__name__:
+        steps = {}
+    else:
+        raise MlflowException(f"Unsupported model type {model_type}. ")
+    for file in sorted(os.listdir(load_path)):
+        if file != _RUNNABLE_STEPS_FILE_NAME:
+            step = file.split(".")[0]
+            config = steps_conf.get(step)
+            runnable = _load_model_from_path(os.path.join(load_path, file), config)
+            if type(steps) == list:
+                steps.append(runnable)
+            elif type(steps) == dict:
+                steps[step] = runnable
+
+    if model_type == RunnableSequence.__name__:
+        return runnable_sequence_from_steps(steps)
+    if model_type == RunnableParallel.__name__:
+        return RunnableParallel(steps)
+
+
+def runnable_sequence_from_steps(steps):
+    """
+    Construct a RunnableSequence from steps.
+
+    :param steps: List of steps to construct the RunnableSequence from.
+    """
+    from langchain.schema.runnable import RunnableSequence
+
+    if len(steps) < 2:
+        raise ValueError(f"RunnableSequence must have at least 2 steps, got {len(steps)}.")
+
+    first, *middle, last = steps
+    return RunnableSequence(first=first, middle=middle, last=last)
+
+
+def _save_runnable_with_steps(steps, file_path: Union[Path, str], loader_fn=None, persist_dir=None):
+    """
+    Save the model.
+
+    :steps: steps of the runnable.
+    :param file_path: Path to file to save the model to.
+    """
+    # Convert file to Path object.
+    save_path = Path(file_path) if isinstance(file_path, str) else file_path
+    save_path.mkdir(parents=True, exist_ok=True)
+
+    if isinstance(steps, list):
+        generator = enumerate(steps)
+    elif isinstance(steps, dict):
+        generator = steps.items()
+    unsaved_runnables = {}
+    steps_conf = {}
+    for key, runnable in generator:
+        step = str(key)
+        steps_conf[step] = {}
+        if isinstance(runnable, lc_runnables_types()):
+            steps_conf[step][_MODEL_TYPE_KEY] = runnable.__class__.__name__
+            steps_conf[step].update(
+                _save_runnables(runnable, save_path, step, loader_fn, persist_dir)
+            )
+        elif isinstance(runnable, base_lc_types()):
+            save_runnable_path = f"{save_path!s}/{step}"
+            mkdir(save_runnable_path)
+            lc_model = _validate_and_wrap_lc_model(runnable, loader_fn)
+            steps_conf[step][_MODEL_TYPE_KEY] = lc_model.__class__.__name__
+            steps_conf[step].update(
+                _save_base_lcs(lc_model, save_runnable_path, loader_fn, persist_dir)
+            )
+        else:
+            steps_conf[step][_MODEL_TYPE_KEY] = runnable.__class__.__name__
+            steps_conf[step][_MODEL_DATA_KEY] = f"{step}.yaml"
+            save_runnable_path = f"{save_path!s}/{step}.yaml"
+            # Save some simple runnables that langchain natively supports.
+            if hasattr(runnable, "save"):
+                runnable.save(save_runnable_path)
+            # TODO: check if `dict` is enough to load it back
+            elif hasattr(runnable, "dict"):
+                runnable_dict = runnable.dict()
+                with open(save_runnable_path, "w") as f:
+                    yaml.dump(runnable_dict, f, default_flow_style=False)
+            else:
+                unsaved_runnables[step] = str(runnable)
+
+    if unsaved_runnables:
+        raise MlflowException(
+            f"Failed to save runnable sequence: {unsaved_runnables}. "
+            "Runnable must have either `save` or `dict` method."
+        )
+
+    with save_path.joinpath(_RUNNABLE_STEPS_FILE_NAME).open("w") as f:
+        yaml.dump(steps_conf, f, default_flow_style=False)
+
+
+def _save_pickable_runnable(model, path):
+    if not path.endswith(".pkl"):
+        raise ValueError(f"File path must end with .pkl, got {path!s}.")
+    with open(path, "wb") as f:
+        cloudpickle.dump(model, f)
+
+
+def _save_runnables(model, path, model_data_path=None, loader_fn=None, persist_dir=None):
+    from langchain.schema.runnable import RunnableParallel, RunnableSequence
+
+    model_data_kwargs = {_MODEL_LOAD_KEY: _RUNNABLE_LOAD_KEY}
+    model_data_path = model_data_path or "model"
+    if isinstance(model, (RunnableSequence, RunnableParallel)):
+        save_path = os.path.join(path, model_data_path)
+        _save_runnable_with_steps(model.steps, save_path, loader_fn, persist_dir)
+    elif isinstance(model, pickable_runnable_types()):
+        if not model_data_path.endswith(".pkl"):
+            model_data_path += ".pkl"
+        save_path = os.path.join(path, model_data_path)
+        _save_pickable_runnable(model, save_path)
+    else:
+        raise MlflowException.invalid_parameter_value(
+            _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=type(model).__name__)
+        )
+    model_data_kwargs.update({_MODEL_DATA_KEY: model_data_path})
+    return model_data_kwargs
+
+
+def _load_runnables(path, conf):
+    from langchain.schema.runnable import RunnableParallel, RunnableSequence
+
+    model_type = conf.get(_MODEL_TYPE_KEY)
+    model_data = conf.get(_MODEL_DATA_KEY, _MODEL_DATA_FILE_NAME)
+    if model_type in (RunnableSequence.__name__, RunnableParallel.__name__):
+        return _load_runnable_with_steps(path, model_type)
+    elif model_type in (x.__name__ for x in pickable_runnable_types()) or model_data.endswith(
+        ".pkl"
+    ):
+        return _load_from_pickle(path)
+    else:
+        raise MlflowException.invalid_parameter_value(
+            _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=model_type)
+        )

--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -92,16 +92,16 @@ def _load_runnable_with_steps(file_path: Union[Path, str], model_type: str):
     steps_conf = _load_from_yaml(steps_conf_file)
     if model_type == RunnableSequence.__name__:
         steps = []
-        generator = sorted(
+        files = sorted(
             os.listdir(load_path),
             key=lambda x: int(x.split(".")[0]) if x != _RUNNABLE_STEPS_FILE_NAME else -1,
         )
     elif model_type == RunnableParallel.__name__:
         steps = {}
-        generator = os.listdir(load_path)
+        files = os.listdir(load_path)
     else:
         raise MlflowException(f"Unsupported model type {model_type}. ")
-    for file in generator:
+    for file in files:
         if file != _RUNNABLE_STEPS_FILE_NAME:
             step = file.split(".")[0]
             config = steps_conf.get(step)

--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -53,7 +53,7 @@ def _load_model_from_config(path, model_config):
         config = _load_from_json(config_path)
     else:
         raise MlflowException(
-            f"Cannot load runnable without a config file. Got path {config_path!s}."
+            f"Cannot load runnable without a config file. Got path {config_path}."
         )
     _type = config.get("_type")
     if _type in chains_type_to_loader_dict:
@@ -91,7 +91,7 @@ def _load_runnable_with_steps(file_path: Union[Path, str], model_type: str):
     load_path = Path(file_path) if isinstance(file_path, str) else file_path
     if not load_path.exists() or not load_path.is_dir():
         raise MlflowException(
-            f"File {load_path!s} must exist and must be a directory "
+            f"File {load_path} must exist and must be a directory "
             "in order to load runnable with steps."
         )
 
@@ -109,14 +109,11 @@ def _load_runnable_with_steps(file_path: Union[Path, str], model_type: str):
         )
 
     steps = {}
-    files = os.listdir(steps_path)
-    for file in files:
-        if file != _RUNNABLE_STEPS_FILE_NAME:
-            step = file
-            config = steps_conf.get(step)
-            # load model from the folder of the step
-            runnable = _load_model_from_path(os.path.join(steps_path, file), config)
-            steps[step] = runnable
+    for step in os.listdir(steps_path):
+        config = steps_conf.get(step)
+        # load model from the folder of the step
+        runnable = _load_model_from_path(os.path.join(steps_path, step), config)
+        steps[step] = runnable
 
     if model_type == RunnableSequence.__name__:
         steps = [value for _, value in sorted(steps.items(), key=lambda item: int(item[0]))]
@@ -229,7 +226,7 @@ def _save_runnable_with_steps(steps, file_path: Union[Path, str], loader_fn=None
 
 def _save_pickable_runnable(model, path):
     if not path.endswith(".pkl"):
-        raise ValueError(f"File path must end with .pkl, got {path!s}.")
+        raise ValueError(f"File path must end with .pkl, got {path}.")
     with open(path, "wb") as f:
         cloudpickle.dump(model, f)
 

--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -26,7 +26,7 @@ from mlflow.langchain.utils import (
     base_lc_types,
     custom_type_to_loader_dict,
     lc_runnables_types,
-    pickable_runnable_types,
+    picklable_runnable_types,
 )
 
 _STEPS_FOLDER_NAME = "steps"
@@ -224,7 +224,7 @@ def _save_runnable_with_steps(steps, file_path: Union[Path, str], loader_fn=None
         yaml.dump(steps_conf, f, default_flow_style=False)
 
 
-def _save_pickable_runnable(model, path):
+def _save_picklable_runnable(model, path):
     if not path.endswith(".pkl"):
         raise ValueError(f"File path must end with .pkl, got {path}.")
     with open(path, "wb") as f:
@@ -240,9 +240,9 @@ def _save_runnables(model, path, loader_fn=None, persist_dir=None):
         _save_runnable_with_steps(
             model.steps, os.path.join(path, model_data_path), loader_fn, persist_dir
         )
-    elif isinstance(model, pickable_runnable_types()):
+    elif isinstance(model, picklable_runnable_types()):
         model_data_path = _MODEL_DATA_PKL_FILE_NAME
-        _save_pickable_runnable(model, os.path.join(path, model_data_path))
+        _save_picklable_runnable(model, os.path.join(path, model_data_path))
     else:
         raise MlflowException.invalid_parameter_value(
             _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=type(model).__name__)
@@ -259,7 +259,7 @@ def _load_runnables(path, conf):
     if model_type in (x.__name__ for x in lc_runnable_with_steps_types()):
         return _load_runnable_with_steps(os.path.join(path, model_data), model_type)
     if (
-        model_type in (x.__name__ for x in pickable_runnable_types())
+        model_type in (x.__name__ for x in picklable_runnable_types())
         or model_data == _MODEL_DATA_PKL_FILE_NAME
     ):
         return _load_from_pickle(os.path.join(path, model_data))

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -72,28 +72,44 @@ def base_lc_types():
 def pickable_runnable_types():
     from langchain.chat_models.base import SimpleChatModel
     from langchain.prompts import ChatPromptTemplate
-    from langchain.schema.runnable import (
-        RunnableLambda,
-        RunnablePassthrough,
-    )
-    from langchain.schema.runnable.passthrough import RunnableAssign
 
-    return (
-        RunnableAssign,
-        RunnableLambda,
-        RunnablePassthrough,
+    types = (
         SimpleChatModel,
         ChatPromptTemplate,
     )
 
+    try:
+        from langchain.schema.runnable import (
+            RunnableLambda,
+            RunnablePassthrough,
+        )
+
+        types += (RunnableLambda, RunnablePassthrough)
+    except ImportError:
+        pass
+
+    try:
+        from langchain.schema.runnable.passthrough import RunnableAssign
+
+        types += (RunnableAssign,)
+    except ImportError:
+        pass
+
+    return types
+
 
 def lc_runnables_types():
-    from langchain.schema.runnable import (
-        RunnableParallel,
-        RunnableSequence,
-    )
+    try:
+        from langchain.schema.runnable import (
+            RunnableParallel,
+            RunnableSequence,
+        )
 
-    return pickable_runnable_types() + (RunnableSequence, RunnableParallel)
+        types = (RunnableSequence, RunnableParallel)
+    except ImportError:
+        types = ()
+
+    return pickable_runnable_types() + types
 
 
 def supported_lc_types():
@@ -170,7 +186,6 @@ def _validate_and_wrap_lc_model(lc_model, loader_fn):
     import langchain.llms.huggingface_hub
     import langchain.llms.openai
     import langchain.schema
-    import langchain.schema.runnable
 
     if not isinstance(lc_model, supported_lc_types()):
         raise mlflow.MlflowException.invalid_parameter_value(

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -27,11 +27,14 @@ _LOADER_FN_KEY = "loader_fn"
 _LOADER_ARG_KEY = "loader_arg"
 _PERSIST_DIR_NAME = "persist_dir_data"
 _PERSIST_DIR_KEY = "persist_dir"
-_MODEL_DATA_FILE_NAME = "model.yaml"
+_MODEL_DATA_YAML_FILE_NAME = "model.yaml"
+_MODEL_DATA_PKL_FILE_NAME = "model.pkl"
+_MODEL_DATA_FOLDER_NAME = "model"
 _MODEL_DATA_KEY = "model_data"
 _MODEL_TYPE_KEY = "model_type"
 _RUNNABLE_LOAD_KEY = "runnable_load"
 _BASE_LOAD_KEY = "base_load"
+_CONFIG_LOAD_KEY = "config_load"
 _MODEL_LOAD_KEY = "model_load"
 _UNSUPPORTED_MODEL_ERROR_MESSAGE = (
     "MLflow langchain flavor only supports subclasses of "
@@ -98,7 +101,7 @@ def pickable_runnable_types():
     return types
 
 
-def lc_runnables_types():
+def lc_runnable_with_steps_types():
     try:
         from langchain.schema.runnable import RunnableSequence
 
@@ -113,7 +116,11 @@ def lc_runnables_types():
     except ImportError:
         pass
 
-    return pickable_runnable_types() + types
+    return types
+
+
+def lc_runnables_types():
+    return pickable_runnable_types() + lc_runnable_with_steps_types()
 
 
 def supported_lc_types():
@@ -275,8 +282,11 @@ def _save_base_lcs(model, path, loader_fn=None, persist_dir=None):
     import langchain.chains.base
     import langchain.chains.llm
 
-    model_data_path = os.path.join(path, _MODEL_DATA_FILE_NAME)
-    model_data_kwargs = {_MODEL_DATA_KEY: _MODEL_DATA_FILE_NAME, _MODEL_LOAD_KEY: _BASE_LOAD_KEY}
+    model_data_path = os.path.join(path, _MODEL_DATA_YAML_FILE_NAME)
+    model_data_kwargs = {
+        _MODEL_DATA_KEY: _MODEL_DATA_YAML_FILE_NAME,
+        _MODEL_LOAD_KEY: _BASE_LOAD_KEY,
+    }
 
     if isinstance(model, langchain.chains.llm.LLMChain):
         model.save(model_data_path)
@@ -373,7 +383,9 @@ def _load_base_lcs(
     local_model_path,
     conf,
 ):
-    lc_model_path = os.path.join(local_model_path, conf.get(_MODEL_DATA_KEY, _MODEL_DATA_FILE_NAME))
+    lc_model_path = os.path.join(
+        local_model_path, conf.get(_MODEL_DATA_KEY, _MODEL_DATA_YAML_FILE_NAME)
+    )
 
     agent_path = _get_path_by_key(local_model_path, _AGENT_DATA_KEY, conf)
     tools_path = _get_path_by_key(local_model_path, _TOOLS_DATA_KEY, conf)

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -7,7 +7,7 @@ import shutil
 import types
 from functools import lru_cache
 from importlib.util import find_spec
-from typing import NamedTuple
+from typing import Any, List, NamedTuple, Optional
 
 import cloudpickle
 import yaml
@@ -396,3 +396,31 @@ def _load_base_lcs(
 
         model = initialize_agent(tools=tools, llm=llm, agent_path=agent_path, **kwargs)
     return model
+
+
+# This is an internal function that is used to generate
+# a fake chat model for testing purposes.
+# cloudpickle can not pickle a pydantic model defined
+# within the same scope, so put it here.
+def _fake_simple_chat_model():
+    from langchain.callbacks.manager import CallbackManagerForLLMRun
+    from langchain.chat_models.base import SimpleChatModel
+    from langchain.schema.messages import BaseMessage
+
+    class FakeChatModel(SimpleChatModel):
+        """Fake Chat Model wrapper for testing purposes."""
+
+        def _call(
+            self,
+            messages: List[BaseMessage],
+            stop: Optional[List[str]] = None,
+            run_manager: Optional[CallbackManagerForLLMRun] = None,
+            **kwargs: Any,
+        ) -> str:
+            return "Databricks"
+
+        @property
+        def _llm_type(self) -> str:
+            return "fake chat model"
+
+    return FakeChatModel

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -72,7 +72,7 @@ def base_lc_types():
 
 
 @lru_cache
-def pickable_runnable_types():
+def picklable_runnable_types():
     """
     Runnable types that can be pickled and unpickled by cloudpickle.
     """
@@ -126,7 +126,7 @@ def lc_runnable_with_steps_types():
 
 
 def lc_runnables_types():
-    return pickable_runnable_types() + lc_runnable_with_steps_types()
+    return picklable_runnable_types() + lc_runnable_with_steps_types()
 
 
 def supported_lc_types():

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -100,20 +100,44 @@ def pickable_runnable_types():
 
 def lc_runnables_types():
     try:
-        from langchain.schema.runnable import (
-            RunnableParallel,
-            RunnableSequence,
-        )
+        from langchain.schema.runnable import RunnableSequence
 
-        types = (RunnableSequence, RunnableParallel)
+        types = (RunnableSequence,)
     except ImportError:
         types = ()
+
+    try:
+        from langchain.schema.runnable import RunnableParallel
+
+        types += (RunnableParallel,)
+    except ImportError:
+        pass
 
     return pickable_runnable_types() + types
 
 
 def supported_lc_types():
     return base_lc_types() + lc_runnables_types()
+
+
+def runnables_supports_batch_types():
+    try:
+        from langchain.schema.runnable import (
+            RunnableLambda,
+            RunnableSequence,
+        )
+
+        types = (RunnableSequence, RunnableLambda)
+    except ImportError:
+        types = ()
+
+    try:
+        from langchain.schema.runnable import RunnableParallel
+
+        types += (RunnableParallel,)
+    except ImportError:
+        pass
+    return types
 
 
 @lru_cache

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -1,5 +1,4 @@
 """Utility functions for mlflow.langchain."""
-import functools
 import json
 import logging
 import os
@@ -59,6 +58,7 @@ _UNSUPPORTED_LANGCHAIN_VERSION_ERROR_MESSAGE = (
 logger = logging.getLogger(__name__)
 
 
+@lru_cache
 def base_lc_types():
     import langchain.agents.agent
     import langchain.chains.base
@@ -71,8 +71,11 @@ def base_lc_types():
     )
 
 
-# List of runnable types that can be pickled
+@lru_cache
 def pickable_runnable_types():
+    """
+    Runnable types that can be pickled and unpickled by cloudpickle.
+    """
     from langchain.chat_models.base import SimpleChatModel
     from langchain.prompts import ChatPromptTemplate
 
@@ -101,7 +104,10 @@ def pickable_runnable_types():
     return types
 
 
+@lru_cache
 def lc_runnable_with_steps_types():
+    # import them separately because they are added
+    # in different versions of langchain
     try:
         from langchain.schema.runnable import RunnableSequence
 
@@ -127,6 +133,7 @@ def supported_lc_types():
     return base_lc_types() + lc_runnables_types()
 
 
+@lru_cache
 def runnables_supports_batch_types():
     try:
         from langchain.schema.runnable import (
@@ -173,7 +180,7 @@ def _get_special_chain_info_or_none(chain):
             return _SpecialChainInfo(loader_arg=loader_arg)
 
 
-@functools.lru_cache
+@lru_cache
 def _get_map_of_special_chain_class_to_loader_arg():
     import langchain
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,6 @@ forced-separate = ["tests"]
 
 [tool.ruff.flake8-tidy-imports.banned-api]
 "pkg_resources".msg = "We're migrating away from pkg_resources. Please use importlib.resources or importlib.metadata instead."
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,3 @@ forced-separate = ["tests"]
 
 [tool.ruff.flake8-tidy-imports.banned-api]
 "pkg_resources".msg = "We're migrating away from pkg_resources. Please use importlib.resources or importlib.metadata instead."
-
-[tool.hatch.metadata]
-allow-direct-references = true


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10521?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10521/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10521
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Support RunnableSequence and other reasonable runnables within langchain flavor for save/load.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
