### PR TITLE
Remove fluent API

### DIFF
--- a/docs/source/llms/deployments/index.rst
+++ b/docs/source/llms/deployments/index.rst
@@ -143,61 +143,16 @@ and test the exposed routes. Navigate to ``http://{host}:{port}/`` (or ``http://
 The docs endpoint allow for direct interaction with the routes and permits submitting actual requests to the
 provider services by click on the "try it now" option within the endpoint definition entry.
 
-Step 6: Send Requests Using the Fluent API
-------------------------------------------
-For information on formatting requirements and how to pass parameters, see :ref:`gateway_query`.
-
-Here's an example of how to send a chat request using the :ref:`gateway_fluent_api` :
-
-.. code-block:: python
-
-    from mlflow.gateway import query, set_gateway_uri
-
-    set_gateway_uri(gateway_uri="http://localhost:5000")
-
-    response = query(
-        "chat",
-        {"messages": [{"role": "user", "content": "What is the best day of the week?"}]},
-    )
-
-    print(response)
-
-**Note:** Remember to change the uri definition to the actual uri of your Gateway server.
-
-The returned response will be in this data structure (the actual content and token values will likely be different):
-
-.. code-block:: python
-
-    {
-        "candidates": [
-            {
-                "message": {
-                    "role": "assistant",
-                    "content": "\n\nIt's hard to say what the best day of the week is.",
-                },
-                "metadata": {"finish_reason": "stop"},
-            }
-        ],
-        "metadata": {
-            "input_tokens": 13,
-            "output_tokens": 15,
-            "total_tokens": 28,
-            "model": "gpt-3.5-turbo-0301",
-            "route_type": "llm/v1/chat",
-        },
-    }
-
-
-Step 7: Send Requests Using the Client API
+Step 6: Send Requests Using the Client API
 ------------------------------------------
 See the :ref:`gateway_client_api` section for further information.
 
-Step 8: Send Requests to Routes via REST API
+Step 7: Send Requests to Routes via REST API
 --------------------------------------------
 You can now send requests to the exposed routes.
 See the :ref:`REST examples <gateway_rest_api>` for guidance on request formatting.
 
-Step 9: Compare Provider Models
+Step 8: Compare Provider Models
 -------------------------------
 Here's an example of adding a new model from a provider to determine which model instance is better for a given use case.
 
@@ -226,11 +181,9 @@ route that was configured with the ``gpt-3.5-turbo``  model.
 
 Once the configuration file is updated, simply save your changes. The Gateway will automatically create the new route with zero downtime.
 
-At this point, you may use the :ref:`gateway_fluent_api` to query both routes with similar prompts to decide which model performs best for your use case.
-
 If you no longer need a route, you can delete it from the configuration YAML and save your changes. The AI Gateway will automatically remove the route.
 
-Step 10: Use AI Gateway routes for model development
+Step 9: Use AI Gateway routes for model development
 ----------------------------------------------------
 
 Now that you have created several AI Gateway routes, you can create MLflow Models that query these
@@ -908,41 +861,6 @@ MLflow Python Client APIs
 -------------------------
 :class:`MlflowGatewayClient <mlflow.gateway.client.MlflowGatewayClient>` is the user-facing client API that is used to interact with the MLflow AI Gateway.
 It abstracts the HTTP requests to the Gateway via a simple, easy-to-use Python API.
-
-The fluent API is a higher-level interface that supports setting the Gateway URI once and using simple functions to interact with the AI Gateway Server.
-
-.. _deployments_fluent_api:
-
-Fluent API
-~~~~~~~~~~
-For the ``fluent`` API, here are some examples:
-
-1. Set the Gateway URI:
-
-   Before using the Fluent API, the gateway URI must be set via :func:`set_gateway_uri() <mlflow.gateway.set_gateway_uri>`.
-
-   Alternatively to directly calling the ``set_gateway_uri`` function, the environment variable ``MLFLOW_GATEWAY_URI`` can be set
-   directly, achieving the same session-level persistence for all ``fluent`` API usages.
-
-   .. code-block:: python
-
-       from mlflow.gateway import set_gateway_uri
-
-       set_gateway_uri(gateway_uri="http://my.gateway:7000")
-
-2. Query a route:
-
-   The :func:`query() <mlflow.gateway.query>` function queries the specified route and returns the response from the provider
-   in a standardized format. The data structure you send in the query depends on the route.
-
-   .. code-block:: python
-
-       from mlflow.gateway import query
-
-       response = query(
-           "embeddings", {"text": ["It was the best of times", "It was the worst of times"]}
-       )
-       print(response)
 
 .. _deployments_client_api:
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10524?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10524/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10524
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Remove the fluent API sections. There is no fluent API in the deployments API.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
