### PR TITLE
Add Content-Type header validation

### DIFF
--- a/docs/source/auth/rest-api.rst
+++ b/docs/source/auth/rest-api.rst
@@ -12,6 +12,8 @@ The API is hosted under the ``/api`` route on the MLflow tracking server. For ex
 experiments on a tracking server hosted at ``http://localhost:5000``, access
 ``http://localhost:5000/api/2.0/mlflow/users/create``.
 
+.. important::
+    The MLflow REST API requires content type ``application/json`` for all POST requests.
 
 .. contents:: Table of Contents
     :local:

--- a/docs/source/rest-api.rst
+++ b/docs/source/rest-api.rst
@@ -11,12 +11,14 @@ The API is hosted under the ``/api`` route on the MLflow tracking server. For ex
 experiments on a tracking server hosted at ``http://localhost:5000``, make a POST request to
 ``http://localhost:5000/api/2.0/mlflow/experiments/search``.
 
+.. important::
+    The MLflow REST API requires content type ``application/json`` for all POST requests.
+
 .. contents:: Table of Contents
     :local:
     :depth: 1
 
 ===========================
-
 
 
 .. _mlflowMlflowServicecreateExperiment:

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -102,6 +102,7 @@ from mlflow.server.handlers import (
     catch_mlflow_exception,
     get_endpoints,
 )
+from mlflow.server.validation import VALID_CONTENT_TYPE_CHARS
 from mlflow.store.entities import PagedList
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.rest_utils import _REST_API_PATH_PREFIX
@@ -762,7 +763,11 @@ def create_user():
         user = store.create_user(username, password)
         return make_response({"user": user.to_json()})
     else:
-        return make_response(f"Invalid content type: '{content_type}'", 400)
+        message = "Invalid content type"
+        # Avoid XSS by restricting to a set of characters in the error message
+        if VALID_CONTENT_TYPE_CHARS.match(content_type):
+            message += f": '{content_type}'"
+        return make_response(message, 400)
 
 
 @catch_mlflow_exception

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -102,7 +102,6 @@ from mlflow.server.handlers import (
     catch_mlflow_exception,
     get_endpoints,
 )
-from mlflow.server.validation import VALID_CONTENT_TYPE_CHAR_PATTERN
 from mlflow.store.entities import PagedList
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.rest_utils import _REST_API_PATH_PREFIX
@@ -763,10 +762,10 @@ def create_user():
         user = store.create_user(username, password)
         return make_response({"user": user.to_json()})
     else:
-        message = "Invalid content type"
-        # Avoid XSS by restricting to a set of characters in the error message
-        if VALID_CONTENT_TYPE_CHAR_PATTERN.match(content_type):
-            message += f": '{content_type}'"
+        message = (
+            "Invalid content type. Must be one of: "
+            "application/x-www-form-urlencoded, application/json"
+        )
         return make_response(message, 400)
 
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -102,7 +102,7 @@ from mlflow.server.handlers import (
     catch_mlflow_exception,
     get_endpoints,
 )
-from mlflow.server.validation import VALID_CONTENT_TYPE_CHARS
+from mlflow.server.validation import VALID_CONTENT_TYPE_CHAR_PATTERN
 from mlflow.store.entities import PagedList
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.rest_utils import _REST_API_PATH_PREFIX
@@ -765,7 +765,7 @@ def create_user():
     else:
         message = "Invalid content type"
         # Avoid XSS by restricting to a set of characters in the error message
-        if VALID_CONTENT_TYPE_CHARS.match(content_type):
+        if VALID_CONTENT_TYPE_CHAR_PATTERN.match(content_type):
             message += f": '{content_type}'"
         return make_response(message, 400)
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -91,6 +91,7 @@ from mlflow.protos.service_pb2 import (
     UpdateExperiment,
     UpdateRun,
 )
+from mlflow.server.validation import _validate_content_type
 from mlflow.store.artifact.artifact_repo import MultipartUploadMixin
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.db.db_types import DATABASE_ENGINES
@@ -403,6 +404,7 @@ def _validate_param_against_schema(schema, param, value, proto_parsing_succeeded
 
 
 def _get_request_json(flask_request=request):
+    _validate_content_type(flask_request, ["application/json"])
     return flask_request.get_json(force=True, silent=True)
 
 
@@ -1112,6 +1114,7 @@ def get_metric_history_bulk_handler():
 @_disable_if_artifacts_only
 def search_datasets_handler():
     MAX_EXPERIMENT_IDS_PER_REQUEST = 20
+    _validate_content_type(request, ["application/json"])
     experiment_ids = request.json.get("experiment_ids", [])
     if not experiment_ids:
         raise MlflowException(
@@ -1178,6 +1181,8 @@ def create_promptlab_run_handler():
                 message=f"CreatePromptlabRun request must specify {arg_name}.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
+
+    _validate_content_type(request, ["application/json"])
 
     args = request.json
     experiment_id = args.get("experiment_id")

--- a/mlflow/server/validation.py
+++ b/mlflow/server/validation.py
@@ -20,7 +20,7 @@ def _validate_content_type(flask_request, allowed_content_types: Union[str, List
     if isinstance(allowed_content_types, str):
         allowed_content_types = [allowed_content_types]
 
-    # Remove any parameters from the content type, e.g. "application/json; charset=utf-8" -> "application/json"
+    # Remove any parameters e.g. "application/json; charset=utf-8" -> "application/json"
     content_type = flask_request.content_type.split(";")[0] if flask_request.content_type else None
     if content_type not in allowed_content_types:
         message = f"Bad Request. Content-Type must be one of [{', '.join(allowed_content_types)}]."

--- a/mlflow/server/validation.py
+++ b/mlflow/server/validation.py
@@ -17,13 +17,19 @@ def _validate_content_type(flask_request, allowed_content_types: List[str]):
     if flask_request.method not in ["POST", "PUT"]:
         return
 
+    if flask_request.content_type is None:
+        raise MlflowException(
+            message="Bad Request. Content-Type header is missing.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
     # Remove any parameters e.g. "application/json; charset=utf-8" -> "application/json"
-    content_type = flask_request.content_type.split(";")[0] if flask_request.content_type else None
+    content_type = flask_request.content_type.split(";")[0]
     if content_type not in allowed_content_types:
         message = f"Bad Request. Content-Type must be one of {allowed_content_types}."
 
         # Avoid XSS by restricting to a set of characters
-        if isinstance(content_type, str) and VALID_CONTENT_TYPE_CHAR_PATTERN.match(content_type):
+        if VALID_CONTENT_TYPE_CHAR_PATTERN.match(content_type):
             message += f" Got '{content_type}'."
 
         raise MlflowException(

--- a/mlflow/server/validation.py
+++ b/mlflow/server/validation.py
@@ -1,32 +1,29 @@
 import re
-from typing import List, Union
+from typing import List
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
-VALID_CONTENT_TYPE_CHARS = re.compile(r"^[a-zA-Z0-9\-/;,+_ ]*$")
+VALID_CONTENT_TYPE_CHAR_PATTERN = re.compile(r"^[a-zA-Z0-9\-/;,+_ ]*$")
 
 
-def _validate_content_type(flask_request, allowed_content_types: Union[str, List[str]]):
+def _validate_content_type(flask_request, allowed_content_types: List[str]):
     """
     Validates that the request content type is one of the allowed content types.
 
     :param flask_request: Flask request object (flask.request)
-    :param allowed_content_types: Allowed content types, either a single content type or a list.
+    :param allowed_content_types: A list of allowed content types
     """
     if flask_request.method not in ["POST", "PUT"]:
         return
 
-    if isinstance(allowed_content_types, str):
-        allowed_content_types = [allowed_content_types]
-
     # Remove any parameters e.g. "application/json; charset=utf-8" -> "application/json"
     content_type = flask_request.content_type.split(";")[0] if flask_request.content_type else None
     if content_type not in allowed_content_types:
-        message = f"Bad Request. Content-Type must be one of [{', '.join(allowed_content_types)}]."
+        message = f"Bad Request. Content-Type must be one of {allowed_content_types}."
 
         # Avoid XSS by restricting to a set of characters
-        if isinstance(content_type, str) and VALID_CONTENT_TYPE_CHARS.match(content_type):
+        if isinstance(content_type, str) and VALID_CONTENT_TYPE_CHAR_PATTERN.match(content_type):
             message += f" Got '{content_type}'."
 
         raise MlflowException(

--- a/mlflow/server/validation.py
+++ b/mlflow/server/validation.py
@@ -1,0 +1,35 @@
+import re
+from typing import List, Union
+
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+
+VALID_CONTENT_TYPE_CHARS = re.compile(r"^[a-zA-Z0-9\-/;,+_ ]*$")
+
+
+def _validate_content_type(flask_request, allowed_content_types: Union[str, List[str]]):
+    """
+    Validates that the request content type is one of the allowed content types.
+
+    :param flask_request: Flask request object (flask.request)
+    :param allowed_content_types: Allowed content types, either a single content type or a list.
+    """
+    if flask_request.method not in ["POST", "PUT"]:
+        return
+
+    if isinstance(allowed_content_types, str):
+        allowed_content_types = [allowed_content_types]
+
+    # Remove any parameters from the content type, e.g. "application/json; charset=utf-8" -> "application/json"
+    content_type = flask_request.content_type.split(";")[0] if flask_request.content_type else None
+    if content_type not in allowed_content_types:
+        message = f"Bad Request. Content-Type must be one of [{', '.join(allowed_content_types)}]."
+
+        # Avoid XSS by restricting to a set of characters
+        if isinstance(content_type, str) and VALID_CONTENT_TYPE_CHARS.match(content_type):
+            message += f" Got '{content_type}'."
+
+        raise MlflowException(
+            message=message,
+            error_code=INVALID_PARAMETER_VALUE,
+        )

--- a/mlflow/server/validation.py
+++ b/mlflow/server/validation.py
@@ -1,10 +1,7 @@
-import re
 from typing import List
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-
-VALID_CONTENT_TYPE_CHAR_PATTERN = re.compile(r"^[a-zA-Z0-9\-/;,+_ ]*$")
 
 
 def _validate_content_type(flask_request, allowed_content_types: List[str]):
@@ -27,10 +24,6 @@ def _validate_content_type(flask_request, allowed_content_types: List[str]):
     content_type = flask_request.content_type.split(";")[0]
     if content_type not in allowed_content_types:
         message = f"Bad Request. Content-Type must be one of {allowed_content_types}."
-
-        # Avoid XSS by restricting to a set of characters
-        if VALID_CONTENT_TYPE_CHAR_PATTERN.match(content_type):
-            message += f" Got '{content_type}'."
 
         raise MlflowException(
             message=message,

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -230,7 +230,8 @@ def test_can_block_post_request_and_not_printing_back_malformed_content_type():
     request.get_json = mock.MagicMock()
     request.get_json.return_value = {"name": "hello"}
     with pytest.raises(
-        MlflowException, match=r"Bad Request. Content-Type must be one of \[application/json\].$"
+        MlflowException,
+        match=r"Bad Request. Content-Type must be one of \[\'application/json\'\].$",
     ):
         _get_request_message(CreateExperiment(), flask_request=request)
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -223,19 +223,6 @@ def test_can_block_post_request_with_missing_content_type():
         _get_request_message(CreateExperiment(), flask_request=request)
 
 
-def test_can_block_post_request_and_not_printing_back_malformed_content_type():
-    request = mock.MagicMock()
-    request.method = "POST"
-    request.content_type = "<script>I am a malicious content type</script>"
-    request.get_json = mock.MagicMock()
-    request.get_json.return_value = {"name": "hello"}
-    with pytest.raises(
-        MlflowException,
-        match=r"Bad Request. Content-Type must be one of \[\'application/json\'\].$",
-    ):
-        _get_request_message(CreateExperiment(), flask_request=request)
-
-
 def test_search_runs_default_view_type(mock_get_request_message, mock_tracking_store):
     """
     Search Runs default view type is filled in as ViewType.ACTIVE_ONLY

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -156,6 +156,7 @@ def test_all_model_registry_endpoints_available():
 def test_can_parse_json():
     request = mock.MagicMock()
     request.method = "POST"
+    request.content_type = "application/json"
     request.get_json = mock.MagicMock()
     request.get_json.return_value = {"name": "hello"}
     msg = _get_request_message(CreateExperiment(), flask_request=request)
@@ -165,8 +166,19 @@ def test_can_parse_json():
 def test_can_parse_post_json_with_unknown_fields():
     request = mock.MagicMock()
     request.method = "POST"
+    request.content_type = "application/json"
     request.get_json = mock.MagicMock()
     request.get_json.return_value = {"name": "hello", "WHAT IS THIS FIELD EVEN": "DOING"}
+    msg = _get_request_message(CreateExperiment(), flask_request=request)
+    assert msg.name == "hello"
+
+
+def test_can_parse_post_json_with_content_type_params():
+    request = mock.MagicMock()
+    request.method = "POST"
+    request.content_type = "application/json; charset=utf-8"
+    request.get_json = mock.MagicMock()
+    request.get_json.return_value = {"name": "hello"}
     msg = _get_request_message(CreateExperiment(), flask_request=request)
     assert msg.name == "hello"
 
@@ -184,10 +196,43 @@ def test_can_parse_get_json_with_unknown_fields():
 def test_can_parse_json_string():
     request = mock.MagicMock()
     request.method = "POST"
+    request.content_type = "application/json"
     request.get_json = mock.MagicMock()
     request.get_json.return_value = '{"name": "hello2"}'
     msg = _get_request_message(CreateExperiment(), flask_request=request)
     assert msg.name == "hello2"
+
+
+def test_can_block_post_request_with_invalid_content_type():
+    request = mock.MagicMock()
+    request.method = "POST"
+    request.content_type = "text/plain"
+    request.get_json = mock.MagicMock()
+    request.get_json.return_value = {"name": "hello"}
+    with pytest.raises(MlflowException, match=r"Bad Request. Content-Type"):
+        _get_request_message(CreateExperiment(), flask_request=request)
+
+
+def test_can_block_post_request_with_missing_content_type():
+    request = mock.MagicMock()
+    request.method = "POST"
+    request.content_type = None
+    request.get_json = mock.MagicMock()
+    request.get_json.return_value = {"name": "hello"}
+    with pytest.raises(MlflowException, match=r"Bad Request. Content-Type"):
+        _get_request_message(CreateExperiment(), flask_request=request)
+
+
+def test_can_block_post_request_and_not_printing_back_malformed_content_type():
+    request = mock.MagicMock()
+    request.method = "POST"
+    request.content_type = "<script>I am a malicious content type</script>"
+    request.get_json = mock.MagicMock()
+    request.get_json.return_value = {"name": "hello"}
+    with pytest.raises(
+        MlflowException, match=r"Bad Request. Content-Type must be one of \[application/json\].$"
+    ):
+        _get_request_message(CreateExperiment(), flask_request=request)
 
 
 def test_search_runs_default_view_type(mock_get_request_message, mock_tracking_store):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10526?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10526/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10526
```

</p>
</details>

### Related Issues/PRs
#9530 
#10492

### What changes are proposed in this pull request?

Add content type validation for security guardrail. Some content types bypass CORS preflight check.
Our ajax calls always add content type 'application/json' to the header so we don't need to modify at all.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The MLflow REST API now requires content type ``application/json`` for all POST requests.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
