### PR TITLE
Threaded proxy multipart upload

### DIFF
--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -7,20 +7,25 @@ import requests
 from requests import HTTPError
 
 from mlflow.entities import FileInfo
-from mlflow.entities.multipart_upload import CreateMultipartUploadResponse, MultipartUploadPart
+from mlflow.entities.multipart_upload import (
+    CreateMultipartUploadResponse,
+    MultipartUploadCredential,
+    MultipartUploadPart,
+)
 from mlflow.environment_variables import (
     MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD,
     MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE,
     MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE,
 )
-from mlflow.exceptions import _UnsupportedMultipartUploadException
+from mlflow.exceptions import MlflowException, _UnsupportedMultipartUploadException
 from mlflow.store.artifact.artifact_repo import (
     ArtifactRepository,
     MultipartUploadMixin,
     verify_artifact_path,
 )
+from mlflow.store.artifact.cloud_artifact_repo import _complete_futures
 from mlflow.tracking._tracking_service.utils import _get_default_host_creds
-from mlflow.utils.file_utils import relative_path_to_artifact_path
+from mlflow.utils.file_utils import read_chunk, relative_path_to_artifact_path
 from mlflow.utils.mime_type_utils import _guess_mime_type
 from mlflow.utils.rest_utils import augmented_raise_for_status, http_request
 
@@ -145,13 +150,22 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         resp = http_request(host_creds, endpoint, "POST", json=params)
         augmented_raise_for_status(resp)
 
+    @staticmethod
+    def _upload_part(credential: MultipartUploadCredential, local_file, size, start_byte):
+        data = read_chunk(local_file, size, start_byte)
+        response = requests.put(credential.url, data=data, headers=credential.headers)
+        augmented_raise_for_status(response)
+        return MultipartUploadPart(
+            part_number=credential.part_number,
+            etag=response.headers.get("ETag", ""),
+        )
+
     def _try_multipart_upload(self, local_file, artifact_path=None):
         """
         Attempts to perform multipart upload to log an artifact.
         Returns if the multipart upload is successful.
         Raises UnsupportedMultipartUploadException if multipart upload is unsupported.
         """
-        parts = []
         chunk_size = MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get()
         size = os.path.getsize(local_file)
         num_parts = math.ceil(size / chunk_size)
@@ -168,17 +182,22 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             raise
 
         try:
-            with open(local_file, "rb") as f:
-                for credential in create.credentials:
-                    chunk = f.read(chunk_size)
-                    response = requests.put(credential.url, data=chunk)
-                    augmented_raise_for_status(response)
-                    parts.append(
-                        MultipartUploadPart(
-                            part_number=credential.part_number,
-                            etag=response.headers["ETag"],
-                        )
-                    )
+            futures = {}
+            for i, credential in enumerate(create.credentials):
+                future = self.thread_pool.submit(
+                    self._upload_part,
+                    credential=credential,
+                    local_file=local_file,
+                    size=chunk_size,
+                    start_byte=chunk_size * i,
+                )
+                futures[future] = credential.part_number
+
+            parts, errors = _complete_futures(futures, local_file)
+            if errors:
+                raise MlflowException(
+                    f"Failed to upload at least one part of {local_file}. Errors: {errors}"
+                )
 
             self.complete_multipart_upload(local_file, create.upload_id, parts, artifact_path)
         except Exception as e:

--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -197,7 +197,7 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
                     f"Failed to upload at least one part of {local_file}. Errors: {errors}"
                 )
 
-            parts = sorted(parts, key=lambda part: part.part_number)
+            parts = sorted(list(parts.values()), key=lambda part: part.part_number)
             self.complete_multipart_upload(local_file, create.upload_id, parts, artifact_path)
         except Exception as e:
             self.abort_multipart_upload(local_file, create.upload_id, artifact_path)

--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -197,7 +197,7 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
                     f"Failed to upload at least one part of {local_file}. Errors: {errors}"
                 )
 
-            parts = sorted(list(parts.values()), key=lambda part: part.part_number)
+            parts = sorted(parts.values(), key=lambda part: part.part_number)
             self.complete_multipart_upload(local_file, create.upload_id, parts, artifact_path)
         except Exception as e:
             self.abort_multipart_upload(local_file, create.upload_id, artifact_path)

--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -1,5 +1,4 @@
 import logging
-import math
 import os
 import posixpath
 
@@ -23,7 +22,7 @@ from mlflow.store.artifact.artifact_repo import (
     MultipartUploadMixin,
     verify_artifact_path,
 )
-from mlflow.store.artifact.cloud_artifact_repo import _complete_futures
+from mlflow.store.artifact.cloud_artifact_repo import _complete_futures, _compute_num_chunks
 from mlflow.tracking._tracking_service.utils import _get_default_host_creds
 from mlflow.utils.file_utils import read_chunk, relative_path_to_artifact_path
 from mlflow.utils.mime_type_utils import _guess_mime_type
@@ -167,8 +166,7 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         Raises UnsupportedMultipartUploadException if multipart upload is unsupported.
         """
         chunk_size = MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get()
-        size = os.path.getsize(local_file)
-        num_parts = math.ceil(size / chunk_size)
+        num_parts = _compute_num_chunks(local_file, chunk_size)
 
         try:
             create = self.create_multipart_upload(local_file, num_parts, artifact_path)

--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -197,6 +197,7 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
                     f"Failed to upload at least one part of {local_file}. Errors: {errors}"
                 )
 
+            parts = sorted(parts, key=lambda part: part.part_number)
             self.complete_multipart_upload(local_file, create.upload_id, parts, artifact_path)
         except Exception as e:
             self.abort_multipart_upload(local_file, create.upload_id, artifact_path)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/gabrielfu/mlflow/pull/10534?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10534/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10534
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Upload multiple parts in parallel

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
