### PR TITLE
bugfix: Update documentation to fix KeyError in demo code in quickstart

### DIFF
--- a/docs/source/getting-started/quickstart-2/index.rst
+++ b/docs/source/getting-started/quickstart-2/index.rst
@@ -167,7 +167,7 @@ Finally, we will run the hyperparameter sweep using Hyperopt, passing in the ``o
         # Log the best parameters, loss, and model
         mlflow.log_params(best)
         mlflow.log_metric("rmse", best_run["loss"])
-        mlflow.tensorflow.log_model(best["model"], "model", signature=signature)
+        mlflow.tensorflow.log_model(best_run["model"], "model", signature=signature)
 
         # Print out the best parameters and corresponding loss
         print(f"Best parameters: {best}")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/wllgrnt/mlflow/pull/10540?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10540/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10540
```

</p>
</details>

### Related Issues/PRs
<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #10539 
### What changes are proposed in this pull request?
Updates the documentation so that the demo code  [here](https://mlflow.org/docs/latest/getting-started/quickstart-2/index.html) doesn't throw a KeyError when run.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
![image](https://github.com/mlflow/mlflow/assets/14338351/38d0f119-93ce-47c8-b2fa-8393a6bd4950)

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
This one-liner change updates the hyperopt usage example code in the quickstart documentaion so that the correct variable is referenced when logging the best tensorflow model.


#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
