### PR TITLE
Fix linking order in Line Chart

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsLinePlot.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsLinePlot.tsx
@@ -129,18 +129,22 @@ export const RunsMetricsLinePlot = React.memo(
         // Generate separate data trace for each run
         runsData.map((runEntry) => {
           if (runEntry.metricsHistory) {
+            // Sort metrics history by the given x-axis
+            const sortedMetricsHistory = runEntry.metricsHistory[metricKey]?.sort(
+              (a, b) => (xAxisKey === 'step') ? a.step - b.step : a.timestamp - b.timestamp
+            );
             return {
               // Let's add UUID to each run so it can be distinguished later (e.g. on hover)
               uuid: runEntry.runInfo.run_uuid,
               name: runEntry.runInfo.run_name,
-              x: prepareMetricHistoryByAxisType(runEntry.metricsHistory[metricKey], xAxisKey),
+              x: prepareMetricHistoryByAxisType(sortedMetricsHistory, xAxisKey),
               // The actual value is on Y axis
               y: EMA(
-                runEntry.metricsHistory[metricKey]?.map((e) => normalizeChartValue(e.value)),
+                sortedMetricsHistory?.map((e) => normalizeChartValue(e.value)),
                 lineSmoothness,
               ),
               // Always record the step so it can be accessed even if x-axis contains timestamp
-              z: runEntry.metricsHistory[metricKey]?.map(({ step }) => step),
+              z: sortedMetricsHistory?.map(({ step }) => step),
               hovertext: runEntry.runInfo.run_name,
               text: 'x',
               textposition: 'outside',


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10553?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10553/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10553
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #10536

### What changes are proposed in this pull request?

In line chart view, metrics are always linked by the arrival time order, not by the selected x-axis. For example, following code gives a collapsed chart when we selects 'step' as x-asis.

```
import mlflow
with mlflow.start_run(run_name="test"):
    mlflow.log_metric("loss", 7, step=4)
    mlflow.log_metric("loss", 10, step=1)
    mlflow.log_metric("loss", 9, step=2)
    mlflow.log_metric("loss", 4, step=7)
    mlflow.log_metric("loss", 3, step=8)
    mlflow.log_metric("loss", 3, step=9)
    mlflow.log_metric("loss", 6, step=5)
    mlflow.log_metric("loss", 5, step=6)
```

<img width="848" alt="Screenshot 2023-11-30 at 22 13 42" src="https://github.com/mlflow/mlflow/assets/31463517/82d45d2f-8823-4d90-a8bc-efcc25fda2c7">

(metric coordinates are correct, but line linking is broken as it's ordered by arrival time.)

This PR fixes the issue by properly sorting metrics datapoint with the selected x-axis.


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<img width="859" alt="Screenshot 2023-11-30 at 22 34 34" src="https://github.com/mlflow/mlflow/assets/31463517/f0a3fed9-8834-44c7-b55d-b4809b854e76">
<img width="857" alt="Screenshot 2023-11-30 at 22 34 45" src="https://github.com/mlflow/mlflow/assets/31463517/e78219b6-3b7b-4b54-9e97-bd4f0c0708cf">


<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug in line connection in Line Chart view when the selected x-axis gives different order than the metrics arrival time.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
