### PR TITLE
Support reading model registry URI from spark conf

### DIFF
--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -25,6 +25,7 @@ from mlflow.tracking._tracking_service.utils import (
     get_tracking_uri,
 )
 from mlflow.utils import rest_utils
+from mlflow.utils._spark_utils import _get_active_spark_session
 from mlflow.utils.databricks_utils import (
     get_databricks_host_creds,
     warn_on_deprecated_cross_workspace_registry_uri,
@@ -93,12 +94,18 @@ def set_registry_uri(uri: str) -> None:
     _registry_uri = uri
 
 
+def _get_registry_uri_from_spark_session():
+    if (session := _get_active_spark_session()) is None:
+        return None
+    return session.conf.get("spark.mlflow.modelRegistryUri", None)
+
 def _get_registry_uri_from_context():
     global _registry_uri
-    # in the future, REGISTRY_URI env var support can go here
     if _registry_uri is not None:
         return _registry_uri
     elif uri := MLFLOW_REGISTRY_URI.get():
+        return uri
+    elif uri := _get_registry_uri_from_spark_session():
         return uri
     return _registry_uri
 

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -105,9 +105,7 @@ def _get_registry_uri_from_context():
     global _registry_uri
     if _registry_uri is not None:
         return _registry_uri
-    elif uri := MLFLOW_REGISTRY_URI.get():
-        return uri
-    elif uri := _get_registry_uri_from_spark_session():
+    elif (uri := MLFLOW_REGISTRY_URI.get()) or (uri := _get_registry_uri_from_spark_session()):
         return uri
     return _registry_uri
 

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -99,6 +99,7 @@ def _get_registry_uri_from_spark_session():
         return None
     return session.conf.get("spark.mlflow.modelRegistryUri", None)
 
+
 def _get_registry_uri_from_context():
     global _registry_uri
     if _registry_uri is not None:

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -95,7 +95,8 @@ def set_registry_uri(uri: str) -> None:
 
 
 def _get_registry_uri_from_spark_session():
-    if (session := _get_active_spark_session()) is None:
+    session = _get_active_spark_session()
+    if session is None:
         return None
     return session.conf.get("spark.mlflow.modelRegistryUri", None)
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1290,6 +1290,7 @@ def test_get_parent_run():
 
     assert mlflow.get_parent_run(run_id) is None
 
+
 def test_log_metric_async():
     run_operations = []
 
@@ -1368,15 +1369,18 @@ def test_set_tag_async():
     assert parent_run.data.tags["async single tag"] == "1"
     for num in range(100):
         assert parent_run.data.tags[f"async batch tag {num}"] == str(num)
+
+
 @pytest.fixture
 def spark_session_with_registry_uri(request):
     with mock.patch(
-            "mlflow.tracking._model_registry.utils._get_active_spark_session"
+        "mlflow.tracking._model_registry.utils._get_active_spark_session"
     ) as spark_session_getter:
         spark = mock.MagicMock()
         spark_session_getter.return_value = spark
         spark.conf.get.side_effect = lambda key, _: "http://custom.uri"
         yield spark
+
 
 def test_registry_uri_from_spark_conf(spark_session_with_registry_uri):
     assert mlflow.get_registry_uri() == "http://custom.uri"

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -31,6 +31,7 @@ from mlflow.entities import (
 from mlflow.environment_variables import (
     MLFLOW_EXPERIMENT_ID,
     MLFLOW_EXPERIMENT_NAME,
+    MLFLOW_REGISTRY_URI,
     MLFLOW_RUN_ID,
 )
 from mlflow.exceptions import MlflowException
@@ -1384,3 +1385,7 @@ def spark_session_with_registry_uri(request):
 
 def test_registry_uri_from_spark_conf(spark_session_with_registry_uri):
     assert mlflow.get_registry_uri() == "http://custom.uri"
+    # The MLFLOW_REGISTRY_URI environment variable should still take precedence over the
+    # spark conf if present
+    with mock.patch.dict(os.environ, {MLFLOW_REGISTRY_URI.name: "something-else"}):
+        assert mlflow.get_registry_uri() == "something-else"

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1290,7 +1290,6 @@ def test_get_parent_run():
 
     assert mlflow.get_parent_run(run_id) is None
 
-
 def test_log_metric_async():
     run_operations = []
 
@@ -1369,3 +1368,15 @@ def test_set_tag_async():
     assert parent_run.data.tags["async single tag"] == "1"
     for num in range(100):
         assert parent_run.data.tags[f"async batch tag {num}"] == str(num)
+@pytest.fixture
+def spark_session_with_registry_uri(request):
+    with mock.patch(
+            "mlflow.tracking._model_registry.utils._get_active_spark_session"
+    ) as spark_session_getter:
+        spark = mock.MagicMock()
+        spark_session_getter.return_value = spark
+        spark.conf.get.side_effect = lambda key, _: "http://custom.uri"
+        yield spark
+
+def test_registry_uri_from_spark_conf(spark_session_with_registry_uri):
+    assert mlflow.get_registry_uri() == "http://custom.uri"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smurching/mlflow/pull/10556?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10556/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10556
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Support reading model registry URI from spark conf, to allow for easier configuration in environments where setting environment variables is difficult.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
