### PR TITLE
Quick fix for promptlab gateway migration

### DIFF
--- a/mlflow/_promptlab.py
+++ b/mlflow/_promptlab.py
@@ -62,9 +62,9 @@ class _PromptlabModel:
         route_type = get_route(self.model_route).route_type
 
         if route_type == "llm/v1/completions":
-            return response["candidates"][0]["text"]
+            return response["choices"][0]["text"]
         elif route_type == "llm/v1/chat":
-            return response["candidates"][0]["message"]["content"]
+            return response["choices"][0]["message"]["content"]
         else:
             raise MlflowException(
                 "Error when parsing gateway response: "

--- a/tests/promptlab/test_promptlab_model.py
+++ b/tests/promptlab/test_promptlab_model.py
@@ -52,7 +52,7 @@ def test_promptlab_prompt_replacement():
 
 def test_promptlab_works_with_chat_route():
     mock_response = {
-        "candidates": [
+        "choices": [
             {"message": {"role": "user", "content": "test"}, "metadata": {"finish_reason": "stop"}}
         ]
     }
@@ -70,7 +70,7 @@ def test_promptlab_works_with_chat_route():
 
 def test_promptlab_works_with_completions_route():
     mock_response = {
-        "candidates": [
+        "choices": [
             {
                 "text": "test",
                 "metadata": {"finish_reason": "stop"},


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/10563?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10563/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10563
```

</p>
</details>

### Related Issues/PRs

### What changes are proposed in this pull request?

`candidates` -> `choices`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
