### PR TITLE
Fix mobile layout for MLflow Tracking page

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -219,11 +219,12 @@ The following diagram and table show a few common setups for the MLflow Tracking
 
 .. figure:: _static/images/tracking/tracking-setup-overview.png
     :align: center
-    :figwidth: 80%
+    :figwidth: 100%
 
 .. list-table::
     :widths: 45 20 20 20
     :header-rows: 1
+    :class: wrap-table
 
     * -
       - **1. Localhost (default)**
@@ -255,41 +256,41 @@ learning the basic setup and continue to the following materials for advanced co
 
 .. |local-server| raw:: html
 
-        <div style="display: flex;">
-            <div style="width: 70%; display: flex; flex-direction: column; padding: 0 20px;">
-                <h4 style="margin-bottom: 20px">Using MLflow Tracking Server Locally</h4>
+        <div class="tracking-responsive-tab-container">
+            <div>
+                <h4>Using MLflow Tracking Server Locally</h4>
                 <p>You can of course run MLflow Tracking Server locally. While this doesn't provide much additional benefit over directly using
                   the local files or database, might useful for testing your team development workflow locally or running your machine learning 
                   code on a container environment.</p>
             </div>
-            <img src="_static/images/tracking/tracking-setup-local-server.png" style="margin: auto 20px; width: 30%"/>
+            <img src="_static/images/tracking/tracking-setup-local-server.png"/>
         </div>
 
 .. |artifact-only| raw:: html
 
-        <div style="display: flex;">
-            <div style="width: 70%; display: flex; flex-direction: column; padding: 0 20px;">
-              <h4 style="margin-bottom: 20px">Running MLflow Tracking Server in Artifacts-only Mode</h4>
+        <div class="tracking-responsive-tab-container">
+            <div>
+              <h4>Running MLflow Tracking Server in Artifacts-only Mode</h4>
               <p> MLflow Tracking Server has <code>--artifacts-only</code> option, which lets the server to serve (proxy) only artifacts
                 and not metadata. This is particularly useful when you are in a large organization or training huge models, you might have high artifact
                  transfer volumes and want to split out the traffic for serving artifacts to not impact tracking functionality. Please read
                  <a href="tracking/server.html#optionally-using-a-tracking-server-instance-exclusively-for-artifact-handling">Optionally using a Tracking Server instance exclusively for artifact handling</a> for more details on how to use this mode.
               </p>
-             </div>
-            <img src="_static/images/tracking/tracking-setup-artifacts-only.png" style="margin: auto 20px; width: 30%"/>
+            </div>
+            <img src="_static/images/tracking/tracking-setup-artifacts-only.png"/>
         </div>
 
 .. |no-proxy| raw:: html
 
-        <div style="display: flex;">
-            <div style="width: 70%; display: flex; flex-direction: column; padding: 0 20px;">
-              <h4 style="margin-bottom: 20px"> Disable Artifact Proxying to Allow Direct Access to Artifacts</h4>
+        <div class="tracking-responsive-tab-container">
+            <div>
+              <h4> Disable Artifact Proxying to Allow Direct Access to Artifacts</h4>
               <p>MLflow Tracking Server, by default, serves both artifacts and only metadata. However, in some cases, you may want
                 to allow direct access to the remote artifacts storage to avoid the overhead of a proxy while preserving the functionality 
                 of metadata tracking. This can be done by disabling artifact proxying by starting server with <code>--no-serve-artifacts</code> option.
                 Refer to <a href="tracking/server.html#use-tracking-server-w-o-proxying-artifacts-access">Use Tracking Server without Proxying Artifacts Access</a> for how to set this up.</p>
-             </div>
-            <img src="_static/images/tracking/tracking-setup-no-serve-artifacts.png" style="margin: auto 20px; width: 30%"/>
+            </div>
+            <img src="_static/images/tracking/tracking-setup-no-serve-artifacts.png"/>
         </div>
 
 .. tabs::
@@ -330,11 +331,11 @@ if you are using it for personal projects or testing. You can achieve this by fo
 1. Set up artifacts configuration such as credentials and endpoints, just like you would for the MLflow Tracking Server. See :ref:`configure artifact storage <artifacts-store-supported-storages>` for more details.
 2. Create an experiment with an explicit artifact location,
 
-    .. code-block:: python
+.. code-block:: python
 
-        experiment_name = "your_experiment_name"
-        mlflow.create_experiment(experiment_name, artifact_location="s3://your-bucket")
-        mlflow.set_experiment(experiment_name)
+    experiment_name = "your_experiment_name"
+    mlflow.create_experiment(experiment_name, artifact_location="s3://your-bucket")
+    mlflow.set_experiment(experiment_name)
 
 Your runs under this experiment will log artifacts to the remote storage directly.
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -256,7 +256,7 @@ learning the basic setup and continue to the following materials for advanced co
 
 .. |local-server| raw:: html
 
-        <div class="tracking-responsive-tab-container">
+        <div class="tracking-responsive-tab-panel">
             <div>
                 <h4>Using MLflow Tracking Server Locally</h4>
                 <p>You can of course run MLflow Tracking Server locally. While this doesn't provide much additional benefit over directly using
@@ -268,7 +268,7 @@ learning the basic setup and continue to the following materials for advanced co
 
 .. |artifact-only| raw:: html
 
-        <div class="tracking-responsive-tab-container">
+        <div class="tracking-responsive-tab-panel">
             <div>
               <h4>Running MLflow Tracking Server in Artifacts-only Mode</h4>
               <p> MLflow Tracking Server has <code>--artifacts-only</code> option, which lets the server to serve (proxy) only artifacts
@@ -282,7 +282,7 @@ learning the basic setup and continue to the following materials for advanced co
 
 .. |no-proxy| raw:: html
 
-        <div class="tracking-responsive-tab-container">
+        <div class="tracking-responsive-tab-panel">
             <div>
               <h4> Disable Artifact Proxying to Allow Direct Access to Artifacts</h4>
               <p>MLflow Tracking Server, by default, serves both artifacts and only metadata. However, in some cases, you may want
@@ -293,19 +293,21 @@ learning the basic setup and continue to the following materials for advanced co
             <img src="_static/images/tracking/tracking-setup-no-serve-artifacts.png"/>
         </div>
 
-.. tabs::
+.. container:: tracking-responsive-tabs
 
-    .. tab:: Local Tracking Server
+    .. tabs::
 
-        |local-server|
+        .. tab:: Local Tracking Server
 
-    .. tab:: Artifacts-only Mode
+            |local-server|
 
-        |artifact-only|
+        .. tab:: Artifacts-only Mode
 
-    .. tab:: Direct Access to Artifacts
+            |artifact-only|
 
-        |no-proxy|
+        .. tab:: Direct Access to Artifacts
+
+            |no-proxy|
 
 FAQ
 ===

--- a/docs/theme/mlflow/layout.html
+++ b/docs/theme/mlflow/layout.html
@@ -61,6 +61,7 @@
     <link rel="stylesheet" href="{{ pathto('_static/css/custom.css', 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/css/cards.css', 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/css/grids.css', 1) }}" type="text/css" />
+    <link rel="stylesheet" href="{{ pathto('_static/css/mobile.css', 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/css/simple-cards.css', 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/css/tabs.css', 1) }}" type="text/css" />
     {% if target_cloud == 'azure' %}

--- a/docs/theme/mlflow/static/css/mobile.css
+++ b/docs/theme/mlflow/static/css/mobile.css
@@ -1,0 +1,50 @@
+/*
+ * Custom CSSs for optimizing mobile view
+ *
+ * *** PLEASE DO NOT OVERUSE *** as having two different styles reduces maintainability.
+ */
+
+
+/* Mobile styling */
+@media only screen and (max-width: 768px) {
+    /*
+    * Fix table overflow issue on mobile. Sphinx apply no word wrapping by default,
+    * resulted in showing very wide 1-line cells on mobile.
+    * To apply those CSSs to your table, add `:class wrap-table` to your table
+    */
+    .wy-table-responsive .wrap-table td,
+    .wy-table-responsive .warp-table th {
+        max-width: 300px;
+        white-space: normal;
+    }
+
+    /*
+    * Handle layout for the tab contents in the tracking page
+    */
+    .tracking-responsive-tab-container {
+        flex-direction: column;
+     }
+
+    .tracking-responsive-tab-container img {
+        width: 100%;
+        margin: 10px auto;
+    }
+
+    .tracking-responsive-tab-container div {
+        width: 100%;
+        padding: 0 10px;
+    }
+}
+
+/* Desktop styling corresponding to above styles*/
+@media only screen and (min-width: 768px) {
+    .tracking-responsive-tab-container img {
+        width: 30%;
+        margin: auto 20px;
+    }
+
+    .tracking-responsive-tab-container div {
+        width: 70%;
+        padding: 0 20px;
+    }
+}

--- a/docs/theme/mlflow/static/css/mobile.css
+++ b/docs/theme/mlflow/static/css/mobile.css
@@ -12,8 +12,7 @@
     * resulted in showing very wide 1-line cells on mobile.
     * To apply those CSSs to your table, add `:class wrap-table` to your table
     */
-    .wy-table-responsive .wrap-table td,
-    .wy-table-responsive .wrap-table th {
+    .wy-table-responsive .wrap-table td {
         max-width: 300px;
         white-space: normal;
     }

--- a/docs/theme/mlflow/static/css/mobile.css
+++ b/docs/theme/mlflow/static/css/mobile.css
@@ -20,29 +20,40 @@
     /*
     * Handle layout for the tab contents in the tracking page
     */
-    .tracking-responsive-tab-container {
+    .tracking-responsive-tab-panel {
         flex-direction: column;
      }
 
-    .tracking-responsive-tab-container img {
+    .tracking-responsive-tab-panel img {
         width: 100%;
         margin: 10px auto;
     }
 
-    .tracking-responsive-tab-container div {
+    .tracking-responsive-tab-panel div {
         width: 100%;
         padding: 0 10px;
+    }
+
+    /*
+    * Make the tab headers stand in one horizontal row (and reduce padding)
+    */
+    .tracking-responsive-tabs .sphinx-tabs > div[aria-label="Tabbed content"][role="tablist"] {
+        display: flex;
+    }
+
+    .tracking-responsive-tabs .sphinx-tabs-tab {
+        padding: 0.75rem 0;
     }
 }
 
 /* Desktop styling corresponding to above styles*/
 @media only screen and (min-width: 768px) {
-    .tracking-responsive-tab-container img {
+    .tracking-responsive-tab-panel img {
         width: 30%;
         margin: auto 20px;
     }
 
-    .tracking-responsive-tab-container div {
+    .tracking-responsive-tab-panel div {
         width: 70%;
         padding: 0 20px;
     }

--- a/docs/theme/mlflow/static/css/mobile.css
+++ b/docs/theme/mlflow/static/css/mobile.css
@@ -13,7 +13,7 @@
     * To apply those CSSs to your table, add `:class wrap-table` to your table
     */
     .wy-table-responsive .wrap-table td,
-    .wy-table-responsive .warp-table th {
+    .wy-table-responsive .wrap-table th {
         max-width: 300px;
         white-space: normal;
     }

--- a/docs/theme/mlflow/static/css/tabs.css
+++ b/docs/theme/mlflow/static/css/tabs.css
@@ -94,3 +94,16 @@ body[data-theme="dark"] .sphinx-tabs-tab[aria-selected="true"] {
 border-bottom: 2px solid rgb(50, 50, 50);
 background-color: rgb(50, 50, 50);
 }
+
+/*
+ * Additional Custom CSS
+ */
+
+ /* Handling mobile view for the tab widget in the tracking page */
+ .tracking-responsive-tab-container {
+    display: flex;
+ }
+
+.tracking-responsive-tab-container h4 {
+    margin-bottom: 20px;
+}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10567?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10567/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10567
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Tables and tags added in #10471 are displayed super ugly in mobile view ([link](https://output.circle-artifacts.com/output/job/abd4b54a-f83b-47b3-9a5b-54975a4bf4d1/artifacts/0/docs/build/html/tracking.html#common-setups)). This PR tries to make it *better*, still far from the best, but trying to make it at least readable. Hopefully we can make find fundamental solution in the new markdown based framework.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
