### PR TITLE
Replace `candidates` with `choices`

### DIFF
--- a/mlflow/gateway/providers/mlflow.py
+++ b/mlflow/gateway/providers/mlflow.py
@@ -16,19 +16,19 @@ class ServingTextResponse(BaseModel):
     predictions: List[StrictStr]
 
     @validator("predictions", pre=True)
-    def extract_candidates(cls, predictions):
+    def extract_choices(cls, predictions):
         if isinstance(predictions, list) and not predictions:
             raise ValueError("The input list is empty")
         if isinstance(predictions, dict):
-            if "candidates" not in predictions and len(predictions) > 1:
+            if "choices" not in predictions and len(predictions) > 1:
                 raise ValueError(
                     "The dict format is invalid for this route type. Ensure the served model "
-                    "returns a dict key containing 'candidates'"
+                    "returns a dict key containing 'choices'"
                 )
             if len(predictions) == 1:
                 predictions = next(iter(predictions.values()))
             else:
-                predictions = predictions.get("candidates", predictions)
+                predictions = predictions.get("choices", predictions)
             if not predictions:
                 raise ValueError("The input list is empty")
         return predictions

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -53,11 +53,11 @@ def _format_args_string(grading_context_columns: Optional[List[str]], eval_value
 def _extract_score_and_justification(output):
     if (
         isinstance(output, dict)
-        and "candidates" in output
-        and isinstance(output["candidates"], list)
-        and output["candidates"]
+        and "choices" in output
+        and isinstance(output["choices"], list)
+        and output["choices"]
     ):
-        text = output["candidates"][0]["text"]
+        text = output["choices"][0]["text"]
 
     if text:
         # Attempt to parse JSON

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -145,7 +145,7 @@ def _convert_to_openai_request(payload):
 
 def _convert_from_openai_response(resp):
     return {
-        "candidates": [
+        "choices": [
             {
                 "text": c["message"]["content"],
                 "metadata": {"finish_reason": c["finish_reason"]},

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -3104,7 +3104,7 @@ def test_evaluate_with_latency_static_dataset():
 
 
 properly_formatted_openai_response1 = {
-    "candidates": [
+    "choices": [
         {
             "text": '{\n  "score": 3,\n  "justification": "' "justification" '"\n}',
             "metadata": {"finish_reason": "stop"},

--- a/tests/gateway/providers/test_mlflow.py
+++ b/tests/gateway/providers/test_mlflow.py
@@ -88,14 +88,14 @@ async def test_completions():
             ],
         ),
         (
-            {"predictions": {"candidates": ["string1", "string2"]}},
+            {"predictions": {"choices": ["string1", "string2"]}},
             [
                 completions.Choice(index=0, text="string1", finish_reason=None),
                 completions.Choice(index=1, text="string2", finish_reason=None),
             ],
         ),
         (
-            {"predictions": {"candidates": ["string1", "string2"], "ignored": ["a", "b"]}},
+            {"predictions": {"choices": ["string1", "string2"], "ignored": ["a", "b"]}},
             [
                 completions.Choice(index=0, text="string1", finish_reason=None),
                 completions.Choice(index=1, text="string2", finish_reason=None),
@@ -123,11 +123,11 @@ def test_valid_completions_input_parsing(input_data, expected_output):
     "invalid_data",
     [
         {"predictions": [1, 2, 3]},  # List of integers
-        {"predictions": {"candidates": [1, 2, 3]}},  # Dict with list of integers
+        {"predictions": {"choices": [1, 2, 3]}},  # Dict with list of integers
         {"predictions": {"arbitrary_key": [1, 2, 3]}},  # Dict with list of integers
         {"predictions": {"key1": ["string1"], "key2": ["string2"]}},  # Multiple keys in dict
         {"predictions": []},  # Empty list
-        {"predictions": {"candidates": []}},  # Dict with empty list
+        {"predictions": {"choices": []}},  # Dict with empty list
     ],
 )
 def test_validation_errors(invalid_data):

--- a/tests/gateway/providers/test_palm.py
+++ b/tests/gateway/providers/test_palm.py
@@ -30,7 +30,7 @@ def completions_config():
 
 def completions_response():
     return {
-        "candidates": [
+        "choices": [
             {
                 "output": "This is a test",
                 "safetyRatings": [
@@ -118,7 +118,7 @@ def chat_config():
 
 def chat_response():
     return {
-        "candidates": [{"author": "1", "content": "Hi there! How can I help you today?"}],
+        "choices": [{"author": "1", "content": "Hi there! How can I help you today?"}],
         "messages": [{"author": "0", "content": "hi"}],
     }
 

--- a/tests/gateway/providers/test_palm.py
+++ b/tests/gateway/providers/test_palm.py
@@ -30,7 +30,7 @@ def completions_config():
 
 def completions_response():
     return {
-        "choices": [
+        "candidates": [
             {
                 "output": "This is a test",
                 "safetyRatings": [
@@ -118,7 +118,7 @@ def chat_config():
 
 def chat_response():
     return {
-        "choices": [{"author": "1", "content": "Hi there! How can I help you today?"}],
+        "candidates": [{"author": "1", "content": "Hi there! How can I help you today?"}],
         "messages": [{"author": "0", "content": "hi"}],
     }
 

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -38,7 +38,7 @@ openai_justification1 = (
 
 # Example properly formatted response from OpenAI
 properly_formatted_openai_response1 = {
-    "candidates": [
+    "choices": [
         {
             "text": '{\n  "score": 3,\n  "justification": "' f"{openai_justification1}" '"\n}',
             "metadata": {"finish_reason": "stop"},
@@ -54,7 +54,7 @@ properly_formatted_openai_response1 = {
 }
 
 properly_formatted_openai_response2 = {
-    "candidates": [
+    "choices": [
         {
             "text": '{\n  "score": 2,\n  "justification": "The provided output gives a correct '
             "and adequate explanation of what Apache Spark is, covering its main functions and "
@@ -79,7 +79,7 @@ properly_formatted_openai_response2 = {
 
 # Example incorrectly formatted response from OpenAI
 incorrectly_formatted_openai_response = {
-    "candidates": [
+    "choices": [
         {
             "text": "score: 2\njustification: \n\nThe provided output gives some relevant "
             "information about MLflow including its capabilities such as experiment tracking, "
@@ -605,7 +605,7 @@ def test_format_args_string():
 def test_extract_score_and_justification():
     score1, justification1 = _extract_score_and_justification(
         output={
-            "candidates": [
+            "choices": [
                 {
                     "text": '{"score": 4, "justification": "This is a justification"}',
                 }
@@ -618,7 +618,7 @@ def test_extract_score_and_justification():
 
     score2, justification2 = _extract_score_and_justification(
         output={
-            "candidates": [
+            "choices": [
                 {
                     "text": "score: 2 \njustification: This is a justification",
                 }
@@ -641,7 +641,7 @@ def test_extract_score_and_justification():
 
     score4, justification4 = _extract_score_and_justification(
         output={
-            "candidates": [
+            "choices": [
                 {
                     "text": '{"score": "4", "justification": "This is a justification"}',
                 }
@@ -654,7 +654,7 @@ def test_extract_score_and_justification():
 
     score5, justification5 = _extract_score_and_justification(
         output={
-            "candidates": [
+            "choices": [
                 {
                     "text": "  Score: 2 \nJustification:\nThis is a justification",
                 }
@@ -665,7 +665,7 @@ def test_extract_score_and_justification():
     assert justification5 == "This is a justification"
 
     malformed_output = {
-        "candidates": [
+        "choices": [
             {
                 "text": '{"score": 4, "justification": {"foo": "bar"}}',
             }

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -192,7 +192,7 @@ def test_score_model_azure_openai_bad_envs(set_bad_azure_envs):
 
 def test_score_model_gateway():
     expected_output = {
-        "candidates": [
+        "choices": [
             {
                 "message": {
                     "role": "assistant",
@@ -236,7 +236,7 @@ def test_score_model_endpoints(set_deployment_envs):
         "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
     }
     expected_output = {
-        "candidates": [
+        "choices": [
             {
                 "text": "\n\nHello there, how may I assist you today?",
                 "metadata": {"finish_reason": "stop"},


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10569?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10569/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10569
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Replace `candidates` with `choices`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
