### PR TITLE
[Bug-fix] Fixing the error state bug for Mlflow deployments

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/actions/ModelGatewayActions.ts
+++ b/mlflow/server/js/src/experiment-tracking/actions/ModelGatewayActions.ts
@@ -7,6 +7,7 @@ import {
   ModelGatewayService,
   SearchModelGatewayRouteResponse,
   ModelGatewayResponseType,
+  gatewayErrorHandler,
 } from '../sdk/ModelGatewayService';
 
 export const SEARCH_MODEL_GATEWAY_ROUTES_API = 'SEARCH_MODEL_GATEWAY_ROUTES_API';
@@ -52,10 +53,13 @@ export const queryModelGatewayRouteApi = (
 
   return {
     type: QUERY_MODEL_GATEWAY_ROUTE_API,
-    payload: MlflowService.gatewayProxyPost({
-      gateway_path: route.endpoint_url.substring(1),
-      json_data: processed_data,
-    }) as Promise<ModelGatewayResponseType>,
+    payload: MlflowService.gatewayProxyPost(
+      {
+        gateway_path: route.endpoint_url.substring(1),
+        json_data: processed_data,
+      },
+      gatewayErrorHandler,
+    ) as Promise<ModelGatewayResponseType>,
     meta: { id: getUUID(), startTime: performance.now() },
   };
 };

--- a/mlflow/server/js/src/experiment-tracking/actions/PromptEngineeringActions.ts
+++ b/mlflow/server/js/src/experiment-tracking/actions/PromptEngineeringActions.ts
@@ -13,6 +13,7 @@ import {
   ModelGatewayQueryPayload,
   ModelGatewayResponseType,
   ModelGatewayService,
+  gatewayErrorHandler,
 } from '../sdk/ModelGatewayService';
 import { EvaluationArtifactTable } from '../types';
 import { searchModelGatewayRoutesApi } from './ModelGatewayActions';
@@ -83,10 +84,13 @@ export const evaluatePromptTableValue =
         ...textPayload,
         ...modelGatewayRequestPayload.parameters,
       };
-      return MlflowService.gatewayProxyPost({
-        gateway_path: gatewayRoute.endpoint_url.substring(1),
-        json_data: processed_data,
-      });
+      return MlflowService.gatewayProxyPost(
+        {
+          gateway_path: gatewayRoute.endpoint_url.substring(1),
+          json_data: processed_data,
+        },
+        gatewayErrorHandler,
+      );
     };
 
     const action = {

--- a/mlflow/server/js/src/experiment-tracking/sdk/MlflowService.ts
+++ b/mlflow/server/js/src/experiment-tracking/sdk/MlflowService.ts
@@ -163,8 +163,8 @@ export class MlflowService {
   /**
    * Proxy post request to gateway server
    */
-  static gatewayProxyPost = (data: { gateway_path: string; json_data: any }) =>
-    postJson({ relativeUrl: 'ajax-api/2.0/mlflow/gateway-proxy', data });
+  static gatewayProxyPost = (data: { gateway_path: string; json_data: any }, error: any = null) =>
+    postJson({ relativeUrl: 'ajax-api/2.0/mlflow/gateway-proxy', data, error });
 
   /**
    * Proxy get request to gateway server

--- a/mlflow/server/js/src/experiment-tracking/sdk/ModelGatewayService.ts
+++ b/mlflow/server/js/src/experiment-tracking/sdk/ModelGatewayService.ts
@@ -101,7 +101,7 @@ export class GatewayErrorWrapper extends ErrorWrapper {
   }
 }
 
-const gatewayErrorHandler = ({
+export const gatewayErrorHandler = ({
   reject,
   response,
   err,
@@ -146,11 +146,13 @@ export class ModelGatewayService {
       case ModelGatewayRouteType.LLM_V1_EMBEDDINGS: {
         // Should never happen
         throw new GatewayErrorWrapper(
-          `Unsupported AI gateway route type "${route.endpoint_type}"!`,
+          `Unsupported MLflow deployment endpoint type "${route.endpoint_type}"!`,
         );
       }
       default:
-        throw new GatewayErrorWrapper(`Unknown AI gateway route type "${route.endpoint_type}"!`);
+        throw new GatewayErrorWrapper(
+          `Unknown MLflow deployment endpoint type "${route.endpoint_type}"!`,
+        );
     }
   }
   static parseEvaluationResponse(response: ModelGatewayResponseType) {
@@ -171,7 +173,7 @@ export class ModelGatewayService {
     }
     // Should not happen since we shouldn't call other route types for now
     throw new GatewayErrorWrapper(
-      `Unrecognizable AI gateway response object "${response.object}"!`,
+      `Unrecognizable MLflow deployment response object "${response.object}"!`,
     );
   }
   /**


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sunishsheth2009/mlflow/pull/10575?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10575/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10575
```

</p>
</details>

### What changes are proposed in this pull request?
[Bug-fix] Fixing the error state bug for Mlflow deployments

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

![image](https://github.com/mlflow/mlflow/assets/5621432/dd84b084-39c8-4aac-bb13-c02c704f0c2d)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
