### PR TITLE
Support saving torch_dtype for transformers with components logging

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -105,7 +105,13 @@ _TOKENIZER_KEY = "tokenizer"
 _TOKENIZER_TYPE_KEY = "tokenizer_type"
 _TORCH_DTYPE_KEY = "torch_dtype"
 _METADATA_PIPELINE_SCALAR_CONFIG_KEYS = {_FRAMEWORK_KEY}
-_SUPPORTED_SAVE_KEYS = {_MODEL_KEY, _TOKENIZER_KEY, _FEATURE_EXTRACTOR_KEY, _IMAGE_PROCESSOR_KEY}
+_SUPPORTED_SAVE_KEYS = {
+    _MODEL_KEY,
+    _TOKENIZER_KEY,
+    _FEATURE_EXTRACTOR_KEY,
+    _IMAGE_PROCESSOR_KEY,
+    _TORCH_DTYPE_KEY,
+}
 
 _logger = logging.getLogger(__name__)
 
@@ -1505,6 +1511,7 @@ class _TransformersModel(NamedTuple):
     feature_extractor: Any = None
     image_processor: Any = None
     processor: Any = None
+    torch_dtype: Any = None
 
     def to_dict(self):
         dict_repr = self._asdict()
@@ -1528,8 +1535,9 @@ class _TransformersModel(NamedTuple):
 
     @classmethod
     def _validate_submitted_types(
-        cls, model, tokenizer, feature_extractor, image_processor, processor
+        cls, model, tokenizer, feature_extractor, image_processor, processor, torch_dtype
     ):
+        from torch import dtype
         from transformers import (
             FeatureExtractionMixin,
             FlaxPreTrainedModel,
@@ -1556,6 +1564,7 @@ class _TransformersModel(NamedTuple):
             ),
             (image_processor, "image_processor", ImageProcessingMixin),
             (processor, "processor", ProcessorMixin),
+            (torch_dtype, "torch_dtype", dtype),
         ]
         invalid_types = []
 
@@ -1573,13 +1582,16 @@ class _TransformersModel(NamedTuple):
         feature_extractor=None,
         image_processor=None,
         processor=None,
+        torch_dtype=None,
         **kwargs,  # pylint: disable=unused-argument
     ):
         cls._validate_submitted_types(
-            model, tokenizer, feature_extractor, image_processor, processor
+            model, tokenizer, feature_extractor, image_processor, processor, torch_dtype
         )
 
-        return _TransformersModel(model, tokenizer, feature_extractor, image_processor, processor)
+        return _TransformersModel(
+            model, tokenizer, feature_extractor, image_processor, processor, torch_dtype
+        )
 
 
 def _get_model_config(local_path, pyfunc_config):

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1537,7 +1537,6 @@ class _TransformersModel(NamedTuple):
     def _validate_submitted_types(
         cls, model, tokenizer, feature_extractor, image_processor, processor, torch_dtype
     ):
-        from torch import dtype
         from transformers import (
             FeatureExtractionMixin,
             FlaxPreTrainedModel,
@@ -1564,13 +1563,18 @@ class _TransformersModel(NamedTuple):
             ),
             (image_processor, "image_processor", ImageProcessingMixin),
             (processor, "processor", ProcessorMixin),
-            (torch_dtype, "torch_dtype", dtype),
         ]
         invalid_types = []
 
         for arg, name, types in validation:
             if arg and not isinstance(arg, types):
                 invalid_types.append(cls._build_exception_msg(arg, name, types))
+        # only import torch when torch_dtype is not None
+        if torch_dtype is not None:
+            from torch import dtype
+
+            if not isinstance(torch_dtype, dtype):
+                invalid_types.append(cls._build_exception_msg(torch_dtype, "torch_dtype", dtype))
         if invalid_types:
             raise MlflowException("\n".join(invalid_types), error_code=BAD_REQUEST)
 

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -2931,6 +2931,28 @@ def test_extraction_of_torch_dtype_from_pipeline(dtype):
 
 
 @pytest.mark.parametrize(
+    "dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64, torch.float]
+)
+@pytest.mark.skipcacheclean
+@pytest.mark.skipif(
+    Version(transformers.__version__) < Version("4.26.1"), reason="Feature does not exist"
+)
+def test_extraction_of_torch_dtype_from_components(dtype, model_path):
+    components = {
+        "model": transformers.T5ForConditionalGeneration.from_pretrained("t5-small"),
+        "tokenizer": transformers.T5TokenizerFast.from_pretrained("t5-small", model_max_length=100),
+        "torch_dtype": dtype,
+    }
+
+    mlflow.transformers.save_model(transformers_model=components, path=model_path)
+
+    base_loaded = mlflow.transformers.load_model(model_path)
+    assert base_loaded.torch_dtype == dtype
+    assert base_loaded.framework == "pt"
+    assert base_loaded.model.dtype == dtype
+
+
+@pytest.mark.parametrize(
     "dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64, torch.int32, torch.int64]
 )
 @pytest.mark.skipcacheclean


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10586?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10586/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10586
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Previously when saving transformers models with components, we do not support torch_dtype.
This PR supports it by passing the value to internal _TransformersModel and save with the model conf.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/gateway`: AI Gateway service, Gateway client APIs, third-party Gateway integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
