### PR TITLE
Support extra env vars in spark udf

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1490,18 +1490,8 @@ Compound types:
     )
 
     tracking_uri = mlflow.get_tracking_uri()
-    update_envs = {}
-    if mlflow_home is not None:
-        update_envs["MLFLOW_HOME"] = mlflow_home
-    if openai_env_vars:
-        update_envs.update(openai_env_vars)
-    if mlflow_testing:
-        update_envs[_MLFLOW_TESTING.name] = mlflow_testing
-    if extra_env:
-        update_envs.update(extra_env)
 
     @pandas_udf(result_type)
-    @modified_environ(update_envs)
     def udf(
         iterator: Iterator[Tuple[Union[pandas.Series, pandas.DataFrame], ...]]
     ) -> Iterator[result_type_hint]:
@@ -1513,134 +1503,148 @@ Compound types:
 
         # Note: this is a pandas udf function in iteration style, which takes an iterator of
         # tuple of pandas.Series and outputs an iterator of pandas.Series.
+        update_envs = {}
+        if mlflow_home is not None:
+            update_envs["MLFLOW_HOME"] = mlflow_home
+        if openai_env_vars:
+            update_envs.update(openai_env_vars)
+        if mlflow_testing:
+            update_envs[_MLFLOW_TESTING.name] = mlflow_testing
+        if extra_env:
+            update_envs.update(extra_env)
 
         #  use `modified_environ` to temporarily set the envs and restore them finally
-        scoring_server_proc = None
-        # set tracking_uri inside udf so that with spark_connect
-        # we can load the model from correct path
-        mlflow.set_tracking_uri(tracking_uri)
+        with modified_environ(update=update_envs):
+            scoring_server_proc = None
+            # set tracking_uri inside udf so that with spark_connect
+            # we can load the model from correct path
+            mlflow.set_tracking_uri(tracking_uri)
 
-        if env_manager != _EnvManager.LOCAL:
-            if should_use_spark_to_broadcast_file:
-                local_model_path_on_executor = _SparkDirectoryDistributor.get_or_extract(
-                    archive_path
-                )
-                # Call "prepare_env" in advance in order to reduce scoring server launch time.
-                # So that we can use a shorter timeout when call `client.wait_server_ready`,
-                # otherwise we have to set a long timeout for `client.wait_server_ready` time,
-                # this prevents spark UDF task failing fast if other exception raised
-                # when scoring server launching.
-                # Set "capture_output" so that if "conda env create" command failed, the command
-                # stdout/stderr output will be attached to the exception message and included in
-                # driver side exception.
-                pyfunc_backend.prepare_env(
-                    model_uri=local_model_path_on_executor, capture_output=True
-                )
-            else:
-                local_model_path_on_executor = None
-
-            if check_port_connectivity():
-                # launch scoring server
-                server_port = find_free_port()
-                host = "127.0.0.1"
-                scoring_server_proc = pyfunc_backend.serve(
-                    model_uri=local_model_path_on_executor or local_model_path,
-                    port=server_port,
-                    host=host,
-                    timeout=MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT.get(),
-                    enable_mlserver=False,
-                    synchronous=False,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                )
-
-                client = ScoringServerClient(host, server_port)
-            else:
-                scoring_server_proc = pyfunc_backend.serve_stdin(
-                    model_uri=local_model_path_on_executor or local_model_path,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                )
-                client = StdinScoringServerClient(scoring_server_proc)
-
-            _logger.info("Using %s", client.__class__.__name__)
-
-            server_tail_logs = collections.deque(maxlen=_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP)
-
-            def server_redirect_log_thread_func(child_stdout):
-                for line in child_stdout:
-                    decoded = line.decode() if isinstance(line, bytes) else line
-                    server_tail_logs.append(decoded)
-                    sys.stdout.write("[model server] " + decoded)
-
-            server_redirect_log_thread = threading.Thread(
-                target=server_redirect_log_thread_func,
-                args=(scoring_server_proc.stdout,),
-                daemon=True,
-            )
-            server_redirect_log_thread.start()
-
-            try:
-                client.wait_server_ready(timeout=90, scoring_server_proc=scoring_server_proc)
-            except Exception as e:
-                err_msg = "During spark UDF task execution, mlflow model server failed to launch. "
-                if len(server_tail_logs) == _MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP:
-                    err_msg += (
-                        f"Last {_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP} "
-                        "lines of MLflow model server output:\n"
+            if env_manager != _EnvManager.LOCAL:
+                if should_use_spark_to_broadcast_file:
+                    local_model_path_on_executor = _SparkDirectoryDistributor.get_or_extract(
+                        archive_path
+                    )
+                    # Call "prepare_env" in advance in order to reduce scoring server launch time.
+                    # So that we can use a shorter timeout when call `client.wait_server_ready`,
+                    # otherwise we have to set a long timeout for `client.wait_server_ready` time,
+                    # this prevents spark UDF task failing fast if other exception raised
+                    # when scoring server launching.
+                    # Set "capture_output" so that if "conda env create" command failed, the command
+                    # stdout/stderr output will be attached to the exception message and included in
+                    # driver side exception.
+                    pyfunc_backend.prepare_env(
+                        model_uri=local_model_path_on_executor, capture_output=True
                     )
                 else:
-                    err_msg += "MLflow model server output:\n"
-                err_msg += "".join(server_tail_logs)
-                raise MlflowException(err_msg) from e
+                    local_model_path_on_executor = None
 
-            def batch_predict_fn(pdf, params=None):
-                if inspect.signature(client.invoke).parameters.get("params"):
-                    return client.invoke(pdf, params=params).get_predictions()
-                _log_warning_if_params_not_in_predict_signature(_logger, params)
-                return client.invoke(pdf).get_predictions()
+                if check_port_connectivity():
+                    # launch scoring server
+                    server_port = find_free_port()
+                    host = "127.0.0.1"
+                    scoring_server_proc = pyfunc_backend.serve(
+                        model_uri=local_model_path_on_executor or local_model_path,
+                        port=server_port,
+                        host=host,
+                        timeout=MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT.get(),
+                        enable_mlserver=False,
+                        synchronous=False,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                    )
 
-        elif env_manager == _EnvManager.LOCAL:
-            if is_spark_connect and not should_spark_connect_use_nfs:
-                model_path = os.path.join(
-                    tempfile.gettempdir(),
-                    "mlflow",
-                    insecure_hash.sha1(model_uri.encode()).hexdigest(),
-                )
-                try:
-                    loaded_model = mlflow.pyfunc.load_model(model_path)
-                except Exception:
-                    os.makedirs(model_path, exist_ok=True)
-                    loaded_model = mlflow.pyfunc.load_model(model_uri, dst_path=model_path)
-            elif should_use_spark_to_broadcast_file:
-                loaded_model, _ = SparkModelCache.get_or_load(archive_path)
-            else:
-                loaded_model = mlflow.pyfunc.load_model(local_model_path)
-
-            def batch_predict_fn(pdf, params=None):
-                if inspect.signature(loaded_model.predict).parameters.get("params"):
-                    return loaded_model.predict(pdf, params=params)
-                _log_warning_if_params_not_in_predict_signature(_logger, params)
-                return loaded_model.predict(pdf)
-
-        try:
-            for input_batch in iterator:
-                # If the UDF is called with only multiple arguments,
-                # the `input_batch` is a tuple which composes of several pd.Series/pd.DataFrame
-                # objects.
-                # If the UDF is called with only one argument,
-                # the `input_batch` instance will be an instance of `pd.Series`/`pd.DataFrame`,
-                if isinstance(input_batch, (pandas.Series, pandas.DataFrame)):
-                    # UDF is called with only one argument
-                    row_batch_args = (input_batch,)
+                    client = ScoringServerClient(host, server_port)
                 else:
-                    row_batch_args = input_batch
+                    scoring_server_proc = pyfunc_backend.serve_stdin(
+                        model_uri=local_model_path_on_executor or local_model_path,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                    )
+                    client = StdinScoringServerClient(scoring_server_proc)
 
-                if len(row_batch_args[0]) > 0:
-                    yield _predict_row_batch(batch_predict_fn, row_batch_args)
-        finally:
-            if scoring_server_proc is not None:
-                os.kill(scoring_server_proc.pid, signal.SIGTERM)
+                _logger.info("Using %s", client.__class__.__name__)
+
+                server_tail_logs = collections.deque(
+                    maxlen=_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP
+                )
+
+                def server_redirect_log_thread_func(child_stdout):
+                    for line in child_stdout:
+                        decoded = line.decode() if isinstance(line, bytes) else line
+                        server_tail_logs.append(decoded)
+                        sys.stdout.write("[model server] " + decoded)
+
+                server_redirect_log_thread = threading.Thread(
+                    target=server_redirect_log_thread_func,
+                    args=(scoring_server_proc.stdout,),
+                    daemon=True,
+                )
+                server_redirect_log_thread.start()
+
+                try:
+                    client.wait_server_ready(timeout=90, scoring_server_proc=scoring_server_proc)
+                except Exception as e:
+                    err_msg = (
+                        "During spark UDF task execution, mlflow model server failed to launch. "
+                    )
+                    if len(server_tail_logs) == _MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP:
+                        err_msg += (
+                            f"Last {_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP} "
+                            "lines of MLflow model server output:\n"
+                        )
+                    else:
+                        err_msg += "MLflow model server output:\n"
+                    err_msg += "".join(server_tail_logs)
+                    raise MlflowException(err_msg) from e
+
+                def batch_predict_fn(pdf, params=None):
+                    if inspect.signature(client.invoke).parameters.get("params"):
+                        return client.invoke(pdf, params=params).get_predictions()
+                    _log_warning_if_params_not_in_predict_signature(_logger, params)
+                    return client.invoke(pdf).get_predictions()
+
+            elif env_manager == _EnvManager.LOCAL:
+                if is_spark_connect and not should_spark_connect_use_nfs:
+                    model_path = os.path.join(
+                        tempfile.gettempdir(),
+                        "mlflow",
+                        insecure_hash.sha1(model_uri.encode()).hexdigest(),
+                    )
+                    try:
+                        loaded_model = mlflow.pyfunc.load_model(model_path)
+                    except Exception:
+                        os.makedirs(model_path, exist_ok=True)
+                        loaded_model = mlflow.pyfunc.load_model(model_uri, dst_path=model_path)
+                elif should_use_spark_to_broadcast_file:
+                    loaded_model, _ = SparkModelCache.get_or_load(archive_path)
+                else:
+                    loaded_model = mlflow.pyfunc.load_model(local_model_path)
+
+                def batch_predict_fn(pdf, params=None):
+                    if inspect.signature(loaded_model.predict).parameters.get("params"):
+                        return loaded_model.predict(pdf, params=params)
+                    _log_warning_if_params_not_in_predict_signature(_logger, params)
+                    return loaded_model.predict(pdf)
+
+            try:
+                for input_batch in iterator:
+                    # If the UDF is called with only multiple arguments,
+                    # the `input_batch` is a tuple which composes of several pd.Series/pd.DataFrame
+                    # objects.
+                    # If the UDF is called with only one argument,
+                    # the `input_batch` instance will be an instance of `pd.Series`/`pd.DataFrame`,
+                    if isinstance(input_batch, (pandas.Series, pandas.DataFrame)):
+                        # UDF is called with only one argument
+                        row_batch_args = (input_batch,)
+                    else:
+                        row_batch_args = input_batch
+
+                    if len(row_batch_args[0]) > 0:
+                        yield _predict_row_batch(batch_predict_fn, row_batch_args)
+            finally:
+                if scoring_server_proc is not None:
+                    os.kill(scoring_server_proc.pid, signal.SIGTERM)
 
     udf.metadata = model_metadata
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -271,6 +271,7 @@ from mlflow.utils import (
     insecure_hash,
 )
 from mlflow.utils import env_manager as _EnvManager
+from mlflow.utils._spark_utils import modified_environ
 from mlflow.utils.annotations import deprecated, experimental
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
@@ -1108,7 +1109,7 @@ def spark_udf(
     result_type=None,
     env_manager=_EnvManager.LOCAL,
     params: Optional[Dict[str, Any]] = None,
-    extra_env_vars: Optional[Dict[str, str]] = None,
+    extra_env: Optional[Dict[str, str]] = None,
 ):
     """
     A Spark UDF that can be used to invoke the Python function formatted model.
@@ -1218,7 +1219,7 @@ def spark_udf(
                    .. Note:: Experimental: This parameter may change or be removed in a future
                                            release without warning.
 
-    :param extra_env_vars: Extral environment variables to pass to the UDF executors.
+    :param extra_env: Extra environment variables to pass to the UDF executors.
     :return: Spark UDF that applies the model's ``predict`` method to the data and returns a
              type specified by ``result_type``, which by default is a double.
     """
@@ -1502,151 +1503,148 @@ Compound types:
 
         # Note: this is a pandas udf function in iteration style, which takes an iterator of
         # tuple of pandas.Series and outputs an iterator of pandas.Series.
-        # Save original environment variables so that we convert it back after udf task
-        original_envs = {}
+        update_envs = {}
         if mlflow_home is not None:
-            original_envs["MLFLOW_HOME"] = os.environ.get("MLFLOW_HOME")
-            os.environ["MLFLOW_HOME"] = mlflow_home
+            update_envs["MLFLOW_HOME"] = mlflow_home
         if openai_env_vars:
-            original_envs.update({k: os.environ.get(k) for k in openai_env_vars})
-            os.environ.update(openai_env_vars)
+            update_envs.update(openai_env_vars)
         if mlflow_testing:
-            original_envs[_MLFLOW_TESTING.name] = os.environ.get(_MLFLOW_TESTING.name)
-            _MLFLOW_TESTING.set(mlflow_testing)
-        if extra_env_vars:
-            original_envs.update({k: os.environ.get(k) for k in extra_env_vars})
-            os.environ.update(extra_env_vars)
+            update_envs[_MLFLOW_TESTING.name] = mlflow_testing
+        if extra_env:
+            update_envs.update(extra_env)
 
-        scoring_server_proc = None
-        # set tracking_uri inside udf so that with spark_connect
-        # we can load the model from correct path
-        mlflow.set_tracking_uri(tracking_uri)
+        #  use `modified_environ` to temporarily set the envs and restore them finally
+        with modified_environ(update=update_envs):
+            scoring_server_proc = None
+            # set tracking_uri inside udf so that with spark_connect
+            # we can load the model from correct path
+            mlflow.set_tracking_uri(tracking_uri)
 
-        if env_manager != _EnvManager.LOCAL:
-            if should_use_spark_to_broadcast_file:
-                local_model_path_on_executor = _SparkDirectoryDistributor.get_or_extract(
-                    archive_path
-                )
-                # Call "prepare_env" in advance in order to reduce scoring server launch time.
-                # So that we can use a shorter timeout when call `client.wait_server_ready`,
-                # otherwise we have to set a long timeout for `client.wait_server_ready` time,
-                # this prevents spark UDF task failing fast if other exception raised when scoring
-                # server launching.
-                # Set "capture_output" so that if "conda env create" command failed, the command
-                # stdout/stderr output will be attached to the exception message and included in
-                # driver side exception.
-                pyfunc_backend.prepare_env(
-                    model_uri=local_model_path_on_executor, capture_output=True
-                )
-            else:
-                local_model_path_on_executor = None
-
-            if check_port_connectivity():
-                # launch scoring server
-                server_port = find_free_port()
-                host = "127.0.0.1"
-                scoring_server_proc = pyfunc_backend.serve(
-                    model_uri=local_model_path_on_executor or local_model_path,
-                    port=server_port,
-                    host=host,
-                    timeout=MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT.get(),
-                    enable_mlserver=False,
-                    synchronous=False,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                )
-
-                client = ScoringServerClient(host, server_port)
-            else:
-                scoring_server_proc = pyfunc_backend.serve_stdin(
-                    model_uri=local_model_path_on_executor or local_model_path,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                )
-                client = StdinScoringServerClient(scoring_server_proc)
-
-            _logger.info("Using %s", client.__class__.__name__)
-
-            server_tail_logs = collections.deque(maxlen=_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP)
-
-            def server_redirect_log_thread_func(child_stdout):
-                for line in child_stdout:
-                    decoded = line.decode() if isinstance(line, bytes) else line
-                    server_tail_logs.append(decoded)
-                    sys.stdout.write("[model server] " + decoded)
-
-            server_redirect_log_thread = threading.Thread(
-                target=server_redirect_log_thread_func,
-                args=(scoring_server_proc.stdout,),
-                daemon=True,
-            )
-            server_redirect_log_thread.start()
-
-            try:
-                client.wait_server_ready(timeout=90, scoring_server_proc=scoring_server_proc)
-            except Exception as e:
-                err_msg = "During spark UDF task execution, mlflow model server failed to launch. "
-                if len(server_tail_logs) == _MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP:
-                    err_msg += (
-                        f"Last {_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP} "
-                        "lines of MLflow model server output:\n"
+            if env_manager != _EnvManager.LOCAL:
+                if should_use_spark_to_broadcast_file:
+                    local_model_path_on_executor = _SparkDirectoryDistributor.get_or_extract(
+                        archive_path
+                    )
+                    # Call "prepare_env" in advance in order to reduce scoring server launch time.
+                    # So that we can use a shorter timeout when call `client.wait_server_ready`,
+                    # otherwise we have to set a long timeout for `client.wait_server_ready` time,
+                    # this prevents spark UDF task failing fast if other exception raised
+                    # when scoring server launching.
+                    # Set "capture_output" so that if "conda env create" command failed, the command
+                    # stdout/stderr output will be attached to the exception message and included in
+                    # driver side exception.
+                    pyfunc_backend.prepare_env(
+                        model_uri=local_model_path_on_executor, capture_output=True
                     )
                 else:
-                    err_msg += "MLflow model server output:\n"
-                err_msg += "".join(server_tail_logs)
-                raise MlflowException(err_msg) from e
+                    local_model_path_on_executor = None
 
-            def batch_predict_fn(pdf, params=None):
-                if inspect.signature(client.invoke).parameters.get("params"):
-                    return client.invoke(pdf, params=params).get_predictions()
-                _log_warning_if_params_not_in_predict_signature(_logger, params)
-                return client.invoke(pdf).get_predictions()
+                if check_port_connectivity():
+                    # launch scoring server
+                    server_port = find_free_port()
+                    host = "127.0.0.1"
+                    scoring_server_proc = pyfunc_backend.serve(
+                        model_uri=local_model_path_on_executor or local_model_path,
+                        port=server_port,
+                        host=host,
+                        timeout=MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT.get(),
+                        enable_mlserver=False,
+                        synchronous=False,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                    )
 
-        elif env_manager == _EnvManager.LOCAL:
-            if is_spark_connect and not should_spark_connect_use_nfs:
-                model_path = os.path.join(
-                    tempfile.gettempdir(),
-                    "mlflow",
-                    insecure_hash.sha1(model_uri.encode()).hexdigest(),
-                )
-                try:
-                    loaded_model = mlflow.pyfunc.load_model(model_path)
-                except Exception:
-                    os.makedirs(model_path, exist_ok=True)
-                    loaded_model = mlflow.pyfunc.load_model(model_uri, dst_path=model_path)
-            elif should_use_spark_to_broadcast_file:
-                loaded_model, _ = SparkModelCache.get_or_load(archive_path)
-            else:
-                loaded_model = mlflow.pyfunc.load_model(local_model_path)
-
-            def batch_predict_fn(pdf, params=None):
-                if inspect.signature(loaded_model.predict).parameters.get("params"):
-                    return loaded_model.predict(pdf, params=params)
-                _log_warning_if_params_not_in_predict_signature(_logger, params)
-                return loaded_model.predict(pdf)
-
-        try:
-            for input_batch in iterator:
-                # If the UDF is called with only multiple arguments,
-                # the `input_batch` is a tuple which composes of several pd.Series/pd.DataFrame
-                # objects.
-                # If the UDF is called with only one argument,
-                # the `input_batch` instance will be an instance of `pd.Series`/`pd.DataFrame`,
-                if isinstance(input_batch, (pandas.Series, pandas.DataFrame)):
-                    # UDF is called with only one argument
-                    row_batch_args = (input_batch,)
+                    client = ScoringServerClient(host, server_port)
                 else:
-                    row_batch_args = input_batch
+                    scoring_server_proc = pyfunc_backend.serve_stdin(
+                        model_uri=local_model_path_on_executor or local_model_path,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                    )
+                    client = StdinScoringServerClient(scoring_server_proc)
 
-                if len(row_batch_args[0]) > 0:
-                    yield _predict_row_batch(batch_predict_fn, row_batch_args)
-        finally:
-            if scoring_server_proc is not None:
-                os.kill(scoring_server_proc.pid, signal.SIGTERM)
+                _logger.info("Using %s", client.__class__.__name__)
 
-        # restore original environment variables
-        for k, v in original_envs.items():
-            os.environ.pop(k) if v is None else os.environ.update({k: v})
+                server_tail_logs = collections.deque(
+                    maxlen=_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP
+                )
+
+                def server_redirect_log_thread_func(child_stdout):
+                    for line in child_stdout:
+                        decoded = line.decode() if isinstance(line, bytes) else line
+                        server_tail_logs.append(decoded)
+                        sys.stdout.write("[model server] " + decoded)
+
+                server_redirect_log_thread = threading.Thread(
+                    target=server_redirect_log_thread_func,
+                    args=(scoring_server_proc.stdout,),
+                    daemon=True,
+                )
+                server_redirect_log_thread.start()
+
+                try:
+                    client.wait_server_ready(timeout=90, scoring_server_proc=scoring_server_proc)
+                except Exception as e:
+                    err_msg = (
+                        "During spark UDF task execution, mlflow model server failed to launch. "
+                    )
+                    if len(server_tail_logs) == _MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP:
+                        err_msg += (
+                            f"Last {_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP} "
+                            "lines of MLflow model server output:\n"
+                        )
+                    else:
+                        err_msg += "MLflow model server output:\n"
+                    err_msg += "".join(server_tail_logs)
+                    raise MlflowException(err_msg) from e
+
+                def batch_predict_fn(pdf, params=None):
+                    if inspect.signature(client.invoke).parameters.get("params"):
+                        return client.invoke(pdf, params=params).get_predictions()
+                    _log_warning_if_params_not_in_predict_signature(_logger, params)
+                    return client.invoke(pdf).get_predictions()
+
+            elif env_manager == _EnvManager.LOCAL:
+                if is_spark_connect and not should_spark_connect_use_nfs:
+                    model_path = os.path.join(
+                        tempfile.gettempdir(),
+                        "mlflow",
+                        insecure_hash.sha1(model_uri.encode()).hexdigest(),
+                    )
+                    try:
+                        loaded_model = mlflow.pyfunc.load_model(model_path)
+                    except Exception:
+                        os.makedirs(model_path, exist_ok=True)
+                        loaded_model = mlflow.pyfunc.load_model(model_uri, dst_path=model_path)
+                elif should_use_spark_to_broadcast_file:
+                    loaded_model, _ = SparkModelCache.get_or_load(archive_path)
+                else:
+                    loaded_model = mlflow.pyfunc.load_model(local_model_path)
+
+                def batch_predict_fn(pdf, params=None):
+                    if inspect.signature(loaded_model.predict).parameters.get("params"):
+                        return loaded_model.predict(pdf, params=params)
+                    _log_warning_if_params_not_in_predict_signature(_logger, params)
+                    return loaded_model.predict(pdf)
+
+            try:
+                for input_batch in iterator:
+                    # If the UDF is called with only multiple arguments,
+                    # the `input_batch` is a tuple which composes of several pd.Series/pd.DataFrame
+                    # objects.
+                    # If the UDF is called with only one argument,
+                    # the `input_batch` instance will be an instance of `pd.Series`/`pd.DataFrame`,
+                    if isinstance(input_batch, (pandas.Series, pandas.DataFrame)):
+                        # UDF is called with only one argument
+                        row_batch_args = (input_batch,)
+                    else:
+                        row_batch_args = input_batch
+
+                    if len(row_batch_args[0]) > 0:
+                        yield _predict_row_batch(batch_predict_fn, row_batch_args)
+            finally:
+                if scoring_server_proc is not None:
+                    os.kill(scoring_server_proc.pid, signal.SIGTERM)
 
     udf.metadata = model_metadata
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1108,7 +1108,7 @@ def spark_udf(
     result_type=None,
     env_manager=_EnvManager.LOCAL,
     params: Optional[Dict[str, Any]] = None,
-    extra_udf_env_vars=None,
+    extra_env_vars: Optional[Dict[str, str]] = None,
 ):
     """
     A Spark UDF that can be used to invoke the Python function formatted model.
@@ -1218,8 +1218,7 @@ def spark_udf(
                    .. Note:: Experimental: This parameter may change or be removed in a future
                                            release without warning.
 
-    :param extra_udf_env_vars: Extral environment variables to pass to the udf.
-                               Should be a dictionary.
+    :param extra_env_vars: Extral environment variables to pass to the UDF executors.
     :return: Spark UDF that applies the model's ``predict`` method to the data and returns a
              type specified by ``result_type``, which by default is a double.
     """
@@ -1246,10 +1245,6 @@ def spark_udf(
     mlflow_home = os.environ.get("MLFLOW_HOME")
     openai_env_vars = mlflow.openai._OpenAIEnvVar.read_environ()
     mlflow_testing = _MLFLOW_TESTING.get_raw()
-    if extra_udf_env_vars and not isinstance(extra_udf_env_vars, dict):
-        raise MlflowException(
-            f"env_vars must be a dictionary, but got type {type(extra_udf_env_vars)}."
-        )
 
     _EnvManager.validate(env_manager)
 
@@ -1518,9 +1513,9 @@ Compound types:
         if mlflow_testing:
             original_envs[_MLFLOW_TESTING.name] = os.environ.get(_MLFLOW_TESTING.name)
             _MLFLOW_TESTING.set(mlflow_testing)
-        if extra_udf_env_vars:
-            original_envs.update({k: os.environ.get(k) for k in extra_udf_env_vars})
-            os.environ.update(extra_udf_env_vars)
+        if extra_env_vars:
+            original_envs.update({k: os.environ.get(k) for k in extra_env_vars})
+            os.environ.update(extra_env_vars)
 
         scoring_server_proc = None
         # set tracking_uri inside udf so that with spark_connect

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1490,8 +1490,18 @@ Compound types:
     )
 
     tracking_uri = mlflow.get_tracking_uri()
+    update_envs = {}
+    if mlflow_home is not None:
+        update_envs["MLFLOW_HOME"] = mlflow_home
+    if openai_env_vars:
+        update_envs.update(openai_env_vars)
+    if mlflow_testing:
+        update_envs[_MLFLOW_TESTING.name] = mlflow_testing
+    if extra_env:
+        update_envs.update(extra_env)
 
     @pandas_udf(result_type)
+    @modified_environ(update_envs)
     def udf(
         iterator: Iterator[Tuple[Union[pandas.Series, pandas.DataFrame], ...]]
     ) -> Iterator[result_type_hint]:
@@ -1503,148 +1513,134 @@ Compound types:
 
         # Note: this is a pandas udf function in iteration style, which takes an iterator of
         # tuple of pandas.Series and outputs an iterator of pandas.Series.
-        update_envs = {}
-        if mlflow_home is not None:
-            update_envs["MLFLOW_HOME"] = mlflow_home
-        if openai_env_vars:
-            update_envs.update(openai_env_vars)
-        if mlflow_testing:
-            update_envs[_MLFLOW_TESTING.name] = mlflow_testing
-        if extra_env:
-            update_envs.update(extra_env)
 
         #  use `modified_environ` to temporarily set the envs and restore them finally
-        with modified_environ(update=update_envs):
-            scoring_server_proc = None
-            # set tracking_uri inside udf so that with spark_connect
-            # we can load the model from correct path
-            mlflow.set_tracking_uri(tracking_uri)
+        scoring_server_proc = None
+        # set tracking_uri inside udf so that with spark_connect
+        # we can load the model from correct path
+        mlflow.set_tracking_uri(tracking_uri)
 
-            if env_manager != _EnvManager.LOCAL:
-                if should_use_spark_to_broadcast_file:
-                    local_model_path_on_executor = _SparkDirectoryDistributor.get_or_extract(
-                        archive_path
-                    )
-                    # Call "prepare_env" in advance in order to reduce scoring server launch time.
-                    # So that we can use a shorter timeout when call `client.wait_server_ready`,
-                    # otherwise we have to set a long timeout for `client.wait_server_ready` time,
-                    # this prevents spark UDF task failing fast if other exception raised
-                    # when scoring server launching.
-                    # Set "capture_output" so that if "conda env create" command failed, the command
-                    # stdout/stderr output will be attached to the exception message and included in
-                    # driver side exception.
-                    pyfunc_backend.prepare_env(
-                        model_uri=local_model_path_on_executor, capture_output=True
-                    )
-                else:
-                    local_model_path_on_executor = None
+        if env_manager != _EnvManager.LOCAL:
+            if should_use_spark_to_broadcast_file:
+                local_model_path_on_executor = _SparkDirectoryDistributor.get_or_extract(
+                    archive_path
+                )
+                # Call "prepare_env" in advance in order to reduce scoring server launch time.
+                # So that we can use a shorter timeout when call `client.wait_server_ready`,
+                # otherwise we have to set a long timeout for `client.wait_server_ready` time,
+                # this prevents spark UDF task failing fast if other exception raised
+                # when scoring server launching.
+                # Set "capture_output" so that if "conda env create" command failed, the command
+                # stdout/stderr output will be attached to the exception message and included in
+                # driver side exception.
+                pyfunc_backend.prepare_env(
+                    model_uri=local_model_path_on_executor, capture_output=True
+                )
+            else:
+                local_model_path_on_executor = None
 
-                if check_port_connectivity():
-                    # launch scoring server
-                    server_port = find_free_port()
-                    host = "127.0.0.1"
-                    scoring_server_proc = pyfunc_backend.serve(
-                        model_uri=local_model_path_on_executor or local_model_path,
-                        port=server_port,
-                        host=host,
-                        timeout=MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT.get(),
-                        enable_mlserver=False,
-                        synchronous=False,
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.STDOUT,
-                    )
-
-                    client = ScoringServerClient(host, server_port)
-                else:
-                    scoring_server_proc = pyfunc_backend.serve_stdin(
-                        model_uri=local_model_path_on_executor or local_model_path,
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.STDOUT,
-                    )
-                    client = StdinScoringServerClient(scoring_server_proc)
-
-                _logger.info("Using %s", client.__class__.__name__)
-
-                server_tail_logs = collections.deque(
-                    maxlen=_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP
+            if check_port_connectivity():
+                # launch scoring server
+                server_port = find_free_port()
+                host = "127.0.0.1"
+                scoring_server_proc = pyfunc_backend.serve(
+                    model_uri=local_model_path_on_executor or local_model_path,
+                    port=server_port,
+                    host=host,
+                    timeout=MLFLOW_SCORING_SERVER_REQUEST_TIMEOUT.get(),
+                    enable_mlserver=False,
+                    synchronous=False,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
                 )
 
-                def server_redirect_log_thread_func(child_stdout):
-                    for line in child_stdout:
-                        decoded = line.decode() if isinstance(line, bytes) else line
-                        server_tail_logs.append(decoded)
-                        sys.stdout.write("[model server] " + decoded)
-
-                server_redirect_log_thread = threading.Thread(
-                    target=server_redirect_log_thread_func,
-                    args=(scoring_server_proc.stdout,),
-                    daemon=True,
+                client = ScoringServerClient(host, server_port)
+            else:
+                scoring_server_proc = pyfunc_backend.serve_stdin(
+                    model_uri=local_model_path_on_executor or local_model_path,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
                 )
-                server_redirect_log_thread.start()
+                client = StdinScoringServerClient(scoring_server_proc)
 
-                try:
-                    client.wait_server_ready(timeout=90, scoring_server_proc=scoring_server_proc)
-                except Exception as e:
-                    err_msg = (
-                        "During spark UDF task execution, mlflow model server failed to launch. "
-                    )
-                    if len(server_tail_logs) == _MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP:
-                        err_msg += (
-                            f"Last {_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP} "
-                            "lines of MLflow model server output:\n"
-                        )
-                    else:
-                        err_msg += "MLflow model server output:\n"
-                    err_msg += "".join(server_tail_logs)
-                    raise MlflowException(err_msg) from e
+            _logger.info("Using %s", client.__class__.__name__)
 
-                def batch_predict_fn(pdf, params=None):
-                    if inspect.signature(client.invoke).parameters.get("params"):
-                        return client.invoke(pdf, params=params).get_predictions()
-                    _log_warning_if_params_not_in_predict_signature(_logger, params)
-                    return client.invoke(pdf).get_predictions()
+            server_tail_logs = collections.deque(maxlen=_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP)
 
-            elif env_manager == _EnvManager.LOCAL:
-                if is_spark_connect and not should_spark_connect_use_nfs:
-                    model_path = os.path.join(
-                        tempfile.gettempdir(),
-                        "mlflow",
-                        insecure_hash.sha1(model_uri.encode()).hexdigest(),
-                    )
-                    try:
-                        loaded_model = mlflow.pyfunc.load_model(model_path)
-                    except Exception:
-                        os.makedirs(model_path, exist_ok=True)
-                        loaded_model = mlflow.pyfunc.load_model(model_uri, dst_path=model_path)
-                elif should_use_spark_to_broadcast_file:
-                    loaded_model, _ = SparkModelCache.get_or_load(archive_path)
-                else:
-                    loaded_model = mlflow.pyfunc.load_model(local_model_path)
+            def server_redirect_log_thread_func(child_stdout):
+                for line in child_stdout:
+                    decoded = line.decode() if isinstance(line, bytes) else line
+                    server_tail_logs.append(decoded)
+                    sys.stdout.write("[model server] " + decoded)
 
-                def batch_predict_fn(pdf, params=None):
-                    if inspect.signature(loaded_model.predict).parameters.get("params"):
-                        return loaded_model.predict(pdf, params=params)
-                    _log_warning_if_params_not_in_predict_signature(_logger, params)
-                    return loaded_model.predict(pdf)
+            server_redirect_log_thread = threading.Thread(
+                target=server_redirect_log_thread_func,
+                args=(scoring_server_proc.stdout,),
+                daemon=True,
+            )
+            server_redirect_log_thread.start()
 
             try:
-                for input_batch in iterator:
-                    # If the UDF is called with only multiple arguments,
-                    # the `input_batch` is a tuple which composes of several pd.Series/pd.DataFrame
-                    # objects.
-                    # If the UDF is called with only one argument,
-                    # the `input_batch` instance will be an instance of `pd.Series`/`pd.DataFrame`,
-                    if isinstance(input_batch, (pandas.Series, pandas.DataFrame)):
-                        # UDF is called with only one argument
-                        row_batch_args = (input_batch,)
-                    else:
-                        row_batch_args = input_batch
+                client.wait_server_ready(timeout=90, scoring_server_proc=scoring_server_proc)
+            except Exception as e:
+                err_msg = "During spark UDF task execution, mlflow model server failed to launch. "
+                if len(server_tail_logs) == _MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP:
+                    err_msg += (
+                        f"Last {_MLFLOW_SERVER_OUTPUT_TAIL_LINES_TO_KEEP} "
+                        "lines of MLflow model server output:\n"
+                    )
+                else:
+                    err_msg += "MLflow model server output:\n"
+                err_msg += "".join(server_tail_logs)
+                raise MlflowException(err_msg) from e
 
-                    if len(row_batch_args[0]) > 0:
-                        yield _predict_row_batch(batch_predict_fn, row_batch_args)
-            finally:
-                if scoring_server_proc is not None:
-                    os.kill(scoring_server_proc.pid, signal.SIGTERM)
+            def batch_predict_fn(pdf, params=None):
+                if inspect.signature(client.invoke).parameters.get("params"):
+                    return client.invoke(pdf, params=params).get_predictions()
+                _log_warning_if_params_not_in_predict_signature(_logger, params)
+                return client.invoke(pdf).get_predictions()
+
+        elif env_manager == _EnvManager.LOCAL:
+            if is_spark_connect and not should_spark_connect_use_nfs:
+                model_path = os.path.join(
+                    tempfile.gettempdir(),
+                    "mlflow",
+                    insecure_hash.sha1(model_uri.encode()).hexdigest(),
+                )
+                try:
+                    loaded_model = mlflow.pyfunc.load_model(model_path)
+                except Exception:
+                    os.makedirs(model_path, exist_ok=True)
+                    loaded_model = mlflow.pyfunc.load_model(model_uri, dst_path=model_path)
+            elif should_use_spark_to_broadcast_file:
+                loaded_model, _ = SparkModelCache.get_or_load(archive_path)
+            else:
+                loaded_model = mlflow.pyfunc.load_model(local_model_path)
+
+            def batch_predict_fn(pdf, params=None):
+                if inspect.signature(loaded_model.predict).parameters.get("params"):
+                    return loaded_model.predict(pdf, params=params)
+                _log_warning_if_params_not_in_predict_signature(_logger, params)
+                return loaded_model.predict(pdf)
+
+        try:
+            for input_batch in iterator:
+                # If the UDF is called with only multiple arguments,
+                # the `input_batch` is a tuple which composes of several pd.Series/pd.DataFrame
+                # objects.
+                # If the UDF is called with only one argument,
+                # the `input_batch` instance will be an instance of `pd.Series`/`pd.DataFrame`,
+                if isinstance(input_batch, (pandas.Series, pandas.DataFrame)):
+                    # UDF is called with only one argument
+                    row_batch_args = (input_batch,)
+                else:
+                    row_batch_args = input_batch
+
+                if len(row_batch_args[0]) > 0:
+                    yield _predict_row_batch(batch_predict_fn, row_batch_args)
+        finally:
+            if scoring_server_proc is not None:
+                os.kill(scoring_server_proc.pid, signal.SIGTERM)
 
     udf.metadata = model_metadata
 

--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -171,4 +171,7 @@ def modified_environ(update):
         yield
     finally:
         for k, v in original_env.items():
-            os.environ.pop(k) if v is None else os.environ.update({k: v})
+            if v is None:
+                os.environ.pop(k)
+            else:
+                os.environ[k] = v

--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -1,8 +1,8 @@
+import contextlib
 import os
 import shutil
 import tempfile
 import zipfile
-from functools import wraps
 
 
 def _get_active_spark_session():
@@ -153,52 +153,25 @@ class _SparkDirectoryDistributor:
         return _SparkDirectoryDistributor._extracted_dir_paths[archive_path]
 
 
-# @contextlib.contextmanager
-# def modified_environ(update):
-#     """
-#     Temporarily updates the ``os.environ`` dictionary in-place.
+@contextlib.contextmanager
+def modified_environ(update):
+    """
+    Temporarily updates the ``os.environ`` dictionary in-place.
 
-#     The ``os.environ`` dictionary is updated in-place so that the modification
-#     is sure to work in all situations.
+    The ``os.environ`` dictionary is updated in-place so that the modification
+    is sure to work in all situations.
 
-#     :param update: Dictionary of environment variables and values to add/update.
-#     """
-#     update = update or {}
-#     original_env = {k: os.environ.get(k) for k in update}
+    :param update: Dictionary of environment variables and values to add/update.
+    """
+    update = update or {}
+    original_env = {k: os.environ.get(k) for k in update}
 
-#     try:
-#         os.environ.update(update)
-#         yield
-#     finally:
-#         for k, v in original_env.items():
-#             if v is None:
-#                 os.environ.pop(k)
-#             else:
-#                 os.environ[k] = v
-
-
-def modified_environ(update=None):
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            # Save original environment
-            update_env = update or {}
-            original_env = {k: os.environ.get(k) for k in update_env}
-
-            # Update environment
-            os.environ.update(update_env)
-
-            try:
-                # Execute the decorated function
-                return func(*args, **kwargs)
-            finally:
-                # Restore original environment
-                for k, v in original_env.items():
-                    if v is None:
-                        os.environ.pop(k, None)
-                    else:
-                        os.environ[k] = v
-
-        return wrapper
-
-    return decorator
+    try:
+        os.environ.update(update)
+        yield
+    finally:
+        for k, v in original_env.items():
+            if v is None:
+                os.environ.pop(k)
+            else:
+                os.environ[k] = v

--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -172,6 +172,6 @@ def modified_environ(update):
     finally:
         for k, v in original_env.items():
             if v is None:
-                os.environ.pop(k)
+                os.environ.pop(k, None)
             else:
                 os.environ[k] = v

--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -1,8 +1,8 @@
-import contextlib
 import os
 import shutil
 import tempfile
 import zipfile
+from functools import wraps
 
 
 def _get_active_spark_session():
@@ -153,25 +153,52 @@ class _SparkDirectoryDistributor:
         return _SparkDirectoryDistributor._extracted_dir_paths[archive_path]
 
 
-@contextlib.contextmanager
-def modified_environ(update):
-    """
-    Temporarily updates the ``os.environ`` dictionary in-place.
+# @contextlib.contextmanager
+# def modified_environ(update):
+#     """
+#     Temporarily updates the ``os.environ`` dictionary in-place.
 
-    The ``os.environ`` dictionary is updated in-place so that the modification
-    is sure to work in all situations.
+#     The ``os.environ`` dictionary is updated in-place so that the modification
+#     is sure to work in all situations.
 
-    :param update: Dictionary of environment variables and values to add/update.
-    """
-    update = update or {}
-    original_env = {k: os.environ.get(k) for k in update}
+#     :param update: Dictionary of environment variables and values to add/update.
+#     """
+#     update = update or {}
+#     original_env = {k: os.environ.get(k) for k in update}
 
-    try:
-        os.environ.update(update)
-        yield
-    finally:
-        for k, v in original_env.items():
-            if v is None:
-                os.environ.pop(k)
-            else:
-                os.environ[k] = v
+#     try:
+#         os.environ.update(update)
+#         yield
+#     finally:
+#         for k, v in original_env.items():
+#             if v is None:
+#                 os.environ.pop(k)
+#             else:
+#                 os.environ[k] = v
+
+
+def modified_environ(update=None):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            # Save original environment
+            update_env = update or {}
+            original_env = {k: os.environ.get(k) for k in update_env}
+
+            # Update environment
+            os.environ.update(update_env)
+
+            try:
+                # Execute the decorated function
+                return func(*args, **kwargs)
+            finally:
+                # Restore original environment
+                for k, v in original_env.items():
+                    if v is None:
+                        os.environ.pop(k, None)
+                    else:
+                        os.environ[k] = v
+
+        return wrapper
+
+    return decorator

--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import shutil
 import tempfile
@@ -150,3 +151,24 @@ class _SparkDirectoryDistributor:
 
         _SparkDirectoryDistributor._extracted_dir_paths[archive_path] = temp_dir
         return _SparkDirectoryDistributor._extracted_dir_paths[archive_path]
+
+
+@contextlib.contextmanager
+def modified_environ(update):
+    """
+    Temporarily updates the ``os.environ`` dictionary in-place.
+
+    The ``os.environ`` dictionary is updated in-place so that the modification
+    is sure to work in all situations.
+
+    :param update: Dictionary of environment variables and values to add/update.
+    """
+    update = update or {}
+    original_env = {k: os.environ.get(k) for k in update}
+
+    try:
+        os.environ.update(update)
+        yield
+    finally:
+        for k, v in original_env.items():
+            os.environ.pop(k) if v is None else os.environ.update({k: v})

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1331,9 +1331,6 @@ def test_spark_udf_set_extra_udf_env_vars(spark):
 
 
 def test_modified_environ():
-    @modified_environ({"TEST_ENV_VAR": "test"})
-    def test():
+    with modified_environ({"TEST_ENV_VAR": "test"}):
         assert os.environ["TEST_ENV_VAR"] == "test"
-
-    test()
     assert os.environ.get("TEST_ENV_VAR") is None

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1298,3 +1298,32 @@ def test_spark_udf_with_model_serving(spark):
 
         res = spark_df.withColumn("res", udf("input_col")).select("res").toPandas()
         assert res["res"][0] == ("string")
+
+
+def test_spark_udf_set_extra_udf_env_vars(spark):
+    class TestModel(PythonModel):
+        def predict(self, context, model_input, params=None):
+            return [os.environ["TEST_ENV_VAR"]] * len(model_input)
+
+    signature = mlflow.models.infer_signature(["input"])
+    spark_df = spark.createDataFrame(
+        [("input1",), ("input2",), ("input3",)],
+        ["input_col"],
+    )
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            "model",
+            python_model=TestModel(),
+            signature=signature,
+        )
+
+    udf = mlflow.pyfunc.spark_udf(
+        spark,
+        model_info.model_uri,
+        result_type=StringType(),
+        env_manager="local",
+        extra_udf_env_vars={"TEST_ENV_VAR": "test"},
+    )
+
+    res = spark_df.withColumn("res", udf("input_col")).select("res").toPandas()
+    assert res["res"][0] == ("test")

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -50,6 +50,7 @@ from mlflow.pyfunc import (
 )
 from mlflow.pyfunc.spark_model_cache import SparkModelCache
 from mlflow.types import ColSpec, Schema, TensorSpec
+from mlflow.utils._spark_utils import modified_environ
 
 import tests
 
@@ -1327,3 +1328,9 @@ def test_spark_udf_set_extra_udf_env_vars(spark):
 
     res = spark_df.withColumn("res", udf("input_col")).select("res").toPandas()
     assert res["res"][0] == ("test")
+
+
+def test_modified_environ():
+    with modified_environ({"TEST_ENV_VAR": "test"}):
+        assert os.environ["TEST_ENV_VAR"] == "test"
+    assert os.environ.get("TEST_ENV_VAR") is None

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1322,7 +1322,7 @@ def test_spark_udf_set_extra_udf_env_vars(spark):
         model_info.model_uri,
         result_type=StringType(),
         env_manager="local",
-        extra_env_vars={"TEST_ENV_VAR": "test"},
+        extra_env={"TEST_ENV_VAR": "test"},
     )
 
     res = spark_df.withColumn("res", udf("input_col")).select("res").toPandas()

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1322,7 +1322,7 @@ def test_spark_udf_set_extra_udf_env_vars(spark):
         model_info.model_uri,
         result_type=StringType(),
         env_manager="local",
-        extra_udf_env_vars={"TEST_ENV_VAR": "test"},
+        extra_env_vars={"TEST_ENV_VAR": "test"},
     )
 
     res = spark_df.withColumn("res", udf("input_col")).select("res").toPandas()

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1331,6 +1331,9 @@ def test_spark_udf_set_extra_udf_env_vars(spark):
 
 
 def test_modified_environ():
-    with modified_environ({"TEST_ENV_VAR": "test"}):
+    @modified_environ({"TEST_ENV_VAR": "test"})
+    def test():
         assert os.environ["TEST_ENV_VAR"] == "test"
+
+    test()
     assert os.environ.get("TEST_ENV_VAR") is None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10605?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10605/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10605
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Support passing extra environment variables to spark_udf

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
