### PR TITLE
Refactor: move tests cases to pytest in SQLAlchemy test suite [ver#5]

### DIFF
--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -887,6 +887,465 @@ def test_get_deleted_runs(store: SqlAlchemyStore):
     assert deleted_run_ids == [run.info.run_uuid]
 
 
+def test_log_metric(store: SqlAlchemyStore):
+    run = _run_factory(store)
+
+    tkey = "blahmetric"
+    tval = 100.0
+    metric = entities.Metric(tkey, tval, get_current_time_millis(), 0)
+    metric2 = entities.Metric(tkey, tval, get_current_time_millis() + 2, 0)
+    nan_metric = entities.Metric("NaN", float("nan"), 0, 0)
+    pos_inf_metric = entities.Metric("PosInf", float("inf"), 0, 0)
+    neg_inf_metric = entities.Metric("NegInf", -float("inf"), 0, 0)
+    store.log_metric(run.info.run_id, metric)
+    store.log_metric(run.info.run_id, metric2)
+    store.log_metric(run.info.run_id, nan_metric)
+    store.log_metric(run.info.run_id, pos_inf_metric)
+    store.log_metric(run.info.run_id, neg_inf_metric)
+
+    run = store.get_run(run.info.run_id)
+    assert tkey in run.data.metrics
+    assert run.data.metrics[tkey] == tval
+
+    # SQL store _get_run method returns full history of recorded metrics.
+    # Should return duplicates as well
+    # MLflow RunData contains only the last reported values for metrics.
+    with store.ManagedSessionMaker() as session:
+        sql_run_metrics = store._get_run(session, run.info.run_id).metrics
+        assert len(sql_run_metrics) == 5
+        assert len(run.data.metrics) == 4
+        assert math.isnan(run.data.metrics["NaN"])
+        assert run.data.metrics["PosInf"] == 1.7976931348623157e308
+        assert run.data.metrics["NegInf"] == -1.7976931348623157e308
+
+
+def test_log_metric_concurrent_logging_succeeds(store: SqlAlchemyStore):
+    """
+    Verifies that concurrent logging succeeds without deadlock, which has been an issue
+    in previous MLflow releases
+    """
+    experiment_id = _create_experiments(store, "concurrency_exp")
+    run_config = _get_run_configs(experiment_id=experiment_id)
+    run1 = _run_factory(store, run_config)
+    run2 = _run_factory(store, run_config)
+
+    def log_metrics(run):
+        for metric_val in range(100):
+            store.log_metric(
+                run.info.run_id, Metric("metric_key", metric_val, get_current_time_millis(), 0)
+            )
+        for batch_idx in range(5):
+            store.log_batch(
+                run.info.run_id,
+                metrics=[
+                    Metric(
+                        f"metric_batch_{batch_idx}",
+                        (batch_idx * 100) + val_offset,
+                        get_current_time_millis(),
+                        0,
+                    )
+                    for val_offset in range(100)
+                ],
+                params=[],
+                tags=[],
+            )
+        for metric_val in range(100):
+            store.log_metric(
+                run.info.run_id, Metric("metric_key", metric_val, get_current_time_millis(), 0)
+            )
+        return "success"
+
+    log_metrics_futures = []
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        # Log metrics to two runs across four threads
+        log_metrics_futures = [
+            executor.submit(log_metrics, run) for run in [run1, run2, run1, run2]
+        ]
+
+    for future in log_metrics_futures:
+        assert future.result() == "success"
+
+    for run in [run1, run2, run1, run2]:
+        # We visit each run twice, logging 100 metric entries for 6 metric names; the same entry
+        # may be written multiple times concurrently; we assert that at least 100 metric entries
+        # are present because at least 100 unique entries must have been written
+        assert len(store.get_metric_history(run.info.run_id, "metric_key")) >= 100
+        for batch_idx in range(5):
+            assert (
+                len(store.get_metric_history(run.info.run_id, f"metric_batch_{batch_idx}")) >= 100
+            )
+
+
+def test_log_metric_allows_multiple_values_at_same_ts_and_run_data_uses_max_ts_value(
+    store: SqlAlchemyStore,
+):
+    run = _run_factory(store)
+    run_id = run.info.run_id
+    metric_name = "test-metric-1"
+    # Check that we get the max of (step, timestamp, value) in that order
+    tuples_to_log = [
+        (0, 100, 1000),
+        (3, 40, 100),  # larger step wins even though it has smaller value
+        (3, 50, 10),  # larger timestamp wins even though it has smaller value
+        (3, 50, 20),  # tiebreak by max value
+        (3, 50, 20),  # duplicate metrics with same (step, timestamp, value) are ok
+        # verify that we can log steps out of order / negative steps
+        (-3, 900, 900),
+        (-1, 800, 800),
+    ]
+    for step, timestamp, value in reversed(tuples_to_log):
+        store.log_metric(run_id, Metric(metric_name, value, timestamp, step))
+
+    metric_history = store.get_metric_history(run_id, metric_name)
+    logged_tuples = [(m.step, m.timestamp, m.value) for m in metric_history]
+    assert set(logged_tuples) == set(tuples_to_log)
+
+    run_data = store.get_run(run_id).data
+    run_metrics = run_data.metrics
+    assert len(run_metrics) == 1
+    assert run_metrics[metric_name] == 20
+    metric_obj = run_data._metric_objs[0]
+    assert metric_obj.key == metric_name
+    assert metric_obj.step == 3
+    assert metric_obj.timestamp == 50
+    assert metric_obj.value == 20
+
+
+def test_get_metric_history_paginated_request_raises(store: SqlAlchemyStore):
+    with pytest.raises(
+        MlflowException,
+        match="The SQLAlchemyStore backend does not support pagination for the "
+        "`get_metric_history` API.",
+    ):
+        store.get_metric_history("fake_run", "fake_metric", max_results=50, page_token="42")
+
+
+def test_log_null_metric(store: SqlAlchemyStore):
+    run = _run_factory(store)
+
+    tkey = "blahmetric"
+    tval = None
+    metric = entities.Metric(tkey, tval, get_current_time_millis(), 0)
+
+    with pytest.raises(
+        MlflowException, match=r"Got invalid value None for metric"
+    ) as exception_context:
+        store.log_metric(run.info.run_id, metric)
+    assert exception_context.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def test_log_param(store: SqlAlchemyStore):
+    run = _run_factory(store)
+
+    tkey = "blahmetric"
+    tval = "100.0"
+    param = entities.Param(tkey, tval)
+    param2 = entities.Param("new param", "new key")
+    store.log_param(run.info.run_id, param)
+    store.log_param(run.info.run_id, param2)
+    store.log_param(run.info.run_id, param2)
+
+    run = store.get_run(run.info.run_id)
+    assert len(run.data.params) == 2
+    assert tkey in run.data.params
+    assert run.data.params[tkey] == tval
+
+
+def test_log_param_uniqueness(store: SqlAlchemyStore):
+    run = _run_factory(store)
+
+    tkey = "blahmetric"
+    tval = "100.0"
+    param = entities.Param(tkey, tval)
+    param2 = entities.Param(tkey, "newval")
+    store.log_param(run.info.run_id, param)
+
+    with pytest.raises(MlflowException, match=r"Changing param values is not allowed"):
+        store.log_param(run.info.run_id, param2)
+
+
+def test_log_empty_str(store: SqlAlchemyStore):
+    run = _run_factory(store)
+
+    tkey = "blahmetric"
+    tval = ""
+    param = entities.Param(tkey, tval)
+    param2 = entities.Param("new param", "new key")
+    store.log_param(run.info.run_id, param)
+    store.log_param(run.info.run_id, param2)
+
+    run = store.get_run(run.info.run_id)
+    assert len(run.data.params) == 2
+    assert tkey in run.data.params
+    assert run.data.params[tkey] == tval
+
+
+def test_log_null_param(store: SqlAlchemyStore):
+    run = _run_factory(store)
+
+    tkey = "blahmetric"
+    tval = None
+    param = entities.Param(tkey, tval)
+
+    dialect = store._get_dialect()
+    regex = {
+        SQLITE: r"NOT NULL constraint failed",
+        POSTGRES: r"null value in column .+ of relation .+ violates not-null constrain",
+        MYSQL: r"Column .+ cannot be null",
+        MSSQL: r"Cannot insert the value NULL into column .+, table .+",
+    }[dialect]
+    with pytest.raises(MlflowException, match=regex) as exception_context:
+        store.log_param(run.info.run_id, param)
+    if dialect != MYSQL:
+        assert exception_context.value.error_code == ErrorCode.Name(BAD_REQUEST)
+    else:
+        # Some MySQL client packages (and there are several available, e.g.
+        # PyMySQL, mysqlclient, mysql-connector-python... reports some
+        # errors, including NULL constraint violations, as a SQLAlchemy
+        # OperationalError, even though they should be reported as a more
+        # generic SQLAlchemyError. If that is fixed, we can remove this
+        # special case.
+        assert exception_context.value.error_code == ErrorCode.Name(
+            BAD_REQUEST
+        ) or exception_context.value.error_code == ErrorCode.Name(TEMPORARILY_UNAVAILABLE)
+
+
+@pytest.mark.skipif(
+    Version(sqlalchemy.__version__) < Version("2.0")
+    and mlflow.get_tracking_uri().startswith("mssql"),
+    reason="large string parameters are sent as TEXT/NTEXT; "
+    "see tests/db/compose.yml for details",
+)
+def test_log_param_max_length_value(store: SqlAlchemyStore):
+    run = _run_factory(store)
+    tkey = "blahmetric"
+    tval = "x" * 6000
+    param = entities.Param(tkey, tval)
+    store.log_param(run.info.run_id, param)
+    run = store.get_run(run.info.run_id)
+    assert run.data.params[tkey] == str(tval)
+    with pytest.raises(MlflowException, match="exceeded length"):
+        store.log_param(run.info.run_id, entities.Param(tkey, "x" * 6001))
+
+
+def test_set_experiment_tag(store: SqlAlchemyStore):
+    exp_id = _create_experiments(store, "setExperimentTagExp")
+    tag = entities.ExperimentTag("tag0", "value0")
+    new_tag = entities.RunTag("tag0", "value00000")
+    store.set_experiment_tag(exp_id, tag)
+    experiment = store.get_experiment(exp_id)
+    assert experiment.tags["tag0"] == "value0"
+    # test that updating a tag works
+    store.set_experiment_tag(exp_id, new_tag)
+    experiment = store.get_experiment(exp_id)
+    assert experiment.tags["tag0"] == "value00000"
+    # test that setting a tag on 1 experiment does not impact another experiment.
+    exp_id_2 = _create_experiments(store, "setExperimentTagExp2")
+    experiment2 = store.get_experiment(exp_id_2)
+    assert len(experiment2.tags) == 0
+    # setting a tag on different experiments maintains different values across experiments
+    different_tag = entities.RunTag("tag0", "differentValue")
+    store.set_experiment_tag(exp_id_2, different_tag)
+    experiment = store.get_experiment(exp_id)
+    assert experiment.tags["tag0"] == "value00000"
+    experiment2 = store.get_experiment(exp_id_2)
+    assert experiment2.tags["tag0"] == "differentValue"
+    # test can set multi-line tags
+    multi_line_Tag = entities.ExperimentTag("multiline tag", "value2\nvalue2\nvalue2")
+    store.set_experiment_tag(exp_id, multi_line_Tag)
+    experiment = store.get_experiment(exp_id)
+    assert experiment.tags["multiline tag"] == "value2\nvalue2\nvalue2"
+    # test cannot set tags that are too long
+    long_tag = entities.ExperimentTag("longTagKey", "a" * 5001)
+    with pytest.raises(MlflowException, match="exceeded length limit of 5000"):
+        store.set_experiment_tag(exp_id, long_tag)
+    # test can set tags that are somewhat long
+    long_tag = entities.ExperimentTag("longTagKey", "a" * 4999)
+    store.set_experiment_tag(exp_id, long_tag)
+    # test cannot set tags on deleted experiments
+    store.delete_experiment(exp_id)
+    with pytest.raises(MlflowException, match="must be in the 'active' state"):
+        store.set_experiment_tag(exp_id, entities.ExperimentTag("should", "notset"))
+
+
+def test_set_tag(store: SqlAlchemyStore):
+    run = _run_factory(store)
+
+    tkey = "test tag"
+    tval = "a boogie"
+    new_val = "new val"
+    tag = entities.RunTag(tkey, tval)
+    new_tag = entities.RunTag(tkey, new_val)
+    store.set_tag(run.info.run_id, tag)
+    # Overwriting tags is allowed
+    store.set_tag(run.info.run_id, new_tag)
+    # test setting tags that are too long fails.
+    with pytest.raises(MlflowException, match="exceeded length limit of 5000"):
+        store.set_tag(run.info.run_id, entities.RunTag("longTagKey", "a" * 5001))
+    # test can set tags that are somewhat long
+    store.set_tag(run.info.run_id, entities.RunTag("longTagKey", "a" * 4999))
+    run = store.get_run(run.info.run_id)
+    assert tkey in run.data.tags
+    assert run.data.tags[tkey] == new_val
+
+
+def test_delete_tag(store: SqlAlchemyStore):
+    run = _run_factory(store)
+    k0, v0 = "tag0", "val0"
+    k1, v1 = "tag1", "val1"
+    tag0 = entities.RunTag(k0, v0)
+    tag1 = entities.RunTag(k1, v1)
+    store.set_tag(run.info.run_id, tag0)
+    store.set_tag(run.info.run_id, tag1)
+    # delete a tag and check whether it is correctly deleted.
+    store.delete_tag(run.info.run_id, k0)
+    run = store.get_run(run.info.run_id)
+    assert k0 not in run.data.tags
+    assert k1 in run.data.tags
+    assert run.data.tags[k1] == v1
+
+    # test that deleting a tag works correctly with multiple runs having the same tag.
+    run2 = _run_factory(store, config=_get_run_configs(run.info.experiment_id))
+    store.set_tag(run.info.run_id, tag0)
+    store.set_tag(run2.info.run_id, tag0)
+    store.delete_tag(run.info.run_id, k0)
+    run = store.get_run(run.info.run_id)
+    run2 = store.get_run(run2.info.run_id)
+    assert k0 not in run.data.tags
+    assert k0 in run2.data.tags
+    # test that you cannot delete tags that don't exist.
+    with pytest.raises(MlflowException, match="No tag with name"):
+        store.delete_tag(run.info.run_id, "fakeTag")
+    # test that you cannot delete tags for nonexistent runs
+    with pytest.raises(MlflowException, match="Run with id=randomRunId not found"):
+        store.delete_tag("randomRunId", k0)
+    # test that you cannot delete tags for deleted runs.
+    store.delete_run(run.info.run_id)
+    with pytest.raises(MlflowException, match="must be in the 'active' state"):
+        store.delete_tag(run.info.run_id, k1)
+
+
+def test_get_metric_history(store: SqlAlchemyStore):
+    run = _run_factory(store)
+
+    key = "test"
+    expected = [
+        models.SqlMetric(key=key, value=0.6, timestamp=1, step=0).to_mlflow_entity(),
+        models.SqlMetric(key=key, value=0.7, timestamp=2, step=0).to_mlflow_entity(),
+    ]
+
+    for metric in expected:
+        store.log_metric(run.info.run_id, metric)
+
+    actual = store.get_metric_history(run.info.run_id, key)
+
+    assert sorted(
+        [(m.key, m.value, m.timestamp) for m in expected],
+    ) == sorted(
+        [(m.key, m.value, m.timestamp) for m in actual],
+    )
+
+
+def test_rename_experiment(store: SqlAlchemyStore):
+    new_name = "new name"
+    experiment_id = _create_experiments(store, "test name")
+    experiment = store.get_experiment(experiment_id)
+    time.sleep(0.01)
+    store.rename_experiment(experiment_id, new_name)
+
+    renamed_experiment = store.get_experiment(experiment_id)
+
+    assert renamed_experiment.name == new_name
+    assert renamed_experiment.last_update_time > experiment.last_update_time
+
+
+def test_update_run_info(store: SqlAlchemyStore):
+    experiment_id = _create_experiments(store, "test_update_run_info")
+    for new_status_string in models.RunStatusTypes:
+        run = _run_factory(config=_get_run_configs(experiment_id=experiment_id))
+        endtime = get_current_time_millis()
+        actual = store.update_run_info(
+            run.info.run_id, RunStatus.from_string(new_status_string), endtime, None
+        )
+        assert actual.status == new_status_string
+        assert actual.end_time == endtime
+
+    # test updating run name without changing other attributes.
+    origin_run_info = store.get_run(run.info.run_id).info
+    updated_info = store.update_run_info(run.info.run_id, None, None, "name_abc2")
+    assert updated_info.run_name == "name_abc2"
+    assert updated_info.status == origin_run_info.status
+    assert updated_info.end_time == origin_run_info.end_time
+
+
+def test_update_run_name(store: SqlAlchemyStore):
+    experiment_id = _create_experiments(store, "test_update_run_name")
+    configs = _get_run_configs(experiment_id=experiment_id)
+
+    run_id = store.create_run(**configs).info.run_id
+    run = store.get_run(run_id)
+    assert run.info.run_name == configs["run_name"]
+
+    store.update_run_info(run_id, RunStatus.FINISHED, 1000, "new name")
+    run = store.get_run(run_id)
+    assert run.info.run_name == "new name"
+    assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "new name"
+
+    store.update_run_info(run_id, RunStatus.FINISHED, 1000, None)
+    run = store.get_run(run_id)
+    assert run.info.run_name == "new name"
+    assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "new name"
+
+    store.update_run_info(run_id, RunStatus.FINISHED, 1000, "")
+    run = store.get_run(run_id)
+    assert run.info.run_name == "new name"
+    assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "new name"
+
+    store.delete_tag(run_id, mlflow_tags.MLFLOW_RUN_NAME)
+    run = store.get_run(run_id)
+    assert run.info.run_name == "new name"
+    assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) is None
+
+    store.update_run_info(run_id, RunStatus.FINISHED, 1000, "newer name")
+    run = store.get_run(run_id)
+    assert run.info.run_name == "newer name"
+    assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "newer name"
+
+    store.set_tag(run_id, entities.RunTag(mlflow_tags.MLFLOW_RUN_NAME, "newest name"))
+    run = store.get_run(run_id)
+    assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "newest name"
+    assert run.info.run_name == "newest name"
+
+    store.log_batch(
+        run_id,
+        metrics=[],
+        params=[],
+        tags=[entities.RunTag(mlflow_tags.MLFLOW_RUN_NAME, "batch name")],
+    )
+    run = store.get_run(run_id)
+    assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "batch name"
+    assert run.info.run_name == "batch name"
+
+
+def test_restore_experiment(store: SqlAlchemyStore):
+    experiment_id = _create_experiments(store, "helloexp")
+    exp = store.get_experiment(experiment_id)
+    assert exp.lifecycle_stage == entities.LifecycleStage.ACTIVE
+
+    experiment_id = exp.experiment_id
+    store.delete_experiment(experiment_id)
+
+    deleted = store.get_experiment(experiment_id)
+    assert deleted.experiment_id == experiment_id
+    assert deleted.lifecycle_stage == entities.LifecycleStage.DELETED
+    time.sleep(0.01)
+    store.restore_experiment(exp.experiment_id)
+    restored = store.get_experiment(exp.experiment_id)
+    assert restored.experiment_id == experiment_id
+    assert restored.lifecycle_stage == entities.LifecycleStage.ACTIVE
+    assert restored.last_update_time > deleted.last_update_time
+
+
 # This unit test class is under refactoring. Please use pytest for new unit tests: #10042
 class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
     def _get_store(self, db_uri=""):
@@ -983,448 +1442,6 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
             config["experiment_id"] = experiment_id
 
         return self.store.create_run(**config)
-
-    def test_log_metric(self):
-        run = self._run_factory()
-
-        tkey = "blahmetric"
-        tval = 100.0
-        metric = entities.Metric(tkey, tval, get_current_time_millis(), 0)
-        metric2 = entities.Metric(tkey, tval, get_current_time_millis() + 2, 0)
-        nan_metric = entities.Metric("NaN", float("nan"), 0, 0)
-        pos_inf_metric = entities.Metric("PosInf", float("inf"), 0, 0)
-        neg_inf_metric = entities.Metric("NegInf", -float("inf"), 0, 0)
-        self.store.log_metric(run.info.run_id, metric)
-        self.store.log_metric(run.info.run_id, metric2)
-        self.store.log_metric(run.info.run_id, nan_metric)
-        self.store.log_metric(run.info.run_id, pos_inf_metric)
-        self.store.log_metric(run.info.run_id, neg_inf_metric)
-
-        run = self.store.get_run(run.info.run_id)
-        assert tkey in run.data.metrics
-        assert run.data.metrics[tkey] == tval
-
-        # SQL store _get_run method returns full history of recorded metrics.
-        # Should return duplicates as well
-        # MLflow RunData contains only the last reported values for metrics.
-        with self.store.ManagedSessionMaker() as session:
-            sql_run_metrics = self.store._get_run(session, run.info.run_id).metrics
-            assert len(sql_run_metrics) == 5
-            assert len(run.data.metrics) == 4
-            assert math.isnan(run.data.metrics["NaN"])
-            assert run.data.metrics["PosInf"] == 1.7976931348623157e308
-            assert run.data.metrics["NegInf"] == -1.7976931348623157e308
-
-    def test_log_metric_concurrent_logging_succeeds(self):
-        """
-        Verifies that concurrent logging succeeds without deadlock, which has been an issue
-        in previous MLflow releases
-        """
-        experiment_id = self._experiment_factory("concurrency_exp")
-        run_config = self._get_run_configs(experiment_id=experiment_id)
-        run1 = self._run_factory(run_config)
-        run2 = self._run_factory(run_config)
-
-        def log_metrics(run):
-            for metric_val in range(100):
-                self.store.log_metric(
-                    run.info.run_id, Metric("metric_key", metric_val, get_current_time_millis(), 0)
-                )
-            for batch_idx in range(5):
-                self.store.log_batch(
-                    run.info.run_id,
-                    metrics=[
-                        Metric(
-                            f"metric_batch_{batch_idx}",
-                            (batch_idx * 100) + val_offset,
-                            get_current_time_millis(),
-                            0,
-                        )
-                        for val_offset in range(100)
-                    ],
-                    params=[],
-                    tags=[],
-                )
-            for metric_val in range(100):
-                self.store.log_metric(
-                    run.info.run_id, Metric("metric_key", metric_val, get_current_time_millis(), 0)
-                )
-            return "success"
-
-        log_metrics_futures = []
-        with ThreadPoolExecutor(max_workers=4) as executor:
-            # Log metrics to two runs across four threads
-            log_metrics_futures = [
-                executor.submit(log_metrics, run) for run in [run1, run2, run1, run2]
-            ]
-
-        for future in log_metrics_futures:
-            assert future.result() == "success"
-
-        for run in [run1, run2, run1, run2]:
-            # We visit each run twice, logging 100 metric entries for 6 metric names; the same entry
-            # may be written multiple times concurrently; we assert that at least 100 metric entries
-            # are present because at least 100 unique entries must have been written
-            assert len(self.store.get_metric_history(run.info.run_id, "metric_key")) >= 100
-            for batch_idx in range(5):
-                assert (
-                    len(self.store.get_metric_history(run.info.run_id, f"metric_batch_{batch_idx}"))
-                    >= 100
-                )
-
-    def test_log_metric_allows_multiple_values_at_same_ts_and_run_data_uses_max_ts_value(self):
-        run = self._run_factory()
-        run_id = run.info.run_id
-        metric_name = "test-metric-1"
-        # Check that we get the max of (step, timestamp, value) in that order
-        tuples_to_log = [
-            (0, 100, 1000),
-            (3, 40, 100),  # larger step wins even though it has smaller value
-            (3, 50, 10),  # larger timestamp wins even though it has smaller value
-            (3, 50, 20),  # tiebreak by max value
-            (3, 50, 20),  # duplicate metrics with same (step, timestamp, value) are ok
-            # verify that we can log steps out of order / negative steps
-            (-3, 900, 900),
-            (-1, 800, 800),
-        ]
-        for step, timestamp, value in reversed(tuples_to_log):
-            self.store.log_metric(run_id, Metric(metric_name, value, timestamp, step))
-
-        metric_history = self.store.get_metric_history(run_id, metric_name)
-        logged_tuples = [(m.step, m.timestamp, m.value) for m in metric_history]
-        assert set(logged_tuples) == set(tuples_to_log)
-
-        run_data = self.store.get_run(run_id).data
-        run_metrics = run_data.metrics
-        assert len(run_metrics) == 1
-        assert run_metrics[metric_name] == 20
-        metric_obj = run_data._metric_objs[0]
-        assert metric_obj.key == metric_name
-        assert metric_obj.step == 3
-        assert metric_obj.timestamp == 50
-        assert metric_obj.value == 20
-
-    def test_get_metric_history_paginated_request_raises(self):
-        with pytest.raises(
-            MlflowException,
-            match="The SQLAlchemyStore backend does not support pagination for the "
-            "`get_metric_history` API.",
-        ):
-            self.store.get_metric_history(
-                "fake_run", "fake_metric", max_results=50, page_token="42"
-            )
-
-    def test_log_null_metric(self):
-        run = self._run_factory()
-
-        tkey = "blahmetric"
-        tval = None
-        metric = entities.Metric(tkey, tval, get_current_time_millis(), 0)
-
-        with pytest.raises(
-            MlflowException, match=r"Got invalid value None for metric"
-        ) as exception_context:
-            self.store.log_metric(run.info.run_id, metric)
-        assert exception_context.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-
-    def test_log_param(self):
-        run = self._run_factory()
-
-        tkey = "blahmetric"
-        tval = "100.0"
-        param = entities.Param(tkey, tval)
-        param2 = entities.Param("new param", "new key")
-        self.store.log_param(run.info.run_id, param)
-        self.store.log_param(run.info.run_id, param2)
-        self.store.log_param(run.info.run_id, param2)
-
-        run = self.store.get_run(run.info.run_id)
-        assert len(run.data.params) == 2
-        assert tkey in run.data.params
-        assert run.data.params[tkey] == tval
-
-    def test_log_param_uniqueness(self):
-        run = self._run_factory()
-
-        tkey = "blahmetric"
-        tval = "100.0"
-        param = entities.Param(tkey, tval)
-        param2 = entities.Param(tkey, "newval")
-        self.store.log_param(run.info.run_id, param)
-
-        with pytest.raises(MlflowException, match=r"Changing param values is not allowed"):
-            self.store.log_param(run.info.run_id, param2)
-
-    def test_log_empty_str(self):
-        run = self._run_factory()
-
-        tkey = "blahmetric"
-        tval = ""
-        param = entities.Param(tkey, tval)
-        param2 = entities.Param("new param", "new key")
-        self.store.log_param(run.info.run_id, param)
-        self.store.log_param(run.info.run_id, param2)
-
-        run = self.store.get_run(run.info.run_id)
-        assert len(run.data.params) == 2
-        assert tkey in run.data.params
-        assert run.data.params[tkey] == tval
-
-    def test_log_null_param(self):
-        run = self._run_factory()
-
-        tkey = "blahmetric"
-        tval = None
-        param = entities.Param(tkey, tval)
-
-        dialect = self.store._get_dialect()
-        regex = {
-            SQLITE: r"NOT NULL constraint failed",
-            POSTGRES: r"null value in column .+ of relation .+ violates not-null constrain",
-            MYSQL: r"Column .+ cannot be null",
-            MSSQL: r"Cannot insert the value NULL into column .+, table .+",
-        }[dialect]
-        with pytest.raises(MlflowException, match=regex) as exception_context:
-            self.store.log_param(run.info.run_id, param)
-        if dialect != MYSQL:
-            assert exception_context.value.error_code == ErrorCode.Name(BAD_REQUEST)
-        else:
-            # Some MySQL client packages (and there are several available, e.g.
-            # PyMySQL, mysqlclient, mysql-connector-python... reports some
-            # errors, including NULL constraint violations, as a SQLAlchemy
-            # OperationalError, even though they should be reported as a more
-            # generic SQLAlchemyError. If that is fixed, we can remove this
-            # special case.
-            assert exception_context.value.error_code == ErrorCode.Name(
-                BAD_REQUEST
-            ) or exception_context.value.error_code == ErrorCode.Name(TEMPORARILY_UNAVAILABLE)
-
-    @pytest.mark.skipif(
-        Version(sqlalchemy.__version__) < Version("2.0")
-        and mlflow.get_tracking_uri().startswith("mssql"),
-        reason="large string parameters are sent as TEXT/NTEXT; "
-        "see tests/db/compose.yml for details",
-    )
-    def test_log_param_max_length_value(self):
-        run = self._run_factory()
-        tkey = "blahmetric"
-        tval = "x" * 6000
-        param = entities.Param(tkey, tval)
-        self.store.log_param(run.info.run_id, param)
-        run = self.store.get_run(run.info.run_id)
-        assert run.data.params[tkey] == str(tval)
-        with pytest.raises(MlflowException, match="exceeded length"):
-            self.store.log_param(run.info.run_id, entities.Param(tkey, "x" * 6001))
-
-    def test_set_experiment_tag(self):
-        exp_id = self._experiment_factory("setExperimentTagExp")
-        tag = entities.ExperimentTag("tag0", "value0")
-        new_tag = entities.RunTag("tag0", "value00000")
-        self.store.set_experiment_tag(exp_id, tag)
-        experiment = self.store.get_experiment(exp_id)
-        assert experiment.tags["tag0"] == "value0"
-        # test that updating a tag works
-        self.store.set_experiment_tag(exp_id, new_tag)
-        experiment = self.store.get_experiment(exp_id)
-        assert experiment.tags["tag0"] == "value00000"
-        # test that setting a tag on 1 experiment does not impact another experiment.
-        exp_id_2 = self._experiment_factory("setExperimentTagExp2")
-        experiment2 = self.store.get_experiment(exp_id_2)
-        assert len(experiment2.tags) == 0
-        # setting a tag on different experiments maintains different values across experiments
-        different_tag = entities.RunTag("tag0", "differentValue")
-        self.store.set_experiment_tag(exp_id_2, different_tag)
-        experiment = self.store.get_experiment(exp_id)
-        assert experiment.tags["tag0"] == "value00000"
-        experiment2 = self.store.get_experiment(exp_id_2)
-        assert experiment2.tags["tag0"] == "differentValue"
-        # test can set multi-line tags
-        multi_line_Tag = entities.ExperimentTag("multiline tag", "value2\nvalue2\nvalue2")
-        self.store.set_experiment_tag(exp_id, multi_line_Tag)
-        experiment = self.store.get_experiment(exp_id)
-        assert experiment.tags["multiline tag"] == "value2\nvalue2\nvalue2"
-        # test cannot set tags that are too long
-        long_tag = entities.ExperimentTag("longTagKey", "a" * 5001)
-        with pytest.raises(MlflowException, match="exceeded length limit of 5000"):
-            self.store.set_experiment_tag(exp_id, long_tag)
-        # test can set tags that are somewhat long
-        long_tag = entities.ExperimentTag("longTagKey", "a" * 4999)
-        self.store.set_experiment_tag(exp_id, long_tag)
-        # test cannot set tags on deleted experiments
-        self.store.delete_experiment(exp_id)
-        with pytest.raises(MlflowException, match="must be in the 'active' state"):
-            self.store.set_experiment_tag(exp_id, entities.ExperimentTag("should", "notset"))
-
-    def test_set_tag(self):
-        run = self._run_factory()
-
-        tkey = "test tag"
-        tval = "a boogie"
-        new_val = "new val"
-        tag = entities.RunTag(tkey, tval)
-        new_tag = entities.RunTag(tkey, new_val)
-        self.store.set_tag(run.info.run_id, tag)
-        # Overwriting tags is allowed
-        self.store.set_tag(run.info.run_id, new_tag)
-        # test setting tags that are too long fails.
-        with pytest.raises(MlflowException, match="exceeded length limit of 5000"):
-            self.store.set_tag(run.info.run_id, entities.RunTag("longTagKey", "a" * 5001))
-        # test can set tags that are somewhat long
-        self.store.set_tag(run.info.run_id, entities.RunTag("longTagKey", "a" * 4999))
-        run = self.store.get_run(run.info.run_id)
-        assert tkey in run.data.tags
-        assert run.data.tags[tkey] == new_val
-
-    def test_delete_tag(self):
-        run = self._run_factory()
-        k0, v0 = "tag0", "val0"
-        k1, v1 = "tag1", "val1"
-        tag0 = entities.RunTag(k0, v0)
-        tag1 = entities.RunTag(k1, v1)
-        self.store.set_tag(run.info.run_id, tag0)
-        self.store.set_tag(run.info.run_id, tag1)
-        # delete a tag and check whether it is correctly deleted.
-        self.store.delete_tag(run.info.run_id, k0)
-        run = self.store.get_run(run.info.run_id)
-        assert k0 not in run.data.tags
-        assert k1 in run.data.tags
-        assert run.data.tags[k1] == v1
-
-        # test that deleting a tag works correctly with multiple runs having the same tag.
-        run2 = self._run_factory(config=self._get_run_configs(run.info.experiment_id))
-        self.store.set_tag(run.info.run_id, tag0)
-        self.store.set_tag(run2.info.run_id, tag0)
-        self.store.delete_tag(run.info.run_id, k0)
-        run = self.store.get_run(run.info.run_id)
-        run2 = self.store.get_run(run2.info.run_id)
-        assert k0 not in run.data.tags
-        assert k0 in run2.data.tags
-        # test that you cannot delete tags that don't exist.
-        with pytest.raises(MlflowException, match="No tag with name"):
-            self.store.delete_tag(run.info.run_id, "fakeTag")
-        # test that you cannot delete tags for nonexistent runs
-        with pytest.raises(MlflowException, match="Run with id=randomRunId not found"):
-            self.store.delete_tag("randomRunId", k0)
-        # test that you cannot delete tags for deleted runs.
-        self.store.delete_run(run.info.run_id)
-        with pytest.raises(MlflowException, match="must be in the 'active' state"):
-            self.store.delete_tag(run.info.run_id, k1)
-
-    def test_get_metric_history(self):
-        run = self._run_factory()
-
-        key = "test"
-        expected = [
-            models.SqlMetric(key=key, value=0.6, timestamp=1, step=0).to_mlflow_entity(),
-            models.SqlMetric(key=key, value=0.7, timestamp=2, step=0).to_mlflow_entity(),
-        ]
-
-        for metric in expected:
-            self.store.log_metric(run.info.run_id, metric)
-
-        actual = self.store.get_metric_history(run.info.run_id, key)
-
-        assert sorted(
-            [(m.key, m.value, m.timestamp) for m in expected],
-        ) == sorted(
-            [(m.key, m.value, m.timestamp) for m in actual],
-        )
-
-    def test_rename_experiment(self):
-        new_name = "new name"
-        experiment_id = self._experiment_factory("test name")
-        experiment = self.store.get_experiment(experiment_id)
-        time.sleep(0.01)
-        self.store.rename_experiment(experiment_id, new_name)
-
-        renamed_experiment = self.store.get_experiment(experiment_id)
-
-        assert renamed_experiment.name == new_name
-        assert renamed_experiment.last_update_time > experiment.last_update_time
-
-    def test_update_run_info(self):
-        experiment_id = self._experiment_factory("test_update_run_info")
-        for new_status_string in models.RunStatusTypes:
-            run = self._run_factory(config=self._get_run_configs(experiment_id=experiment_id))
-            endtime = get_current_time_millis()
-            actual = self.store.update_run_info(
-                run.info.run_id, RunStatus.from_string(new_status_string), endtime, None
-            )
-            assert actual.status == new_status_string
-            assert actual.end_time == endtime
-
-        # test updating run name without changing other attributes.
-        origin_run_info = self.store.get_run(run.info.run_id).info
-        updated_info = self.store.update_run_info(run.info.run_id, None, None, "name_abc2")
-        assert updated_info.run_name == "name_abc2"
-        assert updated_info.status == origin_run_info.status
-        assert updated_info.end_time == origin_run_info.end_time
-
-    def test_update_run_name(self):
-        experiment_id = self._experiment_factory("test_update_run_name")
-        configs = self._get_run_configs(experiment_id=experiment_id)
-
-        run_id = self.store.create_run(**configs).info.run_id
-        run = self.store.get_run(run_id)
-        assert run.info.run_name == configs["run_name"]
-
-        self.store.update_run_info(run_id, RunStatus.FINISHED, 1000, "new name")
-        run = self.store.get_run(run_id)
-        assert run.info.run_name == "new name"
-        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "new name"
-
-        self.store.update_run_info(run_id, RunStatus.FINISHED, 1000, None)
-        run = self.store.get_run(run_id)
-        assert run.info.run_name == "new name"
-        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "new name"
-
-        self.store.update_run_info(run_id, RunStatus.FINISHED, 1000, "")
-        run = self.store.get_run(run_id)
-        assert run.info.run_name == "new name"
-        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "new name"
-
-        self.store.delete_tag(run_id, mlflow_tags.MLFLOW_RUN_NAME)
-        run = self.store.get_run(run_id)
-        assert run.info.run_name == "new name"
-        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) is None
-
-        self.store.update_run_info(run_id, RunStatus.FINISHED, 1000, "newer name")
-        run = self.store.get_run(run_id)
-        assert run.info.run_name == "newer name"
-        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "newer name"
-
-        self.store.set_tag(run_id, entities.RunTag(mlflow_tags.MLFLOW_RUN_NAME, "newest name"))
-        run = self.store.get_run(run_id)
-        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "newest name"
-        assert run.info.run_name == "newest name"
-
-        self.store.log_batch(
-            run_id,
-            metrics=[],
-            params=[],
-            tags=[entities.RunTag(mlflow_tags.MLFLOW_RUN_NAME, "batch name")],
-        )
-        run = self.store.get_run(run_id)
-        assert run.data.tags.get(mlflow_tags.MLFLOW_RUN_NAME) == "batch name"
-        assert run.info.run_name == "batch name"
-
-    def test_restore_experiment(self):
-        experiment_id = self._experiment_factory("helloexp")
-        exp = self.store.get_experiment(experiment_id)
-        assert exp.lifecycle_stage == entities.LifecycleStage.ACTIVE
-
-        experiment_id = exp.experiment_id
-        self.store.delete_experiment(experiment_id)
-
-        deleted = self.store.get_experiment(experiment_id)
-        assert deleted.experiment_id == experiment_id
-        assert deleted.lifecycle_stage == entities.LifecycleStage.DELETED
-        time.sleep(0.01)
-        self.store.restore_experiment(exp.experiment_id)
-        restored = self.store.get_experiment(exp.experiment_id)
-        assert restored.experiment_id == experiment_id
-        assert restored.lifecycle_stage == entities.LifecycleStage.ACTIVE
-        assert restored.last_update_time > deleted.last_update_time
 
     def test_delete_restore_run(self):
         run = self._run_factory()

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1262,7 +1262,7 @@ def test_rename_experiment(store: SqlAlchemyStore):
 def test_update_run_info(store: SqlAlchemyStore):
     experiment_id = _create_experiments(store, "test_update_run_info")
     for new_status_string in models.RunStatusTypes:
-        run = _run_factory(config=_get_run_configs(experiment_id=experiment_id))
+        run = _run_factory(store, config=_get_run_configs(experiment_id=experiment_id))
         endtime = get_current_time_millis()
         actual = store.update_run_info(
             run.info.run_id, RunStatus.from_string(new_status_string), endtime, None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/10609?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10609/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10609
```

</p>
</details>

### Related Issues/PRs

https://github.com/mlflow/mlflow/pull/10266

### What changes are proposed in this pull request?

This is the 5th PR of https://github.com/mlflow/mlflow/issues/10042, which tries to refactor https://github.com/mlflow/mlflow/blob/master/tests/store/tracking/test_sqlalchemy_store.py into the pytest style

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
