### PR TITLE
Handle multiple optimizers in PyTorch Lightning step autologging

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -927,9 +927,12 @@ def autolog(
 
     :param log_every_n_epoch: If specified, logs metrics once every `n` epochs. By default, metrics
                        are logged after every epoch.
-    :param log_every_n_step: If specified, logs batch metrics once every `n` global step.
+    :param log_every_n_step: If specified, logs batch metrics once every `n` training step.
                        By default, metrics are not logged for steps. Note that setting this to 1 can
                        cause performance issues and is not recommended.
+                       Metrics are logged against Lightning's global step number,
+                       and when multiple optimizers are used it is assumed that all optimizers
+                       are stepped in each training step.
     :param log_models: If ``True``, trained models are logged as MLflow model artifacts.
                        If ``False``, trained models are not logged.
     :param log_datasets: If ``True``, dataset information is logged to MLflow Tracking.

--- a/mlflow/pytorch/_lightning_autolog.py
+++ b/mlflow/pytorch/_lightning_autolog.py
@@ -86,7 +86,7 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
         self.log_models = log_models
         self.log_every_n_epoch = log_every_n_epoch
         self.log_every_n_step = log_every_n_step
-        self._num_optimizers = 1
+        self._global_steps_per_training_step = 1
         # Sets for tracking which metrics are logged on steps and which are logged on epochs
         self._step_metrics = set()
         self._epoch_metrics = set()
@@ -213,9 +213,7 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
         ]
         self._step_metrics.update(name for (name, _) in metric_items)
         step = trainer.global_step
-        # Lightning increments the global step once per optimizer, so to correctly handle
-        # the step interval we divide the step by the number of optimizers.
-        if ((step // self._num_optimizers) + 1) % self.log_every_n_step == 0:
+        if ((step // self._global_steps_per_training_step) + 1) % self.log_every_n_step == 0:
             self._log_metrics(trainer, step, metric_items)
 
     @rank_zero_only
@@ -239,7 +237,10 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
         #    to rename the optimizer parameters based on keys in default dictionary.
 
         if hasattr(trainer, "optimizers"):
-            self._num_optimizers = len(trainer.optimizers)
+            # Lightning >= 1.6.0 increments the global step every time an optimizer is stepped.
+            # We assume every optimizer will be stepped in each training step.
+            if _pl_version >= Version("1.6.0"):
+                self._global_steps_per_training_step = len(trainer.optimizers)
             optimizer = trainer.optimizers[0]
             params["optimizer_name"] = _get_optimizer_name(optimizer)
 

--- a/tests/pytorch/iris.py
+++ b/tests/pytorch/iris.py
@@ -106,5 +106,38 @@ class IrisClassificationWithoutValidation(IrisClassificationBase):
         self.log("test_acc", self.test_acc.compute())
 
 
+class IrisClassificationMultiOptimizer(IrisClassificationBase):
+    """
+    Contrived lightning module that uses multiple optimizers. In real-world scenarios
+    multiple optimizers might be used for Generative Adversarial Networks (GANs).
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.automatic_optimization = False
+
+    def training_step(self, batch, batch_idx):
+        opt1, opt2 = self.optimizers()
+
+        x, y = batch
+        logits = self.forward(x)
+        loss = self.cross_entropy_loss(logits, y)
+
+        opt1.zero_grad()
+        opt2.zero_grad()
+
+        self.manual_backward(loss)
+
+        opt1.step()
+        opt2.step()
+
+        self.log("loss", loss, on_epoch=True, on_step=True)
+
+    def configure_optimizers(self):
+        opt1 = torch.optim.Adam(self.parameters(), 0.01)
+        opt2 = torch.optim.Adam(self.parameters(), 0.01)
+        return [opt1, opt2]
+
+
 if __name__ == "__main__":
     pass

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -195,8 +195,7 @@ def test_pytorch_autolog_log_on_step_with_multiple_optimizers(
     pytorch_multi_optimizer_model,
 ):
     trainer, run, log_every_n_epoch, log_every_n_step = pytorch_multi_optimizer_model
-    # Global step is incremented twice for every batch due to using 2 optimizers
-    num_logged_steps = trainer.global_step // (2 * log_every_n_step)
+    num_logged_steps = NUM_EPOCHS * len(trainer.train_dataloader) // log_every_n_step
     num_logged_epochs = NUM_EPOCHS // log_every_n_epoch
 
     client = MlflowClient()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/adamreeve/mlflow/pull/10613?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10613/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10613
```

</p>
</details>

### Related Issues/PRs

Resolve #10594 

### What changes are proposed in this pull request?

Adjusts the logic for determining whether to log metrics after a training step to account for the number of optimizers. I've assumed that the global step will always be incremented by the number of optimizers in each training step. It's possible that users would not always step every optimizer in every training step, although I'm not aware of scenarios where this is done. In that case though the logging would be more frequently than expected, which I think is better than the current situation where metrics might not be logged at all.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix bug in PyTorch Lightning autologging with multiple optimizers where metrics are not logged on training steps.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
