### PR TITLE
Feature/non interactive databricks login

### DIFF
--- a/docs/source/getting-started/tracking-server-overview/index.rst
+++ b/docs/source/getting-started/tracking-server-overview/index.rst
@@ -217,6 +217,14 @@ If the authentication succeeds, you should see a message "Succesfully signed in 
   Password: ··········
   2023/10/25 22:59:38 INFO mlflow.utils.credentials: Succesfully signed in Databricks!
 
+To disable the interactive prompt for credentials (useful in CI/CD pipelines), use the `interactive` argument:
+
+.. code-block:: python
+  import mlflow
+
+  mlflow.login(interactive=False)
+
+This will raise an exception if the credentials are not already configured, instead of requesting user input.
 
 Connect MLflow Session to Databricks CE
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/getting-started/tracking-server-overview/index.rst
+++ b/docs/source/getting-started/tracking-server-overview/index.rst
@@ -220,6 +220,7 @@ If the authentication succeeds, you should see a message "Succesfully signed in 
 To disable the interactive prompt for credentials (useful in CI/CD pipelines), use the `interactive` argument:
 
 .. code-block:: python
+
   import mlflow
 
   mlflow.login(interactive=False)

--- a/docs/source/getting-started/tracking-server-overview/index.rst
+++ b/docs/source/getting-started/tracking-server-overview/index.rst
@@ -217,15 +217,6 @@ If the authentication succeeds, you should see a message "Succesfully signed in 
   Password: ··········
   2023/10/25 22:59:38 INFO mlflow.utils.credentials: Succesfully signed in Databricks!
 
-To disable the interactive prompt for credentials (useful in CI/CD pipelines), use the `interactive` argument:
-
-.. code-block:: python
-
-  import mlflow
-
-  mlflow.login(interactive=False)
-
-This will raise an exception if the credentials are not already configured, instead of requesting user input.
 
 Connect MLflow Session to Databricks CE
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/utils/test_credentials.py
+++ b/tests/utils/test_credentials.py
@@ -133,3 +133,16 @@ def test_mlflow_login(tmp_path, monkeypatch):
 
     # Assert that the tracking URI is set to the databricks.
     assert get_tracking_uri() == "databricks"
+
+
+def test_mlflow_noninteractive_login():
+    # Forces mlflw.utils.credentials._validate_databricks_auth to raise `MlflowException()`
+    with patch(
+        "mlflow.utils.credentials._validate_databricks_auth",
+        side_effect=MlflowException("Failed to validate datbricks credentials."),
+    ):
+        with pytest.raises(
+            MlflowException,
+            match="No valid Databricks credentials found while running in non-interactive mode",
+        ):
+            login(backend="databricks", interactive=False)

--- a/tests/utils/test_credentials.py
+++ b/tests/utils/test_credentials.py
@@ -135,11 +135,11 @@ def test_mlflow_login(tmp_path, monkeypatch):
     assert get_tracking_uri() == "databricks"
 
 
-def test_mlflow_noninteractive_login():
+def test_mlflow_login_noninteractive():
     # Forces mlflw.utils.credentials._validate_databricks_auth to raise `MlflowException()`
     with patch(
         "mlflow.utils.credentials._validate_databricks_auth",
-        side_effect=MlflowException("Failed to validate datbricks credentials."),
+        side_effect=MlflowException("Failed to validate databricks credentials."),
     ):
         with pytest.raises(
             MlflowException,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/henxing/mlflow/pull/10623?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10623/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10623
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
#10571

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

This adds the `interactive` argument to `mlflow.login()`. If it is set to `False` (default: `True`), it will raise an exception, rather than ask for user input, if no valid credentials are found.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
