### PR TITLE
Revert Changes to PythonModel that introduced loading issues

### DIFF
--- a/mlflow/models/flavor_backend.py
+++ b/mlflow/models/flavor_backend.py
@@ -4,11 +4,13 @@ from mlflow.utils.annotations import developer_stable
 
 
 @developer_stable
-class FlavorBackend(metaclass=ABCMeta):
+class FlavorBackend:
     """
     Abstract class for Flavor Backend.
     This class defines the API interface for local model deployment of MLflow model flavors.
     """
+
+    __metaclass__ = ABCMeta
 
     def __init__(self, config, **kwargs):  # pylint: disable=unused-argument
         self._config = config

--- a/mlflow/projects/backend/abstract_backend.py
+++ b/mlflow/projects/backend/abstract_backend.py
@@ -4,7 +4,7 @@ from mlflow.utils.annotations import developer_stable
 
 
 @developer_stable
-class AbstractBackend(metaclass=ABCMeta):
+class AbstractBackend:
     """
     Abstract plugin class defining the interface needed to execute MLflow projects. You can define
     subclasses of ``AbstractBackend`` and expose them as third-party plugins to enable running
@@ -12,6 +12,8 @@ class AbstractBackend(metaclass=ABCMeta):
     in-house cluster or job scheduler). See `MLflow Plugins <../../plugins.html>`_ for more
     information.
     """
+
+    __metaclass__ = ABCMeta
 
     @abstractmethod
     def run(

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -74,13 +74,15 @@ def _log_warning_if_params_not_in_predict_signature(logger, params):
         )
 
 
-class PythonModel(metaclass=ABCMeta):
+class PythonModel:
     """
     Represents a generic Python model that evaluates inputs and produces API-compatible outputs.
     By subclassing :class:`~PythonModel`, users can create customized MLflow models with the
     "python_function" ("pyfunc") flavor, leveraging custom inference logic and artifact
     dependencies.
     """
+
+    __metaclass__ = ABCMeta
 
     def __new__(cls, *args, **kwargs):
         cls._warn_on_setting_model_in_init()

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -7,7 +7,6 @@ import inspect
 import logging
 import os
 import shutil
-import warnings
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -34,7 +33,7 @@ from mlflow.utils.environment import (
     _PythonEnv,
 )
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree, get_total_file_size, write_to
-from mlflow.utils.model_utils import _check_model_assignment_in_init, _get_flavor_configuration
+from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.utils.requirements_utils import _get_pinned_requirement
 
 CONFIG_KEY_ARTIFACTS = "artifacts"
@@ -83,33 +82,6 @@ class PythonModel:
     """
 
     __metaclass__ = ABCMeta
-
-    def __new__(cls, *args, **kwargs):
-        cls._warn_on_setting_model_in_init()
-        return super().__new__(cls)
-
-    @classmethod
-    def _warn_on_setting_model_in_init(cls):
-        try:
-            model_assigned = _check_model_assignment_in_init(cls)
-            if model_assigned and cls.load_context == PythonModel.load_context:
-                message = (
-                    "It looks like you're trying to save a model as an instance attribute. "
-                    "This is not recommended as it can cause problems with model serialization, "
-                    "especially for large models. Please use the `artifacts` parameter, "
-                    "and load your external model in the `load_context()` method instead.\n\n"
-                    "For example:\n\n"
-                    "class MyModel(mlflow.pyfunc.PythonModel):\n"
-                    "    def load_context(self, context):\n"
-                    "        model_path = context.artifacts['my_model_path']\n"
-                    "        // custom load logic here\n"
-                    "        self.model = load_model(model_path)\n"
-                )
-                warnings.warn(message, stacklevel=3)
-        except Exception:
-            # it's possible that inspect.getsource might fail, but since we
-            # just want to warn the user, we shouldn't throw an exception
-            pass
 
     def load_context(self, context):
         """

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -34,11 +34,13 @@ def _truncate_error(err: str, max_length: int = 10_000) -> str:
 
 
 @developer_stable
-class ArtifactRepository(metaclass=ABCMeta):
+class ArtifactRepository:
     """
     Abstract artifact repo that defines how to upload (log) and download potentially large
     artifacts from different storage backends.
     """
+
+    __metaclass__ = ABCMeta
 
     def __init__(self, artifact_uri):
         self.artifact_uri = artifact_uri

--- a/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
+++ b/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
@@ -11,7 +11,9 @@ from mlflow.store._unity_catalog.registry.utils import (
     get_full_name_from_sc,
 )
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
-from mlflow.store.artifact.utils.models import get_model_name_and_version
+from mlflow.store.artifact.utils.models import (
+    get_model_name_and_version,
+)
 from mlflow.utils._spark_utils import _get_active_spark_session
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.proto_json_utils import message_to_json
@@ -123,9 +125,6 @@ class UnityCatalogModelsArtifactRepository(ArtifactRepository):
 
     def log_artifacts(self, local_dir, artifact_path=None):
         raise MlflowException("This repository does not support logging artifacts.")
-
-    def _download_file(self, remote_file_path, local_path):
-        raise NotImplementedError("This artifact repository does not support downloading files")
 
     def delete_artifacts(self, artifact_path=None):
         raise NotImplementedError("This artifact repository does not support deleting artifacts")

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -14,10 +14,12 @@ AWAIT_MODEL_VERSION_CREATE_SLEEP_INTERVAL_SECONDS = 3
 
 
 @developer_stable
-class AbstractStore(metaclass=ABCMeta):
+class AbstractStore:
     """
     Abstract class that defines API interfaces for storing Model Registry metadata.
     """
+
+    __metaclass__ = ABCMeta
 
     def __init__(self, store_uri=None, tracking_uri=None):
         """

--- a/mlflow/store/model_registry/base_rest_store.py
+++ b/mlflow/store/model_registry/base_rest_store.py
@@ -9,10 +9,12 @@ from mlflow.utils.rest_utils import (
 
 
 @experimental
-class BaseRestStore(AbstractStore, metaclass=ABCMeta):  # pylint: disable=abstract-method
+class BaseRestStore(AbstractStore):  # pylint: disable=abstract-method
     """
     Base class client for a remote model registry server accessed via REST API calls
     """
+
+    __metaclass__ = ABCMeta
 
     def __init__(self, get_host_creds):
         super().__init__()

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -10,11 +10,13 @@ from mlflow.utils.async_logging.run_operations import RunOperations
 
 
 @developer_stable
-class AbstractStore(metaclass=ABCMeta):
+class AbstractStore:
     """
     Abstract class for Backend Storage.
     This class defines the API interface for front ends to connect with various types of backends.
     """
+
+    __metaclass__ = ABCMeta
 
     def __init__(self):
         """

--- a/mlflow/tracking/context/abstract_context.py
+++ b/mlflow/tracking/context/abstract_context.py
@@ -4,7 +4,7 @@ from mlflow.utils.annotations import developer_stable
 
 
 @developer_stable
-class RunContextProvider(metaclass=ABCMeta):
+class RunContextProvider:
     """
     Abstract base class for context provider objects specifying custom tags at run-creation time
     (e.g. tags specifying the git repo with which the run is associated).
@@ -14,6 +14,8 @@ class RunContextProvider(metaclass=ABCMeta):
     MLflow calls the ``tags`` method on the context provider to compute context tags for the run.
     All context tags are then merged together and set on the newly-created run.
     """
+
+    __metaclass__ = ABCMeta
 
     @abstractmethod
     def in_context(self):

--- a/mlflow/tracking/default_experiment/abstract_context.py
+++ b/mlflow/tracking/default_experiment/abstract_context.py
@@ -4,7 +4,7 @@ from mlflow.utils.annotations import developer_stable
 
 
 @developer_stable
-class DefaultExperimentProvider(metaclass=ABCMeta):
+class DefaultExperimentProvider:
     """
     Abstract base class for objects that provide the ID of an MLflow Experiment based on the
     current client context. For example, when the MLflow client is running in a Databricks Job,
@@ -17,6 +17,8 @@ class DefaultExperimentProvider(metaclass=ABCMeta):
     ``in_context()`` method returns ``True``; MLflow then calls the provider's
     ``get_experiment_id()`` method and uses the resulting experiment ID for Tracking operations.
     """
+
+    __metaclass__ = ABCMeta
 
     @abstractmethod
     def in_context(self):

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -23,7 +23,7 @@ class UnsupportedModelRegistryStoreURIException(MlflowException):
         self.supported_uri_schemes = supported_uri_schemes
 
 
-class StoreRegistry(metaclass=ABCMeta):
+class StoreRegistry:
     """
     Abstract class defining a scheme-based registry for store implementations.
 
@@ -37,6 +37,8 @@ class StoreRegistry(metaclass=ABCMeta):
     select which implementation to instantiate, which will be called with same
     arguments passed to the `get_store` method.
     """
+
+    __metaclass__ = ABCMeta
 
     @abstractmethod
     def __init__(self, group_name):

--- a/mlflow/tracking/request_header/abstract_request_header_provider.py
+++ b/mlflow/tracking/request_header/abstract_request_header_provider.py
@@ -4,7 +4,7 @@ from mlflow.utils.annotations import developer_stable
 
 
 @developer_stable
-class RequestHeaderProvider(metaclass=ABCMeta):
+class RequestHeaderProvider:
     """
     Abstract base class for specifying custom request headers to add to outgoing requests
     (e.g. request headers specifying the environment from which mlflow is running).
@@ -15,6 +15,8 @@ class RequestHeaderProvider(metaclass=ABCMeta):
 
     All resulting request headers will then be merged together and sent with the request.
     """
+
+    __metaclass__ = ABCMeta
 
     @abstractmethod
     def in_context(self):

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -1,9 +1,6 @@
-import ast
-import inspect
 import json
 import os
 import sys
-import textwrap
 from typing import Any, Dict
 
 from mlflow.exceptions import MlflowException
@@ -266,31 +263,3 @@ def _validate_pyfunc_model_config(model_config):
             "Values in the provided ``model_config`` are of an unsupported type. Only "
             "JSON-serializable data types can be provided as values."
         )
-
-
-def _check_model_assignment_in_init(cls):
-    """
-    Checks for the presence of `self.model = <something>` in the init method
-    of a class. Intended to be used `PythonModel` to encourage best practices
-    when declaring pyfunc models.
-    """
-    cls_init_source = textwrap.dedent(inspect.getsource(cls.__init__))
-
-    class ModelAssignVisitor(ast.NodeVisitor):
-        def __init__(self):
-            self.has_model = False
-
-        def visit_Assign(self, node):
-            if (
-                isinstance(node.targets[0], ast.Attribute)
-                and node.targets[0].attr == "model"
-                and isinstance(node.targets[0].value, ast.Name)
-                and node.targets[0].value.id == "self"
-            ):
-                self.has_model = True
-
-    visitor = ModelAssignVisitor()
-    tree = ast.parse(cls_init_source)
-    visitor.visit(tree)
-
-    return visitor.has_model

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -30,8 +30,12 @@ from mlflow.models.model import _DATABRICKS_FS_LOADER_MODULE
 from mlflow.models.utils import _read_example
 from mlflow.pyfunc.model import _load_pyfunc
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
-from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.tracking.artifact_utils import get_artifact_uri as utils_get_artifact_uri
+from mlflow.tracking.artifact_utils import (
+    _download_artifact_from_uri,
+)
+from mlflow.tracking.artifact_utils import (
+    get_artifact_uri as utils_get_artifact_uri,
+)
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -1083,11 +1087,6 @@ def test_save_and_load_model_with_special_chars(
     )
 
 
-class TestPythonModel(mlflow.pyfunc.PythonModel):
-    def predict(self, context, model_input, params=None):
-        raise NotImplementedError("This model used to test the PythonModel API")
-
-
 def test_model_with_code_path_containing_main(tmp_path):
     """Test that the __main__ module is unaffected by model loading"""
     directory = tmp_path.joinpath("model_with_main")
@@ -1097,7 +1096,7 @@ def test_model_with_code_path_containing_main(tmp_path):
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model(
             artifact_path="model",
-            python_model=TestPythonModel(),
+            python_model=mlflow.pyfunc.model.PythonModel(),
             code_path=[str(directory)],
         )
 
@@ -1112,7 +1111,7 @@ def test_model_save_load_with_metadata(tmp_path):
     mlflow.pyfunc.save_model(
         path=pyfunc_model_path,
         conda_env=_conda_env(),
-        python_model=TestPythonModel(),
+        python_model=mlflow.pyfunc.model.PythonModel(),
         metadata={"metadata_key": "metadata_value"},
     )
 
@@ -1125,7 +1124,7 @@ def test_model_log_with_metadata():
     with mlflow.start_run():
         mlflow.pyfunc.log_model(
             artifact_path=pyfunc_artifact_path,
-            python_model=TestPythonModel(),
+            python_model=mlflow.pyfunc.model.PythonModel(),
             metadata={"metadata_key": "metadata_value"},
         )
         pyfunc_model_uri = f"runs:/{mlflow.active_run().info.run_id}/{pyfunc_artifact_path}"

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
+import tempfile
 import uuid
 from subprocess import PIPE, Popen
 from typing import Any, Dict, List, Tuple
@@ -18,6 +20,7 @@ import sklearn.datasets
 import sklearn.linear_model
 import sklearn.neighbors
 import yaml
+from packaging.version import Version
 
 import mlflow
 import mlflow.pyfunc
@@ -39,6 +42,7 @@ from mlflow.tracking.artifact_utils import (
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
+from mlflow.utils.os import is_windows
 
 import tests
 from tests.helper_functions import (
@@ -1464,3 +1468,88 @@ def test_load_model_fails_for_feature_store_models(tmp_path):
         MlflowException, match="mlflow.pyfunc.load_model is not supported for Feature Store models"
     ):
         mlflow.pyfunc.load_model(f"runs:/{run.info.run_id}/model")
+
+
+# NOTE: This is a stop-gap measure to ensure that we have corrected the condition of the
+# regression introduced in 2.9.0 release.
+# After release, we should replace this test with a more permanent and resilient solution.
+def run_command(command, env):
+    subprocess.run(command, shell=True, check=True, env=env)
+
+
+@pytest.fixture
+def mlflow_env():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        env_name = os.path.join(tmp_dir, "mlflow_test_env")
+        run_command(f"python -m venv {env_name}", os.environ.copy())
+
+        yield env_name
+
+
+@pytest.mark.skipif(is_windows(), reason="This test is not Windows compatible")
+def test_mlflow_backward_compatibility(tmp_path):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        cloudpickle_version = cloudpickle.__version__
+        env_vars = os.environ.copy()
+        env_name = os.path.join(tmp_dir, "mlflow_test_env")
+        python_executable = os.path.join(env_name, "bin", "python")
+        activate_script = os.path.join(env_name, "bin", "activate")
+
+        # Create and activate the virtual environment
+        run_command(f"python -m venv {env_name}", env_vars)
+
+        run_command(
+            f"{python_executable} -m pip install -U mlflow cloudpickle=={cloudpickle_version}",
+            env_vars,
+        )
+
+        model_save_path = tmp_path / "test_model"
+        model_path = str(model_save_path)
+
+        # Prepare the Python script
+        model_logging_script = f"""
+import mlflow
+
+mlflow.set_experiment("Backwards Test")
+
+class TestModel(mlflow.pyfunc.PythonModel):
+    def predict(self, context, model_input):
+        return model_input
+
+mlflow.pyfunc.save_model(
+    path='{model_path}',
+    python_model=TestModel(),
+    pip_requirements=['cloudpickle=={cloudpickle_version}']
+)
+"""
+
+        # Write the script to a temporary file
+        script_path = tmp_path / "model_logging_script.py"
+        script_path.write_text(model_logging_script)
+
+        shell_script = f"""
+        #!/bin/bash
+        source {activate_script}
+        {python_executable} {script_path}
+        """
+
+        # Write the shell script to a temporary file
+        shell_script_path = tmp_path / "run_model_logging.sh"
+        shell_script_path.write_text(shell_script)
+        run_command(f"chmod +x {shell_script_path}", env_vars)
+
+        # Clear out the python path so that the subprocess doesn't attempt to use the
+        # pytest environment
+        env_vars["PYTHONPATH"] = ""
+        # Run the shell script
+        run_command(str(shell_script_path), env_vars)
+
+    model = mlflow.pyfunc.load_model(model_path)
+
+    assert model is not None
+
+    mlmodel_file = yaml.safe_load(model_save_path.joinpath("MLmodel").read_bytes())
+
+    logged_mlflow_version = Version(mlmodel_file["mlflow_version"])
+    assert logged_mlflow_version < Version(mlflow.__version__)
+    assert not logged_mlflow_version.is_devrelease

--- a/tests/pyfunc/test_pyfunc_model_config.py
+++ b/tests/pyfunc/test_pyfunc_model_config.py
@@ -91,37 +91,3 @@ def test_pyfunc_loader_without_model_config(model_path):
     pyfunc_model = mlflow.pyfunc.load_model(model_path, model_config=inference_override)
 
     assert not pyfunc_model.model_config
-
-
-def test_pyfunc_warn_on_model_assignment_no_context(model_path):
-    # should warn on self.model assignment in __init__
-    # if load_context is not overridden
-    class MyModelBad(mlflow.pyfunc.PythonModel):
-        def __init__(self, llm):
-            self.model = llm
-
-        def predict(self, context, model_input, params=None):
-            return model_input
-
-    msg = "It looks like you're trying to save a model"
-    with pytest.warns(UserWarning, match=msg):
-        MyModelBad(1)
-
-
-def test_pyfunc_no_warn_on_model_assignment_with_context(model_path):
-    # don't warn on model assignment if users override load_context
-    class MyModelGood(mlflow.pyfunc.PythonModel):
-        def __init__(self):
-            self.model = None
-
-        def load_context(self, context):
-            self.model = "gpt4"
-
-        def predict(self, context, model_input, params=None):
-            return model_input
-
-    with pytest.warns(None) as record:
-        MyModelGood()
-
-    # assert no warnings
-    assert not record


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/10626?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10626/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10626
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Revert #10509 and #10435 due to incompatibilities with pyfunc cloudpickle loading mechanism. 

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

Verified that:

on current 2.9.0 release:

Saving as pyfunc and loading works.
Saving a pyfunc in 2.8.0 and attempting to load in 2.9.0 results in the following stack trace:

```
TypeError                                 Traceback (most recent call last)
<command-2462680315737415> in <module>
      1 # Load a model from MLflow 2.8.0
      2 import mlflow
----> 3 mlflow.pyfunc.load_model("models:/colton_model3/2") #model saved with 2.8.0

/local_disk0/.ephemeral_nfs/envs/pythonEnv-57863628-bd0a-49fd-bb96-f60fb3476e98/lib/python3.8/site-packages/mlflow/pyfunc/__init__.py in load_model(model_uri, suppress_warnings, dst_path, model_config)
    678             model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path, model_config)
    679         else:
--> 680             model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
    681     except ModuleNotFoundError as e:
    682         if conf[MAIN] == _DATABRICKS_FS_LOADER_MODULE:

/local_disk0/.ephemeral_nfs/envs/pythonEnv-57863628-bd0a-49fd-bb96-f60fb3476e98/lib/python3.8/site-packages/mlflow/pyfunc/model.py in _load_pyfunc(model_path, model_config)
    409         raise MlflowException("Python model path was not specified in the model configuration")
    410     with open(os.path.join(model_path, python_model_subpath), "rb") as f:
--> 411         python_model = cloudpickle.load(f)
    412 
```

Reverting these two PRs allow for saving / loading older models. Each reversion independently causes a different failure mechanism.

Reverting only #10435 [`git+https://github.com/BenWilson2/mlflow.git@revert-10435`] (while retaining the changes in #10509) results in:
For attempting to load an older model version from MLflow 2.8.0

```
TypeError: Can't instantiate abstract class MyPyfunc with abstract methods predict
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<command-2462680315737421> in <module>
----> 1 mlflow.pyfunc.load_model("models:/colton_model3/2")

/local_disk0/.ephemeral_nfs/envs/pythonEnv-57863628-bd0a-49fd-bb96-f60fb3476e98/lib/python3.8/site-packages/mlflow/pyfunc/__init__.py in load_model(model_uri, suppress_warnings, dst_path, model_config)
    678             model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path, model_config)
    679         else:
--> 680             model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
    681     except ModuleNotFoundError as e:
    682         if conf[MAIN] == _DATABRICKS_FS_LOADER_MODULE:

/local_disk0/.ephemeral_nfs/envs/pythonEnv-57863628-bd0a-49fd-bb96-f60fb3476e98/lib/python3.8/site-packages/mlflow/pyfunc/model.py in _load_pyfunc(model_path, model_config)
    381         raise MlflowException("Python model path was not specified in the model configuration")
    382     with open(os.path.join(model_path, python_model_subpath), "rb") as f:
--> 383         python_model = cloudpickle.load(f)
    384 
    385     artifacts = {}
```

While reverting only #10509 [`git+https://github.com/BenWilson2/mlflow.git@revert-10509`]results in:
When trying to load a model saved in MLflow 2.8.0

```
TypeError: Can't instantiate abstract class MyPyfunc with abstract methods predict
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<command-2462680315737475> in <module>
----> 1 mlflow.pyfunc.load_model("models:/colton_model3/2")

/local_disk0/.ephemeral_nfs/envs/pythonEnv-57863628-bd0a-49fd-bb96-f60fb3476e98/lib/python3.8/site-packages/mlflow/pyfunc/__init__.py in load_model(model_uri, suppress_warnings, dst_path, model_config)
    678             model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path, model_config)
    679         else:
--> 680             model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
    681     except ModuleNotFoundError as e:
    682         if conf[MAIN] == _DATABRICKS_FS_LOADER_MODULE:

/local_disk0/.ephemeral_nfs/envs/pythonEnv-57863628-bd0a-49fd-bb96-f60fb3476e98/lib/python3.8/site-packages/mlflow/pyfunc/model.py in _load_pyfunc(model_path, model_config)
    381         raise MlflowException("Python model path was not specified in the model configuration")
    382     with open(os.path.join(model_path, python_model_subpath), "rb") as f:
--> 383         python_model = cloudpickle.load(f)
    384 
    385     artifacts = {}
```


### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Revert a critical bug that was introduced in MLflow 2.9.0 regarding loading of pyfunc models from any earlier version of MLflow

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
