### PR TITLE
Make MPU / MPD chunk size configurable via environment variables

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -483,7 +483,13 @@ MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE = _EnvironmentVariable(
 )
 
 #: Specifies the chunk size in bytes to use when performing multipart upload
-#: (default: ``104_857_600`` (100 MB))
+#: (default: ``104_857_60`` (10 MB))
 MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE = _EnvironmentVariable(
-    "MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE", int, 100 * 1024**2
+    "MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE", int, 10 * 1024**2
+)
+
+#: Specifies the chunk size in bytes to use when performing multipart download
+#: (default: ``104_857_600`` (100 MB))
+MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE = _EnvironmentVariable(
+    "MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE", int, 100 * 1024**2
 )

--- a/mlflow/store/artifact/cloud_artifact_repo.py
+++ b/mlflow/store/artifact/cloud_artifact_repo.py
@@ -9,6 +9,9 @@ from concurrent.futures import as_completed
 from mlflow.environment_variables import (
     MLFLOW_ENABLE_ARTIFACTS_PROGRESS_BAR,
     MLFLOW_ENABLE_MULTIPART_DOWNLOAD,
+    MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE,
+    MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE,
+    MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
@@ -23,9 +26,6 @@ from mlflow.utils.file_utils import (
 from mlflow.utils.uri import is_fuse_or_uc_volumes_uri
 
 _logger = logging.getLogger(__name__)
-_DOWNLOAD_CHUNK_SIZE = 100_000_000  # 100 MB
-_MULTIPART_DOWNLOAD_MINIMUM_FILE_SIZE = 500_000_000  # 500 MB
-_MULTIPART_UPLOAD_CHUNK_SIZE = 10_000_000  # 10 MB
 _ARTIFACT_UPLOAD_BATCH_SIZE = (
     50  # Max number of artifacts for which to fetch write credentials at once.
 )
@@ -51,7 +51,7 @@ def _complete_futures(futures_dict, file):
     with ArtifactProgressBar.chunks(
         os.path.getsize(file),
         f"Uploading {file}",
-        _MULTIPART_UPLOAD_CHUNK_SIZE,
+        MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get(),
     ) as pbar:
         for future in as_completed(futures_dict):
             key = futures_dict[future]
@@ -207,7 +207,7 @@ class CloudArtifactRepository(ArtifactRepository):
                 remote_file_path=remote_file_path,
                 file_size=file_size,
                 uri_type=cloud_credential_info.type,
-                chunk_size=_DOWNLOAD_CHUNK_SIZE,
+                chunk_size=MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE.get(),
                 env=parallel_download_subproc_env,
                 headers=self._extract_headers_from_credentials(cloud_credential_info.headers),
             )
@@ -239,7 +239,7 @@ class CloudArtifactRepository(ArtifactRepository):
         if (
             not MLFLOW_ENABLE_MULTIPART_DOWNLOAD.get()
             or not file_size
-            or file_size < _MULTIPART_DOWNLOAD_MINIMUM_FILE_SIZE
+            or file_size < MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE.get()
             or is_fuse_or_uc_volumes_uri(local_path)
         ):
             self._download_from_cloud(remote_file_path, local_path)

--- a/mlflow/store/artifact/cloud_artifact_repo.py
+++ b/mlflow/store/artifact/cloud_artifact_repo.py
@@ -9,8 +9,8 @@ from concurrent.futures import as_completed
 from mlflow.environment_variables import (
     MLFLOW_ENABLE_ARTIFACTS_PROGRESS_BAR,
     MLFLOW_ENABLE_MULTIPART_DOWNLOAD,
-    MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE,
     MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE,
+    MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE,
     MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE,
 )
 from mlflow.exceptions import MlflowException

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -16,8 +16,8 @@ from mlflow.azure.client import (
 )
 from mlflow.entities import FileInfo
 from mlflow.environment_variables import (
-    MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE,
     MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE,
+    MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_artifacts_pb2 import (

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -250,7 +250,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
             futures = {}
             num_chunks = _compute_num_chunks(local_file, MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get())
             for index in range(num_chunks):
-                start_byte = index * MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.ge()
+                start_byte = index * MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get()
                 future = self.chunk_thread_pool.submit(
                     self._azure_upload_chunk,
                     credentials=credentials,

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -15,6 +15,10 @@ from mlflow.azure.client import (
     put_block_list,
 )
 from mlflow.entities import FileInfo
+from mlflow.environment_variables import (
+    MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE,
+    MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE,
+)
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_artifacts_pb2 import (
     ArtifactCredentialType,
@@ -32,8 +36,6 @@ from mlflow.protos.databricks_pb2 import (
 )
 from mlflow.protos.service_pb2 import GetRun, ListArtifacts, MlflowService
 from mlflow.store.artifact.cloud_artifact_repo import (
-    _DOWNLOAD_CHUNK_SIZE,
-    _MULTIPART_UPLOAD_CHUNK_SIZE,
     CloudArtifactRepository,
     _complete_futures,
     _compute_num_chunks,
@@ -246,9 +248,9 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
         try:
             headers = self._extract_headers_from_credentials(credentials.headers)
             futures = {}
-            num_chunks = _compute_num_chunks(local_file, _MULTIPART_UPLOAD_CHUNK_SIZE)
+            num_chunks = _compute_num_chunks(local_file, MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get())
             for index in range(num_chunks):
-                start_byte = index * _MULTIPART_UPLOAD_CHUNK_SIZE
+                start_byte = index * MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.ge()
                 future = self.chunk_thread_pool.submit(
                     self._azure_upload_chunk,
                     credentials=credentials,
@@ -256,7 +258,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
                     local_file=local_file,
                     artifact_file_path=artifact_file_path,
                     start_byte=start_byte,
-                    size=_MULTIPART_UPLOAD_CHUNK_SIZE,
+                    size=MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get(),
                 )
                 futures[future] = index
 
@@ -319,10 +321,10 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
             # next try to append the file
             futures = {}
             file_size = os.path.getsize(local_file)
-            num_chunks = _compute_num_chunks(local_file, _MULTIPART_UPLOAD_CHUNK_SIZE)
+            num_chunks = _compute_num_chunks(local_file, MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get())
             use_single_part_upload = num_chunks == 1
             for index in range(num_chunks):
-                start_byte = index * _MULTIPART_UPLOAD_CHUNK_SIZE
+                start_byte = index * MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get()
                 future = self.chunk_thread_pool.submit(
                     self._retryable_adls_function,
                     func=patch_adls_file_upload,
@@ -330,7 +332,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
                     sas_url=credentials.signed_uri,
                     local_file=local_file,
                     start_byte=start_byte,
-                    size=_MULTIPART_UPLOAD_CHUNK_SIZE,
+                    size=MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get(),
                     position=start_byte,
                     headers=headers,
                     is_single=use_single_part_upload,
@@ -392,7 +394,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
                 cloud_credential_info, src_file_path, artifact_file_path
             )
         elif cloud_credential_info.type == ArtifactCredentialType.AWS_PRESIGNED_URL:
-            if os.path.getsize(src_file_path) > _MULTIPART_UPLOAD_CHUNK_SIZE:
+            if os.path.getsize(src_file_path) > MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get():
                 self._multipart_upload(src_file_path, artifact_file_path)
             else:
                 self._signed_url_upload_file(cloud_credential_info, src_file_path)
@@ -431,7 +433,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
             download_file_using_http_uri(
                 cloud_credential_info.signed_uri,
                 local_path,
-                _DOWNLOAD_CHUNK_SIZE,
+                MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE.get(),
                 self._extract_headers_from_credentials(cloud_credential_info.headers),
             )
         except Exception as err:
@@ -486,7 +488,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
         futures = {}
         for index, cred_info in enumerate(create_mpu_resp.upload_credential_infos):
             part_number = index + 1
-            start_byte = index * _MULTIPART_UPLOAD_CHUNK_SIZE
+            start_byte = index * MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get()
             future = self.chunk_thread_pool.submit(
                 self._upload_part_retry,
                 cred_info=cred_info,
@@ -494,7 +496,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
                 part_number=part_number,
                 local_file=local_file,
                 start_byte=start_byte,
-                size=_MULTIPART_UPLOAD_CHUNK_SIZE,
+                size=MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get(),
             )
             futures[future] = part_number
 
@@ -535,7 +537,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
         run_relative_artifact_path = posixpath.join(
             self.run_relative_artifact_repo_root_path, artifact_file_path or ""
         )
-        num_parts = _compute_num_chunks(local_file, _MULTIPART_UPLOAD_CHUNK_SIZE)
+        num_parts = _compute_num_chunks(local_file, MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get())
         create_mpu_resp = self._create_multipart_upload(
             self.run_id, run_relative_artifact_path, num_parts
         )

--- a/mlflow/store/artifact/optimized_s3_artifact_repo.py
+++ b/mlflow/store/artifact/optimized_s3_artifact_repo.py
@@ -9,8 +9,8 @@ from mimetypes import guess_type
 from mlflow.entities import FileInfo
 from mlflow.environment_variables import (
     MLFLOW_ENABLE_MULTIPART_UPLOAD,
-    MLFLOW_S3_UPLOAD_EXTRA_ARGS,
     MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE,
+    MLFLOW_S3_UPLOAD_EXTRA_ARGS,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialInfo

--- a/mlflow/store/artifact/optimized_s3_artifact_repo.py
+++ b/mlflow/store/artifact/optimized_s3_artifact_repo.py
@@ -10,11 +10,11 @@ from mlflow.entities import FileInfo
 from mlflow.environment_variables import (
     MLFLOW_ENABLE_MULTIPART_UPLOAD,
     MLFLOW_S3_UPLOAD_EXTRA_ARGS,
+    MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialInfo
 from mlflow.store.artifact.cloud_artifact_repo import (
-    _MULTIPART_UPLOAD_CHUNK_SIZE,
     CloudArtifactRepository,
     _complete_futures,
 )
@@ -127,7 +127,7 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
         key = posixpath.normpath(dest_path)
         if (
             MLFLOW_ENABLE_MULTIPART_UPLOAD.get()
-            and os.path.getsize(src_file_path) > _MULTIPART_UPLOAD_CHUNK_SIZE
+            and os.path.getsize(src_file_path) > MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get()
         ):
             self._multipart_upload(cloud_credential_info, src_file_path, self.bucket, key)
         else:
@@ -140,7 +140,9 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
         upload_id = response["UploadId"]
 
         # Create presigned URL for each part
-        num_parts = math.ceil(os.path.getsize(local_file) / _MULTIPART_UPLOAD_CHUNK_SIZE)
+        num_parts = math.ceil(
+            os.path.getsize(local_file) / MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get()
+        )
 
         # define helper functions for uploading data
         def _upload_part(part_number, local_file, start_byte, size):
@@ -163,13 +165,13 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
             futures = {}
             for index in range(num_parts):
                 part_number = index + 1
-                start_byte = index * _MULTIPART_UPLOAD_CHUNK_SIZE
+                start_byte = index * MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get()
                 future = self.chunk_thread_pool.submit(
                     _upload_part,
                     part_number=part_number,
                     local_file=local_file,
                     start_byte=start_byte,
-                    size=_MULTIPART_UPLOAD_CHUNK_SIZE,
+                    size=MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get(),
                 )
                 futures[future] = part_number
 

--- a/tests/store/artifact/test_azure_data_lake_artifact_repo.py
+++ b/tests/store/artifact/test_azure_data_lake_artifact_repo.py
@@ -228,7 +228,7 @@ def test_log_artifacts_in_parallel_when_necessary(tmp_path, monkeypatch):
 
 @pytest.mark.parametrize(
     ("file_size", "is_parallel_download"),
-    [(None, False), (100, False), (499_999_999, False), (500_000_000, True)],
+    [(None, False), (100, False), (500 * 1024**2 - 1, False), (500 * 1024**2, True)],
 )
 def test_download_file_in_parallel_when_necessary(file_size, is_parallel_download):
     repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, None)

--- a/tests/store/artifact/test_azure_data_lake_artifact_repo.py
+++ b/tests/store/artifact/test_azure_data_lake_artifact_repo.py
@@ -201,7 +201,7 @@ def test_log_artifacts(mock_filesystem_client, mock_directory_client, tmp_path):
     mock_directory_client.get_file_client("subdir/empty-file.txt").create_file.assert_called()
 
 
-def test_log_artifacts_in_parallel_when_necessary(tmp_path):
+def test_log_artifacts_in_parallel_when_necessary(tmp_path, monkeypatch):
     fake_sas_token = "fake_session_token"
     repo = AzureDataLakeArtifactRepository(TEST_DATA_LAKE_URI, AzureSasCredential(fake_sas_token))
 
@@ -209,7 +209,8 @@ def test_log_artifacts_in_parallel_when_necessary(tmp_path):
     parentd.mkdir()
     parentd.joinpath("a.txt").write_text("ABCDE")
 
-    with mock.patch(f"{ADLS_REPOSITORY_PACKAGE}._MULTIPART_UPLOAD_CHUNK_SIZE", 0), mock.patch(
+    monkeypatch.setenv("MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE", "0")
+    with mock.patch(
         f"{ADLS_ARTIFACT_REPOSITORY}._multipart_upload", return_value=None
     ) as multipart_upload_mock, mock.patch(
         f"{ADLS_ARTIFACT_REPOSITORY}.log_artifact", return_value=None

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -1225,6 +1225,7 @@ def mock_chunk_size(monkeypatch):
     # Use a smaller chunk size for faster comparison
     monkeypatch.setenv("MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE", "10")
 
+
 @pytest.fixture
 def large_file(tmp_path, mock_chunk_size):
     path = tmp_path.joinpath("large_file")

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -972,7 +972,7 @@ def test_databricks_download_file_with_relative_path(remote_file_path, local_pat
 
 @pytest.mark.parametrize(
     ("file_size", "is_parallel_download"),
-    [(None, False), (100, False), (499_999_999, False), (500_000_000, True)],
+    [(None, False), (100, False), (500 * 1024**2 - 1, False), (500 * 1024**2, True)],
 )
 def test_databricks_download_file_in_parallel_when_necessary(
     databricks_artifact_repo, file_size, is_parallel_download

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -307,7 +307,7 @@ def test_log_artifact_adls_gen2(
 
 @pytest.mark.parametrize(("artifact_path", "expected_location"), [(None, "test.txt")])
 def test_log_artifact_adls_gen2_with_headers(
-    databricks_artifact_repo, test_file, artifact_path, expected_location
+    databricks_artifact_repo, test_file, artifact_path, expected_location, monkeypatch
 ):
     mock_azure_headers = {
         "x-ms-content-type": "test-type",
@@ -329,15 +329,13 @@ def test_log_artifact_adls_gen2_with_headers(
             for header_name, header_value in mock_azure_headers.items()
         ],
     )
+    monkeypatch.setenv("MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE", "5")
     with mock.patch(
         f"{DATABRICKS_ARTIFACT_REPOSITORY}._get_credential_infos",
         return_value=[mock_credential_info],
     ) as get_credential_infos_mock, mock.patch(
         "requests.Session.request", return_value=mock_response
-    ) as request_mock, mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}._MULTIPART_UPLOAD_CHUNK_SIZE",
-        5,
-    ):
+    ) as request_mock:
         databricks_artifact_repo.log_artifact(test_file, artifact_path)
         get_credential_infos_mock.assert_called_with(
             GetCredentialsForWrite, MOCK_RUN_ID, [expected_location]
@@ -1223,14 +1221,9 @@ def test_log_artifacts_provides_failure_info(databricks_artifact_repo, tmp_path)
 
 
 @pytest.fixture
-def mock_chunk_size():
+def mock_chunk_size(monkeypatch):
     # Use a smaller chunk size for faster comparison
-    chunk_size = 10
-    with mock.patch(
-        f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}._MULTIPART_UPLOAD_CHUNK_SIZE", chunk_size
-    ):
-        yield chunk_size
-
+    monkeypatch.setenv("MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE", "10")
 
 @pytest.fixture
 def large_file(tmp_path, mock_chunk_size):

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -1223,7 +1223,9 @@ def test_log_artifacts_provides_failure_info(databricks_artifact_repo, tmp_path)
 @pytest.fixture
 def mock_chunk_size(monkeypatch):
     # Use a smaller chunk size for faster comparison
-    monkeypatch.setenv("MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE", "10")
+    chunk_size = 10
+    monkeypatch.setenv("MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE", str(chunk_size))
+    return chunk_size
 
 
 @pytest.fixture

--- a/tests/store/artifact/test_databricks_models_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_models_artifact_repo.py
@@ -5,11 +5,11 @@ from unittest.mock import ANY
 import pytest
 
 from mlflow import MlflowClient
+from mlflow.environment_variables import MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE
 from mlflow.entities import FileInfo
 from mlflow.entities.model_registry import ModelVersion
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.databricks_models_artifact_repo import (
-    _DOWNLOAD_CHUNK_SIZE,
     DatabricksModelsArtifactRepository,
 )
 from mlflow.utils.file_utils import _Chunk
@@ -270,7 +270,9 @@ def test_parallelized_download_file_using_http_uri_succcess(
 
     with mock.patch(
         DATABRICKS_MODEL_ARTIFACT_REPOSITORY + ".list_artifacts",
-        return_value=[FileInfo(remote_file_path, True, _DOWNLOAD_CHUNK_SIZE + 1)],
+        return_value=[
+            FileInfo(remote_file_path, True, MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE.get() + 1)
+        ],
     ), mock.patch(
         DATABRICKS_MODEL_ARTIFACT_REPOSITORY + "._get_signed_download_uri",
         return_value=(signed_uri_mock["signed_uri"], signed_uri_mock["headers"]),
@@ -303,7 +305,9 @@ def test_parallelized_download_file_using_http_uri_with_error_downloads(
 
     with mock.patch(
         DATABRICKS_MODEL_ARTIFACT_REPOSITORY + ".list_artifacts",
-        return_value=[FileInfo(remote_file_path, True, _DOWNLOAD_CHUNK_SIZE + 1)],
+        return_value=[
+            FileInfo(remote_file_path, True, MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE.get() + 1)
+        ],
     ), mock.patch(
         DATABRICKS_MODEL_ARTIFACT_REPOSITORY + "._get_signed_download_uri",
         return_value=(signed_uri_mock["signed_uri"], signed_uri_mock["headers"]),
@@ -346,7 +350,9 @@ def test_parallelized_download_file_using_http_uri_with_failed_downloads(
 
     with mock.patch(
         DATABRICKS_MODEL_ARTIFACT_REPOSITORY + ".list_artifacts",
-        return_value=[FileInfo(remote_file_path, True, _DOWNLOAD_CHUNK_SIZE + 1)],
+        return_value=[
+            FileInfo(remote_file_path, True, MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE.get() + 1)
+        ],
     ), mock.patch(
         DATABRICKS_MODEL_ARTIFACT_REPOSITORY + "._get_signed_download_uri",
         return_value=(signed_uri_mock["signed_uri"], signed_uri_mock["headers"]),

--- a/tests/store/artifact/test_databricks_models_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_models_artifact_repo.py
@@ -5,9 +5,9 @@ from unittest.mock import ANY
 import pytest
 
 from mlflow import MlflowClient
-from mlflow.environment_variables import MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE
 from mlflow.entities import FileInfo
 from mlflow.entities.model_registry import ModelVersion
+from mlflow.environment_variables import MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.databricks_models_artifact_repo import (
     DatabricksModelsArtifactRepository,

--- a/tests/store/artifact/test_optimized_s3_artifact_repo.py
+++ b/tests/store/artifact/test_optimized_s3_artifact_repo.py
@@ -168,7 +168,7 @@ def test_log_artifacts_in_parallel_when_necessary(
 
 @pytest.mark.parametrize(
     ("file_size", "is_parallel_download"),
-    [(None, False), (100, False), (499_999_999, False), (500_000_000, True)],
+    [(None, False), (100, False), (500 * 1024**2 - 1, False), (500 * 1024**2, True)],
 )
 def test_download_file_in_parallel_when_necessary(
     s3_artifact_root, file_size, is_parallel_download

--- a/tests/store/artifact/test_optimized_s3_artifact_repo.py
+++ b/tests/store/artifact/test_optimized_s3_artifact_repo.py
@@ -147,7 +147,9 @@ def test_s3_creds_passed_to_client(s3_artifact_root):
         )
 
 
-def test_log_artifacts_in_parallel_when_necessary(s3_artifact_root, mock_s3_bucket, tmp_path):
+def test_log_artifacts_in_parallel_when_necessary(
+    s3_artifact_root, mock_s3_bucket, tmp_path, monkeypatch
+):
     repo = OptimizedS3ArtifactRepository(posixpath.join(s3_artifact_root, "some/path"))
 
     file_a_name = "a.txt"
@@ -156,7 +158,8 @@ def test_log_artifacts_in_parallel_when_necessary(s3_artifact_root, mock_s3_buck
     with open(file_a_path, "w") as f:
         f.write(file_a_text)
 
-    with mock.patch(f"{S3_REPOSITORY_MODULE}._MULTIPART_UPLOAD_CHUNK_SIZE", 0), mock.patch(
+    monkeypatch.setenv("MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE", "0")
+    with mock.patch(
         f"{S3_ARTIFACT_REPOSITORY}._multipart_upload", return_value=None
     ) as multipart_upload_mock:
         repo.log_artifacts(tmp_path)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10648?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10648/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10648
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Make MPU / MPD chunk size configurable via environment variables.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
