### PR TITLE
Fix local uri

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -266,15 +266,6 @@ MLFLOW_HUGGINGFACE_MODEL_MAX_SHARD_SIZE = _EnvironmentVariable(
     "MLFLOW_HUGGINGFACE_MODEL_MAX_SHARD_SIZE", str, "500MB"
 )
 
-#: Specifies whether or not to allow using a file URI as a model version source.
-#: Please be aware that setting this environment variable to True is potentially risky
-#: because it can allow access to arbitrary files on the specified filesystem
-#: (default: ``False``).
-MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE = _BooleanEnvironmentVariable(
-    "MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE", False
-)
-
-
 #: Specifies the name of the Databricks secret scope to use for storing OpenAI API keys.
 MLFLOW_OPENAI_SECRET_SCOPE = _EnvironmentVariable("MLFLOW_OPENAI_SECRET_SCOPE", str, None)
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -18,10 +18,7 @@ from google.protobuf.json_format import ParseError
 from mlflow.entities import DatasetInput, ExperimentTag, FileInfo, Metric, Param, RunTag, ViewType
 from mlflow.entities.model_registry import ModelVersionTag, RegisteredModelTag
 from mlflow.entities.multipart_upload import MultipartUploadPart
-from mlflow.environment_variables import (
-    MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE,
-    MLFLOW_DEPLOYMENTS_TARGET,
-)
+from mlflow.environment_variables import MLFLOW_DEPLOYMENTS_TARGET
 from mlflow.exceptions import MlflowException, _UnsupportedMultipartUploadException
 from mlflow.models import Model
 from mlflow.protos import databricks_pb2
@@ -105,7 +102,7 @@ from mlflow.utils.mime_type_utils import _guess_mime_type
 from mlflow.utils.promptlab_utils import _create_promptlab_run_impl
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.string_utils import is_string_type
-from mlflow.utils.uri import is_file_uri, is_local_uri, validate_path_is_safe, validate_query_string
+from mlflow.utils.uri import is_local_uri, validate_path_is_safe, validate_query_string
 from mlflow.utils.validation import _validate_batch_log_api_req
 
 _logger = logging.getLogger(__name__)
@@ -1601,18 +1598,6 @@ def _validate_source(source: str, run_id: str) -> None:
             f"Invalid model version source: '{source}'. To use a local path as a model version "
             "source, the run_id request parameter has to be specified and the local path has to be "
             "contained within the artifact directory of the run specified by the run_id.",
-            INVALID_PARAMETER_VALUE,
-        )
-
-    # There might be file URIs that are local but can bypass the above check. To prevent this, we
-    # disallow using file URIs as model version sources by default unless it's explicitly allowed
-    # by setting the MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE environment variable to True.
-    if not MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE.get() and is_file_uri(source):
-        raise MlflowException(
-            f"Invalid model version source: '{source}'. MLflow tracking server doesn't allow using "
-            "a file URI as a model version source for security reasons. To disable this check, set "
-            f"the {MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE} environment variable to "
-            "True.",
             INVALID_PARAMETER_VALUE,
         )
 

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -42,14 +42,24 @@ def is_local_uri(uri, is_tracking_or_registry_uri=True):
 
     parsed_uri = urllib.parse.urlparse(uri)
     scheme = parsed_uri.scheme
-    if scheme == "file" or scheme == "":
+    if scheme == "":
         return True
 
-    if parsed_uri.hostname and not (
+    is_remote_hostname = parsed_uri.hostname and not (
         parsed_uri.hostname == "."
         or parsed_uri.hostname.startswith("localhost")
         or parsed_uri.hostname.startswith("127.0.0.1")
-    ):
+    )
+    if scheme == "file":
+        if is_remote_hostname:
+            raise MlflowException(
+                f"{uri} is not a valid remote uri. For remote access "
+                "on windows, please consider using a different scheme "
+                "such as SMB (e.g. smb://<hostname>/<path>)."
+            )
+        return True
+
+    if is_remote_hostname:
         return False
 
     if is_windows() and len(scheme) == 1 and scheme.lower() == pathlib.Path(uri).drive.lower()[0]:

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -40,10 +40,11 @@ def is_local_uri(uri, is_tracking_or_registry_uri=True):
         # windows network drive path looks like: "\\<server name>\path\..."
         return False
 
+    if is_file_uri(uri):
+        return True
+
     parsed_uri = urllib.parse.urlparse(uri)
     scheme = parsed_uri.scheme
-    if scheme == "" or scheme == "file":
-        return True
 
     if parsed_uri.hostname and not (
         parsed_uri.hostname == "."

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -40,11 +40,10 @@ def is_local_uri(uri, is_tracking_or_registry_uri=True):
         # windows network drive path looks like: "\\<server name>\path\..."
         return False
 
-    if is_file_uri(uri):
-        return True
-
     parsed_uri = urllib.parse.urlparse(uri)
     scheme = parsed_uri.scheme
+    if scheme == "file" or scheme == "":
+        return True
 
     if parsed_uri.hostname and not (
         parsed_uri.hostname == "."
@@ -61,7 +60,7 @@ def is_local_uri(uri, is_tracking_or_registry_uri=True):
 
 def is_file_uri(uri):
     scheme = urllib.parse.urlparse(uri).scheme
-    return scheme == "file" or scheme == ""
+    return scheme == "file"
 
 
 def is_http_uri(uri):

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -42,7 +42,7 @@ def is_local_uri(uri, is_tracking_or_registry_uri=True):
 
     parsed_uri = urllib.parse.urlparse(uri)
     scheme = parsed_uri.scheme
-    if scheme == "":
+    if scheme == "" or scheme == "file":
         return True
 
     if parsed_uri.hostname and not (
@@ -52,9 +52,6 @@ def is_local_uri(uri, is_tracking_or_registry_uri=True):
     ):
         return False
 
-    if scheme == "file":
-        return True
-
     if is_windows() and len(scheme) == 1 and scheme.lower() == pathlib.Path(uri).drive.lower()[0]:
         return True
 
@@ -62,7 +59,8 @@ def is_local_uri(uri, is_tracking_or_registry_uri=True):
 
 
 def is_file_uri(uri):
-    return urllib.parse.urlparse(uri).scheme == "file"
+    scheme = urllib.parse.urlparse(uri).scheme
+    return scheme == "file" or scheme == ""
 
 
 def is_http_uri(uri):

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -8,7 +8,7 @@ import pytest
 
 import mlflow
 from mlflow.exceptions import MlflowException
-from mlflow.utils.file_utils import local_file_uri_to_path, mkdir, path_to_local_file_uri
+from mlflow.utils.file_utils import mkdir, path_to_local_file_uri
 from mlflow.utils.os import is_windows
 
 Artifact = namedtuple("Artifact", ["uri", "content"])
@@ -246,24 +246,4 @@ def test_log_artifact_windows_path_with_hostname(text_artifact):
             assert (
                 rf"{experiment_test_1_artifact_location}\{run.info.run_id}"
                 rf"\artifacts\{text_artifact.artifact_name}" == local_path
-            )
-
-    experiment_test_2_artifact_location = "file://my_server/my_path/my_sub_path"
-    experiment_test_2_id = mlflow.create_experiment(
-        "test_exp_e", experiment_test_2_artifact_location
-    )
-    with mlflow.start_run(experiment_id=experiment_test_2_id) as run:
-        with mock.patch("shutil.copy2") as copyfile_mock, mock.patch(
-            "os.path.exists", return_value=True
-        ) as exists_mock:
-            mlflow.log_artifact(text_artifact.artifact_path)
-            copyfile_mock.assert_called_once()
-            exists_mock.assert_called_once()
-            local_path = mlflow.artifacts.download_artifacts(
-                run_id=run.info.run_id, artifact_path=text_artifact.artifact_name
-            )
-            assert (
-                local_file_uri_to_path(experiment_test_2_artifact_location)
-                + rf"\{run.info.run_id}\artifacts\{text_artifact.artifact_name}"
-                == local_path
             )

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -2077,7 +2077,7 @@ def _assert_create_run_appends_to_artifact_uri_path_correctly(
     [
         (
             "\\my_server/my_path/my_sub_path",
-            "\\my_server/my_path/my_sub_path/{e}/{r}/artifacts",
+            "file:///{drive}my_server/my_path/my_sub_path/{e}/{r}/artifacts",
         ),
         ("path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}/{r}/artifacts"),
         ("/path/to/local/folder", "file:///{drive}path/to/local/folder/{e}/{r}/artifacts"),
@@ -2179,7 +2179,7 @@ def _assert_create_experiment_appends_to_artifact_uri_path_correctly(
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
-        ("\\my_server/my_path/my_sub_path", "\\my_server/my_path/my_sub_path/{e}"),
+        ("\\my_server/my_path/my_sub_path", "file:///{drive}my_server/my_path/my_sub_path/{e}"),
         ("path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}"),
         ("/path/to/local/folder", "file:///{drive}path/to/local/folder/{e}"),
         ("#path/to/local/folder?", "file://{cwd}/{e}#path/to/local/folder?"),

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -2076,8 +2076,8 @@ def _assert_create_run_appends_to_artifact_uri_path_correctly(
     ("input_uri", "expected_uri"),
     [
         (
-            "file://my_server/my_path/my_sub_path",
-            "file://my_server/my_path/my_sub_path/{e}/{r}/artifacts",
+            "\\my_server/my_path/my_sub_path",
+            "\\my_server/my_path/my_sub_path/{e}/{r}/artifacts",
         ),
         ("path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}/{r}/artifacts"),
         ("/path/to/local/folder", "file:///{drive}path/to/local/folder/{e}/{r}/artifacts"),
@@ -2179,7 +2179,7 @@ def _assert_create_experiment_appends_to_artifact_uri_path_correctly(
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
-        ("file://my_server/my_path/my_sub_path", "file://my_server/my_path/my_sub_path/{e}"),
+        ("\\my_server/my_path/my_sub_path", "\\my_server/my_path/my_sub_path/{e}"),
         ("path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}"),
         ("/path/to/local/folder", "file:///{drive}path/to/local/folder/{e}"),
         ("#path/to/local/folder?", "file://{cwd}/{e}#path/to/local/folder?"),

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -3738,7 +3738,7 @@ def _assert_create_experiment_appends_to_artifact_uri_path_correctly(
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
-        ("file://my_server/my_path/my_sub_path", "file://my_server/my_path/my_sub_path/{e}"),
+        ("\\my_server/my_path/my_sub_path", "\\my_server/my_path/my_sub_path/{e}"),
         ("path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}"),
         ("/path/to/local/folder", "file:///{drive}path/to/local/folder/{e}"),
         ("#path/to/local/folder?", "file://{cwd}/{e}#path/to/local/folder?"),
@@ -3841,8 +3841,8 @@ def _assert_create_run_appends_to_artifact_uri_path_correctly(
     ("input_uri", "expected_uri"),
     [
         (
-            "file://my_server/my_path/my_sub_path",
-            "file://my_server/my_path/my_sub_path/{e}/{r}/artifacts",
+            "\\my_server/my_path/my_sub_path",
+            "\\my_server/my_path/my_sub_path/{e}/{r}/artifacts",
         ),
         ("path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}/{r}/artifacts"),
         ("/path/to/local/folder", "file:///{drive}path/to/local/folder/{e}/{r}/artifacts"),

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -3738,7 +3738,7 @@ def _assert_create_experiment_appends_to_artifact_uri_path_correctly(
 @pytest.mark.parametrize(
     ("input_uri", "expected_uri"),
     [
-        ("\\my_server/my_path/my_sub_path", "\\my_server/my_path/my_sub_path/{e}"),
+        ("\\my_server/my_path/my_sub_path", "file:///{drive}my_server/my_path/my_sub_path/{e}"),
         ("path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}"),
         ("/path/to/local/folder", "file:///{drive}path/to/local/folder/{e}"),
         ("#path/to/local/folder?", "file://{cwd}/{e}#path/to/local/folder?"),
@@ -3842,7 +3842,7 @@ def _assert_create_run_appends_to_artifact_uri_path_correctly(
     [
         (
             "\\my_server/my_path/my_sub_path",
-            "\\my_server/my_path/my_sub_path/{e}/{r}/artifacts",
+            "file:///{drive}my_server/my_path/my_sub_path/{e}/{r}/artifacts",
         ),
         ("path/to/local/folder", "file://{cwd}/path/to/local/folder/{e}/{r}/artifacts"),
         ("/path/to/local/folder", "file:///{drive}path/to/local/folder/{e}/{r}/artifacts"),

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -1390,31 +1390,7 @@ def test_create_model_version_with_file_uri(mlflow_client):
         },
     )
     assert response.status_code == 400
-    assert "MLflow tracking server doesn't allow" in response.json()["message"]
-
-
-def test_create_model_version_with_file_uri_env_var(tmp_path):
-    backend_uri = tmp_path.joinpath("file").as_uri()
-    with _init_server(
-        backend_uri,
-        root_artifact_uri=tmp_path.as_uri(),
-        extra_env={"MLFLOW_ALLOW_FILE_URI_AS_MODEL_VERSION_SOURCE": "true"},
-    ) as url:
-        mlflow_client = MlflowClient(url)
-
-        name = "test"
-        mlflow_client.create_registered_model(name)
-        exp_id = mlflow_client.create_experiment("test")
-        run = mlflow_client.create_run(experiment_id=exp_id)
-        response = requests.post(
-            f"{mlflow_client.tracking_uri}/api/2.0/mlflow/model-versions/create",
-            json={
-                "name": name,
-                "source": "file://123.456.789.123/path/to/source",
-                "run_id": run.info.run_id,
-            },
-        )
-        assert response.status_code == 200
+    assert "To use a local path as a model version" in response.json()["message"]
 
 
 def test_logging_model_with_local_artifact_uri(mlflow_client):

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -1389,8 +1389,8 @@ def test_create_model_version_with_file_uri(mlflow_client):
             "run_id": run.info.run_id,
         },
     )
-    assert response.status_code == 400
-    assert "To use a local path as a model version" in response.json()["message"]
+    assert response.status_code == 500, response.json()
+    assert "is not a valid remote uri" in response.json()["message"]
 
 
 def test_logging_model_with_local_artifact_uri(mlflow_client):

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -340,7 +340,6 @@ def test_handle_readonly_on_windows(tmp_path):
 @pytest.mark.parametrize(
     ("input_uri", "expected_path"),
     [
-        ("file://my_server/my_path/my_sub_path", r"\\my_server\my_path\my_sub_path"),
         (r"\\my_server\my_path\my_sub_path", r"\\my_server\my_path\my_sub_path"),
     ],
 )

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -100,10 +100,10 @@ def test_is_local_uri():
     assert is_local_uri("file://localhost:5000/mlruns")
     assert is_local_uri("file://127.0.0.1/mlruns")
     assert is_local_uri("file://127.0.0.1:5000/mlruns")
+    assert is_local_uri("file://myhostname/path/to/file")
     assert is_local_uri("//proc/self/root")
     assert is_local_uri("/proc/self/root")
 
-    assert not is_local_uri("file://myhostname/path/to/file")
     assert not is_local_uri("https://whatever")
     assert not is_local_uri("http://whatever")
     assert not is_local_uri("databricks")

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -684,7 +684,7 @@ def _assert_resolve_uri_if_local(input_uri, expected_uri):
     [
         ("my/path", "{cwd}/my/path"),
         ("#my/path?a=b", "{cwd}/#my/path?a=b"),
-        ("file://myhostname/my/path", "file://myhostname/my/path"),
+        ("file://localhost/my/path", "file://localhost/my/path"),
         ("file:///my/path", "file:///{drive}my/path"),
         ("file:my/path", "file://{cwd}/my/path"),
         ("/home/my/path", "/home/my/path"),
@@ -702,7 +702,7 @@ def test_resolve_uri_if_local(input_uri, expected_uri):
     [
         ("my/path", "file://{cwd}/my/path"),
         ("#my/path?a=b", "file://{cwd}/#my/path?a=b"),
-        ("file://myhostname/my/path", "file://myhostname/my/path"),
+        ("\\myhostname/my/path", "\\myhostname/my/path"),
         ("file:///my/path", "file:///{drive}my/path"),
         ("file:my/path", "file://{cwd}/my/path"),
         ("/home/my/path", "file:///{drive}home/my/path"),

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -100,7 +100,6 @@ def test_is_local_uri():
     assert is_local_uri("file://localhost:5000/mlruns")
     assert is_local_uri("file://127.0.0.1/mlruns")
     assert is_local_uri("file://127.0.0.1:5000/mlruns")
-    assert is_local_uri("file://myhostname/path/to/file")
     assert is_local_uri("//proc/self/root")
     assert is_local_uri("/proc/self/root")
 
@@ -109,6 +108,9 @@ def test_is_local_uri():
     assert not is_local_uri("databricks")
     assert not is_local_uri("databricks:whatever")
     assert not is_local_uri("databricks://whatever")
+
+    with pytest.raises(MlflowException, match="is not a valid remote uri."):
+        is_local_uri("file://myhostname/path/to/file")
 
 
 @pytest.mark.skipif(not is_windows(), reason="Windows-only test")

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -702,7 +702,7 @@ def test_resolve_uri_if_local(input_uri, expected_uri):
     [
         ("my/path", "file://{cwd}/my/path"),
         ("#my/path?a=b", "file://{cwd}/#my/path?a=b"),
-        ("\\myhostname/my/path", "\\myhostname/my/path"),
+        ("\\myhostname/my/path", "file:///{drive}myhostname/my/path"),
         ("file:///my/path", "file:///{drive}my/path"),
         ("file:my/path", "file://{cwd}/my/path"),
         ("/home/my/path", "file:///{drive}home/my/path"),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10651?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10651/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10651
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix local uri check

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
