### PR TITLE
Patch `setfit.Trainer` if `setfit >= 1.0`

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse
 import numpy as np
 import pandas as pd
 import yaml
+from packaging.version import Version
 
 from mlflow import pyfunc
 from mlflow.environment_variables import (
@@ -2722,7 +2723,15 @@ def autolog(
         import setfit
 
         safe_patch(
-            FLAVOR_NAME, setfit.SetFitTrainer, "train", functools.partial(train), manage_run=False
+            FLAVOR_NAME,
+            (
+                setfit.SetFitTrainer
+                if Version(setfit.__version__) < Version("1.0.0")
+                else setfit.Trainer
+            ),
+            "train",
+            functools.partial(train),
+            manage_run=False,
         )
 
     with contextlib.suppress(ImportError):

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -2719,20 +2719,20 @@ def autolog(
         with disable_discrete_autologging(DISABLED_ANCILLARY_FLAVOR_AUTOLOGGING):
             return original(*args, **kwargs)
 
-    with contextlib.suppress(ImportError):
-        import setfit
+    # with contextlib.suppress(ImportError):
+    import setfit
 
-        safe_patch(
-            FLAVOR_NAME,
-            (
-                setfit.SetFitTrainer
-                if Version(setfit.__version__) < Version("1.0.0")
-                else setfit.Trainer
-            ),
-            "train",
-            functools.partial(train),
-            manage_run=False,
-        )
+    safe_patch(
+        FLAVOR_NAME,
+        (
+            setfit.SetFitTrainer
+            if Version(setfit.__version__) < Version("1.0.0")
+            else setfit.Trainer
+        ),
+        "train",
+        functools.partial(train),
+        manage_run=False,
+    )
 
     with contextlib.suppress(ImportError):
         import transformers

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -2719,20 +2719,20 @@ def autolog(
         with disable_discrete_autologging(DISABLED_ANCILLARY_FLAVOR_AUTOLOGGING):
             return original(*args, **kwargs)
 
-    # with contextlib.suppress(ImportError):
-    import setfit
+    with contextlib.suppress(ImportError):
+        import setfit
 
-    safe_patch(
-        FLAVOR_NAME,
-        (
-            setfit.SetFitTrainer
-            if Version(setfit.__version__) < Version("1.0.0")
-            else setfit.Trainer
-        ),
-        "train",
-        functools.partial(train),
-        manage_run=False,
-    )
+        safe_patch(
+            FLAVOR_NAME,
+            (
+                setfit.SetFitTrainer
+                if Version(setfit.__version__) < Version("1.0.0")
+                else setfit.Trainer
+            ),
+            "train",
+            functools.partial(train),
+            manage_run=False,
+        )
 
     with contextlib.suppress(ImportError):
         import transformers

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -20,7 +20,6 @@ from transformers import (
 )
 
 import mlflow
-from mlflow import MlflowException
 
 
 @pytest.fixture

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -8,7 +8,9 @@ import sklearn.cluster
 import torch
 from datasets import load_dataset
 from sentence_transformers.losses import CosineSimilarityLoss
-from setfit import SetFitModel, SetFitTrainer, sample_dataset
+from setfit import SetFitModel, sample_dataset
+from setfit import Trainer as SetFitTrainer
+from setfit import TrainingArguments as SetFitTrainingArguments
 from transformers import (
     DistilBertForSequenceClassification,
     DistilBertTokenizerFast,
@@ -34,18 +36,21 @@ def setfit_trainer():
     train_dataset = sample_dataset(dataset["train"], label_column="label", num_samples=8)
     eval_dataset = dataset["validation"]
 
-    model = SetFitModel.from_pretrained("sentence-transformers/paraphrase-mpnet-base-v2")
+    model = SetFitModel.from_pretrained("sentence-transformers/all-MiniLM-L6-v2")
 
     return SetFitTrainer(
         model=model,
         train_dataset=train_dataset,
         eval_dataset=eval_dataset,
-        loss_class=CosineSimilarityLoss,
         metric="accuracy",
-        batch_size=16,
-        num_iterations=20,
-        num_epochs=1,
         column_mapping={"sentence": "text", "label": "label"},
+        args=SetFitTrainingArguments(
+            loss=CosineSimilarityLoss,
+            batch_size=16,
+            num_iterations=5,
+            num_epochs=1,
+            report_to="none",
+        ),
     )
 
 
@@ -296,9 +301,7 @@ def test_transformers_autolog_adheres_to_global_behavior_using_setfit(setfit_tra
     mlflow.transformers.autolog(disable=False)
 
     setfit_trainer.train()
-    # setfit does not have an MLflow callback. There should be no active run.
-    with pytest.raises(MlflowException, match="Run with id"):
-        mlflow.last_active_run()
+    assert len(mlflow.search_runs()) == 0
     preds = setfit_trainer.model(["Jim, I'm a doctor, not an archaeologist!"])
     assert len(preds) == 1
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10652?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10652/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10652
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix https://github.com/mlflow-automation/mlflow/actions/runs/7128742910/job/19420551145#step:14:1009

Patch `setfit.Trainer` if `setfit >= 1.0`. `setfit.SetFitTrainer` is deprecated.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
