### PR TITLE
Disable '..' in query string for artifact URI

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -105,7 +105,7 @@ from mlflow.utils.mime_type_utils import _guess_mime_type
 from mlflow.utils.promptlab_utils import _create_promptlab_run_impl
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.string_utils import is_string_type
-from mlflow.utils.uri import is_file_uri, is_local_uri, validate_path_is_safe
+from mlflow.utils.uri import is_file_uri, is_local_uri, validate_path_is_safe, validate_query_string
 from mlflow.utils.validation import _validate_batch_log_api_req
 
 _logger = logging.getLogger(__name__)
@@ -586,6 +586,11 @@ def _create_experiment():
     )
 
     tags = [ExperimentTag(tag.key, tag.value) for tag in request_message.tags]
+
+    # Validate query string in artifact location to prevent attacks
+    parsed_artifact_locaion = urllib.parse.urlparse(request_message.artifact_location)
+    validate_query_string(parsed_artifact_locaion.query)
+
     experiment_id = _get_tracking_store().create_experiment(
         request_message.name, request_message.artifact_location, tags
     )

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -264,6 +264,11 @@ def append_to_uri_path(uri, *paths):
         path = _join_posixpaths_and_append_absolute_suffixes(path, subpath)
 
     parsed_uri = urllib.parse.urlparse(uri)
+
+    # Validate query string not to contain any traveral path (../) before appending
+    # to the end of the path, otherwise they will be resolved as part of the path.
+    validate_query_string(parsed_uri.query)
+
     if len(parsed_uri.scheme) == 0:
         # If the input URI does not define a scheme, we assume that it is a POSIX path
         # and join it with the specified input paths
@@ -430,11 +435,11 @@ def validate_path_is_safe(path):
     """
     from mlflow.utils.file_utils import local_file_uri_to_path
 
-    # We must decode URL before validating it
-    path = urllib.parse.unquote(path)
+    # We must decode path before validating it
+    path = _decode(path)
 
     exc = MlflowException("Invalid path", error_code=INVALID_PARAMETER_VALUE)
-    if any((s in path) for s in ("#", "%23")):
+    if "#" in path:
         raise exc
 
     if is_file_uri(path):
@@ -447,3 +452,20 @@ def validate_path_is_safe(path):
         or (is_windows() and len(path) >= 2 and path[1] == ":")
     ):
         raise exc
+
+
+def validate_query_string(query):
+    query = _decode(query)
+    # Block query strings contain any traveral path (../) because they
+    # could be resolved as part of the path and allow path traversal.
+    if ".." in query:
+        raise MlflowException("Invalid query string", error_code=INVALID_PARAMETER_VALUE)
+
+
+def _decode(url):
+    # Keep decoding until the url stops changing
+    while True:
+        decoded = urllib.parse.unquote(url)
+        if decoded == url:
+            return url
+        url = decoded

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -463,9 +463,11 @@ def validate_query_string(query):
 
 
 def _decode(url):
-    # Keep decoding until the url stops changing
-    while True:
+    # Keep decoding until the url stops changing (with a max of 10 iterations)
+    for _ in range(10):
         decoded = urllib.parse.unquote(url)
         if decoded == url:
             return url
         url = decoded
+
+    raise ValueError("Failed to decode url")

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -235,6 +235,22 @@ def test_append_to_uri_path_handles_special_uri_characters_in_posixpaths():
 
 
 @pytest.mark.parametrize(
+    "uri",
+    [
+        # query string contains '..' (and its encoded form) are considered invalid
+        "https://example.com?..",
+        "https://example.com?/path/../path/../path",
+        "https://example.com?key=value&../../path",
+        "https://example.com?key=value&%2E%2E%2Fpath",
+        "https://example.com?key=value&%252E%252E%252Fpath",
+    ],
+)
+def test_append_to_uri_throws_for_malicious_query_string_in_uri(uri):
+    with pytest.raises(MlflowException, match=r"Invalid query string"):
+        append_to_uri_path(uri)
+
+
+@pytest.mark.parametrize(
     ("uri", "existing_query_params", "query_params", "expected"),
     [
         ("https://example.com", "", [("key", "value")], "https://example.com?key=value"),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10653?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10653/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10653
```

</p>
</details>

### What changes are proposed in this pull request?
Solving path traversal vulnerability.

#### Problem
When users create experiment with base artifact URI like `http://foo/bar`, MLflow appends `/{{run_id}}/artifact` sub path to it when saving/reading each run's artifact, such as `http://foo/bar/{{run_id}}/artifact". Every GET request for artifacts are validated so that the requested path are under this path, effectively prevents attackers to read any files outside the that run directory.

However, there is one hack to bypass this, which is query string. When MLflow appends `/{{run_id}}/artifact`, it will be inserted **before** query string of the specified artifact root. For example, if the artifact root is `http://foo/bar?a=a`, the run's artifact URI will be ``http://foo/bar{{run_id}}/artifact?a=a`.

This allows path traversal by adding malformed query string like "../../../../etc", which results in run's artifact location to be ``http://foo/bar{{run_id}}/artifact?../../../../etc``, which is then resolved to `/etc` as a local path.

#### Solution
This PR resolves this by explicitly validating query string passed as a part of artifact URI. It simply check if the query string contains ".." or not (with decoding).

There were some alternatives considered:
- Ignore query string entirely when appending ``{{run_id}}/artifacts`` => I'm afraid that some cases we need query string to access artifact location e.g. S3 ARN can have a region as query string.
- Remove all string after "?" when resolving local path. => "?" is a valid character in some OS.

Currently users can specify any query strings to artifact URI, for example, "http:///?/../path".


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Validated the fix prevents experiment creation with malformed query string:
```
curl -X POST -H 'Content-Type: application/json' -d '{"name": "poc", "artifact_location": "http:///??/../../../../../../../../../../../../../../etc/"}' 'http://127.0.0.1:5000/ajax-api/2.0/mlflow/experiments/create'
```
```
{"error_code": "INVALID_PARAMETER_VALUE", "message": "Invalid query string"}
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
