### PR TITLE
Add env variable to disable redirects

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -487,3 +487,9 @@ MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE = _EnvironmentVariable(
 MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE = _EnvironmentVariable(
     "MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE", int, 100 * 1024**2
 )
+
+#: Specifies whether or not to allow the MLflow server to follow redirects when
+#: making HTTP requests. If set to True, the server will throw an exception if it
+#: encounters a redirect response.
+#: (default: ``False``)
+MLFLOW_DISABLE_HTTP_REDIRECTS = _BooleanEnvironmentVariable("MLFLOW_DISABLE_HTTP_REDIRECTS", False)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -489,7 +489,7 @@ MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE = _EnvironmentVariable(
 )
 
 #: Specifies whether or not to allow the MLflow server to follow redirects when
-#: making HTTP requests. If set to True, the server will throw an exception if it
+#: making HTTP requests. If set to False, the server will throw an exception if it
 #: encounters a redirect response.
-#: (default: ``False``)
-MLFLOW_DISABLE_HTTP_REDIRECTS = _BooleanEnvironmentVariable("MLFLOW_DISABLE_HTTP_REDIRECTS", False)
+#: (default: ``True``)
+MLFLOW_ALLOW_HTTP_REDIRECTS = _BooleanEnvironmentVariable("MLFLOW_ALLOW_HTTP_REDIRECTS", True)

--- a/mlflow/utils/request_utils.py
+++ b/mlflow/utils/request_utils.py
@@ -188,7 +188,11 @@ def _get_http_response_with_retries(
         max_retries, backoff_factor, backoff_jitter, retry_codes, raise_on_status
     )
 
-    disable_redirects = os.getenv("MLFLOW_DISABLE_HTTP_REDIRECTS", False)
+    # the environment variable is hardcoded here to avoid importing mlflow.
+    # however, documentation is available in environment_variables.py
+    env_value = os.getenv("MLFLOW_DISABLE_HTTP_REDIRECTS", "0").lower()
+    disable_redirects = env_value in ["true", "1"]
+
     if disable_redirects:
         kwargs["allow_redirects"] = False
 

--- a/mlflow/utils/request_utils.py
+++ b/mlflow/utils/request_utils.py
@@ -190,16 +190,12 @@ def _get_http_response_with_retries(
 
     # the environment variable is hardcoded here to avoid importing mlflow.
     # however, documentation is available in environment_variables.py
-    env_value = os.getenv("MLFLOW_DISABLE_HTTP_REDIRECTS", "0").lower()
-    disable_redirects = env_value in ["true", "1"]
+    env_value = os.getenv("MLFLOW_ALLOW_HTTP_REDIRECTS", "1").lower()
+    allow_redirects = env_value in ["true", "1"]
 
-    if disable_redirects:
-        kwargs["allow_redirects"] = False
+    response = session.request(method, url, allow_redirects=allow_redirects, **kwargs)
 
-    response = session.request(method, url, **kwargs)
-    response_is_redirect = response.is_redirect or 300 <= response.status_code < 400
-
-    if disable_redirects and response_is_redirect:
+    if not allow_redirects and (response.is_redirect or 300 <= response.status_code < 400):
         raise HTTPError(
             "HTTP redirects are disabled through the MLFLOW_DISABLE_HTTP_REDIRECTS "
             "environment variable, but the server responded with a redirect. Response text: "

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -449,6 +449,7 @@ def test_databricks_http_request_integration(get_config, request):
         headers["Authorization"] = "Basic dXNlcjpwYXNz"
         assert args == ("PUT", "host/clusters/list")
         assert kwargs == {
+            "allow_redirects": True,
             "headers": headers,
             "verify": True,
             "json": {"a": "b"},

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -258,6 +258,7 @@ def test_log_artifact_azure_with_headers(
         request_mock.assert_called_with(
             "put",
             f"{MOCK_AZURE_SIGNED_URI}?comp=blocklist",
+            allow_redirects=True,
             data=ANY,
             headers=filtered_azure_headers,
             timeout=None,
@@ -346,12 +347,14 @@ def test_log_artifact_adls_gen2_with_headers(
         request_mock.assert_any_call(
             "put",
             f"{MOCK_ADLS_GEN2_SIGNED_URI}?resource=file",
+            allow_redirects=True,
             headers=filtered_azure_headers,
             timeout=None,
         )
         request_mock.assert_any_call(
             "patch",
             f"{MOCK_ADLS_GEN2_SIGNED_URI}?action=append&position=0",
+            allow_redirects=True,
             data=ANY,
             headers=filtered_azure_headers,
             timeout=None,
@@ -359,6 +362,7 @@ def test_log_artifact_adls_gen2_with_headers(
         request_mock.assert_any_call(
             "patch",
             f"{MOCK_ADLS_GEN2_SIGNED_URI}?action=append&position=5",
+            allow_redirects=True,
             data=ANY,
             headers=filtered_azure_headers,
             timeout=None,
@@ -366,6 +370,7 @@ def test_log_artifact_adls_gen2_with_headers(
         request_mock.assert_any_call(
             "patch",
             f"{MOCK_ADLS_GEN2_SIGNED_URI}?action=append&position=10",
+            allow_redirects=True,
             data=ANY,
             headers=filtered_azure_headers,
             timeout=None,
@@ -373,6 +378,7 @@ def test_log_artifact_adls_gen2_with_headers(
         request_mock.assert_called_with(
             "patch",
             f"{MOCK_ADLS_GEN2_SIGNED_URI}?action=flush&position=14",
+            allow_redirects=True,
             headers=filtered_azure_headers,
             timeout=None,
         )
@@ -404,12 +410,14 @@ def test_log_artifact_adls_gen2_flush_error(databricks_artifact_repo, test_file)
             mock.call(
                 "put",
                 f"{MOCK_ADLS_GEN2_SIGNED_URI}?resource=file",
+                allow_redirects=True,
                 headers={},
                 timeout=None,
             ),
             mock.call(
                 "patch",
                 f"{MOCK_ADLS_GEN2_SIGNED_URI}?action=append&position=0&flush=true",
+                allow_redirects=True,
                 data=ANY,
                 headers={},
                 timeout=None,
@@ -436,7 +444,7 @@ def test_log_artifact_aws(databricks_artifact_repo, test_file, artifact_path, ex
             GetCredentialsForWrite, MOCK_RUN_ID, [expected_location]
         )
         request_mock.assert_called_with(
-            "put", MOCK_AWS_SIGNED_URI, data=ANY, headers={}, timeout=None
+            "put", MOCK_AWS_SIGNED_URI, allow_redirects=True, data=ANY, headers={}, timeout=None
         )
 
 
@@ -464,7 +472,12 @@ def test_log_artifact_aws_with_headers(
             GetCredentialsForWrite, MOCK_RUN_ID, [expected_location]
         )
         request_mock.assert_called_with(
-            "put", MOCK_AWS_SIGNED_URI, data=ANY, headers=expected_headers, timeout=None
+            "put",
+            MOCK_AWS_SIGNED_URI,
+            allow_redirects=True,
+            data=ANY,
+            headers=expected_headers,
+            timeout=None,
         )
 
 
@@ -502,7 +515,7 @@ def test_log_artifact_gcp(databricks_artifact_repo, test_file, artifact_path, ex
             GetCredentialsForWrite, MOCK_RUN_ID, [expected_location]
         )
         request_mock.assert_called_with(
-            "put", MOCK_GCP_SIGNED_URL, data=ANY, headers={}, timeout=None
+            "put", MOCK_GCP_SIGNED_URL, allow_redirects=True, data=ANY, headers={}, timeout=None
         )
 
 
@@ -530,7 +543,12 @@ def test_log_artifact_gcp_with_headers(
             GetCredentialsForWrite, MOCK_RUN_ID, [expected_location]
         )
         request_mock.assert_called_with(
-            "put", MOCK_GCP_SIGNED_URL, data=ANY, headers=expected_headers, timeout=None
+            "put",
+            MOCK_GCP_SIGNED_URL,
+            allow_redirects=True,
+            data=ANY,
+            headers=expected_headers,
+            timeout=None,
         )
 
 
@@ -1298,6 +1316,7 @@ def test_multipart_upload(databricks_artifact_repo, large_file, mock_chunk_size)
                 mock.call(
                     "put",
                     f"{MOCK_AWS_SIGNED_URI}partNumber={i + 1}",
+                    allow_redirects=True,
                     data=f.read(mock_chunk_size),
                     headers={"header": f"part-{i + 1}"},
                     timeout=None,
@@ -1387,6 +1406,7 @@ def test_multipart_upload_retry_part_upload(databricks_artifact_repo, large_file
                 mock.call(
                     "put",
                     f"{MOCK_AWS_SIGNED_URI}partNumber={i + 1}",
+                    allow_redirects=True,
                     data=f.read(mock_chunk_size),
                     headers={"header": f"part-{i + 1}"},
                     timeout=None,
@@ -1445,6 +1465,7 @@ def test_multipart_upload_abort(databricks_artifact_repo, large_file, mock_chunk
                 mock.call(
                     "put",
                     f"{MOCK_AWS_SIGNED_URI}partNumber={i + 1}",
+                    allow_redirects=True,
                     data=f.read(mock_chunk_size),
                     headers={"header": f"part-{i + 1}"},
                     timeout=None,
@@ -1463,6 +1484,7 @@ def test_multipart_upload_abort(databricks_artifact_repo, large_file, mock_chunk
         assert abort_call == mock.call(
             "delete",
             f"{MOCK_AWS_SIGNED_URI}uploadId=abort",
+            allow_redirects=True,
             headers={"header": "abort"},
             timeout=None,
         )

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -70,6 +70,7 @@ def test_successful_http_request(request):
         assert args == ("POST", "https://hello/api/2.0/mlflow/experiments/search")
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
         assert kwargs == {
+            "allow_redirects": True,
             "json": {"view_type": "ACTIVE_ONLY"},
             "headers": DefaultRequestHeaderProvider().request_headers(),
             "verify": True,

--- a/tests/utils/test_request_utils.py
+++ b/tests/utils/test_request_utils.py
@@ -72,14 +72,7 @@ def test_redirects_disabled_if_env_var_set(env_value):
         mock_request.return_value.text = "mock response"
 
         with pytest.raises(HTTPError, match="HTTP redirects are disabled"):
-            request_utils._get_http_response_with_retries(
-                "GET",
-                "http://localhost:5000",
-                5,  # max_retries
-                2,  # backoff_factor
-                1.0,  # backoff_jitter
-                request_utils._TRANSIENT_FAILURE_RESPONSE_CODES,  # retry_codes
-            )
+            request_utils.cloud_storage_http_request("GET", "http://localhost:5000")
 
 
 @pytest.mark.parametrize("env_value", ["0", "false", "False", "FALSE"])
@@ -90,13 +83,9 @@ def test_redirects_enabled_by_default(env_value):
         mock_request.return_value.status_code = 302
         mock_request.return_value.text = "mock response"
 
-        response = request_utils._get_http_response_with_retries(
+        response = request_utils.cloud_storage_http_request(
             "GET",
             "http://localhost:5000",
-            5,  # max_retries
-            2,  # backoff_factor
-            1.0,  # backoff_jitter
-            request_utils._TRANSIENT_FAILURE_RESPONSE_CODES,  # retry_codes
         )
 
         assert response.text == "mock response"

--- a/tests/utils/test_request_utils.py
+++ b/tests/utils/test_request_utils.py
@@ -75,9 +75,22 @@ def test_redirects_disabled_if_env_var_set(monkeypatch, env_value):
 
 
 @pytest.mark.parametrize("env_value", ["1", "true", "True", "TRUE"])
-def test_redirects_enabled_by_default(monkeypatch, env_value):
+def test_redirects_enabled_if_env_var_set(monkeypatch, env_value):
     monkeypatch.setenv("MLFLOW_ALLOW_HTTP_REDIRECTS", env_value)
 
+    with mock.patch("requests.Session.request") as mock_request:
+        mock_request.return_value.status_code = 302
+        mock_request.return_value.text = "mock response"
+
+        response = request_utils.cloud_storage_http_request(
+            "GET",
+            "http://localhost:5000",
+        )
+
+        assert response.text == "mock response"
+
+
+def test_redirects_enabled_by_default():
     with mock.patch("requests.Session.request") as mock_request:
         mock_request.return_value.status_code = 302
         mock_request.return_value.text = "mock response"

--- a/tests/utils/test_request_utils.py
+++ b/tests/utils/test_request_utils.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 import sys
 from unittest import mock
@@ -61,11 +60,11 @@ def test_download_chunk_incomplete_read(tmp_path):
             )
 
 
-@pytest.mark.parametrize("env_value", ["1", "true", "True", "TRUE"])
-def test_redirects_disabled_if_env_var_set(env_value):
+@pytest.mark.parametrize("env_value", ["0", "false", "False", "FALSE"])
+def test_redirects_disabled_if_env_var_set(monkeypatch, env_value):
     from requests.exceptions import HTTPError
 
-    os.environ["MLFLOW_DISABLE_HTTP_REDIRECTS"] = env_value
+    monkeypatch.setenv("MLFLOW_ALLOW_HTTP_REDIRECTS", env_value)
 
     with mock.patch("requests.Session.request") as mock_request:
         mock_request.return_value.status_code = 302
@@ -75,9 +74,9 @@ def test_redirects_disabled_if_env_var_set(env_value):
             request_utils.cloud_storage_http_request("GET", "http://localhost:5000")
 
 
-@pytest.mark.parametrize("env_value", ["0", "false", "False", "FALSE"])
-def test_redirects_enabled_by_default(env_value):
-    os.environ["MLFLOW_DISABLE_HTTP_REDIRECTS"] = env_value
+@pytest.mark.parametrize("env_value", ["1", "true", "True", "TRUE"])
+def test_redirects_enabled_by_default(monkeypatch, env_value):
+    monkeypatch.setenv("MLFLOW_ALLOW_HTTP_REDIRECTS", env_value)
 
     with mock.patch("requests.Session.request") as mock_request:
         mock_request.return_value.status_code = 302

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -116,6 +116,7 @@ def test_http_request_hostonly(request):
     request.assert_called_with(
         "GET",
         "http://my-host/my/endpoint",
+        allow_redirects=True,
         verify=True,
         headers=DefaultRequestHeaderProvider().request_headers(),
         timeout=120,
@@ -133,6 +134,7 @@ def test_http_request_cleans_hostname(request):
     request.assert_called_with(
         "GET",
         "http://my-host/my/endpoint",
+        allow_redirects=True,
         verify=True,
         headers=DefaultRequestHeaderProvider().request_headers(),
         timeout=120,
@@ -151,6 +153,7 @@ def test_http_request_with_basic_auth(request):
     request.assert_called_with(
         "GET",
         "http://my-host/my/endpoint",
+        allow_redirects=True,
         verify=True,
         headers=headers,
         timeout=120,
@@ -183,6 +186,7 @@ def test_http_request_with_aws_sigv4(request, monkeypatch):
     request.assert_called_once_with(
         "GET",
         "http://my-host/my/endpoint",
+        allow_redirects=True,
         verify=mock.ANY,
         headers=mock.ANY,
         timeout=mock.ANY,
@@ -207,6 +211,7 @@ def test_http_request_with_auth(fetch_auth, request):
     request.assert_called_with(
         "GET",
         "http://my-host/my/endpoint",
+        allow_redirects=True,
         verify=mock.ANY,
         headers=mock.ANY,
         timeout=mock.ANY,
@@ -226,6 +231,7 @@ def test_http_request_with_token(request):
     request.assert_called_with(
         "GET",
         "http://my-host/my/endpoint",
+        allow_redirects=True,
         verify=True,
         headers=headers,
         timeout=120,
@@ -242,6 +248,7 @@ def test_http_request_with_insecure(request):
     request.assert_called_with(
         "GET",
         "http://my-host/my/endpoint",
+        allow_redirects=True,
         verify=False,
         headers=DefaultRequestHeaderProvider().request_headers(),
         timeout=120,
@@ -258,6 +265,7 @@ def test_http_request_client_cert_path(request):
     request.assert_called_with(
         "GET",
         "http://my-host/my/endpoint",
+        allow_redirects=True,
         verify=True,
         cert="/some/path",
         headers=DefaultRequestHeaderProvider().request_headers(),
@@ -275,6 +283,7 @@ def test_http_request_server_cert_path(request):
     request.assert_called_with(
         "GET",
         "http://my-host/my/endpoint",
+        allow_redirects=True,
         verify="/some/path",
         headers=DefaultRequestHeaderProvider().request_headers(),
         timeout=120,
@@ -295,6 +304,7 @@ def test_http_request_with_content_type_header(request):
     request.assert_called_with(
         "GET",
         "http://my-host/my/endpoint",
+        allow_redirects=True,
         verify=True,
         headers=headers,
         timeout=120,
@@ -320,6 +330,7 @@ def test_http_request_request_headers(request):
         request.assert_called_with(
             "GET",
             "http://my-host/my/endpoint",
+            allow_redirects=True,
             verify="/some/path",
             headers={**DefaultRequestHeaderProvider().request_headers(), "test": "header"},
             timeout=120,
@@ -356,6 +367,7 @@ def test_http_request_request_headers_user_agent(request):
         request.assert_called_with(
             "GET",
             "http://my-host/my/endpoint",
+            allow_redirects=True,
             verify="/some/path",
             headers=expected_headers,
             timeout=120,
@@ -393,6 +405,7 @@ def test_http_request_request_headers_user_agent_and_extra_header(request):
         request.assert_called_with(
             "GET",
             "http://my-host/my/endpoint",
+            allow_redirects=True,
             verify="/some/path",
             headers=expected_headers,
             timeout=120,
@@ -440,6 +453,7 @@ def test_http_request_wrapper(request):
     request.assert_called_with(
         "GET",
         "http://my-host/my/endpoint",
+        allow_redirects=True,
         verify=False,
         headers=DefaultRequestHeaderProvider().request_headers(),
         timeout=120,
@@ -450,6 +464,7 @@ def test_http_request_wrapper(request):
     request.assert_called_with(
         "GET",
         "http://my-host/my/endpoint",
+        allow_redirects=True,
         verify=False,
         headers=DefaultRequestHeaderProvider().request_headers(),
         timeout=120,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/10655?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10655/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10655
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add an environment variable so users can disable following redirects if they want.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

HTTP redirects can be disabled through the MLFLOW_DISABLE_HTTP_REDIRECTS environment variable.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
