### PR TITLE
Fix Tensorflow flavor docstring and style

### DIFF
--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -125,9 +125,9 @@ def get_global_custom_objects():
     :return: A live reference to the global dictionary of custom objects.
     """
     try:
-        from tensorflow.keras.saving import get_custom_objects
+        from tensorflow import keras
 
-        return get_custom_objects()
+        return keras.saving.get_custom_objects()
     except Exception:
         pass
 
@@ -259,17 +259,6 @@ _NO_MODEL_SIGNATURE_WARNING = (
 )
 
 
-def _get_keras_version(keras_module):
-    import tensorflow
-
-    if Version(tensorflow.__version__) >= Version("2.6.0"):
-        import keras
-
-        return keras.__version__
-    else:
-        return keras_module.__version__
-
-
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 def save_model(
     model,
@@ -341,14 +330,14 @@ def save_model(
                      .. Note:: Experimental: This parameter may change or be removed in a future
                                              release without warning.
     """
-    import tensorflow
+    import tensorflow as tf
     from tensorflow.keras.models import Model as KerasModel
 
     if signature is None and input_example is not None:
         wrapped_model = None
         if isinstance(model, KerasModel):
             wrapped_model = _KerasModelWrapper(model, signature)
-        elif isinstance(model, tensorflow.Module):
+        elif isinstance(model, tf.Module):
             wrapped_model = _TF2ModuleWrapper(model, signature)
         if wrapped_model is not None:
             signature = _infer_signature_from_input_example(input_example, wrapped_model)
@@ -432,7 +421,7 @@ def save_model(
         # it only supports saving model in .h5 or .keras format
         if save_format == "h5":
             file_extension = ".h5"
-        elif Version(tensorflow.__version__).release >= (2, 16):
+        elif Version(tf.__version__).release >= (2, 16):
             file_extension = ".keras"
         else:
             file_extension = ""
@@ -454,14 +443,14 @@ def save_model(
         flavor_options = {
             **pyfunc_options,
             "model_type": _MODEL_TYPE_KERAS,
-            "keras_version": _get_keras_version(keras_module),
+            "keras_version": tf.__version__,
             "save_format": save_format,
         }
-    elif isinstance(model, tensorflow.Module):
+    elif isinstance(model, tf.Module):
         saved_model_kwargs = saved_model_kwargs or {}
         model_dir_subpath = "tf2model"
         model_path = os.path.join(path, model_dir_subpath)
-        tensorflow.saved_model.save(model, model_path, **saved_model_kwargs)
+        tf.saved_model.save(model, model_path, **saved_model_kwargs)
         pyfunc_options = {}
         flavor_options = {
             "saved_model_dir": model_dir_subpath,
@@ -559,11 +548,9 @@ def _load_keras_model(model_path, keras_module, save_format, **kwargs):
     elif os.path.exists(model_path + ".keras"):
         model_path += ".keras"
 
-    # keras in tensorflow used to have a '-tf' suffix in the version:
-    # https://github.com/tensorflow/tensorflow/blob/v2.2.1/tensorflow/python/keras/__init__.py#L36
-    unsuffixed_version = re.sub(r"-tf$", "", _get_keras_version(keras_module))
-    if save_format == "h5" and (2, 2, 3) <= Version(unsuffixed_version).release < (2, 16):
-        # NOTE: Keras 2.2.3 does not work with unicode paths in python2. Pass in h5py.File instead
+    import tensorflow as tf
+    if save_format == "h5" and Version("2.2.3") <= Version(tf.__version__) < Version("2.16"):
+        # NOTE: TF 2.2.3 does not work with unicode paths in python2. Pass in h5py.File instead
         # of string to avoid issues.
         import h5py
 
@@ -616,29 +603,8 @@ def load_model(model_uri, dst_path=None, saved_model_kwargs=None, keras_model_kw
                                Only available when you are loading a Keras model.
 
     :return: A callable graph (tf.function) that takes inputs and returns inferences.
-
-    .. code-block:: python
-        :caption: Example
-
-        import mlflow
-        import tensorflow as tf
-
-        tf_graph = tf.Graph()
-        tf_sess = tf.Session(graph=tf_graph)
-        with tf_graph.as_default():
-            signature_definition = mlflow.tensorflow.load_model(
-                model_uri="model_uri", tf_sess=tf_sess
-            )
-            input_tensors = [
-                tf_graph.get_tensor_by_name(input_signature.name)
-                for _, input_signature in signature_definition.inputs.items()
-            ]
-            output_tensors = [
-                tf_graph.get_tensor_by_name(output_signature.name)
-                for _, output_signature in signature_definition.outputs.items()
-            ]
     """
-    import tensorflow
+    import tensorflow as tf
 
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
 
@@ -674,7 +640,7 @@ def load_model(model_uri, dst_path=None, saved_model_kwargs=None, keras_model_kw
     if model_type == _MODEL_TYPE_TF2_MODULE:
         saved_model_kwargs = saved_model_kwargs or {}
         tf_saved_model_dir = os.path.join(local_model_path, flavor_conf["saved_model_dir"])
-        return tensorflow.saved_model.load(tf_saved_model_dir, **saved_model_kwargs)
+        return tf.saved_model.load(tf_saved_model_dir, **saved_model_kwargs)
 
     raise MlflowException(f"Unknown model_type: {model_type}")
 
@@ -697,9 +663,9 @@ def _load_tf1_estimator_saved_model(tf_saved_model_dir, tf_meta_graph_tags, tf_s
                                  ``tf.saved_model.builder.SavedModelBuilder`` method.
     :return: A callable graph (tensorflow.function) that takes inputs and returns inferences.
     """
-    import tensorflow
+    import tensorflow as tf
 
-    loaded = tensorflow.saved_model.load(  # pylint: disable=no-value-for-parameter
+    loaded = tf.saved_model.load(  # pylint: disable=no-value-for-parameter
         tags=tf_meta_graph_tags, export_dir=tf_saved_model_dir
     )
     loaded_sig = loaded.signatures
@@ -719,7 +685,7 @@ def _load_pyfunc(path):
 
     :param path: Local filesystem path to the MLflow Model with the ``tensorflow`` flavor.
     """
-    import tensorflow
+    import tensorflow as tf
 
     model_meta_path1 = os.path.join(path, MLMODEL_FILE_NAME)
     model_meta_path2 = os.path.join(os.path.dirname(path), MLMODEL_FILE_NAME)
@@ -737,9 +703,9 @@ def _load_pyfunc(path):
             with open(os.path.join(path, _KERAS_MODULE_SPEC_PATH)) as f:
                 keras_module = importlib.import_module(f.read())
         else:
-            import tensorflow.keras
+            from tensorflow import keras
 
-            keras_module = tensorflow.keras
+            keras_module = keras
 
         # By default, we assume the save_format is h5 for backwards compatibility
         save_format = "h5"
@@ -748,16 +714,12 @@ def _load_pyfunc(path):
             with open(save_format_path) as f:
                 save_format = f.read()
 
-        # In SavedModel format, if we don't compile the model
+        # In SavedModel format, loaded model should be compiled.
         should_compile = save_format == "tf"
-        K = importlib.import_module(keras_module.__name__ + ".backend")
-        if K.backend() == "tensorflow":
-            m = _load_keras_model(
-                path, keras_module=keras_module, save_format=save_format, compile=should_compile
-            )
-            return _KerasModelWrapper(m, model_meta.signature)
-        else:
-            raise MlflowException(f"Unsupported backend '{K._BACKEND}'")
+        m = _load_keras_model(
+            path, keras_module=keras_module, save_format=save_format, compile=should_compile
+        )
+        return _KerasModelWrapper(m, model_meta.signature)
     if model_type == _MODEL_TYPE_TF1_ESTIMATOR:
         flavor_conf = _get_flavor_configuration(path, FLAVOR_NAME)
 
@@ -765,14 +727,14 @@ def _load_pyfunc(path):
         tf_meta_graph_tags = flavor_conf["meta_graph_tags"]
         tf_signature_def_key = flavor_conf["signature_def_key"]
 
-        loaded_model = tensorflow.saved_model.load(  # pylint: disable=no-value-for-parameter
+        loaded_model = tf.saved_model.load(  # pylint: disable=no-value-for-parameter
             export_dir=tf_saved_model_dir, tags=tf_meta_graph_tags
         )
         return _TF2Wrapper(model=loaded_model, infer=loaded_model.signatures[tf_signature_def_key])
     if model_type == _MODEL_TYPE_TF2_MODULE:
         flavor_conf = _get_flavor_configuration(path, FLAVOR_NAME)
         tf_saved_model_dir = os.path.join(path, flavor_conf["saved_model_dir"])
-        loaded_model = tensorflow.saved_model.load(tf_saved_model_dir)
+        loaded_model = tf.saved_model.load(tf_saved_model_dir)
         return _TF2ModuleWrapper(model=loaded_model, signature=model_meta.signature)
 
     raise MlflowException("Unknown model_type.")
@@ -808,11 +770,11 @@ class _TF2Wrapper:
 
         :return: Model predictions.
         """
-        import tensorflow
+        import tensorflow as tf
 
         feed_dict = {}
         if isinstance(data, dict):
-            feed_dict = {k: tensorflow.constant(v) for k, v in data.items()}
+            feed_dict = {k: tf.constant(v) for k, v in data.items()}
         elif isinstance(data, pandas.DataFrame):
             for df_col_name in list(data):
                 # If there are multiple columns with the same name, selecting the shared name
@@ -821,7 +783,7 @@ class _TF2Wrapper:
                 # DataFrames, so we convert the DataFrame to a numpy array here.
                 val = data[df_col_name]
                 val = val.values if isinstance(val, pandas.DataFrame) else np.array(val.to_list())
-                feed_dict[df_col_name] = tensorflow.constant(val)
+                feed_dict[df_col_name] = tf.constant(val)
         else:
             raise TypeError("Only dict and DataFrame input types are supported")
 
@@ -860,17 +822,17 @@ class _TF2ModuleWrapper:
 
         :return: Model predictions.
         """
-        import tensorflow
+        import tensorflow as tf
 
         if isinstance(data, (np.ndarray, list)):
-            data = tensorflow.convert_to_tensor(data)
+            data = tf.convert_to_tensor(data)
         else:
             raise MlflowException(
                 f"Unsupported input data type: {type(data)}, the input data must be "
                 "numpy array or a list."
             )
         result = self.model(data)
-        if isinstance(result, tensorflow.Tensor):
+        if isinstance(result, tf.Tensor):
             return result.numpy()
         return result
 
@@ -947,10 +909,10 @@ def _log_event(event):
 
 @picklable_exception_safe_function
 def _get_tensorboard_callback(lst):
-    import tensorflow
+    import tensorflow as tf
 
     for x in lst:
-        if isinstance(x, tensorflow.keras.callbacks.TensorBoard):
+        if isinstance(x, tf.keras.callbacks.TensorBoard):
             return x
     return None
 
@@ -1008,7 +970,7 @@ def autolog(
 ):  # pylint: disable=unused-argument
     # pylint: disable=no-name-in-module
     """
-    Enables autologging for ``tf.keras`` and ``keras``.
+    Enables autologging for ``tf.keras``.
     Note that only ``tensorflow>=2.3`` are supported.
     As an example, try running the
     `Keras/TensorFlow example <https://github.com/mlflow/mlflow/blob/master/examples/keras/train.py>`_.
@@ -1018,14 +980,16 @@ def autolog(
     **tf.keras**
      - **Metrics** and **Parameters**
 
-      - Training loss; validation loss; user-specified metrics
-      - ``fit()`` or ``fit_generator()`` parameters; optimizer name; learning rate; epsilon
+      - Training and validation loss.
+      - User-specified metrics.
+      - Optimizer config, e.g., learning_rate, momentum, etc.
+      - Training configs, e.g., epochs, batch_size, etc.
 
      - **Artifacts**
 
-      - Model summary on training start
-      - `MLflow Model <https://mlflow.org/docs/latest/models.html>`_ (Keras model)
-      - TensorBoard logs on training end
+      - Model summary on training start.
+      - Saved Keras model in `MLflow Model <https://mlflow.org/docs/latest/models.html>`_ format.
+      - TensorBoard logs on training end.
 
     **tf.keras.callbacks.EarlyStopping**
      - **Metrics** and **Parameters**
@@ -1082,21 +1046,21 @@ def autolog(
     :param keras_model_kwargs: a dict of kwargs to pass to ``keras_model.save`` method.
     :param extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
     """
-    import tensorflow
+    import tensorflow as tf
 
     global _LOG_EVERY_N_STEPS
     _LOG_EVERY_N_STEPS = every_n_iter
 
     atexit.register(flush_metrics_queue)
 
-    if Version(tensorflow.__version__) < Version("2.3"):
+    if Version(tf.__version__) < Version("2.3"):
         warnings.warn("Could not log to MLflow. TensorFlow versions below 2.3 are not supported.")
         return
 
     @picklable_exception_safe_function
     def _get_early_stop_callback(callbacks):
         for callback in callbacks:
-            if isinstance(callback, tensorflow.keras.callbacks.EarlyStopping):
+            if isinstance(callback, tf.keras.callbacks.EarlyStopping):
                 return callback
         return None
 
@@ -1156,7 +1120,7 @@ def autolog(
 
     def _log_keras_model(history, args):
         def _infer_model_signature(input_data_slice):
-            # In certain TensorFlow versions, calling `predict()` on model  may modify
+            # In certain TensorFlow versions, calling `predict()` on model may modify
             # the `stop_training` attribute, so we save and restore it accordingly
             original_stop_training = history.model.stop_training
             model_output = history.model.predict(input_data_slice)
@@ -1213,11 +1177,11 @@ def autolog(
             try:
                 is_single_input_model = isinstance(inst.input_shape, tuple)
                 training_data = kwargs["x"] if "x" in kwargs else args[0]
-                if isinstance(training_data, tensorflow.data.Dataset) and hasattr(
+                if isinstance(training_data, tf.data.Dataset) and hasattr(
                     training_data, "_batch_size"
                 ):
                     batch_size = training_data._batch_size.numpy()
-                elif isinstance(training_data, tensorflow.keras.utils.Sequence):
+                elif isinstance(training_data, tf.keras.utils.Sequence):
                     first_batch_inputs, *_ = training_data[0]
                     if is_single_input_model:
                         batch_size = len(first_batch_inputs)
@@ -1333,7 +1297,7 @@ def autolog(
                 shutil.rmtree(self.log_dir.location)
 
     managed = [
-        (tensorflow.keras.Model, "fit", FitPatch),
+        (tf.keras.Model, "fit", FitPatch),
     ]
 
     for p in managed:
@@ -1341,22 +1305,22 @@ def autolog(
 
 
 def _log_tensorflow_dataset(tensorflow_dataset, source, context, name=None, targets=None):
-    import tensorflow
+    import tensorflow as tf
 
     # create a dataset
     if isinstance(tensorflow_dataset, np.ndarray):
         dataset = from_numpy(features=tensorflow_dataset, targets=targets, source=source, name=name)
-    elif isinstance(tensorflow_dataset, tensorflow.Tensor):
+    elif isinstance(tensorflow_dataset, tf.Tensor):
         dataset = from_tensorflow(
             features=tensorflow_dataset, targets=targets, source=source, name=name
         )
-    elif isinstance(tensorflow_dataset, tensorflow.data.Dataset):
+    elif isinstance(tensorflow_dataset, tf.data.Dataset):
         dataset = from_tensorflow(features=tensorflow_dataset, source=source, name=name)
     elif isinstance(tensorflow_dataset, tuple):
         x = tensorflow_dataset[0]
         y = tensorflow_dataset[1]
         # check if x and y are tensors
-        if isinstance(x, tensorflow.Tensor) and isinstance(y, tensorflow.Tensor):
+        if isinstance(x, tf.Tensor) and isinstance(y, tf.Tensor):
             dataset = from_tensorflow(features=x, source=source, targets=y, name=name)
         else:
             dataset = from_numpy(features=x, targets=y, source=source, name=name)

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -11,7 +11,6 @@ import atexit
 import importlib
 import logging
 import os
-import re
 import shutil
 import tempfile
 import warnings
@@ -549,6 +548,7 @@ def _load_keras_model(model_path, keras_module, save_format, **kwargs):
         model_path += ".keras"
 
     import tensorflow as tf
+
     if save_format == "h5" and Version("2.2.3") <= Version(tf.__version__) < Version("2.16"):
         # NOTE: TF 2.2.3 does not work with unicode paths in python2. Pass in h5py.File instead
         # of string to avoid issues.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/10662?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10662/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10662
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

A few fixes:
- Remove the confusing code example. 
- Use `import tensorflow as tf` to replace `import tensorflow`, which is the standard.
- Fix some docstring issues.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
