### PR TITLE
Support langchain signature

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -33,6 +33,7 @@ from mlflow.langchain.utils import (
 )
 from mlflow.models import Model, ModelInputExample, ModelSignature
 from mlflow.models.model import MLMODEL_FILE_NAME
+from mlflow.models.signature import _infer_signature_from_input_example
 from mlflow.models.utils import _save_example
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -185,6 +186,7 @@ def save_model(
                         See a complete example in examples/langchain/retrieval_qa_chain.py.
     """
     import langchain
+    from langchain.schema import BaseRetriever
 
     lc_model = _validate_and_wrap_lc_model(lc_model, loader_fn)
 
@@ -193,6 +195,40 @@ def save_model(
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
+
+    if signature is None:
+        if input_example is not None:
+            wrapped_model = _LangChainModelWrapper(lc_model)
+            signature = _infer_signature_from_input_example(input_example, wrapped_model)
+        else:
+            if hasattr(lc_model, "input_keys"):
+                input_columns = [
+                    ColSpec(type=DataType.string, name=input_key)
+                    for input_key in lc_model.input_keys
+                ]
+                input_schema = Schema(input_columns)
+            else:
+                input_schema = None
+            if (
+                hasattr(lc_model, "output_keys")
+                and len(lc_model.output_keys) == 1
+                and not isinstance(lc_model, BaseRetriever)
+            ):
+                output_columns = [
+                    ColSpec(type=DataType.string, name=output_key)
+                    for output_key in lc_model.output_keys
+                ]
+                output_schema = Schema(output_columns)
+            else:
+                # TODO: empty output schema if multiple output_keys or is a retriever. fix later!
+                # https://databricks.atlassian.net/browse/ML-34706
+                output_schema = None
+
+            signature = (
+                ModelSignature(input_schema, output_schema)
+                if input_schema or output_schema
+                else None
+            )
 
     if mlflow_model is None:
         mlflow_model = Model()
@@ -369,31 +405,7 @@ def log_model(
     :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
              metadata of the logged model.
     """
-    from langchain.schema import BaseRetriever
-
     lc_model = _validate_and_wrap_lc_model(lc_model, loader_fn)
-
-    # infer signature if signature is not provided
-    if signature is None:
-        if hasattr(lc_model, "input_keys") and hasattr(lc_model, "output_keys"):
-            input_columns = [
-                ColSpec(type=DataType.string, name=input_key) for input_key in lc_model.input_keys
-            ]
-            input_schema = Schema(input_columns)
-
-            output_columns = [
-                ColSpec(type=DataType.string, name=output_key)
-                for output_key in lc_model.output_keys
-            ]
-            output_schema = Schema(output_columns)
-
-            # TODO: empty output schema if multiple output_keys or is a retriever. fix later!
-            # https://databricks.atlassian.net/browse/ML-34706
-            if len(lc_model.output_keys) > 1 or isinstance(lc_model, BaseRetriever):
-                output_schema = None
-
-            signature = ModelSignature(input_schema, output_schema)
-        # TODO: support signature for other runnables
 
     return Model.log(
         artifact_path=artifact_path,
@@ -452,23 +464,41 @@ class _LangChainModelWrapper:
 
         :return: Model predictions.
         """
+
+        # numpy array is not json serializable, so we convert it to list
+        # then send it to the model
+        def _convert_ndarray_to_list(data):
+            import numpy as np
+
+            if isinstance(data, np.ndarray):
+                return data.tolist()
+            if isinstance(data, list):
+                return [_convert_ndarray_to_list(d) for d in data]
+            if isinstance(data, dict):
+                return {k: _convert_ndarray_to_list(v) for k, v in data.items()}
+            return data
+
         from mlflow.langchain.api_request_parallel_processor import process_api_requests
 
+        return_first_element = False
         if isinstance(data, pd.DataFrame):
             messages = data.to_dict(orient="records")
-        elif isinstance(self.lc_model, lc_runnables_types()):
-            messages = [data]
-            return process_api_requests(lc_model=self.lc_model, requests=messages)[0]
-        elif isinstance(data, list) and (
-            all(isinstance(d, str) for d in data) or all(isinstance(d, dict) for d in data)
-        ):
-            messages = data
         else:
-            raise mlflow.MlflowException.invalid_parameter_value(
-                "Input must be a pandas DataFrame or a list of strings or a list of dictionaries "
-                f"for model {self.lc_model.__class__.__name__}"
-            )
-        return process_api_requests(lc_model=self.lc_model, requests=messages)
+            data = _convert_ndarray_to_list(data)
+            if isinstance(self.lc_model, lc_runnables_types()):
+                messages = [data]
+                return_first_element = True
+            elif isinstance(data, list) and (
+                all(isinstance(d, str) for d in data) or all(isinstance(d, dict) for d in data)
+            ):
+                messages = data
+            else:
+                raise mlflow.MlflowException.invalid_parameter_value(
+                    "Input must be a pandas DataFrame or a list of strings or a list of dictionaries "
+                    f"for model {self.lc_model.__class__.__name__}"
+                )
+        results = process_api_requests(lc_model=self.lc_model, requests=messages)
+        return results[0] if return_first_element else results
 
 
 class _TestLangChainWrapper(_LangChainModelWrapper):

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -494,7 +494,8 @@ class _LangChainModelWrapper:
                 messages = data
             else:
                 raise mlflow.MlflowException.invalid_parameter_value(
-                    "Input must be a pandas DataFrame or a list of strings or a list of dictionaries "
+                    "Input must be a pandas DataFrame or a list of strings "
+                    "or a list of dictionaries "
                     f"for model {self.lc_model.__class__.__name__}"
                 )
         results = process_api_requests(lc_model=self.lc_model, requests=messages)

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -162,8 +162,8 @@ class APIRequest:
                     self._prepare_to_serialize(response)
 
             _logger.debug(f"Request #{self.index} succeeded")
-            status_tracker.complete_task(success=True)
             self.results.append((self.index, response))
+            status_tracker.complete_task(success=True)
         except Exception as e:
             self.errors[
                 self.index

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -132,9 +132,6 @@ class APIRequest:
                     {"page_content": doc.page_content, "metadata": doc.metadata} for doc in docs
                 ]
             elif isinstance(self.lc_model, lc_runnables_types()):
-                if isinstance(self.request_json, np.ndarray):
-                    # numpy array is not json serializable, so we convert it to list
-                    self.request_json = self.request_json.tolist()
                 if isinstance(self.request_json, dict):
                     # This is a temporary fix for the case when spark_udf converts
                     # input into pandas dataframe with column name, while the model
@@ -149,8 +146,6 @@ class APIRequest:
                             "invoke with the first value of the dictionary."
                         )
                         self.request_json = next(iter(self.request_json.values()))
-                        if isinstance(self.request_json, np.ndarray):
-                            self.request_json = self.request_json.tolist()
                         response = self.lc_model.invoke(self.request_json)
                 elif isinstance(self.request_json, list) and isinstance(
                     self.lc_model, runnables_supports_batch_types()

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -118,7 +118,6 @@ class APIRequest:
         """
         Calls the LangChain API and stores results.
         """
-        import numpy as np
         from langchain.schema import BaseRetriever
 
         from mlflow.langchain.utils import lc_runnables_types, runnables_supports_batch_types

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -138,10 +138,10 @@ class APIRequest:
                     # Expected Scalar value for String field \'query_text\'\\n
                     try:
                         response = self.lc_model.invoke(self.request_json)
-                    except Exception:
+                    except Exception as e:
                         _logger.warning(
                             f"Failed to invoke {self.lc_model.__class__.__name__} "
-                            "with {self.request_json}. Error: {e!r}. Trying to "
+                            f"with {self.request_json}. Error: {e!r}. Trying to "
                             "invoke with the first value of the dictionary."
                         )
                         self.request_json = next(iter(self.request_json.values()))

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -238,30 +238,21 @@ class _Example:
                 if isinstance(x, np.ndarray) and len(x.shape) > 1:
                     raise TensorsNotSupportedException(f"Row '{i}' has shape {x.shape}")
             if all(_is_scalar(x) for x in input_example):
-                if all(isinstance(x, str) for x in input_example):
-                    _logger.info(
-                        "Lists of string values are not converted to a pandas DataFrame. "
-                        "If you expect to use pandas DataFrames for inference, please "
-                        "construct a DataFrame and pass it to input_example instead."
-                    )
-                    self._inference_data = input_example
-                    self.data = {"inputs": self._inference_data}
-                    self.info.update(
-                        {
-                            "type": "ndarray",
-                            "format": "tf-serving",
-                        }
-                    )
-                # For backwards compatibility, sklearn model for example
-                else:
-                    self._inference_data = pd.DataFrame([input_example])
-                    self.data = _handle_dataframe_input(self._inference_data)
-                    self.info.update(
-                        {
-                            "type": "dataframe",
-                            "pandas_orient": "split",
-                        }
-                    )
+                # We should not convert data for langchain flavors
+                # List[scalar] is a typical langchain model input type
+                _logger.info(
+                    "Lists of scalar values are not converted to a pandas DataFrame. "
+                    "If you expect to use pandas DataFrames for inference, please "
+                    "construct a DataFrame and pass it to input_example instead."
+                )
+                self._inference_data = input_example
+                self.data = {"inputs": self._inference_data}
+                self.info.update(
+                    {
+                        "type": "ndarray",
+                        "format": "tf-serving",
+                    }
+                )
             else:
                 self._inference_data = pd.DataFrame(input_example)
                 self.data = _handle_dataframe_input(self._inference_data)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1440,11 +1440,7 @@ Compound types:
             return pandas.Series(result_values)
 
         if not isinstance(result, pandas.DataFrame):
-            result = (
-                pandas.DataFrame(data=result)
-                if isinstance(result, (dict, list))
-                else pandas.DataFrame([result])
-            )
+            result = pandas.DataFrame([result]) if np.isscalar(result) else pandas.DataFrame(result)
 
         if isinstance(result_type, SparkStructType):
             result_dict = {}

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1440,7 +1440,11 @@ Compound types:
             return pandas.Series(result_values)
 
         if not isinstance(result, pandas.DataFrame):
-            result = pandas.DataFrame(data=result)
+            result = (
+                pandas.DataFrame(data=result)
+                if isinstance(result, (dict, list))
+                else pandas.DataFrame([result])
+            )
 
         if isinstance(result_type, SparkStructType):
             result_dict = {}

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -363,6 +363,7 @@ def _get_jsonable_obj(data, pandas_orient="records"):
 def convert_data_type(data, spec):
     """
     Convert input data to the type specified in the spec.
+    This method converts data into numpy array for backwards compatibility.
 
     :param data: Input data.
     :param spec: ColSpec or TensorSpec.
@@ -439,15 +440,16 @@ def _cast_schema_type(input_data, schema=None):
             spec = schema.inputs[0] if schema else None
             input_data = convert_data_type(input_data, spec)
     else:
-        if schema is None:
-            input_data = np.array(input_data)
-        else:
+        spec = schema.inputs[0] if schema else None
+        try:
+            input_data = convert_data_type(input_data, spec)
+        except Exception as e:
             raise MlflowInvalidInputException(
                 "Failed to parse input data. This model contains a tensor-based model "
                 "signature with input names, which suggests a dictionary / a list of "
                 "dictionaries input mapping input name to tensor or a pure list, but "
-                f"an input of {input_data} was found."
-            )
+                f"an input of `{input_data}` was found."
+            ) from e
     return input_data
 
 

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -401,8 +401,6 @@ def convert_data_type(data, spec):
 
 
 def _cast_schema_type(input_data, schema=None):
-    import numpy as np
-
     input_data = deepcopy(input_data)
     # spec_name -> spec mapping
     types_dict = schema.input_dict() if schema and schema.has_input_names() else {}

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -46,7 +46,7 @@ import mlflow
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.deployments import PredictionsResponse
 from mlflow.exceptions import MlflowException
-from mlflow.models.signature import ModelSignature, Schema
+from mlflow.models.signature import ModelSignature, Schema, infer_signature
 from mlflow.openai.utils import (
     TEST_CONTENT,
     TEST_INTERMEDIATE_STEPS,
@@ -807,7 +807,7 @@ def test_save_load_runnable_passthrough():
     Version(langchain.__version__) < Version("0.0.311"),
     reason="feature not existing",
 )
-def test_save_load_runnable_lambda():
+def test_save_load_runnable_lambda(spark):
     from langchain.schema.runnable import RunnableLambda
 
     def add_one(x: int) -> int:
@@ -819,15 +819,23 @@ def test_save_load_runnable_lambda():
     assert runnable.batch([1, 2, 3]) == [2, 3, 4]
 
     with mlflow.start_run():
-        model_info = mlflow.langchain.log_model(runnable, "runnable_lambda")
+        model_info = mlflow.langchain.log_model(
+            runnable, "runnable_lambda", input_example=[1, 2, 3]
+        )
 
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
     assert loaded_model.invoke(1) == 2
     assert loaded_model.batch([1, 2, 3]) == [2, 3, 4]
 
     loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
-    assert loaded_model.predict(1) == 2
+    assert loaded_model.predict(1) == [2]
     assert loaded_model.predict([1, 2, 3]) == [2, 3, 4]
+
+    udf = mlflow.pyfunc.spark_udf(spark, model_info.model_uri, result_type="long")
+    df = spark.createDataFrame([(1,), (2,), (3,)], ["data"])
+    df = df.withColumn("answer", udf("data"))
+    pdf = df.toPandas()
+    assert pdf["answer"].tolist() == [2, 3, 4]
 
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
@@ -859,12 +867,12 @@ def test_save_load_runnable_lambda_in_sequence():
     assert sequence.invoke(1) == 4
 
     with mlflow.start_run():
-        model_info = mlflow.langchain.log_model(sequence, "model_path")
+        model_info = mlflow.langchain.log_model(sequence, "model_path", input_example=[1, 2, 3])
 
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
     assert loaded_model.invoke(1) == 4
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
-    assert pyfunc_loaded_model.predict(1) == 4
+    assert pyfunc_loaded_model.predict(1) == [4]
     assert pyfunc_loaded_model.predict([1, 2, 3]) == [4, 6, 8]
 
     response = pyfunc_serve_and_score_model(
@@ -892,11 +900,13 @@ def test_save_load_runnable_parallel():
     assert runnable.invoke("hello") == {"llm": "completion"}
     assert runnable.batch(["hello", "world"]) == [{"llm": "completion"}, {"llm": "completion"}]
     with mlflow.start_run():
-        model_info = mlflow.langchain.log_model(runnable, "model_path")
+        model_info = mlflow.langchain.log_model(
+            runnable, "model_path", input_example=["hello", "world"]
+        )
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
     assert loaded_model.invoke("hello") == {"llm": "completion"}
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
-    assert pyfunc_loaded_model.predict("hello") == {"llm": "completion"}
+    assert pyfunc_loaded_model.predict("hello") == [{"llm": "completion"}]
     assert pyfunc_loaded_model.predict(["hello", "world"]) == [
         {"llm": "completion"},
         {"llm": "completion"},
@@ -926,7 +936,9 @@ def tests_save_load_complex_runnable_parallel():
         expected_result = {"llm": {"product": "MLflow", "text": TEST_CONTENT}}
         assert runnable.invoke({"product": "MLflow"}) == expected_result
         with mlflow.start_run():
-            model_info = mlflow.langchain.log_model(runnable, "model_path")
+            model_info = mlflow.langchain.log_model(
+                runnable, "model_path", input_example=[{"product": "MLflow"}]
+            )
         loaded_model = mlflow.langchain.load_model(model_info.model_uri)
         assert loaded_model.invoke("MLflow") == expected_result
         pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
@@ -965,7 +977,9 @@ def test_save_load_runnable_parallel_and_assign_in_sequence():
     assert runnable.invoke("hello") == expected_result
 
     with mlflow.start_run():
-        model_info = mlflow.langchain.log_model(runnable, "model_path")
+        model_info = mlflow.langchain.log_model(
+            runnable, "model_path", input_example=["hello", "world"]
+        )
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
     assert loaded_model.invoke("hello") == expected_result
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
@@ -1042,7 +1056,9 @@ def test_save_load_complex_runnable_sequence():
         assert chain.invoke({"product": "MLflow"}) == expected_result
 
         with mlflow.start_run():
-            model_info = mlflow.langchain.log_model(chain, "model_path")
+            model_info = mlflow.langchain.log_model(
+                chain, "model_path", input_example=[{"product": "MLflow"}]
+            )
 
         loaded_model = mlflow.langchain.load_model(model_info.model_uri)
         result = loaded_model.invoke({"product": "MLflow"})
@@ -1077,8 +1093,10 @@ def test_save_load_simple_chat_model(spark):
     chain = prompt | chat_model | StrOutputParser()
     assert chain.invoke({"product": "MLflow"}) == "Databricks"
     # signature is required for spark_udf
-    # TODO: support inferring signature from runnables
-    signature = ModelSignature(inputs=Schema([ColSpec("string", "product")]))
+    signature = infer_signature({"product": "MLflow"}, "Databricks")
+    assert signature == ModelSignature(
+        Schema([ColSpec("string", "product")]), Schema([ColSpec("string")])
+    )
     with mlflow.start_run():
         model_info = mlflow.langchain.log_model(chain, "model_path", signature=signature)
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
@@ -1148,14 +1166,13 @@ def test_save_load_rag(tmp_path, spark):
     question = "What is a good name for a company that makes MLflow?"
     answer = "Databricks"
     assert retrieval_chain.invoke(question) == answer
-    signature = ModelSignature(inputs=Schema([ColSpec("string", "question")]))
     with mlflow.start_run():
         model_info = mlflow.langchain.log_model(
             retrieval_chain,
             "model_path",
             loader_fn=load_retriever,
             persist_dir=persist_dir,
-            signature=signature,
+            input_example=question,
         )
 
     # Remove the persist_dir
@@ -1164,7 +1181,7 @@ def test_save_load_rag(tmp_path, spark):
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
     assert loaded_model.invoke(question) == answer
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
-    assert pyfunc_loaded_model.predict({"question": [question]}) == [answer]
+    assert pyfunc_loaded_model.predict(question) == [answer]
 
     udf = mlflow.pyfunc.spark_udf(spark, model_info.model_uri, result_type="string")
     df = spark.createDataFrame([(question,), (question,)], ["question"])
@@ -1174,7 +1191,7 @@ def test_save_load_rag(tmp_path, spark):
 
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
-        data=json.dumps({"inputs": [question]}),
+        data=json.dumps({"inputs": question}),
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
         extra_args=["--env-manager", "local"],
     )
@@ -1200,6 +1217,9 @@ def test_runnable_branch_save_load():
     assert branch.invoke({}) == "goodbye"
 
     with mlflow.start_run():
+        # We only support single input format for now, so we should
+        # not save signature for runnable branch which accepts multiple
+        # input types
         model_info = mlflow.langchain.log_model(branch, "model_path")
 
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
@@ -1270,7 +1290,9 @@ def test_complex_runnable_branch_save_load():
     assert chain.invoke({"query": "Are you happy today?"}) == "Something went wrong."
 
     with mlflow.start_run():
-        model_info = mlflow.langchain.log_model(chain, "model_path")
+        model_info = mlflow.langchain.log_model(
+            chain, "model_path", input_example={"query": "Who owns MLflow?"}
+        )
 
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
     assert loaded_model.invoke({"query": "Who owns MLflow?"}) == "Databricks"
@@ -1280,12 +1302,13 @@ def test_complex_runnable_branch_save_load():
     )
     assert loaded_model.invoke({"query": "Are you happy today?"}) == "Something went wrong."
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
-    assert pyfunc_loaded_model.predict({"query": "Who owns MLflow?"}) == "Databricks"
-    assert (
-        pyfunc_loaded_model.predict({"query": "Do you like cat?"})
-        == "I cannot answer questions that are not about MLflow."
-    )
-    assert pyfunc_loaded_model.predict({"query": "Are you happy today?"}) == "Something went wrong."
+    assert pyfunc_loaded_model.predict({"query": "Who owns MLflow?"}) == ["Databricks"]
+    assert pyfunc_loaded_model.predict({"query": "Do you like cat?"}) == [
+        "I cannot answer questions that are not about MLflow."
+    ]
+    assert pyfunc_loaded_model.predict({"query": "Are you happy today?"}) == [
+        "Something went wrong."
+    ]
 
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,
@@ -1294,5 +1317,5 @@ def test_complex_runnable_branch_save_load():
         extra_args=["--env-manager", "local"],
     )
     assert PredictionsResponse.from_json(response.content.decode("utf-8")) == {
-        "predictions": "Databricks"
+        "predictions": ["Databricks"]
     }

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1321,6 +1321,9 @@ def test_complex_runnable_branch_save_load():
     }
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
+)
 def test_chat_with_history(spark):
     from langchain.schema.output_parser import StrOutputParser
     from langchain.schema.runnable import RunnableLambda

--- a/tests/models/test_model_input_examples.py
+++ b/tests/models/test_model_input_examples.py
@@ -390,7 +390,7 @@ def iris_model():
             "petal length (cm)": 1.4,
             "petal width (cm)": 0.2,
         },
-        [5.1, 3.5, 1.4, 0.2],
+        pd.DataFrame([[5.1, 3.5, 1.4, 0.2]]),
         pd.DataFrame(
             {
                 "sepal length (cm)": 5.1,

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -814,7 +814,6 @@ def test_model_log_with_metadata(sklearn_knn_model):
 
 
 def test_model_log_with_signature_inference(sklearn_knn_model, iris_signature):
-    # test
     artifact_path = "model"
     X = sklearn_knn_model.inference_data
     example = X.iloc[[0]]

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -814,6 +814,7 @@ def test_model_log_with_metadata(sklearn_knn_model):
 
 
 def test_model_log_with_signature_inference(sklearn_knn_model, iris_signature):
+    # test
     artifact_path = "model"
     X = sklearn_knn_model.inference_data
     example = X.iloc[[0]]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10668?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10668/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10668
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Support signature for some langchain runnables and support inferring from input_example

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
