### PR TITLE
Fix ImportError in new langchain version

### DIFF
--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -4,6 +4,7 @@ from typing import Union
 
 import cloudpickle
 import yaml
+from packaging.version import Version
 
 from mlflow.exceptions import MlflowException
 from mlflow.langchain.utils import (
@@ -44,11 +45,20 @@ except ImportError:
 
 
 def _load_model_from_config(path, model_config):
-    from langchain.chains.loading import load_chain
+    import langchain
     from langchain.chains.loading import type_to_loader_dict as chains_type_to_loader_dict
-    from langchain.llms.loading import get_type_to_cls_dict as llms_get_type_to_cls_dict
-    from langchain.llms.loading import load_llm
-    from langchain.prompts.loading import load_prompt
+
+    if Version(langchain.__version__) < Version("0.0.349"):
+        from langchain.llms.loading import get_type_to_cls_dict as llms_get_type_to_cls_dict
+    else:
+        try:
+            from langchain_community.llms import get_type_to_cls_dict as llms_get_type_to_cls_dict
+        except ImportError:
+
+            def llms_get_type_to_cls_dict():
+                return {}
+
+            return llms_get_type_to_cls_dict
 
     config_path = os.path.join(path, model_config.get(_MODEL_DATA_KEY, _MODEL_DATA_YAML_FILE_NAME))
     # Load runnables from config file
@@ -62,10 +72,16 @@ def _load_model_from_config(path, model_config):
         )
     _type = config.get("_type")
     if _type in chains_type_to_loader_dict:
+        from langchain.chains.loading import load_chain
+
         return load_chain(config_path)
     elif _type in prompts_types:
+        from langchain.prompts.loading import load_prompt
+
         return load_prompt(config_path)
     elif _type in llms_get_type_to_cls_dict():
+        from langchain.llms.loading import load_llm
+
         return load_llm(config_path)
     elif _type in custom_type_to_loader_dict():
         return custom_type_to_loader_dict()[_type](config)

--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -52,7 +52,7 @@ def _load_model_from_config(path, model_config):
         from langchain.llms.loading import get_type_to_cls_dict as llms_get_type_to_cls_dict
     else:
         try:
-            from langchain_community.llms import get_type_to_cls_dict as llms_get_type_to_cls_dict
+            from langchain.llms import get_type_to_cls_dict as llms_get_type_to_cls_dict
         except ImportError:
 
             def llms_get_type_to_cls_dict():

--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -4,7 +4,6 @@ from typing import Union
 
 import cloudpickle
 import yaml
-from packaging.version import Version
 
 from mlflow.exceptions import MlflowException
 from mlflow.langchain.utils import (
@@ -38,27 +37,15 @@ _BRANCHES_FOLDER_NAME = "branches"
 _RUNNABLE_BRANCHES_FILE_NAME = "branches.yaml"
 _DEFAULT_BRANCH_NAME = "default"
 
-try:
-    from langchain.prompts.loading import type_to_loader_dict as prompts_types
-except ImportError:
-    prompts_types = {"prompt", "few_shot_prompt"}
-
 
 def _load_model_from_config(path, model_config):
-    import langchain
     from langchain.chains.loading import type_to_loader_dict as chains_type_to_loader_dict
+    from langchain.llms import get_type_to_cls_dict as llms_get_type_to_cls_dict
 
-    if Version(langchain.__version__) < Version("0.0.349"):
-        from langchain.llms.loading import get_type_to_cls_dict as llms_get_type_to_cls_dict
-    else:
-        try:
-            from langchain.llms import get_type_to_cls_dict as llms_get_type_to_cls_dict
-        except ImportError:
-
-            def llms_get_type_to_cls_dict():
-                return {}
-
-            return llms_get_type_to_cls_dict
+    try:
+        from langchain.prompts.loading import type_to_loader_dict as prompts_types
+    except ImportError:
+        prompts_types = {"prompt", "few_shot_prompt"}
 
     config_path = os.path.join(path, model_config.get(_MODEL_DATA_KEY, _MODEL_DATA_YAML_FILE_NAME))
     # Load runnables from config file


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10677?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10677/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10677
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Since langchain 0.0.349 it moves langchain.llms.loading.get_type_to_cls_dict to langchain_community.llms.get_type_to_cls_dict. This PR fixes the import error.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
