### PR TITLE
Update DBFS tests with asserts on base network call

### DIFF
--- a/tests/store/artifact/test_dbfs_rest_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_rest_artifact_repo.py
@@ -213,7 +213,7 @@ def test_log_artifacts(dbfs_artifact_repo, test_dir, artifact_path):
             mock.call("POST", "http://host/dbfs/test/test.txt", **MOCK_REQUEST_KWARGS),
             mock.call("POST", "http://host/dbfs/test/subdir/test.txt", **MOCK_REQUEST_KWARGS),
         ]
-        mock_base_request.assert_has_calls(mock_calls)
+        mock_base_request.assert_has_calls(mock_calls, any_order=True)
 
 
 def test_log_artifacts_error(dbfs_artifact_repo, test_dir):

--- a/tests/store/artifact/test_dbfs_rest_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_rest_artifact_repo.py
@@ -13,7 +13,7 @@ from mlflow.store.artifact.dbfs_artifact_repo import (
 )
 from mlflow.store.tracking.file_store import FileStore
 from mlflow.store.tracking.rest_store import RestStore
-from mlflow.utils.rest_utils import MlflowHostCreds
+from mlflow.utils.rest_utils import MlflowHostCreds, http_request
 
 
 @pytest.fixture
@@ -61,6 +61,15 @@ LIST_ARTIFACTS_SINGLE_FILE_RESPONSE = {
     "files": [{"path": "/test/a.txt", "is_dir": False, "file_size": 0}]
 }
 
+MOCK_SUCCESS_RESPONSE = Mock(status_code=200, text="{}")
+MOCK_REQUEST_KWARGS = {
+    "allow_redirects": False,
+    "verify": True,
+    "headers": mock.ANY,
+    "timeout": mock.ANY,
+    "data": mock.ANY,
+}
+
 
 def test_init_validation_and_cleaning():
     with mock.patch(
@@ -101,43 +110,58 @@ def test_init_get_host_creds_with_databricks_profile_uri():
     [(None, "/dbfs/test/test.txt"), ("output", "/dbfs/test/output/test.txt")],
 )
 def test_log_artifact(dbfs_artifact_repo, test_file, artifact_path, expected_endpoint):
-    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
+    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock, mock.patch(
+        "requests.Session.request", return_value=MOCK_SUCCESS_RESPONSE
+    ) as mock_base_request:
         endpoints = []
         data = []
 
         def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
             endpoints.append(kwargs["endpoint"])
             data.append(kwargs["data"].read())
-            return Mock(status_code=200, text="{}")
+            return http_request(host_creds, **kwargs)
 
         http_request_mock.side_effect = my_http_request
         dbfs_artifact_repo.log_artifact(test_file, artifact_path)
         assert endpoints == [expected_endpoint]
         assert data == [TEST_FILE_1_CONTENT]
+        mock_base_request.assert_called_once_with(
+            "POST", f"http://host{expected_endpoint}", **MOCK_REQUEST_KWARGS
+        )
 
 
 def test_log_artifact_empty_file(dbfs_artifact_repo, test_dir):
-    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
+    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock, mock.patch(
+        "requests.Session.request", return_value=MOCK_SUCCESS_RESPONSE
+    ) as mock_base_request:
 
         def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
             assert kwargs["endpoint"] == "/dbfs/test/empty-file"
             assert kwargs["data"] == ""
-            return Mock(status_code=200, text="{}")
+            return http_request(host_creds, **kwargs)
 
         http_request_mock.side_effect = my_http_request
         dbfs_artifact_repo.log_artifact(os.path.join(test_dir, "empty-file"))
+        mock_base_request.assert_called_once_with(
+            "POST", "http://host/dbfs/test/empty-file", **MOCK_REQUEST_KWARGS
+        )
 
 
 def test_log_artifact_empty_artifact_path(dbfs_artifact_repo, test_file):
-    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
+    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock, mock.patch(
+        "requests.Session.request", return_value=MOCK_SUCCESS_RESPONSE
+    ) as mock_base_request:
 
         def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
             assert kwargs["endpoint"] == "/dbfs/test/test.txt"
             assert kwargs["data"].read() == TEST_FILE_1_CONTENT
-            return Mock(status_code=200, text="{}")
+            return http_request(host_creds, **kwargs)
 
         http_request_mock.side_effect = my_http_request
         dbfs_artifact_repo.log_artifact(test_file, "")
+        mock_base_request.assert_called_once_with(
+            "POST", "http://host/dbfs/test/test.txt", **MOCK_REQUEST_KWARGS
+        )
 
 
 def test_log_artifact_error(dbfs_artifact_repo, test_file):
@@ -157,7 +181,9 @@ def test_log_artifact_error(dbfs_artifact_repo, test_file):
     ],
 )
 def test_log_artifacts(dbfs_artifact_repo, test_dir, artifact_path):
-    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
+    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock, mock.patch(
+        "requests.Session.request", return_value=MOCK_SUCCESS_RESPONSE
+    ) as mock_base_request:
         endpoints = []
         data = []
 
@@ -167,7 +193,7 @@ def test_log_artifacts(dbfs_artifact_repo, test_dir, artifact_path):
                 data.append(kwargs["data"])
             else:
                 data.append(kwargs["data"].read())
-            return Mock(status_code=200, text="{}")
+            return http_request(host_creds, **kwargs)
 
         http_request_mock.side_effect = my_http_request
         dbfs_artifact_repo.log_artifacts(test_dir, artifact_path)
@@ -181,6 +207,13 @@ def test_log_artifacts(dbfs_artifact_repo, test_dir, artifact_path):
             TEST_FILE_3_CONTENT,
             "",
         }
+
+        mock_calls = [
+            mock.call("POST", "http://host/dbfs/test/empty-file", **MOCK_REQUEST_KWARGS),
+            mock.call("POST", "http://host/dbfs/test/test.txt", **MOCK_REQUEST_KWARGS),
+            mock.call("POST", "http://host/dbfs/test/subdir/test.txt", **MOCK_REQUEST_KWARGS),
+        ]
+        mock_base_request.assert_has_calls(mock_calls)
 
 
 def test_log_artifacts_error(dbfs_artifact_repo, test_dir):
@@ -216,21 +249,28 @@ def test_log_artifacts_error(dbfs_artifact_repo, test_dir):
 def test_log_artifacts_with_artifact_path(
     dbfs_artifact_repo, test_dir, artifact_path, expected_endpoints
 ):
-    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
+    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock, mock.patch(
+        "requests.Session.request", return_value=MOCK_SUCCESS_RESPONSE
+    ) as mock_base_request:
         endpoints = []
 
         def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
             endpoints.append(kwargs["endpoint"])
-            return Mock(status_code=200, text="{}")
+            return http_request(host_creds, **kwargs)
 
         http_request_mock.side_effect = my_http_request
         dbfs_artifact_repo.log_artifacts(test_dir, artifact_path)
         assert set(endpoints) == expected_endpoints
+        mock_calls = [
+            mock.call("POST", f"http://host{endpoint}", **MOCK_REQUEST_KWARGS)
+            for endpoint in expected_endpoints
+        ]
+        mock_base_request.assert_has_calls(mock_calls, any_order=True)
 
 
 def test_list_artifacts(dbfs_artifact_repo):
-    with mock.patch(DBFS_ARTIFACT_REPOSITORY_PACKAGE + ".http_request") as http_request_mock:
-        http_request_mock.return_value.text = json.dumps(LIST_ARTIFACTS_RESPONSE)
+    with mock.patch("requests.Session.request") as mock_base_request:
+        mock_base_request.return_value = Mock(text=json.dumps(LIST_ARTIFACTS_RESPONSE))
         artifacts = dbfs_artifact_repo.list_artifacts()
         assert len(artifacts) == 2
         assert artifacts[0].path == "a.txt"
@@ -239,10 +279,28 @@ def test_list_artifacts(dbfs_artifact_repo):
         assert artifacts[1].path == "dir"
         assert artifacts[1].is_dir is True
         assert artifacts[1].file_size is None
+        mock_base_request.assert_called_with(
+            "GET",
+            "http://host/api/2.0/dbfs/list",
+            allow_redirects=True,
+            headers=mock.ANY,
+            verify=True,
+            timeout=mock.ANY,
+            params={"path": "/test/"},
+        )
         # Calling list_artifacts() on a path that's a file should return an empty list
-        http_request_mock.return_value.text = json.dumps(LIST_ARTIFACTS_SINGLE_FILE_RESPONSE)
+        mock_base_request.return_value.text = json.dumps(LIST_ARTIFACTS_SINGLE_FILE_RESPONSE)
         list_on_file = dbfs_artifact_repo.list_artifacts("a.txt")
         assert len(list_on_file) == 0
+        mock_base_request.assert_called_with(
+            "GET",
+            "http://host/api/2.0/dbfs/list",
+            allow_redirects=True,
+            headers=mock.ANY,
+            verify=True,
+            timeout=mock.ANY,
+            params={"path": "/test/a.txt"},
+        )
 
 
 def test_download_artifacts(dbfs_artifact_repo):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/10680?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10680/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10680
```

</p>
</details>

### Related Issues/PRs

### What changes are proposed in this pull request?

Update DBFS artifact repo tests with asserts on the base network call. We have these in the other artifact tests, and this would have helped prevent the revert of #10655

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
