### PR TITLE
add log_model example to sentence_transformers

### DIFF
--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -221,6 +221,29 @@ def log_model(
     Log a ``sentence_transformers`` model as an MLflow artifact for the current run.
 
     :param model: A trained ``sentence-transformers`` model.
+
+        An example of using log_model for a sentence-transformers model and architecture:
+
+        from sentence_transformers import SentenceTransformer
+        import mlflow.sentence_transformers
+
+        model = SentenceTransformer("all-MiniLM-L6-v2")
+
+        signature = mlflow.models.infer_signature(
+            model_input=example_sentences,
+            model_output=model.encode(example_sentences),
+        )
+
+        with mlflow.start_rin():
+            logged_model = mlflow.sentence_transformers.log_model(
+                model=model,
+                artifact_path="sbert_model",
+                signature=signature,
+                input_example=example_sentences,
+            )
+
+
+
     :param artifact_path: Local path destination for the serialized model to be saved.
     :param inference_config:
         A dict of valid overrides that can be applied to a ``sentence-transformer`` model instance

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -222,10 +222,12 @@ def log_model(
 
     :param model: A trained ``sentence-transformers`` model.
 
+    .. code-block:: python
+
         An example of using log_model for a sentence-transformers model and architecture:
 
         from sentence_transformers import SentenceTransformer
-        import mlflow.sentence_transformers
+        import mlflow
 
         model = SentenceTransformer("all-MiniLM-L6-v2")
 
@@ -234,7 +236,7 @@ def log_model(
             model_output=model.encode(example_sentences),
         )
 
-        with mlflow.start_rin():
+        with mlflow.start_run():
             logged_model = mlflow.sentence_transformers.log_model(
                 model=model,
                 artifact_path="sbert_model",

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -230,7 +230,7 @@ def log_model(
         import mlflow
 
         model = SentenceTransformer("all-MiniLM-L6-v2")
-
+        data = "MLflow is awesome!"
         signature = mlflow.models.infer_signature(
             model_input=example_sentences,
             model_output=model.encode(example_sentences),
@@ -241,6 +241,7 @@ def log_model(
                 model=model,
                 artifact_path="sbert_model",
                 signature=signature,
+                input_example=data,
             )
 
 

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -241,7 +241,6 @@ def log_model(
                 model=model,
                 artifact_path="sbert_model",
                 signature=signature,
-                input_example=example_sentences,
             )
 
 

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -232,8 +232,8 @@ def log_model(
         model = SentenceTransformer("all-MiniLM-L6-v2")
         data = "MLflow is awesome!"
         signature = mlflow.models.infer_signature(
-            model_input=example_sentences,
-            model_output=model.encode(example_sentences),
+            model_input=data,
+            model_output=model.encode(data),
         )
 
         with mlflow.start_run():

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -237,7 +237,7 @@ def log_model(
         )
 
         with mlflow.start_run():
-            logged_model = mlflow.sentence_transformers.log_model(
+            mlflow.sentence_transformers.log_model(
                 model=model,
                 artifact_path="sbert_model",
                 signature=signature,

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -224,7 +224,7 @@ def log_model(
 
     .. code-block:: python
 
-        An example of using log_model for a sentence-transformers model and architecture:
+        # An example of using log_model for a sentence-transformers model and architecture:
 
         from sentence_transformers import SentenceTransformer
         import mlflow


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/cdreetz/mlflow/pull/10682?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10682/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10682
```

</p>
</details>

### Related Issues/PRs
[DOC-FIX] add examples for sentence transformers log model #10456
<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve

### What changes are proposed in this pull request?

Adding an example to the docstring of mlflow.sentence_transformers so that the docs show an example for log_model similar to the way the transformers docs does

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
