### PR TITLE
Fix version check for Tensorflow nightly

### DIFF
--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -549,7 +549,9 @@ def _load_keras_model(model_path, keras_module, save_format, **kwargs):
 
     import tensorflow as tf
 
-    if save_format == "h5" and Version("2.2.3") <= Version(tf.__version__) < Version("2.16"):
+    # Using base version here because otherwise dev version e.g. 2.16.0.dev2023010 is considered
+    # as ahead of 2.16. We rather want to consider it is a part of 2.16 here.
+    if save_format == "h5" and Version("2.2.3") <= Version(tf.__version__).base_version < Version("2.16"):
         # NOTE: TF 2.2.3 does not work with unicode paths in python2. Pass in h5py.File instead
         # of string to avoid issues.
         import h5py

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -549,9 +549,10 @@ def _load_keras_model(model_path, keras_module, save_format, **kwargs):
 
     import tensorflow as tf
 
-    # Using base version here because otherwise dev version e.g. 2.16.0.dev2023010 is considered
-    # as ahead of 2.16. We rather want to consider it is a part of 2.16 here.
-    if save_format == "h5" and Version("2.2.3") <= Version(tf.__version__).base_version < Version("2.16"):
+    # Using naive tuple-based comparison here rather than packaging.version.Version, because
+    # the latter consider dev version e.g. 2.16.0.dev2023010 as ahead of 2.16. While that is
+    # 'correct', we rather want to treat it is a part of 2.16 here.
+    if save_format == "h5" and (2, 2, 3) <= Version(tf.__version__).release < (2, 16):
         # NOTE: TF 2.2.3 does not work with unicode paths in python2. Pass in h5py.File instead
         # of string to avoid issues.
         import h5py


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10696?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10696/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10696
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

As Keras 3.0 introduced breaking change for model saving, we have special handling in [_load_keras_model]() method. It checks whether the version is prior to 2.16.

Recently, the logic was [refactored](https://github.com/mlflow/mlflow/commit/96a862ef0823df88f434d565e56698c18b0a858a) to use `Version(xxx)` from tuple of release version. However, this changed behavior for dev version `2.16.0.dev20231213`.

```
Version("2.16.0.dev20231213") < Version("2.16.0") => True
Version("2.16.0.dev20231213").release < (2, 16) => False
```
While the new version is "correct" (dev version is prior to stable release), this is not what we want - we want to consider 2.16.0.dev as 2.16.

This change reverts the change, while sticking to `Version` comparison as it is more reliable in general.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
