### PR TITLE
Fix cross vetsion test for tf-nightly

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -90,8 +90,9 @@ tensorflow:
       ">= 2.7.0": ["pandas<2.0"]
       # TensorFlow == 2.6.5 are incompatible with SQLAlchemy 2.x due to
       # transitive dependency version conflicts with the `typing-extensions` package
-      # They are also incompatible with alembic 1.10.1 with the TypeGuard dependency in py3.8
-      "== 2.6.5": ["sqlalchemy<2", "alembic<1.10"]
+      # They are also incompatible with alembic 1.10.1 and anyio 4.2.0 with the
+      # TypeGuard dependency in py3.8
+      "== 2.6.5": ["sqlalchemy<2", "alembic<1.10", "anyio<4.2.0"]
     run: |
       pytest \
         tests/tensorflow/test_load_saved_tensorflow_estimator.py \
@@ -108,8 +109,9 @@ tensorflow:
       "< 2.7.0": ["pandas==1.3.5"]
       # TensorFlow == 2.6.5 are incompatible with SQLAlchemy 2.x due to
       # transitive dependency version conflicts with the `typing-extensions` package
-      # They are also incompatible with alembic 1.10.1 with the TypeGuard dependency in py3.8
-      "== 2.6.5": ["sqlalchemy<2", "alembic<1.10"]
+      # They are also incompatible with alembic 1.10.1 and anyio 4.2.0 with the
+      # TypeGuard dependency in py3.8
+      "== 2.6.5": ["sqlalchemy<2", "alembic<1.10", "anyio<4.2.0"]
     run: |
       pytest tests/tensorflow/test_tensorflow2_autolog.py
 

--- a/tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py
+++ b/tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py
@@ -5,12 +5,19 @@ import numpy as np
 import pandas as pd
 import pytest
 import tensorflow as tf
+from packaging.version import Version
 from pyspark.sql.functions import struct
 from sklearn import datasets
 from tensorflow.keras.layers import Concatenate, Dense, Input, Lambda
 from tensorflow.keras.models import Model, Sequential
 from tensorflow.keras.optimizers import SGD
-from tensorflow.keras.utils import register_keras_serializable
+
+# Tensorflow >= 2.16 removed register_keras_serializable from
+# keras.utils and only export it from keras.saving.
+if Version(tf.__version__).release >= (2, 16):
+    from tensorflow.keras.saving import register_keras_serializable
+else:
+    from tensorflow.keras.utils import register_keras_serializable
 
 import mlflow
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10710?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10710/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10710
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fixing Tensorflow corss version tests failure
- Dev version (tf-nightly) failed as `register_keras_serializable` decorator was moved from `keras.utils` to `keras.saving` comletely.
- 2.6.5 also failed (more recently) due to conflict with the latest anyio release (4.2.0)

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
