### PR TITLE
Add basic graphql handler

### DIFF
--- a/mlflow/server/graphql/graphql_schema_extensions.py
+++ b/mlflow/server/graphql/graphql_schema_extensions.py
@@ -1,0 +1,15 @@
+import graphene
+
+
+class Test(graphene.ObjectType):
+    output = graphene.String(description="Echoes the input string")
+
+
+class Query(graphene.ObjectType):
+    test = graphene.Field(Test, input_string=graphene.String(), description="Simple echoing field")
+
+    def resolve_test(self, info, input_string):
+        return {"output": input_string}
+
+
+schema = graphene.Schema(query=Query)

--- a/requirements/core-requirements.txt
+++ b/requirements/core-requirements.txt
@@ -18,3 +18,4 @@ markdown<4,>=3.3
 Jinja2<4,>=2.11; platform_system != 'Windows'
 Jinja2<4,>=3.0; platform_system == 'Windows'
 matplotlib<4
+graphene<4

--- a/requirements/core-requirements.yaml
+++ b/requirements/core-requirements.yaml
@@ -81,3 +81,7 @@ Jinja2-windows:
 matplotlib:
   pip_release: matplotlib
   max_major_version: 3
+
+graphene:
+  pip_release: graphene
+  max_major_version: 3

--- a/requirements/skinny-requirements.txt
+++ b/requirements/skinny-requirements.txt
@@ -14,3 +14,4 @@ requests<3,>=2.17.3
 packaging<24
 importlib_metadata<8,>=3.7.0,!=4.7.0
 sqlparse<1,>=0.4.0
+graphene<4

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -65,3 +65,7 @@ sqlparse:
   # Lower bound sqlparse for: https://github.com/andialbrecht/sqlparse/pull/567
   minimum: "0.4.0"
   max_major_version: 0
+
+graphene:
+  pip_release: graphene
+  max_major_version: 3

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -44,3 +44,4 @@ databricks-sdk
 openai<1.0
 # Required for showing pytest stats
 psutil
+graphene<4

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -1761,3 +1761,16 @@ def test_upload_artifact_handler(mlflow_client):
     )
     assert response.status_code == 200
     assert response.text == "hello world"
+
+
+def test_graphql_handler(mlflow_client):
+    response = requests.request(
+        "post",
+        f"{mlflow_client.tracking_uri}/graphql",
+        json={
+            "query": 'query testQuery {test(inputString: "abc") { output }}',
+            "operationName": "testQuery",
+        },
+        headers={"content-type": "application/json; charset=utf-8"},
+    )
+    assert response.status_code == 200


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/edwardfeng-db/mlflow/pull/10714?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10714/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10714
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx
https://github.com/mlflow/mlflow/pull/10474

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
- Adding basic graphql handler and a basic graphql schema

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
