### PR TITLE
correctly parse hp search space

### DIFF
--- a/mlflow/recipes/steps/train.py
+++ b/mlflow/recipes/steps/train.py
@@ -206,12 +206,14 @@ class TrainStep(BaseStep):
                         error_code=INVALID_PARAMETER_VALUE,
                     )
                 try:
-                    param_details_to_pass["high"] = float(param_details_to_pass["high"])
-                    param_details_to_pass["low"] = float(param_details_to_pass["low"])
+                    if isinstance(param_details_to_pass["low"], str):
+                        param_details_to_pass["low"] = float(param_details_to_pass["low"])
+                    if isinstance(param_details_to_pass["high"], str):
+                        param_details_to_pass["high"] = float(param_details_to_pass["high"])
                 except ValueError:
                     raise MlflowException(
                         f"Parameter {param_name} distribution 'high' and 'low' values must be "
-                        f"valid floats",
+                        f"valid numbers",
                         error_code=INVALID_PARAMETER_VALUE,
                     )
                 param_details_to_pass.pop("distribution")

--- a/mlflow/recipes/steps/train.py
+++ b/mlflow/recipes/steps/train.py
@@ -199,6 +199,21 @@ class TrainStep(BaseStep):
             elif "distribution" in param_details:
                 hp_tuning_fn = getattr(hp, param_details["distribution"])
                 param_details_to_pass = param_details.copy()
+                # convert high/low to float in case yaml is parsed to str scientific notation
+                if "high" not in param_details_to_pass or "low" not in param_details_to_pass:
+                    raise MlflowException(
+                        f"Parameter {param_name} distribution must contain 'high' and 'low' values",
+                        error_code=INVALID_PARAMETER_VALUE,
+                    )
+                try:
+                    param_details_to_pass["high"] = float(param_details_to_pass["high"])
+                    param_details_to_pass["low"] = float(param_details_to_pass["low"])
+                except ValueError:
+                    raise MlflowException(
+                        f"Parameter {param_name} distribution 'high' and 'low' values must be "
+                        f"valid floats",
+                        error_code=INVALID_PARAMETER_VALUE,
+                    )
                 param_details_to_pass.pop("distribution")
                 search_space[param_name] = hp_tuning_fn(param_name, **param_details_to_pass)
             else:

--- a/tests/recipes/test_train_step.py
+++ b/tests/recipes/test_train_step.py
@@ -1,4 +1,5 @@
 import importlib
+import importlib.util
 import math
 import os
 import random
@@ -553,7 +554,7 @@ def test_train_step_with_tuning_child_runs_and_early_stop(
     assert ordered_metrics == sorted(ordered_metrics)
 
 
-@pytest.mark.skipif("hyperopt" not in sys.modules, reason="requires hyperopt to be installed")
+@pytest.mark.skipif(importlib.util.find_spec("hyperopt") is None, reason="requires hyperopt")
 def test_search_space(tmp_recipe_root_path):
     tuning_params_yaml = tmp_recipe_root_path.joinpath("tuning_params.yaml")
     tuning_params_yaml.write_text(
@@ -570,7 +571,7 @@ def test_search_space(tmp_recipe_root_path):
     assert "alpha" in search_space
 
 
-@pytest.mark.skipif("hyperopt" not in sys.modules, reason="requires hyperopt to be installed")
+@pytest.mark.skipif(importlib.util.find_spec("hyperopt") is None, reason="requires hyperopt")
 def test_search_space_with_small_boundaries(tmp_recipe_root_path):
     tuning_params_yaml = tmp_recipe_root_path.joinpath("tuning_params.yaml")
     tuning_params_yaml.write_text(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dan-licht/mlflow/pull/10716?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10716/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10716
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
This PR resolves a bug in MLflow Recipes when hyperparameter tuning is enabled and the distribution range contains large decimal values. Previously, when the specified `low` or `high` contained a decimal with more than 4 digits, the `yaml.safe_load` function would convert the float to a string in scientific notation. This leads to a downstream error from `hyperopt` like
```
TypeError: '<' not supported between instances of 'str' and 'float'
```
Here is an example snippet of what the train step config YAML may look like to create this issue
```yaml
TRAIN_CONFIG:
  using: "custom"
  estimator_method: estimator_method
  estimator_params:
    ...
  tuning:
    enabled: true
    max_trials: 200
    algorithm: "hyperopt.tpe.suggest"
    parallelism: 1
    parameters:
      alpha:
        distribution: "uniform"
        low: 0.0000001
        high: 0.001
```
In this scenario, when the `step_config` is loaded with `yaml.safe_load`, the value for `low` is converted to a string of  "1e-7", leading to the error mentioned above. My solution ensures that the values for `low` and `high` are cast to floats, when necessary, to prevent this error.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
