### PR TITLE
Refactor PyTorch flavor docstring and code examples

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -159,37 +159,34 @@ def log_model(
             can correctly provide valid input.
 
     :param pytorch_model: PyTorch model to be saved. Can be either an eager model (subclass of
-                          ``torch.nn.Module``) or scripted model prepared via ``torch.jit.script``
-                          or ``torch.jit.trace``.
+        ``torch.nn.Module``) or scripted model prepared via ``torch.jit.script`` or
+        ``torch.jit.trace``.
 
-                          The model accept a single ``torch.FloatTensor`` as
-                          input and produce a single output tensor.
+        The model accept a single ``torch.FloatTensor`` as input and produce a single output tensor.
 
-                          If saving an eager model, any code dependencies of the
-                          model's class, including the class definition itself, should be
-                          included in one of the following locations:
+        If saving an eager model, any code dependencies of the model's class, including the class
+        definition itself, should be included in one of the following locations:
 
-                          - The package(s) listed in the model's Conda environment, specified
-                            by the ``conda_env`` parameter.
-                          - One or more of the files specified by the ``code_paths`` parameter.
+            - The package(s) listed in the model's Conda environment, specified by the ``conda_env``
+                parameter.
+            - One or more of the files specified by the ``code_paths`` parameter.
 
     :param artifact_path: Run-relative artifact path.
     :param conda_env: {{ conda_env }}
     :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
+        containing file dependencies). These files are *prepended* to the system path when the model
+        is loaded.
     :param pickle_module: The module that PyTorch should use to serialize ("pickle") the specified
-                          ``pytorch_model``. This is passed as the ``pickle_module`` parameter
-                          to ``torch.save()``. By default, this module is also used to
-                          deserialize ("unpickle") the PyTorch model at load time.
-    :param registered_model_name: If given, create a model version under
-                                  ``registered_model_name``, also creating a registered model if one
-                                  with the given name does not exist.
+        ``pytorch_model``. This is passed as the ``pickle_module`` parameter to ``torch.save()``.
+        By default, this module is also used to deserialize ("unpickle") the PyTorch model at load
+        time.
+    :param registered_model_name: If given, create a model version under ``registered_model_name``,
+        also create a registered model if one with the given name does not exist.
     :param signature: {{ signature }}
     :param input_example: {{ input_example }}
     :param await_registration_for: Number of seconds to wait for the model version to finish
-                            being created and is in ``READY`` status. By default, the function
-                            waits for five minutes. Specify 0 or None to skip waiting.
+        being created and is in ``READY`` status. By default, the function waits for five minutes.
+        Specify 0 or None to skip waiting.
 
     :param requirements_file:
 
@@ -207,25 +204,25 @@ def log_model(
         In this case, the ``"my_file"`` requirements file is downloaded from S3. If ``None``,
         no requirements file is added to the model.
 
-    :param extra_files: A list containing the paths to corresponding extra files. Remote URIs
-                      are resolved to absolute filesystem paths.
-                      For example, consider the following ``extra_files`` list -
+    :param extra_files: A list containing the paths to corresponding extra files, if ``None``, no
+        extra files are added to the model. Remote URIs are resolved to absolute filesystem paths.
+        For example, consider the following ``extra_files`` list:
 
-                      extra_files = ["s3://my-bucket/path/to/my_file1",
-                                    "s3://my-bucket/path/to/my_file2"]
+        .. code-block:: python
 
-                      In this case, the ``"my_file1 & my_file2"`` extra file is downloaded from S3.
+            extra_files = ["s3://my-bucket/path/to/my_file1", "s3://my-bucket/path/to/my_file2"]
 
-                      If ``None``, no extra files are added to the model.
+        In this case, the ``"my_file1 & my_file2"`` extra file is downloaded from S3.
+
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
     :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
+        .. Note:: Experimental: This parameter may change or be removed in a future
+                                release without warning.
     :param kwargs: kwargs to pass to ``torch.save`` method.
     :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
-             metadata of the logged model.
+        metadata of the logged model.
 
     .. code-block:: python
         :caption: Example
@@ -333,30 +330,25 @@ def save_model(
     Save a PyTorch model to a path on the local file system.
 
     :param pytorch_model: PyTorch model to be saved. Can be either an eager model (subclass of
-                          ``torch.nn.Module``) or scripted model prepared via ``torch.jit.script``
-                          or ``torch.jit.trace``.
+        ``torch.nn.Module``) or a scripted model prepared via ``torch.jit.script`` or
+        ``torch.jit.trace``.
 
-                          The model accept a single ``torch.FloatTensor`` as
-                          input and produce a single output tensor.
+        To save an eager model, any code dependencies of the model's class, including the class
+        definition itself, should be included in one of the following locations:
 
-                          If saving an eager model, any code dependencies of the
-                          model's class, including the class definition itself, should be
-                          included in one of the following locations:
-
-                          - The package(s) listed in the model's Conda environment, specified
-                            by the ``conda_env`` parameter.
-                          - One or more of the files specified by the ``code_paths`` parameter.
+            - The package(s) listed in the model's Conda environment, specified by the ``conda_env``
+                parameter.
+            - One or more of the files specified by the ``code_paths`` parameter.
 
     :param path: Local path where the model is to be saved.
     :param conda_env: {{ conda_env }}
     :param mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
     :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
+        containing file dependencies). These files are *prepended* to the system path when the model
+        is loaded.
     :param pickle_module: The module that PyTorch should use to serialize ("pickle") the specified
-                          ``pytorch_model``. This is passed as the ``pickle_module`` parameter
-                          to ``torch.save()``. By default, this module is also used to
-                          deserialize ("unpickle") the PyTorch model at load time.
+        ``pytorch_model``. This is passed as the ``pickle_module`` parameter to ``torch.save()``. By
+        default, this module is also used to deserialize ("unpickle") the model at loading time.
     :param signature: {{ signature }}
     :param input_example: {{ input_example }}
     :param requirements_file:
@@ -376,42 +368,32 @@ def save_model(
         no requirements file is added to the model.
 
     :param extra_files: A list containing the paths to corresponding extra files. Remote URIs
-                      are resolved to absolute filesystem paths.
-                      For example, consider the following ``extra_files`` list -
+        are resolved to absolute filesystem paths.
+        For example, consider the following ``extra_files`` list -
 
-                      extra_files = ["s3://my-bucket/path/to/my_file1",
-                                    "s3://my-bucket/path/to/my_file2"]
+        extra_files = ["s3://my-bucket/path/to/my_file1",
+                    "s3://my-bucket/path/to/my_file2"]
 
-                      In this case, the ``"my_file1 & my_file2"`` extra file is downloaded from S3.
+        In this case, the ``"my_file1 & my_file2"`` extra file is downloaded from S3.
 
-                      If ``None``, no extra files are added to the model.
+        If ``None``, no extra files are added to the model.
     :param pip_requirements: {{ pip_requirements }}
     :param extra_pip_requirements: {{ extra_pip_requirements }}
     :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
+        .. Note:: Experimental: This parameter may change or be removed in a future
+                                release without warning.
     :param kwargs: kwargs to pass to ``torch.save`` method.
 
     .. code-block:: python
         :caption: Example
 
         import os
-
+        import mlflow
         import torch
-        import mlflow.pytorch
 
 
-        # Class defined here
-        class LinearNNModel(torch.nn.Module):
-            ...
-
-
-        # Initialize our model, criterion and optimizer
-        ...
-
-        # Training loop
-        ...
+        model = nn.Linear(1, 1)
 
         # Save PyTorch models to current working directory
         with mlflow.start_run() as run:
@@ -446,6 +428,7 @@ def save_model(
         predict X: 8.0, y_pred: 15.92
         predict X: 12.0, y_pred: 23.96
         predict X: 30.0, y_pred: 60.13
+
     """
     import torch
 
@@ -643,21 +626,19 @@ def load_model(model_uri, dst_path=None, **kwargs):
 
     :param model_uri: The location, in URI format, of the MLflow model, for example:
 
-                      - ``/Users/me/path/to/local/model``
-                      - ``relative/path/to/local/model``
-                      - ``s3://my_bucket/path/to/model``
-                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
-                      - ``models:/<model_name>/<model_version>``
-                      - ``models:/<model_name>/<stage>``
+        - ``/Users/me/path/to/local/model``
+        - ``relative/path/to/local/model``
+        - ``s3://my_bucket/path/to/model``
+        - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+        - ``models:/<model_name>/<model_version>``
+        - ``models:/<model_name>/<stage>``
 
-                      For more information about supported URI schemes, see
-                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
-                      artifact-locations>`_.
+        For more information about supported URI schemes, see `Referencing Artifacts \
+        <https://www.mlflow.org/docs/latest/concepts.html#artifact-locations>`_.
     :param dst_path: The local filesystem path to which to download the model artifact.
-                     This directory must already exist. If unspecified, a local output
-                     path will be created.
-
+        This directory must already exist. If unspecified, a local output path will be created.
     :param kwargs: kwargs to pass to ``torch.load`` method.
+
     :return: A PyTorch model.
 
     .. code-block:: python
@@ -667,20 +648,11 @@ def load_model(model_uri, dst_path=None, **kwargs):
         import mlflow.pytorch
 
 
-        # Class defined here
-        class LinearNNModel(torch.nn.Module):
-            ...
-
-
-        # Initialize our model, criterion and optimizer
-        ...
-
-        # Training loop
-        ...
+        model = nn.Linear(1, 1)
 
         # Log the model
         with mlflow.start_run() as run:
-            mlflow.pytorch.log_model(model, "model", signature=signature)
+            mlflow.pytorch.log_model(model, "model")
 
         # Inference after loading the logged model
         model_uri = f"runs:/{run.info.run_id}/model"
@@ -736,8 +708,8 @@ class _PyTorchWrapper:
         :param data: Model input data.
         :param params: Additional parameters to pass to the model for inference.
 
-                       .. Note:: Experimental: This parameter may change or be removed in a future
-                                               release without warning.
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                                    release without warning.
 
         :return: Model predictions.
         """
@@ -857,14 +829,13 @@ def load_state_dict(state_dict_uri, **kwargs):
 
     :param state_dict_uri: The location, in URI format, of the state_dict, for example:
 
-                    - ``/Users/me/path/to/local/state_dict``
-                    - ``relative/path/to/local/state_dict``
-                    - ``s3://my_bucket/path/to/state_dict``
-                    - ``runs:/<mlflow_run_id>/run-relative/path/to/state_dict``
+        - ``/Users/me/path/to/local/state_dict``
+        - ``relative/path/to/local/state_dict``
+        - ``s3://my_bucket/path/to/state_dict``
+        - ``runs:/<mlflow_run_id>/run-relative/path/to/state_dict``
 
-                    For more information about supported URI schemes, see
-                    `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
-                    artifact-locations>`_.
+        For more information about supported URI schemes, see `Referencing Artifacts \
+        <https://www.mlflow.org/docs/latest/concepts.html#artifact-locations>`_.
 
     :param kwargs: kwargs to pass to ``torch.load``.
     :return: A state_dict
@@ -923,34 +894,33 @@ def autolog(
     no notion of an "epoch".
 
     .. Note:: Only pytorch-lightning modules between versions MIN_REQ_VERSION and
-              MAX_REQ_VERSION are known to be compatible with mlflow's autologging.
+        MAX_REQ_VERSION are known to be compatible with mlflow's autologging.
 
     :param log_every_n_epoch: If specified, logs metrics once every `n` epochs. By default, metrics
-                       are logged after every epoch.
+        are logged after every epoch.
     :param log_every_n_step: If specified, logs batch metrics once every `n` training step.
-                       By default, metrics are not logged for steps. Note that setting this to 1 can
-                       cause performance issues and is not recommended.
-                       Metrics are logged against Lightning's global step number,
-                       and when multiple optimizers are used it is assumed that all optimizers
-                       are stepped in each training step.
+        By default, metrics are not logged for steps. Note that setting this to 1 can cause
+        performance issues and is not recommended. Metrics are logged against Lightning's global
+        step number, and when multiple optimizers are used it is assumed that all optimizers
+        are stepped in each training step.
     :param log_models: If ``True``, trained models are logged as MLflow model artifacts.
-                       If ``False``, trained models are not logged.
+        If ``False``, trained models are not logged.
     :param log_datasets: If ``True``, dataset information is logged to MLflow Tracking.
-                         If ``False``, dataset information is not logged.
+        If ``False``, dataset information is not logged.
     :param disable: If ``True``, disables the PyTorch Lightning autologging integration.
-                    If ``False``, enables the PyTorch Lightning autologging integration.
+        If ``False``, enables the PyTorch Lightning autologging integration.
     :param exclusive: If ``True``, autologged content is not logged to user-created fluent runs.
-                      If ``False``, autologged content is logged to the active fluent run,
-                      which may be user-created.
+        If ``False``, autologged content is logged to the active fluent run, which may be
+        user-created.
     :param disable_for_unsupported_versions: If ``True``, disable autologging for versions of
-                      pytorch and pytorch-lightning that have not been tested against this version
-                      of the MLflow client or are incompatible.
+        pytorch and pytorch-lightning that have not been tested against this version
+        of the MLflow client or are incompatible.
     :param silent: If ``True``, suppress all event logs and warnings from MLflow during PyTorch
-                   Lightning autologging. If ``False``, show all events and warnings during
-                   PyTorch Lightning autologging.
+        Lightning autologging. If ``False``, show all events and warnings during PyTorch Lightning
+        autologging.
     :param registered_model_name: If given, each time a model is trained, it is registered as a
-                                  new model version of the registered model with this name.
-                                  The registered model is created if it does not already exist.
+        new model version of the registered model with this name. The registered model is created if
+        it does not already exist.
     :param extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
 
     .. testcode:: python

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -52,15 +52,14 @@ def patched_add_event(original, self, event, *args, mlflow_log_every_n_step, **k
         global_step = args[0] if len(args) > 0 else kwargs.get("global_step", None)
         global_step = global_step or 0
         for v in summary.value:
-            if v.HasField("simple_value"):
-                if global_step % mlflow_log_every_n_step == 0:
-                    add_to_metrics_queue(
-                        key=v.tag,
-                        value=v.simple_value,
-                        step=global_step,
-                        time=int((event.wall_time or time.time()) * 1000),
-                        run_id=run.info.run_id,
-                    )
+            if v.HasField("simple_value") and global_step % mlflow_log_every_n_step == 0:
+                add_to_metrics_queue(
+                    key=v.tag,
+                    value=v.simple_value,
+                    step=global_step,
+                    time=int((event.wall_time or time.time()) * 1000),
+                    run_id=run.info.run_id,
+                )
 
     return original(self, event, *args, **kwargs)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/10717?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10717/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10717
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Two small changes:
- Replace vertical alignment with 4-space indentation. Since the current docstring does not comply to either rule (many vertical alignment is broken).
- Make the code example runnable.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
