### PR TITLE
Fix error message for missing "targets" column

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1478,7 +1478,9 @@ class DefaultEvaluator(ModelEvaluator):
         remaining_params = [param for param in param_names if param not in special_params]
 
         if remaining_params:
-            error_message_parts.append(f"  - columns {remaining_params} to be defined or mapped")
+            error_message_parts.append(
+                f"  - missing columns {remaining_params} to be defined or mapped"
+            )
 
         return "".join(error_message_parts)
 
@@ -1520,8 +1522,9 @@ class DefaultEvaluator(ModelEvaluator):
             Input Columns: {input_columns}
             Output Columns: {output_columns}
 
-            To resolve this issue, you may want specify any required parameters or map any missing
-            columns to an existing column using the following configuration:
+            To resolve this issue, you may need to specify any required parameters, or if you are
+            missing columns, you may want to map them to an existing column using the following
+            configuration:
             evaluator_config={{'col_mapping': {{<missing column name>: <existing column name>}}}}"""
             stripped_message = "\n".join(l.lstrip() for l in full_message.splitlines())
             raise MlflowException(stripped_message)

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1468,7 +1468,7 @@ class DefaultEvaluator(ModelEvaluator):
             )
 
     def _get_error_message_missing_columns(self, metric_name, param_names):
-        error_message_parts = [f"Metric '{metric_name}' requires the following:\n"]
+        error_message_parts = [f"Metric '{metric_name}' requires the following:"]
 
         special_params = ["targets", "predictions"]
         for param in special_params:
@@ -1479,10 +1479,10 @@ class DefaultEvaluator(ModelEvaluator):
 
         if remaining_params:
             error_message_parts.append(
-                f"  - missing columns {remaining_params} to be defined or mapped"
+                f"  - missing columns {remaining_params} need to be defined or mapped"
             )
 
-        return "".join(error_message_parts)
+        return "\n".join(error_message_parts)
 
     def _check_args(self, metrics, eval_df):
         failed_metrics = []

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1473,7 +1473,7 @@ class DefaultEvaluator(ModelEvaluator):
         special_params = ["targets", "predictions"]
         for param in special_params:
             if param in param_names:
-                error_message_parts.append(f"  - the '{param}' parameter be specified")
+                error_message_parts.append(f"  - the '{param}' parameter needs to be specified")
 
         remaining_params = [param for param in param_names if param not in special_params]
 
@@ -1520,8 +1520,8 @@ class DefaultEvaluator(ModelEvaluator):
             Input Columns: {input_columns}
             Output Columns: {output_columns}
 
-            To resolve this issue, you may want to map the missing column to an existing column
-            using the following configuration:
+            To resolve this issue, you may want specify any required paramters or map any missing 
+            columns to an existing column using the following configuration:
             evaluator_config={{'col_mapping': {{<missing column name>: <existing column name>}}}}"""
             stripped_message = "\n".join(l.lstrip() for l in full_message.splitlines())
             raise MlflowException(stripped_message)

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1471,14 +1471,19 @@ class DefaultEvaluator(ModelEvaluator):
 
     def _get_error_message_missing_columns(self, metric_name, param_names):
         error_message_parts = [f"Metric '{metric_name}' requires "]
-        if "targets" in param_names:
-            param_names.remove("targets")
-            error_message_parts.append("that the 'targets' parameter be specified ")
-        if "predictions" in param_names:
-            param_names.remove("predictions")
-            error_message_parts.append("that the 'predictions' parameter be specified ")
-        error_message_parts.append(f"requires the columns {param_names}")
-        return error_message_parts.join("and ")
+
+        special_params = ["targets", "predictions"]
+        for param in special_params:
+            if param in param_names:
+                error_message_parts.append(f"that the '{param}' parameter be specified, ")
+
+        remaining_params = [param for param in param_names if param not in special_params]
+
+        if remaining_params:
+            formatted_params = ", ".join(remaining_params)
+            error_message_parts.append(f"the following columns: {formatted_params}")
+
+        return "and ".join(error_message_parts)
 
     def _check_args(self, metrics, eval_df):
         failed_metrics = []

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1520,7 +1520,7 @@ class DefaultEvaluator(ModelEvaluator):
             Input Columns: {input_columns}
             Output Columns: {output_columns}
 
-            To resolve this issue, you may want specify any required paramaters or map any missing
+            To resolve this issue, you may want specify any required parameters or map any missing
             columns to an existing column using the following configuration:
             evaluator_config={{'col_mapping': {{<missing column name>: <existing column name>}}}}"""
             stripped_message = "\n".join(l.lstrip() for l in full_message.splitlines())

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1520,7 +1520,7 @@ class DefaultEvaluator(ModelEvaluator):
             Input Columns: {input_columns}
             Output Columns: {output_columns}
 
-            To resolve this issue, you may want specify any required paramters or map any missing 
+            To resolve this issue, you may want specify any required paramaters or map any missing
             columns to an existing column using the following configuration:
             evaluator_config={{'col_mapping': {{<missing column name>: <existing column name>}}}}"""
             stripped_message = "\n".join(l.lstrip() for l in full_message.splitlines())

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1468,18 +1468,17 @@ class DefaultEvaluator(ModelEvaluator):
             )
 
     def _get_error_message_missing_columns(self, metric_name, param_names):
-        error_message_parts = [f"Metric '{metric_name}' requires:\n"]
+        error_message_parts = [f"Metric '{metric_name}' requires the following:\n"]
 
         special_params = ["targets", "predictions"]
         for param in special_params:
             if param in param_names:
-                error_message_parts.append(f"  - that the '{param}' parameter be specified")
+                error_message_parts.append(f"  - the '{param}' parameter be specified")
 
         remaining_params = [param for param in param_names if param not in special_params]
 
         if remaining_params:
-            formatted_params = ", ".join(remaining_params)
-            error_message_parts.append(f"  - the following columns: {formatted_params}")
+            error_message_parts.append(f"  - columns {remaining_params} to be defined or mapped")
 
         return "".join(error_message_parts)
 
@@ -1520,6 +1519,7 @@ class DefaultEvaluator(ModelEvaluator):
             Below are the existing column names for the input/output data:
             Input Columns: {input_columns}
             Output Columns: {output_columns}
+
             To resolve this issue, you may want to map the missing column to an existing column
             using the following configuration:
             evaluator_config={{'col_mapping': {{<missing column name>: <existing column name>}}}}"""

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1198,6 +1198,8 @@ class DefaultEvaluator(ModelEvaluator):
                 elif column == "targets" or column == self.dataset.targets_name:
                     if "target" in eval_df_copy:
                         eval_fn_args.append(eval_df_copy["target"])
+                    elif "targets" in eval_df_copy:
+                        eval_fn_args.append(eval_df_copy["targets"])
                     else:
                         if param.default == inspect.Parameter.empty:
                             params_not_found.append(param_name)

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1198,8 +1198,8 @@ class DefaultEvaluator(ModelEvaluator):
                 elif column == "targets" or column == self.dataset.targets_name:
                     if "target" in eval_df_copy:
                         eval_fn_args.append(eval_df_copy["target"])
-                    elif "targets" in eval_df_copy:
-                        eval_fn_args.append(eval_df_copy["targets"])
+                    elif "targets" in input_df:
+                        eval_fn_args.append(input_df["targets"])
                     else:
                         if param.default == inspect.Parameter.empty:
                             params_not_found.append(param_name)
@@ -1469,6 +1469,17 @@ class DefaultEvaluator(ModelEvaluator):
                 )
             )
 
+    def _get_error_message_missing_columns(self, metric_name, param_names):
+        error_message_parts = [f"Metric '{metric_name}' requires "]
+        if "targets" in param_names:
+            param_names.remove("targets")
+            error_message_parts.append("that the 'targets' parameter be specified ")
+        if "predictions" in param_names:
+            param_names.remove("predictions")
+            error_message_parts.append("that the 'predictions' parameter be specified ")
+        error_message_parts.append(f"requires the columns {param_names}")
+        return error_message_parts.join("and ")
+
     def _check_args(self, metrics, eval_df):
         failed_metrics = []
         # collect all failures for getting metric arguments
@@ -1496,7 +1507,7 @@ class DefaultEvaluator(ModelEvaluator):
                     input_columns.append("targets")
 
             error_messages = [
-                f"Metric '{metric_name}' requires the columns {param_names}"
+                self._get_error_message_missing_columns(metric_name, param_names)
                 for metric_name, param_names in failed_metrics
             ]
             joined_error_message = "\n".join(error_messages)

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1468,20 +1468,20 @@ class DefaultEvaluator(ModelEvaluator):
             )
 
     def _get_error_message_missing_columns(self, metric_name, param_names):
-        error_message_parts = [f"Metric '{metric_name}' requires "]
+        error_message_parts = [f"Metric '{metric_name}' requires:\n"]
 
         special_params = ["targets", "predictions"]
         for param in special_params:
             if param in param_names:
-                error_message_parts.append(f"that the '{param}' parameter be specified, ")
+                error_message_parts.append(f"  - that the '{param}' parameter be specified")
 
         remaining_params = [param for param in param_names if param not in special_params]
 
         if remaining_params:
             formatted_params = ", ".join(remaining_params)
-            error_message_parts.append(f"the following columns: {formatted_params}")
+            error_message_parts.append(f"  - the following columns: {formatted_params}")
 
-        return "and ".join(error_message_parts)
+        return "".join(error_message_parts)
 
     def _check_args(self, metrics, eval_df):
         failed_metrics = []

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1198,8 +1198,6 @@ class DefaultEvaluator(ModelEvaluator):
                 elif column == "targets" or column == self.dataset.targets_name:
                     if "target" in eval_df_copy:
                         eval_fn_args.append(eval_df_copy["target"])
-                    elif "targets" in input_df:
-                        eval_fn_args.append(input_df["targets"])
                     else:
                         if param.default == inspect.Parameter.empty:
                             params_not_found.append(param_name)

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2190,13 +2190,17 @@ def test_missing_args_raises_exception():
 
     error_message = (
         r"Error: Metric calculation failed for the following metrics:\n"
-        r"Metric 'metric_1' requires the columns \['param_1', 'param_2'\]\n"
-        r"Metric 'metric_2' requires the columns \['param_3', 'builtin_metrics'\]\n\n"
+        r"Metric 'metric_1' requires the following:\n"
+        r"- the 'targets' parameter needs to be specified\n"
+        r"- missing columns \['param_1', 'param_2'\] need to be defined or mapped\n"
+        r"Metric 'metric_2' requires the following:\n"
+        r"- missing columns \['param_3', 'builtin_metrics'\] need to be defined or mapped\n\n"
         r"Below are the existing column names for the input/output data:\n"
         r"Input Columns: \['question', 'answer'\]\n"
-        r"Output Columns: \['predictions'\]\n"
-        r"To resolve this issue, you may want to map the missing column to an existing column\n"
-        r"using the following configuration:\n"
+        r"Output Columns: \['predictions'\]\n\n"
+        r"To resolve this issue, you may need to specify any required parameters, or if you are\n"
+        r"missing columns, you may want to map them to an existing column using the following\n"
+        r"configuration:\n"
         r"evaluator_config=\{'col_mapping': \{<missing column name>: <existing column name>\}\}"
     )
 
@@ -2208,7 +2212,6 @@ def test_missing_args_raises_exception():
             mlflow.evaluate(
                 model_info.model_uri,
                 data,
-                targets="answer",
                 evaluators="default",
                 model_type="question-answering",
                 extra_metrics=[metric_1, metric_2],


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/annzhang-db/mlflow/pull/10723?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10723/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10723
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- Neither "target" or "targets" is accepted as a column from dataset, since "prediction" and "target" are not normal columns we should not treat them like columns (seems more confusing, since they will behave differently from other columns and we want users to use targets= instead of col_mapping)
- Instead, clarify the requirements to ask for targets parameter or predictions parameter to be specified

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<img width="739" alt="Screenshot 2023-12-20 at 4 46 15 PM" src="https://github.com/mlflow/mlflow/assets/105813440/94d040d6-eccc-489b-8983-e082667853a9">

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
