### PR TITLE
Support nullable boolean column in schema enforcement

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -546,6 +546,11 @@ def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
             raise MlflowException(
                 "Failed to convert column {name} from type {values.dtype} to {t}."
             ) from e
+
+    if t == DataType.boolean and values.dtype == object:
+        # Should not convert type otherwise it converts None to boolean False
+        return values
+
     if t == DataType.double and values.dtype == decimal.Decimal:
         # NB: Pyspark Decimal column get converted to decimal.Decimal when converted to pandas
         # DataFrame. In order to support decimal data training from spark data frame, we add this

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -1613,13 +1613,13 @@ def test_enforce_schema_in_python_model_predict(sample_params_basic, param_schem
 
 def test_schema_enforcement_all_feature_types_pandas():
     data = {
-        "f1": list(range(0, 200)),
-        "f2": [(i % 3) == 0 for i in range(0, 200)],
-        "f3": [f"string id: {i}" for i in range(0, 200)],
-        "f4": [pd.Timestamp(f"2020-07-14 00:{i//60}:{i%60}") for i in range(1, 201)],
-        "f1_nulls": [True if i % 4 != 0 else None for i in range(200)],
-        "f2_nulls": ["test" if i % 4 != 1 else None for i in range(200)],
-        "f3_nulls": [i if i % 4 != 2 else None for i in range(200)],
+        "f1": [1, 2, 3],
+        "f2": [True, False, False],
+        "f3": ["a", "b", "c"],
+        "f4": [pd.Timestamp("2020-07-14 00:00:00")] * 3,
+        "f1_nulls": [True, None, False],
+        "f2_nulls": ["a", "b", None],
+        "f3_nulls": [1.0, 2.0, None],
     }
     df = pd.DataFrame.from_dict(data)
     schema = Schema(

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -1613,24 +1613,24 @@ def test_enforce_schema_in_python_model_predict(sample_params_basic, param_schem
 
 def test_schema_enforcement_all_feature_types_pandas():
     data = {
-        "f1": [1, 2, 3],
-        "f2": [True, False, False],
-        "f3": ["a", "b", "c"],
-        "f4": [pd.Timestamp("2020-07-14 00:00:00")] * 3,
-        "f1_nulls": [True, None, False],
-        "f2_nulls": ["a", "b", None],
-        "f3_nulls": [1.0, 2.0, None],
+        "long": [1, 2, 3],
+        "bool": [True, False, False],
+        "string": ["a", "b", "c"],
+        "datetime": [pd.Timestamp("2020-07-14 00:00:00")] * 3,
+        "bool_nullable": [True, None, False],
+        "string_nullable": ["a", "b", None],
+        "double_nullable": [1.0, 2.0, None],
     }
     df = pd.DataFrame.from_dict(data)
     schema = Schema(
         [
-            ColSpec(DataType.long, "f1"),
-            ColSpec(DataType.boolean, "f2"),
-            ColSpec(DataType.string, "f3"),
-            ColSpec(DataType.datetime, "f4"),
-            ColSpec(DataType.boolean, "f1_nulls", required=False),
-            ColSpec(DataType.string, "f2_nulls", required=False),
-            ColSpec(DataType.double, "f3_nulls", required=False),
+            ColSpec(DataType.long, "long"),
+            ColSpec(DataType.boolean, "bool"),
+            ColSpec(DataType.string, "string"),
+            ColSpec(DataType.datetime, "datetime"),
+            ColSpec(DataType.boolean, "bool_nullable", required=False),
+            ColSpec(DataType.string, "string_nullable", required=False),
+            ColSpec(DataType.double, "double_nullable", required=False),
         ]
     )
     pd.testing.assert_frame_equal(_enforce_schema(df, schema), df, check_dtype=False)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10727?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10727/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10727
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Allow boolean column with nulls pass schema enforcement 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
