### PR TITLE
Fix ReplAwareDatasourceAttributeExtractor

### DIFF
--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/DatasourceAttributeExtractor.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/DatasourceAttributeExtractor.scala
@@ -109,7 +109,9 @@ object ReplAwareDatasourceAttributeExtractor extends DatasourceAttributeExtracto
         val deltaFileIndexOpt = ReflectionUtils.callMethod(obj, "unapply", Seq(lr)).asInstanceOf[Option[Any]]
         deltaFileIndexOpt.map(fileIndex => {
           val path = ReflectionUtils.getField(fileIndex, "path").toString
-          val versionOpt = Option(ReflectionUtils.callMethod(fileIndex, "tableVersion", Seq.empty)).map(_.toString)
+          val versionOpt = ReflectionUtils.maybeCallMethod(fileIndex, "tableVersion", Seq.empty).getOrElse(
+            ReflectionUtils.maybeCallMethod(fileIndex, "version", Seq.empty)
+          ).map(_.toString)
           SparkTableInfo(path, versionOpt, Option("delta"))
         })
       case other => None

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/DatasourceAttributeExtractor.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/DatasourceAttributeExtractor.scala
@@ -109,7 +109,7 @@ object ReplAwareDatasourceAttributeExtractor extends DatasourceAttributeExtracto
         val deltaFileIndexOpt = ReflectionUtils.callMethod(obj, "unapply", Seq(lr)).asInstanceOf[Option[Any]]
         deltaFileIndexOpt.map(fileIndex => {
           val path = ReflectionUtils.getField(fileIndex, "path").toString
-          val versionOpt = ReflectionUtils.maybeCallMethod(fileIndex, "tableVersion", Seq.empty).getOrElse(
+          val versionOpt = ReflectionUtils.maybeCallMethod(fileIndex, "tableVersion", Seq.empty).orElse(
             ReflectionUtils.maybeCallMethod(fileIndex, "version", Seq.empty)
           ).map(_.toString)
           SparkTableInfo(path, versionOpt, Option("delta"))

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReflectionUtils.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReflectionUtils.scala
@@ -51,4 +51,20 @@ private[autologging] object ReflectionUtils {
         s"[${declaredMethods.map(_.getName).mkString(", ")}]"))
     method.invoke(obj, args: _*)
   }
+
+  def maybeCallMethod(obj: Any, name: Any, args: Seq[Object]): Option[Any] = {
+    var declaredMethods: mutable.Buffer[Method] = obj.getClass.getDeclaredMethods.toBuffer
+    var superClass = obj.getClass.getSuperclass
+    while (superClass != null) {
+      declaredMethods = declaredMethods ++ superClass.getDeclaredMethods
+      superClass = superClass.getSuperclass
+    }
+
+    val methodOpt = declaredMethods.find(_.getName == name)
+
+    methodOpt match {
+      case Some(method) => Some(method.invoke(obj, args: _*))
+      case None => None
+    }
+  }
 }

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
@@ -63,7 +63,7 @@ class ReflectionUtilsSuite extends AnyFunSuite {
     val fileIndex = ReflectionUtils.getScalaObjectByName("org.mlflow.spark.autologging.TestFileIndex")
 
     val versionOpt0 = ReflectionUtils.maybeCallMethod(fileIndex, "version", Seq.empty).orElse(
-      "second thing"
+      Option("second thing")
     ).map(_.toString)
     assert(versionOpt1 == Some("1.0"))
 

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
@@ -62,10 +62,21 @@ class ReflectionUtilsSuite extends AnyFunSuite {
   test("chaining maybeCallMethod works") {
     val fileIndex = ReflectionUtils.getScalaObjectByName("org.mlflow.spark.autologging.TestFileIndex")
 
-    val versionOpt = ReflectionUtils.maybeCallMethod(fileIndex, "tableVersion", Seq.empty).orElse(
+    val versionOpt0 = ReflectionUtils.maybeCallMethod(fileIndex, "version", Seq.empty).orElse(
+      "second thing"
+    ).map(_.toString)
+    assert(versionOpt1 == Some("1.0"))
+
+    // if only the second method exists, return it
+    val versionOpt1 = ReflectionUtils.maybeCallMethod(fileIndex, "tableVersion", Seq.empty).orElse(
       ReflectionUtils.maybeCallMethod(fileIndex, "version", Seq.empty)
     ).map(_.toString)
+    assert(versionOpt1 == Some("1.0"))
 
-    assert(versionOpt == Some("1.0"))
+    // if both don't exist, just return None
+    val versionOpt2 = ReflectionUtils.maybeCallMethod(fileIndex, "tableVersion", Seq.empty).orElse(
+      ReflectionUtils.maybeCallMethod(fileIndex, "anotherTableVersion", Seq.empty)
+    ).map(_.toString)
+    assert(versionOpt2 == None)
   }
 }

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
@@ -6,6 +6,10 @@ object TestObject {
   def myMethod: String = "hi"
 }
 
+object TestFileIndex {
+  def version: String = "1.0"
+}
+
 abstract class TestAbstractClass {
   protected def addNumbers(x: Int, y: Int): Int = x + y
   protected val myProtectedVal: Int = 5
@@ -50,11 +54,18 @@ class ReflectionUtilsSuite extends AnyFunSuite {
   }
 
   test("maybeCallMethod invokes the method if the method is found") {
-    val obj = new RealClass()
+    val obj = new TestObject()
     val res0 = ReflectionUtils.maybeCallMethod(obj, "myMethod", Seq.empty).getOrElse("")
-    assert (res == "hi")
+    assert(res0 == "hi")
+  }
 
-    val res1 = ReflectionUtils.maybeCallMethod(obj, "MyField", Seq.empty).getOrElse("")
-    assert (res1 == "myCoolVal")
+  test("chaining maybeCallMethod works") {
+    val fileIndex = new TestFileIndex()
+
+    val versionOpt = ReflectionUtils.maybeCallMethod(fileIndex, "tableVersion", Seq.empty).orElse(
+      ReflectionUtils.maybeCallMethod(fileIndex, "version", Seq.empty)
+    ).map(_.toString)
+
+    assert(versionOpt == Some("1.0"))
   }
 }

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
@@ -41,4 +41,20 @@ class ReflectionUtilsSuite extends AnyFunSuite {
     val res = ReflectionUtils.callMethod(obj, "myMethod", Seq.empty).asInstanceOf[String]
     assert(res == "hi")
   }
+
+  test("maybeCallMethod None if method not found") {
+    val obj = new RealClass()
+    val res = ReflectionUtils.maybeCallMethod(obj, "nonExistentMethod", Seq.empty)
+
+    assert (res.isEmpty)
+  }
+
+  test("maybeCallMethod invokes the method if the method is found") {
+    val obj = new RealClass()
+    val res0 = ReflectionUtils.maybeCallMethod(obj, "myMethod", Seq.empty).getOrElse("")
+    assert (res == "hi")
+
+    val res1 = ReflectionUtils.maybeCallMethod(obj, "MyField", Seq.empty).getOrElse("")
+    assert (res1 == "myCoolVal")
+  }
 }

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
@@ -54,13 +54,13 @@ class ReflectionUtilsSuite extends AnyFunSuite {
   }
 
   test("maybeCallMethod invokes the method if the method is found") {
-    val obj = new TestObject()
+    val obj = ReflectionUtils.getScalaObjectByName("org.mlflow.spark.autologging.TestObject")
     val res0 = ReflectionUtils.maybeCallMethod(obj, "myMethod", Seq.empty).getOrElse("")
     assert(res0 == "hi")
   }
 
   test("chaining maybeCallMethod works") {
-    val fileIndex = new TestFileIndex()
+    val fileIndex = ReflectionUtils.getScalaObjectByName("org.mlflow.spark.autologging.TestFileIndex")
 
     val versionOpt = ReflectionUtils.maybeCallMethod(fileIndex, "tableVersion", Seq.empty).orElse(
       ReflectionUtils.maybeCallMethod(fileIndex, "version", Seq.empty)

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
@@ -65,7 +65,7 @@ class ReflectionUtilsSuite extends AnyFunSuite {
     val versionOpt0 = ReflectionUtils.maybeCallMethod(fileIndex, "version", Seq.empty).orElse(
       Option("second thing")
     ).map(_.toString)
-    assert(versionOpt1 == Some("1.0"))
+    assert(versionOpt0 == Some("1.0"))
 
     // if only the second method exists, return it
     val versionOpt1 = ReflectionUtils.maybeCallMethod(fileIndex, "tableVersion", Seq.empty).orElse(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/10729?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10729/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10729
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR add `maybeCallFunction` to the `ReplAwareDatasourceAttributeExtractor`. The previous function we used throws if the method is not found. Instead, we want to return None.

Additionally, this PR checks for `version` instead of `tableVersion`, which is deprecated in newer versions of DBR

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [x] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
