### PR TITLE
Support saving input_example with no conversion

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -875,9 +875,13 @@ To include an input example with your model, add it to the appropriate log_model
 :py:func:`sklearn.log_model() <mlflow.sklearn.log_model>`. Input examples are also used to infer
 model signatures in log_model calls when signatures aren't specified.
 
-Similar to model signatures, model inputs can be column-based (i.e DataFrames) or tensor-based
-(i.e numpy.ndarrays). We offer support for input_example with params by using tuple to combine model
-inputs and params. See examples below:
+By default, if input example is a dictionary, we convert it to pandas DataFrame format when saving.
+Note that for langchain, openai, pyfunc and transformers flavors, input example could be saved without
+conversion by setting ``example_no_conversion`` to ``False``.
+
+Similar to model signatures, model inputs can be column-based (i.e DataFrames), tensor-based
+(i.e numpy.ndarrays) or json object (i.e python dictionary). We offer support for input_example 
+with params by using tuple to combine model inputs and params. See examples below:
 
 How To Log Model With Column-based Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -928,6 +932,27 @@ The following example demonstrates how you can log a tensor-based input example 
         dtype=np.uint8,
     )
     mlflow.tensorflow.log_model(..., input_example=input_example)
+
+How To Log Model With Json Object
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For models accepting python dictionary inputs instead of pandas DataFrame, we support saving the example
+directly as it is. To enable this, ``example_no_conversion`` should be set to ``True`` when logging the model. 
+This feature is only supported for langchain, openai, pyfunc and transformers flavors, where saving the example
+directly is useful for inference and model serving.
+By default, ``example_no_conversion`` is set to ``False`` for backwards compatibility.
+
+The following example demonstrates how you can log a json object input example with your model:
+
+.. code-block:: python
+
+    input_example = {
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "assistant", "content": "What would you like to ask?"},
+            {"role": "user", "content": "Who owns MLflow?"},
+        ]
+    }
+    mlflow.langchain.log_model(..., input_example=input_example, example_no_conversion=True)
 
 How To Log Model With Example Containing Params
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -98,6 +98,7 @@ def save_model(
     metadata=None,
     loader_fn=None,
     persist_dir=None,
+    **kwargs,
 ):
     """
     Save a LangChain model to a path on the local file system.
@@ -236,7 +237,8 @@ def save_model(
         mlflow_model.signature = signature
 
     if input_example is not None:
-        _save_example(mlflow_model, input_example, path)
+        no_conversion = kwargs.get("example_no_conversion", False)
+        _save_example(mlflow_model, input_example, path, no_conversion)
     if metadata is not None:
         mlflow_model.metadata = metadata
 
@@ -306,6 +308,7 @@ def log_model(
     metadata=None,
     loader_fn=None,
     persist_dir=None,
+    **kwargs,
 ):
     """
     Log a LangChain model as an MLflow artifact for the current run.
@@ -422,6 +425,7 @@ def log_model(
         metadata=metadata,
         loader_fn=loader_fn,
         persist_dir=persist_dir,
+        **kwargs,
     )
 
 

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -98,7 +98,7 @@ def save_model(
     metadata=None,
     loader_fn=None,
     persist_dir=None,
-    **kwargs,
+    example_no_conversion=False,
 ):
     """
     Save a LangChain model to a path on the local file system.
@@ -237,8 +237,7 @@ def save_model(
         mlflow_model.signature = signature
 
     if input_example is not None:
-        no_conversion = kwargs.get("example_no_conversion", False)
-        _save_example(mlflow_model, input_example, path, no_conversion)
+        _save_example(mlflow_model, input_example, path, example_no_conversion)
     if metadata is not None:
         mlflow_model.metadata = metadata
 
@@ -308,7 +307,7 @@ def log_model(
     metadata=None,
     loader_fn=None,
     persist_dir=None,
-    **kwargs,
+    example_no_conversion=False,
 ):
     """
     Log a LangChain model as an MLflow artifact for the current run.
@@ -425,7 +424,7 @@ def log_model(
         metadata=metadata,
         loader_fn=loader_fn,
         persist_dir=persist_dir,
-        **kwargs,
+        example_no_conversion=example_no_conversion,
     )
 
 

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -185,6 +185,7 @@ def save_model(
                                 )
 
                         See a complete example in examples/langchain/retrieval_qa_chain.py.
+    :param example_no_conversion: {{ example_no_conversion }}
     """
     import langchain
     from langchain.schema import BaseRetriever
@@ -404,6 +405,7 @@ def log_model(
                                 )
 
                         See a complete example in examples/langchain/retrieval_qa_chain.py.
+    :param example_no_conversion: {{ example_no_conversion }}
     :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
              metadata of the logged model.
     """

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -352,6 +352,8 @@ def _save_example(
                 "Failed to save input example. Please make sure the input example is jsonable "
                 f"when no_conversion is True. Got error: {e}"
             )
+        else:
+            mlflow_model.saved_input_example_info = example_info
     else:
         example = _Example(input_example)
         example.save(path)

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -341,8 +341,7 @@ def _save_example(
     if no_conversion:
         example_info = {
             INPUT_EXAMPLE_PATH: EXAMPLE_FILENAME,
-            # TODO: update type to json_object and support in UI/_read_example
-            "type": "ndarray",
+            "type": "json_object",
         }
         try:
             with open(os.path.join(path, example_info[INPUT_EXAMPLE_PATH]), "w") as f:
@@ -371,7 +370,13 @@ def _get_mlflow_model_input_example_dict(mlflow_model: Model, path: str):
     if mlflow_model.saved_input_example_info is None:
         return None
     example_type = mlflow_model.saved_input_example_info["type"]
-    if example_type not in ["dataframe", "ndarray", "sparse_matrix_csc", "sparse_matrix_csr"]:
+    if example_type not in [
+        "dataframe",
+        "ndarray",
+        "sparse_matrix_csc",
+        "sparse_matrix_csr",
+        "json_object",
+    ]:
         raise MlflowException(f"This version of mlflow can not load example of type {example_type}")
     path = os.path.join(path, mlflow_model.saved_input_example_info["artifact_path"])
     with open(path) as handle:
@@ -396,6 +401,8 @@ def _read_example(mlflow_model: Model, path: str):
     input_schema = mlflow_model.signature.inputs if mlflow_model.signature is not None else None
     if mlflow_model.saved_input_example_info.get(EXAMPLE_PARAMS_KEY, None):
         input_example = input_example[EXAMPLE_DATA_KEY]
+    if example_type == "json_object":
+        return input_example
     if example_type == "ndarray":
         return _read_tensor_input_from_json(input_example, schema=input_schema)
     if example_type in ["sparse_matrix_csc", "sparse_matrix_csr"]:

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -350,7 +350,7 @@ def _save_example(
             raise MlflowException.invalid_parameter_value(
                 "Failed to save input example. Please make sure the input example is jsonable "
                 f"when no_conversion is True. Got error: {e}"
-            )
+            ) from e
         else:
             mlflow_model.saved_input_example_info = example_info
     else:

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -259,6 +259,7 @@ def save_model(
     pip_requirements=None,
     extra_pip_requirements=None,
     metadata=None,
+    example_no_conversion=False,
     **kwargs,
 ):
     """
@@ -372,7 +373,7 @@ def save_model(
         )
 
     if input_example is not None:
-        _save_example(mlflow_model, input_example, path)
+        _save_example(mlflow_model, input_example, path, example_no_conversion)
     if metadata is not None:
         mlflow_model.metadata = metadata
     model_data_path = os.path.join(path, MODEL_FILENAME)
@@ -457,6 +458,7 @@ def log_model(
     pip_requirements=None,
     extra_pip_requirements=None,
     metadata=None,
+    example_no_conversion=False,
     **kwargs,
 ):
     """
@@ -550,6 +552,7 @@ def log_model(
         pip_requirements=pip_requirements,
         extra_pip_requirements=extra_pip_requirements,
         metadata=metadata,
+        example_no_conversion=example_no_conversion,
         **kwargs,
     )
 

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -297,6 +297,7 @@ def save_model(
 
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
+        example_no_conversion: {{ example_no_conversion }}
         kwargs: Keyword arguments specific to the OpenAI task, such as the ``messages`` (see
             :ref:`mlflow.openai.messages` for more details on this parameter)
             or ``top_p`` value to use for chat completion.
@@ -502,6 +503,7 @@ def log_model(
 
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
+        example_no_conversion: {{ example_no_conversion }}
         kwargs: Keyword arguments specific to the OpenAI task, such as the ``messages`` (see
             :ref:`mlflow.openai.messages` for more details on this parameter)
             or ``top_p`` value to use for chat completion.

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1881,6 +1881,7 @@ def save_model(
 
                      .. Note:: Experimental: This parameter may change or be removed in a future
                                              release without warning.
+    :param example_no_conversion: {{ example_no_conversion }}
     """
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
     _validate_pyfunc_model_config(model_config)
@@ -2161,6 +2162,7 @@ def log_model(
 
                      .. Note:: Experimental: This parameter may change or be removed in a future
                                              release without warning.
+    :param example_no_conversion: {{ example_no_conversion }}
     :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
              metadata of the logged model.
     """

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2013,6 +2013,7 @@ def log_model(
     extra_pip_requirements=None,
     metadata=None,
     model_config=None,
+    **kwargs,
 ):
     """
     Log a Pyfunc model with custom inference logic and optional data dependencies as an MLflow
@@ -2180,6 +2181,7 @@ def log_model(
         extra_pip_requirements=extra_pip_requirements,
         metadata=metadata,
         model_config=model_config,
+        **kwargs,
     )
 
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1893,6 +1893,7 @@ def save_model(
                 "`pip_requirements`, or `extra_pip_requirements` must be specified."
             )
 
+    example_no_conversion = kwargs.pop("example_no_conversion", False)
     mlflow_model = kwargs.pop("model", mlflow_model)
     if len(kwargs) > 0:
         raise TypeError(f"save_model() got unexpected keyword arguments: {kwargs}")
@@ -1963,7 +1964,7 @@ def save_model(
                     _logger.warning(f"Failed to infer model signature from input example. {e}")
 
     if input_example is not None:
-        _save_example(mlflow_model, input_example, path)
+        _save_example(mlflow_model, input_example, path, example_no_conversion)
     if metadata is not None:
         mlflow_model.metadata = metadata
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1741,6 +1741,7 @@ def save_model(
     extra_pip_requirements=None,
     metadata=None,
     model_config=None,
+    example_no_conversion=False,
     **kwargs,
 ):
     """
@@ -1893,7 +1894,6 @@ def save_model(
                 "`pip_requirements`, or `extra_pip_requirements` must be specified."
             )
 
-    example_no_conversion = kwargs.pop("example_no_conversion", False)
     mlflow_model = kwargs.pop("model", mlflow_model)
     if len(kwargs) > 0:
         raise TypeError(f"save_model() got unexpected keyword arguments: {kwargs}")
@@ -2013,7 +2013,7 @@ def log_model(
     extra_pip_requirements=None,
     metadata=None,
     model_config=None,
-    **kwargs,
+    example_no_conversion=False,
 ):
     """
     Log a Pyfunc model with custom inference logic and optional data dependencies as an MLflow
@@ -2181,7 +2181,7 @@ def log_model(
         extra_pip_requirements=extra_pip_requirements,
         metadata=metadata,
         model_config=model_config,
-        **kwargs,
+        example_no_conversion=example_no_conversion,
     )
 
 

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -234,6 +234,7 @@ def save_model(
     conda_env=None,
     metadata: Optional[Dict[str, Any]] = None,
     model_config: Optional[Dict[str, Any]] = None,
+    example_no_conversion: bool = False,
     **kwargs,  # pylint: disable=unused-argument
 ) -> None:
     """
@@ -453,8 +454,7 @@ def save_model(
         mlflow_model.signature = signature
     if input_example is not None:
         input_example = _format_input_example_for_special_cases(input_example, built_pipeline)
-        no_conversion = kwargs.get("example_no_conversion", False)
-        _save_example(mlflow_model, input_example, str(path), no_conversion)
+        _save_example(mlflow_model, input_example, str(path), example_no_conversion)
     if metadata is not None:
         mlflow_model.metadata = metadata
 
@@ -593,6 +593,7 @@ def log_model(
     conda_env=None,
     metadata: Optional[Dict[str, Any]] = None,
     model_config: Optional[Dict[str, Any]] = None,
+    example_no_conversion: bool = False,
     **kwargs,
 ):
     """
@@ -795,6 +796,7 @@ def log_model(
         pip_requirements=pip_requirements,
         extra_pip_requirements=extra_pip_requirements,
         model_config=model_config,
+        example_no_conversion=example_no_conversion,
         **kwargs,
     )
 

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -453,7 +453,8 @@ def save_model(
         mlflow_model.signature = signature
     if input_example is not None:
         input_example = _format_input_example_for_special_cases(input_example, built_pipeline)
-        _save_example(mlflow_model, input_example, str(path))
+        no_conversion = kwargs.get("example_no_conversion", False)
+        _save_example(mlflow_model, input_example, str(path), no_conversion)
     if metadata is not None:
         mlflow_model.metadata = metadata
 

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -408,7 +408,7 @@ def save_model(
 
                      .. Note:: Experimental: This parameter may change or be removed in a future
                                              release without warning.
-
+    :param example_no_conversion: {{ example_no_conversion }}
     :param kwargs: Optional additional configurations for transformers serialization.
     :return: None
     """
@@ -776,6 +776,7 @@ def log_model(
 
                      .. Note:: Experimental: This parameter may change or be removed in a future
                                              release without warning.
+    :param example_no_conversion: {{ example_no_conversion }}
     :param kwargs: Additional arguments for :py:class:`mlflow.models.model.Model`
     """
     return Model.log(

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -244,6 +244,13 @@ by converting it to a list. Bytes are base64-encoded. When the ``signature`` par
 ``None``, the input example is used to infer a model signature.
 """
         ),
+        "example_no_conversion": (
+            """If ``True``, the input example will not be converted to a Pandas DataFrame
+format when saving. This is useful when the model expects a non-DataFrame input and the
+input example could be passed directly to the model. Defaults to ``False`` for backwards
+compatibility.
+"""
+        ),
     }
 )
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10741?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10741/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10741
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Due to backwards compatibility issue, we convert input_example into pandas DataFrame by default. This is to add a param that supports saving input_example directly without converting it.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested on dogfood that it saves input_example directly.
<img width="863" alt="image" src="https://github.com/mlflow/mlflow/assets/82044803/29b7b57d-7b4e-4f6b-80e1-52f331f77f96">

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

<img width="1352" alt="image" src="https://github.com/mlflow/mlflow/assets/82044803/26b77ca0-2655-4c84-9b24-4542d30c0ac3">
<img width="1348" alt="image" src="https://github.com/mlflow/mlflow/assets/82044803/ff31d46e-1c15-4d11-907d-c66d572b6883">


### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
