### PR TITLE
Make pytorch model supporting model load-time param 'device'

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -737,7 +737,7 @@ class _PyTorchWrapper:
         """
         import torch
 
-        if "device" in params:
+        if params and "device" in params:
             raise ValueError(
                 "device' param is no longer inference param but becomes load-time param, "
                 "please use command like "

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -691,7 +691,7 @@ def load_model(model_uri, dst_path=None, **kwargs):
     return _load_model(path=torch_model_artifacts_path, **kwargs)
 
 
-def _load_pyfunc(path, model_config):
+def _load_pyfunc(path, model_config=None):
     """
     Load PyFunc implementation. Called by ``pyfunc.load_model``.
 
@@ -699,7 +699,7 @@ def _load_pyfunc(path, model_config):
     """
     import torch
 
-    device = model_config.get("device", None)
+    device = model_config.get("device", None) if model_config else None
     # if CUDA is available, we use the default CUDA device.
     # To force inference to the CPU when the GPU is available, please set
     # MLFLOW_DEFAULT_PREDICTION_DEVICE to "cpu"
@@ -739,8 +739,9 @@ class _PyTorchWrapper:
 
         if params and "device" in params:
             raise ValueError(
-                "device' param is no longer inference param but becomes load-time param, "
-                "please use command like "
+                "device' can no longer be specified as an inference parameter. "
+                "It must be specified at load time. "
+                "Please specify the device at load time, for example: "
                 "`mlflow.pyfunc.load_model(model_uri, model_config={'device': 'cuda'})`."
             )
 

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -531,6 +531,7 @@ def save_model(
         code=code_dir_subpath,
         conda_env=_CONDA_ENV_FILE_NAME,
         python_env=_PYTHON_ENV_FILE_NAME,
+        model_config={"device": None},
     )
     if size := get_total_file_size(path):
         mlflow_model.model_size_bytes = size
@@ -571,7 +572,7 @@ def save_model(
     _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
-def _load_model(path, **kwargs):
+def _load_model(path, device=None, **kwargs):
     """
     :param path: The path to a serialized PyTorch model.
     :param kwargs: Additional kwargs to pass to the PyTorch ``torch.load`` function.
@@ -608,16 +609,21 @@ def _load_model(path, **kwargs):
         model_path = path
 
     if Version(torch.__version__) >= Version("1.5.0"):
-        return torch.load(model_path, **kwargs)
+        pytorch_model = torch.load(model_path, **kwargs)
     else:
         try:
             # load the model as an eager model.
-            return torch.load(model_path, **kwargs)
+            pytorch_model = torch.load(model_path, **kwargs)
         except Exception:
             # If fails, assume the model as a scripted model
             # `torch.jit.load` does not accept `pickle_module`.
             kwargs.pop("pickle_module", None)
-            return torch.jit.load(model_path, **kwargs)
+            pytorch_model = torch.jit.load(model_path, **kwargs)
+
+    pytorch_model.eval()
+    if device:
+        pytorch_model.to(device=device)
+    return pytorch_model
 
 
 def load_model(model_uri, dst_path=None, **kwargs):
@@ -685,13 +691,28 @@ def load_model(model_uri, dst_path=None, **kwargs):
     return _load_model(path=torch_model_artifacts_path, **kwargs)
 
 
-def _load_pyfunc(path, **kwargs):
+def _load_pyfunc(path, model_config):
     """
     Load PyFunc implementation. Called by ``pyfunc.load_model``.
 
     :param path: Local filesystem path to the MLflow Model with the ``pytorch`` flavor.
     """
-    return _PyTorchWrapper(_load_model(path, **kwargs))
+    import torch
+
+    device = model_config.get("device", None)
+    # if CUDA is available, we use the default CUDA device.
+    # To force inference to the CPU when the GPU is available, please set
+    # MLFLOW_DEFAULT_PREDICTION_DEVICE to "cpu"
+    # If a specific non-default device is passed in, we continue to respect that.
+    if device is None:
+        if MLFLOW_DEFAULT_PREDICTION_DEVICE.get():
+            device = MLFLOW_DEFAULT_PREDICTION_DEVICE.get()
+        elif torch.cuda.is_available():
+            device = _TORCH_DEFAULT_GPU_DEVICE_NAME
+        else:
+            device = _TORCH_CPU_DEVICE_NAME
+
+    return _PyTorchWrapper(_load_model(path, device=device), device=device)
 
 
 class _PyTorchWrapper:
@@ -700,8 +721,9 @@ class _PyTorchWrapper:
     predict(data: pd.DataFrame) -> model's output as pd.DataFrame (pandas DataFrame)
     """
 
-    def __init__(self, pytorch_model):
+    def __init__(self, pytorch_model, device):
         self.pytorch_model = pytorch_model
+        self.device = device
 
     def predict(self, data, params: Optional[Dict[str, Any]] = None):
         """
@@ -715,18 +737,6 @@ class _PyTorchWrapper:
         """
         import torch
 
-        device = params.get("device", None) if params else None
-        # if CUDA is available, we use the default CUDA device.
-        # To force inference to the CPU when the GPU is available, please set
-        # MLFLOW_DEFAULT_PREDICTION_DEVICE to "cpu"
-        # If a specific non-default device is passed in, we continue to respect that.
-        if device is None:
-            if MLFLOW_DEFAULT_PREDICTION_DEVICE.get():
-                device = MLFLOW_DEFAULT_PREDICTION_DEVICE.get()
-            elif torch.cuda.is_available():
-                device = _TORCH_DEFAULT_GPU_DEVICE_NAME
-            else:
-                device = _TORCH_CPU_DEVICE_NAME
         if isinstance(data, pd.DataFrame):
             inp_data = data.values.astype(np.float32)
         elif isinstance(data, np.ndarray):
@@ -739,8 +749,7 @@ class _PyTorchWrapper:
         else:
             raise TypeError("Input data should be pandas.DataFrame or numpy.ndarray")
 
-        self.pytorch_model.to(device)
-        self.pytorch_model.eval()
+        device = self.device
         with torch.no_grad():
             input_tensor = torch.from_numpy(inp_data).to(device)
             preds = self.pytorch_model(input_tensor)

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -737,6 +737,13 @@ class _PyTorchWrapper:
         """
         import torch
 
+        if "device" in params:
+            raise ValueError(
+                "device' param is no longer inference param but becomes load-time param, "
+                "please use command like "
+                "`mlflow.pyfunc.load_model(model_uri, model_config={'device': 'cuda'})`."
+            )
+
         if isinstance(data, pd.DataFrame):
             inp_data = data.values.astype(np.float32)
         elif isinstance(data, np.ndarray):

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -442,7 +442,7 @@ def save_model(
     _validate_and_prepare_target_save_path(path)
 
     if signature is None and input_example is not None:
-        wrapped_model = _PyTorchWrapper(pytorch_model)
+        wrapped_model = _PyTorchWrapper(pytorch_model, device="cpu")
         signature = _infer_signature_from_input_example(input_example, wrapped_model)
     elif signature is False:
         signature = None

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -1237,9 +1237,9 @@ def test_model_log_with_signature_inference(sequential_model, data):
 
 
 @pytest.mark.parametrize("scripted_model", [False])
-def test_load_model_to_device():
+def test_load_model_to_device(sequential_model):
     with mock.patch("mlflow.pytorch._load_model") as load_model_mock:
-        with mlflow.start_run(sequential_model):
+        with mlflow.start_run():
             model_info = mlflow.pytorch.log_model(sequential_model, artifact_path="pytorch")
             mlflow.pyfunc.load_model(
                 model_uri=model_info.model_uri, model_config={'device': 'cuda'}

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -1234,3 +1234,18 @@ def test_model_log_with_signature_inference(sequential_model, data):
         inputs=Schema([TensorSpec(np.dtype("float32"), (-1, 4))]),
         outputs=Schema([TensorSpec(np.dtype("float32"), (-1, 1))]),
     )
+
+
+@pytest.mark.parametrize("scripted_model", [False])
+def test_load_model_to_device():
+    with mock.patch("mlflow.pytorch._load_model") as load_model_mock:
+        with mlflow.start_run(sequential_model):
+            model_info = mlflow.pytorch.log_model(sequential_model, artifact_path="pytorch")
+            mlflow.pyfunc.load_model(
+                model_uri=model_info.model_uri, model_config={'device': 'cuda'}
+            )
+            load_model_mock.assert_called_with(mock.ANY, device='cuda')
+            mlflow.pytorch.load_model(
+                model_uri=model_info.model_uri, device='cuda'
+            )
+            load_model_mock.assert_called_with(path=mock.ANY, device='cuda')

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -1242,10 +1242,8 @@ def test_load_model_to_device(sequential_model):
         with mlflow.start_run():
             model_info = mlflow.pytorch.log_model(sequential_model, artifact_path="pytorch")
             mlflow.pyfunc.load_model(
-                model_uri=model_info.model_uri, model_config={'device': 'cuda'}
+                model_uri=model_info.model_uri, model_config={"device": "cuda"}
             )
-            load_model_mock.assert_called_with(mock.ANY, device='cuda')
-            mlflow.pytorch.load_model(
-                model_uri=model_info.model_uri, device='cuda'
-            )
-            load_model_mock.assert_called_with(path=mock.ANY, device='cuda')
+            load_model_mock.assert_called_with(mock.ANY, device="cuda")
+            mlflow.pytorch.load_model(model_uri=model_info.model_uri, device="cuda")
+            load_model_mock.assert_called_with(path=mock.ANY, device="cuda")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/10755?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10755/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10755
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Make pytorch model supporting model load-time param 'device'

Current master code setting model device in `_PyTorchWrapper.predict`, which is not a good way.

Manual test:
```
import torch
import mlflow

m1 = torch.nn.Linear(3, 5)
model_meta = mlflow.pytorch.log_model(m1, artifact_path="model")

model = mlflow.pyfunc.load_model(model_meta.model_uri, model_config={'device': 'cuda'})
```

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
