### PR TITLE
Enhance `predict` API to serve for env validation purpose.

### DIFF
--- a/docs/source/deployment/index.rst
+++ b/docs/source/deployment/index.rst
@@ -169,3 +169,144 @@ Almost all functionalities available in MLflow deployment can also be accessed v
 
 FAQ
 ---
+
+How to test my model before deploying to the production environment?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Testing your model before deployment is a critical step to ensure production readiness.
+MLflow provides a few ways to test your model locally, either in a virtual environment or a Docker container.
+
+Testing offline prediction with a virtual environment
+*****************************************************
+You can use MLflow `predict` API via CLI or Python to making test predictions with your model.
+This wiill load your model from the model URI, create a virtual environemnt with the model dependencies (defined in MLflow Model),
+and run offline predictions with the model.
+Please refer to :py:func:`mlflow.models.predict` or `CLI reference <../cli.html#mlflow-models>`_ for more detailed usage for the `predict` API.
+
+.. tabs::
+
+    .. code-tab:: bash
+
+        mlflow models predict -m runs:/<run_id>/model-i <input_path>
+
+    .. code-tab:: python
+
+        import mlflow
+
+        mlflow.model.predict(
+            model_uri="runs:/<run_id>/model",
+            input_data=<input_data>,
+        )
+
+Using the `predict` API is convenient for testing your model and inference environment as being a relatively light weight and quick.
+However, it is not a perfect simulation of the serving because it does not start the online inference server.
+
+Testing online inference endpoint with a virtual environment
+************************************************************
+If you want to test your model with actually running the online inference server, you can use MLflow `serve` API.
+This will create a virtual environment with your model and dependencies, similarly to the `predict` API, but will start the inference server
+and expose the REST endpoints. Then you can send a test request and validate the response.
+Please refer to `CLI reference <../cli.html#mlflow-models>`_ for more detailed usage for the `serve` API.
+
+.. code-block:: bash
+
+    mlflow models serve -m runs:/<run_id>/model -p <port>
+
+    # In another terminal
+    curl -X POST -H "Content-Type: application/json" \
+        --data '{"inputs": [[1, 2], [3, 4]]}' \
+        http://localhost:<port>/invocations
+
+
+While this is reliable way to test your model before deployment, one caveat is that virtual environment doesn't absorb the OS level differences
+between your machine and the production environment. For example, if you are using Windows as a local dev machine but your deployment target is
+running on Linux, you may encounter some issues that are not reproducible in the virtual environment.
+
+In this case, you can use Docker container to test your model.
+
+Testing online inference endpoint with a Docker container
+*********************************************************
+MLflow `build-docker` API for CLI and Python, which builds an Ubuntu-based Docker image for serving your mdoel.
+The image will contain your model and dependencies and has an entrypoint to start the inference server. Similarly to the `serve` API,
+you can send a test request and validate the response.
+Please refer to `CLI reference <../cli.html#mlflow-models>`_ for more detailed usage for the `build-docker` API.
+
+.. code-block:: bash
+
+    mlflow models build-docker -m runs:/<run_id>/model -n <image_name>
+
+    docker run -p <port>:8080 <image_name>
+
+    # In another terminal
+    curl -X POST -H "Content-Type: application/json" \
+        --data '{"inputs": [[1, 2], [3, 4]]}' \
+        http://localhost:<port>/invocations
+
+
+How to fix dependency errors when serving my model?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+One common issue during model deployment is dependency issue. When logging/saving your model, MLflow tries to infer the
+model dependencies and save them as part of the MLflow Model metadata. However, this inference is not always accurate and may
+miss some dependencies. This can cause errors when serving your model, such as "ModuleNotFoundError" or "ImportError". Here 
+is the steps to fix missing dependencies error.
+
+1. Check the missing dependencies
+*********************************
+The missing dependencies are listed in the error message. For example, if you see the following error message:
+
+.. code-block:: bash
+
+    ModuleNotFoundError: No module named 'cv2'
+
+2. Try adding the dependencies using the `predict` API
+******************************************************
+Now that you know the missing dependencies, you can create a new model version with the correct dependencies.
+However, creating a new model for trying new dependencies might be a bit tedious, particularly because you may need to
+iterate multiple times to find the correct solution. Instead, you can use the `predict` API to test your change without
+actually mutating the model.
+
+To do so, use the `pip-requirements-override` option to specify pip dependencies like `opencv-python==4.8.0`.
+
+.. tabs::
+
+    .. code-tab:: bash
+
+        mlflow models predict \
+            -m runs:/<run_id>/model \
+            -i <input_path> \
+            --pip-requirements-override opencv-python==4.8.0
+
+    .. code-tab:: python
+
+        import mlflow
+
+        mlflow.model.predict(
+            model_uri="runs:/<run_id>/model",
+            input_data=<input_data>,
+            pip_requirements="opencv-python==4.8.0",
+        )
+
+The specified dependencies will be installed to the virtual environment in addition to (or instead of) the dependencies
+defined in the model metadata. Since this doesn't mutate the model, you can iterate quickly and safely to find the correct dependencies.
+
+3. Update the model metadata
+****************************
+Once you find the correct dependencies, you can create a new model with the correct dependencies.
+To do so, specify either `pip_requirements` or `extra_pip_requirements` option when logging the model.
+
+.. code:: python
+
+    import mlflow
+
+    mlflow.pyfunc.log_model(
+        artifact_path="model",
+        python_model=python_model,
+        # If you want to define all dependencies from scratch, use `pip_requirements` option.
+        # Both options also accept a path to a pip requirements file e.g. requirements.txt.
+        extra_pip_requirements=["opencv-python==4.8.0"],
+    )
+
+.. note::
+
+    Alternatively, you can directly update the model metadata stored in the artifact storage. For example, `<path-to-model>/requirements.txt`
+    defines pip dependencies to be installed for serving your model (or `<path-to-model>/conda.yaml` if you use conda as a package manager).
+    However, this approach is not recommended because this is error-prone and also you need to do this for every model version.

--- a/docs/source/deployment/index.rst
+++ b/docs/source/deployment/index.rst
@@ -177,8 +177,8 @@ MLflow provides a few ways to test your model locally, either in a virtual envir
 
 Testing offline prediction with a virtual environment
 *****************************************************
-You can use MLflow `predict` API via CLI or Python to making test predictions with your model.
-This wiill load your model from the model URI, create a virtual environemnt with the model dependencies (defined in MLflow Model),
+You can use `mlflow models predict` API via CLI or Python to making test predictions with your model.
+This wiil load your model from the model URI, create a virtual environment with the model dependencies (defined in MLflow Model),
 and run offline predictions with the model.
 Please refer to :py:func:`mlflow.models.predict` or `CLI reference <../cli.html#mlflow-models>`_ for more detailed usage for the `predict` API.
 
@@ -192,12 +192,12 @@ Please refer to :py:func:`mlflow.models.predict` or `CLI reference <../cli.html#
 
         import mlflow
 
-        mlflow.model.predict(
+        mlflow.models.predict(
             model_uri="runs:/<run_id>/model",
             input_data=<input_data>,
         )
 
-Using the `predict` API is convenient for testing your model and inference environment as being a relatively light weight and quick.
+Using the `predict` API is convenient for testing your model and inference environment quickly.
 However, it is not a perfect simulation of the serving because it does not start the online inference server.
 
 Testing online inference endpoint with a virtual environment
@@ -218,10 +218,12 @@ Please refer to `CLI reference <../cli.html#mlflow-models>`_ for more detailed u
 
 
 While this is reliable way to test your model before deployment, one caveat is that virtual environment doesn't absorb the OS level differences
-between your machine and the production environment. For example, if you are using Windows as a local dev machine but your deployment target is
+between your machine and the production environment. For example, if you are using MacOS as a local dev machine but your deployment target is
 running on Linux, you may encounter some issues that are not reproducible in the virtual environment.
 
-In this case, you can use Docker container to test your model.
+In this case, you can use Docker container to test your model. While it doesn't provide full OS level isolation unlike virtual machine e.g. we
+can't run Windows container on Linux machine, Docker covers some popular test scenario such as running different versions of Linux or simulating
+Linux environment on Mac/Windows.
 
 Testing online inference endpoint with a Docker container
 *********************************************************
@@ -257,8 +259,8 @@ The missing dependencies are listed in the error message. For example, if you se
 
     ModuleNotFoundError: No module named 'cv2'
 
-2. Try adding the dependencies using the `predict` API
-******************************************************
+2. Try adding the dependencies using the `mlflow models predict` API
+********************************************************************
 Now that you know the missing dependencies, you can create a new model version with the correct dependencies.
 However, creating a new model for trying new dependencies might be a bit tedious, particularly because you may need to
 iterate multiple times to find the correct solution. Instead, you can use the `predict` API to test your change without
@@ -279,7 +281,7 @@ To do so, use the `pip-requirements-override` option to specify pip dependencies
 
         import mlflow
 
-        mlflow.model.predict(
+        mlflow.models.predict(
             model_uri="runs:/<run_id>/model",
             input_data=<input_data>,
             pip_requirements="opencv-python==4.8.0",
@@ -291,7 +293,7 @@ defined in the model metadata. Since this doesn't mutate the model, you can iter
 3. Update the model metadata
 ****************************
 Once you find the correct dependencies, you can create a new model with the correct dependencies.
-To do so, specify either `pip_requirements` or `extra_pip_requirements` option when logging the model.
+To do so, specify `extra_pip_requirements` option when logging the model.
 
 .. code:: python
 
@@ -307,6 +309,6 @@ To do so, specify either `pip_requirements` or `extra_pip_requirements` option w
 
 .. note::
 
-    Alternatively, you can directly update the model metadata stored in the artifact storage. For example, `<path-to-model>/requirements.txt`
+    Alternatively, you can manually edit the model metadata stored in the artifact storage. For example, `<path-to-model>/requirements.txt`
     defines pip dependencies to be installed for serving your model (or `<path-to-model>/conda.yaml` if you use conda as a package manager).
     However, this approach is not recommended because this is error-prone and also you need to do this for every model version.

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -45,7 +45,6 @@ from mlflow.models.evaluation import (
 from mlflow.models.flavor_backend import FlavorBackend
 from mlflow.models.flavor_backend_registry import get_flavor_backend
 from mlflow.models.model import Model, get_model_info
-from mlflow.pyfunc import PyfuncInput
 from mlflow.utils import env_manager as _EnvManager
 from mlflow.utils.environment import infer_pip_requirements
 from mlflow.utils.file_utils import TempDir
@@ -92,7 +91,7 @@ def build_docker(
 
 def predict(
     model_uri: str,
-    input_data_or_path: Union[str, PyfuncInput],
+    input_data_or_path: str,
     content_type: str = "json",
     output_path: str = None,
     env_manager: _EnvManager = _EnvManager.VIRTUALENV,
@@ -103,6 +102,12 @@ def predict(
     data formats accepted by this function, see the following documentation:
     https://www.mlflow.org/docs/latest/models.html#built-in-deployment-tools.
     """
+    if not isinstance(input_data_or_path, str):
+        raise TypeError(
+            f"Input_data_or_path must be a string, but got {type(input_data_or_path)}. "
+            "Please serialize input data into a string before passing e.g. json.dumps(input)."
+        )
+
     def _predict(_input_path: str):
         return get_flavor_backend(
             model_uri, env_manager=env_manager, install_mlflow=install_mlflow

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -41,7 +41,7 @@ from mlflow.models.evaluation import (
 )
 from mlflow.models.flavor_backend import FlavorBackend
 from mlflow.models.model import Model, get_model_info
-from mlflow.models.python_api import build_docker, predict
+from mlflow.models.python_api import build_docker
 from mlflow.utils.environment import infer_pip_requirements
 
 __all__ = [
@@ -57,13 +57,13 @@ __all__ = [
     "list_evaluators",
     "MetricThreshold",
     "build_docker",
-    "predict",
 ]
 
 
 # Under skinny-mlflow requirements, the following packages cannot be imported
 # because of lack of numpy/pandas library, so wrap them with try...except block
 try:
+    from mlflow.models.python_api import predict
     from mlflow.models.signature import ModelSignature, infer_signature, set_signature
     from mlflow.models.utils import ModelInputExample, add_libraries_to_model, validate_schema
 
@@ -74,6 +74,7 @@ try:
         "validate_schema",
         "add_libraries_to_model",
         "set_signature",
+        "predict",
     ]
 except ImportError:
     pass

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -31,7 +31,7 @@ The built-in flavors are:
 For details, see `MLflow Models <../models.html>`_.
 """
 import os
-from typing import Union
+from typing import Optional
 
 from mlflow.models.evaluation import (
     EvaluationArtifact,
@@ -93,7 +93,7 @@ def predict(
     model_uri: str,
     input_data_or_path: str,
     content_type: str = "json",
-    output_path: str = None,
+    output_path: Optional[str] = None,
     env_manager: _EnvManager = _EnvManager.VIRTUALENV,
     install_mlflow=False,
 ):
@@ -112,11 +112,12 @@ def predict(
         return get_flavor_backend(
             model_uri, env_manager=env_manager, install_mlflow=install_mlflow
         ).predict(
-                    model_uri=model_uri,
-                    input_path=_input_path,
-                    output_path=output_path,
-                    content_type=content_type,
+            model_uri=model_uri,
+            input_path=_input_path,
+            output_path=output_path,
+            content_type=content_type,
         )
+
     if os.path.exists(input_data_or_path) and os.path.isfile(input_data_or_path):
         _predict(input_data_or_path)
     else:

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -44,8 +44,6 @@ from mlflow.models.model import Model, get_model_info
 from mlflow.models.python_api import build_docker, predict
 from mlflow.utils.environment import infer_pip_requirements
 
-
-
 __all__ = [
     "Model",
     "FlavorBackend",

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -31,7 +31,7 @@ The built-in flavors are:
 For details, see `MLflow Models <../models.html>`_.
 """
 import os
-from typing import Optional
+from typing import List, Optional
 
 from mlflow.models.evaluation import (
     EvaluationArtifact,
@@ -92,15 +92,33 @@ def build_docker(
 def predict(
     model_uri: str,
     input_data_or_path: str,
-    content_type: str = "json",
     output_path: Optional[str] = None,
+    content_type: str = "json",
     env_manager: _EnvManager = _EnvManager.VIRTUALENV,
-    install_mlflow=False,
+    install_mlflow: bool = False,
+    pip_requirements_override: Optional[List[str]] = None,
 ):
     """
     Generate predictions in json format using a saved MLflow model. For information about the input
     data formats accepted by this function, see the following documentation:
     https://www.mlflow.org/docs/latest/models.html#built-in-deployment-tools.
+
+    :param model_uri: URI to the model. A local path, a local or remote URI e.g. runs:/, s3://.
+    :param input_data_or_path: A serialized JSON or CSV string, or a path to a local CSV file
+        containing input data.
+    :param output_path: File to output results to as json. If not provided, output to stdout.
+    :param content_type: Content type of the input file. Can be one of {‘json’, ‘csv’}.
+    :param env_manager: If specified, create an environment for MLmodel using the specified
+        environment manager. The following values are supported:
+            - virtualenv (default): use virtualenv (and pyenv for Python version management)
+            - local: use the local environment
+            - conda: use conda
+    :param install_mlflow: If specified and there is a conda or virtualenv environment to be
+        activated mlflow will be installed into the environment after it has been activated.
+        The version of installed mlflow will be the same as the one used to invoke this command.
+    :param pip_requirements_override: If specified, install the specified python dependencies to
+        the model inference environment. This is particularly useful when you want to add extra
+        dependencies or try different versions of the dependencies defined in the logged model.
     """
     if not isinstance(input_data_or_path, str):
         raise TypeError(
@@ -116,6 +134,7 @@ def predict(
             input_path=_input_path,
             output_path=output_path,
             content_type=content_type,
+            pip_requirements_override=pip_requirements_override,
         )
 
     if os.path.exists(input_data_or_path) and os.path.isfile(input_data_or_path):

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -2,7 +2,7 @@ import logging
 
 import click
 
-import mlflow.models.python_api as python_api
+from mlflow.models import python_api
 from mlflow.models.flavor_backend_registry import get_flavor_backend
 from mlflow.utils import cli_args
 from mlflow.utils import env_manager as _EnvManager

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -2,8 +2,7 @@ import logging
 
 import click
 
-from mlflow.models import build_docker as build_docker_api
-from mlflow.models import predict as predict_api
+import mlflow.models.python_api as python_api
 from mlflow.models.flavor_backend_registry import get_flavor_backend
 from mlflow.utils import cli_args
 from mlflow.utils import env_manager as _EnvManager
@@ -148,13 +147,13 @@ def predict(
     https://www.mlflow.org/docs/latest/models.html#built-in-deployment-tools.
     """
     env_manager = env_manager or _EnvManager.VIRTUALENV
-    return get_flavor_backend(
-        model_uri, env_manager=env_manager, install_mlflow=install_mlflow
-    ).predict(
+    return python_api.predict(
         model_uri=model_uri,
-        input_path=input_path,
+        input_data_or_path=input_path,
         output_path=output_path,
         content_type=content_type,
+        env_manager=env_manager,
+        install_mlflow=install_mlflow,
         pip_requirements_override=pip_requirements_override,
     )
 
@@ -274,7 +273,7 @@ def build_docker(model_uri, name, env_manager, mlflow_home, install_mlflow, enab
     'python_function' flavor.
     """
     env_manager = env_manager or _EnvManager.VIRTUALENV
-    build_docker_api(
+    python_api.build_docker(
         model_uri,
         name,
         env_manager=env_manager,

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -97,7 +97,7 @@ def serve(
         }'
 
     """
-    env_manager = _EnvManager.LOCAL if no_conda else env_manager or _EnvManager.VIRTUALENV
+    env_manager = _EnvManager.LOCAL if no_conda else env_manager
 
     return get_flavor_backend(
         model_uri, env_manager=env_manager, workers=workers, install_mlflow=install_mlflow
@@ -132,30 +132,13 @@ def serve(
     help="Specify packages and versions to override the dependencies defined"
     "in the model. Must be a comma-separated string like x==y,z==a.",
 )
-def predict(
-    model_uri,
-    input_path,
-    output_path,
-    content_type,
-    env_manager,
-    install_mlflow,
-    pip_requirements_override,
-):
+def predict(**kwargs):
     """
     Generate predictions in json format using a saved MLflow model. For information about the input
     data formats accepted by this function, see the following documentation:
     https://www.mlflow.org/docs/latest/models.html#built-in-deployment-tools.
     """
-    env_manager = env_manager or _EnvManager.VIRTUALENV
-    return python_api.predict(
-        model_uri=model_uri,
-        input_data_or_path=input_path,
-        output_path=output_path,
-        content_type=content_type,
-        env_manager=env_manager,
-        install_mlflow=install_mlflow,
-        pip_requirements_override=pip_requirements_override,
-    )
+    return python_api.predict(**kwargs)
 
 
 @commands.command("prepare-env")
@@ -172,7 +155,6 @@ def prepare_env(
     downloading dependencies or initializing a conda environment. After preparation,
     calling predict or serve should be fast.
     """
-    env_manager = env_manager or _EnvManager.VIRTUALENV
     return get_flavor_backend(
         model_uri, env_manager=env_manager, install_mlflow=install_mlflow
     ).prepare_env(model_uri=model_uri)
@@ -203,7 +185,6 @@ def generate_dockerfile(
         _logger.info("Generating Dockerfile for model %s", model_uri)
     else:
         _logger.info("Generating Dockerfile")
-    env_manager = env_manager or _EnvManager.VIRTUALENV
     backend = get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager)
     if backend.can_build_image():
         backend.generate_dockerfile(
@@ -229,7 +210,7 @@ def generate_dockerfile(
 @cli_args.MLFLOW_HOME
 @cli_args.INSTALL_MLFLOW
 @cli_args.ENABLE_MLSERVER
-def build_docker(model_uri, name, env_manager, mlflow_home, install_mlflow, enable_mlserver):
+def build_docker(**kwargs):
     """
     Builds a Docker image whose default entrypoint serves an MLflow model at port 8080, using the
     python_function flavor. The container serves the model referenced by ``--model-uri``, if
@@ -272,12 +253,4 @@ def build_docker(model_uri, name, env_manager, mlflow_home, install_mlflow, enab
     See https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html for more information on the
     'python_function' flavor.
     """
-    env_manager = env_manager or _EnvManager.VIRTUALENV
-    python_api.build_docker(
-        model_uri,
-        name,
-        env_manager=env_manager,
-        mlflow_home=mlflow_home,
-        install_mlflow=install_mlflow,
-        enable_mlserver=enable_mlserver,
-    )
+    python_api.build_docker(**kwargs)

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -129,7 +129,7 @@ def serve(
     "--pip-requirements-override",
     "-r",
     default=None,
-    help="Specify packages and versions to override the dependencies defined"
+    help="Specify packages and versions to override the dependencies defined "
     "in the model. Must be a comma-separated string like x==y,z==a.",
 )
 def predict(**kwargs):

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -125,6 +125,13 @@ def serve(
 )
 @cli_args.ENV_MANAGER
 @cli_args.INSTALL_MLFLOW
+@click.option(
+    "--pip-requirements-override",
+    "-r",
+    default=None,
+    help="Specify packages and versions to override the dependencies defined"
+    "in the modela. Must be a comma-separated string like x==y,z==a.",
+)
 def predict(
     model_uri,
     input_path,
@@ -132,6 +139,7 @@ def predict(
     content_type,
     env_manager,
     install_mlflow,
+    pip_requirements_override,
 ):
     """
     Generate predictions in json format using a saved MLflow model. For information about the input
@@ -146,6 +154,7 @@ def predict(
         input_path=input_path,
         output_path=output_path,
         content_type=content_type,
+        pip_requirements_override=pip_requirements_override,
     )
 
 

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -3,6 +3,7 @@ import logging
 import click
 
 from mlflow.models import build_docker as build_docker_api
+from mlflow.models import predict as predict_api
 from mlflow.models.flavor_backend_registry import get_flavor_backend
 from mlflow.utils import cli_args
 from mlflow.utils import env_manager as _EnvManager

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -130,7 +130,7 @@ def serve(
     "-r",
     default=None,
     help="Specify packages and versions to override the dependencies defined"
-    "in the modela. Must be a comma-separated string like x==y,z==a.",
+    "in the model. Must be a comma-separated string like x==y,z==a.",
 )
 def predict(
     model_uri,

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -1,8 +1,9 @@
-from io import StringIO
 import json
 import os
-import pandas as pd
+from io import StringIO
 from typing import Any, Dict, List, Optional, Union
+
+import pandas as pd
 
 from mlflow.exceptions import MlflowException
 from mlflow.models.flavor_backend_registry import get_flavor_backend
@@ -76,10 +77,10 @@ def predict(
     :param model_uri: URI to the model. A local path, a local or remote URI e.g. runs:/, s3://.
     :param input_data_or_path: Input data for prediction. It can be one of the following:
 
-                  - A Python dictionary that represents either
+                  - A Python dictionary that contains either:
                      - single input payload, when content type is "json".
                      - Pandas DataFrame, when content type is "csv".
-                  - A Python list that represents input data array. The content type has to be "csv".
+                  - A Python list. The content type has to be "csv".
                   - A Pandas DataFrame. The content type has to be "csv".
                   - A string represents serialized input data. e.g. '{"inputs": [1, 2]}'
                   - A path to a local file contains input data, either a JSON or a CSV file.
@@ -121,7 +122,7 @@ def predict(
         )
 
     """
-    if not content_type in [_CONTENT_TYPE_JSON, _CONTENT_TYPE_CSV]:
+    if content_type not in [_CONTENT_TYPE_JSON, _CONTENT_TYPE_CSV]:
         raise MlflowException.invalid_parameter_value(
             f"Content type must be one of {_CONTENT_TYPE_JSON} or {_CONTENT_TYPE_CSV}."
         )
@@ -176,7 +177,7 @@ def _serialize_input_data(input_data: Union[str, List, Dict, pd.DataFrame], cont
             return json.dumps(input_data)
     except Exception as e:
         raise MlflowException.invalid_parameter_value(
-            message="Input data could not be serialized to the specified content type: {content_type}."
+            message="Input data could not be serialized to {content_type}."
         ) from e
 
 

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -1,0 +1,193 @@
+from io import StringIO
+import json
+import os
+import pandas as pd
+from typing import Any, Dict, List, Optional, Union
+
+from mlflow.exceptions import MlflowException
+from mlflow.models.flavor_backend_registry import get_flavor_backend
+from mlflow.utils import env_manager as _EnvManager
+from mlflow.utils.file_utils import TempDir
+
+
+def build_docker(
+    model_uri=None,
+    name="mlflow-pyfunc",
+    env_manager=_EnvManager.VIRTUALENV,
+    mlflow_home=None,
+    install_mlflow=False,
+    enable_mlserver=False,
+):
+    """
+    Builds a Docker image whose default entrypoint serves an MLflow model at port 8080, using the
+    python_function flavor. The container serves the model referenced by ``model_uri``, if
+    specified. If ``model_uri`` is not specified, an MLflow Model directory must be mounted as a
+    volume into the /opt/ml/model directory in the container.
+
+    .. warning::
+
+        If ``model_uri`` is unspecified, the resulting image doesn't support serving models with
+        the RFunc or Java MLeap model servers.
+
+    NB: by default, the container will start nginx and gunicorn processes. If you don't need the
+    nginx process to be started (for instance if you deploy your container to Google Cloud Run),
+    you can disable it via the DISABLE_NGINX environment variable:
+
+    .. code:: bash
+
+        docker run -p 5001:8080 -e DISABLE_NGINX=true "my-image-name"
+
+    See https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html for more information on the
+    'python_function' flavor.
+    """
+    get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager).build_image(
+        model_uri,
+        name,
+        mlflow_home=mlflow_home,
+        install_mlflow=install_mlflow,
+        enable_mlserver=enable_mlserver,
+    )
+
+
+_CONTENT_TYPE_CSV = "csv"
+_CONTENT_TYPE_JSON = "json"
+
+_SUPPORTED_INPUT_DATA_TYPES = {
+    _CONTENT_TYPE_CSV: (str, list, dict, pd.DataFrame),
+    _CONTENT_TYPE_JSON: (str, dict),
+}
+
+
+def predict(
+    model_uri: str,
+    # Subset of PyfuncInput
+    input_data_or_path: Union[str, Dict[str, Any], List[Any], pd.DataFrame, None],
+    content_type: str = _CONTENT_TYPE_JSON,
+    output_path: Optional[str] = None,
+    env_manager: _EnvManager = _EnvManager.VIRTUALENV,
+    install_mlflow: bool = False,
+    pip_requirements_override: Optional[List[str]] = None,
+):
+    """
+    Generate predictions in json format using a saved MLflow model. For information about the input
+    data formats accepted by this function, see the following documentation:
+    https://www.mlflow.org/docs/latest/models.html#built-in-deployment-tools.
+
+    :param model_uri: URI to the model. A local path, a local or remote URI e.g. runs:/, s3://.
+    :param input_data_or_path: A input data or a path to a local file contains input data.
+        Supported formats are:
+            - A Python dictionary that represents one of the following:
+              (1) single input payload, when content type is "json".
+              (2) Pandas DataFrame, when content type is "csv".
+            - A Python list that represents input data array. The content type has to be "csv".
+            - A Pandas DataFrame. The content type has to be "csv".
+            - A string represents serialized input data. e.g. '{"inputs": [1, 2]}'
+            - A path to a local file contains input data, either a JSON or a CSV file.
+            - None to input data from stdin.
+    :param content_type: Content type of the input data. Can be one of {‘json’, ‘csv’}.
+    :param output_path: File to output results to as json. If not provided, output to stdout.
+    :param env_manager: If specified, create an environment for MLmodel using the specified
+        environment manager. The following values are supported:
+            - virtualenv (default): use virtualenv (and pyenv for Python version management)
+            - local: use the local environment
+            - conda: use conda
+    :param install_mlflow: If specified and there is a conda or virtualenv environment to be
+        activated mlflow will be installed into the environment after it has been activated.
+        The version of installed mlflow will be the same as the one used to invoke this command.
+    :param pip_requirements_override: If specified, install the specified python dependencies to
+        the model inference environment. This is particularly useful when you want to add extra
+        dependencies or try different versions of the dependencies defined in the logged model.
+
+    Code example:
+
+    .. code-block:: python
+
+        import mlflow
+
+        run_id = "..."
+
+        mlflow.pyfunc.predict(
+            model_uri=f"runs:/{run_id}/model",
+            input_data={"x": 1, "y": 2},
+            content_type="json",
+        )
+
+        # Run prediction with addtioanl pip dependencies
+        mlflow.pyfunc.predict(
+            model_uri=f"runs:/{run_id}/model",
+            input_data='{"x": 1, "y": 2}',
+            content_type="json",
+            pip_requirements_override=["scikit-learn==0.23.2"],
+        )
+
+    """
+    if not content_type in [_CONTENT_TYPE_JSON, _CONTENT_TYPE_CSV]:
+        raise MlflowException.invalid_parameter_value(
+            f"Content type must be one of {_CONTENT_TYPE_JSON} or {_CONTENT_TYPE_CSV}."
+        )
+
+    def _predict(_input_path: str):
+        return get_flavor_backend(
+            model_uri, env_manager=env_manager, install_mlflow=install_mlflow
+        ).predict(
+            model_uri=model_uri,
+            input_path=_input_path,
+            output_path=output_path,
+            content_type=content_type,
+            pip_requirements_override=pip_requirements_override,
+        )
+
+    if input_data_or_path is None or _is_filepath(input_data_or_path):
+        _predict(input_data_or_path)
+    else:
+        input_data = _serialize_input_data(input_data_or_path, content_type)
+
+        # Write input data to a temporary file
+        with TempDir() as tmp:
+            input_path = os.path.join(tmp.path(), f"input.{content_type}")
+            with open(input_path, "w") as f:
+                f.write(input_data)
+
+            _predict(input_path)
+
+
+def _is_filepath(x):
+    return isinstance(x, str) and os.path.exists(x) and os.path.isfile(x)
+
+
+def _serialize_input_data(input_data: Union[str, List, Dict, pd.DataFrame], content_type: str):
+    valid_input_types = _SUPPORTED_INPUT_DATA_TYPES[content_type]
+    if not isinstance(input_data, valid_input_types):
+        raise MlflowException.invalid_parameter_value(
+            f"Input data must be one of {valid_input_types} when content type is '{content_type}'."
+        )
+
+    # If the input is already string, check if the input string can be deserialized correctly
+    if isinstance(input_data, str):
+        _validate_string(input_data, content_type)
+        return input_data
+
+    try:
+        if content_type == _CONTENT_TYPE_CSV:
+            # We should not set header=False here because the scoring server expects the
+            # first row to be the header
+            return pd.DataFrame(input_data).to_csv(index=False)
+        else:
+            return json.dumps(input_data)
+    except Exception as e:
+        raise MlflowException.invalid_parameter_value(
+            message="Input data could not be serialized to the specified content type: {content_type}."
+        ) from e
+
+
+def _validate_string(input_data: str, content_type: str):
+    try:
+        if content_type == _CONTENT_TYPE_CSV:
+            pd.read_csv(StringIO(input_data))
+        else:
+            json.loads(input_data)
+    except Exception as e:
+        target = "JSON" if content_type == _CONTENT_TYPE_JSON else "Pandas Dataframe"
+        raise MlflowException.invalid_parameter_value(
+            message=f"Failed to deserialize input string data to {target}."
+        ) from e

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -74,23 +74,23 @@ def predict(
     https://www.mlflow.org/docs/latest/models.html#built-in-deployment-tools.
 
     :param model_uri: URI to the model. A local path, a local or remote URI e.g. runs:/, s3://.
-    :param input_data_or_path: A input data or a path to a local file contains input data.
-        Supported formats are:
-            - A Python dictionary that represents one of the following:
-              (1) single input payload, when content type is "json".
-              (2) Pandas DataFrame, when content type is "csv".
-            - A Python list that represents input data array. The content type has to be "csv".
-            - A Pandas DataFrame. The content type has to be "csv".
-            - A string represents serialized input data. e.g. '{"inputs": [1, 2]}'
-            - A path to a local file contains input data, either a JSON or a CSV file.
-            - None to input data from stdin.
+    :param input_data_or_path: Input data for prediction. It can be one of the following:
+
+                  - A Python dictionary that represents either
+                     - single input payload, when content type is "json".
+                     - Pandas DataFrame, when content type is "csv".
+                  - A Python list that represents input data array. The content type has to be "csv".
+                  - A Pandas DataFrame. The content type has to be "csv".
+                  - A string represents serialized input data. e.g. '{"inputs": [1, 2]}'
+                  - A path to a local file contains input data, either a JSON or a CSV file.
+                  - None to input data from stdin.
     :param content_type: Content type of the input data. Can be one of {‘json’, ‘csv’}.
     :param output_path: File to output results to as json. If not provided, output to stdout.
-    :param env_manager: If specified, create an environment for MLmodel using the specified
-        environment manager. The following values are supported:
-            - virtualenv (default): use virtualenv (and pyenv for Python version management)
-            - local: use the local environment
-            - conda: use conda
+    :param env_manager: Specify a way to create an environment for MLmodel inference:
+
+                  - virtualenv (default): use virtualenv (and pyenv for Python version management)
+                  - local: use the local environment
+                  - conda: use conda
     :param install_mlflow: If specified and there is a conda or virtualenv environment to be
         activated mlflow will be installed into the environment after it has been activated.
         The version of installed mlflow will be the same as the one used to invoke this command.

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -55,7 +55,7 @@ _CONTENT_TYPE_JSON = "json"
 def predict(
     model_uri: str,
     # Subset of PyfuncInput
-    input_data_or_path: Union[str, Dict[str, Any], List[Any], 'pd.DataFrame', None],
+    input_data_or_path: Union[str, Dict[str, Any], List[Any], "pd.DataFrame", None],  # noqa: F821
     content_type: str = _CONTENT_TYPE_JSON,
     output_path: Optional[str] = None,
     env_manager: _EnvManager = _EnvManager.VIRTUALENV,
@@ -70,21 +70,23 @@ def predict(
     :param model_uri: URI to the model. A local path, a local or remote URI e.g. runs:/, s3://.
     :param input_data_or_path: Input data for prediction. It can be one of the following:
 
-                  - A Python dictionary that contains either:
-                     - single input payload, when content type is "json".
-                     - Pandas DataFrame, when content type is "csv".
-                  - A Python list. The content type has to be "csv".
-                  - A Pandas DataFrame. The content type has to be "csv".
-                  - A string represents serialized input data. e.g. '{"inputs": [1, 2]}'
-                  - A path to a local file contains input data, either a JSON or a CSV file.
-                  - None to input data from stdin.
+        - A Python dictionary that contains either:
+           - single input payload, when content type is "json".
+           - Pandas DataFrame, when content type is "csv".
+        - A Python list. The content type has to be "csv".
+        - A Pandas DataFrame. The content type has to be "csv".
+        - A string represents serialized input data. e.g. '{"inputs": [1, 2]}'
+        - A path to a local file contains input data, either a JSON or a CSV file.
+        - None to input data from stdin.
+
     :param content_type: Content type of the input data. Can be one of {‘json’, ‘csv’}.
     :param output_path: File to output results to as json. If not provided, output to stdout.
     :param env_manager: Specify a way to create an environment for MLmodel inference:
 
-                  - virtualenv (default): use virtualenv (and pyenv for Python version management)
-                  - local: use the local environment
-                  - conda: use conda
+        - virtualenv (default): use virtualenv (and pyenv for Python version management)
+        - local: use the local environment
+        - conda: use conda
+
     :param install_mlflow: If specified and there is a conda or virtualenv environment to be
         activated mlflow will be installed into the environment after it has been activated.
         The version of installed mlflow will be the same as the one used to invoke this command.
@@ -149,12 +151,12 @@ def _is_filepath(x):
     return isinstance(x, str) and os.path.exists(x) and os.path.isfile(x)
 
 
-def _serialize_input_data(input_data: Union[str, List, Dict, 'pd.DataFrame'], content_type: str):
+def _serialize_input_data(input_data, content_type):
     # build-docker command is available in mlflow-skinny (which doesn't contain pandas)
     # so we shouldn't import pandas at the top level
     import pandas as pd
 
-    valid_input_types =  {
+    valid_input_types = {
         _CONTENT_TYPE_CSV: (str, list, dict, pd.DataFrame),
         _CONTENT_TYPE_JSON: (str, dict),
     }.get(content_type)
@@ -186,6 +188,7 @@ def _validate_string(input_data: str, content_type: str):
     try:
         if content_type == _CONTENT_TYPE_CSV:
             import pandas as pd
+
             pd.read_csv(StringIO(input_data))
         else:
             json.loads(input_data)

--- a/mlflow/pyfunc/_mlflow_pyfunc_backend_predict.py
+++ b/mlflow/pyfunc/_mlflow_pyfunc_backend_predict.py
@@ -2,7 +2,6 @@
 This script should be executed in a fresh python interpreter process using `subprocess`.
 """
 import argparse
-import re
 
 from mlflow.pyfunc.scoring_server import _predict
 
@@ -53,8 +52,7 @@ def main():
             content_type=args.content_type,
         )
     except ModuleNotFoundError as e:
-        missing_module = re.search(r"No module named '(.*)'", str(e)).group(1)
-        message = _MISSING_MODULE_HELP_MSG.format(e=str(e), missing_module=missing_module)
+        message = _MISSING_MODULE_HELP_MSG.format(e=str(e), missing_module=e.name)
         raise RuntimeError(message) from e
 
 

--- a/mlflow/pyfunc/_mlflow_pyfunc_backend_predict.py
+++ b/mlflow/pyfunc/_mlflow_pyfunc_backend_predict.py
@@ -35,6 +35,9 @@ _MISSING_MODULE_HELP_MSG = (
         extra_pip_requirements=["{missing_module}==x.y.z"]
     )
     ----
+
+    For mode guidance on fixing missing dependencies, please refer to the MLflow docs:
+    https://www.mlflow.org/docs/latest/deployment/index.html#how-to-fix-dependency-errors-when-serving-my-model
 """
 )
 

--- a/mlflow/pyfunc/_mlflow_pyfunc_backend_predict.py
+++ b/mlflow/pyfunc/_mlflow_pyfunc_backend_predict.py
@@ -2,6 +2,7 @@
 This script should be executed in a fresh python interpreter process using `subprocess`.
 """
 import argparse
+import re
 
 from mlflow.pyfunc.scoring_server import _predict
 
@@ -15,14 +16,43 @@ def parse_args():
     return parser.parse_args()
 
 
+# Guidance for fixing missing module error
+_MISSING_MODULE_HELP_MSG = (
+    "Exception occurred while running inference: {e}"
+    "\n\n"
+    "\033[93m[Hint] It appears to be your MLflow Model doesn't contain the required "
+    "dependency '{missing_module}' to run model inference. When logging a model, MLflow "
+    "detects dependencies based on the model flavor but it is possible that some "
+    "dependencies are not captured. In this case, you can manually add dependencies "
+    "using the `extra_pip_requirements` parameter of `mlflow.pyfunc.log_model`.\033[0m"
+    """
+
+\033[1mSample code:\033[0m
+    ----
+    mlflow.pyfunc.log_model(
+        artifact_path="model",
+        python_model=your_model,
+        extra_pip_requirements=["{missing_module}==x.y.z"]
+    )
+    ----
+"""
+)
+
+
 def main():
     args = parse_args()
-    _predict(
-        model_uri=args.model_uri,
-        input_path=args.input_path if args.input_path else None,
-        output_path=args.output_path if args.output_path else None,
-        content_type=args.content_type,
-    )
+
+    try:
+        _predict(
+            model_uri=args.model_uri,
+            input_path=args.input_path if args.input_path else None,
+            output_path=args.output_path if args.output_path else None,
+            content_type=args.content_type,
+        )
+    except ModuleNotFoundError as e:
+        missing_module = re.search(r"No module named '(.*)'", str(e)).group(1)
+        message = _MISSING_MODULE_HELP_MSG.format(e=str(e), missing_module=missing_module)
+        raise RuntimeError(message) from e
 
 
 if __name__ == "__main__":

--- a/mlflow/pyfunc/_mlflow_pyfunc_backend_predict.py
+++ b/mlflow/pyfunc/_mlflow_pyfunc_backend_predict.py
@@ -20,9 +20,9 @@ def parse_args():
 _MISSING_MODULE_HELP_MSG = (
     "Exception occurred while running inference: {e}"
     "\n\n"
-    "\033[93m[Hint] It appears to be your MLflow Model doesn't contain the required "
+    "\033[93m[Hint] It appears that your MLflow Model doesn't contain the required "
     "dependency '{missing_module}' to run model inference. When logging a model, MLflow "
-    "detects dependencies based on the model flavor but it is possible that some "
+    "detects dependencies based on the model flavor, but it is possible that some "
     "dependencies are not captured. In this case, you can manually add dependencies "
     "using the `extra_pip_requirements` parameter of `mlflow.pyfunc.log_model`.\033[0m"
     """

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -50,29 +50,6 @@ _IS_UNIX = os.name != "nt"
 _STDIN_SERVER_SCRIPT = Path(__file__).parent.joinpath("stdin_server.py")
 
 
-# Guidance for fixing missing module error
-_MISSING_MODULE_HELP_MSG = (
-    "Exception occurred while running inference: {e}"
-    "\n\n"
-    "\033[93m[Hint] It appears to be your MLflow Model doesn't contain the required "
-    "dependencies '{module_name}' to run inference. When logging a model, MLflow "
-    "detects dependencies based on the model flavor but it is possible that some "
-    "dependencies are not captured. In this case, you can manually add dependencies "
-    "using `extra_pip_requirements` parameter of `mlflow.pyfunc.log_model`.\033[0m"
-    """
-
-\033[1mSample code:\033[0m
-    ----
-    mlflow.pyfunc.log_model(
-        artifact_path="model",
-        python_model=your_model,
-        extra_pip_requirements=["{module_name}==x.y.z"]
-    )
-    ----
-"""
-)
-
-
 class PyFuncBackend(FlavorBackend):
     """
     Flavor backend implementation for the generic python models.

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -11,6 +11,7 @@ import warnings
 from pathlib import Path
 
 from mlflow.environment_variables import MLFLOW_DISABLE_ENV_CREATION
+from mlflow.exceptions import MlflowException
 from mlflow.models import FlavorBackend
 from mlflow.models.container import ENABLE_MLSERVER
 from mlflow.models.docker_utils import (
@@ -184,14 +185,14 @@ class PyFuncBackend(FlavorBackend):
             try:
                 environment.execute(" ".join(predict_cmd))
             except ShellCommandException as e:
-                raise ShellCommandException(
+                raise MlflowException(
                     f"{e}\n\nAn exception occurred while running model prediction within a "
                     f"{self._env_manager} environment. You can find the error message "
                     f"from the prediction subprocess by scrolling above."
                 ) from None
         else:
             if pip_requirements_override:
-                raise Exception(
+                raise MlflowException(
                     "`pip_requirements_override` is not supported for local env manager."
                     "Please use conda or virtualenv instead."
                 )

--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -27,11 +27,13 @@ class RFuncBackend(FlavorBackend):
 
     version_pattern = re.compile(r"version ([0-9]+\.[0-9]+\.[0-9]+)")
 
-    def predict(self, model_uri, input_path, output_path, content_type):
+    def predict(self, model_uri, input_path, output_path, content_type, pip_requirements_override = None):
         """
         Generate predictions using R model saved with MLflow.
         Return the prediction results as a JSON.
         """
+        if pip_requirements_override is not None:
+            raise Exception("pip_requirements_override is not supported in the R backend.")
         model_path = _download_artifact_from_uri(model_uri)
         str_cmd = (
             "mlflow:::mlflow_rfunc_predict(model_path = '{0}', input_path = {1}, "

--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -27,7 +27,9 @@ class RFuncBackend(FlavorBackend):
 
     version_pattern = re.compile(r"version ([0-9]+\.[0-9]+\.[0-9]+)")
 
-    def predict(self, model_uri, input_path, output_path, content_type, pip_requirements_override = None):
+    def predict(
+        self, model_uri, input_path, output_path, content_type, pip_requirements_override=None
+    ):
         """
         Generate predictions using R model saved with MLflow.
         Return the prediction results as a JSON.

--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -3,8 +3,8 @@ import os
 import re
 import subprocess
 import sys
-from mlflow.exceptions import MlflowException
 
+from mlflow.exceptions import MlflowException
 from mlflow.models import FlavorBackend
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.string_utils import quote

--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 import sys
+from mlflow.exceptions import MlflowException
 
 from mlflow.models import FlavorBackend
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -35,7 +36,7 @@ class RFuncBackend(FlavorBackend):
         Return the prediction results as a JSON.
         """
         if pip_requirements_override is not None:
-            raise Exception("pip_requirements_override is not supported in the R backend.")
+            raise MlflowException("pip_requirements_override is not supported in the R backend.")
         model_path = _download_artifact_from_uri(model_uri)
         str_cmd = (
             "mlflow:::mlflow_rfunc_predict(model_path = '{0}', input_path = {1}, "

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -80,10 +80,10 @@ def _resolve_env_manager(_, __, env_manager):
     return None
 
 
-def _create_env_manager_option(help_string):
+def _create_env_manager_option(help_string, default=None):
     return click.option(
         "--env-manager",
-        default=_EnvManager.VIRTUALENV,
+        default=default,
         type=click.UNPROCESSED,
         callback=_resolve_env_manager,
         help=help_string,
@@ -91,6 +91,7 @@ def _create_env_manager_option(help_string):
 
 
 ENV_MANAGER = _create_env_manager_option(
+    default=_EnvManager.VIRTUALENV,
     # '\b' prevents rewrapping text:
     # https://click.palletsprojects.com/en/8.1.x/documentation/#preventing-rewrapping
     help_string="""

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -83,7 +83,7 @@ def _resolve_env_manager(_, __, env_manager):
 def _create_env_manager_option(help_string):
     return click.option(
         "--env-manager",
-        default=None,
+        default=_EnvManager.VIRTUALENV,
         type=click.UNPROCESSED,
         callback=_resolve_env_manager,
         help=help_string,

--- a/mlflow/utils/conda.py
+++ b/mlflow/utils/conda.py
@@ -287,8 +287,9 @@ def get_or_create_conda_env(
                 "Installing additional dependencies specified"
                 f"by pip_requirements_override: {pip_requirements_override}"
             )
-            cmd = [conda_path, "install", "--yes", "--quiet", *pip_requirements_override]
-            conda_env.execute(" ".join(cmd), capture_output=capture_output)
+            cmd = [conda_path, "install", "-n", project_env_name,
+                    "--yes", "--quiet", *pip_requirements_override]
+            process._exec_cmd(cmd, extra_env=conda_extra_env_vars, capture_output=capture_output)
 
         return conda_env
 

--- a/mlflow/utils/conda.py
+++ b/mlflow/utils/conda.py
@@ -287,8 +287,15 @@ def get_or_create_conda_env(
                 "Installing additional dependencies specified"
                 f"by pip_requirements_override: {pip_requirements_override}"
             )
-            cmd = [conda_path, "install", "-n", project_env_name,
-                    "--yes", "--quiet", *pip_requirements_override]
+            cmd = [
+                conda_path,
+                "install",
+                "-n",
+                project_env_name,
+                "--yes",
+                "--quiet",
+                *pip_requirements_override,
+            ]
             process._exec_cmd(cmd, extra_env=conda_extra_env_vars, capture_output=capture_output)
 
         return conda_env

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -195,7 +195,7 @@ def _get_python_env(local_model_path):
     requirements_file = local_model_path / _REQUIREMENTS_FILE_NAME
 
     if python_env_file.exists():
-        python_env = _PythonEnv.from_yaml(python_env_file)
+        return _PythonEnv.from_yaml(python_env_file)
     else:
         _logger.info(
             "This model is missing %s, which is because it was logged in an older version"
@@ -207,15 +207,13 @@ def _get_python_env(local_model_path):
         )
         if requirements_file.exists():
             deps = _PythonEnv.get_dependencies_from_conda_yaml(conda_env_file)
-            python_env = _PythonEnv(
+            return _PythonEnv(
                 python=deps["python"],
                 build_dependencies=deps["build_dependencies"],
                 dependencies=[f"-r {_REQUIREMENTS_FILE_NAME}"],
             )
         else:
-            python_env = _PythonEnv.from_conda_yaml(conda_env_file)
-
-    return python_env
+            return _PythonEnv.from_conda_yaml(conda_env_file)
 
 
 def _get_virtualenv_name(python_env, work_dir_path, env_id=None):

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -368,7 +368,7 @@ def test_predict_check_content_type(iris_data, sk_model, tmp_path):
         check=False,
     )
     assert prc.returncode != 0
-    assert "Unknown content type" in prc.stderr.decode("utf-8")
+    assert "Content type must be one of json or csv." in prc.stderr.decode("utf-8")
 
 
 def test_predict_check_input_path(iris_data, sk_model, tmp_path):

--- a/tests/models/test_python_api.py
+++ b/tests/models/test_python_api.py
@@ -1,24 +1,24 @@
 import json
-import pandas as pd
-import pytest
 from tempfile import NamedTemporaryFile
 from unittest import mock
 
+import pandas as pd
+import pytest
+
 import mlflow
 from mlflow.exceptions import MlflowException
-from mlflow.utils.file_utils import TempDir
 from mlflow.models.python_api import (
     _CONTENT_TYPE_CSV,
     _CONTENT_TYPE_JSON,
     _serialize_input_data,
 )
+from mlflow.utils.file_utils import TempDir
 
 
 @pytest.fixture
 def mock_backend():
     mock_backend = mock.MagicMock()
-    with mock.patch("mlflow.models.python_api.get_flavor_backend",
-                    return_value=mock_backend):
+    with mock.patch("mlflow.models.python_api.get_flavor_backend", return_value=mock_backend):
         yield mock_backend
 
 
@@ -61,7 +61,7 @@ def test_predict_with_input_csv(mock_backend):
                 pip_requirements_override=None,
             )
 
-            with open(tmp.path() + "/input.csv", "r") as f:
+            with open(tmp.path() + "/input.csv") as f:
                 df = pd.read_csv(f)
                 assert df.equals(input_data)
 
@@ -88,7 +88,7 @@ def test_predict_with_input_json(mock_backend):
                 pip_requirements_override=None,
             )
 
-            with open(tmp.path() + "/input.json", "r") as f:
+            with open(tmp.path() + "/input.json") as f:
                 assert json.load(f) == input_data
 
 
@@ -121,18 +121,28 @@ def test_predict_invalid_content_type(mock_backend):
     ("input_data", "content_type", "expected"),
     [
         # String (no change)
-        ("{\"inputs\": [1, 2, 3]}", _CONTENT_TYPE_JSON, "{\"inputs\": [1, 2, 3]}"),
+        ('{"inputs": [1, 2, 3]}', _CONTENT_TYPE_JSON, '{"inputs": [1, 2, 3]}'),
         ("x,y,z\n1,2,3\n4,5,6", _CONTENT_TYPE_CSV, "x,y,z\n1,2,3\n4,5,6"),
         # List
-        ([1, 2, 3], _CONTENT_TYPE_CSV, "0\n1\n2\n3\n"), # a header '0' is added by pandas
+        ([1, 2, 3], _CONTENT_TYPE_CSV, "0\n1\n2\n3\n"),  # a header '0' is added by pandas
         ([[1, 2, 3], [4, 5, 6]], _CONTENT_TYPE_CSV, "0,1,2\n1,2,3\n4,5,6\n"),
         # Dict (pandas)
-        ({"x": [1, 2,], "y": [3, 4]}, _CONTENT_TYPE_CSV, "x,y\n1,3\n2,4\n"),
+        (
+            {
+                "x": [
+                    1,
+                    2,
+                ],
+                "y": [3, 4],
+            },
+            _CONTENT_TYPE_CSV,
+            "x,y\n1,3\n2,4\n",
+        ),
         # Dict (json)
-        ({"inputs": [1, 2, 3]}, _CONTENT_TYPE_JSON, "{\"inputs\": [1, 2, 3]}"),
+        ({"inputs": [1, 2, 3]}, _CONTENT_TYPE_JSON, '{"inputs": [1, 2, 3]}'),
         # Pandas DataFrame
         (pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}), _CONTENT_TYPE_CSV, "x,y\n1,4\n2,5\n3,6\n"),
-    ]
+    ],
 )
 def test_serialize_input_data(input_data, content_type, expected):
     assert _serialize_input_data(input_data, content_type) == expected
@@ -153,9 +163,9 @@ def test_serialize_input_data(input_data, content_type, expected):
         # Invalid list
         ([[1, 2], [3, 4], 5], _CONTENT_TYPE_CSV),
         # Invalid dict (unserealizable)
-        ({"x": 1, "y": set([1, 2, 3])}, _CONTENT_TYPE_JSON),
-    ]
+        ({"x": 1, "y": {1, 2, 3}}, _CONTENT_TYPE_JSON),
+    ],
 )
 def test_serialize_input_data_invalid_format(input_data, content_type):
-    with pytest.raises(MlflowException):
+    with pytest.raises(MlflowException):  # noqa: PT011
         _serialize_input_data(input_data, content_type)

--- a/tests/models/test_python_api.py
+++ b/tests/models/test_python_api.py
@@ -1,0 +1,161 @@
+import json
+import pandas as pd
+import pytest
+from tempfile import NamedTemporaryFile
+from unittest import mock
+
+import mlflow
+from mlflow.exceptions import MlflowException
+from mlflow.utils.file_utils import TempDir
+from mlflow.models.python_api import (
+    _CONTENT_TYPE_CSV,
+    _CONTENT_TYPE_JSON,
+    _serialize_input_data,
+)
+
+
+@pytest.fixture
+def mock_backend():
+    mock_backend = mock.MagicMock()
+    with mock.patch("mlflow.models.python_api.get_flavor_backend",
+                    return_value=mock_backend):
+        yield mock_backend
+
+
+def test_predict_with_input_path(mock_backend):
+    with NamedTemporaryFile() as input_file:
+        mlflow.models.predict(
+            model_uri="runs:/test/Model",
+            input_data_or_path=input_file.name,
+            content_type=_CONTENT_TYPE_CSV,
+        )
+
+    mock_backend.predict.assert_called_once_with(
+        model_uri="runs:/test/Model",
+        input_path=input_file.name,
+        output_path=None,
+        content_type=_CONTENT_TYPE_CSV,
+        pip_requirements_override=None,
+    )
+
+
+def test_predict_with_input_csv(mock_backend):
+    input_data = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+
+    with TempDir() as tmp:
+        # Mock TempDir in the predict function to return the same temp dir we created
+        mock_tempdir = mock.MagicMock()
+        mock_tempdir.__enter__.return_value.path.return_value = tmp.path()
+        with mock.patch("mlflow.models.python_api.TempDir", return_value=mock_tempdir):
+            mlflow.models.predict(
+                model_uri="runs:/test/Model",
+                input_data_or_path=input_data,
+                content_type=_CONTENT_TYPE_CSV,
+            )
+
+            mock_backend.predict.assert_called_once_with(
+                model_uri="runs:/test/Model",
+                input_path=tmp.path() + "/input.csv",
+                output_path=None,
+                content_type=_CONTENT_TYPE_CSV,
+                pip_requirements_override=None,
+            )
+
+            with open(tmp.path() + "/input.csv", "r") as f:
+                df = pd.read_csv(f)
+                assert df.equals(input_data)
+
+
+def test_predict_with_input_json(mock_backend):
+    input_data = {"inputs": [1, 2, 3]}
+
+    with TempDir() as tmp:
+        # Mock TempDir in the predict function to return the same temp dir we created
+        mock_tempdir = mock.MagicMock()
+        mock_tempdir.__enter__.return_value.path.return_value = tmp.path()
+        with mock.patch("mlflow.models.python_api.TempDir", return_value=mock_tempdir):
+            mlflow.models.predict(
+                model_uri="runs:/test/Model",
+                input_data_or_path=input_data,
+                content_type=_CONTENT_TYPE_JSON,
+            )
+
+            mock_backend.predict.assert_called_once_with(
+                model_uri="runs:/test/Model",
+                input_path=tmp.path() + "/input.json",
+                output_path=None,
+                content_type=_CONTENT_TYPE_JSON,
+                pip_requirements_override=None,
+            )
+
+            with open(tmp.path() + "/input.json", "r") as f:
+                assert json.load(f) == input_data
+
+
+def test_predict_with_input_none(mock_backend):
+    mlflow.models.predict(
+        model_uri="runs:/test/Model",
+        input_data_or_path=None,
+        content_type=_CONTENT_TYPE_CSV,
+    )
+
+    mock_backend.predict.assert_called_once_with(
+        model_uri="runs:/test/Model",
+        input_path=None,
+        output_path=None,
+        content_type=_CONTENT_TYPE_CSV,
+        pip_requirements_override=None,
+    )
+
+
+def test_predict_invalid_content_type(mock_backend):
+    with pytest.raises(MlflowException, match=r"Content type must be one of"):
+        mlflow.models.predict(
+            model_uri="runs:/test/Model",
+            input_data_or_path={"inputs": [1, 2, 3]},
+            content_type="any",
+        )
+
+
+@pytest.mark.parametrize(
+    ("input_data", "content_type", "expected"),
+    [
+        # String (no change)
+        ("{\"inputs\": [1, 2, 3]}", _CONTENT_TYPE_JSON, "{\"inputs\": [1, 2, 3]}"),
+        ("x,y,z\n1,2,3\n4,5,6", _CONTENT_TYPE_CSV, "x,y,z\n1,2,3\n4,5,6"),
+        # List
+        ([1, 2, 3], _CONTENT_TYPE_CSV, "0\n1\n2\n3\n"), # a header '0' is added by pandas
+        ([[1, 2, 3], [4, 5, 6]], _CONTENT_TYPE_CSV, "0,1,2\n1,2,3\n4,5,6\n"),
+        # Dict (pandas)
+        ({"x": [1, 2,], "y": [3, 4]}, _CONTENT_TYPE_CSV, "x,y\n1,3\n2,4\n"),
+        # Dict (json)
+        ({"inputs": [1, 2, 3]}, _CONTENT_TYPE_JSON, "{\"inputs\": [1, 2, 3]}"),
+        # Pandas DataFrame
+        (pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}), _CONTENT_TYPE_CSV, "x,y\n1,4\n2,5\n3,6\n"),
+    ]
+)
+def test_serialize_input_data(input_data, content_type, expected):
+    assert _serialize_input_data(input_data, content_type) == expected
+
+
+@pytest.mark.parametrize(
+    ("input_data", "content_type"),
+    [
+        # Invalid input datatype for the content type
+        (1, _CONTENT_TYPE_CSV),
+        ({1, 2, 3}, _CONTENT_TYPE_CSV),
+        (1, _CONTENT_TYPE_JSON),
+        (True, _CONTENT_TYPE_JSON),
+        ([1, 2, 3], _CONTENT_TYPE_JSON),
+        # Invalid string
+        ("{inputs: [1, 2, 3]}", _CONTENT_TYPE_JSON),
+        ("x,y\n1,2\n3,4,5\n", _CONTENT_TYPE_CSV),
+        # Invalid list
+        ([[1, 2], [3, 4], 5], _CONTENT_TYPE_CSV),
+        # Invalid dict (unserealizable)
+        ({"x": 1, "y": set([1, 2, 3])}, _CONTENT_TYPE_JSON),
+    ]
+)
+def test_serialize_input_data_invalid_format(input_data, content_type):
+    with pytest.raises(MlflowException):
+        _serialize_input_data(input_data, content_type)

--- a/tests/models/test_python_api.py
+++ b/tests/models/test_python_api.py
@@ -26,7 +26,7 @@ def test_predict_with_input_path(mock_backend):
     with NamedTemporaryFile() as input_file:
         mlflow.models.predict(
             model_uri="runs:/test/Model",
-            input_data_or_path=input_file.name,
+            input_path=input_file.name,
             content_type=_CONTENT_TYPE_CSV,
         )
 
@@ -39,7 +39,7 @@ def test_predict_with_input_path(mock_backend):
     )
 
 
-def test_predict_with_input_csv(mock_backend):
+def test_predict_with_input_data_csv(mock_backend):
     input_data = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
 
     with TempDir() as tmp:
@@ -49,7 +49,7 @@ def test_predict_with_input_csv(mock_backend):
         with mock.patch("mlflow.models.python_api.TempDir", return_value=mock_tempdir):
             mlflow.models.predict(
                 model_uri="runs:/test/Model",
-                input_data_or_path=input_data,
+                input_data=input_data,
                 content_type=_CONTENT_TYPE_CSV,
             )
 
@@ -66,7 +66,7 @@ def test_predict_with_input_csv(mock_backend):
                 assert df.equals(input_data)
 
 
-def test_predict_with_input_json(mock_backend):
+def test_predict_with_input_data_json(mock_backend):
     input_data = {"inputs": [1, 2, 3]}
 
     with TempDir() as tmp:
@@ -76,7 +76,7 @@ def test_predict_with_input_json(mock_backend):
         with mock.patch("mlflow.models.python_api.TempDir", return_value=mock_tempdir):
             mlflow.models.predict(
                 model_uri="runs:/test/Model",
-                input_data_or_path=input_data,
+                input_data=input_data,
                 content_type=_CONTENT_TYPE_JSON,
             )
 
@@ -95,7 +95,6 @@ def test_predict_with_input_json(mock_backend):
 def test_predict_with_input_none(mock_backend):
     mlflow.models.predict(
         model_uri="runs:/test/Model",
-        input_data_or_path=None,
         content_type=_CONTENT_TYPE_CSV,
     )
 
@@ -108,11 +107,21 @@ def test_predict_with_input_none(mock_backend):
     )
 
 
+def test_predict_with_both_input_data_and_path_raise(mock_backend):
+    with pytest.raises(MlflowException, match=r"Both input_data and input_path are provided"):
+        mlflow.models.predict(
+            model_uri="runs:/test/Model",
+            input_data={"inputs": [1, 2, 3]},
+            input_path="input.csv",
+            content_type=_CONTENT_TYPE_CSV,
+        )
+
+
 def test_predict_invalid_content_type(mock_backend):
     with pytest.raises(MlflowException, match=r"Content type must be one of"):
         mlflow.models.predict(
             model_uri="runs:/test/Model",
-            input_data_or_path={"inputs": [1, 2, 3]},
+            input_data={"inputs": [1, 2, 3]},
             content_type="any",
         )
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10759?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10759/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10759
```

</p>
</details>

### What changes are proposed in this pull request?

Enhance `mlflow models predict` CLI command so that users can use it (more easily) for validating model environment before deployment.
1. Add Python API for convenience in the notebook environment. Almost same as CLI, but also support serialized json/csv string as input data (while CLI only supports file path or stdin) for the sake of notebook experience.
2. Show better error message and guidance when some packages are missing in the model. Basically introduce usage of `extra_pip_requirements`.
3. Add `pip-requirement-override` argument to both Python/CLI APIs, so that users can try additional/updated dependencies without having to create and log model (as Python only emits error one by one, this process can be very annoying otherwise).


**Note**
Will work on OSS/Databricks docs as a follow-up.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified the functionality works in Databricks. Note that it takes a bit log for the first time creating virtualenv (0:20~0:45 in the video).

https://github.com/mlflow/mlflow/assets/31463517/c26dd903-2954-45df-8440-042f76c291ec

In Databricks, I was able to test only with virtualenv as we don't have conda installed. For conda, I tested on devbox and it worked as same.

### Does this PR require documentation update?
Will work on doc update.

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Enhanced `predict` API for MLflow Model so it can be used for inference environment validation before model deployment: (1) add Python API for the sake of notebook convenience (2) introduce `pip-requirement-overrides` argument to test dependency change (3) enrich error message.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
