### PR TITLE
Gateway Streaming for OpenAI

### DIFF
--- a/docs/source/llms/deployments/index.rst
+++ b/docs/source/llms/deployments/index.rst
@@ -875,24 +875,24 @@ The results of the query follow the `OpenAI schema <https://platform.openai.com/
 Chat
 ^^^^
 
-.. code-block:: json
+.. code-block:: text
 
-    {"choices": [{"delta": {"content": null, "role": "assistant"}, "finish_reason": null, "index": 0}],
+    data: {"choices": [{"delta": {"content": null, "role": "assistant"}, "finish_reason": null, "index": 0}],
      "created": 1701161926,
      "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
      "model": "gpt-35-turbo",
      "object": "chat.completion.chunk"}
-    {"choices": [{"delta": {"content": "Hello", "role": null}, "finish_reason": null, "index": 0}],
+    data: {"choices": [{"delta": {"content": "Hello", "role": null}, "finish_reason": null, "index": 0}],
      "created": 1701161926,
      "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
      "model": "gpt-35-turbo",
      "object": "chat.completion.chunk"}
-    {"choices": [{"delta": {"content": " there", "role": null}, "finish_reason": null, "index": 0}],
+    data: {"choices": [{"delta": {"content": " there", "role": null}, "finish_reason": null, "index": 0}],
      "created": 1701161926,
      "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
      "model": "gpt-35-turbo",
      "object": "chat.completion.chunk"}
-    {"choices": [{"delta": {"content": null, "role": null}, "finish_reason": "stop", "index": 0}],
+    data: {"choices": [{"delta": {"content": null, "role": null}, "finish_reason": "stop", "index": 0}],
      "created": 1701161926,
      "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
      "model": "gpt-35-turbo",
@@ -902,24 +902,24 @@ Chat
 Completions
 ^^^^^^^^^^^
 
-.. code-block:: json
+.. code-block:: text
 
-    {"choices": [{"delta": {"role": null, "content": null}, "finish_reason": null, "index": 0}],
+    data: {"choices": [{"delta": {"role": null, "content": null}, "finish_reason": null, "index": 0}],
      "created": 1701161629,
      "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
      "model": "gpt-35-turbo",
      "object": "text_completion_chunk"}
-    {"choices": [{"delta": {"role": null, "content": "If"}, "finish_reason": null, "index": 0}],
+    data: {"choices": [{"delta": {"role": null, "content": "If"}, "finish_reason": null, "index": 0}],
      "created": 1701161629,
      "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
      "model": "gpt-35-turbo",
      "object": "text_completion_chunk"}
-    {"choices": [{"delta": {"role": null, "content": " an"}, "finish_reason": null, "index": 0}],
+    data: {"choices": [{"delta": {"role": null, "content": " an"}, "finish_reason": null, "index": 0}],
      "created": 1701161629,
      "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
      "model": "gpt-35-turbo",
      "object": "text_completion_chunk"}
-    {"choices": [{"delta": {"role": null, "content": " asteroid"}, "finish_reason": null, "index": 0}],
+    data: {"choices": [{"delta": {"role": null, "content": " asteroid"}, "finish_reason": null, "index": 0}],
      "created": 1701161629,
      "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
      "model": "gpt-35-turbo",

--- a/docs/source/llms/deployments/index.rst
+++ b/docs/source/llms/deployments/index.rst
@@ -804,10 +804,7 @@ In addition to the :ref:`standard_query_parameters`, you can pass any additional
 - ``top_k`` (supported by MosaicML, Anthropic, PaLM, Cohere)
 - ``frequency_penalty`` (supported by OpenAI, Cohere, AI21 Labs)
 - ``presence_penalty`` (supported by OpenAI, Cohere, AI21 Labs)
-
-The following parameters are not allowed:
-
-- ``stream`` is not supported. Setting this parameter on any provider will not work currently.
+- ``stream`` (supported by OpenAI)
 
 Below is an example of submitting a query request to an MLflow Deployments Server endpoint using additional parameters:
 
@@ -853,6 +850,86 @@ The results of the query are:
             "total_tokens": 635,
         },
     }
+
+Streaming
+~~~~~~~~~
+
+Some providers support streaming responses. Streaming responses are useful when you want to
+receive responses as they are generated, rather than waiting for the entire response to be
+generated before receiving it. Streaming responses are supported by the following providers:
+
+- OpenAI
+
+To enable streaming responses, set the ``stream`` parameter to ``true`` in your request. For example:
+
+.. code-block:: bash
+
+     curl -X POST http://my.deployments:8888/endpoints/chat/invocations \
+        -H "Content-Type: application/json" \
+        -d '{"messages": [{"role": "user", "content": "hello"}], "stream": true}'
+
+
+The results of the query follow the `OpenAI schema <https://platform.openai.com/docs/api-reference/chat/streaming>`_.
+
+
+Chat
+^^^^
+
+.. code-block:: json
+
+    {"choices": [{"delta": {"content": null, "role": "assistant"}, "finish_reason": null, "index": 0}],
+     "created": 1701161926,
+     "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
+     "model": "gpt-35-turbo",
+     "object": "chat.completion.chunk"}
+    {"choices": [{"delta": {"content": "Hello", "role": null}, "finish_reason": null, "index": 0}],
+     "created": 1701161926,
+     "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
+     "model": "gpt-35-turbo",
+     "object": "chat.completion.chunk"}
+    {"choices": [{"delta": {"content": " there", "role": null}, "finish_reason": null, "index": 0}],
+     "created": 1701161926,
+     "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
+     "model": "gpt-35-turbo",
+     "object": "chat.completion.chunk"}
+    {"choices": [{"delta": {"content": null, "role": null}, "finish_reason": "stop", "index": 0}],
+     "created": 1701161926,
+     "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
+     "model": "gpt-35-turbo",
+     "object": "chat.completion.chunk"}
+
+
+Completions
+^^^^^^^^^^^
+
+.. code-block:: json
+
+    {"choices": [{"delta": {"role": null, "content": null}, "finish_reason": null, "index": 0}],
+     "created": 1701161629,
+     "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
+     "model": "gpt-35-turbo",
+     "object": "text_completion_chunk"}
+    {"choices": [{"delta": {"role": null, "content": "If"}, "finish_reason": null, "index": 0}],
+     "created": 1701161629,
+     "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
+     "model": "gpt-35-turbo",
+     "object": "text_completion_chunk"}
+    {"choices": [{"delta": {"role": null, "content": " an"}, "finish_reason": null, "index": 0}],
+     "created": 1701161629,
+     "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
+     "model": "gpt-35-turbo",
+     "object": "text_completion_chunk"}
+    {"choices": [{"delta": {"role": null, "content": " asteroid"}, "finish_reason": null, "index": 0}],
+     "created": 1701161629,
+     "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
+     "model": "gpt-35-turbo",
+     "object": "text_completion_chunk"}
+    {"choices": [{"delta": {"role": null, "content": null}, "finish_reason": "length", "index": 0}],
+     "created": 1701161629,
+     "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
+     "model": "gpt-35-turbo",
+     "object": "text_completion_chunk"}
+
 
 FastAPI Documentation ("/docs")
 -------------------------------

--- a/docs/source/llms/deployments/index.rst
+++ b/docs/source/llms/deployments/index.rst
@@ -877,13 +877,13 @@ Chat
 
 .. code-block:: text
 
-    data: {"choices":[{"delta":{"content":null,"role":"assistant"} "finish_reason":null,"index":0}],"created":1701161926,"id":"chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3","model":"gpt-35-turbo","object":"chat.completion.chunk"}
+    data: {"choices": [{"delta": {"content": null, "role": "assistant"}, "finish_reason": null, "index": 0}], "created": 1701161926, "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3", "model": "gpt-35-turbo", "object": "chat.completion.chunk"}
 
-    data: {"choices":[{"delta":{"content":"Hello","role":null},"finish_reason":null,"index":0}],"created":1701161926,"id":"chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3","model":"gpt-35-turbo","object":"chat.completion.chunk"}
+    data: {"choices": [{"delta": {"content": "Hello", "role": null}, "finish_reason": null, "index": 0}], "created": 1701161926, "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3", "model": "gpt-35-turbo", "object": "chat.completion.chunk"}
 
-    data: {"choices":[{"delta":{"content":" there","role":null},"finish_reason":null,"index":0}],"created":1701161926,"id":"chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3","model":"gpt-35-turbo","object":"chat.completion.chunk"}
+    data: {"choices": [{"delta": {"content": " there", "role": null}, "finish_reason": null, "index": 0}], "created": 1701161926, "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3", "model": "gpt-35-turbo", "object": "chat.completion.chunk"}
 
-    data: {"choices":[{"delta":{"content":null,"role":null},"finish_reason":"stop","index":0}],"created":1701161926,"id":"chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3","model":"gpt-35-turbo","object":"chat.completion.chunk"}
+    data: {"choices": [{"delta": {"content": null, "role": null}, "finish_reason": "stop", "index": 0}], "created": 1701161926, "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3", "model": "gpt-35-turbo", "object": "chat.completion.chunk"}
 
 
 Completions
@@ -891,15 +891,15 @@ Completions
 
 .. code-block:: text
 
-    data: {"choices":[{"delta":{"role":null,"content":null},"finish_reason":null,"index":0}],"created":1701161629,"id":"chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2","model":"gpt-35-turbo","object":"text_completion_chunk"}
+    data: {"choices": [{"delta": {"role": null, "content": null}, "finish_reason": null, "index": 0}], "created": 1701161629, "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2", "model": "gpt-35-turbo", "object": "text_completion_chunk"}
 
-    data: {"choices":[{"delta":{"role":null,"content":"If"},"finish_reason":null,"index":0}],"created":1701161629,"id":"chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2","model":"gpt-35-turbo","object":"text_completion_chunk"}
+    data: {"choices": [{"delta": {"role": null, "content": "If"}, "finish_reason": null, "index": 0}], "created": 1701161629, "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2", "model": "gpt-35-turbo", "object": "text_completion_chunk"}
 
-    data: {"choices":[{"delta":{"role":null,"content":" an"},"finish_reason":null,"index":0}],"created":1701161629,"id":"chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2","model":"gpt-35-turbo","object":"text_completion_chunk"}
+    data: {"choices": [{"delta": {"role": null, "content": " an"}, "finish_reason": null, "index": 0}], "created": 1701161629, "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2", "model": "gpt-35-turbo", "object": "text_completion_chunk"}
 
-    data: {"choices":[{"delta":{"role":null,"content":" asteroid"},"finish_reason":null,"index":0}],"created":1701161629,"id":"chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2","model":"gpt-35-turbo","object":"text_completion_chunk"}
+    data: {"choices": [{"delta": {"role": null, "content": " asteroid"}, "finish_reason": null, "index": 0}], "created": 1701161629, "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2", "model": "gpt-35-turbo", "object": "text_completion_chunk"}
 
-    data: {"choices":[{"delta":{"role":null,"content":null},"finish_reason":"length","index":0}],"created":1701161629,"id":"chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2","model":"gpt-35-turbo","object":"text_completion_chunk"}
+    data: {"choices": [{"delta": {"role": null, "content": null}, "finish_reason": "length", "index": 0}], "created": 1701161629, "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2", "model": "gpt-35-turbo", "object": "text_completion_chunk"}
 
 
 FastAPI Documentation ("/docs")

--- a/docs/source/llms/deployments/index.rst
+++ b/docs/source/llms/deployments/index.rst
@@ -877,26 +877,13 @@ Chat
 
 .. code-block:: text
 
-    data: {"choices": [{"delta": {"content": null, "role": "assistant"}, "finish_reason": null, "index": 0}],
-     "created": 1701161926,
-     "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
-     "model": "gpt-35-turbo",
-     "object": "chat.completion.chunk"}
-    data: {"choices": [{"delta": {"content": "Hello", "role": null}, "finish_reason": null, "index": 0}],
-     "created": 1701161926,
-     "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
-     "model": "gpt-35-turbo",
-     "object": "chat.completion.chunk"}
-    data: {"choices": [{"delta": {"content": " there", "role": null}, "finish_reason": null, "index": 0}],
-     "created": 1701161926,
-     "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
-     "model": "gpt-35-turbo",
-     "object": "chat.completion.chunk"}
-    data: {"choices": [{"delta": {"content": null, "role": null}, "finish_reason": "stop", "index": 0}],
-     "created": 1701161926,
-     "id": "chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3",
-     "model": "gpt-35-turbo",
-     "object": "chat.completion.chunk"}
+    data: {"choices":[{"delta":{"content":null,"role":"assistant"} "finish_reason":null,"index":0}],"created":1701161926,"id":"chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3","model":"gpt-35-turbo","object":"chat.completion.chunk"}
+
+    data: {"choices":[{"delta":{"content":"Hello","role":null},"finish_reason":null,"index":0}],"created":1701161926,"id":"chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3","model":"gpt-35-turbo","object":"chat.completion.chunk"}
+
+    data: {"choices":[{"delta":{"content":" there","role":null},"finish_reason":null,"index":0}],"created":1701161926,"id":"chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3","model":"gpt-35-turbo","object":"chat.completion.chunk"}
+
+    data: {"choices":[{"delta":{"content":null,"role":null},"finish_reason":"stop","index":0}],"created":1701161926,"id":"chatcmpl-8PoDWSiVE8MHNsUZF2awkW5gNGYs3","model":"gpt-35-turbo","object":"chat.completion.chunk"}
 
 
 Completions
@@ -904,31 +891,15 @@ Completions
 
 .. code-block:: text
 
-    data: {"choices": [{"delta": {"role": null, "content": null}, "finish_reason": null, "index": 0}],
-     "created": 1701161629,
-     "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
-     "model": "gpt-35-turbo",
-     "object": "text_completion_chunk"}
-    data: {"choices": [{"delta": {"role": null, "content": "If"}, "finish_reason": null, "index": 0}],
-     "created": 1701161629,
-     "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
-     "model": "gpt-35-turbo",
-     "object": "text_completion_chunk"}
-    data: {"choices": [{"delta": {"role": null, "content": " an"}, "finish_reason": null, "index": 0}],
-     "created": 1701161629,
-     "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
-     "model": "gpt-35-turbo",
-     "object": "text_completion_chunk"}
-    data: {"choices": [{"delta": {"role": null, "content": " asteroid"}, "finish_reason": null, "index": 0}],
-     "created": 1701161629,
-     "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
-     "model": "gpt-35-turbo",
-     "object": "text_completion_chunk"}
-    {"choices": [{"delta": {"role": null, "content": null}, "finish_reason": "length", "index": 0}],
-     "created": 1701161629,
-     "id": "chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2",
-     "model": "gpt-35-turbo",
-     "object": "text_completion_chunk"}
+    data: {"choices":[{"delta":{"role":null,"content":null},"finish_reason":null,"index":0}],"created":1701161629,"id":"chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2","model":"gpt-35-turbo","object":"text_completion_chunk"}
+
+    data: {"choices":[{"delta":{"role":null,"content":"If"},"finish_reason":null,"index":0}],"created":1701161629,"id":"chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2","model":"gpt-35-turbo","object":"text_completion_chunk"}
+
+    data: {"choices":[{"delta":{"role":null,"content":" an"},"finish_reason":null,"index":0}],"created":1701161629,"id":"chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2","model":"gpt-35-turbo","object":"text_completion_chunk"}
+
+    data: {"choices":[{"delta":{"role":null,"content":" asteroid"},"finish_reason":null,"index":0}],"created":1701161629,"id":"chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2","model":"gpt-35-turbo","object":"text_completion_chunk"}
+
+    data: {"choices":[{"delta":{"role":null,"content":null},"finish_reason":"length","index":0}],"created":1701161629,"id":"chatcmpl-8Po8jVXzljc245k1Ah4UsAcm2zxQ2","model":"gpt-35-turbo","object":"text_completion_chunk"}
 
 
 FastAPI Documentation ("/docs")

--- a/mlflow/deployments/server/app.py
+++ b/mlflow/deployments/server/app.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.responses import FileResponse, RedirectResponse
 from pydantic import BaseModel
+from starlette.responses import StreamingResponse
 
 from mlflow.deployments.server.config import Endpoint
 from mlflow.deployments.server.constants import (
@@ -37,7 +38,7 @@ from mlflow.gateway.constants import (
 )
 from mlflow.gateway.providers import get_provider
 from mlflow.gateway.schemas import chat, completions, embeddings
-from mlflow.gateway.utils import SearchRoutesToken
+from mlflow.gateway.utils import SearchRoutesToken, to_sse_chunk
 from mlflow.version import VERSION
 
 _logger = logging.getLogger(__name__)
@@ -75,8 +76,16 @@ class GatewayAPI(FastAPI):
 def _create_chat_endpoint(config: RouteConfig):
     prov = get_provider(config.model.provider)(config)
 
-    async def _chat(payload: chat.RequestPayload) -> chat.ResponsePayload:
-        return await prov.chat(payload)
+    async def _chat(
+        payload: chat.RequestPayload,
+    ) -> Union[chat.ResponsePayload, chat.StreamResponsePayload]:
+        if payload.stream:
+            return StreamingResponse(
+                (to_sse_chunk(d.json()) async for d in prov.chat_stream(payload)),
+                media_type="text/event-stream",
+            )
+        else:
+            return await prov.chat(payload)
 
     return _chat
 
@@ -86,8 +95,14 @@ def _create_completions_endpoint(config: RouteConfig):
 
     async def _completions(
         payload: completions.RequestPayload,
-    ) -> completions.ResponsePayload:
-        return await prov.completions(payload)
+    ) -> Union[completions.ResponsePayload, completions.StreamResponsePayload]:
+        if payload.stream:
+            return StreamingResponse(
+                (to_sse_chunk(d.json()) async for d in prov.completions_stream(payload)),
+                media_type="text/event-stream",
+            )
+        else:
+            return await prov.completions(payload)
 
     return _completions
 

--- a/mlflow/gateway/providers/ai21labs.py
+++ b/mlflow/gateway/providers/ai21labs.py
@@ -31,7 +31,7 @@ class AI21LabsProvider(BaseProvider):
                 raise HTTPException(
                     status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
-        if payload.get("stream", None) == "true":
+        if payload.get("stream", False):
             raise HTTPException(
                 status_code=422,
                 detail="Setting the 'stream' parameter to 'true' is not supported with the MLflow "

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -57,7 +57,7 @@ class AnthropicAdapter(ProviderAdapter):
 
         payload["max_tokens"] = max_tokens
 
-        if payload.get("stream", None) == "true":
+        if payload.get("stream", False):
             raise HTTPException(
                 status_code=422,
                 detail="Setting the 'stream' parameter to 'true' is not supported with the MLflow "

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractclassmethod
-from typing import Tuple, AsyncIterable
+from typing import AsyncIterable, Tuple
 
 from fastapi import HTTPException
 

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractclassmethod
-from typing import Tuple
+from typing import Tuple, AsyncIterable
 
 from fastapi import HTTPException
 
@@ -18,7 +18,17 @@ class BaseProvider(ABC):
     def __init__(self, config: RouteConfig):
         self.config = config
 
+    async def chat_stream(
+        self, payload: chat.RequestPayload
+    ) -> AsyncIterable[chat.StreamResponsePayload]:
+        raise NotImplementedError
+
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        raise NotImplementedError
+
+    async def completions_stream(
+        self, payload: completions.RequestPayload
+    ) -> AsyncIterable[completions.StreamResponsePayload]:
         raise NotImplementedError
 
     async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 from typing import AsyncIterable
 
@@ -102,7 +101,6 @@ class OpenAIProvider(BaseProvider):
             if data == "[DONE]":
                 return
 
-            await asyncio.sleep(0.05)
             resp = json.loads(data)
             yield chat.StreamResponsePayload(
                 id=resp["id"],
@@ -232,7 +230,6 @@ class OpenAIProvider(BaseProvider):
             if data == "[DONE]":
                 return
 
-            await asyncio.sleep(0.05)
             resp = json.loads(data)
             yield completions.StreamResponsePayload(
                 id=resp["id"],

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -6,7 +6,7 @@ from mlflow.gateway.config import OpenAIAPIType, OpenAIConfig, RouteConfig
 from mlflow.gateway.providers.base import BaseProvider
 from mlflow.gateway.providers.utils import send_request, send_stream_request
 from mlflow.gateway.schemas import chat, completions, embeddings
-from mlflow.gateway.utils import strip_sse_prefix
+from mlflow.gateway.utils import handle_incomplete_chunks, strip_sse_prefix
 from mlflow.utils.uri import append_to_uri_path, append_to_uri_query_params
 
 
@@ -92,7 +92,7 @@ class OpenAIProvider(BaseProvider):
             payload=self._add_model_to_payload_if_necessary(payload),
         )
 
-        async for chunk in stream:
+        async for chunk in handle_incomplete_chunks(stream):
             chunk = chunk.strip()
             if not chunk:
                 continue
@@ -221,7 +221,7 @@ class OpenAIProvider(BaseProvider):
             payload=self._add_model_to_payload_if_necessary(payload),
         )
 
-        async for chunk in stream:
+        async for chunk in handle_incomplete_chunks(stream):
             chunk = chunk.strip()
             if not chunk:
                 continue

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -233,7 +233,10 @@ class OpenAIProvider(BaseProvider):
             resp = json.loads(data)
             yield completions.StreamResponsePayload(
                 id=resp["id"],
-                object=resp["object"],
+                # The chat models response from OpenAI is of object type "chat.completion_chunk". Since
+                # we're using the completions response format here, we hardcode the "text_completion_chunk"
+                # object type in the response instead
+                object="text_completion_chunk",
                 created=resp["created"],
                 model=resp["model"],
                 choices=[

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -109,13 +109,13 @@ class OpenAIProvider(BaseProvider):
                 model=resp["model"],
                 choices=[
                     chat.StreamChoice(
-                        index=idx,
+                        index=c["index"],
                         finish_reason=c["finish_reason"],
                         delta=chat.StreamDelta(
                             role=c["delta"].get("role"), content=c["delta"].get("content")
                         ),
                     )
-                    for idx, c in enumerate(resp["choices"])
+                    for c in resp["choices"]
                 ],
             )
 
@@ -241,13 +241,13 @@ class OpenAIProvider(BaseProvider):
                 model=resp["model"],
                 choices=[
                     completions.StreamChoice(
-                        index=idx,
+                        index=c["index"],
                         finish_reason=c["finish_reason"],
                         delta=completions.StreamDelta(
                             content=c["delta"].get("content"),
                         ),
                     )
-                    for idx, c in enumerate(resp["choices"])
+                    for c in resp["choices"]
                 ],
             )
 

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -233,9 +233,9 @@ class OpenAIProvider(BaseProvider):
             resp = json.loads(data)
             yield completions.StreamResponsePayload(
                 id=resp["id"],
-                # The chat models response from OpenAI is of object type "chat.completion_chunk". Since
-                # we're using the completions response format here, we hardcode the "text_completion_chunk"
-                # object type in the response instead
+                # The chat models response from OpenAI is of object type "chat.completion_chunk".
+                # Since we're using the completions response format here, we hardcode the
+                # "text_completion_chunk" object type in the response instead
                 object="text_completion_chunk",
                 created=resp["created"],
                 model=resp["model"],

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -233,7 +233,7 @@ class OpenAIProvider(BaseProvider):
             resp = json.loads(data)
             yield completions.StreamResponsePayload(
                 id=resp["id"],
-                # The chat models response from OpenAI is of object type "chat.completion_chunk".
+                # The chat models response from OpenAI is of object type "chat.completion.chunk".
                 # Since we're using the completions response format here, we hardcode the
                 # "text_completion_chunk" object type in the response instead
                 object="text_completion_chunk",

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -1,5 +1,5 @@
 from contextlib import asynccontextmanager
-from typing import Any, Dict, AsyncGenerator
+from typing import Any, AsyncGenerator, Dict
 
 import aiohttp
 

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict
+from contextlib import asynccontextmanager
+from typing import Any, Dict, AsyncGenerator
 
 import aiohttp
 
@@ -6,6 +7,15 @@ from mlflow.gateway.constants import (
     MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS,
 )
 from mlflow.utils.uri import append_to_uri_path
+
+
+@asynccontextmanager
+async def _aiohttp_post(headers: Dict[str, str], base_url: str, path: str, payload: Dict[str, Any]):
+    async with aiohttp.ClientSession(headers=headers) as session:
+        url = append_to_uri_path(base_url, path)
+        timeout = aiohttp.ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS)
+        async with session.post(url, json=payload, timeout=timeout) as response:
+            yield response
 
 
 async def send_request(headers: Dict[str, str], base_url: str, path: str, payload: Dict[str, Any]):
@@ -21,27 +31,41 @@ async def send_request(headers: Dict[str, str], base_url: str, path: str, payloa
     """
     from fastapi import HTTPException
 
-    async with aiohttp.ClientSession(headers=headers) as session:
-        url = append_to_uri_path(base_url, path)
-        timeout = aiohttp.ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS)
-        async with session.post(url, json=payload, timeout=timeout) as response:
-            content_type = response.headers.get("Content-Type")
-            if content_type and "application/json" in content_type:
-                js = await response.json()
-            elif content_type and "text/plain" in content_type:
-                js = {"message": await response.text()}
-            else:
-                raise HTTPException(
-                    status_code=502,
-                    detail=f"The returned data type from the route service is not supported. "
-                    f"Received content type: {content_type}",
-                )
-            try:
-                response.raise_for_status()
-            except aiohttp.ClientResponseError as e:
-                detail = js.get("error", {}).get("message", e.message) if "error" in js else js
-                raise HTTPException(status_code=e.status, detail=detail)
-            return js
+    async with _aiohttp_post(headers, base_url, path, payload) as response:
+        content_type = response.headers.get("Content-Type")
+        if content_type and "application/json" in content_type:
+            js = await response.json()
+        elif content_type and "text/plain" in content_type:
+            js = {"message": await response.text()}
+        else:
+            raise HTTPException(
+                status_code=502,
+                detail=f"The returned data type from the route service is not supported. "
+                f"Received content type: {content_type}",
+            )
+        try:
+            response.raise_for_status()
+        except aiohttp.ClientResponseError as e:
+            detail = js.get("error", {}).get("message", e.message) if "error" in js else js
+            raise HTTPException(status_code=e.status, detail=detail)
+        return js
+
+
+async def send_stream_request(
+    headers: Dict[str, str], base_url: str, path: str, payload: Dict[str, Any]
+) -> AsyncGenerator[bytes, None]:
+    """
+    Send an HTTP request to a specific URL path with given headers and payload.
+    :param headers: The headers to include in the request.
+    :param base_url: The base URL where the request will be sent.
+    :param path: The specific path of the URL to which the request will be sent.
+    :param payload: The payload (or data) to be included in the request.
+    :return: The server's response as a JSON object.
+    :raise: HTTPException if the HTTP request fails.
+    """
+    async with _aiohttp_post(headers, base_url, path, payload) as response:
+        async for line in response.content:
+            yield line
 
 
 def rename_payload_keys(payload: Dict[str, Any], mapping: Dict[str, str]) -> Dict[str, Any]:

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -16,6 +16,7 @@ class BaseRequestPayload(RequestModel):
     n: int = Field(1, ge=1)
     stop: Optional[List[str]] = Field(None, min_items=1)
     max_tokens: Optional[int] = Field(None, ge=1)
+    stream: Optional[bool] = None
 
 
 _REQUEST_PAYLOAD_EXTRA_SCHEMA = {
@@ -27,6 +28,7 @@ _REQUEST_PAYLOAD_EXTRA_SCHEMA = {
     "max_tokens": 64,
     "stop": ["END"],
     "n": 1,
+    "stream": False,
 }
 
 
@@ -88,3 +90,45 @@ class ResponsePayload(ResponseModel):
             json_schema_extra = _RESPONSE_PAYLOAD_EXTRA_SCHEMA
         else:
             schema_extra = _RESPONSE_PAYLOAD_EXTRA_SCHEMA
+
+
+class StreamDelta(ResponseModel):
+    role: Optional[str] = None
+    content: Optional[str] = None
+
+
+class StreamChoice(ResponseModel):
+    index: int
+    finish_reason: Optional[str] = None
+    delta: StreamDelta
+
+
+_STREAM_RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
+    "example": {
+        "id": "3cdb958c-e4cc-4834-b52b-1d1a7f324714",
+        "object": "chat.completion",
+        "created": 1700173217,
+        "model": "llama-2-70b-chat-hf",
+        "choices": [
+            {
+                "index": 6,
+                "finish_reason": "stop",
+                "delta": {"role": "assistant", "content": "you?"},
+            }
+        ],
+    }
+}
+
+
+class StreamResponsePayload(ResponseModel):
+    id: str
+    object: str
+    created: int
+    model: str
+    choices: List[StreamChoice]
+
+    class Config:
+        if IS_PYDANTIC_V2:
+            json_schema_extra = _STREAM_RESPONSE_PAYLOAD_EXTRA_SCHEMA
+        else:
+            schema_extra = _STREAM_RESPONSE_PAYLOAD_EXTRA_SCHEMA

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -122,7 +122,7 @@ _STREAM_RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
 
 class StreamResponsePayload(ResponseModel):
     id: str
-    object: str
+    object: Literal["chat.completion.chunk"] = "chat.completion.chunk"
     created: int
     model: str
     choices: List[StreamChoice]

--- a/mlflow/gateway/schemas/completions.py
+++ b/mlflow/gateway/schemas/completions.py
@@ -96,7 +96,7 @@ _STREAM_RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
 
 class StreamResponsePayload(ResponseModel):
     id: str
-    object: str
+    object: Literal["text_completion_chunk"] = "text_completion_chunk"
     created: int
     model: str
     choices: List[StreamChoice]

--- a/mlflow/gateway/schemas/completions.py
+++ b/mlflow/gateway/schemas/completions.py
@@ -64,3 +64,45 @@ class ResponsePayload(ResponseModel):
             json_schema_extra = _RESPONSE_PAYLOAD_EXTRA_SCHEMA
         else:
             schema_extra = _RESPONSE_PAYLOAD_EXTRA_SCHEMA
+
+
+class StreamDelta(ResponseModel):
+    role: Optional[str] = None
+    content: Optional[str] = None
+
+
+class StreamChoice(ResponseModel):
+    index: int
+    finish_reason: Optional[str] = None
+    delta: StreamDelta
+
+
+_STREAM_RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
+    "example": {
+        "id": "cmpl-123",
+        "object": "text_completion",
+        "created": 1589478378,
+        "model": "gpt-4",
+        "choices": [
+            {
+                "index": 6,
+                "finish_reason": "stop",
+                "delta": {"role": "assistant", "content": "you?"},
+            }
+        ],
+    }
+}
+
+
+class StreamResponsePayload(ResponseModel):
+    id: str
+    object: str
+    created: int
+    model: str
+    choices: List[StreamChoice]
+
+    class Config:
+        if IS_PYDANTIC_V2:
+            json_schema_extra = _STREAM_RESPONSE_PAYLOAD_EXTRA_SCHEMA
+        else:
+            schema_extra = _STREAM_RESPONSE_PAYLOAD_EXTRA_SCHEMA

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -259,3 +259,13 @@ def is_valid_mosiacml_chat_model(model_name: str) -> bool:
 
 def is_valid_ai21labs_model(model_name: str) -> bool:
     return model_name in {"j2-ultra", "j2-mid", "j2-light"}
+
+
+def strip_sse_prefix(s: str) -> str:
+    # https://html.spec.whatwg.org/multipage/server-sent-events.html
+    return re.sub(r"^data:\s+", "", s)
+
+
+def to_sse_chunk(data: str) -> str:
+    # https://html.spec.whatwg.org/multipage/server-sent-events.html
+    return f"data: {data}\n\n"

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -273,10 +273,9 @@ def to_sse_chunk(data: str) -> str:
 
 def _find_boundary(buffer: bytes) -> int:
     try:
-        boundary = buffer.index(b"\n")
+        return buffer.index(b"\n")
     except ValueError:
         return -1
-    return boundary
 
 
 async def handle_incomplete_chunks(

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -283,16 +283,17 @@ def _find_boundary(buffer: bytes) -> int:
 async def handle_incomplete_chunks(
     stream: AsyncGenerator[bytes, Any]
 ) -> AsyncGenerator[bytes, Any]:
-    """Wraps a streaming response and handles incomplete chunks from the server."""
+    """
+    Wraps a streaming response and handles incomplete chunks from the server.
+    See https://community.openai.com/t/incomplete-stream-chunks-for-completions-api/383520
+    for more information.
+    """
     buffer = b""
     async for chunk in stream:
         buffer += chunk
-        boundary = _find_boundary(buffer)
-        while boundary != -1:
-            obj = buffer[:boundary]
+        while (boundary := _find_boundary(buffer)) != -1:
+            yield buffer[:boundary]
             buffer = buffer[boundary + 1 :]
-            yield obj
-            boundary = _find_boundary(buffer)
 
 
 async def make_streaming_response(resp):

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -118,9 +118,26 @@ def chat_stream_response():
     ]
 
 
+def chat_stream_response_incomplete():
+    return [
+        # contains first half of a chunk
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test","choi'
+        # contains second half of first chunk and first half of second chunk
+        b'ces":[{"index":0,"finish_reason":null,"delta":{"role":"assistant"}}]}\n\n'
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"te',
+        # contains second half of second chunk
+        b'st","choices":[{"index":0,"finish_reason":null,"delta":{"content":"test"}}]}\n',
+        b"\n",
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test",'
+        b'"choices":[{"index":0,"finish_reason":"stop","delta":{}}]}\n',
+        b"\n",
+        b"data: [DONE]\n",
+    ]
+
+
+@pytest.mark.parametrize("resp", [chat_stream_response(), chat_stream_response_incomplete()])
 @pytest.mark.asyncio
-async def test_chat_stream():
-    resp = chat_stream_response()
+async def test_chat_stream(resp):
     config = chat_config()
     mock_client = mock_http_client(MockAsyncStreamingResponse(resp))
 
@@ -261,9 +278,29 @@ def completions_stream_response():
     ]
 
 
+def completions_stream_response_incomplete():
+    return [
+        # contains first half of a chunk
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test","choi',
+        # contains second half of first chunk and first half of second chunk
+        b'ces":[{"index":0,"finish_reason":null,"delta":{"role":"assistant", '
+        b'"content": ""}}]}\n\ndata: {"id":"test-id","object":"chat.comp',
+        # contains second half of second chunk
+        b'letion.chunk","created":1,"model":"test","choices":[{"index":0,"finish_reason":null,'
+        b'"delta":{"content":"test"}}]}\n',
+        b"\n",
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test",'
+        b'"choices":[{"index":0,"finish_reason":"length","delta":{}}]}\n',
+        b"\n",
+        b"data: [DONE]\n",
+    ]
+
+
+@pytest.mark.parametrize(
+    "resp", [completions_stream_response(), completions_stream_response_incomplete()]
+)
 @pytest.mark.asyncio
-async def test_completions_stream():
-    resp = completions_stream_response()
+async def test_completions_stream(resp):
     config = completions_config()
     mock_client = mock_http_client(MockAsyncStreamingResponse(resp))
 

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -285,7 +285,7 @@ async def test_completions_stream():
                 "created": 1,
                 "id": "test-id",
                 "model": "test",
-                "object": "chat.completion.chunk",
+                "object": "text_completion_chunk",
             },
             {
                 "choices": [
@@ -294,7 +294,7 @@ async def test_completions_stream():
                 "created": 1,
                 "id": "test-id",
                 "model": "test",
-                "object": "chat.completion.chunk",
+                "object": "text_completion_chunk",
             },
             {
                 "choices": [
@@ -307,7 +307,7 @@ async def test_completions_stream():
                 "created": 1,
                 "id": "test-id",
                 "model": "test",
-                "object": "chat.completion.chunk",
+                "object": "text_completion_chunk",
             },
         ]
 

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -12,7 +12,7 @@ from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
 from mlflow.gateway.providers.openai import OpenAIProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
-from tests.gateway.tools import MockAsyncResponse, mock_http_client
+from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse, mock_http_client
 
 
 def chat_config():
@@ -103,6 +103,84 @@ async def test_chat():
         )
 
 
+def chat_stream_response():
+    return [
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test",'
+        b'"choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant"}}]}\n',
+        b"\n",
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test",'
+        b'"choices":[{"index":0,"finish_reason":null,"delta":{"content":"test"}}]}\n',
+        b"\n",
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test",'
+        b'"choices":[{"index":0,"finish_reason":"stop","delta":{}}]}\n',
+        b"\n",
+        b"data: [DONE]\n",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_chat_stream():
+    resp = chat_stream_response()
+    config = chat_config()
+    mock_client = mock_http_client(MockAsyncStreamingResponse(resp))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client) as mock_build_client:
+        provider = OpenAIProvider(RouteConfig(**config))
+        payload = {"messages": [{"role": "user", "content": "Tell me a joke"}]}
+        response = provider.chat_stream(chat.RequestPayload(**payload))
+
+        chunks = [jsonable_encoder(chunk) async for chunk in response]
+        assert chunks == [
+            {
+                "choices": [
+                    {
+                        "delta": {"content": None, "role": "assistant"},
+                        "finish_reason": None,
+                        "index": 0,
+                    }
+                ],
+                "created": 1,
+                "id": "test-id",
+                "model": "test",
+                "object": "chat.completion.chunk",
+            },
+            {
+                "choices": [
+                    {"delta": {"content": "test", "role": None}, "finish_reason": None, "index": 0}
+                ],
+                "created": 1,
+                "id": "test-id",
+                "model": "test",
+                "object": "chat.completion.chunk",
+            },
+            {
+                "choices": [
+                    {"delta": {"content": None, "role": None}, "finish_reason": "stop", "index": 0}
+                ],
+                "created": 1,
+                "id": "test-id",
+                "model": "test",
+                "object": "chat.completion.chunk",
+            },
+        ]
+
+        mock_build_client.assert_called_once_with(
+            headers={
+                "Authorization": "Bearer key",
+            }
+        )
+        mock_client.post.assert_called_once_with(
+            "https://api.openai.com/v1/chat/completions",
+            json={
+                "model": "gpt-3.5-turbo",
+                "temperature": 0,
+                "n": 1,
+                **payload,
+            },
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
+        )
+
+
 def completions_config():
     return {
         "name": "completions",
@@ -164,6 +242,91 @@ async def test_completions_throws_if_prompt_contains_non_string(prompt):
     payload = {"prompt": prompt}
     with pytest.raises(ValidationError, match=r"prompt"):
         await provider.completions(completions.RequestPayload(**payload))
+
+
+def completions_stream_response():
+    return [
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test",'
+        b'"choices":[{"index":0,"finish_reason":null,'
+        b'"delta":{"role":"assistant", "content": ""}}]}\n',
+        b"\n",
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test",'
+        b'"choices":[{"index":0,"finish_reason":null,'
+        b'"delta":{"content":"test"}}]}\n',
+        b"\n",
+        b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,"model":"test",'
+        b'"choices":[{"index":0,"finish_reason":"length","delta":{}}]}\n',
+        b"\n",
+        b"data: [DONE]\n",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_completions_stream():
+    resp = completions_stream_response()
+    config = completions_config()
+    mock_client = mock_http_client(MockAsyncStreamingResponse(resp))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client) as mock_build_client:
+        provider = OpenAIProvider(RouteConfig(**config))
+        payload = {"prompt": "This is a test"}
+        response = provider.completions_stream(completions.RequestPayload(**payload))
+
+        chunks = [jsonable_encoder(chunk) async for chunk in response]
+        assert chunks == [
+            {
+                "choices": [
+                    {
+                        "delta": {"role": None, "content": ""},
+                        "finish_reason": None,
+                        "index": 0,
+                    }
+                ],
+                "created": 1,
+                "id": "test-id",
+                "model": "test",
+                "object": "chat.completion.chunk",
+            },
+            {
+                "choices": [
+                    {"delta": {"role": None, "content": "test"}, "finish_reason": None, "index": 0}
+                ],
+                "created": 1,
+                "id": "test-id",
+                "model": "test",
+                "object": "chat.completion.chunk",
+            },
+            {
+                "choices": [
+                    {
+                        "delta": {"role": None, "content": None},
+                        "finish_reason": "length",
+                        "index": 0,
+                    }
+                ],
+                "created": 1,
+                "id": "test-id",
+                "model": "test",
+                "object": "chat.completion.chunk",
+            },
+        ]
+
+        mock_build_client.assert_called_once_with(
+            headers={
+                "Authorization": "Bearer key",
+                "OpenAI-Organization": "test-organization",
+            }
+        )
+        mock_client.post.assert_called_once_with(
+            "https://api.openai.com/v1/chat/completions",
+            json={
+                "model": "gpt-4-32k",
+                "temperature": 0,
+                "n": 1,
+                "messages": [{"role": "user", "content": "This is a test"}],
+            },
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
+        )
 
 
 def embedding_config():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/gabrielfu/mlflow/pull/10765?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10765/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10765
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #10520

### What changes are proposed in this pull request?

Add streaming support for OpenAI provider on MLflow Deployments chat and completions endpoints.

To run:

```shell
mlflow deployments start-server --config-path config.yaml --workers 1
```

```shell
curl -X POST http://127.0.0.1:5000/endpoints/chat/invocations \
  -H "Content-Type: application/json" \
  -d '{"messages": [{"role": "user", "content": "Can you write a limerick about orange flavored popsicles?"}], "stream": true}'
```

output:

```text
data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": "assistant", "content": ""}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": "In"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " summer"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": "'s"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " sc"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": "orch"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": "ing"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " heat"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": ","}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " we"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " seek"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": ",\n"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": "A"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " treat"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " that"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": "'s"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " refreshing"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " and"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " chic"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": ",\n"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": "Orange"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " pops"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": "icles"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": ","}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " so"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " bright"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": ",\n"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": "Bring"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " pure"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " delight"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": ",\n"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": "With"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " each"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " icy"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " bite"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": ","}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " joy"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " will"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": " peak"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": null, "delta": {"role": null, "content": "!"}}]}

data: {"id": "chatcmpl-8cPOs8mc1nR7MHCZdShSglpfGE5TQ", "object": "chat.completion.chunk", "created": 1704164794, "model": "gpt-3.5-turbo-0613", "choices": [{"index": 0, "finish_reason": "stop", "delta": {"role": null, "content": null}}]}
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add streaming support for OpenAI provider on MLflow Deployments chat and completions endpoints.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
