### PR TITLE
Update OCI Plugin Documentation and Add `oci-mlflow` to `oci` dependencies

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -410,6 +410,55 @@ To use XetHub as an artifact store, an XetHub URI of the form ``xet://<username>
 In the example provided above, the ``log_model`` operation creates three entries in the OSS storage ``xet://mlflow-test/$RUN_ID/artifacts/model_test/``, the MLmodel file
 and the conda.yaml file associated with the model.
 
+Oracle Cloud Infrastructure Plugin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+The `oci-mlflow <https://pypi.org/project/oci-mlflow/>`_ package allows MLflow to use Oracle Cloud Infrastructure for storing artifacts, running MLProjects, and deploying models.
+
+.. code-block:: bash
+
+        pip install mlflow[oci]
+
+After installation, you can use MLflow as usual, and the Oracle Cloud Infrastructure support will be provided automatically.
+
+Refer `OCI's SDK and CLI Configuration File Documentation <https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm#SDK_and_CLI_Configuration_File>`_ to setup authentication.
+
+For more details, please visit the `oci-mlflow Quickstart <https://oci-mlflow.readthedocs.io/en/latest/quickstart.html>`_ documentation.
+
+.. code-block:: python
+
+        import mlflow
+        import mlflow.pyfunc
+
+
+        class Mod(mlflow.pyfunc.PythonModel):
+            def predict(self, ctx, inp, params=None):
+                return 7
+
+
+        exp_name = "myexp"
+        mlflow.create_experiment(exp_name, artifact_location="oci://<your bucket>@<your namespace>/myexperiment/")
+        mlflow.set_experiment(exp_name)
+        mlflow.pyfunc.log_model("model_test", python_model=Mod())
+
+In the example provided above, the ``log_model`` saves the model to Object Storage ``oci://<my-bucket>@<my-namespace>/myexperiment/$RUN_ID/artifacts/model_test/``, the MLmodel file
+and the conda.yaml file associated with the model. To list the content in the object storage artifact location, run - 
+
+.. code-block:: bash
+
+  oci os object list -bn mayoor-dev -ns idtlxnfdweil --prefix myexperiment | jq '.data[].name'
+
+Output should list following files -  
+
+
+  * "myexperiment/$RUN_ID/artifacts/model_test/MLmodel"
+  * "myexperiment/$RUN_ID/artifacts/model_test/conda.yaml"
+  * "myexperiment/$RUN_ID/artifacts/model_test/python_env.yaml"
+  * "myexperiment/$RUN_ID/artifacts/model_test/python_model.pkl"
+  * "myexperiment/$RUN_ID/artifacts/model_test/requirements.txt"
+
+
 
 Deployment Plugins
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -438,16 +438,16 @@ For more details, please visit the `oci-mlflow Quickstart <https://oci-mlflow.re
 
 
         exp_name = "myexp"
-        mlflow.create_experiment(exp_name, artifact_location="oci://<your bucket>@<your namespace>/myexperiment/")
+        mlflow.create_experiment(exp_name, artifact_location="oci://<your-bucket>@<your-namespace>/myexperiment/")
         mlflow.set_experiment(exp_name)
         mlflow.pyfunc.log_model("model_test", python_model=Mod())
 
-In the example provided above, the ``log_model`` saves the model to Object Storage ``oci://<my-bucket>@<my-namespace>/myexperiment/$RUN_ID/artifacts/model_test/``, the MLmodel file
+In the example provided above, the ``log_model`` saves the model to Object Storage ``oci://<your-bucket>@<your-namespace>/myexperiment/$RUN_ID/artifacts/model_test/``, the MLmodel file
 and the conda.yaml file associated with the model. To list the content in the object storage artifact location, run - 
 
 .. code-block:: bash
 
-  oci os object list -bn mayoor-dev -ns idtlxnfdweil --prefix myexperiment | jq '.data[].name'
+  oci os object list -bn <your-bucket> -ns <your-namespace> --prefix myexperiment | jq '.data[].name'
 
 Output should list following files -  
 

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -447,7 +447,7 @@ and the conda.yaml file associated with the model. To list the content in the ob
 
 .. code-block:: bash
 
-  oci os object list -bn <your-bucket> -ns <your-namespace> --prefix myexperiment | jq '.data[].name'
+        oci os object list -bn <your-bucket> -ns <your-namespace> --prefix myexperiment | jq '.data[].name'
 
 Output should list following files -  
 

--- a/setup.py
+++ b/setup.py
@@ -175,6 +175,7 @@ setup(
         "sqlserver": ["mlflow-dbstore"],
         "aliyun-oss": ["aliyunstoreplugin"],
         "xethub": ["mlflow-xethub"],
+        "oci": ["oci-mlflow"],
     },
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mayoor/mlflow/pull/10768?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10768/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10768
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

* Adds [oci-mlflow](https://github.com/oracle/oci-mlflow) dependency in setup.py such that the users can install all the required dependency through `pip install mlflow[oci]` while using with Oracle Cloud Infrastructure(OCI)
* Instruction to install mlflow with OCI dependency

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
- [ ] Examples
- [ ] API references
- [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
