### PR TITLE
Pin Python to 3.9 for statsmodels dev version

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -136,11 +136,7 @@ jobs:
       - name: Get python version
         id: get-python-version
         run: |
-          if { [ "${{ matrix.package }}" = "tensorflow" ] || [ "${{ matrix.package }}" = "scikit-learn" ]; } && [ "${{ matrix.version }}" = "dev" ]; then
-            python_version=3.9
-          else
-            python_version=$(python dev/get_minimum_required_python.py -p ${{ matrix.package }} -v ${{ matrix.version }} --python-versions "3.8,3.9")
-          fi
+          python_version=$(python dev/get_minimum_required_python.py -p ${{ matrix.package }} -v ${{ matrix.version }} --python-versions "3.8,3.9")
           echo "version=$python_version" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/setup-python
         with:

--- a/dev/get_minimum_required_python.py
+++ b/dev/get_minimum_required_python.py
@@ -11,8 +11,14 @@ import requests
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
+# "dev" versions are installed from source so we can't programmatically get the required python.
+_DEV_PACKAGES_REQUIRE_PYTHON_39 = {"tensorflow", "scikit-learn", "statsmodels"}
+
 
 def get_requires_python(package: str, version: str) -> t.Optional[str]:
+    if version == "dev" and package in _DEV_PACKAGES_REQUIRE_PYTHON_39:
+        return ">=3.9"
+
     resp = requests.get(f"https://pypi.python.org/pypi/{package}/json")
     resp.raise_for_status()
     return next(

--- a/dev/get_minimum_required_python.py
+++ b/dev/get_minimum_required_python.py
@@ -12,12 +12,16 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 # "dev" versions are installed from source so we can't programmatically get the required python.
-_DEV_PACKAGES_REQUIRE_PYTHON_39 = {"tensorflow", "scikit-learn", "statsmodels"}
+_DEV_PACKAGES_PYTHON_VERSIONS = {
+    "tensorflow": ">=3.9",
+    "scikit-learn": ">=3.9",
+    "statsmodels": ">=3.9",
+}
 
 
 def get_requires_python(package: str, version: str) -> t.Optional[str]:
-    if version == "dev" and package in _DEV_PACKAGES_REQUIRE_PYTHON_39:
-        return ">=3.9"
+    if version == "dev" and package in _DEV_PACKAGES_PYTHON_VERSIONS:
+        return _DEV_PACKAGES_PYTHON_VERSIONS[package]
 
     resp = requests.get(f"https://pypi.python.org/pypi/{package}/json")
     resp.raise_for_status()

--- a/mlflow/statsmodels/__init__.py
+++ b/mlflow/statsmodels/__init__.py
@@ -63,6 +63,8 @@ STATSMODELS_DATA_SUBPATH = "model.statsmodels"
 _logger = logging.getLogger(__name__)
 
 
+_I_AM_A_DUMMY = None
+
 def get_default_pip_requirements():
     """
     :return: A list of default pip requirements for MLflow Models produced by this flavor.

--- a/mlflow/statsmodels/__init__.py
+++ b/mlflow/statsmodels/__init__.py
@@ -63,8 +63,6 @@ STATSMODELS_DATA_SUBPATH = "model.statsmodels"
 _logger = logging.getLogger(__name__)
 
 
-_I_AM_A_DUMMY = None
-
 def get_default_pip_requirements():
     """
     :return: A list of default pip requirements for MLflow Models produced by this flavor.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10771?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10771/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10771
```

</p>
</details>

### What changes are proposed in this pull request?

Statsmodels dev version requires Python 3.9 ([commit](https://github.com/statsmodels/statsmodels/commit/1d5492e748bee85477953b1dc62b33a9273e9cf5)).

Hardcoded Python version in cross-version test to 3.9 and also moved logic to Python script to avoid further complication.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Validated cross version tests passed with dev version using dummy commit.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
