### PR TITLE
Add deduplication logic for pip requirements and extras handling for MLflow models

### DIFF
--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -656,22 +656,23 @@ def _validate_version_constraints(requirements):
         _validate_version_constraints(["tensorflow<2.0", "tensorflow>2.3"])
         # This will raise an exception due to boundary validity.
     """
-    with tempfile.NamedTemporaryFile(mode="w+") as tmp_file:
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tmp_file:
         tmp_file.write("\n".join(requirements))
-        tmp_file.flush()
         tmp_file_name = tmp_file.name
 
-        try:
-            subprocess.run(
-                ["pip", "install", "--dry-run", "-r", tmp_file_name],
-                check=True,
-                capture_output=True,
-            )
-        except subprocess.CalledProcessError as e:
-            raise MlflowException.invalid_parameter_value(
-                "The specified requirements versions are incompatible. Detected "
-                f"conflicts: \n{e.stderr.decode()}"
-            )
+    try:
+        subprocess.run(
+            ["pip", "install", "--dry-run", "-r", tmp_file_name],
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as e:
+        raise MlflowException.invalid_parameter_value(
+            "The specified requirements versions are incompatible. Detected "
+            f"conflicts: \n{e.stderr.decode()}"
+        )
+    finally:
+        os.remove(tmp_file_name)
 
 
 def _process_conda_env(conda_env):

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -656,19 +656,22 @@ def _validate_version_constraints(requirements):
         _validate_version_constraints(["tensorflow<2.0", "tensorflow>2.3"])
         # This will raise an exception due to boundary validity.
     """
-    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tmp_file:
+    with tempfile.NamedTemporaryFile(mode="w+") as tmp_file:
         tmp_file.write("\n".join(requirements))
+        tmp_file.flush()
         tmp_file_name = tmp_file.name
 
-    try:
-        subprocess.run(
-            ["pip", "install", "--dry-run", "-r", tmp_file_name], check=True, capture_output=True
-        )
-    except subprocess.CalledProcessError as e:
-        raise MlflowException.invalid_parameter_value(
-            "The specified requirements versions are incompatible. Detected "
-            f"conflicts: \n{e.stderr.decode()}"
-        )
+        try:
+            subprocess.run(
+                ["pip", "install", "--dry-run", "-r", tmp_file_name],
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError as e:
+            raise MlflowException.invalid_parameter_value(
+                "The specified requirements versions are incompatible. Detected "
+                f"conflicts: \n{e.stderr.decode()}"
+            )
 
 
 def _process_conda_env(conda_env):

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -5,6 +5,7 @@ import yaml
 
 from mlflow.utils.environment import (
     _contains_mlflow_requirement,
+    _deduplicate_requirements,
     _find_duplicate_requirements,
     _get_pip_deps,
     _get_pip_requirement_specifier,
@@ -281,6 +282,19 @@ def test_process_pip_requirements(tmp_path):
     assert reqs == [expected_mlflow_ver, "b", "-c constraints.txt"]
     assert cons == ["c"]
 
+    conda_env, reqs, cons = _process_pip_requirements(["a"], extra_pip_requirements=["a[extras]"])
+    assert _get_pip_deps(conda_env) == [expected_mlflow_ver, "a[extras]"]
+    assert reqs == [expected_mlflow_ver, "a[extras]"]
+    assert cons == []
+
+    conda_env, reqs, cons = _process_pip_requirements(
+        ["mlflow==1.2.3", "b[extra1]", "a==1.2.3"],
+        extra_pip_requirements=["b[extra2]", "a[extras]"],
+    )
+    assert _get_pip_deps(conda_env) == ["mlflow==1.2.3", "b[extra1,extra2]", "a[extras]"]
+    assert reqs == ["mlflow==1.2.3", "b[extra1,extra2]", "a[extras]"]
+    assert cons == []
+
 
 def test_process_conda_env(tmp_path):
     def make_conda_env(pip_deps):
@@ -354,3 +368,37 @@ def test_duplicate_pip_requirements():
     ]
     evaluation = _find_duplicate_requirements(packages)
     assert sorted(evaluation) == ["fastapi", "numpy", "package"]
+
+
+@pytest.mark.parametrize(
+    ("input_requirements", "expected"),
+    [
+        # Simple cases
+        (["packageA", "packageB"], ["packageA", "packageB"]),
+        # Duplicates without extras, preserving version restrictions
+        (["packageA", "packageA==1.0"], ["packageA==1.0"]),
+        # Duplicates with extras
+        (["packageA", "packageA[extras]"], ["packageA[extras]"]),
+        # Mixed cases
+        (
+            ["packageA", "packageB", "packageA[extras]", "packageC<=2.0"],
+            ["packageA[extras]", "packageB", "packageC<=2.0"],
+        ),
+        # Mixed versions and extras
+        (["packageX==1.0", "packageX[extras]", "packageX==2.0"], ["packageX[extras]"]),
+        # Overlapping extras
+        (
+            ["packageZ[extra1]", "packageZ[extra2]", "packageZ"],
+            ["packageZ[extra1,extra2]"],
+        ),
+        # Version constraints with extras
+        (["packageW<=1.0", "packageW[extras]>=2.0"], ["packageW[extras]>=2.0"]),
+        # Version mixing with extras and conflicting base version
+        (
+            ["packageW==2.0.1", "packageW[extra1]", "packageW[extra1]==1.9.0"],
+            ["packageW[extra1]==1.9.0"],
+        ),
+    ],
+)
+def test_deduplicate_requirements(input_requirements, expected):
+    assert _deduplicate_requirements(input_requirements) == expected


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/10778?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10778/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10778
```

</p>
</details>

### Related Issues/PRs

Resolve #10684

### What changes are proposed in this pull request?

Add a deduplication and requirements handler for package extras for dependencies when logging models. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adjusted the dependency resolution logic for pip and conda requirements when saving or logging models to ensure that duplicate entries are removed and the specification of extras on libraries are preserved, superseding base requirements declarations.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
