### PR TITLE
Create a better identification of functional models in mlflow.pyfunc

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -412,11 +412,13 @@ def _validate_params(params, model_metadata):
     return
 
 def _is_functional_model(python_model):
-    """Returns True if the given python model is a functional model.
+    """
+    Returns True if the given python model is a functional model.
     If the model is a subclass of PythonModel, it is considered a functional model.
     """
     if not isinstance(python_model, PythonModel) and callable(python_model):
         return True
+    return False
 
 class PyFuncModel:
     """

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -411,6 +411,12 @@ def _validate_params(params, model_metadata):
         )
     return
 
+def _is_functional_model(python_model):
+    """Returns True if the given python model is a functional model.
+    If the model is a subclass of PythonModel, it is considered a functional model.
+    """
+    if not isinstance(python_model, PythonModel) and callable(python_model):
+        return True
 
 class PyFuncModel:
     """
@@ -1709,13 +1715,13 @@ Compound types:
 
 
 def _validate_function_python_model(python_model):
-    if not (isinstance(python_model, PythonModel) or callable(python_model)):
+    if not (isinstance(python_model, PythonModel) or _is_functional_model(python_model)):
         raise MlflowException(
             "`python_model` must be a PythonModel instance or a callable object",
             error_code=INVALID_PARAMETER_VALUE,
         )
 
-    if callable(python_model):
+    if _is_functional_model(python_model):
         num_args = len(inspect.signature(python_model).parameters)
         if num_args != 1:
             raise MlflowException(
@@ -1887,7 +1893,7 @@ def save_model(
     _validate_pyfunc_model_config(model_config)
     if python_model:
         _validate_function_python_model(python_model)
-        if callable(python_model) and all(
+        if _is_functional_model(python_model) and all(
             a is None for a in (input_example, pip_requirements, extra_pip_requirements)
         ):
             raise MlflowException(
@@ -1942,7 +1948,7 @@ def save_model(
     if signature is not None:
         mlflow_model.signature = signature
     elif python_model is not None:
-        if callable(python_model):
+        if _is_functional_model(python_model):
             input_arg_index = 0  # first argument
             if signature := _infer_signature_from_type_hints(
                 python_model, input_arg_index, input_example=input_example

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -240,7 +240,7 @@ def _save_model_with_class_artifacts_params(
     custom_model_config_kwargs = {
         CONFIG_KEY_CLOUDPICKLE_VERSION: cloudpickle.__version__,
     }
-    if callable(python_model):
+    if mlflow.pyfunc._is_functional_model(python_model):
         python_model = _FunctionPythonModel(python_model, hints, signature)
     saved_python_model_subpath = "python_model.pkl"
     with open(os.path.join(path, saved_python_model_subpath), "wb") as out:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/DougTrajano/mlflow/pull/10787?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10787/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10787
```

</p>
</details>

### Related Issues/PRs

#10777

### What changes are proposed in this pull request?

In this PR, we are creating a specific function to properly identify the functional models in the mlflow.pyfunc flavor.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
