### PR TITLE
Support saving prompt templates for transformers

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -265,7 +265,6 @@ class Model:
         mlflow_version: Union[str, None] = mlflow.version.VERSION,
         metadata: Optional[Dict[str, Any]] = None,
         model_size_bytes: Optional[int] = None,
-        prompt_template: Optional[str] = None,
         **kwargs,
     ):
         # store model id instead of run_id and path to avoid confusion when model gets exported
@@ -281,7 +280,6 @@ class Model:
         self.mlflow_version = mlflow_version
         self.metadata = metadata
         self.model_size_bytes = model_size_bytes
-        self.prompt_template = prompt_template
         self.__dict__.update(kwargs)
 
     def __eq__(self, other):
@@ -446,23 +444,6 @@ class Model:
         # pylint: disable=attribute-defined-outside-init
         self._model_size_bytes = value
 
-    @property
-    def prompt_template(self) -> Optional[str]:
-        """
-        An optional string that represents the prompt template for the model. Only relevant
-        for the `transformers` flavor.
-
-        :getter: Retrieves the prompt template if it's set when the model is saved
-        :setter: Sets the prompt template to a model instance
-        :type: Optional[str]
-        """
-        return self._prompt_template
-
-    @prompt_template.setter
-    def prompt_template(self, value: Optional[str]):
-        # pylint: disable=attribute-defined-outside-init
-        self._prompt_template = value
-
     def get_model_info(self):
         """
         Create a :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
@@ -498,8 +479,6 @@ class Model:
             res["metadata"] = self.metadata
         if self.model_size_bytes is not None:
             res["model_size_bytes"] = self.model_size_bytes
-        if self.prompt_template is not None:
-            res["prompt_template"] = self.prompt_template
         return res
 
     def to_yaml(self, stream=None):

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -265,6 +265,7 @@ class Model:
         mlflow_version: Union[str, None] = mlflow.version.VERSION,
         metadata: Optional[Dict[str, Any]] = None,
         model_size_bytes: Optional[int] = None,
+        prompt_template: Optional[str] = None,
         **kwargs,
     ):
         # store model id instead of run_id and path to avoid confusion when model gets exported
@@ -280,6 +281,7 @@ class Model:
         self.mlflow_version = mlflow_version
         self.metadata = metadata
         self.model_size_bytes = model_size_bytes
+        self.prompt_template = prompt_template
         self.__dict__.update(kwargs)
 
     def __eq__(self, other):
@@ -443,6 +445,22 @@ class Model:
         # pylint: disable=attribute-defined-outside-init
         self._model_size_bytes = value
 
+    @property
+    def prompt_template(self) -> Optional[str]:
+        """
+        An optional string that represents the prompt template for the model. Only relevant
+        for the `transformers` flavor.
+        :getter: Retrieves the prompt template if it's set when the model is saved
+        :setter: Sets the prompt template to a model instance
+        :type: Optional[str]
+        """
+        return self._prompt_template
+
+    @prompt_template.setter
+    def prompt_template(self, value: Optional[str]):
+        # pylint: disable=attribute-defined-outside-init
+        self._prompt_template = value
+
     def get_model_info(self):
         """
         Create a :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
@@ -478,6 +496,8 @@ class Model:
             res["metadata"] = self.metadata
         if self.model_size_bytes is not None:
             res["model_size_bytes"] = self.model_size_bytes
+        if self.prompt_template is not None:
+            res["prompt_template"] = self.prompt_template
         return res
 
     def to_yaml(self, stream=None):

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -434,6 +434,7 @@ class Model:
     def model_size_bytes(self) -> Optional[int]:
         """
         An optional integer that represents the model size in bytes
+
         :getter: Retrieves the model size if it's calculated when the model is saved
         :setter: Sets the model size to a model instance
         :type: Optional[int]
@@ -450,6 +451,7 @@ class Model:
         """
         An optional string that represents the prompt template for the model. Only relevant
         for the `transformers` flavor.
+
         :getter: Retrieves the prompt template if it's set when the model is saved
         :setter: Sets the prompt template to a model instance
         :type: Optional[str]

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -439,6 +439,7 @@ def save_model(
         example_no_conversion: {{ example_no_conversion }}
         prompt_template: {{ prompt_template }}
         kwargs: Optional additional configurations for transformers serialization.
+
     """
     import transformers
 

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -555,10 +555,8 @@ def save_model(
         # extra text for end-users
         if prompt_template is not None and built_pipeline.task == "text-generation":
             return_full_text_key = "return_full_text"
-            if model_config is None:
-                model_config = {return_full_text_key: False}
-                _logger.info(_PROMPT_TEMPLATE_RETURN_FULL_TEXT_INFO)
-            elif return_full_text_key not in model_config:
+            model_config = model_config or {}
+            if return_full_text_key not in model_config:
                 model_config[return_full_text_key] = False
                 _logger.info(_PROMPT_TEMPLATE_RETURN_FULL_TEXT_INFO)
 

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -258,9 +258,11 @@ compatibility.
 """
         ),
         "prompt_template": (
-            """A template string that, if provided, will be used to wrap the user's input.
-The template string should contain a single placeholder, `{prompt}`, which will be replaced with
-the user's input. Currently, only the following task types are supported:
+            """A string that, if provided, will be used to format the user's input prior
+to inference. The string should contain a single placeholder, ``{prompt}``, which will be
+replaced with the user's input. For example: ``"Answer the following question. Q: {prompt} A:"``.
+
+Currently, only the following pipeline types are supported:
 
 - `feature-extraction <https://huggingface.co/transformers/main_classes/pipelines.html#transformers.FeatureExtractionPipeline>`_
 - `fill-mask <https://huggingface.co/transformers/main_classes/pipelines.html#transformers.FillMaskPipeline>`_

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -257,6 +257,12 @@ input example could be passed directly to the model. Defaults to ``False`` for b
 compatibility.
 """
         ),
+        "prompt_template": (
+            """A template string that, if provided, will be used to wrap the user's input.
+The template string should contain a single placeholder, `{ prompt }`, which will be replaced with
+the user's input.
+"""
+        ),
     }
 )
 

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -259,8 +259,14 @@ compatibility.
         ),
         "prompt_template": (
             """A template string that, if provided, will be used to wrap the user's input.
-The template string should contain a single placeholder, `{ prompt }`, which will be replaced with
-the user's input.
+The template string should contain a single placeholder, `{prompt}`, which will be replaced with
+the user's input. Currently, only the following task types are supported:
+
+- `feature-extraction <https://huggingface.co/transformers/main_classes/pipelines.html#transformers.FeatureExtractionPipeline>`_
+- `fill-mask <https://huggingface.co/transformers/main_classes/pipelines.html#transformers.FillMaskPipeline>`_
+- `summarization <https://huggingface.co/transformers/main_classes/pipelines.html#transformers.SummarizationPipeline>`_
+- `text2text-generation <https://huggingface.co/transformers/main_classes/pipelines.html#transformers.Text2TextGenerationPipeline>`_
+- `text-generation <https://huggingface.co/transformers/main_classes/pipelines.html#transformers.TextGenerationPipeline>`_
 """
         ),
     }

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -305,7 +305,7 @@ def _validate_prompt_template(prompt_template):
     if len(format_args) != 1 or format_args[0] != "prompt":
         raise MlflowException(
             "Argument `prompt_template` should be a string with a single format arg, 'prompt'. "
-            "For example: 'Answer the following question in a friendly tone: {prompt}.'\n"
+            "For example: 'Answer the following question in a friendly tone. Q: {prompt}. A:'\n"
             f"Received {prompt_template}. ",
             INVALID_PARAMETER_VALUE,
         )

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -1,6 +1,5 @@
 import json
 import os
-import string
 import sys
 from typing import Any, Dict
 
@@ -8,7 +7,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.protos.databricks_pb2 import (
-    INVALID_PARAMETER_VALUE,
     RESOURCE_ALREADY_EXISTS,
     RESOURCE_DOES_NOT_EXIST,
 )
@@ -272,40 +270,4 @@ def _validate_pyfunc_model_config(model_config):
         raise MlflowException(
             "Values in the provided ``model_config`` are of an unsupported type. Only "
             "JSON-serializable data types can be provided as values."
-        )
-
-
-def _get_prompt_template(model_path):
-    model_configuration_path = os.path.join(model_path, MLMODEL_FILE_NAME)
-    if not os.path.exists(model_configuration_path):
-        raise MlflowException(
-            f'Could not find an "{MLMODEL_FILE_NAME}" configuration file at "{model_path}"',
-            RESOURCE_DOES_NOT_EXIST,
-        )
-
-    model_conf = Model.load(model_configuration_path)
-    return model_conf.prompt_template
-
-
-def _validate_prompt_template(prompt_template):
-    if prompt_template is None:
-        return
-
-    if not isinstance(prompt_template, str):
-        raise MlflowException(
-            f"Argument `prompt_template` should be a string, received {type(prompt_template)}",
-            INVALID_PARAMETER_VALUE,
-        )
-
-    format_args = [
-        tup[1] for tup in string.Formatter().parse(prompt_template) if tup[1] is not None
-    ]
-
-    # expect there to only be one format arg, and for that arg to be "prompt"
-    if len(format_args) != 1 or format_args[0] != "prompt":
-        raise MlflowException(
-            "Argument `prompt_template` should be a string with a single format arg, 'prompt'. "
-            "For example: 'Answer the following question in a friendly tone. Q: {prompt}. A:'\n"
-            f"Received {prompt_template}. ",
-            INVALID_PARAMETER_VALUE,
         )

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -6,10 +6,7 @@ from typing import Any, Dict
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
-from mlflow.protos.databricks_pb2 import (
-    RESOURCE_ALREADY_EXISTS,
-    RESOURCE_DOES_NOT_EXIST,
-)
+from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, RESOURCE_DOES_NOT_EXIST
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository

--- a/tests/transformers/test_transformers_prompt_templating.py
+++ b/tests/transformers/test_transformers_prompt_templating.py
@@ -1,0 +1,169 @@
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+from transformers import pipeline
+
+import mlflow
+from mlflow.exceptions import MlflowException
+from mlflow.models.model import MLMODEL_FILE_NAME
+from mlflow.transformers import _SUPPORTED_PROMPT_TEMPLATING_TASK_TYPES
+from mlflow.utils.model_utils import _validate_prompt_template
+
+# session fixtures to prevent saving and loading a ~400mb model every time
+TEST_PROMPT_TEMPLATE = "Answer the following question like a pirate:\nQ: {prompt}\nA: "
+
+UNSUPPORTED_PIPELINES = [
+    "audio-classification",
+    "automatic-speech-recognition",
+    "text-to-audio",
+    "text-to-speech",
+    "text-classification",
+    "sentiment-analysis",
+    "token-classification",
+    "ner",
+    "question-answering",
+    "table-question-answering",
+    "visual-question-answering",
+    "vqa",
+    "document-question-answering",
+    "translation",
+    "zero-shot-classification",
+    "zero-shot-image-classification",
+    "zero-shot-audio-classification",
+    "conversational",
+    "image-classification",
+    "image-segmentation",
+    "image-to-text",
+    "object-detection",
+    "zero-shot-object-detection",
+    "depth-estimation",
+    "video-classification",
+    "mask-generation",
+    "image-to-image",
+]
+
+
+@pytest.fixture(scope="session")
+def small_text_generation_model():
+    return pipeline("text-generation", model="distilgpt2")
+
+
+@pytest.fixture(scope="session")
+def saved_transformers_model_path(tmp_path_factory, small_text_generation_model):
+    tmp_path = tmp_path_factory.mktemp("model")
+    mlflow.transformers.save_model(
+        transformers_model=small_text_generation_model,
+        path=tmp_path,
+        prompt_template=TEST_PROMPT_TEMPLATE,
+    )
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "{multiple} {placeholders}",
+        "No placeholders",
+        "Placeholder {that} isn't `prompt`",
+        1001,  # not a string
+    ],
+)
+def test_prompt_validation_throws_on_invalid_templates(template):
+    match = (
+        "Argument `prompt_template` should be a string with a single format arg, 'prompt'."
+        if isinstance(template, str)
+        else "Argument `prompt_template` should be a string"
+    )
+    with pytest.raises(MlflowException, match=match):
+        _validate_prompt_template(template)
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "Single placeholder {prompt}",
+        "Text can be before {prompt} and after",
+        # the formatter will interpret the double braces as a literal single brace
+        "Escaped braces {{ work fine {prompt} }}",
+    ],
+)
+def test_prompt_validation_succeeds_on_valid_templates(template):
+    assert _validate_prompt_template(template) is None
+
+
+# test that prompt is saved to mlmodel file and is present in model load
+def test_prompt_save_and_load(saved_transformers_model_path):
+    mlmodel_path = saved_transformers_model_path / MLMODEL_FILE_NAME
+    with open(mlmodel_path) as f:
+        mlmodel_dict = yaml.safe_load(f)
+
+    assert mlmodel_dict["prompt_template"] == TEST_PROMPT_TEMPLATE
+
+    model = mlflow.pyfunc.load_model(saved_transformers_model_path)
+    assert model._model_impl.prompt_template == TEST_PROMPT_TEMPLATE
+
+
+def test_saving_prompt_throws_on_unsupported_task():
+    model = pipeline("text-generation", model="distilgpt2")
+
+    for pipeline_type in UNSUPPORTED_PIPELINES:
+        # mock the task by setting it explicitly
+        model.task = pipeline_type
+
+        with pytest.raises(
+            MlflowException,
+            match=f"Prompt templating is not supported for the `{pipeline_type}` task type.",
+        ):
+            mlflow.transformers.save_model(
+                transformers_model=model,
+                path="model",
+                prompt_template=TEST_PROMPT_TEMPLATE,
+            )
+
+
+def test_prompt_formatting(saved_transformers_model_path):
+    model_impl = mlflow.pyfunc.load_model(saved_transformers_model_path)._model_impl
+
+    # test that unsupported pipelines don't apply the prompt template.
+    # this is a bit of a redundant test, because the pipeline should not
+    # be able to be saved with a prompt template in the first place.
+    for pipeline_type in UNSUPPORTED_PIPELINES:
+        model_impl.pipeline = MagicMock(task=pipeline_type, return_value="")
+        result = model_impl._wrap_input_in_prompt_template("test")
+        assert result == "test"
+
+        result_list = model_impl._wrap_input_in_prompt_template(["item1", "item2"])
+        assert result_list == ["item1", "item2"]
+
+    # test that supported pipelines apply the prompt template
+    for pipeline_type in _SUPPORTED_PROMPT_TEMPLATING_TASK_TYPES:
+        model_impl.pipeline = MagicMock(task=pipeline_type, return_value="")
+        result = model_impl._wrap_input_in_prompt_template("test")
+        assert result == TEST_PROMPT_TEMPLATE.format(prompt="test")
+
+        result_list = model_impl._wrap_input_in_prompt_template(["item1", "item2"])
+        assert result_list == [
+            TEST_PROMPT_TEMPLATE.format(prompt="item1"),
+            TEST_PROMPT_TEMPLATE.format(prompt="item2"),
+        ]
+
+
+# test that prompt is used in pyfunc predict
+def test_prompt_used_in_predict(saved_transformers_model_path):
+    model = mlflow.pyfunc.load_model(saved_transformers_model_path)
+    prompt = "What is MLflow?"
+    formatted_prompt = TEST_PROMPT_TEMPLATE.format(prompt=prompt)
+    mock_response = "MLflow be a tool fer machine lernin'"
+    mock_return = [[{"generated_text": formatted_prompt + mock_response}]]
+
+    model._model_impl.pipeline = MagicMock(
+        spec=model._model_impl.pipeline, task="text-generation", return_value=mock_return
+    )
+
+    response = model.predict(prompt)
+    # check that the underlying pipeline was called with the formatted prompt template
+    model._model_impl.pipeline.assert_called_once_with([formatted_prompt])
+
+    # check that the response strips the prompt template from the generated text
+    assert response == [mock_response]

--- a/tests/transformers/test_transformers_prompt_templating.py
+++ b/tests/transformers/test_transformers_prompt_templating.py
@@ -66,6 +66,8 @@ def saved_transformers_model_path(tmp_path_factory, small_text_generation_model)
         "{multiple} {placeholders}",
         "No placeholders",
         "Placeholder {that} isn't `prompt`",
+        "Placeholder without a {} name",
+        "Placeholder with {prompt} and {} empty",
         1001,  # not a string
     ],
 )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/10791?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10791/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10791
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds the ability for users to save a prompt template to a `mlflow.transformers` model. If a template is saved, it will be used to format the user's input during inference time (when the user loads the model via `mlflow.pyfunc.load_model()`).

Some technical details:
1. The prompt template is saved in the `MLmodel` YAML file during serialization. In order to enable this, I've added a new property to `mlflow.models.Model`, since the MLmodel file is generated by calling the `to_dict()` function on this class.
2. For now, prompt templates can only be saved for certain pipeline types (attempting to save one with other pipeline types will result in an exception). More will be added in the future (specifically, the question-answering pipelines), but this PR starts with the following as they receive simple string inputs.
  a. feature-extraction
  b. fill-mask
  c. summarization
  d. text2text-generation
  e. text-generation
3. The prompt template needs to have a specific format—a template string with a single placeholder, `{prompt}`. This format can be up for debate (e.g. we can allow arbitrary names, or no names at all like `Answer the following question: Q: {}`), but it seemed reasonable to me. Exceptions with helpful error messages are thrown if the template does not conform.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

Added some docstrings, but I'll raise another PR to add a couple of guides to the docs after this PR.

<img width="1265" alt="Screenshot 2024-01-10 at 1 56 40 PM" src="https://github.com/mlflow/mlflow/assets/148037680/94068f3c-7ffa-43d8-a497-4aedbc97dbcb">

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Prompt templates can now be saved for certain `transformers` pipelines by proving the `prompt_template` kwarg to `mlflow.transformers.save_model()` or `mlflow.transformers.log_model()`. The prompt template must be a string with a single placeholder, `{prompt}`. For example: `"Answer the following question. Q: {prompt} A:"`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
