### PR TITLE
Remove the Redundant duplication check in transformers dependency validation

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -59,7 +59,6 @@ from mlflow.utils.environment import (
     _CONSTRAINTS_FILE_NAME,
     _PYTHON_ENV_FILE_NAME,
     _REQUIREMENTS_FILE_NAME,
-    _find_duplicate_requirements,
     _mlflow_conda_env,
     _process_conda_env,
     _process_pip_requirements,
@@ -553,14 +552,6 @@ def save_model(
         )
     else:
         conda_env, pip_requirements, pip_constraints = _process_conda_env(conda_env)
-
-    if duplicates := _find_duplicate_requirements(pip_requirements):
-        _logger.warning(
-            "Duplicate packages are present within the pip requirements. Duplicate packages: "
-            f"{duplicates}. Please manually specify the requirements by using the "
-            "`pip_requirements` argument in order to prevent unexpected installation "
-            "issues for this model."
-        )
 
     with path.joinpath(_CONDA_ENV_FILE_NAME).open("w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -2,8 +2,8 @@ import logging
 import os
 import re
 import subprocess
+import sys
 import tempfile
-from collections import Counter
 
 import yaml
 from packaging.requirements import InvalidRequirement, Requirement
@@ -526,25 +526,6 @@ def _process_pip_requirements(
     return conda_env, sanitized_pip_reqs, constraints
 
 
-def _find_duplicate_requirements(requirements):
-    """
-    Checks if duplicate base package requirements are specified in any list of requirements
-    and returns the list of duplicate base package names.
-    Note that git urls and paths to local files are not being considered for duplication checking.
-    """
-    base_package_names = []
-
-    for package in requirements:
-        try:
-            base_package_names.append(Requirement(package).name)
-        except InvalidRequirement:
-            # Skip anything that's not a valid package requirement
-            continue
-
-    package_counts = Counter(base_package_names)
-    return [package for package, count in package_counts.items() if count > 1]
-
-
 def _deduplicate_requirements(requirements):
     """
     De-duplicates a list of pip package requirements, handling complex scenarios such as merging
@@ -662,7 +643,7 @@ def _validate_version_constraints(requirements):
 
     try:
         subprocess.run(
-            ["pip", "install", "--dry-run", "-r", tmp_file_name],
+            [sys.executable, "-m", "pip", "install", "--dry-run", "-r", tmp_file_name],
             check=True,
             capture_output=True,
         )

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1093,32 +1093,16 @@ def test_transformers_log_with_extra_pip_requirements(small_multi_modal_pipeline
         )
 
 
-def test_transformers_log_with_duplicate_pip_requirements(small_multi_modal_pipeline, capsys):
-    with mlflow.start_run():
-        mlflow.transformers.log_model(
-            small_multi_modal_pipeline,
-            "model",
-            pip_requirements=["transformers==99.99.99", "transformers", "mlflow"],
-        )
-    captured = capsys.readouterr()
-    assert (
-        "Duplicate packages are present within the pip requirements. "
-        "Duplicate packages: ['transformers']" in captured.err
-    )
-
-
-def test_transformers_log_with_duplicate_extra_pip_requirements(small_multi_modal_pipeline, capsys):
-    with mlflow.start_run():
-        mlflow.transformers.log_model(
-            small_multi_modal_pipeline,
-            "model",
-            extra_pip_requirements=["transformers==99.99.99"],
-        )
-    captured = capsys.readouterr()
-    assert (
-        "Duplicate packages are present within the pip requirements. "
-        "Duplicate packages: ['transformers']" in captured.err
-    )
+def test_transformers_log_with_duplicate_extra_pip_requirements(small_multi_modal_pipeline):
+    with pytest.raises(
+        MlflowException, match="The specified requirements versions are incompatible"
+    ):
+        with mlflow.start_run():
+            mlflow.transformers.log_model(
+                small_multi_modal_pipeline,
+                "model",
+                extra_pip_requirements=["transformers==1.1.0"],
+            )
 
 
 @pytest.mark.skipif(

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -7,7 +7,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.utils.environment import (
     _contains_mlflow_requirement,
     _deduplicate_requirements,
-    _find_duplicate_requirements,
     _get_pip_deps,
     _get_pip_requirement_specifier,
     _is_mlflow_requirement,
@@ -341,34 +340,6 @@ def test_process_conda_env(tmp_path):
 
     with pytest.raises(TypeError, match=r"Expected .+, but got `int`"):
         _process_conda_env(0)
-
-
-def test_duplicate_pip_requirements():
-    packages = [
-        "numpy==1.21.0",  # specific version
-        "pandas>=1.3.0",  # minimum version
-        "scikit-learn",  # any version
-        "matplotlib<=3.4.2",  # maximum version
-        "seaborn",  # any version
-        "package!=1.2.3",  # any version but this one
-        "package~=1.2.3",  # compatible version (i.e., >= 1.2.3, == 1.2.*)
-        "package>1.2.3",  # version greater than
-        "package<1.2.3",  # version less than
-        "package[extra]==1.2.3",  # specific version with extras
-        "fastapi ===0.21.0",  # specific version (PEP 440: version with spaces around ===)
-        "fastapi @ https://my.package.repo/fastapi-0.21.0-py3-none-any.whl",  # private repo
-        "-e git+https://github.com/mlflow/mlflow@master",  # editable mode, direct from a git repo
-        "-r requirements.txt",  # from a requirements file
-        "pytest-cov; python_version < '3.8'",  # conditional requirements
-        "fastapi @ file:///local/path/to/numpy-0.22.0-py3-none-any.whl",  # wheel from a local file
-        "-c constraints.txt",  # constraint file
-        "--no-binary :all:",  # no binary packages, source code only
-        "--prefer-binary",  # prefer binary packages over source code
-        "numpy<1.24.0",  # maximum version
-        "numpy",  # any version
-    ]
-    evaluation = _find_duplicate_requirements(packages)
-    assert sorted(evaluation) == ["fastapi", "numpy", "package"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/10792?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10792/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10792
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Due to the expanded dependency validation handling in #10778 , the duplicate requirements checks that were defined earlier for the transformers flavor are now redundant and useless. This PR removes the validation check, associated unit tests, and converts a simple validation test within transformers.

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
