### PR TITLE
Add note to docstring for fluent API set_experiment

### DIFF
--- a/docs/source/tracking/tracking-api.rst
+++ b/docs/source/tracking/tracking-api.rst
@@ -60,12 +60,20 @@ local path to log data to a directory. The URI defaults to ``mlruns``.
 
 :py:func:`mlflow.get_tracking_uri` returns the current tracking URI.
 
-:py:func:`mlflow.create_experiment` creates a new experiment and returns its ID. Runs can be
-launched under the experiment by passing the experiment ID to ``mlflow.start_run``.
+:py:func:`mlflow.create_experiment` creates a new experiment and returns the experiment ID. Runs can be
+launched under the experiment by passing the experiment ID to ``mlflow.start_run`` or 
+by setting the active experiment with :py:func:`mlflow.set_experiment`, passing in the experiment ID of the created 
+experiment.
 
-:py:func:`mlflow.set_experiment` sets an experiment as active. If the experiment does not exist,
-creates a new experiment. If you do not specify an experiment in :py:func:`mlflow.start_run`, new
-runs are launched under this experiment.
+:py:func:`mlflow.set_experiment` sets an experiment as active and returns the active experiment instance. If you do not 
+specify an experiment in :py:func:`mlflow.start_run`, new runs are launched under this experiment.
+
+.. note:: 
+    If the experiment being set by name does not exist, a new experiment will be 
+    created with the given name. After the experiment has been created, it will be set 
+    as the active experiment. On certain platforms, such as Databricks, the experiment name 
+    must be an absolute path, e.g. ``"/Users/<username>/my-experiment"``.
+
 
 :py:func:`mlflow.start_run` returns the currently active run (if one exists), or starts a new run
 and returns a :py:class:`mlflow.ActiveRun` object usable as a context manager for the

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -91,7 +91,7 @@ def set_experiment(
     name via `experiment_name` or by ID via `experiment_id`. The experiment name and ID cannot
     both be specified.
 
-    .. note:: If the experiment being set by name does not exist, a new experiment will be created with the 
+    .. note:: If the experiment being set by name does not exist, a new experiment will be created with the
         given name. After the experiment has been created, it will be set as the active experiment.
 
     :param experiment_name: Case sensitive name of the experiment to be activated. If an experiment

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -91,14 +91,13 @@ def set_experiment(
     name via `experiment_name` or by ID via `experiment_id`. The experiment name and ID cannot
     both be specified.
 
-    .. note:: If the experiment being set by name does not exist, a new experiment will be 
-        created with the given name. After the experiment has been created, it will be set 
-        as the active experiment.
+    .. note::
+        If the experiment being set by name does not exist, a new experiment will be
+        created with the given name. After the experiment has been created, it will be set
+        as the active experiment. On certain platforms, such as Databricks, the experiment name
+        must be an absolute path, e.g. ``"/Users/<username>/my-experiment"``.
 
-    :param experiment_name: Case sensitive name of the experiment to be activated. If an experiment
-                            with this name does not exist, a new experiment wth this name is
-                            created. On certain platforms such as Databricks, the experiment name
-                            must an absolute path, e.g. ``"/Users/<username>/my-experiment"``.
+    :param experiment_name: Case sensitive name of the experiment to be activated.
     :param experiment_id: ID of the experiment to be activated. If an experiment with this ID
                           does not exist, an exception is thrown.
     :return: An instance of :py:class:`mlflow.entities.Experiment` representing the new active

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -91,6 +91,9 @@ def set_experiment(
     name via `experiment_name` or by ID via `experiment_id`. The experiment name and ID cannot
     both be specified.
 
+    .. note:: If the experiment being set by name does not exist, a new experiment will be created with the 
+        given name. After the experiment has been created, it will be set as the active experiment.
+
     :param experiment_name: Case sensitive name of the experiment to be activated. If an experiment
                             with this name does not exist, a new experiment wth this name is
                             created. On certain platforms such as Databricks, the experiment name

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -91,8 +91,9 @@ def set_experiment(
     name via `experiment_name` or by ID via `experiment_id`. The experiment name and ID cannot
     both be specified.
 
-    .. note:: If the experiment being set by name does not exist, a new experiment will be created with the
-        given name. After the experiment has been created, it will be set as the active experiment.
+    .. note:: If the experiment being set by name does not exist, a new experiment will be 
+        created with the given name. After the experiment has been created, it will be set 
+        as the active experiment.
 
     :param experiment_name: Case sensitive name of the experiment to be activated. If an experiment
                             with this name does not exist, a new experiment wth this name is


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/10795?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10795/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10795
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adds a clear note about the behavior of set_experiment in the fluent API due to reported confusion about the behavior.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
