### PR TITLE
Automatically convert LangChain responses for OpenAI requests to OpenAI response format

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -484,6 +484,7 @@ class _LangChainModelWrapper:
         data: Union[pd.DataFrame, List[Union[str, Dict[str, Any]]], Any],
         params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
         callback_handlers=None,
+        convert_chat_responses=False,
     ) -> List[str]:
         """
         :param data: Model input data.
@@ -501,7 +502,10 @@ class _LangChainModelWrapper:
             data, pd.DataFrame
         )
         results = process_api_requests(
-            lc_model=self.lc_model, requests=messages, callback_handlers=callback_handlers
+            lc_model=self.lc_model,
+            requests=messages,
+            callback_handlers=callback_handlers,
+            convert_chat_responses=convert_chat_responses,
         )
         return results[0] if return_first_element else results
 

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -23,7 +23,7 @@ import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Union, Literal
 
 import langchain.chains
 import pydantic
@@ -95,6 +95,29 @@ class _ChatRequest(pydantic.BaseModel, extra="forbid"):
     messages: List[_ChatMessage]
 
 
+class _ChatChoice(pydantic.BaseModel, extra="forbid"):
+    index: int
+    message: _ChatMessage
+    finish_reason: Optional[str] = None
+
+
+class _ChatUsage(pydantic.BaseModel, extra="forbid"):
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+
+
+class _ChatResponse(pydantic.BaseModel, extra="forbid"):
+    id: Optional[str] = None
+    object: Literal["chat.completion"] = "chat.completion"
+    created: int
+    # Make the model field optional since we may not be able to get a stable model identifier
+    # for an arbitrary LangChain model
+    model: Optional[str] = None
+    choices: List[_ChatChoice]
+    usage: _ChatUsage
+
+
 @dataclass
 class APIRequest:
     """
@@ -163,44 +186,54 @@ class APIRequest:
                     {"page_content": doc.page_content, "metadata": doc.metadata} for doc in docs
                 ]
             elif isinstance(self.lc_model, lc_runnables_types()):
+                prepared_request_json, did_perform_chat_conversion =\
+                    self._prepare_request_for_runnable_or_chain_inference(
+                        self.request_json
+                    )
                 if isinstance(self.request_json, dict):
                     # This is a temporary fix for the case when spark_udf converts
                     # input into pandas dataframe with column name, while the model
                     # does not accept dictionaries as input, it leads to errors like
                     # Expected Scalar value for String field 'query_text'
                     try:
-                        self.request_json = self._prepare_request_for_runnable_or_chain_inference(
-                            self.request_json
-                        )
-                        response = self.lc_model.invoke(self.request_json)
+                        response = self.lc_model.invoke(prepared_request_json)
                     except TypeError as e:
                         _logger.warning(
                             f"Failed to invoke {self.lc_model.__class__.__name__} "
                             f"with {self.request_json}. Error: {e!r}. Trying to "
                             "invoke with the first value of the dictionary."
                         )
-                        self.request_json = next(iter(self.request_json.values()))
-                        response = self.lc_model.invoke(
-                            self._prepare_request_for_runnable_or_chain_inference(self.request_json)
-                        )
+                        prepared_request_json, did_perform_chat_conversion =\
+                            self._prepare_request_for_runnable_or_chain_inference(
+                                prepared_request_json
+                            )
+                        response = self.lc_model.invoke(prepared_request_json)
                 elif isinstance(self.request_json, list) and isinstance(
                     self.lc_model, runnables_supports_batch_types()
                 ):
-                    response = self.lc_model.batch(
-                        self._prepare_request_for_runnable_or_chain_inference(self.request_json)
-                    )
+                    response = self.lc_model.batch(prepared_request_json)
                 else:
                     response = self.lc_model.invoke(
-                        self._prepare_request_for_runnable_or_chain_inference(self.request_json)
+                        prepared_request_json
                     )
+
+                if did_perform_chat_conversion:
+                    response = APIRequest._try_transform_response_to_chat_format(response)
             else:
+                prepared_request_json, did_perform_chat_conversion =\
+                    self._prepare_request_for_runnable_or_chain_inference(
+                        self.request_json
+                    )
                 response = self.lc_model(
-                    self._prepare_request_for_runnable_or_chain_inference(self.request_json),
+                    prepared_request_json,
                     return_only_outputs=True,
                 )
 
-                # to maintain existing code, single output chains will still return only the result
-                if len(response) == 1:
+                if did_perform_chat_conversion:
+                    response = APIRequest._try_transform_response_to_chat_format(response)
+                elif len(response) == 1:
+                    # to maintain existing code, single output chains will still return
+                    # only the result
                     response = response.popitem()[1]
                 else:
                     self._prepare_to_serialize(response)
@@ -216,16 +249,24 @@ class APIRequest:
             status_tracker.complete_task(success=False)
 
     def _prepare_request_for_runnable_or_chain_inference(self, request_json):
+        """
+        :return: A 2-element tuple containing: 1. the new request and 2. a boolean indicating
+                 whether or not the request was transformed from the OpenAI chat format
+        """
         return APIRequest._transform_request_json_for_chat_if_necessary(request_json, self.lc_model)
 
     @staticmethod
     def _transform_request_json_for_chat_if_necessary(request_json, lc_model):
+        """
+        :return: A 2-element tuple containing: 1. the new request and 2. a boolean indicating
+                 whether or not the request was transformed from the OpenAI chat format
+        """
         input_fields = APIRequest._get_lc_model_input_fields(lc_model)
         if "messages" in input_fields:
             # If the chain accepts a "messages" field directly, don't attempt to convert
             # the request to LangChain's Message format automatically. Assume that the chain
             # is handling the "messages" field by itself
-            return request_json
+            return request_json, False
 
         def json_dict_might_be_chat_request(json: Dict):
             return (
@@ -238,21 +279,54 @@ class APIRequest:
 
         if isinstance(request_json, dict) and json_dict_might_be_chat_request(request_json):
             try:
-                return APIRequest._convert_chat_request_or_throw(request_json)
+                return APIRequest._convert_chat_request_or_throw(request_json), True
             except pydantic.ValidationError:
-                return request_json
+                return request_json, False
         elif isinstance(request_json, list) and all(
             json_dict_might_be_chat_request(json) for json in request_json
         ):
             try:
-                return [
-                    APIRequest._convert_chat_request_or_throw(json_dict)
-                    for json_dict in request_json
-                ]
+                return (
+                    [
+                        APIRequest._convert_chat_request_or_throw(json_dict)
+                        for json_dict in request_json
+                    ],
+                    True
+                )
             except pydantic.ValidationError:
-                return request_json
+                return request_json, False
         else:
-            return request_json
+            return request_json, False
+
+    @staticmethod
+    def _try_transform_response_to_chat_format(response):
+        if isinstance(response, str):
+            message_content = response
+        elif isinstance(response, AIMessage):
+            message_content = response.content
+        else:
+            return response
+
+        return _ChatResponse(
+            id=None,
+            created=int(time.time()),
+            model=None,
+            choices=[
+                _ChatChoice(
+                    index=0,
+                    message=_ChatMessage(
+                        role="assistant",
+                        content=message_content,
+                    ),
+                    finish_reason=None,
+                )
+            ],
+            usage=_ChatUsage(
+                prompt_tokens=None,
+                completion_tokens=None,
+                total_tokens=None,
+            )
+        ).model_dump()
 
     @staticmethod
     def _get_lc_model_input_fields(lc_model) -> Set:

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -209,7 +209,6 @@ class APIRequest:
                             f"with {self.request_json}. Error: {e!r}. Trying to "
                             "invoke with the first value of the dictionary."
                         )
-
                         self.request_json = next(iter(self.request_json.values()))
                         (
                             prepared_request_json,

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1600,13 +1600,11 @@ def test_predict_with_builtin_pyfunc_chat_conversion():
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
         extra_args=["--env-manager", "local"],
     )
-    assert json.loads(response.content.decode("utf-8"))[0]["choices"][0]["message"]["content"] == [
-        (
-            "system: You are a helpful assistant.\n"
-            "ai: What would you like to ask?\n"
-            "human: Who owns MLflow?"
-        )
-    ]
+    assert json.loads(response.content.decode("utf-8"))[0]["choices"][0]["message"]["content"] == (
+        "system: You are a helpful assistant.\n"
+        "ai: What would you like to ask?\n"
+        "human: Who owns MLflow?"
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -953,6 +953,9 @@ def test_predict_with_callbacks():
     }
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
+)
 def test_predict_with_callbacks_supports_chat_response_conversion():
     from langchain.prompts import ChatPromptTemplate
     from langchain.schema.output_parser import StrOutputParser

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1470,7 +1470,7 @@ def test_chat_with_history(spark):
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-def test_predict_with_builtin_pyfunc_chat_conversion(spark):
+def test_predict_with_builtin_pyfunc_chat_conversion():
     from langchain.schema.output_parser import StrOutputParser
 
     from mlflow.langchain.utils import _fake_simple_chat_model
@@ -1588,18 +1588,6 @@ def test_predict_with_builtin_pyfunc_chat_conversion(spark):
 
     with pytest.raises(MlflowException, match="Unrecognized chat message role"):
         pyfunc_loaded_model.predict({"messages": [{"role": "foobar", "content": "test content"}]})
-
-    udf = mlflow.pyfunc.spark_udf(spark, model_info.model_uri, result_type="string")
-    df = spark.createDataFrame([(input_example["messages"],)], ["messages"])
-    df = df.withColumn("answer", udf("messages"))
-    pdf = df.toPandas()
-    assert pdf["answer"].tolist()[0]["choices"][0]["messages"]["content"] == [
-        (
-            "system: You are a helpful assistant.\n"
-            "ai: What would you like to ask?\n"
-            "human: Who owns MLflow?"
-        )
-    ]
 
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -34,7 +34,7 @@ from langchain.llms.base import LLM
 from langchain.memory import ConversationBufferMemory
 from langchain.prompts import PromptTemplate
 from langchain.requests import TextRequestsWrapper
-from langchain.schema import HumanMessage
+from langchain.schema import AIMessage, HumanMessage, SystemMessage
 from langchain.text_splitter import CharacterTextSplitter
 from langchain.tools import Tool
 from langchain.vectorstores import FAISS
@@ -1455,7 +1455,7 @@ def test_predict_with_builtin_pyfunc_chat_conversion(spark):
                                 "system: You are a helpful assistant.\n"
                                 "ai: What would you like to ask?\n"
                                 "human: Who owns MLflow?"
-                            )
+                            ),
                         },
                         "finish_reason": None,
                     }
@@ -1483,7 +1483,7 @@ def test_predict_with_builtin_pyfunc_chat_conversion(spark):
                                 "system: You are a helpful assistant.\n"
                                 "ai: What would you like to ask?\n"
                                 "human: Who owns MLflow?"
-                            )
+                            ),
                         },
                         "finish_reason": None,
                     }
@@ -1508,7 +1508,7 @@ def test_predict_with_builtin_pyfunc_chat_conversion(spark):
                                 "system: You are a helpful assistant.\n"
                                 "ai: What would you like to ask?\n"
                                 "human: Who owns MLflow?"
-                            )
+                            ),
                         },
                         "finish_reason": None,
                     }
@@ -1518,12 +1518,12 @@ def test_predict_with_builtin_pyfunc_chat_conversion(spark):
                     "completion_tokens": None,
                     "total_tokens": None,
                 },
-            }
+            },
         ]
 
     with pytest.raises(MlflowException, match="Unrecognized chat message role"):
         pyfunc_loaded_model.predict({"messages": [{"role": "foobar", "content": "test content"}]})
-    #
+
     udf = mlflow.pyfunc.spark_udf(spark, model_info.model_uri, result_type="string")
     df = spark.createDataFrame([(input_example["messages"],)], ["messages"])
     df = df.withColumn("answer", udf("messages"))
@@ -1554,7 +1554,68 @@ def test_predict_with_builtin_pyfunc_chat_conversion(spark):
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
-def test_pyfunc_builtin_chat_conversion_fails_gracefully():
+def test_predict_with_builtin_pyfunc_chat_conversion_for_aimessage_response():
+    from mlflow.langchain.utils import _fake_simple_chat_model
+
+    class ChatModel(_fake_simple_chat_model()):
+        def _call(self, messages, stop, run_manager, **kwargs):  # pylint: disable=signature-differs
+            return "You own MLflow"
+
+    input_example = {
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "assistant", "content": "What would you like to ask?"},
+            {"role": "user", "content": "Who owns MLflow?"},
+        ]
+    }
+    signature = infer_signature(model_input=input_example)
+
+    chain = ChatModel()
+    assert chain.invoke([HumanMessage(content="Who owns MLflow?")]) == AIMessage(
+        content="You own MLflow"
+    )
+
+    with mlflow.start_run():
+        model_info = mlflow.langchain.log_model(
+            chain, "model_path", signature=signature, input_example=input_example
+        )
+
+    loaded_model = mlflow.langchain.load_model(model_info.model_uri)
+    assert loaded_model.invoke([HumanMessage(content="Who owns MLflow?")]) == AIMessage(
+        content="You own MLflow"
+    )
+
+    pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    with mock.patch("time.time", return_value=1677858242):
+        assert pyfunc_loaded_model.predict(input_example) == [
+            {
+                "id": None,
+                "object": "chat.completion",
+                "created": 1677858242,
+                "model": None,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "You own MLflow",
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": None,
+                    "completion_tokens": None,
+                    "total_tokens": None,
+                },
+            }
+        ]
+
+
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
+)
+def test_pyfunc_builtin_chat_request_conversion_fails_gracefully():
     from langchain.schema.runnable import RunnablePassthrough
 
     chain = RunnablePassthrough() | itemgetter("messages")
@@ -1643,3 +1704,47 @@ def test_pyfunc_builtin_chat_conversion_fails_gracefully():
         [{"role": "user", "content": "content"}],
         [{"role": "user", "content": "content"}, {"role": "user"}],
     ]
+
+
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
+)
+def test_pyfunc_builtin_chat_response_conversion_fails_gracefully():
+    from langchain.schema.runnable import RunnablePassthrough
+
+    llm = OpenAI(temperature=0.9)
+    prompt = PromptTemplate(
+        input_variables=["messages"],
+        template="What is a good name for a company that makes {messages}?",
+    )
+    chain = RunnablePassthrough() | LLMChain(llm=llm, prompt=prompt) | RunnablePassthrough()
+
+    input_example = {
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "assistant", "content": "What would you like to ask?"},
+            {"role": "user", "content": "Who owns MLflow?"},
+        ]
+    }
+    signature = infer_signature(model_input=input_example)
+
+    with _mock_request(return_value=_mock_chat_completion_response()):
+        with mlflow.start_run():
+            logged_model = mlflow.langchain.log_model(
+                chain, "langchain_model", signature=signature, input_example=input_example
+            )
+        loaded_model = mlflow.pyfunc.load_model(logged_model.model_uri)
+        result = loaded_model.predict(input_example)
+        # Verify that the chat request format was converted into LangChain messages correctly, but
+        # the response was not converted to the chat response format because it does not have the
+        # expected structure (a nonstandard dict with 'messages' and 'text' fields is returned)
+        assert result == [
+            {
+                "messages": [
+                    SystemMessage(content="You are a helpful assistant."),
+                    AIMessage(content="What would you like to ask?"),
+                    HumanMessage(content="Who owns MLflow?"),
+                ],
+                "text": TEST_CONTENT,
+            }
+        ]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/10797?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10797/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10797
```

</p>
</details>

### What changes are proposed in this pull request?

Automatically convert LangChain responses for OpenAI requests to OpenAI response format

This enables users to deploy LangChain models with an OpenAI-compatible request / response format

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

No further release note needed beyond https://github.com/mlflow/mlflow/pull/10758

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
