### PR TITLE
Fix r2 get_region_name

### DIFF
--- a/mlflow/store/artifact/optimized_s3_artifact_repo.py
+++ b/mlflow/store/artifact/optimized_s3_artifact_repo.py
@@ -44,6 +44,7 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
         session_token=None,
         addressing_style="path",
         s3_endpoint_url=None,
+        region_name=None,
     ):
         super().__init__(artifact_uri)
         self._access_key_id = access_key_id
@@ -52,7 +53,10 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
         self._addressing_style = addressing_style
         self._s3_endpoint_url = s3_endpoint_url
         self.bucket, self.bucket_path = self.parse_s3_compliant_uri(self.artifact_uri)
-        self._region_name = self._get_region_name()
+        if region_name is None:
+            self._region_name = self._get_region_name()
+        else:
+            self._region_name = region_name
 
     def _get_region_name(self):
         from botocore.exceptions import ClientError

--- a/mlflow/store/artifact/optimized_s3_artifact_repo.py
+++ b/mlflow/store/artifact/optimized_s3_artifact_repo.py
@@ -44,7 +44,6 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
         session_token=None,
         addressing_style="path",
         s3_endpoint_url=None,
-        region_name=None,
     ):
         super().__init__(artifact_uri)
         self._access_key_id = access_key_id
@@ -53,10 +52,7 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
         self._addressing_style = addressing_style
         self._s3_endpoint_url = s3_endpoint_url
         self.bucket, self.bucket_path = self.parse_s3_compliant_uri(self.artifact_uri)
-        if region_name is None:
-            self._region_name = self._get_region_name()
-        else:
-            self._region_name = region_name
+        self._region_name = self._get_region_name()
 
     def _get_region_name(self):
         from botocore.exceptions import ClientError

--- a/mlflow/store/artifact/r2_artifact_repo.py
+++ b/mlflow/store/artifact/r2_artifact_repo.py
@@ -17,6 +17,7 @@ class R2ArtifactRepository(OptimizedS3ArtifactRepository):
         self._secret_access_key = secret_access_key
         self._session_token = session_token
         self._s3_endpoint_url = s3_endpoint_url
+        self.bucket, self.bucket_path = self.parse_s3_compliant_uri(self.artifact_uri)
         super().__init__(
             artifact_uri,
             access_key_id=access_key_id,

--- a/mlflow/store/artifact/r2_artifact_repo.py
+++ b/mlflow/store/artifact/r2_artifact_repo.py
@@ -41,6 +41,20 @@ class R2ArtifactRepository(OptimizedS3ArtifactRepository):
         )
         return temp_client.get_bucket_location(Bucket=self.bucket)["LocationConstraint"]
 
+    def parse_s3_compliant_uri(self, uri):
+        # r2 uri format(virtual): r2://<bucket-name>@<account-id>.r2.cloudflarestorage.com/<path>
+        parsed = urlparse(uri)
+        if parsed.scheme != "r2":
+            raise Exception(f"Not an R2 URI: {uri}")
+
+        host = parsed.netloc
+        path = parsed.path
+
+        bucket = host.split("@")[0]
+        if path.startswith("/"):
+            path = path[1:]
+        return bucket, path
+
     @staticmethod
     def convert_r2_uri_to_s3_endpoint_url(r2_uri):
         host = urlparse(r2_uri).netloc

--- a/mlflow/store/artifact/r2_artifact_repo.py
+++ b/mlflow/store/artifact/r2_artifact_repo.py
@@ -17,7 +17,7 @@ class R2ArtifactRepository(OptimizedS3ArtifactRepository):
         self._secret_access_key = secret_access_key
         self._session_token = session_token
         self._s3_endpoint_url = s3_endpoint_url
-        self.bucket, self.bucket_path = self.parse_s3_compliant_uri(self.artifact_uri)
+        self.bucket, self.bucket_path = self.parse_s3_compliant_uri(artifact_uri)
         super().__init__(
             artifact_uri,
             access_key_id=access_key_id,

--- a/mlflow/store/artifact/r2_artifact_repo.py
+++ b/mlflow/store/artifact/r2_artifact_repo.py
@@ -24,8 +24,9 @@ class R2ArtifactRepository(OptimizedS3ArtifactRepository):
             region_name=self._get_region_name(),
         )
 
-    # Cloudflare implementation of head_bucket is not the same as AWS's, so we temporarily use the old method of
-    # get_bucket_location until cloudflare updates their implementation
+    # Cloudflare implementation of head_bucket is not the same as AWS's, so we
+    # temporarily use the old method of get_bucket_location until cloudflare
+    # updates their implementation
     def _get_region_name(self):
         # note: s3 client enforces path addressing style for get_bucket_location
         temp_client = _get_s3_client(

--- a/mlflow/store/artifact/r2_artifact_repo.py
+++ b/mlflow/store/artifact/r2_artifact_repo.py
@@ -13,7 +13,10 @@ class R2ArtifactRepository(OptimizedS3ArtifactRepository):
         # setup Cloudflare R2 backend to be endpoint_url, otherwise all s3 requests
         # will go to AWS S3 by default
         s3_endpoint_url = self.convert_r2_uri_to_s3_endpoint_url(artifact_uri)
-
+        self._access_key_id = access_key_id
+        self._secret_access_key = secret_access_key
+        self._session_token = session_token
+        self._s3_endpoint_url = s3_endpoint_url
         super().__init__(
             artifact_uri,
             access_key_id=access_key_id,

--- a/mlflow/store/artifact/r2_artifact_repo.py
+++ b/mlflow/store/artifact/r2_artifact_repo.py
@@ -25,7 +25,6 @@ class R2ArtifactRepository(OptimizedS3ArtifactRepository):
             session_token=session_token,
             addressing_style="virtual",
             s3_endpoint_url=s3_endpoint_url,
-            region_name=self._get_region_name(),
         )
 
     # Cloudflare implementation of head_bucket is not the same as AWS's, so we
@@ -41,30 +40,6 @@ class R2ArtifactRepository(OptimizedS3ArtifactRepository):
             s3_endpoint_url=self._s3_endpoint_url,
         )
         return temp_client.get_bucket_location(Bucket=self.bucket)["LocationConstraint"]
-
-    def _get_s3_client(self):
-        return _get_s3_client(
-            addressing_style=self._addressing_style,
-            access_key_id=self._access_key_id,
-            secret_access_key=self._secret_access_key,
-            session_token=self._session_token,
-            region_name=self._region_name,
-            s3_endpoint_url=self._s3_endpoint_url,
-        )
-
-    def parse_s3_compliant_uri(self, uri):
-        # r2 uri format(virtual): r2://<bucket-name>@<account-id>.r2.cloudflarestorage.com/<path>
-        parsed = urlparse(uri)
-        if parsed.scheme != "r2":
-            raise Exception(f"Not an R2 URI: {uri}")
-
-        host = parsed.netloc
-        path = parsed.path
-
-        bucket = host.split("@")[0]
-        if path.startswith("/"):
-            path = path[1:]
-        return bucket, path
 
     @staticmethod
     def convert_r2_uri_to_s3_endpoint_url(r2_uri):

--- a/tests/store/artifact/test_r2_artifact_repo.py
+++ b/tests/store/artifact/test_r2_artifact_repo.py
@@ -67,3 +67,26 @@ def test_s3_endpoint_url_is_used_to_get_s3_client(r2_artifact_root):
             aws_session_token=None,
             region_name=ANY,
         )
+
+
+def test_get_r2_client_region_name_set_correctly(s3_artifact_root):
+    region_name = "us_random_region_42"
+    with mock.patch("boto3.client") as mock_get_s3_client:
+        s3_client_mock = mock.Mock()
+        mock_get_s3_client.return_value = s3_client_mock
+        s3_client_mock.get_bucket_location.return_value = {"LocationConstraint": region_name}
+
+        artifact_uri = posixpath.join(r2_artifact_root, "some/path")
+        repo = get_artifact_repository(artifact_uri)
+        repo._get_s3_client()
+
+        mock_get_s3_client.assert_called_with(
+            "s3",
+            config=ANY,
+            endpoint_url=ANY,
+            verify=None,
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            aws_session_token=None,
+            region_name=region_name,
+        )

--- a/tests/store/artifact/test_r2_artifact_repo.py
+++ b/tests/store/artifact/test_r2_artifact_repo.py
@@ -31,8 +31,7 @@ def test_parse_r2_uri(r2_artifact_root):
 
 def test_s3_client_config_set_correctly(r2_artifact_root):
     with mock.patch(
-        "mlflow.store.artifact.r2_artifact_repo."
-        "R2ArtifactRepository._get_region_name"
+        "mlflow.store.artifact.r2_artifact_repo.R2ArtifactRepository._get_region_name"
     ) as mock_method:
         mock_method.return_value = None
 

--- a/tests/store/artifact/test_r2_artifact_repo.py
+++ b/tests/store/artifact/test_r2_artifact_repo.py
@@ -69,7 +69,7 @@ def test_s3_endpoint_url_is_used_to_get_s3_client(r2_artifact_root):
         )
 
 
-def test_get_r2_client_region_name_set_correctly(s3_artifact_root):
+def test_get_r2_client_region_name_set_correctly(r2_artifact_root):
     region_name = "us_random_region_42"
     with mock.patch("boto3.client") as mock_get_s3_client:
         s3_client_mock = mock.Mock()

--- a/tests/store/artifact/test_r2_artifact_repo.py
+++ b/tests/store/artifact/test_r2_artifact_repo.py
@@ -31,8 +31,8 @@ def test_parse_r2_uri(r2_artifact_root):
 
 def test_s3_client_config_set_correctly(r2_artifact_root):
     with mock.patch(
-        "mlflow.store.artifact.optimized_s3_artifact_repo."
-        "OptimizedS3ArtifactRepository._get_region_name"
+        "mlflow.store.artifact.r2_artifact_repo."
+        "R2ArtifactRepository._get_region_name"
     ) as mock_method:
         mock_method.return_value = None
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kriscon-db/mlflow/pull/10803?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10803/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10803
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Reverting the R2 usage of get_region_name to the old implementation because cloudflare's implementation of head_bucket does not comport with AWS's

### How is this PR tested?

- [ x] Existing unit/integration tests
- [x ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
