### PR TITLE
Google docstring conversion batch 1

### DIFF
--- a/mlflow/deployments/__init__.py
+++ b/mlflow/deployments/__init__.py
@@ -41,7 +41,7 @@ class PredictionsResponse(dict):
 
         Args:
             predictions_format: The format in which to return the predictions. Either
-                "dataframe" or "ndarray".
+                ``"dataframe"`` or ``"ndarray"``.
             dtype: The NumPy datatype to which to coerce the predictions. Only used when
                 the "ndarray" predictions_format is specified.
 

--- a/mlflow/deployments/__init__.py
+++ b/mlflow/deployments/__init__.py
@@ -37,15 +37,20 @@ class PredictionsResponse(dict):
     """
 
     def get_predictions(self, predictions_format="dataframe", dtype=None):
-        """
-        Get the predictions returned from the MLflow Model Server in the specified format.
+        """Get the predictions returned from the MLflow Model Server in the specified format.
 
-        :param predictions_format: The format in which to return the predictions. Either
-                                   ``"dataframe"`` or ``"ndarray"``.
-        :param dtype: The NumPy datatype to which to coerce the predictions. Only used when
-                      the ``"ndarray"`` ``predictions_format`` is specified.
-        :throws: Exception if the predictions cannot be represented in the specified format.
-        :return: The predictions, represented in the specified format.
+        Args:
+            predictions_format: The format in which to return the predictions. Either
+                "dataframe" or "ndarray".
+            dtype: The NumPy datatype to which to coerce the predictions. Only used when
+                the "ndarray" predictions_format is specified.
+
+        Raises:
+            Exception: If the predictions cannot be represented in the specified format.
+
+        Returns:
+            The predictions, represented in the specified format.
+
         """
         import numpy as np
         import pandas as pd
@@ -69,12 +74,15 @@ class PredictionsResponse(dict):
             )
 
     def to_json(self, path=None):
-        """
-        Get the JSON representation of the MLflow Predictions Response.
+        """Get the JSON representation of the MLflow Predictions Response.
 
-        :param path: If specified, the JSON representation is written to this file path.
-        :return: If ``path`` is unspecified, the JSON representation of the MLflow Predictions
-                 Response. Else, None.
+        Args:
+            path: If specified, the JSON representation is written to this file path.
+
+        Returns:
+            If ``path`` is unspecified, the JSON representation of the MLflow Predictions
+            Response. Else, None.
+
         """
         if path is not None:
             with open(path, "w") as f:

--- a/mlflow/deployments/base.py
+++ b/mlflow/deployments/base.py
@@ -16,25 +16,27 @@ from mlflow.utils.annotations import developer_stable
 
 
 def run_local(target, name, model_uri, flavor=None, config=None):  # pylint: disable=unused-argument
-    """
+    """Deploys the specified model locally, for testing. This function should be defined
+    within the plugin module. Also note that this function has a signature which is very
+    similar to :py:meth:`BaseDeploymentClient.create_deployment` since both does logically
+    similar operation.
+
     .. Note::
         This function is kept here only for documentation purpose and not implementing the
         actual feature. It should be implemented in the plugin's top level namescope and should
         be callable with ``plugin_module.run_local``
 
-    Deploys the specified model locally, for testing. This function should be defined
-    within the plugin module. Also note that this function has a signature which is very
-    similar to :py:meth:`BaseDeploymentClient.create_deployment` since both does logically
-    similar operation.
+    Args:
+        target: Which target to use. This information is used to call the appropriate plugin.
+        name: Unique name to use for deployment. If another deployment exists with the same
+            name, create_deployment will raise a
+            :py:class:`mlflow.exceptions.MlflowException`.
+        model_uri: URI of model to deploy.
+        flavor: (optional) Model flavor to deploy. If unspecified, default flavor is chosen.
+        config: (optional) Dict containing updated target-specific config for the deployment.
 
-    :param target: Which target to use. This information is used to call the appropriate plugin
-    :param name:  Unique name to use for deployment. If another deployment exists with the same
-                     name, create_deployment will raise a
-                     :py:class:`mlflow.exceptions.MlflowException`
-    :param model_uri: URI of model to deploy
-    :param flavor: (optional) Model flavor to deploy. If unspecified, default flavor is chosen.
-    :param config: (optional) Dict containing updated target-specific config for the deployment
-    :return: None
+    Returns:
+        None
     """
     raise NotImplementedError(
         "This function should be implemented in the deployment plugin. It is "
@@ -97,17 +99,20 @@ class BaseDeploymentClient(abc.ABC):
         :py:class:`mlflow.exceptions.MlflowException`. See target-specific plugin documentation
         for additional detail on support for asynchronous deployment and other configuration.
 
-        :param name: Unique name to use for deployment. If another deployment exists with the same
-                     name, raises a
-                     :py:class:`mlflow.exceptions.MlflowException`
-        :param model_uri: URI of model to deploy
-        :param flavor: (optional) Model flavor to deploy. If unspecified, a default flavor
-                       will be chosen.
-        :param config: (optional) Dict containing updated target-specific configuration for the
-                       deployment
-        :param endpoint: (optional) Endpoint to create the deployment under. May not be supported
-                         by all targets
-        :return: Dict corresponding to created deployment, which must contain the 'name' key.
+        Args:
+            name: Unique name to use for deployment. If another deployment exists with the same
+                name, raises a :py:class:`mlflow.exceptions.MlflowException`
+            model_uri: URI of model to deploy
+            flavor: (optional) Model flavor to deploy. If unspecified, a default flavor
+                will be chosen.
+            config: (optional) Dict containing updated target-specific configuration for the
+                deployment
+            endpoint: (optional) Endpoint to create the deployment under. May not be supported
+                by all targets
+
+        Returns:
+            Dict corresponding to created deployment, which must contain the 'name' key.
+
         """
         pass
 
@@ -121,50 +126,61 @@ class BaseDeploymentClient(abc.ABC):
         with the updated deployment). See target-specific plugin documentation for additional
         detail on support for asynchronous deployment and other configuration.
 
-        :param name: Unique name of deployment to update
-        :param model_uri: URI of a new model to deploy.
-        :param flavor: (optional) new model flavor to use for deployment. If provided,
-                       ``model_uri`` must also be specified. If ``flavor`` is unspecified but
-                       ``model_uri`` is specified, a default flavor will be chosen and the
-                       deployment will be updated using that flavor.
-        :param config: (optional) dict containing updated target-specific configuration for the
-                       deployment
-        :param endpoint: (optional) Endpoint containing the deployment to update. May not be
-                         supported by all targets
-        :return: None
+        Args:
+            name: Unique name of deployment to update.
+            model_uri: URI of a new model to deploy.
+            flavor: (optional) new model flavor to use for deployment. If provided,
+                ``model_uri`` must also be specified. If ``flavor`` is unspecified but
+                ``model_uri`` is specified, a default flavor will be chosen and the
+                deployment will be updated using that flavor.
+            config: (optional) dict containing updated target-specific configuration for the
+                deployment.
+            endpoint: (optional) Endpoint containing the deployment to update. May not be
+                supported by all targets.
+
+        Returns:
+            None
+
         """
         pass
 
     @abc.abstractmethod
     def delete_deployment(self, name, config=None, endpoint=None):
-        """
-        Delete the deployment with name ``name`` from the specified target. Deletion should be
-        idempotent (i.e. deletion should not fail if retried on a non-existent deployment).
+        """Delete the deployment with name ``name`` from the specified target.
 
-        :param name: Name of deployment to delete
-        :param config: (optional) dict containing updated target-specific configuration for the
-                       deployment
-        :param endpoint: (optional) Endpoint containing the deployment to delete. May not be
-                         supported by all targets
-        :return: None
+        Deletion should be idempotent (i.e. deletion should not fail if retried on a non-existent
+        deployment).
+
+        Args:
+            name: Name of deployment to delete
+            config: (optional) dict containing updated target-specific configuration for the
+                deployment
+            endpoint: (optional) Endpoint containing the deployment to delete. May not be
+                supported by all targets
+
+        Returns:
+            None
         """
         pass
 
     @abc.abstractmethod
     def list_deployments(self, endpoint=None):
-        """
-        List deployments. This method is expected to return an unpaginated list of all
+        """List deployments.
+
+        This method is expected to return an unpaginated list of all
         deployments (an alternative would be to return a dict with a 'deployments' field
         containing the actual deployments, with plugins able to specify other fields, e.g.
         a next_page_token field, in the returned dictionary for pagination, and to accept
         a `pagination_args` argument to this method for passing pagination-related args).
 
-        :param endpoint: (optional) List deployments in the specified endpoint. May not be
-                         supported by all targets
+        Args:
+            endpoint: (optional) List deployments in the specified endpoint. May not be
+                supported by all targets
 
-        :return: A list of dicts corresponding to deployments. Each dict is guaranteed to
-                 contain a 'name' key containing the deployment name. The other fields of
-                 the returned dictionary and their types may vary across deployment targets.
+        Returns:
+            A list of dicts corresponding to deployments. Each dict is guaranteed to
+            contain a 'name' key containing the deployment name. The other fields of
+            the returned dictionary and their types may vary across deployment targets.
         """
         pass
 
@@ -178,27 +194,34 @@ class BaseDeploymentClient(abc.ABC):
         The other fields of the returned dictionary and their types may vary across
         deployment targets.
 
-        :param name: ID of deployment to fetch
-        :param endpoint: (optional) Endpoint containing the deployment to get. May not be
-                         supported by all targets
-        :return: A dict corresponding to the retrieved deployment. The dict is guaranteed to
-                 contain a 'name' key corresponding to the deployment name. The other fields of
-                 the returned dictionary and their types may vary across targets.
+        Args:
+            name: ID of deployment to fetch.
+            endpoint: (optional) Endpoint containing the deployment to get. May not be
+                supported by all targets.
+
+        Returns:
+            A dict corresponding to the retrieved deployment. The dict is guaranteed to
+            contain a 'name' key corresponding to the deployment name. The other fields of
+            the returned dictionary and their types may vary across targets.
         """
         pass
 
     @abc.abstractmethod
     def predict(self, deployment_name=None, inputs=None, endpoint=None):
-        """
-        Compute predictions on inputs using the specified deployment or model endpoint.
+        """Compute predictions on inputs using the specified deployment or model endpoint.
+
         Note that the input/output types of this method match those of `mlflow pyfunc predict`.
 
-        :param deployment_name: Name of deployment to predict against
-        :param inputs: Input data (or arguments) to pass to the deployment or model endpoint for
-                       inference
-        :param endpoint: Endpoint to predict against. May not be supported by all targets
-        :return: A :py:class:`mlflow.deployments.PredictionsResponse` instance representing the
-                 predictions and associated Model Server response metadata.
+        Args:
+            deployment_name: Name of deployment to predict against.
+            inputs: Input data (or arguments) to pass to the deployment or model endpoint for
+                inference.
+            endpoint: Endpoint to predict against. May not be supported by all targets.
+
+        Returns:
+            A :py:class:`mlflow.deployments.PredictionsResponse` instance representing the
+            predictions and associated Model Server response metadata.
+
         """
         pass
 
@@ -210,11 +233,14 @@ class BaseDeploymentClient(abc.ABC):
         ``df`` for the deployed model. Explanation output formats vary by deployment target,
         and can include details like feature importance for understanding/debugging predictions.
 
-        :param deployment_name: Name of deployment to predict against
-        :param df: Pandas DataFrame to use for explaining feature importance in model prediction
-        :param endpoint: Endpoint to predict against. May not be supported by all targets
-        :return: A JSON-able object (pandas dataframe, numpy array, dictionary), or
-                 an exception if the implementation is not available in deployment target's class
+        Args:
+            deployment_name: Name of deployment to predict against
+            df: Pandas DataFrame to use for explaining feature importance in model prediction
+            endpoint: Endpoint to predict against. May not be supported by all targets
+
+        Returns:
+            A JSON-able object (pandas dataframe, numpy array, dictionary), or
+            an exception if the implementation is not available in deployment target's class
         """
         raise MlflowException(
             "Computing model explanations is not yet supported for this deployment target"
@@ -229,11 +255,15 @@ class BaseDeploymentClient(abc.ABC):
         :py:class:`mlflow.exceptions.MlflowException`. See target-specific plugin documentation
         for additional detail on support for asynchronous creation and other configuration.
 
-        :param name: Unique name to use for endpoint. If another endpoint exists with the same
-                     name, raises a :py:class:`mlflow.exceptions.MlflowException`.
-        :param config: (optional) Dict containing target-specific configuration for the
-                       endpoint.
-        :return: Dict corresponding to created endpoint, which must contain the 'name' key.
+        Args:
+            name: Unique name to use for endpoint. If another endpoint exists with the same
+                name, raises a :py:class:`mlflow.exceptions.MlflowException`.
+            config: (optional) Dict containing target-specific configuration for the
+                endpoint.
+
+        Returns:
+            Dict corresponding to created endpoint, which must contain the 'name' key.
+
         """
         raise MlflowException(
             "Method is unimplemented in base client. Implementation should be "
@@ -248,10 +278,14 @@ class BaseDeploymentClient(abc.ABC):
         target-specific plugin documentation for additional detail on support for asynchronous
         update and other configuration.
 
-        :param endpoint: Unique name of endpoint to update
-        :param config: (optional) dict containing target-specific configuration for the
-                       endpoint
-        :return: None
+        Args:
+            endpoint: Unique name of endpoint to update
+            config: (optional) dict containing target-specific configuration for the
+                endpoint
+
+        Returns:
+            None
+
         """
         raise MlflowException(
             "Method is unimplemented in base client. Implementation should be "
@@ -263,8 +297,11 @@ class BaseDeploymentClient(abc.ABC):
         Delete the endpoint from the specified target. Deletion should be idempotent (i.e. deletion
         should not fail if retried on a non-existent deployment).
 
-        :param endpoint: Name of endpoint to delete
-        :return: None
+        Args:
+            endpoint: Name of endpoint to delete
+
+        Returns:
+            None
         """
         raise MlflowException(
             "Method is unimplemented in base client. Implementation should be "
@@ -280,9 +317,10 @@ class BaseDeploymentClient(abc.ABC):
         and to accept a `pagination_args` argument to this method for passing
         pagination-related args).
 
-        :return: A list of dicts corresponding to endpoints. Each dict is guaranteed to
-                 contain a 'name' key containing the endpoint name. The other fields of
-                 the returned dictionary and their types may vary across targets.
+        Returns:
+            A list of dicts corresponding to endpoints. Each dict is guaranteed to
+            contain a 'name' key containing the endpoint name. The other fields of
+            the returned dictionary and their types may vary across targets.
         """
         raise MlflowException(
             "Method is unimplemented in base client. Implementation should be "
@@ -297,10 +335,13 @@ class BaseDeploymentClient(abc.ABC):
         The dict is guaranteed to contain an 'name' key containing the endpoint name.
         The other fields of the returned dictionary and their types may vary across targets.
 
-        :param endpoint: Name of endpoint to fetch
-        :return: A dict corresponding to the retrieved endpoint. The dict is guaranteed to
-                 contain a 'name' key corresponding to the endpoint name. The other fields of
-                 the returned dictionary and their types may vary across targets.
+        Args:
+            endpoint: Name of endpoint to fetch
+
+        Returns:
+            A dict corresponding to the retrieved endpoint. The dict is guaranteed to
+            contain a 'name' key corresponding to the endpoint name. The other fields of
+            the returned dictionary and their types may vary across targets.
         """
         raise MlflowException(
             "Method is unimplemented in base client. Implementation should be "

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -206,7 +206,8 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
     @experimental
     def create_endpoint(self, name, config=None):
-        """Create a new serving endpoint with the provided name and configuration.
+        """
+        Create a new serving endpoint with the provided name and configuration.
 
         See https://docs.databricks.com/api/workspace/servingendpoints/create for request/response
         schema.
@@ -265,7 +266,8 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
     @experimental
     def update_endpoint(self, endpoint, config=None):
-        """Update a specified serving endpoint with the provided configuration.
+        """
+        Update a specified serving endpoint with the provided configuration.
         See https://docs.databricks.com/api/workspace/servingendpoints/updateconfig for
         request/response schema.
 
@@ -369,7 +371,8 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
     @experimental
     def list_endpoints(self):
-        """Retrieve all serving endpoints.
+        """
+        Retrieve all serving endpoints.
 
         See https://docs.databricks.com/api/workspace/servingendpoints/list for request/response
         schema.
@@ -403,7 +406,8 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
     @experimental
     def get_endpoint(self, endpoint):
-        """Get a specified serving endpoint.
+        """
+        Get a specified serving endpoint.
         See https://docs.databricks.com/api/workspace/servingendpoints/get for request/response
         schema.
 

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -151,10 +151,13 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
         See https://docs.databricks.com/api/workspace/servingendpoints/query for request/response
         schema.
 
-        :param deployment_name: Unused.
-        :param inputs: A dictionary containing the model inputs to query.
-        :param endpoint: The name of the serving endpoint to query.
-        :return: A :py:class:`DatabricksEndpoint` object containing the query response.
+        Args:
+            deployment_name: Unused.
+            inputs: A dictionary containing the model inputs to query.
+            endpoint: The name of the serving endpoint to query.
+
+        Returns:
+            A :py:class:`DatabricksEndpoint` object containing the query response.
 
         Example:
 
@@ -203,14 +206,17 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
     @experimental
     def create_endpoint(self, name, config=None):
-        """
-        Create a new serving endpoint with the provided name and configuration.
+        """Create a new serving endpoint with the provided name and configuration.
+
         See https://docs.databricks.com/api/workspace/servingendpoints/create for request/response
         schema.
 
-        :param name: The name of the serving endpoint to create.
-        :param config: A dictionary containing the configuration of the serving endpoint to create.
-        :return: A :py:class:`DatabricksEndpoint` object containing the request response.
+        Args:
+            name: The name of the serving endpoint to create.
+            config: A dictionary containing the configuration of the serving endpoint to create.
+
+        Returns:
+            A :py:class:`DatabricksEndpoint` object containing the request response.
 
         Example:
 
@@ -247,6 +253,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
                 "tags": [...],
                 "id": "88fd3f75a0d24b0380ddc40484d7a31b",
             }
+
         """
         config = config.copy() if config else {}  # avoid mutating config
         extras = {}
@@ -258,14 +265,16 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
     @experimental
     def update_endpoint(self, endpoint, config=None):
-        """
-        Update a specified serving endpoint with the provided configuration.
+        """Update a specified serving endpoint with the provided configuration.
         See https://docs.databricks.com/api/workspace/servingendpoints/updateconfig for
         request/response schema.
 
-        :param endpoint: The name of the serving endpoint to update.
-        :param config: A dictionary containing the configuration of the serving endpoint to update.
-        :return: A :py:class:`DatabricksEndpoint` object containing the request response.
+        Args:
+            endpoint: The name of the serving endpoint to update.
+            config: A dictionary containing the configuration of the serving endpoint to update.
+
+        Returns:
+            A :py:class:`DatabricksEndpoint` object containing the request response.
 
         Example:
 
@@ -341,8 +350,11 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
         See https://docs.databricks.com/api/workspace/servingendpoints/delete for request/response
         schema.
 
-        :param endpoint: The name of the serving endpoint to delete.
-        :return: A :py:class:`DatabricksEndpoint` object containing the request response.
+        Args:
+            endpoint: The name of the serving endpoint to delete.
+
+        Returns:
+            A DatabricksEndpoint object containing the request response.
 
         Example:
 
@@ -357,12 +369,13 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
 
     @experimental
     def list_endpoints(self):
-        """
-        Retrieve all serving endpoints.
+        """Retrieve all serving endpoints.
+
         See https://docs.databricks.com/api/workspace/servingendpoints/list for request/response
         schema.
 
-        :return: A list of :py:class:`DatabricksEndpoint` objects containing the request response.
+        Returns:
+            A list of :py:class:`DatabricksEndpoint` objects containing the request response.
 
         Example:
 
@@ -384,18 +397,21 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
                     "id": "88fd3f75a0d24b0380ddc40484d7a31b",
                 },
             ]
+
         """
         return self._call_endpoint(method="GET").endpoints
 
     @experimental
     def get_endpoint(self, endpoint):
-        """
-        Get a specified serving endpoint.
+        """Get a specified serving endpoint.
         See https://docs.databricks.com/api/workspace/servingendpoints/get for request/response
         schema.
 
-        :param endpoint: The name of the serving endpoint to get.
-        :return: A :py:class:`DatabricksEndpoint` object containing the request response.
+        Args:
+            endpoint: The name of the serving endpoint to get.
+
+        Returns:
+            A DatabricksEndpoint object containing the request response.
 
         Example:
 

--- a/mlflow/deployments/interface.py
+++ b/mlflow/deployments/interface.py
@@ -13,18 +13,17 @@ _logger = Logger(__name__)
 
 
 def get_deploy_client(target_uri=None):
-    """
-    Returns a subclass of :py:class:`mlflow.deployments.BaseDeploymentClient` exposing standard
+    """Returns a subclass of :py:class:`mlflow.deployments.BaseDeploymentClient` exposing standard
     APIs for deploying models to the specified target. See available deployment APIs
     by calling ``help()`` on the returned object or viewing docs for
     :py:class:`mlflow.deployments.BaseDeploymentClient`. You can also run
     ``mlflow deployments help -t <target-uri>`` via the CLI for more details on target-specific
     configuration options.
 
-    :param target_uri: Optional URI of target to deploy to. If no target URI is provided, then
-        MLflow will attempt to get the deployments target set via `get_deployments_target()` or
-        `MLFLOW_DEPLOYMENTS_TARGET` environment variable.
-
+    Args:
+        target_uri: Optional URI of target to deploy to. If no target URI is provided, then
+            MLflow will attempt to get the deployments target set via `get_deployments_target()` or
+            `MLFLOW_DEPLOYMENTS_TARGET` environment variable.
 
     .. code-block:: python
         :caption: Example
@@ -66,18 +65,20 @@ def get_deploy_client(target_uri=None):
 
 
 def run_local(target, name, model_uri, flavor=None, config=None):
-    """
-    Deploys the specified model locally, for testing. Note that models deployed locally cannot
+    """Deploys the specified model locally, for testing. Note that models deployed locally cannot
     be managed by other deployment APIs (e.g. ``update_deployment``, ``delete_deployment``, etc).
 
-    :param target: Target to deploy to.
-    :param name:  Name to use for deployment
-    :param model_uri: URI of model to deploy
-    :param flavor: (optional) Model flavor to deploy. If unspecified, a default flavor
-                   will be chosen.
-    :param config: (optional) Dict containing updated target-specific configuration for
-                   the deployment
-    :return: None
+    Args:
+        target: Target to deploy to.
+        name: Name to use for deployment
+        model_uri: URI of model to deploy
+        flavor: (optional) Model flavor to deploy. If unspecified, a default flavor
+            will be chosen.
+        config: (optional) Dict containing updated target-specific configuration for
+            the deployment
+
+    Returns:
+        None
     """
     return plugin_store[target].run_local(name, model_uri, flavor, config)
 
@@ -95,6 +96,7 @@ def _target_help(target):
       CLI profile https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
     * Any other target-specific details.
 
-    :param target: Which target to use. This information is used to call the appropriate plugin
+    Args:
+        target: Which target to use. This information is used to call the appropriate plugin.
     """
     return plugin_store[target].target_help()

--- a/mlflow/deployments/mlflow/__init__.py
+++ b/mlflow/deployments/mlflow/__init__.py
@@ -141,7 +141,8 @@ class MlflowDeploymentClient(BaseDeploymentClient):
 
     @experimental
     def get_endpoint(self, endpoint) -> "Endpoint":
-        """Gets a specified endpoint configured for the MLflow Deployments Server.
+        """
+        Gets a specified endpoint configured for the MLflow Deployments Server.
 
         Args:
             endpoint: The name of the endpoint to retrieve.
@@ -195,7 +196,8 @@ class MlflowDeploymentClient(BaseDeploymentClient):
 
     @experimental
     def list_endpoints(self) -> "List[Endpoint]":
-        """List endpoints configured for the MLflow Deployments Server.
+        """
+        List endpoints configured for the MLflow Deployments Server.
 
         Returns:
             A list of ``Endpoint`` objects.
@@ -231,7 +233,8 @@ class MlflowDeploymentClient(BaseDeploymentClient):
 
     @experimental
     def predict(self, deployment_name=None, inputs=None, endpoint=None) -> Dict[str, Any]:
-        """Submit a query to a configured provider endpoint.
+        """
+        Submit a query to a configured provider endpoint.
 
         Args:
             deployment_name: Unused.

--- a/mlflow/deployments/mlflow/__init__.py
+++ b/mlflow/deployments/mlflow/__init__.py
@@ -141,11 +141,13 @@ class MlflowDeploymentClient(BaseDeploymentClient):
 
     @experimental
     def get_endpoint(self, endpoint) -> "Endpoint":
-        """
-        Gets a specified endpoint configured for the MLflow Deployments Server.
+        """Gets a specified endpoint configured for the MLflow Deployments Server.
 
-        :param endpoint: The name of the endpoint to retrieve.
-        :return: An `Endpoint` object representing the endpoint.
+        Args:
+            endpoint: The name of the endpoint to retrieve.
+
+        Returns:
+            An `Endpoint` object representing the endpoint.
 
         Example:
 
@@ -193,9 +195,10 @@ class MlflowDeploymentClient(BaseDeploymentClient):
 
     @experimental
     def list_endpoints(self) -> "List[Endpoint]":
-        """
-        List endpoints configured for the MLflow Deployments Server.
-        :return: A list of ``Endpoint`` objects.
+        """List endpoints configured for the MLflow Deployments Server.
+
+        Returns:
+            A list of ``Endpoint`` objects.
 
         Example:
 
@@ -214,6 +217,7 @@ class MlflowDeploymentClient(BaseDeploymentClient):
                     "endpoint_url": "http://localhost:5000/gateway/chat/invocations",
                 },
             ]
+
         """
         endpoints = []
         next_page_token = None
@@ -227,13 +231,15 @@ class MlflowDeploymentClient(BaseDeploymentClient):
 
     @experimental
     def predict(self, deployment_name=None, inputs=None, endpoint=None) -> Dict[str, Any]:
-        """
-        Submit a query to a configured provider endpoint.
+        """Submit a query to a configured provider endpoint.
 
-        :param deployment_name: Unused.
-        :param inputs: The inputs to the query, as a dictionary.
-        :param endpoint: The name of the endpoint to query.
-        :return: A dictionary containing the response from the endpoint.
+        Args:
+            deployment_name: Unused.
+            inputs: The inputs to the query, as a dictionary.
+            endpoint: The name of the endpoint to query.
+
+        Returns:
+            A dictionary containing the response from the endpoint.
 
         Example:
 

--- a/mlflow/deployments/openai/__init__.py
+++ b/mlflow/deployments/openai/__init__.py
@@ -90,14 +90,17 @@ class OpenAIDeploymentClient(BaseDeploymentClient):
         raise NotImplementedError
 
     def predict(self, deployment_name=None, inputs=None, endpoint=None):
-        """
-        Query an OpenAI endpoint.
+        """Query an OpenAI endpoint.
         See https://platform.openai.com/docs/api-reference for more information.
 
-        :param deployment_name: Unused.
-        :param inputs: A dictionary containing the model inputs to query.
-        :param endpoint: The name of the endpoint to query.
-        :return: A dictionary containing the model outputs.
+        Args:
+            deployment_name: Unused.
+            inputs: A dictionary containing the model inputs to query.
+            endpoint: The name of the endpoint to query.
+
+        Returns:
+            A dictionary containing the model outputs.
+
         """
         _check_openai_key()
 

--- a/mlflow/deployments/plugin_manager.py
+++ b/mlflow/deployments/plugin_manager.py
@@ -55,13 +55,13 @@ class PluginManager(abc.ABC):
         return self._has_registered
 
     def register(self, target_name, plugin_module):
-        """
-        Register a deployment client given its target name and module
+        """Register a deployment client given its target name and module
 
-        :param target_name: The name of the deployment target. This name will be used by
-                            `get_deploy_client()` to retrieve a deployment client from
-                            the plugin store
-        :param plugin_module: The module that implements the deployment plugin interface
+        Args:
+            target_name: The name of the deployment target. This name will be used by
+                `get_deploy_client()` to retrieve a deployment client from
+                the plugin store.
+            plugin_module: The module that implements the deployment plugin interface.
         """
         self.registry[target_name] = entrypoints.EntryPoint(target_name, plugin_module, None)
 

--- a/mlflow/deployments/utils.py
+++ b/mlflow/deployments/utils.py
@@ -36,26 +36,29 @@ def _is_valid_uri(uri: str) -> bool:
 
 
 def resolve_endpoint_url(base_url: str, endpoint: str) -> str:
-    """
-    Performs a validation on whether the returned value is a fully qualified url
+    """Performs a validation on whether the returned value is a fully qualified url
     or requires the assembly of a fully qualified url by appending `endpoint`.
 
-    :param base_url: The base URL. Should include the scheme and domain, e.g.,
-                     ``http://127.0.0.1:6000``.
-    :param endpoint: The endpoint to be appended to the base URL, e.g., ``/api/2.0/endpoints/`` or,
-                     in the case of Databricks, the fully qualified url.
-    :return: The complete URL, either directly returned or formed and returned by joining the
-             base URL and the endpoint path.
+    Args:
+        base_url: The base URL. Should include the scheme and domain, e.g.,
+            ``http://127.0.0.1:6000``.
+        endpoint: The endpoint to be appended to the base URL, e.g., ``/api/2.0/endpoints/`` or,
+            in the case of Databricks, the fully qualified url.
+
+    Returns:
+        The complete URL, either directly returned or formed and returned by joining the
+        base URL and the endpoint path.
+
     """
     return endpoint if _is_valid_uri(endpoint) else append_to_uri_path(base_url, endpoint)
 
 
 def set_deployments_target(target: str):
-    """
-    Sets the target deployment client for MLflow deployments
+    """Sets the target deployment client for MLflow deployments
 
-    :param target: The full uri of a running MLflow deployments server or, if running on
-                        Databricks, "databricks".
+    Args:
+        target: The full uri of a running MLflow deployments server or, if running on
+            Databricks, "databricks".
     """
     if not _is_valid_target(target):
         raise MlflowException.invalid_parameter_value(

--- a/mlflow/entities/run_data.py
+++ b/mlflow/entities/run_data.py
@@ -13,11 +13,13 @@ class RunData(_MLflowObject):
     """
 
     def __init__(self, metrics=None, params=None, tags=None):
-        """
-        Construct a new :py:class:`mlflow.entities.RunData` instance.
-        :param metrics: List of :py:class:`mlflow.entities.Metric`.
-        :param params: List of :py:class:`mlflow.entities.Param`.
-        :param tags: List of :py:class:`mlflow.entities.RunTag`.
+        """Construct a new mlflow.entities.RunData instance.
+
+        Args:
+            metrics: List of mlflow.entities.Metric.
+            params: List of mlflow.entities.Param.
+            tags: List of mlflow.entities.RunTag.
+
         """
         # Maintain the original list of metrics so that we can easily convert it back to
         # protobuf

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -103,7 +103,7 @@ def save_model(
     Args:
         fastai_learner: fastai Learner to be saved.
         path: Local path where the model is to be saved.
-        conda_env: Inserted after the argument name.
+        conda_env: {{ conda_env }}
         code_paths: A list of local filesystem paths to Python file dependencies (or directories
             containing file dependencies). These files are *prepended* to the system
             path when the model is loaded.
@@ -121,9 +121,9 @@ def save_model(
                 predictions = ...  # compute model predictions
                 signature = infer_signature(train, predictions)
 
-        input_example: Inserted after the argument name.
-        pip_requirements: Inserted after the argument name.
-        extra_pip_requirements: Inserted after the argument name.
+        input_example: {{ input_example }}
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
         metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
             .. Note:: Experimental: This parameter may change or be removed in a future
@@ -251,7 +251,7 @@ def log_model(
     Args:
         fastai_learner: Fastai model (an instance of `fastai.Learner`_) to be saved.
         artifact_path: Run-relative artifact path.
-        conda_env: Inserted after the argument name.
+        conda_env: {{ conda_env }}
         code_paths: A list of local filesystem paths to Python file dependencies (or directories
             containing file dependencies). These files are *prepended* to the system
             path when the model is loaded.
@@ -272,13 +272,13 @@ def log_model(
               predictions = ...  # compute model predictions
               signature = infer_signature(train, predictions)
 
-        input_example: Inserted after the argument name.
+        input_example: {{ input_example }}
         kwargs: kwargs to pass to `fastai.Learner.export`_ method.
         await_registration_for: Number of seconds to wait for the model version to finish
             being created and is in ``READY`` status. By default, the function
             waits for five minutes. Specify 0 or None to skip waiting.
-        pip_requirements: Inserted after the argument name.
-        extra_pip_requirements: Inserted after the argument name.
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
         metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
             .. Note:: Experimental: This parameter may change or be removed in a future

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -63,9 +63,10 @@ _logger = logging.getLogger(__name__)
 
 def get_default_pip_requirements(include_cloudpickle=False):
     """
-    :return: A list of default pip requirements for MLflow Models produced by this flavor.
-             Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
-             that, at minimum, contains these requirements.
+    Returns:
+        A list of default pip requirements for MLflow Models produced by this flavor.
+        Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
+        that, at minimum, contains these requirements.
     """
     pip_deps = [_get_pinned_requirement("fastai")]
     if include_cloudpickle:
@@ -76,8 +77,9 @@ def get_default_pip_requirements(include_cloudpickle=False):
 
 def get_default_conda_env(include_cloudpickle=False):  # pylint: disable=unused-argument
     """
-    :return: The default Conda environment for MLflow Models produced by calls to
-             :func:`save_model()` and :func:`log_model()`.
+    Returns:
+        The default Conda environment for MLflow Models produced by calls to
+        :func:`save_model()` and :func:`log_model()`.
     """
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
@@ -96,40 +98,36 @@ def save_model(
     metadata=None,
     **kwargs,
 ):
-    """
-    Save a fastai Learner to a path on the local file system.
+    """Save a fastai Learner to a path on the local file system.
 
-    :param fastai_learner: fastai Learner to be saved.
-    :param path: Local path where the model is to be saved.
-    :param conda_env: {{ conda_env }}
-    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
-    :param mlflow_model: MLflow model config this flavor is being added to.
+    Args:
+        fastai_learner: fastai Learner to be saved.
+        path: Local path where the model is to be saved.
+        conda_env: Inserted after the argument name.
+        code_paths: A list of local filesystem paths to Python file dependencies (or directories
+            containing file dependencies). These files are *prepended* to the system
+            path when the model is loaded.
+        mlflow_model: MLflow model config this flavor is being added to.
+        signature: Describes model input and output Schema. The model signature can be inferred
+            from datasets with valid model input (e.g. the training dataset with target
+            column omitted) and valid model output (e.g. model predictions generated on
+            the training dataset), for example:
 
-    :param signature: :py:class:`ModelSignature <mlflow.models.ModelSignature>`
-                      describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
-                      The model signature can be :py:func:`inferred <mlflow.models.infer_signature>`
-                      from datasets with valid model input (e.g. the training dataset with target
-                      column omitted) and valid model output (e.g. model predictions generated on
-                      the training dataset), for example:
+            .. code-block:: python
 
-                      .. code-block:: python
+                from mlflow.models import infer_signature
 
-                        from mlflow.models import infer_signature
+                train = df.drop_column("target_label")
+                predictions = ...  # compute model predictions
+                signature = infer_signature(train, predictions)
+        input_example: Inserted after the argument name.
+        pip_requirements: Inserted after the argument name.
+        extra_pip_requirements: Inserted after the argument name.
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-                        train = df.drop_column("target_label")
-                        predictions = ...  # compute model predictions
-                        signature = infer_signature(train, predictions)
-    :param input_example: {{ input_example }}
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
-
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
-
-    :param kwargs: kwargs to pass to ``Learner.save`` method.
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                release without warning.
+        kwargs: kwargs to pass to ``Learner.save`` method.
 
     .. code-block:: python
         :caption: Example
@@ -246,88 +244,44 @@ def log_model(
     metadata=None,
     **kwargs,
 ):
-    """
-    Log a fastai model as an MLflow artifact for the current run.
+    """Log a fastai model as an MLflow artifact for the current run.
 
-    :param fastai_learner: Fastai model (an instance of `fastai.Learner`_) to be saved.
-    :param artifact_path: Run-relative artifact path.
-    :param conda_env: {{ conda_env }}
-    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
-    :param registered_model_name: This argument may change or be removed in a
-                                  future release without warning. If given, create a model
-                                  version under ``registered_model_name``, also creating a
-                                  registered model if one with the given name does not exist.
+    Args:
+        fastai_learner: Fastai model (an instance of `fastai.Learner`_) to be saved.
+        artifact_path: Run-relative artifact path.
+        conda_env: Inserted after the argument name.
+        code_paths: A list of local filesystem paths to Python file dependencies (or directories
+            containing file dependencies). These files are *prepended* to the system
+            path when the model is loaded.
+        registered_model_name: This argument may change or be removed in a
+            future release without warning. If given, create a model
+            version under ``registered_model_name``, also creating a
+            registered model if one with the given name does not exist.
+        signature: Describes model input and output Schema. The model signature can be inferred
+            from datasets with valid model input (e.g. the training dataset with target
+            column omitted) and valid model output (e.g. model predictions generated on
+            the training dataset), for example:
 
-    :param signature: :py:class:`ModelSignature <mlflow.models.ModelSignature>`
-                      describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
-                      The model signature can be :py:func:`inferred <mlflow.models.infer_signature>`
-                      from datasets with valid model input (e.g. the training dataset with target
-                      column omitted) and valid model output (e.g. model predictions generated on
-                      the training dataset), for example:
+            .. code-block:: python
+              from mlflow.models import infer_signature
 
-                      .. code-block:: python
+              train = df.drop_column("target_label")
+              predictions = ...  # compute model predictions
+              signature = infer_signature(train, predictions)
+        input_example: Inserted after the argument name.
+        kwargs: kwargs to pass to `fastai.Learner.export`_ method.
+        await_registration_for: Number of seconds to wait for the model version to finish
+            being created and is in ``READY`` status. By default, the function
+            waits for five minutes. Specify 0 or None to skip waiting.
+        pip_requirements: Inserted after the argument name.
+        extra_pip_requirements: Inserted after the argument name.
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-                        from mlflow.models import infer_signature
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                release without warning.
 
-                        train = df.drop_column("target_label")
-                        predictions = ...  # compute model predictions
-                        signature = infer_signature(train, predictions)
-    :param input_example: {{ input_example }}
-
-    :param kwargs: kwargs to pass to `fastai.Learner.export`_ method.
-    :param await_registration_for: Number of seconds to wait for the model version to finish
-                            being created and is in ``READY`` status. By default, the function
-                            waits for five minutes. Specify 0 or None to skip waiting.
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
-
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
-    :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
-             metadata of the logged model.
-
-    .. code-block:: python
-        :caption: Example
-
-        import fastai.vision as vis
-        import mlflow.fastai
-        from mlflow import MlflowClient
-
-
-        def main(epochs=5, learning_rate=0.01):
-            # Download and untar the MNIST data set
-            path = vis.untar_data(vis.URLs.MNIST_SAMPLE)
-
-            # Prepare, transform, and normalize the data
-            data = vis.ImageDataBunch.from_folder(
-                path, ds_tfms=(vis.rand_pad(2, 28), []), bs=64
-            )
-            data.normalize(vis.imagenet_stats)
-
-            # Create the CNN Learner model
-            model = vis.cnn_learner(data, vis.models.resnet18, metrics=vis.accuracy)
-
-            # Start MLflow session and log model
-            with mlflow.start_run() as run:
-                model.fit(epochs, learning_rate)
-                mlflow.fastai.log_model(model, "model")
-
-            # fetch the logged model artifacts
-            artifacts = [
-                f.path for f in MlflowClient().list_artifacts(run.info.run_id, "model")
-            ]
-            print(f"artifacts: {artifacts}")
-
-
-        main()
-
-    .. code-block:: text
-        :caption: Output
-
-        artifacts: ['model/MLmodel', 'model/conda.yaml', 'model/model.fastai']
+    Returns:
+        A ModelInfo instance that contains the metadata of the logged model.
     """
     return Model.log(
         artifact_path=artifact_path,
@@ -360,13 +314,15 @@ class _FastaiModelWrapper:
         self, dataframe, params: Optional[Dict[str, Any]] = None  # pylint: disable=unused-argument
     ):
         """
-        :param dataframe: Model input data.
-        :param params: Additional parameters to pass to the model for inference.
+        Args:
+            dataframe: Model input data.
+            params: Additional parameters to pass to the model for inference.
 
-                       .. Note:: Experimental: This parameter may change or be removed in a future
-                                               release without warning.
+                .. Note:: Experimental: This parameter may change or be removed in a future
+                    release without warning.
 
-        :return: Model predictions.
+        Returns:
+            Model predictions.
         """
         dl = self.learner.dls.test_dl(dataframe)
         preds, _ = self.learner.get_preds(dl=dl)
@@ -374,33 +330,35 @@ class _FastaiModelWrapper:
 
 
 def _load_pyfunc(path):
-    """
-    Load PyFunc implementation. Called by ``pyfunc.load_model``.
+    """Load PyFunc implementation. Called by ``pyfunc.load_model``.
 
-    :param path: Local filesystem path to the MLflow Model with the ``fastai`` flavor.
+    Args:
+        path: Local filesystem path to the MLflow Model with the ``fastai`` flavor.
+
     """
     return _FastaiModelWrapper(_load_model(path))
 
 
 def load_model(model_uri, dst_path=None):
-    """
-    Load a fastai model from a local file or a run.
+    """Load a fastai model from a local file or a run.
 
-    :param model_uri: The location, in URI format, of the MLflow model. For example:
+    Args:
+        model_uri: The location, in URI format, of the MLflow model. For example:
 
-                      - ``/Users/me/path/to/local/model``
-                      - ``relative/path/to/local/model``
-                      - ``s3://my_bucket/path/to/model``
-                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+            - ``/Users/me/path/to/local/model``
+            - ``relative/path/to/local/model``
+            - ``s3://my_bucket/path/to/model``
+            - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
 
-                      For more information about supported URI schemes, see
-                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
-                      artifact-locations>`_.
-    :param dst_path: The local filesystem path to which to download the model artifact.
-                     This directory must already exist. If unspecified, a local output
-                     path will be created.
+            For more information about supported URI schemes, see
+            `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
+            artifact-locations>`_.
+        dst_path: The local filesystem path to which to download the model artifact.
+            This directory must already exist. If unspecified, a local output
+            path will be created.
 
-    :return: A fastai model (an instance of `fastai.Learner`_).
+    Returns:
+        A fastai model (an instance of `fastai.Learner`_).
 
     .. code-block:: python
         :caption: Example
@@ -439,35 +397,35 @@ def autolog(
     registered_model_name=None,
     extra_tags=None,
 ):  # pylint: disable=unused-argument
-    """
-    Enable automatic logging from Fastai to MLflow.
-    Logs loss and any other metrics specified in the fit
-    function, and optimizer data as parameters. Model checkpoints
-    are logged as artifacts to a 'models' directory.
+    """Enable automatic logging from Fastai to MLflow.
+
+    Logs loss and any other metrics specified in the fit function, and optimizer data as parameters.
+    Model checkpoints are logged as artifacts to a 'models' directory.
 
     MLflow will also log the parameters of the
     `EarlyStoppingCallback <https://docs.fast.ai/callback.tracker.html#EarlyStoppingCallback>`_
     and `OneCycleScheduler <https://docs.fast.ai/callback.schedule.html#ParamScheduler>`_ callbacks
 
-    :param log_models: If ``True``, trained models are logged as MLflow model artifacts.
-                       If ``False``, trained models are not logged.
-    :param log_datasets: If ``True``, dataset information is logged to MLflow Tracking.
-                         If ``False``, dataset information is not logged.
-    :param disable: If ``True``, disables the Fastai autologging integration. If ``False``,
-                    enables the Fastai autologging integration.
-    :param exclusive: If ``True``, autologged content is not logged to user-created fluent runs.
-                      If ``False``, autologged content is logged to the active fluent run,
-                      which may be user-created.
-    :param disable_for_unsupported_versions: If ``True``, disable autologging for versions of
-                      fastai that have not been tested against this version of the MLflow client
-                      or are incompatible.
-    :param silent: If ``True``, suppress all event logs and warnings from MLflow during Fastai
-                   autologging. If ``False``, show all events and warnings during Fastai
-                   autologging.
-    :param registered_model_name: If given, each time a model is trained, it is registered as a
-                                  new model version of the registered model with this name.
-                                  The registered model is created if it does not already exist.
-    :param extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
+    Args:
+        log_models: If ``True``, trained models are logged as MLflow model artifacts.
+            If ``False``, trained models are not logged.
+        log_datasets: If ``True``, dataset information is logged to MLflow Tracking.
+            If ``False``, dataset information is not logged.
+        disable: If ``True``, disables the Fastai autologging integration. If ``False``,
+            enables the Fastai autologging integration.
+        exclusive: If ``True``, autologged content is not logged to user-created fluent runs.
+            If ``False``, autologged content is logged to the active fluent run,
+            which may be user-created.
+        disable_for_unsupported_versions: If ``True``, disable autologging for versions of
+            fastai that have not been tested against this version of the MLflow client
+            or are incompatible.
+        silent: If ``True``, suppress all event logs and warnings from MLflow during Fastai
+            autologging. If ``False``, show all events and warnings during Fastai
+            autologging.
+        registered_model_name: If given, each time a model is trained, it is registered as a
+            new model version of the registered model with this name.
+            The registered model is created if it does not already exist.
+        extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -120,6 +120,7 @@ def save_model(
                 train = df.drop_column("target_label")
                 predictions = ...  # compute model predictions
                 signature = infer_signature(train, predictions)
+
         input_example: Inserted after the argument name.
         pip_requirements: Inserted after the argument name.
         extra_pip_requirements: Inserted after the argument name.
@@ -127,6 +128,7 @@ def save_model(
 
             .. Note:: Experimental: This parameter may change or be removed in a future
                 release without warning.
+
         kwargs: kwargs to pass to ``Learner.save`` method.
 
     .. code-block:: python
@@ -263,11 +265,13 @@ def log_model(
             the training dataset), for example:
 
             .. code-block:: python
+
               from mlflow.models import infer_signature
 
               train = df.drop_column("target_label")
               predictions = ...  # compute model predictions
               signature = infer_signature(train, predictions)
+
         input_example: Inserted after the argument name.
         kwargs: kwargs to pass to `fastai.Learner.export`_ method.
         await_registration_for: Number of seconds to wait for the model version to finish
@@ -344,7 +348,6 @@ def load_model(model_uri, dst_path=None):
 
     Args:
         model_uri: The location, in URI format, of the MLflow model. For example:
-
             - ``/Users/me/path/to/local/model``
             - ``relative/path/to/local/model``
             - ``s3://my_bucket/path/to/model``
@@ -407,25 +410,26 @@ def autolog(
     and `OneCycleScheduler <https://docs.fast.ai/callback.schedule.html#ParamScheduler>`_ callbacks
 
     Args:
-        log_models: If ``True``, trained models are logged as MLflow model artifacts.
-            If ``False``, trained models are not logged.
-        log_datasets: If ``True``, dataset information is logged to MLflow Tracking.
-            If ``False``, dataset information is not logged.
-        disable: If ``True``, disables the Fastai autologging integration. If ``False``,
-            enables the Fastai autologging integration.
-        exclusive: If ``True``, autologged content is not logged to user-created fluent runs.
-            If ``False``, autologged content is logged to the active fluent run,
-            which may be user-created.
-        disable_for_unsupported_versions: If ``True``, disable autologging for versions of
-            fastai that have not been tested against this version of the MLflow client
-            or are incompatible.
+        log_models: If ``True``, trained models are logged as MLflow model artifacts. If ``False``,
+            trained models are not logged.
+        log_datasets: If ``True``, dataset information is logged to MLflow Tracking. If ``False``,
+            dataset information is not logged.
+        disable: If ``True``, disables the Fastai autologging integration. If ``False``, enables
+            the Fastai autologging integration.
+        exclusive: If ``True``, autologged content is not logged to user-created fluent runs. If
+            ``False``, autologged content is logged to the active fluent run, which may
+            be user-created.
+        disable_for_unsupported_versions: If ``True``, disable autologging for versions of fastai
+            that have not been tested against this version of the MLflow client or are
+            incompatible.
         silent: If ``True``, suppress all event logs and warnings from MLflow during Fastai
-            autologging. If ``False``, show all events and warnings during Fastai
+            autologging. If ``False``, show all events and warnings during Fastai autologging.
+        registered_model_name: If given, each time a model is trained, it is registered as a new
+            model version of the registered model with this name. The registered model is created
+            if it does not already exist.
+        extra_tags: A dictionary of extra tags to set on each managed run created by
             autologging.
-        registered_model_name: If given, each time a model is trained, it is registered as a
-            new model version of the registered model with this name.
-            The registered model is created if it does not already exist.
-        extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
+
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -317,6 +317,11 @@ def log_model(
 
 
         main()
+
+    .. code-block:: text
+        :caption: Output
+
+        artifacts: ['model/MLmodel', 'model/conda.yaml', 'model/model.fastai']
     """
     return Model.log(
         artifact_path=artifact_path,

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -64,21 +64,24 @@ class MlflowGatewayClient:
 
     @property
     def gateway_uri(self):
-        """
-        Get the current value for the URI of the MLflow Gateway.
+        """Get the current value for the URI of the MLflow Gateway.
 
-        :return: The gateway URI.
+        Returns:
+            The gateway URI.
         """
         return self._gateway_uri
 
     def _call_endpoint(self, method: str, route: str, json_body: Optional[str] = None):
-        """
-        Call a specific endpoint on the Gateway API.
+        """Call a specific endpoint on the Gateway API.
 
-        :param method: The HTTP method to use.
-        :param route: The API route to call.
-        :param json_body: Optional JSON body to include in the request.
-        :return: The server's response.
+        Args:
+            method: The HTTP method to use.
+            route: The API route to call.
+            json_body: Optional JSON body to include in the request.
+
+        Returns:
+            The server's response.
+
         """
         if json_body:
             json_body = json.loads(json_body)
@@ -103,15 +106,18 @@ class MlflowGatewayClient:
 
     @gateway_deprecated
     def get_route(self, name: str):
-        """
-        Get a specific query route from the gateway. The routes that are available to retrieve
+        """Get a specific query route from the gateway. The routes that are available to retrieve
         are only those that have been configured through the MLflow Gateway Server configuration
         file (set during server start or through server update commands).
 
-        :param name: The name of the route.
-        :return: The returned data structure is a serialized representation of the `Route` data
+        Args:
+            name: The name of the route.
+
+        Returns:
+            The returned data structure is a serialized representation of the `Route` data
             structure, giving information about the name, type, and model details (model name
             and provider) for the requested route endpoint.
+
         """
         route = assemble_uri_path([MLFLOW_GATEWAY_CRUD_ROUTE_BASE, name])
         response = self._call_endpoint("GET", route).json()
@@ -121,14 +127,17 @@ class MlflowGatewayClient:
 
     @gateway_deprecated
     def search_routes(self, page_token: Optional[str] = None) -> PagedList[Route]:
-        """
-        Search for routes in the Gateway.
+        """Search for routes in the Gateway.
 
-        :param page_token: Token specifying the next page of results. It should be obtained from
-                           a prior ``search_routes()`` call.
-        :return: Returns a list of all configured and initialized `Route` data for the MLflow
+        Args:
+            page_token: Token specifying the next page of results. It should be obtained from
+                a prior ``search_routes()`` call.
+
+        Returns:
+            Returns a list of all configured and initialized `Route` data for the MLflow
             Gateway Server. The return will be a list of dictionaries that detail the name, type,
             and model details of each active route endpoint.
+
         """
         request_parameters = {"page_token": page_token} if page_token is not None else None
         response_json = self._call_endpoint(
@@ -153,8 +162,7 @@ class MlflowGatewayClient:
     def create_route(
         self, name: str, route_type: Optional[str] = None, model: Optional[Dict[str, Any]] = None
     ) -> Route:
-        """
-        Create a new route in the Gateway.
+        """Create a new route in the Gateway.
 
         .. warning::
 
@@ -162,28 +170,29 @@ class MlflowGatewayClient:
             route configuration is handled via updates to the route configuration YAML file that
             is specified during Gateway server start.
 
-        :param name: The name of the route. This parameter is required for all routes.
-        :param route_type: The type of the route (e.g., 'llm/v1/chat', 'llm/v1/completions',
-                           'llm/v1/embeddings'). This parameter is required for routes that are
-                           not managed by Databricks (the provider isn't 'databricks').
-        :param model: A dictionary representing the model details to be associated with the route.
-                      This parameter is required for all routes. This dictionary should define:
+        Args:
+            name: The name of the route. This parameter is required for all routes.
+            route_type: The type of the route (e.g., 'llm/v1/chat', 'llm/v1/completions',
+                'llm/v1/embeddings'). This parameter is required for routes that are
+                not managed by Databricks (the provider isn't 'databricks').
+            model: A dictionary representing the model details to be associated with the route.
+                This parameter is required for all routes. This dictionary should define:
+                - The model name (e.g., "gpt-3.5-turbo")
+                - The provider (e.g., "openai", "anthropic")
+                - The configuration for the model used in the route
 
-                      - The model name (e.g., "gpt-3.5-turbo")
-                      - The provider (e.g., "openai", "anthropic")
-                      - The configuration for the model used in the route
+        Returns:
+            A serialized representation of the `Route` data structure,
+            providing information about the name, type, and model details for the
+            newly created route endpoint.
 
-        :return: A serialized representation of the `Route` data structure,
-                 providing information about the name, type, and model details for the
-                 newly created route endpoint.
-
-        :raises mlflow.MlflowException: If the function is not running within Databricks.
+        Raises:
+            mlflow.MlflowException: If the function is not running within Databricks.
 
         .. note::
 
             See the official Databricks documentation for MLflow Gateway for examples of supported
             model configurations and how to dynamically create new routes within Databricks.
-
 
         Example usage from within Databricks:
 
@@ -206,7 +215,6 @@ class MlflowGatewayClient:
                     },
                 },
             )
-
         """
         if not self._is_databricks_host():
             raise MlflowException(
@@ -228,8 +236,7 @@ class MlflowGatewayClient:
 
     @gateway_deprecated
     def delete_route(self, name: str) -> None:
-        """
-        Delete an existing route in the Gateway.
+        """Delete an existing route in the Gateway.
 
         .. warning::
 
@@ -237,9 +244,11 @@ class MlflowGatewayClient:
             route deletion is handled by removing the corresponding entry from the route
             configuration YAML file that is specified during Gateway server start.
 
-        :param name: The name of the route to delete.
+        Args:
+            name: The name of the route to delete.
 
-        :raises mlflow.MlflowException: If the function is not running within Databricks.
+        Raises:
+            mlflow.MlflowException: If the function is not running within Databricks.
 
         Example usage from within Databricks:
 
@@ -249,7 +258,6 @@ class MlflowGatewayClient:
 
             gateway_client = MlflowGatewayClient("databricks")
             gateway_client.delete_route("my-existing-route")
-
         """
         if not self._is_databricks_host():
             raise MlflowException(
@@ -264,70 +272,76 @@ class MlflowGatewayClient:
 
     @gateway_deprecated
     def query(self, route: str, data: Dict[str, Any]):
-        """
-        Submit a query to a configured provider route.
+        """Submit a query to a configured provider route.
 
-        :param route: The name of the route to submit the query to.
-        :param data: The data to send in the query. A dictionary representing the per-route
-            specific structure required for a given provider.
-        :return: The route's response as a dictionary, standardized to the route type.
+        Args:
+            route: The name of the route to submit the query to.
+            data: The data to send in the query. A dictionary representing the per-route
+                specific structure required for a given provider.
 
-        For chat, the structure should be:
+                For chat, the structure should be:
 
-        .. code-block:: python
+                .. code-block:: python
 
-            from mlflow.gateway import MlflowGatewayClient
+                    from mlflow.gateway import MlflowGatewayClient
 
-            gateway_client = MlflowGatewayClient("http://my.gateway:8888")
+                    gateway_client = MlflowGatewayClient("http://my.gateway:8888")
 
-            response = gateway_client.query(
-                "my-chat-route",
-                {"messages": [{"role": "user", "content": "Tell me a joke about rabbits"}, ...]},
-            )
+                    response = gateway_client.query(
+                        "my-chat-route",
+                        {
+                            "messages": [
+                                {"role": "user", "content": "Tell me a joke about rabbits"},
+                            ]
+                        },
+                    )
 
-        For completions, the structure should be:
+                For completions, the structure should be:
 
-        .. code-block:: python
+                .. code-block:: python
 
-            from mlflow.gateway import MlflowGatewayClient
+                    from mlflow.gateway import MlflowGatewayClient
 
-            gateway_client = MlflowGatewayClient("http://my.gateway:8888")
+                    gateway_client = MlflowGatewayClient("http://my.gateway:8888")
 
-            response = gateway_client.query(
-                "my-completions-route", {"prompt": "It's one small step for"}
-            )
+                    response = gateway_client.query(
+                        "my-completions-route", {"prompt": "It's one small step for"}
+                    )
 
-        For embeddings, the structure should be:
+                For embeddings, the structure should be:
 
-        .. code-block:: python
+                .. code-block:: python
 
-            from mlflow.gateway import MlflowGatewayClient
+                    from mlflow.gateway import MlflowGatewayClient
 
-            gateway_client = MlflowGatewayClient("http://my.gateway:8888")
+                    gateway_client = MlflowGatewayClient("http://my.gateway:8888")
 
-            response = gateway_client.query(
-                "my-embeddings-route",
-                {"text": ["It was the best of times", "It was the worst of times"]},
-            )
+                    response = gateway_client.query(
+                        "my-embeddings-route",
+                        {"text": ["It was the best of times", "It was the worst of times"]},
+                    )
 
-        Additional parameters that are valid for a given provider and route configuration can be
-        included with the request as shown below, using an openai completions route request as
-        an example:
+                Additional parameters that are valid for a given provider and route configuration
+                can be included with the request as shown below, using an openai completions route
+                request as an example:
 
-        .. code-block:: python
+                .. code-block:: python
 
-            from mlflow.gateway import MlflowGatewayClient
+                    from mlflow.gateway import MlflowGatewayClient
 
-            gateway_client = MlflowGatewayClient("http://my.gateway:8888")
+                    gateway_client = MlflowGatewayClient("http://my.gateway:8888")
 
-            response = gateway_client.query(
-                "my-completions-route",
-                {
-                    "prompt": "Give me an example of a properly formatted pytest unit test",
-                    "temperature": 0.3,
-                    "max_tokens": 500,
-                },
-            )
+                    response = gateway_client.query(
+                        "my-completions-route",
+                        {
+                            "prompt": "Give me an example of a properly formatted pytest unit test",
+                            "temperature": 0.3,
+                            "max_tokens": 500,
+                        },
+                    )
+
+        Returns:
+            The route's response as a dictionary, standardized to the route type.
 
         """
 
@@ -353,27 +367,28 @@ class MlflowGatewayClient:
 
     @gateway_deprecated
     def set_limits(self, route: str, limits: List[Dict[str, Any]]) -> LimitsConfig:
-        """
-        Set limits on an existing route in the Gateway.
+        """Set limits on an existing route in the Gateway.
 
         .. warning::
 
             This API is **only available** when running within Databricks.
 
-        :param route: The name of the route to set limits on.
-        :param limits: Limits (Array of dictionary) to set on the route. Each limit is defined by a
-                       dictionary representing the limit details to be associated with the route.
-                       This dictionary should define:
+        Args:
+            route: The name of the route to set limits on.
+            limits: Limits (Array of dictionary) to set on the route. Each limit is defined by a
+                dictionary representing the limit details to be associated with the route.
+                This dictionary should define:
 
-                       - renewal_period: a string representing the length of the window
-                         to enforce limit on (only supports "minute" for now).
-                       - calls: a non-negative integer representing the number of calls
-                         allowed per renewal_period (e.g., 10, 0, 55).
-                       - key: an optional string represents per route limit or per user
-                         limit ("user" for per user limit, "route" for per route limit, if not
-                         supplied, default to per route limit).
+                - renewal_period: a string representing the length of the window
+                  to enforce limit on (only supports "minute" for now).
+                - calls: a non-negative integer representing the number of calls
+                  allowed per renewal_period (e.g., 10, 0, 55).
+                - key: an optional string represents per route limit or per user
+                  limit ("user" for per user limit, "route" for per route limit, if not
+                  supplied, default to per route limit).
 
-        :return: The returned data structure is a serialized representation of the `Limit`
+        Returns:
+            The returned data structure is a serialized representation of the `Limit`
             data structure, giving information about the renewal_period, key, and calls.
 
         Example usage:
@@ -400,16 +415,17 @@ class MlflowGatewayClient:
 
     @gateway_deprecated
     def get_limits(self, route: str) -> LimitsConfig:
-        """
-        Get limits of an existing route in the Gateway.
+        """Get limits of an existing route in the Gateway.
 
         .. warning::
 
             This API is **only available** when connected to a Databricks-hosted AI Gateway.
 
-        :param route: The name of the route to get limits of.
+        Args:
+            route: The name of the route to get limits of.
 
-        :return: The returned data structure is a serialized representation of the `Limit` data
+        Returns:
+            The returned data structure is a serialized representation of the `Limit` data
             structure, giving information about the renewal_period, key, and calls.
 
         Example usage:
@@ -421,7 +437,6 @@ class MlflowGatewayClient:
             gateway_client = MlflowGatewayClient("databricks")
 
             gateway_client.get_limits("my-new-route")
-
         """
         if not route:
             raise MlflowException("A non-empty string is required for the route.", BAD_REQUEST)

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -64,7 +64,8 @@ class MlflowGatewayClient:
 
     @property
     def gateway_uri(self):
-        """Get the current value for the URI of the MLflow Gateway.
+        """
+        Get the current value for the URI of the MLflow Gateway.
 
         Returns:
             The gateway URI.
@@ -72,7 +73,8 @@ class MlflowGatewayClient:
         return self._gateway_uri
 
     def _call_endpoint(self, method: str, route: str, json_body: Optional[str] = None):
-        """Call a specific endpoint on the Gateway API.
+        """
+        Call a specific endpoint on the Gateway API.
 
         Args:
             method: The HTTP method to use.
@@ -106,7 +108,8 @@ class MlflowGatewayClient:
 
     @gateway_deprecated
     def get_route(self, name: str):
-        """Get a specific query route from the gateway. The routes that are available to retrieve
+        """
+        Get a specific query route from the gateway. The routes that are available to retrieve
         are only those that have been configured through the MLflow Gateway Server configuration
         file (set during server start or through server update commands).
 
@@ -127,7 +130,8 @@ class MlflowGatewayClient:
 
     @gateway_deprecated
     def search_routes(self, page_token: Optional[str] = None) -> PagedList[Route]:
-        """Search for routes in the Gateway.
+        """
+        Search for routes in the Gateway.
 
         Args:
             page_token: Token specifying the next page of results. It should be obtained from
@@ -178,9 +182,10 @@ class MlflowGatewayClient:
                 Databricks (the provider isn't 'databricks').
             model: A dictionary representing the model details to be associated with the route.
                 This parameter is required for all routes. This dictionary should define:
-                - The model name (e.g., "gpt-3.5-turbo")
-                - The provider (e.g., "openai", "anthropic")
-                - The configuration for the model used in the route
+
+                    - The model name (e.g., "gpt-3.5-turbo")
+                    - The provider (e.g., "openai", "anthropic")
+                    - The configuration for the model used in the route
 
         Returns:
             A serialized representation of the `Route` data structure,
@@ -237,7 +242,8 @@ class MlflowGatewayClient:
 
     @gateway_deprecated
     def delete_route(self, name: str) -> None:
-        """Delete an existing route in the Gateway.
+        """
+        Delete an existing route in the Gateway.
 
         .. warning::
 
@@ -413,7 +419,8 @@ class MlflowGatewayClient:
 
     @gateway_deprecated
     def get_limits(self, route: str) -> LimitsConfig:
-        """Get limits of an existing route in the Gateway.
+        """
+        Get limits of an existing route in the Gateway.
 
         .. warning::
 

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -162,7 +162,8 @@ class MlflowGatewayClient:
     def create_route(
         self, name: str, route_type: Optional[str] = None, model: Optional[Dict[str, Any]] = None
     ) -> Route:
-        """Create a new route in the Gateway.
+        """
+        Create a new route in the Gateway.
 
         .. warning::
 
@@ -173,8 +174,8 @@ class MlflowGatewayClient:
         Args:
             name: The name of the route. This parameter is required for all routes.
             route_type: The type of the route (e.g., 'llm/v1/chat', 'llm/v1/completions',
-                'llm/v1/embeddings'). This parameter is required for routes that are
-                not managed by Databricks (the provider isn't 'databricks').
+                'llm/v1/embeddings'). This parameter is required for routes that are not managed by
+                Databricks (the provider isn't 'databricks').
             model: A dictionary representing the model details to be associated with the route.
                 This parameter is required for all routes. This dictionary should define:
                 - The model name (e.g., "gpt-3.5-turbo")
@@ -272,7 +273,8 @@ class MlflowGatewayClient:
 
     @gateway_deprecated
     def query(self, route: str, data: Dict[str, Any]):
-        """Submit a query to a configured provider route.
+        """
+        Submit a query to a configured provider route.
 
         Args:
             route: The name of the route to submit the query to.
@@ -367,7 +369,8 @@ class MlflowGatewayClient:
 
     @gateway_deprecated
     def set_limits(self, route: str, limits: List[Dict[str, Any]]) -> LimitsConfig:
-        """Set limits on an existing route in the Gateway.
+        """
+        Set limits on an existing route in the Gateway.
 
         .. warning::
 
@@ -376,16 +379,11 @@ class MlflowGatewayClient:
         Args:
             route: The name of the route to set limits on.
             limits: Limits (Array of dictionary) to set on the route. Each limit is defined by a
-                dictionary representing the limit details to be associated with the route.
-                This dictionary should define:
-
-                - renewal_period: a string representing the length of the window
-                  to enforce limit on (only supports "minute" for now).
-                - calls: a non-negative integer representing the number of calls
-                  allowed per renewal_period (e.g., 10, 0, 55).
-                - key: an optional string represents per route limit or per user
-                  limit ("user" for per user limit, "route" for per route limit, if not
-                  supplied, default to per route limit).
+                dictionary representing the limit details to be associated with the route. This
+                dictionary should define:
+                - renewal_period: a string representing the length of the window to enforce limit on (only supports "minute" for now). # pylint: disable=line-too-long
+                - calls: a non-negative integer representing the number of calls allowed per  renewal_period (e.g., 10, 0, 55). # pylint: disable=line-too-long
+                - key: an optional string represents per route limit or per user limit ("user" for per user limit, "route" for per route limit, if not supplied, default to per route limit). # pylint: disable=line-too-long
 
         Returns:
             The returned data structure is a serialized representation of the `Limit`

--- a/mlflow/gateway/fluent.py
+++ b/mlflow/gateway/fluent.py
@@ -9,27 +9,31 @@ from mlflow.utils import get_results_from_paginated_fn
 
 @gateway_deprecated
 def get_route(name: str) -> Route:
-    """
-    Retrieves a specific route from the MLflow Gateway service.
+    """Retrieves a specific route from the MLflow Gateway service.
 
     This function creates an instance of MlflowGatewayClient and uses it to fetch a route by its
     name from the Gateway service.
 
-    :param name: The name of the route to fetch.
-    :return: An instance of the Route class representing the fetched route.
+    Args:
+        name: The name of the route to fetch.
+
+    Returns:
+        An instance of the Route class representing the fetched route.
+
     """
     return MlflowGatewayClient().get_route(name)
 
 
 @gateway_deprecated
 def search_routes() -> List[Route]:
-    """
-    Searches for routes in the MLflow Gateway service.
+    """Searches for routes in the MLflow Gateway service.
 
     This function creates an instance of MlflowGatewayClient and uses it to fetch a list of routes
     from the Gateway service.
 
-    :return: A list of Route instances.
+    Returns:
+        A list of Route instances.
+
     """
 
     def pagination_wrapper_func(_, next_page_token):
@@ -46,8 +50,7 @@ def search_routes() -> List[Route]:
 def create_route(
     name: str, route_type: Optional[str] = None, model: Optional[Dict[str, Any]] = None
 ) -> Route:
-    """
-    Create a new route in the Gateway.
+    """Create a new route in the Gateway.
 
     .. warning::
 
@@ -55,26 +58,26 @@ def create_route(
         route configuration is handled via updates to the route configuration YAML file that
         is specified during Gateway server start.
 
-    :param name: The name of the route. This parameter is required for all routes.
-    :param route_type: The type of the route (e.g., 'llm/v1/chat', 'llm/v1/completions',
-                       'llm/v1/embeddings'). This parameter is required for routes that are
-                       not managed by Databricks (the provider isn't 'databricks').
-    :param model: A dictionary representing the model details to be associated with the route.
-                  This parameter is required for all routes. This dictionary should define:
+    Args:
+        name: The name of the route. This parameter is required for all routes.
+        route_type: The type of the route (e.g., 'llm/v1/chat', 'llm/v1/completions',
+            'llm/v1/embeddings'). This parameter is required for routes that are
+            not managed by Databricks (the provider isn't 'databricks').
+        model: A dictionary representing the model details to be associated with the route.
+            This parameter is required for all routes. This dictionary should define:
+            - The model name (e.g., "gpt-3.5-turbo")
+            - The provider (e.g., "openai", "anthropic")
+            - The configuration for the model used in the route
 
-                  - The model name (e.g., "gpt-3.5-turbo")
-                  - The provider (e.g., "openai", "anthropic")
-                  - The configuration for the model used in the route
-
-    :return: A serialized representation of the `Route` data structure,
-             providing information about the name, type, and model details for the
-             newly created route endpoint.
+    Returns:
+        A serialized representation of the `Route` data structure,
+        providing information about the name, type, and model details for the
+        newly created route endpoint.
 
     .. note::
 
         See the official Databricks documentation for MLflow Gateway for examples of supported
         model configurations and how to dynamically create new routes within Databricks.
-
 
     Example usage from within Databricks:
 
@@ -97,15 +100,13 @@ def create_route(
                 },
             },
         )
-
     """
     return MlflowGatewayClient().create_route(name, route_type, model)
 
 
 @gateway_deprecated
 def delete_route(name: str) -> None:
-    """
-    Delete an existing route in the Gateway.
+    """Delete an existing route in the Gateway.
 
     .. warning::
 
@@ -113,7 +114,8 @@ def delete_route(name: str) -> None:
         route deletion is handled by removing the corresponding entry from the route
         configuration YAML file that is specified during Gateway server start.
 
-    :param name: The name of the route to delete.
+    Args:
+        name: The name of the route to delete.
 
     Example usage from within Databricks:
 
@@ -124,22 +126,21 @@ def delete_route(name: str) -> None:
         set_gateway_uri(gateway_uri="databricks")
 
         delete_route("my-new-route")
-
     """
     MlflowGatewayClient().delete_route(name)
 
 
 @gateway_deprecated
 def set_limits(route: str, limits: List[Dict[str, Any]]) -> LimitsConfig:
-    """
-    Set limits on an existing route in the Gateway.
+    """Set limits on an existing route in the Gateway.
 
     .. warning::
 
         This API is **only available** when running within Databricks.
 
-    :param route: The name of the route to set limits on.
-    :param limits: Limits to set on the route.
+    Args:
+        route: The name of the route to set limits on.
+        limits: Limits to set on the route.
 
     Example usage from within Databricks:
 
@@ -150,21 +151,20 @@ def set_limits(route: str, limits: List[Dict[str, Any]]) -> LimitsConfig:
         set_gateway_uri(gateway_uri="databricks")
 
         set_limits("my-new-route", [{"key": "user", "renewal_period": "minute", "calls": 50}])
-
     """
     return MlflowGatewayClient().set_limits(route=route, limits=limits)
 
 
 @gateway_deprecated
 def get_limits(route: str) -> LimitsConfig:
-    """
-    Get limits of an existing route in the Gateway.
+    """Get limits of an existing route in the Gateway.
 
     .. warning::
 
         This API is **only available** when connected to a Databricks-hosted AI Gateway.
 
-    :param route: The name of the route to get limits of.
+    Args:
+        route: The name of the route to get limits of.
 
     Example usage from within Databricks:
 
@@ -175,23 +175,24 @@ def get_limits(route: str) -> LimitsConfig:
         set_gateway_uri(gateway_uri="databricks")
 
         get_limits("my-new-route")
-
     """
     return MlflowGatewayClient().get_limits(route=route)
 
 
 @gateway_deprecated
 def query(route: str, data):
-    """
-    Issues a query request to a configured service through a named route on the Gateway Server.
+    """Issues a query request to a configured service through a named route on the Gateway Server.
     This function will interface with a configured route name (examples below) and return the
     response from the provider in a standardized format.
 
-    :param route: The name of the configured route. Route names can be obtained by running
-                  `mlflow.gateway.search_routes()`
-    :param data: The request payload to be submitted to the route. The exact configuration of
-                 the expected structure varies based on the route configuration.
-    :return: The response from the configured route endpoint provider in a standardized format.
+    Args:
+        route: The name of the configured route. Route names can be obtained by running
+            `mlflow.gateway.search_routes()`
+        data: The request payload to be submitted to the route. The exact configuration of
+            the expected structure varies based on the route configuration.
+
+    Returns:
+        The response from the configured route endpoint provider in a standardized format.
 
     Chat example:
 
@@ -242,6 +243,5 @@ def query(route: str, data):
                 "max_tokens": 1000,
             },
         )
-
     """
     return MlflowGatewayClient().query(route, data)

--- a/mlflow/gateway/fluent.py
+++ b/mlflow/gateway/fluent.py
@@ -9,7 +9,8 @@ from mlflow.utils import get_results_from_paginated_fn
 
 @gateway_deprecated
 def get_route(name: str) -> Route:
-    """Retrieves a specific route from the MLflow Gateway service.
+    """
+    Retrieves a specific route from the MLflow Gateway service.
 
     This function creates an instance of MlflowGatewayClient and uses it to fetch a route by its
     name from the Gateway service.
@@ -26,7 +27,8 @@ def get_route(name: str) -> Route:
 
 @gateway_deprecated
 def search_routes() -> List[Route]:
-    """Searches for routes in the MLflow Gateway service.
+    """
+    Searches for routes in the MLflow Gateway service.
 
     This function creates an instance of MlflowGatewayClient and uses it to fetch a list of routes
     from the Gateway service.
@@ -107,7 +109,8 @@ def create_route(
 
 @gateway_deprecated
 def delete_route(name: str) -> None:
-    """Delete an existing route in the Gateway.
+    """
+    Delete an existing route in the Gateway.
 
     .. warning::
 
@@ -133,7 +136,8 @@ def delete_route(name: str) -> None:
 
 @gateway_deprecated
 def set_limits(route: str, limits: List[Dict[str, Any]]) -> LimitsConfig:
-    """Set limits on an existing route in the Gateway.
+    """
+    Set limits on an existing route in the Gateway.
 
     .. warning::
 
@@ -158,7 +162,8 @@ def set_limits(route: str, limits: List[Dict[str, Any]]) -> LimitsConfig:
 
 @gateway_deprecated
 def get_limits(route: str) -> LimitsConfig:
-    """Get limits of an existing route in the Gateway.
+    """
+    Get limits of an existing route in the Gateway.
 
     .. warning::
 
@@ -182,7 +187,8 @@ def get_limits(route: str) -> LimitsConfig:
 
 @gateway_deprecated
 def query(route: str, data):
-    """Issues a query request to a configured service through a named route on the Gateway Server.
+    """
+    Issues a query request to a configured service through a named route on the Gateway Server.
     This function will interface with a configured route name (examples below) and return the
     response from the provider in a standardized format.
 

--- a/mlflow/gateway/fluent.py
+++ b/mlflow/gateway/fluent.py
@@ -50,7 +50,8 @@ def search_routes() -> List[Route]:
 def create_route(
     name: str, route_type: Optional[str] = None, model: Optional[Dict[str, Any]] = None
 ) -> Route:
-    """Create a new route in the Gateway.
+    """
+    Create a new route in the Gateway.
 
     .. warning::
 

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -45,13 +45,16 @@ async def send_request(headers: Dict[str, str], base_url: str, path: str, payloa
 
 
 def rename_payload_keys(payload: Dict[str, Any], mapping: Dict[str, str]) -> Dict[str, Any]:
-    """
-    Rename payload keys based on the specified mapping. If a key is not present in the
+    """Rename payload keys based on the specified mapping. If a key is not present in the
     mapping, the key and its value will remain unchanged.
 
-    :param payload: The original dictionary to transform.
-    :param mapping: A dictionary where each key-value pair represents a mapping from the old
-                    key to the new key.
-    :return: A new dictionary containing the transformed keys.
+    Args:
+        payload: The original dictionary to transform.
+        mapping: A dictionary where each key-value pair represents a mapping from the old
+            key to the new key.
+
+    Returns:
+        A new dictionary containing the transformed keys.
+
     """
     return {mapping.get(k, k): v for k, v in payload.items()}

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -148,13 +148,13 @@ def gateway_deprecated(obj):
 
 @gateway_deprecated
 def set_gateway_uri(gateway_uri: str):
-    """
-    Sets the uri of a configured and running MLflow AI Gateway server in a global context.
+    """Sets the uri of a configured and running MLflow AI Gateway server in a global context.
     Providing a valid uri and calling this function is required in order to use the MLflow
     AI Gateway fluent APIs.
 
-    :param gateway_uri: The full uri of a running MLflow AI Gateway server or, if running on
-                        Databricks, "databricks".
+    Args:
+        gateway_uri: The full uri of a running MLflow AI Gateway server or, if running on
+            Databricks, "databricks".
     """
     if not _is_valid_uri(gateway_uri):
         raise MlflowException.invalid_parameter_value(
@@ -187,11 +187,14 @@ def get_gateway_uri() -> str:
 
 
 def assemble_uri_path(paths: List[str]) -> str:
-    """
-    Assemble a correct URI path from a list of path parts.
+    """Assemble a correct URI path from a list of path parts.
 
-    :param paths: A list of strings representing parts of a URI path.
-    :return: A string representing the complete assembled URI path.
+    Args:
+        paths: A list of strings representing parts of a URI path.
+
+    Returns:
+        A string representing the complete assembled URI path.
+
     """
     stripped_paths = [path.strip("/").lstrip("/") for path in paths if path]
     return "/" + posixpath.join(*stripped_paths) if stripped_paths else "/"
@@ -203,12 +206,15 @@ def resolve_route_url(base_url: str, route: str) -> str:
     with Databricks) or requires the assembly of a fully qualified url by appending the
     Route return route_url to the base url of the AI Gateway server.
 
-    :param base_url: The base URL. Should include the scheme and domain, e.g.,
-                     ``http://127.0.0.1:6000``.
-    :param route: The route to be appended to the base URL, e.g., ``/api/2.0/gateway/routes/`` or,
-                  in the case of Databricks, the fully qualified url.
-    :return: The complete URL, either directly returned or formed and returned by joining the
-             base URL and the route path.
+    Args:
+        base_url: The base URL. Should include the scheme and domain, e.g.,
+            ``http://127.0.0.1:6000``.
+        route: The route to be appended to the base URL, e.g., ``/api/2.0/gateway/routes/`` or,
+            in the case of Databricks, the fully qualified url.
+
+    Returns:
+        The complete URL, either directly returned or formed and returned by joining the
+        base URL and the route path.
     """
     return route if _is_valid_uri(route) else append_to_uri_path(base_url, route)
 

--- a/mlflow/gluon/__init__.py
+++ b/mlflow/gluon/__init__.py
@@ -51,6 +51,7 @@ def load_model(model_uri, ctx, dst_path=None):
 
     Args:
         model_uri: The location, in URI format, of the MLflow model. For example:
+
             - ``/Users/me/path/to/local/model``
             - ``relative/path/to/local/model``
             - ``s3://my_bucket/path/to/model``
@@ -345,6 +346,32 @@ def log_model(
     Returns:
         A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
         metadata of the logged model.
+
+    .. code-block:: python
+        :caption: Example
+
+        from mxnet.gluon import Trainer
+        from mxnet.gluon.contrib import estimator
+        from mxnet.gluon.loss import SoftmaxCrossEntropyLoss
+        from mxnet.gluon.nn import HybridSequential
+        from mxnet.metric import Accuracy
+        import mlflow
+
+        # Build, compile, and train your model
+        net = HybridSequential()
+        with net.name_scope():
+            ...
+        net.hybridize()
+        net.collect_params().initialize()
+        softmax_loss = SoftmaxCrossEntropyLoss()
+        trainer = Trainer(net.collect_params())
+        est = estimator.Estimator(
+            net=net, loss=softmax_loss, metrics=Accuracy(), trainer=trainer
+        )
+        # Log metrics and log the model
+        with mlflow.start_run():
+            est.fit(train_data=train_data, epochs=100, val_data=validation_data)
+            mlflow.gluon.log_model(net, "model")
     """
     return Model.log(
         artifact_path=artifact_path,
@@ -372,7 +399,8 @@ def autolog(
     silent=False,
     registered_model_name=None,
 ):  # pylint: disable=unused-argument
-    """Enables (or disables) and configures autologging from Gluon to MLflow.
+    """
+    Enables (or disables) and configures autologging from Gluon to MLflow.
     Logs loss and any other metrics specified in the fit
     function, and optimizer data as parameters. Model checkpoints
     are logged as artifacts to a 'models' directory.

--- a/mlflow/gluon/__init__.py
+++ b/mlflow/gluon/__init__.py
@@ -46,27 +46,28 @@ _MODEL_SAVE_PATH = "net"
 
 @deprecated(since="2.5.0")
 def load_model(model_uri, ctx, dst_path=None):
-    """
-    Load a Gluon model from a local file or a run.
+    """Load a Gluon model from a local file or a run.
 
-    :param model_uri: The location, in URI format, of the MLflow model. For example:
+    Args:
+        model_uri: The location, in URI format, of the MLflow model. For example:
 
-                      - ``/Users/me/path/to/local/model``
-                      - ``relative/path/to/local/model``
-                      - ``s3://my_bucket/path/to/model``
-                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
-                      - ``models:/<model_name>/<model_version>``
-                      - ``models:/<model_name>/<stage>``
+            - ``/Users/me/path/to/local/model``
+            - ``relative/path/to/local/model``
+            - ``s3://my_bucket/path/to/model``
+            - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+            - ``models:/<model_name>/<model_version>``
+            - ``models:/<model_name>/<stage>``
 
-                      For more information about supported URI schemes, see
-                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
-                      artifact-locations>`_.
-    :param ctx: Either CPU or GPU.
-    :param dst_path: The local filesystem path to which to download the model artifact.
-                     This directory must already exist. If unspecified, a local output
-                     path will be created.
+            For more information about supported URI schemes, see
+            `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
+            artifact-locations>`_.
+        ctx: Either CPU or GPU.
+        dst_path: The local filesystem path to which to download the model artifact.
+            This directory must already exist. If unspecified, a local output
+            path will be created.
 
-    :return: A Gluon model instance.
+    Returns:
+        A Gluon model instance.
 
     .. code-block:: python
         :caption: Example
@@ -104,19 +105,23 @@ class _GluonModelWrapper:
     def predict(
         self, data, params: Optional[Dict[str, Any]] = None  # pylint: disable=unused-argument
     ):
-        """
-        :param data: Either a pandas DataFrame or a numpy array containing input array values.
-                     If the input is a DataFrame, it will be converted to an array first by a
-                     `ndarray = df.values`.
-        :param params: Additional parameters to pass to the model for inference.
+        """This is a docstring. Here is info.
 
-                       .. Note:: Experimental: This parameter may change or be removed in a future
-                                               release without warning.
+        Here is more info.
 
-        :return: Model predictions. If the input is a pandas.DataFrame, the predictions are returned
-                 in a pandas.DataFrame. If the input is a numpy array, the predictions are returned
-                 as either a numpy.ndarray or a plain list for hybrid models.
+        Args:
+            data: Either a pandas DataFrame or a numpy array containing input array values.
+                If the input is a DataFrame, it will be converted to an array first by a
+                `ndarray = df.values`.
+            params: Additional parameters to pass to the model for inference.
 
+                .. Note:: Experimental: This parameter may change or be removed in a future
+                    release without warning.
+
+        Returns:
+            Model predictions. If the input is a pandas.DataFrame, the predictions are returned
+            in a pandas.DataFrame. If the input is a numpy array, the predictions are returned
+            as either a numpy.ndarray or a plain list for hybrid models.
 
         """
         import mxnet as mx
@@ -141,10 +146,11 @@ class _GluonModelWrapper:
 
 
 def _load_pyfunc(path):
-    """
-    Load PyFunc implementation. Called by ``pyfunc.load_model``.
+    """Load PyFunc implementation. Called by ``pyfunc.load_model``.
 
-    :param path: Local filesystem path to the MLflow Model with the ``gluon`` flavor.
+    Args:
+        path: Local filesystem path to the MLflow Model with the ``gluon`` flavor.
+
     """
     import mxnet as mx
 
@@ -166,24 +172,24 @@ def save_model(
     extra_pip_requirements=None,
     metadata=None,
 ):
-    """
-    Save a Gluon model to a path on the local file system.
+    """Save a Gluon model to a path on the local file system.
 
-    :param gluon_model: Gluon model to be saved. Must be already hybridized.
-    :param path: Local path where the model is to be saved.
-    :param mlflow_model: MLflow model config this flavor is being added to.
-    :param conda_env: {{ conda_env }}
-    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
-    :param signature: {{ signature }}
-    :param input_example: {{ input_example }}
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
+    Args:
+        gluon_model: Gluon model to be saved. Must be already hybridized.
+        path: Local path where the model is to be saved.
+        mlflow_model: MLflow model config this flavor is being added to.
+        conda_env: Inserted after the argument name.
+        code_paths: A list of local filesystem paths to Python file dependencies (or directories
+            containing file dependencies). These files are *prepended* to the system
+            path when the model is loaded.
+        signature: Inserted after the argument name.
+        input_example: Inserted after the argument name.
+        pip_requirements: Inserted after the argument name.
+        extra_pip_requirements: Inserted after the argument name.
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                release without warning.
 
     .. code-block:: python
         :caption: Example
@@ -284,17 +290,19 @@ def save_model(
 
 def get_default_pip_requirements():
     """
-    :return: A list of default pip requirements for MLflow Models produced by this flavor.
-             Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
-             that, at minimum, contains these requirements.
+    Returns:
+        A list of default pip requirements for MLflow Models produced by this flavor.
+        Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
+        that, at minimum, contains these requirements.
     """
     return [_get_pinned_requirement("mxnet")]
 
 
 def get_default_conda_env():
     """
-    :return: The default Conda environment for MLflow Models produced by calls to
-             :func:`save_model()` and :func:`log_model()`.
+    Returns:
+        The default Conda environment for MLflow Models produced by calls to
+        :func:`save_model()` and :func:`log_model()`.
     """
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
@@ -313,54 +321,30 @@ def log_model(
     extra_pip_requirements=None,
     metadata=None,
 ):
-    """
-    Log a Gluon model as an MLflow artifact for the current run.
+    """Log a Gluon model as an MLflow artifact for the current run.
 
-    :param gluon_model: Gluon model to be saved. Must be already hybridized.
-    :param artifact_path: Run-relative artifact path.
-    :param conda_env: {{ conda_env }}
-    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
-    :param registered_model_name: If given, create a model version under
-                                  ``registered_model_name``, also creating a registered model if one
-                                  with the given name does not exist.
-    :param signature: {{ signature }}
-    :param input_example: {{ input_example }}
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
+    Args:
+        gluon_model: Gluon model to be saved. Must be already hybridized.
+        artifact_path: Run-relative artifact path.
+        conda_env: Description of conda_env.
+        code_paths: A list of local filesystem paths to Python file dependencies (or directories
+            containing file dependencies). These files are *prepended* to the system
+            path when the model is loaded.
+        registered_model_name: If given, create a model version under
+            ``registered_model_name``, also creating a registered model if one
+            with the given name does not exist.
+        signature: Description of signature.
+        input_example: Description of input_example.
+        pip_requirements: Description of pip_requirements.
+        extra_pip_requirements: Description of extra_pip_requirements.
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
-    :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
-             metadata of the logged model.
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                release without warning.
 
-    .. code-block:: python
-        :caption: Example
-
-        from mxnet.gluon import Trainer
-        from mxnet.gluon.contrib import estimator
-        from mxnet.gluon.loss import SoftmaxCrossEntropyLoss
-        from mxnet.gluon.nn import HybridSequential
-        from mxnet.metric import Accuracy
-        import mlflow
-
-        # Build, compile, and train your model
-        net = HybridSequential()
-        with net.name_scope():
-            ...
-        net.hybridize()
-        net.collect_params().initialize()
-        softmax_loss = SoftmaxCrossEntropyLoss()
-        trainer = Trainer(net.collect_params())
-        est = estimator.Estimator(
-            net=net, loss=softmax_loss, metrics=Accuracy(), trainer=trainer
-        )
-        # Log metrics and log the model
-        with mlflow.start_run():
-            est.fit(train_data=train_data, epochs=100, val_data=validation_data)
-            mlflow.gluon.log_model(net, "model")
+    Returns:
+        A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
+        metadata of the logged model.
     """
     return Model.log(
         artifact_path=artifact_path,
@@ -388,30 +372,31 @@ def autolog(
     silent=False,
     registered_model_name=None,
 ):  # pylint: disable=unused-argument
-    """
-    Enables (or disables) and configures autologging from Gluon to MLflow.
+    """Enables (or disables) and configures autologging from Gluon to MLflow.
     Logs loss and any other metrics specified in the fit
     function, and optimizer data as parameters. Model checkpoints
     are logged as artifacts to a 'models' directory.
 
-    :param log_models: If ``True``, trained models are logged as MLflow model artifacts.
-                       If ``False``, trained models are not logged.
-    :param log_datasets: If ``True``, dataset information is logged to MLflow Tracking.
-                         If ``False``, dataset information is not logged.
-    :param disable: If ``True``, disables the MXNet Gluon autologging integration. If ``False``,
-                    enables the MXNet Gluon autologging integration.
-    :param exclusive: If ``True``, autologged content is not logged to user-created fluent runs.
-                      If ``False``, autologged content is logged to the active fluent run,
-                      which may be user-created.
-    :param disable_for_unsupported_versions: If ``True``, disable autologging for versions of
-                      gluon that have not been tested against this version of the MLflow client
-                      or are incompatible.
-    :param silent: If ``True``, suppress all event logs and warnings from MLflow during MXNet Gluon
-                   autologging. If ``False``, show all events and warnings during MXNet Gluon
-                   autologging.
-    :param registered_model_name: If given, each time a model is trained, it is registered as a
-                                  new model version of the registered model with this name.
-                                  The registered model is created if it does not already exist.
+    Args:
+        log_models: If ``True``, trained models are logged as MLflow model artifacts.
+            If ``False``, trained models are not logged.
+        log_datasets: If ``True``, dataset information is logged to MLflow Tracking.
+            If ``False``, dataset information is not logged.
+        disable: If ``True``, disables the MXNet Gluon autologging integration. If ``False``,
+            enables the MXNet Gluon autologging integration.
+        exclusive: If ``True``, autologged content is not logged to user-created fluent runs.
+            If ``False``, autologged content is logged to the active fluent run,
+            which may be user-created.
+        disable_for_unsupported_versions: If ``True``, disable autologging for versions of
+            gluon that have not been tested against this version of the MLflow client
+            or are incompatible.
+        silent: If ``True``, suppress all event logs and warnings from MLflow during MXNet Gluon
+            autologging. If ``False``, show all events and warnings during MXNet Gluon
+            autologging.
+        registered_model_name: If given, each time a model is trained, it is registered as a
+            new model version of the registered model with this name.
+            The registered model is created if it does not already exist.
+
     """
 
     from mxnet.gluon.contrib.estimator import Estimator

--- a/mlflow/gluon/__init__.py
+++ b/mlflow/gluon/__init__.py
@@ -177,14 +177,14 @@ def save_model(
         gluon_model: Gluon model to be saved. Must be already hybridized.
         path: Local path where the model is to be saved.
         mlflow_model: MLflow model config this flavor is being added to.
-        conda_env: Inserted after the argument name.
+        conda_env: {{ conda_env }}
         code_paths: A list of local filesystem paths to Python file dependencies (or directories
             containing file dependencies). These files are *prepended* to the system
             path when the model is loaded.
-        signature: Inserted after the argument name.
-        input_example: Inserted after the argument name.
-        pip_requirements: Inserted after the argument name.
-        extra_pip_requirements: Inserted after the argument name.
+        signature: {{ signature }}
+        input_example: {{ input_example }}
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
         metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
             .. Note:: Experimental: This parameter may change or be removed in a future

--- a/mlflow/gluon/__init__.py
+++ b/mlflow/gluon/__init__.py
@@ -327,17 +327,17 @@ def log_model(
     Args:
         gluon_model: Gluon model to be saved. Must be already hybridized.
         artifact_path: Run-relative artifact path.
-        conda_env: Description of conda_env.
+        conda_env: {{ conda_env }}
         code_paths: A list of local filesystem paths to Python file dependencies (or directories
             containing file dependencies). These files are *prepended* to the system
             path when the model is loaded.
         registered_model_name: If given, create a model version under
             ``registered_model_name``, also creating a registered model if one
             with the given name does not exist.
-        signature: Description of signature.
-        input_example: Description of input_example.
-        pip_requirements: Description of pip_requirements.
-        extra_pip_requirements: Description of extra_pip_requirements.
+        signature: {{ signature }}
+        input_example: {{ input_example }}
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
         metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
             .. Note:: Experimental: This parameter may change or be removed in a future

--- a/mlflow/gluon/__init__.py
+++ b/mlflow/gluon/__init__.py
@@ -46,11 +46,11 @@ _MODEL_SAVE_PATH = "net"
 
 @deprecated(since="2.5.0")
 def load_model(model_uri, ctx, dst_path=None):
-    """Load a Gluon model from a local file or a run.
+    """
+    Load a Gluon model from a local file or a run.
 
     Args:
         model_uri: The location, in URI format, of the MLflow model. For example:
-
             - ``/Users/me/path/to/local/model``
             - ``relative/path/to/local/model``
             - ``s3://my_bucket/path/to/model``
@@ -105,9 +105,7 @@ class _GluonModelWrapper:
     def predict(
         self, data, params: Optional[Dict[str, Any]] = None  # pylint: disable=unused-argument
     ):
-        """This is a docstring. Here is info.
-
-        Here is more info.
+        """This is a docstring. Here is more info.
 
         Args:
             data: Either a pandas DataFrame or a numpy array containing input array values.
@@ -172,7 +170,8 @@ def save_model(
     extra_pip_requirements=None,
     metadata=None,
 ):
-    """Save a Gluon model to a path on the local file system.
+    """
+    Save a Gluon model to a path on the local file system.
 
     Args:
         gluon_model: Gluon model to be saved. Must be already hybridized.
@@ -321,7 +320,8 @@ def log_model(
     extra_pip_requirements=None,
     metadata=None,
 ):
-    """Log a Gluon model as an MLflow artifact for the current run.
+    """
+    Log a Gluon model as an MLflow artifact for the current run.
 
     Args:
         gluon_model: Gluon model to be saved. Must be already hybridized.

--- a/mlflow/h2o/__init__.py
+++ b/mlflow/h2o/__init__.py
@@ -52,17 +52,19 @@ _logger = logging.getLogger(__name__)
 
 def get_default_pip_requirements():
     """
-    :return: A list of default pip requirements for MLflow Models produced by this flavor.
-             Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
-             that, at minimum, contains these requirements.
+    Returns:
+        A list of default pip requirements for MLflow Models produced by this flavor.
+        Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
+        that, at minimum, contains these requirements.
     """
     return [_get_pinned_requirement("h2o")]
 
 
 def get_default_conda_env():
     """
-    :return: The default Conda environment for MLflow Models produced by calls to
-             :func:`save_model()` and :func:`log_model()`.
+    Returns:
+        The default Conda environment for MLflow Models produced by calls to
+        :func:`save_model()` and :func:`log_model()`.
     """
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
@@ -81,24 +83,24 @@ def save_model(
     extra_pip_requirements=None,
     metadata=None,
 ):
-    """
-    Save an H2O model to a path on the local file system.
+    """Save an H2O model to a path on the local file system.
 
-    :param h2o_model: H2O model to be saved.
-    :param path: Local path where the model is to be saved.
-    :param conda_env: {{ conda_env }}
-    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
-    :param mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
-    :param signature: {{ signature }}
-    :param input_example: {{ input_example }}
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
+    Args:
+        h2o_model: H2O model to be saved.
+        path: Local path where the model is to be saved.
+        conda_env: {{ conda_env }}
+        code_paths: A list of local filesystem paths to Python file dependencies (or directories
+            containing file dependencies). These files are *prepended* to the system
+            path when the model is loaded.
+        mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
+        signature: {{ signature }}
+        input_example: {{ input_example }}
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                release without warning.
     """
     import h2o
 
@@ -209,30 +211,32 @@ def log_model(
     metadata=None,
     **kwargs,
 ):
-    """
-    Log an H2O model as an MLflow artifact for the current run.
+    """Log an H2O model as an MLflow artifact for the current run.
 
-    :param h2o_model: H2O model to be saved.
-    :param artifact_path: Run-relative artifact path.
-    :param conda_env: {{ conda_env }}
-    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
-    :param registered_model_name: If given, create a model version under
-                                  ``registered_model_name``, also creating a registered model if one
-                                  with the given name does not exist.
+    Args:
+        h2o_model: H2O model to be saved.
+        artifact_path: Run-relative artifact path.
+        conda_env: {{ conda_env }}
+        code_paths: A list of local filesystem paths to Python file dependencies (or directories
+            containing file dependencies). These files are *prepended* to the system
+            path when the model is loaded.
+        registered_model_name: If given, create a model version under
+            ``registered_model_name``, also creating a registered model if one
+            with the given name does not exist.
+        signature: {{ signature }}
+        input_example: {{ input_example }}
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-    :param signature: {{ signature }}
-    :param input_example: {{ input_example }}
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                release without warning.
+        kwargs: kwargs to pass to ``h2o.save_model`` method.
 
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
-    :param kwargs: kwargs to pass to ``h2o.save_model`` method.
-    :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
-             metadata of the logged model.
+    Returns:
+        A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
+        metadata of the logged model.
+
     """
     return Model.log(
         artifact_path=artifact_path,
@@ -281,13 +285,15 @@ class _H2OModelWrapper:
         self, dataframe, params: Optional[Dict[str, Any]] = None
     ):  # pylint: disable=unused-argument
         """
-        :param dataframe: Model input data.
-        :param params: Additional parameters to pass to the model for inference.
+        Args:
+            dataframe: Model input data.
+            params: Additional parameters to pass to the model for inference.
 
-                       .. Note:: Experimental: This parameter may change or be removed in a future
-                                               release without warning.
+                .. Note:: Experimental: This parameter may change or be removed in a future
+                    release without warning.
 
-        :return: Model predictions.
+        Returns:
+            Model predictions.
         """
         import h2o
 
@@ -297,37 +303,41 @@ class _H2OModelWrapper:
 
 
 def _load_pyfunc(path):
-    """
-    Load PyFunc implementation. Called by ``pyfunc.load_model``.
+    """Load PyFunc implementation. Called by ``pyfunc.load_model``.
 
-    :param path: Local filesystem path to the MLflow Model with the ``h2o`` flavor.
+    Args:
+        path: Local filesystem path to the MLflow Model with the ``h2o`` flavor.
+
     """
     return _H2OModelWrapper(_load_model(path, init=True))
 
 
 def load_model(model_uri, dst_path=None):
-    """
-    Load an H2O model from a local file (if ``run_id`` is ``None``) or a run.
+    """Load an H2O model from a local file (if ``run_id`` is ``None``) or a run.
+
     This function expects there is an H2O instance initialised with ``h2o.init``.
 
-    :param model_uri: The location, in URI format, of the MLflow model. For example:
+    Args:
+        model_uri: The location, in URI format, of the MLflow model. For example:
 
-                      - ``/Users/me/path/to/local/model``
-                      - ``relative/path/to/local/model``
-                      - ``s3://my_bucket/path/to/model``
-                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
-                      - ``models:/<model_name>/<model_version>``
-                      - ``models:/<model_name>/<stage>``
+            - ``/Users/me/path/to/local/model``
+            - ``relative/path/to/local/model``
+            - ``s3://my_bucket/path/to/model``
+            - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+            - ``models:/<model_name>/<model_version>``
+            - ``models:/<model_name>/<stage>``
 
-                      For more information about supported URI schemes, see
-                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
-                      artifact-locations>`_.
-    :param dst_path: The local filesystem path to which to download the model artifact.
-                     This directory must already exist. If unspecified, a local output
-                     path will be created.
+            For more information about supported URI schemes, see
+            `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
+            artifact-locations>`_.
+        dst_path: The local filesystem path to which to download the model artifact.
+            This directory must already exist. If unspecified, a local output
+            path will be created.
 
-    :return: An `H2OEstimator model object
-             <http://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/intro.html#models>`_.
+    Returns:
+        An `H2OEstimator model object
+        <http://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/intro.html#models>`_.
+
     """
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)

--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -134,9 +134,10 @@ def _set_env_vars():
 @experimental
 def get_default_pip_requirements():
     """
-    :return: A list of default pip requirements for MLflow Models produced by this flavor.
-             Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
-             that, at minimum, contains these requirements.
+    Returns:
+        A list of default pip requirements for MLflow Models produced by this flavor.
+        Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
+        that, at minimum, contains these requirements.
     """
     from johnsnowlabs import settings
 
@@ -183,8 +184,9 @@ def get_default_pip_requirements():
 @experimental
 def get_default_conda_env():
     """
-    :return: The default Conda environment for MLflow Models produced by calls to
-             :func:`save_model()` and :func:`log_model()`.
+    Returns:
+        The default Conda environment for MLflow Models produced by calls to
+        :func:`save_model()` and :func:`log_model()`.
     """
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
@@ -207,74 +209,75 @@ def log_model(
     metadata=None,
     store_license=False,
 ):
-    """
-    Log a ``Johnsnowlabs NLUPipeline`` created via `nlp.load()
+    """Log a ``Johnsnowlabs NLUPipeline`` created via `nlp.load()
     <https://nlp.johnsnowlabs.com/docs/en/jsl/load_api>`_, as an MLflow artifact for the current
     run. This uses the MLlib persistence format and produces an MLflow Model with the
     ``johnsnowlabs`` flavor.
 
     Note: If no run is active, it will instantiate a run to obtain a run_id.
 
-    :param spark_model: NLUPipeline obtained via `nlp.load()
-                        <https://nlp.johnsnowlabs.com/docs/en/jsl/load_api>`_
-    :param store_license: If True, the license will be stored with the model and used and re-loading
-                          it.
-    :param artifact_path: Run relative artifact path.
-    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
-                      Conda environment yaml file. If provided, this describes the environment
-                      this model should be run in. At minimum, it should specify the dependencies
-                      contained in :func:`get_default_conda_env()`. If `None`, the default
-                      :func:`get_default_conda_env()` environment is added to the model.
-                      The following is an *example* dictionary representation of a Conda
-                      environment::
+    Args:
+        spark_model: NLUPipeline obtained via `nlp.load()
+            <https://nlp.johnsnowlabs.com/docs/en/jsl/load_api>`_
+        store_license: If True, the license will be stored with the model and used and re-loading
+            it.
+        artifact_path: Run relative artifact path.
+        conda_env: Either a dictionary representation of a Conda environment or the path to a
+            Conda environment yaml file. If provided, this describes the environment
+            this model should be run in. At minimum, it should specify the dependencies
+            contained in :func:`get_default_conda_env()`. If `None`, the default
+            :func:`get_default_conda_env()` environment is added to the model.
+            The following is an *example* dictionary representation of a Conda
+            environment::
 
-                        {
-                            'name': 'mlflow-env',
-                            'channels': ['defaults'],
-                            'dependencies': [
-                                'python=3.8.15',
-                                'johnsnowlabs'
-                            ]
-                        }
-    :param dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
-                       filesystem if running in local mode. The model is written in this
-                       destination and then copied into the model's artifact directory. This is
-                       necessary as Spark ML models read from and write to DFS if running on a
-                       cluster. If this operation completes successfully, all temporary files
-                       created on the DFS are removed. Defaults to ``/tmp/mlflow``.
-    :param sample_input: A sample input used to add the MLeap flavor to the model.
-                         This must be a PySpark DataFrame that the model can evaluate. If
-                         ``sample_input`` is ``None``, the MLeap flavor is not added.
-    :param registered_model_name: If given, create a model version under
-                                  ``registered_model_name``, also creating a registered model if one
-                                  with the given name does not exist.
+                {
+                    'name': 'mlflow-env',
+                    'channels': ['defaults'],
+                    'dependencies': [
+                        'python=3.8.15',
+                        'johnsnowlabs'
+                    ]
+                }
+        dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
+            filesystem if running in local mode. The model is written in this
+            destination and then copied into the model's artifact directory. This is
+            necessary as Spark ML models read from and write to DFS if running on a
+            cluster. If this operation completes successfully, all temporary files
+            created on the DFS are removed. Defaults to ``/tmp/mlflow``.
+        sample_input: A sample input used to add the MLeap flavor to the model.
+            This must be a PySpark DataFrame that the model can evaluate. If
+            ``sample_input`` is ``None``, the MLeap flavor is not added.
+        registered_model_name: If given, create a model version under
+            ``registered_model_name``, also creating a registered model if one
+            with the given name does not exist.
+        signature: :py:class:`ModelSignature <mlflow.models.ModelSignature>`
+            describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
+            The model signature can be :py:func:`inferred <mlflow.models.infer_signature>`
+            from datasets with valid model input (e.g. the training dataset with target
+            column omitted) and valid model output (e.g. model predictions generated on
+            the training dataset), for example:
 
-    :param signature: :py:class:`ModelSignature <mlflow.models.ModelSignature>`
-                      describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
-                      The model signature can be :py:func:`inferred <mlflow.models.infer_signature>`
-                      from datasets with valid model input (e.g. the training dataset with target
-                      column omitted) and valid model output (e.g. model predictions generated on
-                      the training dataset), for example:
+            .. code-block:: python
 
-                      .. code-block:: python
+                from mlflow.models.signature import infer_signature
 
-                        from mlflow.models.signature import infer_signature
+                train = df.drop_column("target_label")
+                predictions = ...  # compute model predictions
+                signature = infer_signature(train, predictions)
+        input_example: {{ input_example }}
+        await_registration_for: Number of seconds to wait for the model version to finish
+            being created and is in ``READY`` status. By default, the function
+            waits for five minutes. Specify 0 or None to skip waiting.
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-                        train = df.drop_column("target_label")
-                        predictions = ...  # compute model predictions
-                        signature = infer_signature(train, predictions)
-    :param input_example: {{ input_example }}
-    :param await_registration_for: Number of seconds to wait for the model version to finish
-                            being created and is in ``READY`` status. By default, the function
-                            waits for five minutes. Specify 0 or None to skip waiting.
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                release without warning.
 
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
-    :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
-             metadata of the logged model.
+    Returns:
+        A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
+        metadata of the logged model.
 
     .. code-block:: python
         :caption: Example
@@ -313,6 +316,7 @@ def log_model(
         # Log it
         mlflow.johnsnowlabs.log_model(trained_classifier, "my_trained_model")
     """
+
     _validate_env_vars()
     run_id = mlflow.tracking.fluent._get_or_start_run().info.run_id
     run_root_artifact_uri = mlflow.get_artifact_uri()
@@ -497,67 +501,66 @@ def save_model(
     metadata=None,
     store_license=False,
 ):
-    """
-    Save a Spark johnsnowlabs Model to a local path.
+    """Save a Spark johnsnowlabs Model to a local path.
 
     By default, this function saves models using the Spark MLlib persistence mechanism.
     Additionally, if a sample input is specified using the ``sample_input`` parameter, the model
     is also serialized in MLeap format and the MLeap flavor is added.
 
-    :param store_license: If True, the license will be stored with the model and used and
-                          re-loading it.
-    :param spark_model: Either a pyspark.ml.pipeline.PipelineModel or nlu.NLUPipeline object to be
-                        saved. `Every johnsnowlabs model <https://nlp.johnsnowlabs.com/models>`_
-                        is a PipelineModel and loadable as nlu.NLUPipeline.
-    :param path: Local path where the model is to be saved.
-    :param mlflow_model: MLflow model config this flavor is being added to.
-    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
-                      Conda environment yaml file. If provided, this describes the environment
-                      this model should be run in. At minimum, it should specify the dependencies
-                      contained in :func:`get_default_conda_env()`. If `None`, the default
-                      :func:`get_default_conda_env()` environment is added to the model.
-                      The following is an *example* dictionary representation of a Conda
-                      environment::
+    Args:
+        store_license: If True, the license will be stored with the model and used and
+            re-loading it.
+        spark_model: Either a pyspark.ml.pipeline.PipelineModel or nlu.NLUPipeline object to be
+            saved. `Every johnsnowlabs model <https://nlp.johnsnowlabs.com/models>`_
+            is a PipelineModel and loadable as nlu.NLUPipeline.
+        path: Local path where the model is to be saved.
+        mlflow_model: MLflow model config this flavor is being added to.
+        conda_env: Either a dictionary representation of a Conda environment or the path to a
+            Conda environment yaml file. If provided, this describes the environment
+            this model should be run in. At minimum, it should specify the dependencies
+            contained in :func:`get_default_conda_env()`. If `None`, the default
+            :func:`get_default_conda_env()` environment is added to the model.
+            The following is an *example* dictionary representation of a Conda
+            environment::
 
-                        {
-                            'name': 'mlflow-env',
-                            'channels': ['defaults'],
-                            'dependencies': [
-                                'python=3.8.15',
-                                'johnsnowlabs'
-                            ]
-                        }
-    :param dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
-                       filesystem if running in local mode. The model is be written in this
-                       destination and then copied to the requested local path. This is necessary
-                       as Spark ML models read from and write to DFS if running on a cluster. All
-                       temporary files created on the DFS are removed if this operation
-                       completes successfully. Defaults to ``/tmp/mlflow``.
-    :param sample_input: A sample input that is used to add the MLeap flavor to the model.
-                         This must be a PySpark DataFrame that the model can evaluate. If
-                         ``sample_input`` is ``None``, the MLeap flavor is not added.
+                {
+                    'name': 'mlflow-env',
+                    'channels': ['defaults'],
+                    'dependencies': [
+                        'python=3.8.15',
+                        'johnsnowlabs'
+                    ]
+                }
+        dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
+            filesystem if running in local mode. The model is be written in this
+            destination and then copied to the requested local path. This is necessary
+            as Spark ML models read from and write to DFS if running on a cluster. All
+            temporary files created on the DFS are removed if this operation
+            completes successfully. Defaults to ``/tmp/mlflow``.
+        sample_input: A sample input that is used to add the MLeap flavor to the model.
+            This must be a PySpark DataFrame that the model can evaluate. If
+            ``sample_input`` is ``None``, the MLeap flavor is not added.
+        signature: :py:class:`ModelSignature <mlflow.models.ModelSignature>`
+            describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
+            The model signature can be :py:func:`inferred <mlflow.models.infer_signature>`
+            from datasets with valid model input (e.g. the training dataset with target
+            column omitted) and valid model output (e.g. model predictions generated on
+            the training dataset), for example:
 
-    :param signature: :py:class:`ModelSignature <mlflow.models.ModelSignature>`
-                      describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
-                      The model signature can be :py:func:`inferred <mlflow.models.infer_signature>`
-                      from datasets with valid model input (e.g. the training dataset with target
-                      column omitted) and valid model output (e.g. model predictions generated on
-                      the training dataset), for example:
+            .. code-block:: python
 
-                      .. code-block:: python
+                from mlflow.models.signature import infer_signature
 
-                        from mlflow.models.signature import infer_signature
+                train = df.drop_column("target_label")
+                predictions = ...  # compute model predictions
+                signature = infer_signature(train, predictions)
+        input_example: {{ input_example }}
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-                        train = df.drop_column("target_label")
-                        predictions = ...  # compute model predictions
-                        signature = infer_signature(train, predictions)
-    :param input_example: {{ input_example }}
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
-
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                release without warning.
 
     .. code-block:: python
         :caption: Example
@@ -665,28 +668,30 @@ def _load_model(model_uri, dfs_tmpdir_base=None, local_model_path=None):
 def load_model(
     model_uri, dfs_tmpdir=None, dst_path=None, **kwargs
 ):  # pylint: disable=unused-argument
-    """
-    Load the Johnsnowlabs MLflow model from the path.
+    """Load the Johnsnowlabs MLflow model from the path.
 
-    :param model_uri: The location, in URI format, of the MLflow model, for example:
+    Args:
+        model_uri: The location, in URI format, of the MLflow model. For example:
 
-                      - ``/Users/me/path/to/local/model``
-                      - ``relative/path/to/local/model``
-                      - ``s3://my_bucket/path/to/model``
-                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
-                      - ``models:/<model_name>/<model_version>``
-                      - ``models:/<model_name>/<stage>``
+            - ``/Users/me/path/to/local/model``
+            - ``relative/path/to/local/model``
+            - ``s3://my_bucket/path/to/model``
+            - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+            - ``models:/<model_name>/<model_version>``
+            - ``models:/<model_name>/<stage>``
 
-                      For more information about supported URI schemes, see
-                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
-                      artifact-locations>`_.
-    :param dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
-                       filesystem if running in local mode. The model is loaded from this
-                       destination. Defaults to ``/tmp/mlflow``.
-    :param dst_path: The local filesystem path to which to download the model artifact.
-                     This directory must already exist. If unspecified, a local output
-                     path will be created.
-    :return: `nlu.NLUPipeline <https://nlp.johnsnowlabs.com/docs/en/jsl/predict_api>`_
+            For more information about supported URI schemes, see
+            `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
+            artifact-locations>`_.
+        dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
+            filesystem if running in local mode. The model is loaded from this
+            destination. Defaults to ``/tmp/mlflow``.
+        dst_path: The local filesystem path to which to download the model artifact.
+            This directory must already exist. If unspecified, a local output
+            path will be created.
+
+    Returns:
+        `nlu.NLUPipeline <https://nlp.johnsnowlabs.com/docs/en/jsl/predict_api>`_
 
     .. code-block:: python
         :caption: Example
@@ -745,12 +750,16 @@ def load_model(
 
 
 def _load_pyfunc(path, spark=None):
-    """
-    Load PyFunc implementation. Called by ``pyfunc.load_model``.
-    :param path: Local filesystem path to the MLflow Model with the ``johnsnowlabs`` flavor.
-    :param spark: Optionally pass spark context when using pyfunc as UDF. required, because
-                  we cannot fetch the Sparkcontext inside of the Workernode which executes the UDF.
-    :return:
+    """Load PyFunc implementation. Called by ``pyfunc.load_model``.
+
+    Args:
+        path: Local filesystem path to the MLflow Model with the ``johnsnowlabs`` flavor.
+        spark: Optionally pass spark context when using pyfunc as UDF. required, because
+            we cannot fetch the Sparkcontext inside of the Workernode which executes the UDF.
+
+    Returns:
+        None.
+
     """
     return _PyFuncModelWrapper(
         _load_model(model_uri=path),
@@ -759,15 +768,18 @@ def _load_pyfunc(path, spark=None):
 
 
 def _get_or_create_sparksession(model_path=None):
-    """
-    1. Check if SparkSession running and get it
-    2. If none exists, create a new one using jars in model_path
-    3. If model_path not defined, rely on nlp.start() to create a new
-    one using johnsnowlabs Jar resolution method
-    See https://nlp.johnsnowlabs.com/docs/en/jsl/start-a-sparksession
-    and https://nlp.johnsnowlabs.com/docs/en/jsl/install_advanced
-    :param model_path:
-    :return:
+    """Check if SparkSession running and get it.
+
+    If none exists, create a new one using jars in model_path. If model_path not defined, rely on
+    nlp.start() to create a new one using johnsnowlabs Jar resolution method. See
+    https://nlp.johnsnowlabs.com/docs/en/jsl/start-a-sparksession and
+    https://nlp.johnsnowlabs.com/docs/en/jsl/install_advanced.
+
+    Args:
+        model_path:
+
+    Returns:
+
     """
     from johnsnowlabs import nlp
 
@@ -858,15 +870,18 @@ class _PyFuncModelWrapper:
         self.spark_model = spark_model
 
     def predict(self, text, params: Optional[Dict[str, Any]] = None):
-        """
-        Generate predictions given input data in a pandas DataFrame.
+        """Generate predictions given input data in a pandas DataFrame.
 
-        :param text: pandas DataFrame containing input data.
-        :param params: Additional parameters to pass to the model for inference.
+        Args:
+            text: pandas DataFrame containing input data.
+            params: Additional parameters to pass to the model for inference.
 
-                       .. Note:: Experimental: This parameter may change or be removed in a future
-                                               release without warning.
-        :return: List with model predictions.
+                .. Note:: Experimental: This parameter may change or be removed in a future
+                    release without warning.
+
+        Returns:
+            List with model predictions.
+
         """
         output_level = params.get("output_level", "") if params else ""
         return self.spark_model.predict(text, output_level=output_level).reset_index().to_json()

--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -676,6 +676,7 @@ def load_model(
 
     Args:
         model_uri: The location, in URI format, of the MLflow model. For example:
+
             - ``/Users/me/path/to/local/model``
             - ``relative/path/to/local/model``
             - ``s3://my_bucket/path/to/model``

--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -209,7 +209,8 @@ def log_model(
     metadata=None,
     store_license=False,
 ):
-    """Log a ``Johnsnowlabs NLUPipeline`` created via `nlp.load()
+    """
+    Log a ``Johnsnowlabs NLUPipeline`` created via `nlp.load()
     <https://nlp.johnsnowlabs.com/docs/en/jsl/load_api>`_, as an MLflow artifact for the current
     run. This uses the MLlib persistence format and produces an MLflow Model with the
     ``johnsnowlabs`` flavor.
@@ -264,6 +265,7 @@ def log_model(
                 train = df.drop_column("target_label")
                 predictions = ...  # compute model predictions
                 signature = infer_signature(train, predictions)
+
         input_example: {{ input_example }}
         await_registration_for: Number of seconds to wait for the model version to finish
             being created and is in ``READY`` status. By default, the function
@@ -501,7 +503,8 @@ def save_model(
     metadata=None,
     store_license=False,
 ):
-    """Save a Spark johnsnowlabs Model to a local path.
+    """
+    Save a Spark johnsnowlabs Model to a local path.
 
     By default, this function saves models using the Spark MLlib persistence mechanism.
     Additionally, if a sample input is specified using the ``sample_input`` parameter, the model
@@ -668,11 +671,11 @@ def _load_model(model_uri, dfs_tmpdir_base=None, local_model_path=None):
 def load_model(
     model_uri, dfs_tmpdir=None, dst_path=None, **kwargs
 ):  # pylint: disable=unused-argument
-    """Load the Johnsnowlabs MLflow model from the path.
+    """
+    Load the Johnsnowlabs MLflow model from the path.
 
     Args:
         model_uri: The location, in URI format, of the MLflow model. For example:
-
             - ``/Users/me/path/to/local/model``
             - ``relative/path/to/local/model``
             - ``s3://my_bucket/path/to/model``
@@ -691,7 +694,8 @@ def load_model(
             path will be created.
 
     Returns:
-        `nlu.NLUPipeline <https://nlp.johnsnowlabs.com/docs/en/jsl/predict_api>`_
+        A
+        `nlu.NLUPipeline <https://nlp.johnsnowlabs.com/docs/en/jsl/predict_api>`_.
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -102,7 +102,8 @@ def save_model(
     persist_dir=None,
     example_no_conversion=False,
 ):
-    """Save a LangChain model to a path on the local file system.
+    """
+    Save a LangChain model to a path on the local file system.
 
     Args:
         lc_model: A LangChain model, which could be a
@@ -312,7 +313,8 @@ def log_model(
     persist_dir=None,
     example_no_conversion=False,
 ):
-    """Log a LangChain model as an MLflow artifact for the current run.
+    """
+    Log a LangChain model as an MLflow artifact for the current run.
 
     Args:
         lc_model: A LangChain model, which could be a
@@ -629,7 +631,8 @@ def _load_model_from_local_fs(local_model_path):
 
 @experimental
 def load_model(model_uri, dst_path=None):
-    """Load a LangChain model from a local file or a run.
+    """
+    Load a LangChain model from a local file or a run.
 
     Args:
         model_uri: The location, in URI format, of the MLflow model. For example:

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -271,8 +271,12 @@ class APIRequest:
     @staticmethod
     def _transform_request_json_for_chat_if_necessary(request_json, lc_model):
         """
-        :return: A 2-element tuple containing: 1. the new request and 2. a boolean indicating
-                 whether or not the request was transformed from the OpenAI chat format
+        Returns:
+            A 2-element tuple containing:
+
+                1. The new request.
+                2. A boolean indicating whether or not the request was transformed from the OpenAI
+                chat format.
         """
         input_fields = APIRequest._get_lc_model_input_fields(lc_model)
         if "messages" in input_fields:

--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -87,11 +87,11 @@ def _load_model_from_path(path: str, model_config=None):
 
 
 def _load_runnable_with_steps(file_path: Union[Path, str], model_type: str):
-    """
-    Load the model
+    """Load the model
 
-    :param file_path: Path to file to load the model from.
-    :param model_type: Type of the model to load.
+    Args:
+        file_path: Path to file to load the model from.
+        model_type: Type of the model to load.
     """
     from langchain.schema.runnable import RunnableParallel, RunnableSequence
 
@@ -131,10 +131,10 @@ def _load_runnable_with_steps(file_path: Union[Path, str], model_type: str):
 
 
 def runnable_sequence_from_steps(steps):
-    """
-    Construct a RunnableSequence from steps.
+    """Construct a RunnableSequence from steps.
 
-    :param steps: List of steps to construct the RunnableSequence from.
+    Args:
+        steps: List of steps to construct the RunnableSequence from.
     """
     from langchain.schema.runnable import RunnableSequence
 
@@ -146,11 +146,11 @@ def runnable_sequence_from_steps(steps):
 
 
 def _load_runnable_branch(file_path: Union[Path, str], model_type: str):
-    """
-    Load the model
+    """Load the model
 
-    :param file_path: Path to file to load the model from.
-    :param model_type: Type of the model to load.
+    Args:
+        file_path: Path to file to load the model from.
+        model_type: Type of the model to load.
     """
     from langchain.schema.runnable import RunnableBranch
 
@@ -232,8 +232,9 @@ def _save_internal_runnables(runnable, path, loader_fn, persist_dir):
 
 
 def _save_runnable_with_steps(steps, file_path: Union[Path, str], loader_fn=None, persist_dir=None):
-    """
-    Save the model with steps. Currently it supports saving RunnableSequence and RunnableParallel.
+    """Save the model with steps. Currently it supports saving RunnableSequence and
+    RunnableParallel.
+
     If saving a RunnableSequence, steps is a list of Runnable objects. We save each step to the
     subfolder named by the step index.
     e.g.  - model
@@ -255,8 +256,9 @@ def _save_runnable_with_steps(steps, file_path: Union[Path, str], loader_fn=None
 
     We save steps.yaml file to the model folder. It contains each step's model's configuration.
 
-    :steps: steps of the runnable.
-    :param file_path: Path to file to save the model to.
+    Args:
+        steps: Steps of the runnable.
+        file_path: Path to file to save the model to.
     """
     # Convert file to Path object.
     save_path = Path(file_path) if isinstance(file_path, str) else file_path

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -846,10 +846,12 @@ def _load_pyfunc(path):
 
 @experimental
 def load_model(model_uri, dst_path=None):
-    """Load an OpenAI model from a local file or a run.
+    """
+    Load an OpenAI model from a local file or a run.
 
     Args:
         model_uri: The location, in URI format, of the MLflow model. For example:
+
             - ``/Users/me/path/to/local/model``
             - ``relative/path/to/local/model``
             - ``s3://my_bucket/path/to/model``


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/michael-berk/mlflow/pull/10825?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10825/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10825
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
