### PR TITLE
Google docstring conversion batch 2

### DIFF
--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -213,7 +213,7 @@ def log_model(
 
     Returns
         A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
-                metadata of the logged model.
+        metadata of the logged model.
     """
 
     return Model.log(

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -594,6 +594,7 @@ def load_model(model_uri, dst_path=None, saved_model_kwargs=None, keras_model_kw
 
     Args:
         model_uri: The location, in URI format, of the MLflow model. For example:
+
             - ``/Users/me/path/to/local/model``
             - ``relative/path/to/local/model``
             - ``s3://my_bucket/path/to/model``

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -100,9 +100,10 @@ _MODEL_TYPE_TF2_MODULE = "tf2-module"
 
 def get_default_pip_requirements(include_cloudpickle=False):
     """
-    :return: A list of default pip requirements for MLflow Models produced by this flavor.
-             Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
-             that, at minimum, contains these requirements.
+    Returns
+        A list of default pip requirements for MLflow Models produced by this flavor.
+        Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
+        that, at minimum, contains these requirements.
     """
     pip_deps = [_get_pinned_requirement("tensorflow")]
     if include_cloudpickle:
@@ -113,15 +114,17 @@ def get_default_pip_requirements(include_cloudpickle=False):
 
 def get_default_conda_env():
     """
-    :return: The default Conda environment for MLflow Models produced by calls to
-             :func:`save_model()` and :func:`log_model()`.
+    Returns:
+        The default Conda environment for MLflow Models produced by calls to
+        :func:`save_model()` and :func:`log_model()`.
     """
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
 
 def get_global_custom_objects():
     """
-    :return: A live reference to the global dictionary of custom objects.
+    Returns:
+        A live reference to the global dictionary of custom objects.
     """
     try:
         from tensorflow import keras
@@ -179,36 +182,38 @@ def log_model(
             #  - Input with name "field2", shape (-1, 3, 2), type "np.float32"
             signature = ModelSignature(inputs=input_schema)
 
-    :param model: The TF2 core model (inheriting tf.Module) or Keras model to be saved.
-    :param artifact_path: The run-relative path to which to log model artifacts.
-    :param custom_objects: A Keras ``custom_objects`` dictionary mapping names (strings) to
-                           custom classes or functions associated with the Keras model. MLflow saves
-                           these custom layers using CloudPickle and restores them automatically
-                           when the model is loaded with :py:func:`mlflow.tensorflow.load_model` and
-                           :py:func:`mlflow.pyfunc.load_model`.
-    :param conda_env: {{ conda_env }}
-    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
-    :param registered_model_name: If given, create a model version under
-                                  ``registered_model_name``, also creating a registered model if one
-                                  with the given name does not exist.
+    Args:
+        model: The TF2 core model (inheriting tf.Module) or Keras model to be saved.
+        artifact_path: The run-relative path to which to log model artifacts.
+        custom_objects: A Keras ``custom_objects`` dictionary mapping names (strings) to
+            custom classes or functions associated with the Keras model. MLflow saves
+            these custom layers using CloudPickle and restores them automatically
+            when the model is loaded with :py:func:`mlflow.tensorflow.load_model` and
+            :py:func:`mlflow.pyfunc.load_model`.
+        conda_env: {{ conda_env }}
+        code_paths: A list of local filesystem paths to Python file dependencies (or directories
+            containing file dependencies). These files are *prepended* to the system
+            path when the model is loaded.
+        registered_model_name: If given, create a model version under
+            ``registered_model_name``, also creating a registered model if one
+            with the given name does not exist.
+        signature: {{ signature }}
+        input_example: {{ input_example }}
+        await_registration_for: Number of seconds to wait for the model version to finish
+            being created and is in ``READY`` status. By default, the function
+            waits for five minutes. Specify 0 or None to skip waiting.
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
+        saved_model_kwargs: a dict of kwargs to pass to ``tensorflow.saved_model.save`` method.
+        keras_model_kwargs: a dict of kwargs to pass to ``keras_model.save`` method.
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-    :param signature: {{ signature }}
-    :param input_example: {{ input_example }}
-    :param await_registration_for: Number of seconds to wait for the model version to finish
-                            being created and is in ``READY`` status. By default, the function
-                            waits for five minutes. Specify 0 or None to skip waiting.
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param saved_model_kwargs: a dict of kwargs to pass to ``tensorflow.saved_model.save`` method.
-    :param keras_model_kwargs: a dict of kwargs to pass to ``keras_model.save`` method.
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
+                        .. Note:: Experimental: This parameter may change or be removed in a future
+                                                release without warning.
 
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
-    :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
-             metadata of the logged model.
+    Returns
+        A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
+                metadata of the logged model.
     """
 
     return Model.log(
@@ -234,14 +239,15 @@ def _save_keras_custom_objects(path, custom_objects, file_name):
     """
     Save custom objects dictionary to a cloudpickle file so a model can be easily loaded later.
 
-    :param path: An absolute path that points to the data directory within /path/to/model.
-    :param custom_objects: Keras ``custom_objects`` is a dictionary mapping
-                           names (strings) to custom classes or functions to be considered
-                           during deserialization. MLflow saves these custom layers using
-                           CloudPickle and restores them automatically when the model is
-                           loaded with :py:func:`mlflow.keras.load_model` and
-                           :py:func:`mlflow.pyfunc.load_model`.
-    :param file_name: The file name to save the custom objects to.
+    Args:
+        path: An absolute path that points to the data directory within /path/to/model.
+        custom_objects: Keras ``custom_objects`` is a dictionary mapping
+            names (strings) to custom classes or functions to be considered
+            during deserialization. MLflow saves these custom layers using
+            CloudPickle and restores them automatically when the model is
+            loaded with :py:func:`mlflow.keras.load_model` and
+            :py:func:`mlflow.pyfunc.load_model`.
+        file_name: The file name to save the custom objects to.
     """
     import cloudpickle
 
@@ -304,30 +310,31 @@ def save_model(
             #  - Input with name "field2", shape (-1, 3, 2), type "np.float32"
             signature = ModelSignature(inputs=input_schema)
 
-    :param model: The Keras model or Tensorflow module to be saved.
-    :param path: Local path where the MLflow model is to be saved.
-    :param conda_env: {{ conda_env }}
-    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
-    :param mlflow_model: MLflow model configuration to which to add the ``tensorflow`` flavor.
-    :param custom_objects: A Keras ``custom_objects`` dictionary mapping names (strings) to
-                           custom classes or functions associated with the Keras model. MLflow saves
-                           these custom layers using CloudPickle and restores them automatically
-                           when the model is loaded with :py:func:`mlflow.tensorflow.load_model` and
-                           :py:func:`mlflow.pyfunc.load_model`.
-    :param signature: {{ signature }}
-    :param input_example: {{ input_example }}
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param saved_model_kwargs: a dict of kwargs to pass to ``tensorflow.saved_model.save`` method
-                               if the model to be saved is a Tensorflow module.
-    :param keras_model_kwargs: a dict of kwargs to pass to ``model.save`` method if the model
-                               to be saved is a keras model.
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
+    Args:
+        model: The Keras model or Tensorflow module to be saved.
+        path: Local path where the MLflow model is to be saved.
+        conda_env: {{ conda_env }}
+        code_paths: A list of local filesystem paths to Python file dependencies (or directories
+            containing file dependencies). These files are *prepended* to the system
+            path when the model is loaded.
+        mlflow_model: MLflow model configuration to which to add the ``tensorflow`` flavor.
+        custom_objects: A Keras ``custom_objects`` dictionary mapping names (strings) to
+            custom classes or functions associated with the Keras model. MLflow saves
+            these custom layers using CloudPickle and restores them automatically
+            when the model is loaded with :py:func:`mlflow.tensorflow.load_model` and
+            :py:func:`mlflow.pyfunc.load_model`.
+        signature: {{ signature }}
+        input_example: {{ input_example }}
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
+        saved_model_kwargs: a dict of kwargs to pass to ``tensorflow.saved_model.save`` method
+            if the model to be saved is a Tensorflow module.
+        keras_model_kwargs: a dict of kwargs to pass to ``model.save`` method if the model
+            to be saved is a keras model.
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                                    release without warning.
     """
     import tensorflow as tf
     from tensorflow.keras.models import Model as KerasModel
@@ -585,27 +592,28 @@ def load_model(model_uri, dst_path=None, saved_model_kwargs=None, keras_model_kw
     """
     Load an MLflow model that contains the TensorFlow flavor from the specified path.
 
-    :param model_uri: The location, in URI format, of the MLflow model. For example:
+    Args:
+        model_uri: The location, in URI format, of the MLflow model. For example:
+            - ``/Users/me/path/to/local/model``
+            - ``relative/path/to/local/model``
+            - ``s3://my_bucket/path/to/model``
+            - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+            - ``models:/<model_name>/<model_version>``
+            - ``models:/<model_name>/<stage>``
 
-                      - ``/Users/me/path/to/local/model``
-                      - ``relative/path/to/local/model``
-                      - ``s3://my_bucket/path/to/model``
-                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
-                      - ``models:/<model_name>/<model_version>``
-                      - ``models:/<model_name>/<stage>``
+            For more information about supported URI schemes, see
+            `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
+            artifact-locations>`_.
+        dst_path: The local filesystem path to which to download the model artifact.
+            This directory must already exist. If unspecified, a local output
+            path will be created.
+        saved_model_kwargs: kwargs to pass to ``tensorflow.saved_model.load`` method.
+            Only available when you are loading a tensorflow2 core model.
+        keras_model_kwargs: kwargs to pass to ``keras.models.load_model`` method.
+            Only available when you are loading a Keras model.
 
-                      For more information about supported URI schemes, see
-                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
-                      artifact-locations>`_.
-    :param dst_path: The local filesystem path to which to download the model artifact.
-                     This directory must already exist. If unspecified, a local output
-                     path will be created.
-    :param saved_model_kwargs: kwargs to pass to ``tensorflow.saved_model.load`` method.
-                               Only available when you are loading a tensorflow2 core model.
-    :param keras_model_kwargs: kwargs to pass to ``keras.models.load_model`` method.
-                               Only available when you are loading a Keras model.
-
-    :return: A callable graph (tf.function) that takes inputs and returns inferences.
+    Returns
+        A callable graph (tf.function) that takes inputs and returns inferences.
     """
     import tensorflow as tf
 
@@ -653,18 +661,21 @@ def _load_tf1_estimator_saved_model(tf_saved_model_dir, tf_meta_graph_tags, tf_s
     Load a specified TensorFlow model consisting of a TensorFlow metagraph and signature definition
     from a serialized TensorFlow ``SavedModel`` collection.
 
-    :param tf_saved_model_dir: The local filesystem path or run-relative artifact path to the model.
-    :param tf_meta_graph_tags: A list of tags identifying the model's metagraph within the
-                               serialized ``SavedModel`` object. For more information, see the
-                               ``tags`` parameter of the `tf.saved_model.builder.SavedModelBuilder
-                               method <https://www.tensorflow.org/api_docs/python/tf/saved_model/
-                               builder/SavedModelBuilder#add_meta_graph>`_.
-    :param tf_signature_def_key: A string identifying the input/output signature associated with the
-                                 model. This is a key within the serialized ``SavedModel``'s
-                                 signature definition mapping. For more information, see the
-                                 ``signature_def_map`` parameter of the
-                                 ``tf.saved_model.builder.SavedModelBuilder`` method.
-    :return: A callable graph (tensorflow.function) that takes inputs and returns inferences.
+    Args:
+        tf_saved_model_dir: The local filesystem path or run-relative artifact path to the model.
+        tf_meta_graph_tags: A list of tags identifying the model's metagraph within the
+            serialized ``SavedModel`` object. For more information, see the
+            ``tags`` parameter of the `tf.saved_model.builder.SavedModelBuilder
+            method <https://www.tensorflow.org/api_docs/python/tf/saved_model/
+            builder/SavedModelBuilder#add_meta_graph>`_.
+        tf_signature_def_key: A string identifying the input/output signature associated with the
+            model. This is a key within the serialized ``SavedModel``'s
+            signature definition mapping. For more information, see the
+            ``signature_def_map`` parameter of the
+            ``tf.saved_model.builder.SavedModelBuilder`` method.
+
+    Returns:
+        A callable graph (tensorflow.function) that takes inputs and returns inferences.
     """
     import tensorflow as tf
 
@@ -686,7 +697,8 @@ def _load_pyfunc(path):
     model with the TensorFlow flavor into a new TensorFlow graph and exposes it behind the
     ``pyfunc.predict`` interface.
 
-    :param path: Local filesystem path to the MLflow Model with the ``tensorflow`` flavor.
+    Args:
+        path: Local filesystem path to the MLflow Model with the ``tensorflow`` flavor.
     """
     import tensorflow as tf
 
@@ -751,8 +763,9 @@ class _TF2Wrapper:
 
     def __init__(self, model, infer):
         """
-        :param model: A Tensorflow SavedModel.
-        :param infer: Tensorflow function returned by a saved model that is used for inference.
+        Args:
+            model: A Tensorflow SavedModel.
+            infer: Tensorflow function returned by a saved model that is used for inference.
         """
         # Note: we need to retain the model reference in TF2Wrapper object, because the infer
         #  function in tensorflow will be `ConcreteFunction` which only retains WeakRefs to the
@@ -765,13 +778,15 @@ class _TF2Wrapper:
         self, data, params: Optional[Dict[str, Any]] = None  # pylint: disable=unused-argument
     ):
         """
-        :param data: Model input data.
-        :param params: Additional parameters to pass to the model for inference.
+        Args:
+            data: Model input data.
+            params: Additional parameters to pass to the model for inference.
 
-                       .. Note:: Experimental: This parameter may change or be removed in a future
-                                               release without warning.
+                .. Note:: Experimental: This parameter may change or be removed in a future
+                                        release without warning.
 
-        :return: Model predictions.
+        Returns:
+            Model predictions.
         """
         import tensorflow as tf
 
@@ -817,13 +832,15 @@ class _TF2ModuleWrapper:
         self, data, params: Optional[Dict[str, Any]] = None  # pylint: disable=unused-argument
     ):
         """
-        :param data: Model input data.
-        :param params: Additional parameters to pass to the model for inference.
+        Args:
+            data: Model input data.
+            params: Additional parameters to pass to the model for inference.
 
-                       .. Note:: Experimental: This parameter may change or be removed in a future
-                                               release without warning.
+                .. Note:: Experimental: This parameter may change or be removed in a future
+                                        release without warning.
 
-        :return: Model predictions.
+        Returns:
+            Model predictions.
         """
         import tensorflow as tf
 
@@ -849,13 +866,15 @@ class _KerasModelWrapper:
         self, data, params: Optional[Dict[str, Any]] = None  # pylint: disable=unused-argument
     ):
         """
-        :param data: Model input data.
-        :param params: Additional parameters to pass to the model for inference.
+        Args:
+            data: Model input data.
+            params: Additional parameters to pass to the model for inference.
 
-                       .. Note:: Experimental: This parameter may change or be removed in a future
-                                               release without warning.
+                .. Note:: Experimental: This parameter may change or be removed in a future
+                                        release without warning.
 
-        :return: Model predictions.
+        Returns
+            Model predictions.
         """
         if isinstance(data, pandas.DataFrame):
             # This line is for backwards compatibility:
@@ -1011,43 +1030,44 @@ def autolog(
     If you want to include `mlflow.tensorflow.MLflowCallback` in the callback list, please turn off
     autologging by calling `mlflow.tensorflow.autolog(disable=True)`.
 
-    :param every_n_iter: The frequency with which metrics should be logged. For example, a value of
-                         100 will log metrics at step 0, 100, 200, etc.
-    :param log_models: If ``True``, trained models are logged as MLflow model artifacts.
-                       If ``False``, trained models are not logged.
-    :param log_datasets: If ``True``, dataset information is logged to MLflow Tracking.
-                         If ``False``, dataset information is not logged.
-    :param disable: If ``True``, disables the TensorFlow autologging integration. If ``False``,
-                    enables the TensorFlow integration autologging integration.
-    :param exclusive: If ``True``, autologged content is not logged to user-created fluent runs.
-                      If ``False``, autologged content is logged to the active fluent run,
-                      which may be user-created.
-    :param disable_for_unsupported_versions: If ``True``, disable autologging for versions of
-                      tensorflow that have not been tested against this version of the MLflow
-                      client or are incompatible.
-    :param silent: If ``True``, suppress all event logs and warnings from MLflow during TensorFlow
-                   autologging. If ``False``, show all events and warnings during TensorFlow
-                   autologging.
-    :param registered_model_name: If given, each time a model is trained, it is registered as a
-                                  new model version of the registered model with this name.
-                                  The registered model is created if it does not already exist.
-    :param log_input_examples: If ``True``, input examples from training datasets are collected and
-                               logged along with tf/keras model artifacts during training. If
-                               ``False``, input examples are not logged.
-    :param log_model_signatures: If ``True``,
-                                 :py:class:`ModelSignatures <mlflow.models.ModelSignature>`
-                                 describing model inputs and outputs are collected and logged along
-                                 with tf/keras model artifacts during training. If ``False``,
-                                 signatures are not logged. Note that logging TensorFlow models
-                                 with signatures changes their pyfunc inference behavior when
-                                 Pandas DataFrames are passed to ``predict()``.
-                                 When a signature is present, an ``np.ndarray``
-                                 (for single-output models) or a mapping from
-                                 ``str`` -> ``np.ndarray`` (for multi-output models) is returned;
-                                 when a signature is not present, a Pandas DataFrame is returned.
-    :param saved_model_kwargs: a dict of kwargs to pass to ``tensorflow.saved_model.save`` method.
-    :param keras_model_kwargs: a dict of kwargs to pass to ``keras_model.save`` method.
-    :param extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
+    Args:
+        every_n_iter: The frequency with which metrics should be logged. For example, a value of
+            100 will log metrics at step 0, 100, 200, etc.
+        log_models: If ``True``, trained models are logged as MLflow model artifacts.
+            If ``False``, trained models are not logged.
+        log_datasets: If ``True``, dataset information is logged to MLflow Tracking.
+            If ``False``, dataset information is not logged.
+        disable: If ``True``, disables the TensorFlow autologging integration. If ``False``,
+            enables the TensorFlow integration autologging integration.
+        exclusive: If ``True``, autologged content is not logged to user-created fluent runs.
+            If ``False``, autologged content is logged to the active fluent run,
+            which may be user-created.
+        disable_for_unsupported_versions: If ``True``, disable autologging for versions of
+            tensorflow that have not been tested against this version of the MLflow
+            client or are incompatible.
+        silent: If ``True``, suppress all event logs and warnings from MLflow during TensorFlow
+            autologging. If ``False``, show all events and warnings during TensorFlow
+            autologging.
+        registered_model_name: If given, each time a model is trained, it is registered as a
+            new model version of the registered model with this name.
+            The registered model is created if it does not already exist.
+        log_input_examples: If ``True``, input examples from training datasets are collected and
+            logged along with tf/keras model artifacts during training. If
+            ``False``, input examples are not logged.
+        log_model_signatures: If ``True``,
+            :py:class:`ModelSignatures <mlflow.models.ModelSignature>`
+            describing model inputs and outputs are collected and logged along
+            with tf/keras model artifacts during training. If ``False``,
+            signatures are not logged. Note that logging TensorFlow models
+            with signatures changes their pyfunc inference behavior when
+            Pandas DataFrames are passed to ``predict()``.
+            When a signature is present, an ``np.ndarray``
+            (for single-output models) or a mapping from
+            ``str`` -> ``np.ndarray`` (for multi-output models) is returned;
+            when a signature is not present, a Pandas DataFrame is returned.
+        saved_model_kwargs: a dict of kwargs to pass to ``tensorflow.saved_model.save`` method.
+        keras_model_kwargs: a dict of kwargs to pass to ``keras_model.save`` method.
+        extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
     """
     import tensorflow as tf
 

--- a/mlflow/tensorflow/_autolog.py
+++ b/mlflow/tensorflow/_autolog.py
@@ -69,9 +69,12 @@ def _extract_input_example_from_tensor_or_ndarray(
     Extracts first `INPUT_EXAMPLE_SAMPLE_ROWS` from the next_input, which can either be of
     numpy array or tensor type.
 
-    :param input_features: an input of type `np.ndarray` or `tensorflow.Tensor`
-    :return: A slice (of limit `INPUT_EXAMPLE_SAMPLE_ROWS`)  of the input of type `np.ndarray`.
-             Returns `None` if the type of `input_features` is unsupported.
+    Args:
+        input_features: an input of type `np.ndarray` or `tensorflow.Tensor`
+
+    Returns:
+        A slice (of limit `INPUT_EXAMPLE_SAMPLE_ROWS`)  of the input of type `np.ndarray`.
+        Returns `None` if the type of `input_features` is unsupported.
 
     Examples
     --------
@@ -102,9 +105,12 @@ def _extract_sample_numpy_dict(
     Extracts `INPUT_EXAMPLE_SAMPLE_ROWS` sample from next_input
     as numpy array of dict(str -> ndarray) type.
 
-    :param input_numpy_features_dict: A tensor or numpy array
-    :return:a slice (limit `INPUT_EXAMPLE_SAMPLE_ROWS`)  of the input of same type as next_input.
-            Returns `None` if the type of `input_numpy_features_dict` is unsupported.
+    Args:
+        input_numpy_features_dict: A tensor or numpy array
+
+    Returns:
+        A slice (limit `INPUT_EXAMPLE_SAMPLE_ROWS`)  of the input of same type as next_input.
+        Returns `None` if the type of `input_numpy_features_dict` is unsupported.
 
     Examples
     --------
@@ -132,9 +138,12 @@ def _extract_input_example_from_batched_tf_dataset(
     used for tensorflow/keras train or fit methods
 
 
-    :param dataset: a tensorflow batched/unbatched dataset representing tuple of (features, labels)
-    :return: a numpy array of length `INPUT_EXAMPLE_SAMPLE_ROWS`
-             Returns `None` if the type of `dataset` slices are unsupported.
+    Args:
+        dataset: a tensorflow batched/unbatched dataset representing tuple of (features, labels)
+
+    Returns:
+        a numpy array of length `INPUT_EXAMPLE_SAMPLE_ROWS`
+        Returns `None` if the type of `dataset` slices are unsupported.
 
     Examples
     --------
@@ -168,10 +177,13 @@ def extract_input_example_from_tf_input_fn(input_fn):
     Extracts sample data from dict (str -> ndarray),
     ``tensorflow.Tensor`` or ``tensorflow.data.Dataset`` type.
 
-    :param input_fn: Tensorflow's input function used for train method
-    :return: a slice (of limit ``mlflow.utils.autologging_utils.INPUT_EXAMPLE_SAMPLE_ROWS``)
-             of the input of type `np.ndarray`.
-             Returns `None` if the return type of ``input_fn`` is unsupported.
+    Args:
+        input_fn: Tensorflow's input function used for train method
+
+    Returns:
+        A slice (of limit ``mlflow.utils.autologging_utils.INPUT_EXAMPLE_SAMPLE_ROWS``)
+        of the input of type `np.ndarray`.
+        Returns `None` if the return type of ``input_fn`` is unsupported.
     """
 
     input_training_data = input_fn()
@@ -192,13 +204,15 @@ def extract_tf_keras_input_example(input_training_data):
     Generates a sample ndarray or dict (str -> ndarray)
     from the input type 'x' for keras ``fit`` or ``fit_generator``
 
-    :param input_training_data: Keras input function used for ``fit`` or
-                                ``fit_generator`` methods
-    :return: a slice of type ndarray or
-             dict (str -> ndarray) limited to
-             ``mlflow.utils.autologging_utils.INPUT_EXAMPLE_SAMPLE_ROWS``.
-             Throws ``MlflowException`` exception, if input_training_data is unsupported.
-             Returns `None` if the type of input_training_data is unsupported.
+    Args:
+        input_training_data: Keras input function used for ``fit`` or ``fit_generator`` methods.
+
+    Returns:
+        a slice of type ndarray or
+        dict (str -> ndarray) limited to
+        ``mlflow.utils.autologging_utils.INPUT_EXAMPLE_SAMPLE_ROWS``.
+        Throws ``MlflowException`` exception, if input_training_data is unsupported.
+        Returns `None` if the type of input_training_data is unsupported.
     """
     input_data_slice = None
     if isinstance(input_training_data, tensorflow.keras.utils.Sequence):

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -811,6 +811,7 @@ def load_model(
 
     Args:
         model_uri: The location, in URI format, of the MLflow model. For example:
+
             - ``/Users/me/path/to/local/model``
             - ``relative/path/to/local/model``
             - ``s3://my_bucket/path/to/model``

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -120,9 +120,12 @@ def _model_packages(model) -> List[str]:
     """
     Determines which pip libraries should be included based on the base model engine type.
 
-    :param model: The model instance to be saved in order to provide the required underlying
-                  deep learning execution framework dependency requirements.
-    :return: A list of strings representing the underlying engine-specific dependencies
+    Args:
+        model: The model instance to be saved in order to provide the required underlying
+            deep learning execution framework dependency requirements.
+
+    Returns:
+        A list of strings representing the underlying engine-specific dependencies
     """
     engine = _get_engine_type(model)
     if engine == "torch":
@@ -141,12 +144,15 @@ def _model_packages(model) -> List[str]:
 @experimental
 def get_default_pip_requirements(model) -> List[str]:
     """
-    :param model: The model instance to be saved in order to provide the required underlying
-                  deep learning execution framework dependency requirements. Note that this must
-                  be the actual model instance and not a Pipeline.
-    :return: A list of default pip requirements for MLflow Models that have been produced with the
-             ``transformers`` flavor. Calls to :py:func:`save_model()` and :py:func:`log_model()`
-             produce a pip environment that contain these requirements at a minimum.
+    Args:
+        model: The model instance to be saved in order to provide the required underlying
+            deep learning execution framework dependency requirements. Note that this must
+            be the actual model instance and not a Pipeline.
+
+    Returns:
+        A list of default pip requirements for MLflow Models that have been produced with the
+        ``transformers`` flavor. Calls to :py:func:`save_model()` and :py:func:`log_model()`
+        produce a pip environment that contain these requirements at a minimum.
     """
 
     from transformers import FlaxPreTrainedModel, PreTrainedModel, TFPreTrainedModel
@@ -208,8 +214,9 @@ def _validate_transformers_model_dict(transformers_model):
 @experimental
 def get_default_conda_env(model):
     """
-    :return: The default Conda environment for MLflow Models produced with the ``transformers``
-             flavor, based on the model instance framework type of the model to be logged.
+    Returns:
+        The default Conda environment for MLflow Models produced with the ``transformers``
+        flavor, based on the model instance framework type of the model to be logged.
     """
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements(model))
 
@@ -239,177 +246,178 @@ def save_model(
     """
     Save a trained transformers model to a path on the local file system.
 
-    :param transformers_model:
-        A trained transformers `Pipeline` or a dictionary that maps required components of a
-        pipeline to the named keys of ["model", "image_processor", "tokenizer",
-        "feature_extractor"]. The `model` key in the dictionary must map to a value that inherits
-        from `PreTrainedModel`, `TFPreTrainedModel`, or `FlaxPreTrainedModel`.
-        All other component entries in the dictionary must support the defined task type that is
-        associated with the base model type configuration.
+    Args:
+        transformers_model:
+            A trained transformers `Pipeline` or a dictionary that maps required components of a
+            pipeline to the named keys of ["model", "image_processor", "tokenizer",
+            "feature_extractor"]. The `model` key in the dictionary must map to a value that
+            inherits from `PreTrainedModel`, `TFPreTrainedModel`, or `FlaxPreTrainedModel`.
+            All other component entries in the dictionary must support the defined task type that is
+            associated with the base model type configuration.
 
-        An example of supplying component-level parts of a transformers model is shown below:
+            An example of supplying component-level parts of a transformers model is shown below:
 
-        .. code-block:: python
+            .. code-block:: python
 
-          from transformers import MobileBertForQuestionAnswering, AutoTokenizer
+                from transformers import MobileBertForQuestionAnswering, AutoTokenizer
 
-          architecture = "csarron/mobilebert-uncased-squad-v2"
-          tokenizer = AutoTokenizer.from_pretrained(architecture)
-          model = MobileBertForQuestionAnswering.from_pretrained(architecture)
+                architecture = "csarron/mobilebert-uncased-squad-v2"
+                tokenizer = AutoTokenizer.from_pretrained(architecture)
+                model = MobileBertForQuestionAnswering.from_pretrained(architecture)
 
-          with mlflow.start_run():
-              components = {
-                  "model": model,
-                  "tokenizer": tokenizer,
-              }
-              mlflow.transformers.save_model(
-                  transformers_model=components,
-                  path="path/to/save/model",
-              )
+                with mlflow.start_run():
+                    components = {
+                        "model": model,
+                        "tokenizer": tokenizer,
+                    }
+                    mlflow.transformers.save_model(
+                        transformers_model=components,
+                        path="path/to/save/model",
+                    )
 
-        An example of submitting a `Pipeline` from a default pipeline instantiation:
+            An example of submitting a `Pipeline` from a default pipeline instantiation:
 
-        .. code-block:: python
+            .. code-block:: python
 
-          from transformers import pipeline
+                from transformers import pipeline
 
-          qa_pipe = pipeline("question-answering", "csarron/mobilebert-uncased-squad-v2")
+                qa_pipe = pipeline("question-answering", "csarron/mobilebert-uncased-squad-v2")
 
-          with mlflow.start_run():
-              mlflow.transformers.save_model(
-                  transformers_model=qa_pipe,
-                  path="path/to/save/model",
-              )
+                with mlflow.start_run():
+                    mlflow.transformers.save_model(
+                        transformers_model=qa_pipe,
+                        path="path/to/save/model",
+                    )
 
-    :param path: Local path destination for the serialized model to be saved.
-    :param processor: An optional ``Processor`` subclass object. Some model architectures,
-                      particularly multi-modal types, utilize Processors to combine text
-                      encoding and image or audio encoding in a single entrypoint.
+        path: Local path destination for the serialized model to be saved.
+        processor: An optional ``Processor`` subclass object. Some model architectures,
+            particularly multi-modal types, utilize Processors to combine text
+            encoding and image or audio encoding in a single entrypoint.
 
-                      .. Note:: If a processor is supplied when saving a model, the
-                                model will be unavailable for loading as a ``Pipeline`` or for
-                                usage with pyfunc inference.
+            .. Note:: If a processor is supplied when saving a model, the
+                        model will be unavailable for loading as a ``Pipeline`` or for
+                        usage with pyfunc inference.
+        task: The transformers-specific task type of the model. These strings are utilized so
+            that a pipeline can be created with the appropriate internal call architecture
+            to meet the needs of a given model. If this argument is not specified, the
+            pipeline utilities within the transformers library will be used to infer the
+            correct task type. If the value specified is not a supported type within the
+            version of transformers that is currently installed, an Exception will be thrown.
+        model_card: An Optional `ModelCard` instance from `huggingface-hub`. If provided, the
+            contents of the model card will be saved along with the provided
+            `transformers_model`. If not provided, an attempt will be made to fetch
+            the card from the base pretrained model that is provided (or the one that is
+            included within a provided `Pipeline`).
 
-    :param task: The transformers-specific task type of the model. These strings are utilized so
-                 that a pipeline can be created with the appropriate internal call architecture
-                 to meet the needs of a given model. If this argument is not specified, the
-                 pipeline utilities within the transformers library will be used to infer the
-                 correct task type. If the value specified is not a supported type within the
-                 version of transformers that is currently installed, an Exception will be thrown.
-    :param model_card: An Optional `ModelCard` instance from `huggingface-hub`. If provided, the
-                       contents of the model card will be saved along with the provided
-                       `transformers_model`. If not provided, an attempt will be made to fetch
-                       the card from the base pretrained model that is provided (or the one that is
-                       included within a provided `Pipeline`).
+            .. Note:: In order for a ModelCard to be fetched (if not provided),
+                        the huggingface_hub package must be installed and the version
+                        must be >=0.10.0
+        inference_config:
 
-                       .. Note:: In order for a ModelCard to be fetched (if not provided),
-                                 the huggingface_hub package must be installed and the version
-                                 must be >=0.10.0
+            .. Warning:: Deprecated. `inference_config` is deprecated in favor of `model_config`.
 
-    :param inference_config:
+        model_config:
+            A dict of valid overrides that can be applied to a pipeline instance during inference.
+            These arguments are used exclusively for the case of loading the model as a ``pyfunc``
+            Model or for use in Spark.
+            These values are not applied to a returned Pipeline from a call to
+            ``mlflow.transformers.load_model()``
 
-        .. Warning:: Deprecated. `inference_config` is deprecated in favor of `model_config`.
+            .. Warning:: If the key provided is not compatible with either the
+                    Pipeline instance for the task provided or is not a valid
+                    override to any arguments available in the Model, an
+                    Exception will be raised at runtime. It is very important
+                    to validate the entries in this dictionary to ensure
+                    that they are valid prior to saving or logging.
 
-    :param model_config:
-        A dict of valid overrides that can be applied to a pipeline instance during inference.
-        These arguments are used exclusively for the case of loading the model as a ``pyfunc``
-        Model or for use in Spark.
-        These values are not applied to a returned Pipeline from a call to
-        ``mlflow.transformers.load_model()``
+            An example of providing overrides for a question generation model:
 
-        .. Warning:: If the key provided is not compatible with either the
-                  Pipeline instance for the task provided or is not a valid
-                  override to any arguments available in the Model, an
-                  Exception will be raised at runtime. It is very important
-                  to validate the entries in this dictionary to ensure
-                  that they are valid prior to saving or logging.
+            .. code-block:: python
 
-        An example of providing overrides for a question generation model:
+                from transformers import pipeline, AutoTokenizer
 
-        .. code-block:: python
+                task = "text-generation"
+                architecture = "gpt2"
 
-            from transformers import pipeline, AutoTokenizer
+                sentence_pipeline = pipeline(
+                    task=task,
+                    tokenizer=AutoTokenizer.from_pretrained(architecture),
+                    model=architecture,  # pylint: disable=line-too-long
+                )
 
-            task = "text-generation"
-            architecture = "gpt2"
+                # Validate that the overrides function
+                prompts = ["Generative models are", "I'd like a coconut so that I can"]
 
-            sentence_pipeline = pipeline(
-                task=task, tokenizer=AutoTokenizer.from_pretrained(architecture), model=architecture
-            )
+                # validation of config prior to save or log
+                model_config = {
+                    "top_k": 2,
+                    "num_beams": 5,
+                    "max_length": 30,
+                    "temperature": 0.62,
+                    "top_p": 0.85,
+                    "repetition_penalty": 1.15,
+                }
 
-            # Validate that the overrides function
-            prompts = ["Generative models are", "I'd like a coconut so that I can"]
+                # Verify that no exceptions are thrown
+                sentence_pipeline(prompts, **model_config)
 
-            # validation of config prior to save or log
-            model_config = {
-                "top_k": 2,
-                "num_beams": 5,
-                "max_length": 30,
-                "temperature": 0.62,
-                "top_p": 0.85,
-                "repetition_penalty": 1.15,
-            }
+                mlflow.transformers.save_model(
+                    transformers_model=sentence_pipeline,
+                    path="/path/for/model",
+                    task=task,
+                    model_config=model_config,
+                )
 
-            # Verify that no exceptions are thrown
-            sentence_pipeline(prompts, **model_config)
+        code_paths: A list of local filesystem paths to Python file dependencies (or directories
+            containing file dependencies). These files are *prepended* to the system
+            path when the model is loaded.
+        mlflow_model: An MLflow model object that specifies the flavor that this model is being
+            added to.
+        signature: A Model Signature object that describes the input and output Schema of the
+            model. The model signature can be inferred using `infer_signature` function
+            of `mlflow.models.signature`.
+            Example:
 
-            mlflow.transformers.save_model(
-                transformers_model=sentence_pipeline,
-                path="/path/for/model",
-                task=task,
-                model_config=model_config,
-            )
+            .. code-block:: python
 
-    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
-    :param mlflow_model: An MLflow model object that specifies the flavor that this model is being
-                         added to.
-    :param signature: A Model Signature object that describes the input and output Schema of the
-                      model. The model signature can be inferred using `infer_signature` function
-                      of `mlflow.models.signature`.
-                      Example:
+                from mlflow.models import infer_signature
+                from mlflow.transformers import generate_signature_output
+                from transformers import pipeline
 
-                      .. code-block:: python
+                en_to_de = pipeline("translation_en_to_de")
 
-                        from mlflow.models import infer_signature
-                        from mlflow.transformers import generate_signature_output
-                        from transformers import pipeline
+                data = "MLflow is great!"
+                output = generate_signature_output(en_to_de, data)
+                signature = infer_signature(data, output)
 
-                        en_to_de = pipeline("translation_en_to_de")
+                mlflow.transformers.save_model(
+                    transformers_model=en_to_de,
+                    path="/path/to/save/model",
+                    signature=signature,
+                    input_example=data,
+                )
 
-                        data = "MLflow is great!"
-                        output = generate_signature_output(en_to_de, data)
-                        signature = infer_signature(data, output)
+                loaded = mlflow.pyfunc.load_model("/path/to/save/model")
+                print(loaded.predict(data))
+                # MLflow ist großartig!
 
-                        mlflow.transformers.save_model(
-                            transformers_model=en_to_de,
-                            path="/path/to/save/model",
-                            signature=signature,
-                            input_example=data,
-                        )
+            If an input_example is provided and the signature is not, a signature will
+            be inferred automatically and applied to the MLmodel file iff the
+            pipeline type is a text-based model (NLP). If the pipeline type is not
+            a supported type, this inference functionality will not function correctly
+            and a warning will be issued. In order to ensure that a precise signature
+            is logged, it is recommended to explicitly provide one.
+        input_example: {{ input_example }}
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
+        conda_env: {{ conda_env }}
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-                        loaded = mlflow.pyfunc.load_model("/path/to/save/model")
-                        print(loaded.predict(data))
-                        # MLflow ist großartig!
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                                    release without warning.
+        example_no_conversion: {{ example_no_conversion }}
+        kwargs: Optional additional configurations for transformers serialization.
 
-                      If an input_example is provided and the signature is not, a signature will
-                      be inferred automatically and applied to the MLmodel file iff the
-                      pipeline type is a text-based model (NLP). If the pipeline type is not
-                      a supported type, this inference functionality will not function correctly
-                      and a warning will be issued. In order to ensure that a precise signature
-                      is logged, it is recommended to explicitly provide one.
-    :param input_example: {{ input_example }}
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param conda_env: {{ conda_env }}
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
-
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
-    :param example_no_conversion: {{ example_no_conversion }}
-    :param kwargs: Optional additional configurations for transformers serialization.
-    :return: None
     """
     import transformers
 
@@ -590,185 +598,185 @@ def log_model(
     """
     Log a ``transformers`` object as an MLflow artifact for the current run.
 
-    :param transformers_model:
-        A trained transformers `Pipeline` or a dictionary that maps required components of a
-        pipeline to the named keys of ["model", "image_processor", "tokenizer",
-        "feature_extractor"]. The `model` key in the dictionary must map to a value that inherits
-        from `PreTrainedModel`, `TFPreTrainedModel`, or `FlaxPreTrainedModel`.
-        All other component entries in the dictionary must support the defined task type that is
-        associated with the base model type configuration.
+    Args:
+        transformers_model:
+            A trained transformers `Pipeline` or a dictionary that maps required components of a
+            pipeline to the named keys of ["model", "image_processor", "tokenizer",
+            "feature_extractor"]. The `model` key in the dictionary must map to a value that
+            inherits from `PreTrainedModel`, `TFPreTrainedModel`, or `FlaxPreTrainedModel`.
+            All other component entries in the dictionary must support the defined task type that is
+            associated with the base model type configuration.
 
-        An example of supplying component-level parts of a transformers model is shown below:
+            An example of supplying component-level parts of a transformers model is shown below:
 
-        .. code-block:: python
+            .. code-block:: python
 
-          from transformers import MobileBertForQuestionAnswering, AutoTokenizer
+                from transformers import MobileBertForQuestionAnswering, AutoTokenizer
 
-          architecture = "csarron/mobilebert-uncased-squad-v2"
-          tokenizer = AutoTokenizer.from_pretrained(architecture)
-          model = MobileBertForQuestionAnswering.from_pretrained(architecture)
+                architecture = "csarron/mobilebert-uncased-squad-v2"
+                tokenizer = AutoTokenizer.from_pretrained(architecture)
+                model = MobileBertForQuestionAnswering.from_pretrained(architecture)
 
-          with mlflow.start_run():
-              components = {
-                  "model": model,
-                  "tokenizer": tokenizer,
-              }
-              mlflow.transformers.log_model(
-                  transformers_model=components,
-                  artifact_path="my_model",
-              )
+                with mlflow.start_run():
+                    components = {
+                        "model": model,
+                        "tokenizer": tokenizer,
+                    }
+                    mlflow.transformers.log_model(
+                        transformers_model=components,
+                        artifact_path="my_model",
+                    )
 
-        An example of submitting a `Pipeline` from a default pipeline instantiation:
+            An example of submitting a `Pipeline` from a default pipeline instantiation:
 
-        .. code-block:: python
+            .. code-block:: python
 
-          from transformers import pipeline
+                from transformers import pipeline
 
-          qa_pipe = pipeline("question-answering", "csarron/mobilebert-uncased-squad-v2")
+                qa_pipe = pipeline("question-answering", "csarron/mobilebert-uncased-squad-v2")
 
-          with mlflow.start_run():
-              mlflow.transformers.log_model(
-                  transformers_model=qa_pipe,
-                  artifact_path="my_pipeline",
-              )
+                with mlflow.start_run():
+                    mlflow.transformers.log_model(
+                        transformers_model=qa_pipe,
+                        artifact_path="my_pipeline",
+                    )
 
-    :param artifact_path: Local path destination for the serialized model to be saved.
-    :param processor: An optional ``Processor`` subclass object. Some model architectures,
-                  particularly multi-modal types, utilize Processors to combine text
-                  encoding and image or audio encoding in a single entrypoint.
+        artifact_path: Local path destination for the serialized model to be saved.
+        processor: An optional ``Processor`` subclass object. Some model architectures,
+            particularly multi-modal types, utilize Processors to combine text
+            encoding and image or audio encoding in a single entrypoint.
 
-                  .. Note:: If a processor is supplied when logging a model, the
-                            model will be unavailable for loading as a ``Pipeline`` or for usage
-                            with pyfunc inference.
+                .. Note:: If a processor is supplied when logging a model, the
+                    model will be unavailable for loading as a ``Pipeline`` or for usage
+                    with pyfunc inference.
+        task: The transformers-specific task type of the model. These strings are utilized so
+            that a pipeline can be created with the appropriate internal call architecture
+            to meet the needs of a given model. If this argument is not specified, the
+            pipeline utilities within the transformers library will be used to infer the
+            correct task type. If the value specified is not a supported type within the
+            version of transformers that is currently installed, an Exception will be thrown.
+        model_card: An Optional `ModelCard` instance from `huggingface-hub`. If provided, the
+            contents of the model card will be saved along with the provided
+            `transformers_model`. If not provided, an attempt will be made to fetch
+            the card from the base pretrained model that is provided (or the one that is
+            included within a provided `Pipeline`).
 
-    :param task: The transformers-specific task type of the model. These strings are utilized so
-                 that a pipeline can be created with the appropriate internal call architecture
-                 to meet the needs of a given model. If this argument is not specified, the
-                 pipeline utilities within the transformers library will be used to infer the
-                 correct task type. If the value specified is not a supported type within the
-                 version of transformers that is currently installed, an Exception will be thrown.
-    :param model_card: An Optional `ModelCard` instance from `huggingface-hub`. If provided, the
-                       contents of the model card will be saved along with the provided
-                       `transformers_model`. If not provided, an attempt will be made to fetch
-                       the card from the base pretrained model that is provided (or the one that is
-                       included within a provided `Pipeline`).
+                .. Note:: In order for a ModelCard to be fetched (if not provided),
+                    the huggingface_hub package must be installed and the version
+                    must be >=0.10.0
+        inference_config:
 
-                       .. Note:: In order for a ModelCard to be fetched (if not provided),
-                                 the huggingface_hub package must be installed and the version
-                                 must be >=0.10.0
+            .. Warning:: Deprecated. `inference_config` is deprecated in favor of `model_config`.
+        model_config:
+            A dict of valid overrides that can be applied to a pipeline instance during inference.
+            These arguments are used exclusively for the case of loading the model as a ``pyfunc``
+            Model or for use in Spark. These values are not applied to a returned Pipeline from a
+            call to ``mlflow.transformers.load_model()``
 
-    :param inference_config:
+            .. Warning:: If the key provided is not compatible with either the
+                         Pipeline instance for the task provided or is not a valid
+                         override to any arguments available in the Model, an
+                         Exception will be raised at runtime. It is very important
+                         to validate the entries in this dictionary to ensure
+                         that they are valid prior to saving or logging.
 
-        .. Warning:: Deprecated. `inference_config` is deprecated in favor of `model_config`.
+            An example of providing overrides for a question generation model:
 
-    :param model_config:
-        A dict of valid overrides that can be applied to a pipeline instance during inference. These
-        arguments are used exclusively for the case of loading the model as a ``pyfunc`` Model or
-        for use in Spark. These values are not applied to a returned Pipeline from a call to
-        ``mlflow.transformers.load_model()``
+            .. code-block:: python
 
-        .. Warning:: If the key provided is not compatible with either the
-                     Pipeline instance for the task provided or is not a valid
-                     override to any arguments available in the Model, an
-                     Exception will be raised at runtime. It is very important
-                     to validate the entries in this dictionary to ensure
-                     that they are valid prior to saving or logging.
+                from transformers import pipeline, AutoTokenizer
 
-        An example of providing overrides for a question generation model:
+                task = "text-generation"
+                architecture = "gpt2"
 
-        .. code-block:: python
+                sentence_pipeline = pipeline(
+                    task=task,
+                    tokenizer=AutoTokenizer.from_pretrained(architecture),
+                    model=architecture,  # pylint: disable=line-too-long
+                )
 
-          from transformers import pipeline, AutoTokenizer
+                # Validate that the overrides function
+                prompts = ["Generative models are", "I'd like a coconut so that I can"]
 
-          task = "text-generation"
-          architecture = "gpt2"
+                # validation of config prior to save or log
+                model_config = {
+                    "top_k": 2,
+                    "num_beams": 5,
+                    "max_length": 30,
+                    "temperature": 0.62,
+                    "top_p": 0.85,
+                    "repetition_penalty": 1.15,
+                }
 
-          sentence_pipeline = pipeline(
-              task=task, tokenizer=AutoTokenizer.from_pretrained(architecture), model=architecture
-          )
+                # Verify that no exceptions are thrown
+                sentence_pipeline(prompts, **model_config)
 
-          # Validate that the overrides function
-          prompts = ["Generative models are", "I'd like a coconut so that I can"]
+                with mlflow.start_run():
+                    mlflow.transformers.log_model(
+                        transformers_model=sentence_pipeline,
+                        artifact_path="my_sentence_generator",
+                        task=task,
+                        model_config=model_config,
+                    )
 
-          # validation of config prior to save or log
-          model_config = {
-              "top_k": 2,
-              "num_beams": 5,
-              "max_length": 30,
-              "temperature": 0.62,
-              "top_p": 0.85,
-              "repetition_penalty": 1.15,
-          }
+        code_paths: A list of local filesystem paths to Python file dependencies (or directories
+            containing file dependencies). These files are *prepended* to the system
+            path when the model is loaded.
+        registered_model_name: This argument may change or be removed in a
+            future release without warning. If given, create a model
+            version under ``registered_model_name``, also creating a
+            registered model if one with the given name does not exist.
+        signature: A Model Signature object that describes the input and output Schema of the
+            model. The model signature can be inferred using `infer_signature` function
+            of `mlflow.models.signature`.
+            Example:
 
-          # Verify that no exceptions are thrown
-          sentence_pipeline(prompts, **model_config)
+            .. code-block:: python
 
-          with mlflow.start_run():
-              mlflow.transformers.log_model(
-                  transformers_model=sentence_pipeline,
-                  artifact_path="my_sentence_generator",
-                  task=task,
-                  model_config=model_config,
-              )
+                from mlflow.models import infer_signature
+                from mlflow.transformers import generate_signature_output
+                from transformers import pipeline
 
-    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
-    :param registered_model_name: This argument may change or be removed in a
-                                  future release without warning. If given, create a model
-                                  version under ``registered_model_name``, also creating a
-                                  registered model if one with the given name does not exist.
-    :param signature: A Model Signature object that describes the input and output Schema of the
-                      model. The model signature can be inferred using `infer_signature` function
-                      of `mlflow.models.signature`.
-                      Example:
+                en_to_de = pipeline("translation_en_to_de")
 
-                      .. code-block:: python
+                data = "MLflow is great!"
+                output = generate_signature_output(en_to_de, data)
+                signature = infer_signature(data, output)
 
-                        from mlflow.models import infer_signature
-                        from mlflow.transformers import generate_signature_output
-                        from transformers import pipeline
+                with mlflow.start_run() as run:
+                    mlflow.transformers.log_model(
+                        transformers_model=en_to_de,
+                        artifact_path="english_to_german_translator",
+                        signature=signature,
+                        input_example=data,
+                    )
 
-                        en_to_de = pipeline("translation_en_to_de")
+                model_uri = f"runs:/{run.info.run_id}/english_to_german_translator"
+                loaded = mlflow.pyfunc.load_model(model_uri)
 
-                        data = "MLflow is great!"
-                        output = generate_signature_output(en_to_de, data)
-                        signature = infer_signature(data, output)
+                print(loaded.predict(data))
+                # MLflow ist großartig!
 
-                        with mlflow.start_run() as run:
-                            mlflow.transformers.log_model(
-                                transformers_model=en_to_de,
-                                artifact_path="english_to_german_translator",
-                                signature=signature,
-                                input_example=data,
-                            )
+            If an input_example is provided and the signature is not, a signature will
+            be inferred automatically and applied to the MLmodel file iff the
+            pipeline type is a text-based model (NLP). If the pipeline type is not
+            a supported type, this inference functionality will not function correctly
+            and a warning will be issued. In order to ensure that a precise signature
+            is logged, it is recommended to explicitly provide one.
+        input_example: {{ input_example }}
+        await_registration_for: Number of seconds to wait for the model version
+            to finish being created and is in ``READY`` status.
+            By default, the function waits for five minutes.
+            Specify 0 or None to skip waiting.
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
+        conda_env: {{ conda_env }}
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-                        model_uri = f"runs:/{run.info.run_id}/english_to_german_translator"
-                        loaded = mlflow.pyfunc.load_model(model_uri)
-
-                        print(loaded.predict(data))
-                        # MLflow ist großartig!
-
-                      If an input_example is provided and the signature is not, a signature will
-                      be inferred automatically and applied to the MLmodel file iff the
-                      pipeline type is a text-based model (NLP). If the pipeline type is not
-                      a supported type, this inference functionality will not function correctly
-                      and a warning will be issued. In order to ensure that a precise signature
-                      is logged, it is recommended to explicitly provide one.
-    :param input_example: {{ input_example }}
-    :param await_registration_for: Number of seconds to wait for the model version
-                                   to finish being created and is in ``READY`` status.
-                                   By default, the function waits for five minutes.
-                                   Specify 0 or None to skip waiting.
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param conda_env: {{ conda_env }}
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
-
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
-    :param example_no_conversion: {{ example_no_conversion }}
-    :param kwargs: Additional arguments for :py:class:`mlflow.models.model.Model`
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                                    release without warning.
+        example_no_conversion: {{ example_no_conversion }}
+        kwargs: Additional arguments for :py:class:`mlflow.models.model.Model`
     """
     return Model.log(
         artifact_path=artifact_path,
@@ -801,47 +809,49 @@ def load_model(
     """
     Load a ``transformers`` object from a local file or a run.
 
-    :param model_uri: The location, in URI format, of the MLflow model. For example:
+    Args:
+        model_uri: The location, in URI format, of the MLflow model. For example:
+            - ``/Users/me/path/to/local/model``
+            - ``relative/path/to/local/model``
+            - ``s3://my_bucket/path/to/model``
+            - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+            - ``mlflow-artifacts:/path/to/model``
 
-                      - ``/Users/me/path/to/local/model``
-                      - ``relative/path/to/local/model``
-                      - ``s3://my_bucket/path/to/model``
-                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
-                      - ``mlflow-artifacts:/path/to/model``
+            For more information about supported URI schemes, see
+            `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
+            artifact-locations>`_.
+        dst_path: The local filesystem path to utilize for downloading the model artifact.
+            This directory must already exist if provided. If unspecified, a local output
+            path will be created.
+        return_type: A return type modifier for the stored ``transformers`` object.
+            If set as "components", the return type will be a dictionary of the saved
+            individual components of either the ``Pipeline`` or the pre-trained model.
+            The components for NLP-focused models will typically consist of a
+            return representation as shown below with a text-classification example:
 
-                      For more information about supported URI schemes, see
-                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
-                      artifact-locations>`_.
-    :param dst_path: The local filesystem path to utilize for downloading the model artifact.
-                     This directory must already exist if provided. If unspecified, a local output
-                     path will be created.
-    :param return_type: A return type modifier for the stored ``transformers`` object.
-                        If set as "components", the return type will be a dictionary of the saved
-                        individual components of either the ``Pipeline`` or the pre-trained model.
-                        The components for NLP-focused models will typically consist of a
-                        return representation as shown below with a text-classification example:
+            .. code-block:: python
 
-                        .. code-block:: python
+                {"model": BertForSequenceClassification, "tokenizer": BertTokenizerFast}
 
-                          {"model": BertForSequenceClassification, "tokenizer": BertTokenizerFast}
+            Vision models will return an ``ImageProcessor`` instance of the appropriate
+            type, while multi-modal models will return both a ``FeatureExtractor`` and
+            a ``Tokenizer`` along with the model.
+            Returning "components" can be useful for certain model types that do not
+            have the desired pipeline return types for certain use cases.
+            If set as "pipeline", the model, along with any and all required
+            ``Tokenizer``, ``FeatureExtractor``, ``Processor``, or ``ImageProcessor``
+            objects will be returned within a ``Pipeline`` object of the appropriate
+            type defined by the ``task`` set by the model instance type. To override
+            this behavior, supply a valid ``task`` argument during model logging or
+            saving. Default is "pipeline".
+        device: The device on which to load the model. Default is None. Use 0 to
+            load to the default GPU.
+        kwargs: Optional configuration options for loading of a ``transformers`` object.
+            For information on parameters and their usage, see
+            `transformers documentation <https://huggingface.co/docs/transformers/index>`_.
 
-                        Vision models will return an ``ImageProcessor`` instance of the appropriate
-                        type, while multi-modal models will return both a ``FeatureExtractor`` and
-                        a ``Tokenizer`` along with the model.
-                        Returning "components" can be useful for certain model types that do not
-                        have the desired pipeline return types for certain use cases.
-                        If set as "pipeline", the model, along with any and all required
-                        ``Tokenizer``, ``FeatureExtractor``, ``Processor``, or ``ImageProcessor``
-                        objects will be returned within a ``Pipeline`` object of the appropriate
-                        type defined by the ``task`` set by the model instance type. To override
-                        this behavior, supply a valid ``task`` argument during model logging or
-                        saving. Default is "pipeline".
-    :param device: The device on which to load the model. Default is None. Use 0 to
-                   load to the default GPU.
-    :param kwargs: Optional configuration options for loading of a ``transformers`` object.
-                   For information on parameters and their usage, see
-                   `transformers documentation <https://huggingface.co/docs/transformers/index>`_.
-    :return: A ``transformers`` model instance or a dictionary of components
+    Returns:
+        A ``transformers`` model instance or a dictionary of components
     """
 
     if return_type not in _SUPPORTED_RETURN_TYPES:
@@ -1231,9 +1241,12 @@ def _infer_transformers_task_type(model) -> str:
     underlying model's intended use case. This utility relies on the definitions within the
     transformers pipeline construction utility functions.
 
-    :param model: Either the model or the Pipeline object that the task will be extracted or
-                  inferred from
-    :return: The task type string
+    Args:
+        model: Either the model or the Pipeline object that the task will be extracted or
+            inferred from
+
+    Returns:
+        The task type string
     """
     from transformers import Pipeline
     from transformers.pipelines import get_task
@@ -1632,13 +1645,16 @@ def generate_signature_output(pipeline, data, model_config=None, params=None):
     for model saving and logging. This function simulates loading of a saved model or pipeline
     as a ``pyfunc`` model without having to incur a write to disk.
 
-    :param pipeline: A ``transformers`` pipeline object. Note that component-level or model-level
-                     inputs are not permitted for extracting an output example.
-    :param data: An example input that is compatible with the given pipeline
-    :param model_config: Any additional model configuration, provided as kwargs, to inform
-                         the format of the output type from a pipeline inference call.
-    :param params: A dictionary of additional parameters to pass to the pipeline for inference.
-    :return: The output from the ``pyfunc`` pipeline wrapper's ``predict`` method
+    Args:
+        pipeline: A ``transformers`` pipeline object. Note that component-level or model-level
+            inputs are not permitted for extracting an output example.
+        data: An example input that is compatible with the given pipeline
+        model_config: Any additional model configuration, provided as kwargs, to inform
+            the format of the output type from a pipeline inference call.
+        params: A dictionary of additional parameters to pass to the pipeline for inference.
+
+    Returns:
+        The output from the ``pyfunc`` pipeline wrapper's ``predict`` method
     """
     import transformers
 
@@ -1741,13 +1757,15 @@ class _TransformersWrapper:
 
     def predict(self, data, params: Optional[Dict[str, Any]] = None):
         """
-        :param data: Model input data.
-        :param params: Additional parameters to pass to the model for inference.
+        Args:
+            data: Model input data.
+            params: Additional parameters to pass to the model for inference.
 
-                       .. Note:: Experimental: This parameter may change or be removed in a future
-                                               release without warning.
+                .. Note:: Experimental: This parameter may change or be removed in a future
+                                        release without warning.
 
-        :return: Model predictions.
+        Returns:
+            Model predictions.
         """
         self._override_model_config(params)
 

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -144,9 +144,10 @@ class Property:
         required: bool = True,
     ) -> None:
         """
-        :param name: The name of the property
-        :param dtype: The data type of the property
-        :param required: Whether this property is required
+        Args:
+            name: The name of the property
+            dtype: The data type of the property
+            required: Whether this property is required
         """
         if not isinstance(name, str):
             raise MlflowException.invalid_parameter_value(
@@ -996,9 +997,10 @@ class ParamSpec:
 
         Any other type mismatch will raise error.
 
-        :param name: parameter name
-        :param value: parameter value
-        :param t: expected data type
+        Args:
+            name: parameter name
+            value: parameter value
+            t: expected data type
         """
         if value is None:
             return

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -29,17 +29,19 @@ class TensorsNotSupportedException(MlflowException):
 
 
 def _get_tensor_shape(data, variable_dimension: Optional[int] = 0) -> tuple:
-    """
-    Infer the shape of the inputted data.
+    """Infer the shape of the inputted data.
 
     This method creates the shape of the tensor to store in the TensorSpec. The variable dimension
     is assumed to be the first dimension by default. This assumption can be overridden by inputting
     a different variable dimension or `None` to represent that the input tensor does not contain a
     variable dimension.
 
-    :param data: Dataset to infer from.
-    :param variable_dimension: An optional integer representing a variable dimension.
-    :return: tuple : Shape of the inputted data (including a variable dimension)
+    Args:
+        data: Dataset to infer from.
+        variable_dimension: An optional integer representing a variable dimension.
+
+    Returns:
+        tuple: Shape of the inputted data (including a variable dimension)
     """
     from scipy.sparse import csc_matrix, csr_matrix
 
@@ -63,8 +65,11 @@ def clean_tensor_type(dtype: np.dtype):
     This method strips away the size information stored in flexible datatypes such as np.str_ and
     np.bytes_. Other numpy dtypes are returned unchanged.
 
-    :param dtype: Numpy dtype of a tensor
-    :return: dtype: Cleaned numpy dtype
+    Args:
+        dtype: Numpy dtype of a tensor
+
+    Returns:
+        dtype: Cleaned numpy dtype
     """
     if not isinstance(dtype, np.dtype):
         raise TypeError(
@@ -83,8 +88,11 @@ def _infer_colspec_type(data: Any) -> Union[DataType, Array, Object]:
     """
     Infer an MLflow Colspec type from the dataset.
 
-    :param data: data to infer from.
-    :return: Object
+    Args:
+        data: data to infer from.
+
+    Returns:
+        Object
     """
     dtype = _infer_datatype(data)
 
@@ -125,8 +133,11 @@ def _infer_array_datatype(data: Union[List, np.ndarray]) -> Optional[Array]:
         [["a", "b"], []] => Array(Array(string))
         [] => None
 
-    :param data: data to infer from.
-    :return: Array(dtype) or None if undetermined
+    Args:
+        data: data to infer from.
+
+    Returns:
+        Array(dtype) or None if undetermined
     """
     result = None
     for item in data:
@@ -216,9 +227,11 @@ def _infer_schema(data: Any) -> Schema:
     The element types should be mappable to one of :py:class:`mlflow.models.signature.DataType` for
     dataframes and to one of numpy types for tensors.
 
-    :param data: Dataset to infer from.
+    Args:
+        data: Dataset to infer from.
 
-    :return: Schema
+    Returns:
+        Schema
     """
     from scipy.sparse import csc_matrix, csr_matrix
 

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -323,6 +323,7 @@ def load_model(model_uri, dst_path=None):
 
     Args:
         model_uri: The location, in URI format, of the MLflow model. For example:
+
             - ``/Users/me/path/to/local/model``
             - ``relative/path/to/local/model``
             - ``s3://my_bucket/path/to/model``

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -118,24 +118,23 @@ def save_model(
     model_format="xgb",
     metadata=None,
 ):
-    """
-    Save an XGBoost model to a path on the local file system.
+    """Save an XGBoost model to a path on the local file system.
 
-    :param xgb_model: XGBoost model (an instance of `xgboost.Booster`_ or
-                      models that implement the `scikit-learn API`_) to be saved.
-    :param path: Local path where the model is to be saved.
-    :param conda_env: {{ conda_env }}
-    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
-    :param mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
-
-    :param signature: {{ signature }}
-    :param input_example: {{ input_example }}
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param model_format: File format in which the model is to be saved.
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
+    Args:
+        xgb_model: XGBoost model (an instance of `xgboost.Booster`_ or models that implement the
+            `scikit-learn API`_) to be saved.
+        path: Local path where the model is to be saved.
+        conda_env: {{ conda_env }}
+        code_paths: A list of local filesystem paths to Python file dependencies (or directories
+            containing file dependencies). These files are *prepended* to the system
+            path when the model is loaded.
+        mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
+        signature: {{ signature }}
+        input_example: {{ input_example }}
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
+        model_format: File format in which the model is to be saved.
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
                      .. Note:: Experimental: This parameter may change or be removed in a future
                                              release without warning.
@@ -238,34 +237,37 @@ def log_model(
     metadata=None,
     **kwargs,
 ):
-    """
-    Log an XGBoost model as an MLflow artifact for the current run.
+    """Log an XGBoost model as an MLflow artifact for the current run.
 
-    :param xgb_model: XGBoost model (an instance of `xgboost.Booster`_ or
-                      models that implement the `scikit-learn API`_) to be saved.
-    :param artifact_path: Run-relative artifact path.
-    :param conda_env: {{ conda_env }}
-    :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                       containing file dependencies). These files are *prepended* to the system
-                       path when the model is loaded.
-    :param registered_model_name: If given, create a model version under
-                                  ``registered_model_name``, also creating a registered model if one
-                                  with the given name does not exist.
-    :param signature: {{ signature }}
-    :param input_example: {{ input_example }}
-    :param await_registration_for: Number of seconds to wait for the model version to finish
-                            being created and is in ``READY`` status. By default, the function
-                            waits for five minutes. Specify 0 or None to skip waiting.
-    :param pip_requirements: {{ pip_requirements }}
-    :param extra_pip_requirements: {{ extra_pip_requirements }}
-    :param model_format: File format in which the model is to be saved.
-    :param metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
+    Args:
+        xgb_model: XGBoost model (an instance of `xgboost.Booster`_ or models that implement the
+            `scikit-learn API`_) to be saved.
+        artifact_path: Run-relative artifact path.
+        conda_env: {{ conda_env }}
+        code_paths: A list of local filesystem paths to Python file dependencies (or directories
+            containing file dependencies). These files are *prepended* to the system
+            path when the model is loaded.
+        registered_model_name: If given, create a model version under
+            ``registered_model_name``, also creating a registered model if one
+            with the given name does not exist.
+        signature: {{ signature }}
+        input_example: {{ input_example }}
+        await_registration_for: Number of seconds to wait for the model version to finish
+            being created and is in ``READY`` status. By default, the function
+            waits for five minutes. Specify 0 or None to skip waiting.
+        pip_requirements: {{ pip_requirements }}
+        extra_pip_requirements: {{ extra_pip_requirements }}
+        model_format: File format in which the model is to be saved.
+        metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
-                     .. Note:: Experimental: This parameter may change or be removed in a future
-                                             release without warning.
-    :param kwargs: kwargs to pass to `xgboost.Booster.save_model`_ method.
-    :return: A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
-             metadata of the logged model.
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                                    release without warning.
+
+        kwargs: kwargs to pass to `xgboost.Booster.save_model`_ method.
+
+    Returns
+        A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
+        metadata of the logged model.
     """
     return Model.log(
         artifact_path=artifact_path,
@@ -286,12 +288,11 @@ def log_model(
 
 
 def _load_model(path):
-    """
-    Load Model Implementation.
+    """Load Model Implementation.
 
-    :param path: Local filesystem path to
-                    the MLflow Model with the ``xgboost`` flavor (MLflow < 1.22.0) or
-                    the top-level MLflow Model directory (MLflow >= 1.22.0).
+    Args:
+        path: Local filesystem path to the MLflow Model with the ``xgboost`` flavor
+        (MLflow < 1.22.0) or the top-level MLflow Model directory (MLflow >= 1.22.0).
     """
     model_dir = os.path.dirname(path) if os.path.isfile(path) else path
     flavor_conf = _get_flavor_configuration(model_path=model_dir, flavor_name=FLAVOR_NAME)
@@ -309,34 +310,34 @@ def _load_model(path):
 
 
 def _load_pyfunc(path):
-    """
-    Load PyFunc implementation. Called by ``pyfunc.load_model``.
+    """Load PyFunc implementation. Called by ``pyfunc.load_model``.
 
-    :param path: Local filesystem path to the MLflow Model with the ``xgboost`` flavor.
+    Args:
+        path: Local filesystem path to the MLflow Model with the ``xgboost`` flavor.
     """
     return _XGBModelWrapper(_load_model(path))
 
 
 def load_model(model_uri, dst_path=None):
-    """
-    Load an XGBoost model from a local file or a run.
+    """Load an XGBoost model from a local file or a run.
 
-    :param model_uri: The location, in URI format, of the MLflow model. For example:
+    Args:
+        model_uri: The location, in URI format, of the MLflow model. For example:
+            - ``/Users/me/path/to/local/model``
+            - ``relative/path/to/local/model``
+            - ``s3://my_bucket/path/to/model``
+            - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
 
-                      - ``/Users/me/path/to/local/model``
-                      - ``relative/path/to/local/model``
-                      - ``s3://my_bucket/path/to/model``
-                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+            For more information about supported URI schemes, see
+            `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
+            artifact-locations>`_.
+        dst_path: The local filesystem path to which to download the model artifact.
+            This directory must already exist. If unspecified, a local output
+            path will be created.
 
-                      For more information about supported URI schemes, see
-                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
-                      artifact-locations>`_.
-    :param dst_path: The local filesystem path to which to download the model artifact.
-                     This directory must already exist. If unspecified, a local output
-                     path will be created.
-
-    :return: An XGBoost model. An instance of either `xgboost.Booster`_ or XGBoost scikit-learn
-             models, depending on the saved model class specification.
+    Returns:
+        An XGBoost model. An instance of either `xgboost.Booster`_ or XGBoost scikit-learn
+        models, depending on the saved model class specification.
     """
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path)
     flavor_conf = _get_flavor_configuration(local_model_path, FLAVOR_NAME)
@@ -352,13 +353,15 @@ class _XGBModelWrapper:
         self, dataframe, params: Optional[Dict[str, Any]] = None  # pylint: disable=unused-argument
     ):
         """
-        :param dataframe: Model input data.
-        :param params: Additional parameters to pass to the model for inference.
+        Args:
+            dataframe: Model input data.
+            params: Additional parameters to pass to the model for inference.
 
-                       .. Note:: Experimental: This parameter may change or be removed in a future
-                                               release without warning.
+                .. Note:: Experimental: This parameter may change or be removed in a future
+                                        release without warning.
 
-        :return: Model predictions.
+        Returns:
+            Model predictions.
         """
         import xgboost as xgb
 
@@ -386,51 +389,51 @@ def autolog(
     """
     Enables (or disables) and configures autologging from XGBoost to MLflow. Logs the following:
 
-    - parameters specified in `xgboost.train`_.
-    - metrics on each iteration (if ``evals`` specified).
-    - metrics at the best iteration (if ``early_stopping_rounds`` specified).
-    - feature importance as JSON files and plots.
-    - trained model, including:
-        - an example of valid input.
-        - inferred signature of the inputs and outputs of the model.
+        - parameters specified in `xgboost.train`_.
+        - metrics on each iteration (if ``evals`` specified).
+        - metrics at the best iteration (if ``early_stopping_rounds`` specified).
+        - feature importance as JSON files and plots.
+        - trained model, including:
+            - an example of valid input.
+            - inferred signature of the inputs and outputs of the model.
 
     Note that the `scikit-learn API`_ is now supported.
 
-    :param importance_types: Importance types to log. If unspecified, defaults to ``["weight"]``.
-    :param log_input_examples: If ``True``, input examples from training datasets are collected and
-                               logged along with XGBoost model artifacts during training. If
-                               ``False``, input examples are not logged.
-                               Note: Input examples are MLflow model attributes
-                               and are only collected if ``log_models`` is also ``True``.
-    :param log_model_signatures: If ``True``,
-                                 :py:class:`ModelSignatures <mlflow.models.ModelSignature>`
-                                 describing model inputs and outputs are collected and logged along
-                                 with XGBoost model artifacts during training. If ``False``,
-                                 signatures are not logged.
-                                 Note: Model signatures are MLflow model attributes
-                                 and are only collected if ``log_models`` is also ``True``.
-    :param log_models: If ``True``, trained models are logged as MLflow model artifacts.
-                       If ``False``, trained models are not logged.
-                       Input examples and model signatures, which are attributes of MLflow models,
-                       are also omitted when ``log_models`` is ``False``.
-    :param log_datasets: If ``True``, train and validation dataset information is logged to MLflow
-                         Tracking if applicable. If ``False``, dataset information is not logged.
-    :param disable: If ``True``, disables the XGBoost autologging integration. If ``False``,
-                    enables the XGBoost autologging integration.
-    :param exclusive: If ``True``, autologged content is not logged to user-created fluent runs.
-                      If ``False``, autologged content is logged to the active fluent run,
-                      which may be user-created.
-    :param disable_for_unsupported_versions: If ``True``, disable autologging for versions of
-                      xgboost that have not been tested against this version of the MLflow client
-                      or are incompatible.
-    :param silent: If ``True``, suppress all event logs and warnings from MLflow during XGBoost
-                   autologging. If ``False``, show all events and warnings during XGBoost
-                   autologging.
-    :param registered_model_name: If given, each time a model is trained, it is registered as a
-                                  new model version of the registered model with this name.
-                                  The registered model is created if it does not already exist.
-    :param model_format: File format in which the model is to be saved.
-    :param extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
+    Args:
+        importance_types: Importance types to log. If unspecified, defaults to ``["weight"]``.
+        log_input_examples: If ``True``, input examples from training datasets are collected and
+            logged along with XGBoost model artifacts during training. If
+            ``False``, input examples are not logged. Note: Input examples are MLflow model
+            attributes and are only collected if ``log_models`` is also ``True``.
+        log_model_signatures: If ``True``,
+            :py:class:`ModelSignatures <mlflow.models.ModelSignature>`
+            describing model inputs and outputs are collected and logged along
+            with XGBoost model artifacts during training. If ``False``,
+            signatures are not logged.
+            Note: Model signatures are MLflow model attributes
+            and are only collected if ``log_models`` is also ``True``.
+        log_models: If ``True``, trained models are logged as MLflow model artifacts.
+            If ``False``, trained models are not logged.
+            Input examples and model signatures, which are attributes of MLflow models,
+            are also omitted when ``log_models`` is ``False``.
+        log_datasets: If ``True``, train and validation dataset information is logged to MLflow
+            Tracking if applicable. If ``False``, dataset information is not logged.
+        disable: If ``True``, disables the XGBoost autologging integration. If ``False``,
+            enables the XGBoost autologging integration.
+        exclusive: If ``True``, autologged content is not logged to user-created fluent runs.
+            If ``False``, autologged content is logged to the active fluent run,
+            which may be user-created.
+        disable_for_unsupported_versions: If ``True``, disable autologging for versions of
+            xgboost that have not been tested against this version of the MLflow client
+            or are incompatible.
+        silent: If ``True``, suppress all event logs and warnings from MLflow during XGBoost
+            autologging. If ``False``, show all events and warnings during XGBoost
+            autologging.
+        registered_model_name: If given, each time a model is trained, it is registered as a
+            new model version of the registered model with this name.
+            The registered model is created if it does not already exist.
+        model_format: File format in which the model is to be saved.
+        extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
     """
     import numpy as np
     import xgboost


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/michael-berk/mlflow/pull/10826?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10826/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10826
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Google docstring conversion for the below directories:
* Tensorflow
* Transformers
* Types
* XGBoost

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
