### PR TITLE
Fix langchain notebooks

### DIFF
--- a/docs/source/llms/langchain/notebooks/langchain-agent.ipynb
+++ b/docs/source/llms/langchain/notebooks/langchain-agent.ipynb
@@ -47,7 +47,7 @@
     "\n",
     "To use SerpAPI, you'll need to install it via pip. It's a straightforward process, and the package is named `google-search-results`. Once installed, you can create an account at [SerpAPI's Official Website](https://serpapi.com/) and retrieve an API Key. In order to use this integration with LangChain, you can simply load the toolset via `load_tools([\"serpapi\"])` to allow the LangChain agent access to the Google Search APIs.\n",
     "\n",
-    "```sh\n",
+    "```shell\n",
     "    pip install google-search-results\n",
     "```\n",
     "\n",

--- a/docs/source/llms/langchain/notebooks/langchain-agent.ipynb
+++ b/docs/source/llms/langchain/notebooks/langchain-agent.ipynb
@@ -47,7 +47,7 @@
     "\n",
     "To use SerpAPI, you'll need to install it via pip. It's a straightforward process, and the package is named `google-search-results`. Once installed, you can create an account at [SerpAPI's Official Website](https://serpapi.com/) and retrieve an API Key. In order to use this integration with LangChain, you can simply load the toolset via `load_tools([\"serpapi\"])` to allow the LangChain agent access to the Google Search APIs.\n",
     "\n",
-    "```console\n",
+    "```\n",
     "    pip install google-search-results\n",
     "```\n",
     "\n",

--- a/docs/source/llms/langchain/notebooks/langchain-agent.ipynb
+++ b/docs/source/llms/langchain/notebooks/langchain-agent.ipynb
@@ -47,7 +47,7 @@
     "\n",
     "To use SerpAPI, you'll need to install it via pip. It's a straightforward process, and the package is named `google-search-results`. Once installed, you can create an account at [SerpAPI's Official Website](https://serpapi.com/) and retrieve an API Key. In order to use this integration with LangChain, you can simply load the toolset via `load_tools([\"serpapi\"])` to allow the LangChain agent access to the Google Search APIs.\n",
     "\n",
-    "```shell\n",
+    "```console\n",
     "    pip install google-search-results\n",
     "```\n",
     "\n",

--- a/docs/source/llms/langchain/notebooks/langchain-retriever.ipynb
+++ b/docs/source/llms/langchain/notebooks/langchain-retriever.ipynb
@@ -43,7 +43,7 @@
     "#### Installing Requirements\n",
     "Before proceeding with the tutorial, ensure that you have FAISS and [Beautiful Soup](https://pypi.org/project/beautifulsoup4/) installed via `pip`.\n",
     "\n",
-    "```shell\n",
+    "```console\n",
     "    pip install beautifulsoup4 faiss-cpu\n",
     "```\n",
     "\n",

--- a/docs/source/llms/langchain/notebooks/langchain-retriever.ipynb
+++ b/docs/source/llms/langchain/notebooks/langchain-retriever.ipynb
@@ -43,7 +43,7 @@
     "#### Installing Requirements\n",
     "Before proceeding with the tutorial, ensure that you have FAISS and [Beautiful Soup](https://pypi.org/project/beautifulsoup4/) installed via `pip`.\n",
     "\n",
-    "```console\n",
+    "```\n",
     "    pip install beautifulsoup4 faiss-cpu\n",
     "```\n",
     "\n",

--- a/docs/source/llms/langchain/notebooks/langchain-retriever.ipynb
+++ b/docs/source/llms/langchain/notebooks/langchain-retriever.ipynb
@@ -43,7 +43,7 @@
     "#### Installing Requirements\n",
     "Before proceeding with the tutorial, ensure that you have FAISS and [Beautiful Soup](https://pypi.org/project/beautifulsoup4/) installed via `pip`.\n",
     "\n",
-    "```sh\n",
+    "```shell\n",
     "    pip install beautifulsoup4 faiss-cpu\n",
     "```\n",
     "\n",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/10828?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10828/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10828
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Looks like `sh` is not a valid [flavor for code blocks in sphinx](https://build-me-the-docs-please.readthedocs.io/en/latest/Using_Sphinx/ShowingCodeExamplesInSphinx.html#pygments-lexers). Replaced with `console`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Ran the docs job against my branch and no longer seems to fail

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
