### PR TITLE
Add tips for reducing dependency errors

### DIFF
--- a/docs/source/model/dependencies.rst
+++ b/docs/source/model/dependencies.rst
@@ -115,7 +115,7 @@ when logging the model. For example,
             python_model=CustomModel(),
             artifact_path="model",
             extra_pip_requirements=["pandas==2.0.3"],
-            input_example=<input_data>,
+            input_example=input_data,
         )
 
 The extra dependencies will be added to ``requirements.txt`` as follows (and similarly to ``conda.yaml``):
@@ -209,7 +209,7 @@ To do so, specify **code_path** when logging the model. For example, if you have
         mlflow.pyfunc.log_model(
             python_model=MyModel(),
             artifact_path="model",
-            input_example=<input_data>,
+            input_example=input_data,
             code_paths=["utils.py"],
         )
 
@@ -256,7 +256,7 @@ Then the following model code does **not** work:
         mlflow.pyfunc.log_model(
             python_model=MyModel(),
             artifact_path="model",
-            input_example=<input_data>,
+            input_example=input_data,
             code_paths=[
                 "src/utils.py"
             ],  # the file will be saved at code/utils.py not code/src/utils.py
@@ -286,7 +286,7 @@ This way, MLflow will copy the entire ``src/`` directory under ``code/`` and you
         mlflow.pyfunc.log_model(
             python_model=model,
             artifact_path="model",
-            input_example=<input_data>,
+            input_example=input_data,
             code_paths=["src"],  # the whole /src directory will be saved at code/src
         )
 
@@ -470,7 +470,7 @@ To do so, specify the ``extra_pip_requirements`` option when logging the model.
         artifact_path="model",
         python_model=python_model,
         extra_pip_requirements=["opencv-python==4.8.0"],
-        input_example=<input_data>,
+        input_example=input_data,
     )
 
 

--- a/docs/source/model/dependencies.rst
+++ b/docs/source/model/dependencies.rst
@@ -14,9 +14,9 @@ dependencies and guidance for how to customize dependencies for your use case.
 
 .. tip::
 
-    One tip for improving MLflow's dependency inference coverage is to add ``input_example`` when saving your model. This enables MLflow to actually
-    performs a model prediction before saving the model, and capture the dependencies used during the prediction.
-    Please refer to :ref:`Model Input Example <input-example>` for the more detailed usage of this parameter.
+    One tip for improving MLflow's dependency inference accuracy is to add an ``input_example`` when saving your model. This enables MLflow to 
+    perform a model prediction before saving the model, thereby capturing the dependencies used during the prediction.
+    Please refer to :ref:`Model Input Example <input-example>` for additional, detailed usage of this parameter.
 
 .. contents:: Table of Contents
   :local:
@@ -409,9 +409,9 @@ and fix missing dependency errors.
 
 .. hint::
 
-    To reduce the possibility of dependency errors, you can add ``input_example`` when saving your model. This enables MLflow to actually
-    performs a model prediction before saving the model, and capture the dependencies used during the prediction.
-    Please refer to :ref:`Model Input Example <input-example>` for the more detailed usage of this parameter.
+    To reduce the possibility of dependency errors, you can add ``input_example`` when saving your model. This enables MLflow to 
+    perform a model prediction before saving the model, thereby capturing the dependencies used during the prediction.
+    Please refer to :ref:`Model Input Example <input-example>` for additional, detailed usage of this parameter.
 
 
 1. Check the missing dependencies

--- a/docs/source/model/dependencies.rst
+++ b/docs/source/model/dependencies.rst
@@ -12,6 +12,12 @@ worry about managing dependencies in MLflow Model.
 However, in some cases, you may need to add or modify some dependencies. This page provides a high-level description of how MLflow manages
 dependencies and guidance for how to customize dependencies for your use case.
 
+.. tip::
+
+    One tip for improving MLflow's dependency inference coverage is to add ``input_example`` when saving your model. This enables MLflow to actually
+    performs a model prediction before saving the model, and capture the dependencies used during the prediction.
+    Please refer to :ref:`Model Input Example <input-example>` for the more detailed usage of this parameter.
+
 .. contents:: Table of Contents
   :local:
   :depth: 1
@@ -109,6 +115,7 @@ when logging the model. For example,
             python_model=CustomModel(),
             artifact_path="model",
             extra_pip_requirements=["pandas==2.0.3"],
+            input_example=<input_data>,
         )
 
 The extra dependencies will be added to ``requirements.txt`` as follows (and similarly to ``conda.yaml``):
@@ -202,6 +209,7 @@ To do so, specify **code_path** when logging the model. For example, if you have
         mlflow.pyfunc.log_model(
             python_model=MyModel(),
             artifact_path="model",
+            input_example=<input_data>,
             code_paths=["utils.py"],
         )
 
@@ -248,6 +256,7 @@ Then the following model code does **not** work:
         mlflow.pyfunc.log_model(
             python_model=MyModel(),
             artifact_path="model",
+            input_example=<input_data>,
             code_paths=[
                 "src/utils.py"
             ],  # the file will be saved at code/utils.py not code/src/utils.py
@@ -277,6 +286,7 @@ This way, MLflow will copy the entire ``src/`` directory under ``code/`` and you
         mlflow.pyfunc.log_model(
             python_model=model,
             artifact_path="model",
+            input_example=<input_data>,
             code_paths=["src"],  # the whole /src directory will be saved at code/src
         )
 
@@ -397,6 +407,13 @@ model dependencies and save them as part of the MLflow Model metadata. However, 
 for certain libraries. This can cause errors when serving your model, such as "ModuleNotFoundError" or "ImportError". Below are some steps that can help to diagnose
 and fix missing dependency errors.
 
+.. hint::
+
+    To reduce the possibility of dependency errors, you can add ``input_example`` when saving your model. This enables MLflow to actually
+    performs a model prediction before saving the model, and capture the dependencies used during the prediction.
+    Please refer to :ref:`Model Input Example <input-example>` for the more detailed usage of this parameter.
+
+
 1. Check the missing dependencies
 *********************************
 The missing dependencies are listed in the error message. For example, if you see the following error message:
@@ -440,7 +457,7 @@ defined in the model metadata. Since this doesn't mutate the model, you can iter
 
     The ``pip-requirements-override`` option is available since MLflow 2.10.0.
 
-1. Update the model metadata
+3. Update the model metadata
 ****************************
 Once you find the correct dependencies, you can create a new model with the correct dependencies.
 To do so, specify the ``extra_pip_requirements`` option when logging the model.
@@ -453,6 +470,7 @@ To do so, specify the ``extra_pip_requirements`` option when logging the model.
         artifact_path="model",
         python_model=python_model,
         extra_pip_requirements=["opencv-python==4.8.0"],
+        input_example=<input_data>,
     )
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10833?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10833/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10833
```

</p>
</details>

### What changes are proposed in this pull request?

Documenting the tip that users can give `input_example` to reduces the possibility of missing dependency issues. It's not very intuitive but related to how MLflow infers dependencies. By default, it captures all imported modules while loading the model. However, when `input_example` is specified, MLflow also runs prediction no only loading, which should significantly improve the coverage of dependency inference. This information is not documented anywhere but pretty useful.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
