### PR TITLE
Enable hf_transfer for CI test and prefetch

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -199,6 +199,10 @@ jobs:
       - name: Check package versions
         run: |
           python dev/show_package_release_dates.py
+      - name: Prefetch Transformer models
+        if: matrix.package == 'transformers' && matrix.category == 'models'
+        run: |
+          python tests/transformers/helper.py
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         env:
@@ -206,5 +210,6 @@ jobs:
           SPARK_LOCAL_IP: localhost
           PACKAGE_VERSION: ${{ matrix.version }}
           JOHNSNOWLABS_LICENSE_JSON: ${{ secrets.JOHNSNOWLABS_LICENSE_JSON }}
+          HF_HUB_ENABLE_HF_TRANSFER: 1
         run: |
           ${{ matrix.run }}

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -500,6 +500,7 @@ transformers:
       ">= 0.0.0": [
           "datasets",
           "huggingface_hub",
+          "hf_transfer",
           "torch",
           "torchvision",
           "tensorflow",
@@ -526,6 +527,7 @@ transformers:
         [
           "datasets",
           "huggingface_hub",
+          "hf_transfer",
           "torch",
           "torchvision",
           "tensorflow",

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,6 @@ filterwarnings =
   # Prevent deprecated numpy type aliases from being used
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:mlflow
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:tests
+markers =
+  skipcacheclean: skip cleaning the HuggingFace cache directory after test run, only used for Transformers flavor tests
 timeout = 1200

--- a/tests/transformers/conftest.py
+++ b/tests/transformers/conftest.py
@@ -1,0 +1,124 @@
+import pytest
+
+from tests.transformers.helper import (
+    load_audio_classification_pipeline,
+    load_component_multi_modal,
+    load_conversational_pipeline,
+    load_feature_extraction_pipeline,
+    load_fill_mask_pipeline,
+    load_ner_pipeline,
+    load_ner_pipeline_aggregation,
+    load_small_conversational_model,
+    load_small_multi_modal_pipeline,
+    load_small_qa_pipeline,
+    load_small_seq2seq_pipeline,
+    load_small_vision_model,
+    load_summarizer_pipeline,
+    load_table_question_answering_pipeline,
+    load_text2text_generation_pipeline,
+    load_text_classification_pipeline,
+    load_text_generation_pipeline,
+    load_translation_pipeline,
+    load_whisper_pipeline,
+    load_zero_shot_pipeline,
+)
+
+
+@pytest.fixture
+def small_seq2seq_pipeline():
+    return load_small_seq2seq_pipeline()
+
+
+@pytest.fixture
+def small_qa_pipeline():
+    return load_small_qa_pipeline()
+
+
+@pytest.fixture
+def small_vision_model():
+    return load_small_vision_model()
+
+
+@pytest.fixture
+def small_multi_modal_pipeline():
+    return load_small_multi_modal_pipeline()
+
+
+@pytest.fixture
+def component_multi_modal():
+    return load_component_multi_modal()
+
+
+@pytest.fixture
+def small_conversational_model():
+    return load_small_conversational_model()
+
+
+@pytest.fixture
+def fill_mask_pipeline():
+    return load_fill_mask_pipeline()
+
+
+@pytest.fixture
+def text2text_generation_pipeline():
+    return load_text2text_generation_pipeline()
+
+
+@pytest.fixture
+def text_generation_pipeline():
+    return load_text_generation_pipeline()
+
+
+@pytest.fixture
+def translation_pipeline():
+    return load_translation_pipeline()
+
+
+@pytest.fixture
+def text_classification_pipeline():
+    return load_text_classification_pipeline()
+
+
+@pytest.fixture
+def summarizer_pipeline():
+    return load_summarizer_pipeline()
+
+
+@pytest.fixture
+def zero_shot_pipeline():
+    return load_zero_shot_pipeline()
+
+
+@pytest.fixture
+def table_question_answering_pipeline():
+    return load_table_question_answering_pipeline()
+
+
+@pytest.fixture
+def ner_pipeline():
+    return load_ner_pipeline()
+
+
+@pytest.fixture
+def ner_pipeline_aggregation():
+    return load_ner_pipeline_aggregation()
+
+
+@pytest.fixture
+def conversational_pipeline():
+    return load_conversational_pipeline()
+
+
+@pytest.fixture
+def whisper_pipeline():
+    return load_whisper_pipeline()
+
+
+@pytest.fixture
+def audio_classification_pipeline():
+    return load_audio_classification_pipeline()
+
+
+@pytest.fixture
+def feature_extraction_pipeline():
+    return load_feature_extraction_pipeline()

--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -1,0 +1,272 @@
+import inspect
+import logging
+import sys
+import time
+from functools import wraps
+
+import transformers
+from packaging.version import Version
+
+_logger = logging.getLogger(__name__)
+
+transformers_version = Version(transformers.__version__)
+IS_NEW_FEATURE_EXTRACTION_API = transformers_version >= Version("4.27.0")
+
+
+def flaky(max_tries=3):
+    """
+    Annotation decorator for retrying flaky functions up to max_tries times, and raise the Exception
+    if it fails after max_tries attempts.
+    :param max_tries: Maximum number of times to retry the function.
+    :return: Decorated function.
+    """
+
+    def flaky_test_func(test_func):
+        @wraps(test_func)
+        def decorated_func(*args, **kwargs):
+            for i in range(max_tries):
+                try:
+                    return test_func(*args, **kwargs)
+                except Exception as e:
+                    _logger.warning(f"Attempt {i+1} failed with error: {e}")
+                    if i == max_tries - 1:
+                        raise
+                    time.sleep(3)
+
+        return decorated_func
+
+    return flaky_test_func
+
+
+def prefetch(func):
+    """
+    Annotation decorator for marking model loading functions to run before testing.
+    """
+    func.is_prefetch = True
+    return func
+
+
+@prefetch
+@flaky()
+def load_small_seq2seq_pipeline():
+    architecture = "lordtt13/emo-mobilebert"
+    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
+    model = transformers.TFAutoModelForSequenceClassification.from_pretrained(architecture)
+    return transformers.pipeline(task="text-classification", model=model, tokenizer=tokenizer)
+
+
+@prefetch
+@flaky()
+def load_small_qa_pipeline():
+    architecture = "csarron/mobilebert-uncased-squad-v2"
+    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture, low_cpu_mem_usage=True)
+    model = transformers.MobileBertForQuestionAnswering.from_pretrained(
+        architecture, low_cpu_mem_usage=True
+    )
+    return transformers.pipeline(task="question-answering", model=model, tokenizer=tokenizer)
+
+
+@prefetch
+@flaky()
+def load_small_vision_model():
+    architecture = "google/mobilenet_v2_1.0_224"
+    feature_extractor = transformers.AutoFeatureExtractor.from_pretrained(
+        architecture, low_cpu_mem_usage=True
+    )
+    model = transformers.MobileNetV2ForImageClassification.from_pretrained(
+        architecture, low_cpu_mem_usage=True
+    )
+    return transformers.pipeline(
+        task="image-classification", model=model, feature_extractor=feature_extractor
+    )
+
+
+@prefetch
+@flaky()
+def load_small_multi_modal_pipeline():
+    architecture = "dandelin/vilt-b32-finetuned-vqa"
+    return transformers.pipeline(model=architecture)
+
+
+@prefetch
+@flaky()
+def load_component_multi_modal():
+    architecture = "dandelin/vilt-b32-finetuned-vqa"
+    tokenizer = transformers.BertTokenizerFast.from_pretrained(architecture, low_cpu_mem_usage=True)
+    processor = transformers.ViltProcessor.from_pretrained(architecture, low_cpu_mem_usage=True)
+    image_processor = transformers.ViltImageProcessor.from_pretrained(
+        architecture, low_cpu_mem_usage=True
+    )
+    model = transformers.ViltForQuestionAnswering.from_pretrained(
+        architecture, low_cpu_mem_usage=True
+    )
+    transformers_model = {"model": model, "tokenizer": tokenizer}
+    if IS_NEW_FEATURE_EXTRACTION_API:
+        transformers_model["image_processor"] = image_processor
+    else:
+        transformers_model["feature_extractor"] = processor
+    return transformers_model
+
+
+@prefetch
+@flaky()
+def load_small_conversational_model():
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        "microsoft/DialoGPT-small", low_cpu_mem_usage=True
+    )
+    model = transformers.AutoModelWithLMHead.from_pretrained(
+        "satvikag/chatbot", low_cpu_mem_usage=True
+    )
+    return transformers.pipeline(task="conversational", model=model, tokenizer=tokenizer)
+
+
+@prefetch
+@flaky()
+def load_fill_mask_pipeline():
+    architecture = "distilroberta-base"
+    model = transformers.AutoModelForMaskedLM.from_pretrained(architecture, low_cpu_mem_usage=True)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
+    return transformers.pipeline(task="fill-mask", model=model, tokenizer=tokenizer)
+
+
+@prefetch
+@flaky()
+def load_text2text_generation_pipeline():
+    task = "text2text-generation"
+    architecture = "mrm8488/t5-small-finetuned-common_gen"
+    model = transformers.T5ForConditionalGeneration.from_pretrained(architecture)
+    tokenizer = transformers.T5TokenizerFast.from_pretrained(architecture)
+    return transformers.pipeline(task=task, tokenizer=tokenizer, model=model)
+
+
+@prefetch
+@flaky()
+def load_text_generation_pipeline():
+    task = "text-generation"
+    architecture = "distilgpt2"
+    model = transformers.AutoModelWithLMHead.from_pretrained(architecture)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
+    return transformers.pipeline(task=task, model=model, tokenizer=tokenizer)
+
+
+@prefetch
+@flaky()
+def load_translation_pipeline():
+    return transformers.pipeline(
+        task="translation_en_to_de",
+        model=transformers.T5ForConditionalGeneration.from_pretrained("t5-small"),
+        tokenizer=transformers.T5TokenizerFast.from_pretrained("t5-small", model_max_length=100),
+    )
+
+
+@prefetch
+@flaky()
+def load_summarizer_pipeline():
+    task = "summarization"
+    architecture = "sshleifer/distilbart-cnn-6-6"
+    model = transformers.BartForConditionalGeneration.from_pretrained(architecture)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
+    return transformers.pipeline(task=task, tokenizer=tokenizer, model=model)
+
+
+@prefetch
+@flaky()
+def load_text_classification_pipeline():
+    task = "text-classification"
+    architecture = "distilbert-base-uncased-finetuned-sst-2-english"
+    model = transformers.AutoModelForSequenceClassification.from_pretrained(architecture)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
+    return transformers.pipeline(
+        task=task,
+        tokenizer=tokenizer,
+        model=model,
+    )
+
+
+@prefetch
+@flaky()
+def load_zero_shot_pipeline():
+    task = "zero-shot-classification"
+    architecture = "typeform/distilbert-base-uncased-mnli"
+    model = transformers.AutoModelForSequenceClassification.from_pretrained(architecture)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
+    return transformers.pipeline(task=task, tokenizer=tokenizer, model=model)
+
+
+@prefetch
+@flaky()
+def load_table_question_answering_pipeline():
+    return transformers.pipeline(
+        task="table-question-answering", model="google/tapas-tiny-finetuned-wtq"
+    )
+
+
+@prefetch
+@flaky()
+def load_ner_pipeline():
+    return transformers.pipeline(
+        task="token-classification", model="vblagoje/bert-english-uncased-finetuned-pos"
+    )
+
+
+@prefetch
+@flaky()
+def load_ner_pipeline_aggregation():
+    return transformers.pipeline(
+        task="token-classification",
+        model="vblagoje/bert-english-uncased-finetuned-pos",
+        aggregation_strategy="average",
+    )
+
+
+@prefetch
+@flaky()
+def load_conversational_pipeline():
+    return transformers.pipeline(model="AVeryRealHuman/DialoGPT-small-TonyStark")
+
+
+@prefetch
+@flaky()
+def load_whisper_pipeline():
+    task = "automatic-speech-recognition"
+    architecture = "openai/whisper-tiny"
+    model = transformers.WhisperForConditionalGeneration.from_pretrained(architecture)
+    tokenizer = transformers.WhisperTokenizer.from_pretrained(architecture)
+    feature_extractor = transformers.WhisperFeatureExtractor.from_pretrained(architecture)
+    if Version(transformers.__version__) > Version("4.30.2"):
+        model.generation_config.alignment_heads = [[2, 2], [3, 0], [3, 2], [3, 3], [3, 4], [3, 5]]
+    return transformers.pipeline(
+        task=task, model=model, tokenizer=tokenizer, feature_extractor=feature_extractor
+    )
+
+
+@prefetch
+@flaky()
+def load_audio_classification_pipeline():
+    return transformers.pipeline("audio-classification", model="superb/wav2vec2-base-superb-ks")
+
+
+@prefetch
+@flaky()
+def load_feature_extraction_pipeline():
+    st_arch = "sentence-transformers/all-MiniLM-L6-v2"
+    model = transformers.AutoModel.from_pretrained(st_arch)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(st_arch)
+    return transformers.pipeline(model=model, tokenizer=tokenizer, task="feature-extraction")
+
+
+def prefetch_models():
+    """
+    Prefetches models used in the test suite to avoid downloading them during the test run.
+    Fetching model weights from the HuggingFace Hub has been proven to be flaky in the past, so
+    we want to avoid doing it in the middle of the test run, instead, failing fast.
+    """
+    # Get all model loading functions that are marked as @prefetch
+    for _, func in inspect.getmembers(sys.modules[__name__]):
+        if inspect.isfunction(func) and hasattr(func, "is_prefetch") and func.is_prefetch:
+            # Call the function to download the model to HuggingFace cache
+            func()
+
+
+if __name__ == "__main__":
+    prefetch_models()

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -6,8 +6,6 @@ import logging
 import os
 import pathlib
 import textwrap
-import time
-from functools import wraps
 from unittest import mock
 
 import huggingface_hub
@@ -19,7 +17,7 @@ import torch
 import transformers
 import yaml
 from datasets import load_dataset
-from huggingface_hub import ModelCard, scan_cache_dir
+from huggingface_hub import ModelCard
 from packaging.version import Version
 
 import mlflow
@@ -68,11 +66,9 @@ from tests.helper_functions import (
     assert_register_model_called_with_local_model_path,
     pyfunc_serve_and_score_model,
 )
-
-pytestmark = pytest.mark.large
+from tests.transformers.helper import IS_NEW_FEATURE_EXTRACTION_API, flaky
 
 transformers_version = Version(transformers.__version__)
-_FEATURE_EXTRACTION_API_CHANGE_VERSION = "4.27.0"
 _IMAGE_PROCESSOR_API_CHANGE_VERSION = "4.26.0"
 
 # NB: Some pipelines under test in this suite come very close or outright exceed the
@@ -93,31 +89,6 @@ image_file_path = pathlib.Path(pathlib.Path(__file__).parent.parent, "datasets",
 _logger = logging.getLogger(__name__)
 
 
-def flaky(max_tries=3):
-    """
-    Annotation decorator for retrying flaky functions up to max_tries times, and raise the Exception
-    if it fails after max_tries attempts.
-    :param max_tries: Maximum number of times to retry the function.
-    :return: Decorated function.
-    """
-
-    def flaky_test_func(test_func):
-        @wraps(test_func)
-        def decorated_func(*args, **kwargs):
-            for i in range(max_tries):
-                try:
-                    return test_func(*args, **kwargs)
-                except Exception as e:
-                    _logger.warning(f"Attempt {i+1} failed with error: {e}")
-                    if i == max_tries - 1:
-                        raise
-                    time.sleep(3)
-
-        return decorated_func
-
-    return flaky_test_func
-
-
 @pytest.fixture(autouse=True)
 def force_gc():
     # This reduces the memory pressure for the usage of the larger pipeline fixtures ~500MB - 1GB
@@ -126,28 +97,6 @@ def force_gc():
     gc.set_threshold(0)
     gc.collect()
     gc.enable()
-
-
-@pytest.fixture(autouse=True)
-def clean_cache(request):
-    # This function will clean the cache that HuggingFace uses to limit the number of fetches from
-    # the hub repository when instantiating components (tokenizers, models, etc.). Due to the
-    # runner limitations for CI (As of April 2023, the runner image ubuntu-22.04 has a maximum of
-    # 14GB of storage space on the provided SSDs and 7GB of RAM which are both insufficient to run
-    # all validations of this test suite due to the model sizes.
-    # This fixture will clear the cache iff the cache storage is > 2GB when called.
-    if "skipcacheclean" in request.keywords:
-        return
-    else:
-        full_cache = scan_cache_dir()
-        cache_size_in_gb = full_cache.size_on_disk / 1000**3
-
-        if cache_size_in_gb > 2:
-            commits_to_purge = [
-                rev.commit_hash for repo in full_cache.repos for rev in repo.revisions
-            ]
-            delete_strategy = full_cache.delete_revisions(*commits_to_purge)
-            delete_strategy.execute()
 
 
 @pytest.fixture
@@ -169,208 +118,6 @@ def mock_pyfunc_wrapper():
 
 @pytest.fixture
 @flaky()
-def small_seq2seq_pipeline():
-    # The return type of this model's language head is a List[Dict[str, Any]]
-    architecture = "lordtt13/emo-mobilebert"
-    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
-    model = transformers.TFAutoModelForSequenceClassification.from_pretrained(architecture)
-    return transformers.pipeline(task="text-classification", model=model, tokenizer=tokenizer)
-
-
-@pytest.fixture
-@flaky()
-def small_qa_pipeline():
-    # The return type of this model's language head is a Dict[str, Any]
-    architecture = "csarron/mobilebert-uncased-squad-v2"
-    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture, low_cpu_mem_usage=True)
-    model = transformers.MobileBertForQuestionAnswering.from_pretrained(
-        architecture, low_cpu_mem_usage=True
-    )
-    return transformers.pipeline(task="question-answering", model=model, tokenizer=tokenizer)
-
-
-@pytest.fixture
-@flaky()
-def small_vision_model():
-    architecture = "google/mobilenet_v2_1.0_224"
-    feature_extractor = transformers.AutoFeatureExtractor.from_pretrained(
-        architecture, low_cpu_mem_usage=True
-    )
-    model = transformers.MobileNetV2ForImageClassification.from_pretrained(
-        architecture, low_cpu_mem_usage=True
-    )
-    return transformers.pipeline(
-        task="image-classification", model=model, feature_extractor=feature_extractor
-    )
-
-
-@pytest.fixture
-@flaky()
-def small_multi_modal_pipeline():
-    architecture = "dandelin/vilt-b32-finetuned-vqa"
-    return transformers.pipeline(model=architecture)
-
-
-@pytest.fixture
-@flaky()
-def component_multi_modal():
-    architecture = "dandelin/vilt-b32-finetuned-vqa"
-    tokenizer = transformers.BertTokenizerFast.from_pretrained(architecture, low_cpu_mem_usage=True)
-    processor = transformers.ViltProcessor.from_pretrained(architecture, low_cpu_mem_usage=True)
-    image_processor = transformers.ViltImageProcessor.from_pretrained(
-        architecture, low_cpu_mem_usage=True
-    )
-    model = transformers.ViltForQuestionAnswering.from_pretrained(
-        architecture, low_cpu_mem_usage=True
-    )
-    transformers_model = {"model": model, "tokenizer": tokenizer}
-    if transformers_version >= Version(_FEATURE_EXTRACTION_API_CHANGE_VERSION):
-        transformers_model["image_processor"] = image_processor
-    else:
-        transformers_model["feature_extractor"] = processor
-    return transformers_model
-
-
-@pytest.fixture
-@flaky()
-def small_conversational_model():
-    tokenizer = transformers.AutoTokenizer.from_pretrained(
-        "microsoft/DialoGPT-small", low_cpu_mem_usage=True
-    )
-    model = transformers.AutoModelWithLMHead.from_pretrained(
-        "satvikag/chatbot", low_cpu_mem_usage=True
-    )
-    return transformers.pipeline(task="conversational", model=model, tokenizer=tokenizer)
-
-
-@pytest.fixture
-@flaky()
-def fill_mask_pipeline():
-    architecture = "distilroberta-base"
-    model = transformers.AutoModelForMaskedLM.from_pretrained(architecture, low_cpu_mem_usage=True)
-    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
-    return transformers.pipeline(task="fill-mask", model=model, tokenizer=tokenizer)
-
-
-@pytest.fixture
-@flaky()
-def text2text_generation_pipeline():
-    task = "text2text-generation"
-    architecture = "mrm8488/t5-small-finetuned-common_gen"
-    model = transformers.T5ForConditionalGeneration.from_pretrained(architecture)
-    tokenizer = transformers.T5TokenizerFast.from_pretrained(architecture)
-
-    return transformers.pipeline(
-        task=task,
-        tokenizer=tokenizer,
-        model=model,
-    )
-
-
-@pytest.fixture
-@flaky()
-def text_generation_pipeline():
-    task = "text-generation"
-    architecture = "distilgpt2"
-    model = transformers.AutoModelWithLMHead.from_pretrained(architecture)
-    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
-
-    return transformers.pipeline(
-        task=task,
-        model=model,
-        tokenizer=tokenizer,
-    )
-
-
-@pytest.fixture
-@flaky()
-def translation_pipeline():
-    return transformers.pipeline(
-        task="translation_en_to_de",
-        model=transformers.T5ForConditionalGeneration.from_pretrained("t5-small"),
-        tokenizer=transformers.T5TokenizerFast.from_pretrained("t5-small", model_max_length=100),
-    )
-
-
-@pytest.fixture
-@flaky()
-def summarizer_pipeline():
-    task = "summarization"
-    architecture = "sshleifer/distilbart-cnn-6-6"
-    model = transformers.BartForConditionalGeneration.from_pretrained(architecture)
-    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
-    return transformers.pipeline(
-        task=task,
-        tokenizer=tokenizer,
-        model=model,
-    )
-
-
-@pytest.fixture
-@flaky()
-def text_classification_pipeline():
-    task = "text-classification"
-    architecture = "distilbert-base-uncased-finetuned-sst-2-english"
-    model = transformers.AutoModelForSequenceClassification.from_pretrained(architecture)
-    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
-    return transformers.pipeline(
-        task=task,
-        tokenizer=tokenizer,
-        model=model,
-    )
-
-
-@pytest.fixture
-@flaky()
-def zero_shot_pipeline():
-    task = "zero-shot-classification"
-    architecture = "typeform/distilbert-base-uncased-mnli"
-    model = transformers.AutoModelForSequenceClassification.from_pretrained(architecture)
-    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
-    return transformers.pipeline(
-        task=task,
-        tokenizer=tokenizer,
-        model=model,
-    )
-
-
-@pytest.fixture
-@flaky()
-def table_question_answering_pipeline():
-    return transformers.pipeline(
-        task="table-question-answering", model="google/tapas-tiny-finetuned-wtq"
-    )
-
-
-@pytest.fixture
-@flaky()
-def ner_pipeline():
-    return transformers.pipeline(
-        task="token-classification", model="vblagoje/bert-english-uncased-finetuned-pos"
-    )
-
-
-@pytest.fixture
-@flaky()
-def ner_pipeline_aggregation():
-    # Modification to the default aggregation_strategy of `None` changes the output keys in each
-    # of the dictionaries. This fixture allows for testing that the correct data is extracted
-    # as a return value
-    return transformers.pipeline(
-        task="token-classification",
-        model="vblagoje/bert-english-uncased-finetuned-pos",
-        aggregation_strategy="average",
-    )
-
-
-@pytest.fixture
-@flaky()
-def conversational_pipeline():
-    return transformers.pipeline(model="AVeryRealHuman/DialoGPT-small-TonyStark")
-
-
-@pytest.fixture
-@flaky()
 def image_for_test():
     dataset = load_dataset("huggingface/cats-image")
     return dataset["test"]["image"][0]
@@ -388,37 +135,6 @@ def raw_audio_file():
     datasets_path = pathlib.Path(__file__).resolve().parent.parent.joinpath("datasets")
 
     return datasets_path.joinpath("apollo11_launch.wav").read_bytes()
-
-
-@pytest.fixture
-@flaky()
-def whisper_pipeline():
-    task = "automatic-speech-recognition"
-    architecture = "openai/whisper-tiny"
-    model = transformers.WhisperForConditionalGeneration.from_pretrained(architecture)
-    tokenizer = transformers.WhisperTokenizer.from_pretrained(architecture)
-    feature_extractor = transformers.WhisperFeatureExtractor.from_pretrained(architecture)
-    if Version(transformers.__version__) > Version("4.30.2"):
-        model.generation_config.alignment_heads = [[2, 2], [3, 0], [3, 2], [3, 3], [3, 4], [3, 5]]
-    return transformers.pipeline(
-        task=task, model=model, tokenizer=tokenizer, feature_extractor=feature_extractor
-    )
-
-
-@pytest.fixture
-@flaky()
-def audio_classification_pipeline():
-    return transformers.pipeline("audio-classification", model="superb/wav2vec2-base-superb-ks")
-
-
-@pytest.fixture
-@flaky()
-def feature_extraction_pipeline():
-    st_arch = "sentence-transformers/all-MiniLM-L6-v2"
-    model = transformers.AutoModel.from_pretrained(st_arch)
-    tokenizer = transformers.AutoTokenizer.from_pretrained(st_arch)
-
-    return transformers.pipeline(model=model, tokenizer=tokenizer, task="feature-extraction")
 
 
 def test_dependencies_pytorch(small_qa_pipeline):
@@ -554,7 +270,7 @@ def test_pipeline_construction_from_base_nlp_model(small_qa_pipeline):
 
 def test_pipeline_construction_from_base_vision_model(small_vision_model):
     model = {"model": small_vision_model.model, "tokenizer": small_vision_model.tokenizer}
-    if transformers_version >= Version(_FEATURE_EXTRACTION_API_CHANGE_VERSION):
+    if IS_NEW_FEATURE_EXTRACTION_API:
         model.update({"image_processor": small_vision_model.feature_extractor})
     else:
         model.update({"feature_extractor": small_vision_model.feature_extractor})
@@ -564,7 +280,7 @@ def test_pipeline_construction_from_base_vision_model(small_vision_model):
     )
     assert isinstance(generated, type(small_vision_model))
     assert isinstance(generated.tokenizer, type(small_vision_model.tokenizer))
-    if transformers_version >= Version(_FEATURE_EXTRACTION_API_CHANGE_VERSION):
+    if IS_NEW_FEATURE_EXTRACTION_API:
         compare_type = generated.image_processor
     else:
         compare_type = generated.feature_extractor
@@ -731,7 +447,7 @@ def test_basic_save_model_and_load_text_pipeline(small_seq2seq_pipeline, model_p
 
 
 def test_component_saving_multi_modal(component_multi_modal, model_path):
-    if transformers_version >= Version(_FEATURE_EXTRACTION_API_CHANGE_VERSION):
+    if IS_NEW_FEATURE_EXTRACTION_API:
         processor = component_multi_modal["image_processor"]
         expected = {"tokenizer", "processor", "image_processor"}
     else:
@@ -754,7 +470,7 @@ def test_component_saving_multi_modal(component_multi_modal, model_path):
 
 def test_extract_pipeline_components(small_vision_model, small_qa_pipeline):
     components_vision = _record_pipeline_components(small_vision_model)
-    if transformers_version >= Version(_FEATURE_EXTRACTION_API_CHANGE_VERSION):
+    if IS_NEW_FEATURE_EXTRACTION_API:
         component_list = ["feature_extractor", "image_processor"]
     else:
         component_list = ["feature_extractor"]
@@ -767,7 +483,7 @@ def test_extract_pipeline_components(small_vision_model, small_qa_pipeline):
 
 def test_extract_multi_modal_components(small_multi_modal_pipeline):
     components_multi = _record_pipeline_components(small_multi_modal_pipeline)
-    if transformers_version >= Version(_FEATURE_EXTRACTION_API_CHANGE_VERSION):
+    if IS_NEW_FEATURE_EXTRACTION_API:
         assert components_multi["image_processor_type"] == "ViltImageProcessor"
         assert components_multi["components"] == ["tokenizer", "image_processor"]
     elif transformers_version >= Version(_IMAGE_PROCESSOR_API_CHANGE_VERSION):
@@ -779,7 +495,7 @@ def test_extract_multi_modal_components(small_multi_modal_pipeline):
 
 
 def test_basic_save_model_and_load_vision_pipeline(small_vision_model, model_path, image_for_test):
-    if transformers_version >= Version(_FEATURE_EXTRACTION_API_CHANGE_VERSION):
+    if IS_NEW_FEATURE_EXTRACTION_API:
         model = {
             "model": small_vision_model.model,
             "image_processor": small_vision_model.image_processor,
@@ -807,7 +523,7 @@ def test_multi_modal_pipeline_save_and_load(small_multi_modal_pipeline, model_pa
     question = "How many cats are in the picture?"
     # Load components
     components = mlflow.transformers.load_model(model_path, return_type="components")
-    if transformers_version >= Version(_FEATURE_EXTRACTION_API_CHANGE_VERSION):
+    if IS_NEW_FEATURE_EXTRACTION_API:
         expected_components = {"model", "task", "tokenizer", "image_processor"}
     else:
         expected_components = {"model", "task", "tokenizer", "feature_extractor"}
@@ -825,7 +541,7 @@ def test_multi_modal_pipeline_save_and_load(small_multi_modal_pipeline, model_pa
 
 
 def test_multi_modal_component_save_and_load(component_multi_modal, model_path, image_for_test):
-    if transformers_version >= Version(_FEATURE_EXTRACTION_API_CHANGE_VERSION):
+    if IS_NEW_FEATURE_EXTRACTION_API:
         processor = component_multi_modal["image_processor"]
     else:
         processor = component_multi_modal["feature_extractor"]
@@ -844,14 +560,14 @@ def test_multi_modal_component_save_and_load(component_multi_modal, model_path, 
     # This isn't being tested on an actual use case of such a model type due to the size of
     # these types of models that have this interface being ill-suited for CI testing.
 
-    if transformers_version >= Version(_FEATURE_EXTRACTION_API_CHANGE_VERSION):
+    if IS_NEW_FEATURE_EXTRACTION_API:
         processor_key = "image_processor"
         assert isinstance(loaded_components[processor_key], transformers.ViltImageProcessor)
     else:
         processor_key = "feature_extractor"
         assert isinstance(loaded_components[processor_key], transformers.ViltProcessor)
         assert isinstance(loaded_components["processor"], transformers.ViltProcessor)
-    if transformers_version < Version(_FEATURE_EXTRACTION_API_CHANGE_VERSION):
+    if not IS_NEW_FEATURE_EXTRACTION_API:
         # NB: This simulated behavior is no longer valid in versions 4.27.4 and above.
         # With the port of functionality away from feature extractor types, the new architecture
         # for multi-modal models is entirely pipeline based.
@@ -874,7 +590,7 @@ def test_pipeline_saved_model_with_processor_cannot_be_loaded_as_pipeline(
     invalid_pipeline = transformers.pipeline(
         task="visual-question-answering", **component_multi_modal
     )
-    if transformers_version >= Version(_FEATURE_EXTRACTION_API_CHANGE_VERSION):
+    if IS_NEW_FEATURE_EXTRACTION_API:
         processor = component_multi_modal["image_processor"]
     else:
         processor = component_multi_modal["feature_extractor"]
@@ -892,7 +608,7 @@ def test_pipeline_saved_model_with_processor_cannot_be_loaded_as_pipeline(
 def test_component_saved_model_with_processor_cannot_be_loaded_as_pipeline(
     component_multi_modal, model_path
 ):
-    if transformers_version >= Version(_FEATURE_EXTRACTION_API_CHANGE_VERSION):
+    if IS_NEW_FEATURE_EXTRACTION_API:
         processor = component_multi_modal["image_processor"]
     else:
         processor = component_multi_modal["feature_extractor"]
@@ -973,7 +689,7 @@ def test_transformers_log_model_calls_register_model(small_qa_pipeline, tmp_path
 
 
 def test_transformers_log_model_with_no_registered_model_name(small_vision_model, tmp_path):
-    if transformers_version >= Version(_FEATURE_EXTRACTION_API_CHANGE_VERSION):
+    if IS_NEW_FEATURE_EXTRACTION_API:
         model = {
             "model": small_vision_model.model,
             "image_processor": small_vision_model.image_processor,
@@ -985,6 +701,7 @@ def test_transformers_log_model_with_no_registered_model_name(small_vision_model
             "feature_extractor": small_vision_model.feature_extractor,
             "tokenizer": small_vision_model.tokenizer,
         }
+
     artifact_path = "transformers"
     registered_model_patch = mock.patch("mlflow.tracking._model_registry.fluent._register_model")
     with mlflow.start_run(), registered_model_patch:
@@ -2250,6 +1967,7 @@ def test_classifier_pipeline_pyfunc_predict(text_classification_pipeline):
             artifact_path=artifact_path,
             signature=signature,
         )
+
     inference_payload = json.dumps({"inputs": inference_data})
     response = pyfunc_serve_and_score_model(
         model_info.model_uri,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10834?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10834/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10834
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Enabling [faster download protocol ](https://huggingface.co/docs/huggingface_hub/guides/download#faster-downloads)for transformers CI test. Also prefetch all model weights before running test to avoid failing in the middle of the tests. (see ML-37724 for more context)

Note that this could help reliability and avoid intermittent spike of download latency, it doesn't help speeding up CI tests in general. The main reason for transformer test to be slow (> 30mins) is because of dependency inference rather than weight downloading from Hub, which runs at every `log_model` and takes > 95% of total test time. Transformer flavor has special inference logic to handle Pytorch/Tensorflow requirements that basically 3 times slower than general flavors. While it is possible to bypass that for testing e.g. cache requirements and pass it as `pip_requirements`, this PR doesn't try to tackle that to avoid complicate test logic. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
