### PR TITLE
Fix an issue with an incorrect retry default timeout for urllib3 1.x

### DIFF
--- a/mlflow/utils/request_utils.py
+++ b/mlflow/utils/request_utils.py
@@ -45,10 +45,12 @@ class JitteredRetry(Retry):
             backoff_value += random.random() * self.backoff_jitter
         # The attribute `BACKOFF_MAX` was renamed to `DEFAULT_BACKOFF_MAX` in this commit:
         # https://github.com/urllib3/urllib3/commit/f69b1c89f885a74429cabdee2673e030b35979f0
-        # which was part of the major release of 2.0 for urllib3
+        # which was part of the major release of 2.0 for urllib3 and the support for both
+        # constants was added in 1.26.9:
+        # https://github.com/urllib3/urllib3/blob/1.26.9/src/urllib3/util/retry.py
         default_backoff = (
             Retry.BACKOFF_MAX
-            if Version(urllib3.__version__) < Version("2.0")
+            if Version(urllib3.__version__) < Version("1.26.9")
             else Retry.DEFAULT_BACKOFF_MAX
         )
 

--- a/mlflow/utils/request_utils.py
+++ b/mlflow/utils/request_utils.py
@@ -43,7 +43,16 @@ class JitteredRetry(Retry):
         backoff_value = super().get_backoff_time()
         if self.backoff_jitter != 0.0:
             backoff_value += random.random() * self.backoff_jitter
-        return float(max(0, min(Retry.DEFAULT_BACKOFF_MAX, backoff_value)))
+        # The attribute `BACKOFF_MAX` was renamed to `DEFAULT_BACKOFF_MAX` in this commit:
+        # https://github.com/urllib3/urllib3/commit/f69b1c89f885a74429cabdee2673e030b35979f0
+        # which was part of the major release of 2.0 for urllib3
+        default_backoff = (
+            Retry.BACKOFF_MAX
+            if Version(urllib3.__version__) < Version("2.0")
+            else Retry.DEFAULT_BACKOFF_MAX
+        )
+
+        return float(max(0, min(default_backoff, backoff_value)))
 
 
 def augmented_raise_for_status(response):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/10839?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10839/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10839
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fixes an issue where a retry with jittered delay would pull the incorrect constant that had been renamed in urllib3 2.x. This fix handles the renaming resolution. 

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
