### PR TITLE
Suppress feature store dependency warning

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -672,13 +672,11 @@ def load_model(
     model_meta = Model.load(os.path.join(local_path, MLMODEL_FILE_NAME))
 
     conf = model_meta.flavors.get(FLAVOR_NAME)
-
     if conf is None:
         raise MlflowException(
             f'Model does not have the "{FLAVOR_NAME}" flavor',
             RESOURCE_DOES_NOT_EXIST,
         )
-
     model_py_version = conf.get(PY_VERSION)
     if not suppress_warnings:
         _warn_potentially_incompatible_py_version_if_necessary(model_py_version=model_py_version)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -313,7 +313,6 @@ CODE = "code"
 DATA = "data"
 ENV = "env"
 MODEL_CONFIG = "config"
-DATABRICKS_FEATURE_LOOKUP = "databricks-feature-lookup"
 
 
 class EnvType:
@@ -589,11 +588,15 @@ class PyFuncModel:
         return yaml.safe_dump({"mlflow.pyfunc.loaded_model": info}, default_flow_style=False)
 
 
-def _warn_dependency_requirement_mismatches(model_path, module_name=""):
+def _warn_dependency_requirement_mismatches(model_path, module_name=None):
     """
     Inspects the model's dependencies and prints a warning if the current Python environment
     doesn't satisfy them.
+
+    :param model_path: The local path to the model
+    :param module_name: The name of the module that loads the model. Used to suppress warnings
     """
+    _DATABRICKS_FEATURE_LOOKUP = "databricks-feature-lookup"
     req_file_path = os.path.join(model_path, _REQUIREMENTS_FILE_NAME)
     if not os.path.exists(req_file_path):
         return
@@ -606,7 +609,7 @@ def _warn_dependency_requirement_mismatches(model_path, module_name=""):
             if mismatch_info is not None:
                 # Suppress databricks-feature-lookup warning for feature store cases
                 if (
-                    mismatch_info.package_name == DATABRICKS_FEATURE_LOOKUP
+                    mismatch_info.package_name == _DATABRICKS_FEATURE_LOOKUP
                     and module_name == _DATABRICKS_FS_LOADER_MODULE
                 ):
                     continue

--- a/tests/pyfunc/test_dependencies_functions.py
+++ b/tests/pyfunc/test_dependencies_functions.py
@@ -8,6 +8,7 @@ from sklearn.linear_model import LinearRegression
 
 import mlflow.utils.requirements_utils
 from mlflow.exceptions import MlflowException
+from mlflow.models.model import _DATABRICKS_FS_LOADER_MODULE
 from mlflow.pyfunc import _warn_dependency_requirement_mismatches, get_model_dependencies
 from mlflow.utils import PYTHON_VERSION
 
@@ -116,6 +117,48 @@ model's environment and install dependencies using the resulting environment fil
                     "Encountered an unexpected error "
                     "(RuntimeError('check_requirement_satisfied_fn_failed')) while "
                     "detecting model dependency mismatches"
+                )
+            )
+
+
+def test_suppress_warn_dependency_requirement_mismatches_feature_store(tmp_path):
+    req_file = tmp_path.joinpath("requirements.txt")
+    req_file.write_text(
+        f"cloudpickle=={cloudpickle.__version__}\ndatabricks-feature-lookup==999.1.1\n"
+    )
+    with mock.patch("mlflow.pyfunc._logger.warning") as mock_warning:
+        original_get_installed_version_fn = mlflow.utils.requirements_utils._get_installed_version
+
+        def gen_mock_get_installed_version_fn(mock_versions):
+            def mock_get_installed_version_fn(package, module=None):
+                if package in mock_versions:
+                    return mock_versions[package]
+                else:
+                    return original_get_installed_version_fn(package, module)
+
+            return mock_get_installed_version_fn
+
+        # Test case: multiple mismatched packages
+        with mock.patch(
+            "mlflow.utils.requirements_utils._get_installed_version",
+            gen_mock_get_installed_version_fn(
+                {
+                    "databricks-feature-lookup": "9.99.11",
+                    "cloudpickle": "999.99.22",
+                }
+            ),
+        ):
+            _warn_dependency_requirement_mismatches(
+                model_path=tmp_path, module_name=_DATABRICKS_FS_LOADER_MODULE
+            )
+            mock_warning.assert_called_once_with(
+                """
+Detected one or more mismatches between the model's dependencies and the current Python environment:
+ - cloudpickle (current: 999.99.22, required: cloudpickle=={cloudpickle_version})
+To fix the mismatches, call `mlflow.pyfunc.get_model_dependencies(model_uri)` to fetch the \
+model's environment and install dependencies using the resulting environment file.
+""".strip().format(
+                    cloudpickle_version=cloudpickle.__version__
                 )
             )
 

--- a/tests/pyfunc/test_dependencies_functions.py
+++ b/tests/pyfunc/test_dependencies_functions.py
@@ -8,7 +8,6 @@ from sklearn.linear_model import LinearRegression
 
 import mlflow.utils.requirements_utils
 from mlflow.exceptions import MlflowException
-from mlflow.models.model import _DATABRICKS_FS_LOADER_MODULE
 from mlflow.pyfunc import _warn_dependency_requirement_mismatches, get_model_dependencies
 from mlflow.utils import PYTHON_VERSION
 
@@ -148,9 +147,7 @@ def test_suppress_warn_dependency_requirement_mismatches_feature_store(tmp_path)
                 }
             ),
         ):
-            _warn_dependency_requirement_mismatches(
-                model_path=tmp_path, module_name=_DATABRICKS_FS_LOADER_MODULE
-            )
+            _warn_dependency_requirement_mismatches(model_path=tmp_path)
             mock_warning.assert_called_once_with(
                 """
 Detected one or more mismatches between the model's dependencies and the current Python environment:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ernestwong-db/mlflow/pull/10840?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10840/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10840
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

mlflow.pyfunc.load_model throws a warning prompting users to install databricks-feature-lookup when. However, this is not correct and databricks-feature-lookup should not be installed. We suppress this warning for only feature store cases.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
Logged a model with FS. The warning message no longer appears.
### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Databricks Feature Store models will have a suppressed warning for a dependency requirement mismatch.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
