### PR TITLE
Add warning for dependency diff when model loading

### DIFF
--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -17,6 +17,7 @@ from mlflow.utils.process import _exec_cmd
 from mlflow.utils.requirements_utils import (
     _infer_requirements,
     _parse_requirements,
+    warn_dependency_requirement_mismatches,
 )
 from mlflow.version import VERSION
 
@@ -530,6 +531,9 @@ def _process_pip_requirements(
 
     sanitized_pip_reqs = _deduplicate_requirements(pip_reqs)
 
+    # Check if pip requirements contain incompatible version with the current environment
+    warn_dependency_requirement_mismatches(sanitized_pip_reqs)
+
     if constraints:
         sanitized_pip_reqs.append(f"-c {_CONSTRAINTS_FILE_NAME}")
 
@@ -687,6 +691,9 @@ def _process_conda_env(conda_env):
     pip_reqs, constraints = _parse_pip_requirements(pip_reqs)
     if not _contains_mlflow_requirement(pip_reqs):
         pip_reqs.insert(0, _generate_mlflow_version_pinning())
+
+    # Check if pip requirements contain incompatible version with the current environment
+    warn_dependency_requirement_mismatches(pip_reqs)
 
     if constraints:
         pip_reqs.append(f"-c {_CONSTRAINTS_FILE_NAME}")

--- a/tests/pyfunc/test_dependencies_functions.py
+++ b/tests/pyfunc/test_dependencies_functions.py
@@ -1,163 +1,14 @@
 from pathlib import Path
 from unittest import mock
 
-import cloudpickle
 import pytest
 import sklearn
 from sklearn.linear_model import LinearRegression
 
 import mlflow.utils.requirements_utils
 from mlflow.exceptions import MlflowException
-from mlflow.pyfunc import _warn_dependency_requirement_mismatches, get_model_dependencies
+from mlflow.pyfunc import get_model_dependencies
 from mlflow.utils import PYTHON_VERSION
-
-from tests.helper_functions import AnyStringWith
-
-
-def test_warn_dependency_requirement_mismatches(tmp_path):
-    req_file = tmp_path.joinpath("requirements.txt")
-    req_file.write_text(
-        f"cloudpickle=={cloudpickle.__version__}\nscikit-learn=={sklearn.__version__}\n"
-    )
-
-    with mock.patch("mlflow.pyfunc._logger.warning") as mock_warning:
-        # Test case: all packages satisfy requirements.
-        _warn_dependency_requirement_mismatches(model_path=tmp_path)
-        mock_warning.assert_not_called()
-
-        mock_warning.reset_mock()
-
-        original_get_installed_version_fn = mlflow.utils.requirements_utils._get_installed_version
-
-        def gen_mock_get_installed_version_fn(mock_versions):
-            def mock_get_installed_version_fn(package, module=None):
-                if package in mock_versions:
-                    return mock_versions[package]
-                else:
-                    return original_get_installed_version_fn(package, module)
-
-            return mock_get_installed_version_fn
-
-        # Test case: multiple mismatched packages
-        with mock.patch(
-            "mlflow.utils.requirements_utils._get_installed_version",
-            gen_mock_get_installed_version_fn(
-                {
-                    "scikit-learn": "999.99.11",
-                    "cloudpickle": "999.99.22",
-                }
-            ),
-        ):
-            _warn_dependency_requirement_mismatches(model_path=tmp_path)
-            mock_warning.assert_called_once_with(
-                """
-Detected one or more mismatches between the model's dependencies and the current Python environment:
- - cloudpickle (current: 999.99.22, required: cloudpickle=={cloudpickle_version})
- - scikit-learn (current: 999.99.11, required: scikit-learn=={sklearn_version})
-To fix the mismatches, call `mlflow.pyfunc.get_model_dependencies(model_uri)` to fetch the \
-model's environment and install dependencies using the resulting environment file.
-""".strip().format(
-                    sklearn_version=sklearn.__version__, cloudpickle_version=cloudpickle.__version__
-                )
-            )
-
-        mock_warning.reset_mock()
-
-        req_file.write_text("scikit-learn>=0.8,<=0.9")
-
-        # Test case: requirement with multiple version specifiers is satisfied
-        with mock.patch(
-            "mlflow.utils.requirements_utils._get_installed_version",
-            gen_mock_get_installed_version_fn({"scikit-learn": "0.8.1"}),
-        ):
-            _warn_dependency_requirement_mismatches(model_path=tmp_path)
-            mock_warning.assert_not_called()
-
-        mock_warning.reset_mock()
-
-        # Test case: requirement with multiple version specifiers is not satisfied
-        with mock.patch(
-            "mlflow.utils.requirements_utils._get_installed_version",
-            gen_mock_get_installed_version_fn({"scikit-learn": "0.7.1"}),
-        ):
-            _warn_dependency_requirement_mismatches(model_path=tmp_path)
-            mock_warning.assert_called_once_with(
-                AnyStringWith(" - scikit-learn (current: 0.7.1, required: scikit-learn>=0.8,<=0.9)")
-            )
-
-        mock_warning.reset_mock()
-
-        # Test case: required package is uninstalled.
-        req_file.write_text("uninstalled-pkg==1.2.3")
-        _warn_dependency_requirement_mismatches(model_path=tmp_path)
-        mock_warning.assert_called_once_with(
-            AnyStringWith(
-                " - uninstalled-pkg (current: uninstalled, required: uninstalled-pkg==1.2.3)"
-            )
-        )
-
-        mock_warning.reset_mock()
-
-        # Test case: requirement without version specifiers
-        req_file.write_text("mlflow")
-        _warn_dependency_requirement_mismatches(model_path=tmp_path)
-        mock_warning.assert_not_called()
-
-        mock_warning.reset_mock()
-
-        # Test case: an unexpected error happens while detecting mismatched packages.
-        with mock.patch(
-            "mlflow.pyfunc._check_requirement_satisfied",
-            side_effect=RuntimeError("check_requirement_satisfied_fn_failed"),
-        ):
-            _warn_dependency_requirement_mismatches(model_path=tmp_path)
-            mock_warning.assert_called_once_with(
-                AnyStringWith(
-                    "Encountered an unexpected error "
-                    "(RuntimeError('check_requirement_satisfied_fn_failed')) while "
-                    "detecting model dependency mismatches"
-                )
-            )
-
-
-def test_suppress_warn_dependency_requirement_mismatches_feature_store(tmp_path):
-    req_file = tmp_path.joinpath("requirements.txt")
-    req_file.write_text(
-        f"cloudpickle=={cloudpickle.__version__}\ndatabricks-feature-lookup==999.1.1\n"
-    )
-    with mock.patch("mlflow.pyfunc._logger.warning") as mock_warning:
-        original_get_installed_version_fn = mlflow.utils.requirements_utils._get_installed_version
-
-        def gen_mock_get_installed_version_fn(mock_versions):
-            def mock_get_installed_version_fn(package, module=None):
-                if package in mock_versions:
-                    return mock_versions[package]
-                else:
-                    return original_get_installed_version_fn(package, module)
-
-            return mock_get_installed_version_fn
-
-        # Test case: multiple mismatched packages
-        with mock.patch(
-            "mlflow.utils.requirements_utils._get_installed_version",
-            gen_mock_get_installed_version_fn(
-                {
-                    "databricks-feature-lookup": "9.99.11",
-                    "cloudpickle": "999.99.22",
-                }
-            ),
-        ):
-            _warn_dependency_requirement_mismatches(model_path=tmp_path)
-            mock_warning.assert_called_once_with(
-                """
-Detected one or more mismatches between the model's dependencies and the current Python environment:
- - cloudpickle (current: 999.99.22, required: cloudpickle=={cloudpickle_version})
-To fix the mismatches, call `mlflow.pyfunc.get_model_dependencies(model_uri)` to fetch the \
-model's environment and install dependencies using the resulting environment file.
-""".strip().format(
-                    cloudpickle_version=cloudpickle.__version__
-                )
-            )
 
 
 def test_get_model_dependencies_read_req_file(tmp_path):
@@ -286,11 +137,3 @@ def test_get_model_dependencies_with_model_version_uri():
 
     deps = get_model_dependencies("models:/linear/1", format="pip")
     assert f"scikit-learn=={sklearn.__version__}" in Path(deps).read_text()
-
-
-def test_warn_dependency_requirement_mismatches_ignores_file_path(tmp_path):
-    req_file = tmp_path / "requirements.txt"
-    req_file.write_text("/path/to/my.whl")
-    with mock.patch("mlflow.pyfunc._logger.warning") as mock_warning:
-        _warn_dependency_requirement_mismatches(model_path=tmp_path)
-        mock_warning.assert_not_called()

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -162,7 +162,9 @@ def test_spark_udf(spark, model_path):
         code_path=[os.path.dirname(tests.__file__)],
     )
 
-    with mock.patch("mlflow.pyfunc._warn_dependency_requirement_mismatches") as mock_check_fn:
+    with mock.patch(
+        "mlflow.utils.requirements_utils.warn_dependency_requirement_mismatches"
+    ) as mock_check_fn:
         reloaded_pyfunc_model = mlflow.pyfunc.load_model(model_path)
         mock_check_fn.assert_called_once()
 

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -163,7 +163,7 @@ def test_spark_udf(spark, model_path):
     )
 
     with mock.patch(
-        "mlflow.utils.requirements_utils.warn_dependency_requirement_mismatches"
+        "mlflow.pyfunc.warn_dependency_requirement_mismatches"
     ) as mock_check_fn:
         reloaded_pyfunc_model = mlflow.pyfunc.load_model(model_path)
         mock_check_fn.assert_called_once()

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -162,9 +162,7 @@ def test_spark_udf(spark, model_path):
         code_path=[os.path.dirname(tests.__file__)],
     )
 
-    with mock.patch(
-        "mlflow.pyfunc.warn_dependency_requirement_mismatches"
-    ) as mock_check_fn:
+    with mock.patch("mlflow.pyfunc.warn_dependency_requirement_mismatches") as mock_check_fn:
         reloaded_pyfunc_model = mlflow.pyfunc.load_model(model_path)
         mock_check_fn.assert_called_once()
 

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -6,7 +6,6 @@ from unittest import mock
 import cloudpickle
 import importlib_metadata
 import pytest
-import sklearn
 
 import mlflow
 import mlflow.utils.requirements_utils
@@ -440,6 +439,8 @@ def test_capture_imported_modules_includes_gateway_extra():
 
 
 def test_warn_dependency_requirement_mismatches():
+    import sklearn
+
     with mock.patch("mlflow.utils.requirements_utils._logger.warning") as mock_warning:
         # Test case: all packages satisfy requirements.
         warn_dependency_requirement_mismatches(

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -545,11 +545,7 @@ model's environment and install dependencies using the resulting environment fil
 
 
 def test_suppress_warn_dependency_requirement_mismatches_feature_store(tmp_path):
-    req_file = tmp_path.joinpath("requirements.txt")
-    req_file.write_text(
-        f"cloudpickle=={cloudpickle.__version__}\ndatabricks-feature-lookup==999.1.1\n"
-    )
-    with mock.patch("mlflow.pyfunc._logger.warning") as mock_warning:
+    with mock.patch("mlflow.utils.requirements_utils._logger.warning") as mock_warning:
         original_get_installed_version_fn = mlflow.utils.requirements_utils._get_installed_version
 
         def gen_mock_get_installed_version_fn(mock_versions):
@@ -571,7 +567,12 @@ def test_suppress_warn_dependency_requirement_mismatches_feature_store(tmp_path)
                 }
             ),
         ):
-            warn_dependency_requirement_mismatches(model_path=tmp_path)
+            warn_dependency_requirement_mismatches(
+                model_requirements=[
+                    f"cloudpickle=={cloudpickle.__version__}",
+                    "databricks-feature-lookup==999.1.1",
+                ]
+            )
             mock_warning.assert_called_once_with(
                 """
 Detected one or more mismatches between the model's dependencies and the current Python environment:

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -3,8 +3,10 @@ import os
 import sys
 from unittest import mock
 
+import cloudpickle
 import importlib_metadata
 import pytest
+import sklearn
 
 import mlflow
 import mlflow.utils.requirements_utils
@@ -24,7 +26,10 @@ from mlflow.utils.requirements_utils import (
     _PyPIPackageIndex,
     _strip_inline_comment,
     _strip_local_version_label,
+    warn_dependency_requirement_mismatches,
 )
+
+from tests.helper_functions import AnyStringWith
 
 
 def test_is_comment():
@@ -432,3 +437,147 @@ def test_capture_imported_modules_includes_gateway_extra():
 
     pip_requirements = infer_pip_requirements(model_info.model_uri, "pyfunc")
     assert f"mlflow[gateway]=={mlflow.__version__}" in pip_requirements
+
+
+def test_warn_dependency_requirement_mismatches():
+    with mock.patch("mlflow.utils.requirements_utils._logger.warning") as mock_warning:
+        # Test case: all packages satisfy requirements.
+        warn_dependency_requirement_mismatches(
+            model_requirements=[
+                f"cloudpickle=={cloudpickle.__version__}",
+                f"scikit-learn=={sklearn.__version__}",
+            ]
+        )
+        mock_warning.assert_not_called()
+        mock_warning.reset_mock()
+
+        original_get_installed_version_fn = mlflow.utils.requirements_utils._get_installed_version
+
+        def gen_mock_get_installed_version_fn(mock_versions):
+            def mock_get_installed_version_fn(package, module=None):
+                if package in mock_versions:
+                    return mock_versions[package]
+                else:
+                    return original_get_installed_version_fn(package, module)
+
+            return mock_get_installed_version_fn
+
+        # Test case: multiple mismatched packages
+        with mock.patch(
+            "mlflow.utils.requirements_utils._get_installed_version",
+            gen_mock_get_installed_version_fn(
+                {
+                    "scikit-learn": "999.99.11",
+                    "cloudpickle": "999.99.22",
+                }
+            ),
+        ):
+            warn_dependency_requirement_mismatches(
+                model_requirements=[
+                    f"cloudpickle=={cloudpickle.__version__}",
+                    f"scikit-learn=={sklearn.__version__}",
+                ]
+            )
+        mock_warning.assert_called_once_with(
+            f"""
+Detected one or more mismatches between the model's dependencies and the current Python environment:
+ - cloudpickle (current: 999.99.22, required: cloudpickle=={cloudpickle.__version__})
+ - scikit-learn (current: 999.99.11, required: scikit-learn=={sklearn.__version__})
+To fix the mismatches, call `mlflow.pyfunc.get_model_dependencies(model_uri)` to fetch the \
+model's environment and install dependencies using the resulting environment file.
+        """.strip()
+        )
+        mock_warning.reset_mock()
+
+        # Test case: requirement with multiple version specifiers is satisfied
+        with mock.patch(
+            "mlflow.utils.requirements_utils._get_installed_version",
+            gen_mock_get_installed_version_fn({"scikit-learn": "0.8.1"}),
+        ):
+            warn_dependency_requirement_mismatches(model_requirements=["scikit-learn>=0.8,<=0.9"])
+        mock_warning.assert_not_called()
+        mock_warning.reset_mock()
+
+        # Test case: requirement with multiple version specifiers is not satisfied
+        with mock.patch(
+            "mlflow.utils.requirements_utils._get_installed_version",
+            gen_mock_get_installed_version_fn({"scikit-learn": "0.7.1"}),
+        ):
+            warn_dependency_requirement_mismatches(model_requirements=["scikit-learn>=0.8,<=0.9"])
+        mock_warning.assert_called_once_with(
+            AnyStringWith(" - scikit-learn (current: 0.7.1, required: scikit-learn>=0.8,<=0.9)")
+        )
+        mock_warning.reset_mock()
+
+        # Test case: required package is uninstalled.
+        warn_dependency_requirement_mismatches(model_requirements=["uninstalled-pkg==1.2.3"])
+        mock_warning.assert_called_once_with(
+            AnyStringWith(
+                " - uninstalled-pkg (current: uninstalled, required: uninstalled-pkg==1.2.3)"
+            )
+        )
+        mock_warning.reset_mock()
+
+        # Test case: requirement without version specifiers
+        warn_dependency_requirement_mismatches(model_requirements=["mlflow"])
+        mock_warning.assert_not_called()
+        mock_warning.reset_mock()
+
+        # Test case: an unexpected error happens while detecting mismatched packages.
+        with mock.patch(
+            "mlflow.utils.requirements_utils._check_requirement_satisfied",
+            side_effect=RuntimeError("check_requirement_satisfied_fn_failed"),
+        ):
+            warn_dependency_requirement_mismatches(model_requirements=["mlflow"])
+        mock_warning.assert_called_once_with(
+            AnyStringWith(
+                "Encountered an unexpected error "
+                "(RuntimeError('check_requirement_satisfied_fn_failed')) while "
+                "detecting model dependency mismatches"
+            )
+        )
+        mock_warning.reset_mock()
+
+        # Test case: ignore file path
+        warn_dependency_requirement_mismatches(model_requirements=["/path/to/my.whl"])
+        mock_warning.assert_not_called()
+
+
+def test_suppress_warn_dependency_requirement_mismatches_feature_store(tmp_path):
+    req_file = tmp_path.joinpath("requirements.txt")
+    req_file.write_text(
+        f"cloudpickle=={cloudpickle.__version__}\ndatabricks-feature-lookup==999.1.1\n"
+    )
+    with mock.patch("mlflow.pyfunc._logger.warning") as mock_warning:
+        original_get_installed_version_fn = mlflow.utils.requirements_utils._get_installed_version
+
+        def gen_mock_get_installed_version_fn(mock_versions):
+            def mock_get_installed_version_fn(package, module=None):
+                if package in mock_versions:
+                    return mock_versions[package]
+                else:
+                    return original_get_installed_version_fn(package, module)
+
+            return mock_get_installed_version_fn
+
+        # Test case: multiple mismatched packages
+        with mock.patch(
+            "mlflow.utils.requirements_utils._get_installed_version",
+            gen_mock_get_installed_version_fn(
+                {
+                    "databricks-feature-lookup": "9.99.11",
+                    "cloudpickle": "999.99.22",
+                }
+            ),
+        ):
+            warn_dependency_requirement_mismatches(model_path=tmp_path)
+            mock_warning.assert_called_once_with(
+                """
+Detected one or more mismatches between the model's dependencies and the current Python environment:
+ - cloudpickle (current: 999.99.22, required: cloudpickle=={cloudpickle_version})
+To fix the mismatches, call `mlflow.pyfunc.get_model_dependencies(model_uri)` to fetch the \
+model's environment and install dependencies using the resulting environment file.
+""".strip().format(
+                    cloudpickle_version=cloudpickle.__version__
+                )
+            )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10843?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10843/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10843
```

</p>
</details>

### Related Issues/PRs

ML-37766

### What changes are proposed in this pull request?

MLflow shows a warning when loading a model if model's dependency has different version as the current environment. But it doesn't show warning when saving. While the version should match when they are automatically inferred by MLflow, the check should be helpful when manually specifying requirements.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

![Screenshot 2024-01-18 at 16 34 39](https://github.com/mlflow/mlflow/assets/31463517/7272027c-0642-4273-a28b-60f6229398c7)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
