### PR TITLE
Increase Gunicorn worker timeout for MLflow Deployment Server pagenation test

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -44,8 +44,6 @@ jobs:
           pip freeze | tail -n +1 | grep -q '^pydantic==2\.'
       - name: Run tests with pydantic v2
         run: |
-          # TODO: Remove once https://github.com/mlflow/mlflow/issues/10855 is fixed
-          pip install uvicorn!=0.26.0
           pytest tests/gateway
       - name: Downgrade pydantic to v1
         run: |

--- a/mlflow/deployments/constants.py
+++ b/mlflow/deployments/constants.py
@@ -1,11 +1,3 @@
-from mlflow.environment_variables import _EnvironmentVariable
-
-# TODO: Move this to mlflow.environment_variables before merging to master
-# Specifies the timeout for deployment client APIs to declare a request has timed out
-MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT = _EnvironmentVariable(
-    "MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT", int, 120
-)
-
 # Abridged retryable error codes for deployments clients.
 # These are modified from the standard MLflow Tracking server retry codes for the MLflowClient to
 # remove timeouts from the list of the retryable conditions. A long-running timeout with

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -4,9 +4,11 @@ from typing import Any, Dict, Optional
 from mlflow.deployments import BaseDeploymentClient
 from mlflow.deployments.constants import (
     MLFLOW_DEPLOYMENT_CLIENT_REQUEST_RETRY_CODES,
-    MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT,
 )
-from mlflow.environment_variables import MLFLOW_HTTP_REQUEST_TIMEOUT
+from mlflow.environment_variables import (
+    MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT,
+    MLFLOW_HTTP_REQUEST_TIMEOUT,
+)
 from mlflow.utils import AttrDict
 from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import get_databricks_host_creds

--- a/mlflow/deployments/mlflow/__init__.py
+++ b/mlflow/deployments/mlflow/__init__.py
@@ -14,10 +14,7 @@ from mlflow.deployments.server.constants import (
     MLFLOW_DEPLOYMENTS_QUERY_SUFFIX,
 )
 from mlflow.deployments.utils import resolve_endpoint_url
-from mlflow.environment_variables import (
-    MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT,
-    MLFLOW_HTTP_REQUEST_TIMEOUT,
-)
+from mlflow.environment_variables import MLFLOW_HTTP_REQUEST_TIMEOUT
 from mlflow.protos.databricks_pb2 import BAD_REQUEST
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.tracking._tracking_service.utils import _get_default_host_creds

--- a/mlflow/deployments/mlflow/__init__.py
+++ b/mlflow/deployments/mlflow/__init__.py
@@ -14,7 +14,10 @@ from mlflow.deployments.server.constants import (
     MLFLOW_DEPLOYMENTS_QUERY_SUFFIX,
 )
 from mlflow.deployments.utils import resolve_endpoint_url
-from mlflow.environment_variables import MLFLOW_HTTP_REQUEST_TIMEOUT
+from mlflow.environment_variables import (
+    MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT,
+    MLFLOW_HTTP_REQUEST_TIMEOUT,
+)
 from mlflow.protos.databricks_pb2 import BAD_REQUEST
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.tracking._tracking_service.utils import _get_default_host_creds

--- a/mlflow/deployments/mlflow/__init__.py
+++ b/mlflow/deployments/mlflow/__init__.py
@@ -6,7 +6,6 @@ from mlflow import MlflowException
 from mlflow.deployments import BaseDeploymentClient
 from mlflow.deployments.constants import (
     MLFLOW_DEPLOYMENT_CLIENT_REQUEST_RETRY_CODES,
-    MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT,
 )
 from mlflow.deployments.server.config import Endpoint
 from mlflow.deployments.server.constants import (
@@ -15,7 +14,10 @@ from mlflow.deployments.server.constants import (
     MLFLOW_DEPLOYMENTS_QUERY_SUFFIX,
 )
 from mlflow.deployments.utils import resolve_endpoint_url
-from mlflow.environment_variables import MLFLOW_HTTP_REQUEST_TIMEOUT
+from mlflow.environment_variables import (
+    MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT,
+    MLFLOW_HTTP_REQUEST_TIMEOUT,
+)
 from mlflow.protos.databricks_pb2 import BAD_REQUEST
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.tracking._tracking_service.utils import _get_default_host_creds

--- a/mlflow/deployments/server/runner.py
+++ b/mlflow/deployments/server/runner.py
@@ -7,10 +7,7 @@ from typing import Generator
 from watchfiles import watch
 
 from mlflow.deployments.server import app
-from mlflow.environment_variables import (
-    MLFLOW_DEPLOYMENT_SERVER_START_TIMEOUT,
-    MLFLOW_DEPLOYMENTS_CONFIG,
-)
+from mlflow.environment_variables import MLFLOW_DEPLOYMENTS_CONFIG
 from mlflow.gateway.config import _load_route_config
 from mlflow.gateway.utils import kill_child_processes
 
@@ -72,8 +69,6 @@ class Runner:
                 "--worker-class",
                 "uvicorn.workers.UvicornWorker",
                 f"{app.__name__}:create_app_from_env()",
-                "--timeout",
-                str(MLFLOW_DEPLOYMENT_SERVER_START_TIMEOUT.get()),
             ],
             env={
                 **os.environ,

--- a/mlflow/deployments/server/runner.py
+++ b/mlflow/deployments/server/runner.py
@@ -7,7 +7,10 @@ from typing import Generator
 from watchfiles import watch
 
 from mlflow.deployments.server import app
-from mlflow.environment_variables import MLFLOW_DEPLOYMENTS_CONFIG
+from mlflow.environment_variables import (
+    MLFLOW_DEPLOYMENT_SERVER_START_TIMEOUT,
+    MLFLOW_DEPLOYMENTS_CONFIG,
+)
 from mlflow.gateway.config import _load_route_config
 from mlflow.gateway.utils import kill_child_processes
 
@@ -69,6 +72,8 @@ class Runner:
                 "--worker-class",
                 "uvicorn.workers.UvicornWorker",
                 f"{app.__name__}:create_app_from_env()",
+                "--timeout",
+                str(MLFLOW_DEPLOYMENT_SERVER_START_TIMEOUT.get()),
             ],
             env={
                 **os.environ,

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -491,12 +491,6 @@ MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE = _EnvironmentVariable(
 #: (default: ``True``)
 MLFLOW_ALLOW_HTTP_REDIRECTS = _BooleanEnvironmentVariable("MLFLOW_ALLOW_HTTP_REDIRECTS", True)
 
-# Specifies the timeout for starting Gunicorn workers for the MLflow Deployment server.
-# Default 30 seconds comes from the default value of Gunicorn.
-MLFLOW_DEPLOYMENT_SERVER_START_TIMEOUT = _EnvironmentVariable(
-    "MLFLOW_DEPLOYMENT_SERVER_START_TIMEOUT", int, 30
-)
-
 # Specifies the timeout for deployment client APIs to declare a request has timed out
 MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT", int, 120

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -490,3 +490,14 @@ MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE = _EnvironmentVariable(
 #: encounters a redirect response.
 #: (default: ``True``)
 MLFLOW_ALLOW_HTTP_REDIRECTS = _BooleanEnvironmentVariable("MLFLOW_ALLOW_HTTP_REDIRECTS", True)
+
+# Specifies the timeout for starting Gunicorn workers for the MLflow Deployment server.
+# Default 30 seconds comes from the default value of Gunicorn.
+MLFLOW_DEPLOYMENT_SERVER_START_TIMEOUT = _EnvironmentVariable(
+    "MLFLOW_DEPLOYMENT_SERVER_START_TIMEOUT", int, 30
+)
+
+# Specifies the timeout for deployment client APIs to declare a request has timed out
+MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT = _EnvironmentVariable(
+    "MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT", int, 120
+)

--- a/tests/gateway/test_fluent.py
+++ b/tests/gateway/test_fluent.py
@@ -1,3 +1,4 @@
+import os
 from unittest import mock
 
 import pytest
@@ -19,7 +20,6 @@ from mlflow.gateway import (
 )
 from mlflow.gateway.config import Route
 from mlflow.gateway.constants import MLFLOW_GATEWAY_SEARCH_ROUTES_PAGE_SIZE
-from mlflow.gateway.fluent import MlflowGatewayClient
 from mlflow.gateway.utils import resolve_route_url
 
 from tests.gateway.tools import Gateway, save_yaml
@@ -136,16 +136,7 @@ def test_fluent_search_routes(gateway):
         "route_url": resolve_route_url(gateway.url, "gateway/chat/invocations"),
     }
 
-# Mock for counting the number of search_routes calls to validate pagination
-class MockMlflowGatewayClient(MlflowGatewayClient):
-    search_routes_calls = 0
-    def search_routes(self, *args, **kwargs):
-        MockMlflowGatewayClient.search_routes_calls += 1
-        return super().search_routes(*args, **kwargs)
 
-
-@mock.patch("mlflow.gateway.constants.MLFLOW_GATEWAY_SEARCH_ROUTES_PAGE_SIZE", 10)
-@mock.patch("mlflow.gateway.fluent.MlflowGatewayClient", MockMlflowGatewayClient)
 def test_fluent_search_routes_handles_pagination(tmp_path):
     conf = tmp_path / "config.yaml"
     base_route_config = {
@@ -161,17 +152,19 @@ def test_fluent_search_routes_handles_pagination(tmp_path):
             },
         },
     }
-    num_routes = 21
+    num_routes = (MLFLOW_GATEWAY_SEARCH_ROUTES_PAGE_SIZE * 2) + 1
     gateway_route_names = [f"route_{i}" for i in range(num_routes)]
     gateway_config_dict = {
         "routes": [{"name": route_name, **base_route_config} for route_name in gateway_route_names]
     }
     save_yaml(conf, gateway_config_dict)
 
-    with Gateway(conf) as gateway:
-            set_gateway_uri(gateway_uri=gateway.url)
-            assert [route.name for route in search_routes()] == gateway_route_names
-            assert MockMlflowGatewayClient.search_routes_calls == 3
+    # Increase Gunicorn worker timeout from default 30 sec to handle huge number of routes
+    with Gateway(
+        conf, env={**os.environ, "GUNICORN_CMD_ARGS": "--timeout=120 --log-level=debug"}
+    ) as gateway:
+        set_gateway_uri(gateway_uri=gateway.url)
+        assert [route.name for route in search_routes()] == gateway_route_names
 
 
 def test_fluent_get_gateway_uri(gateway):

--- a/tests/gateway/test_fluent.py
+++ b/tests/gateway/test_fluent.py
@@ -4,7 +4,10 @@ import pytest
 from requests.exceptions import HTTPError
 
 import mlflow.gateway.utils
-from mlflow.environment_variables import MLFLOW_GATEWAY_URI
+from mlflow.environment_variables import (
+    MLFLOW_DEPLOYMENT_SERVER_START_TIMEOUT,
+    MLFLOW_GATEWAY_URI,
+)
 from mlflow.exceptions import MlflowException
 from mlflow.gateway import (
     create_route,
@@ -136,7 +139,10 @@ def test_fluent_search_routes(gateway):
     }
 
 
-def test_fluent_search_routes_handles_pagination(tmp_path):
+def test_fluent_search_routes_handles_pagination(tmp_path, monkeypatch):
+    # Set longer timeout for starting the server as this test creates huge number of routes
+    monkeypatch.setenv(MLFLOW_DEPLOYMENT_SERVER_START_TIMEOUT.name, "120")
+
     conf = tmp_path / "config.yaml"
     base_route_config = {
         "route_type": "llm/v1/completions",

--- a/tests/gateway/test_fluent.py
+++ b/tests/gateway/test_fluent.py
@@ -160,9 +160,7 @@ def test_fluent_search_routes_handles_pagination(tmp_path):
     save_yaml(conf, gateway_config_dict)
 
     # Increase Gunicorn worker timeout from default 30 sec to handle huge number of routes
-    with Gateway(
-        conf, env={**os.environ, "GUNICORN_CMD_ARGS": "--timeout=120 --log-level=debug"}
-    ) as gateway:
+    with Gateway(conf, env={**os.environ, "GUNICORN_CMD_ARGS": "--timeout=120"}) as gateway:
         set_gateway_uri(gateway_uri=gateway.url)
         assert [route.name for route in search_routes()] == gateway_route_names
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10857?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10857/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10857
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Close #10855

### What changes are proposed in this pull request?

Gateway tests (`test_fluent_search_routes_handles_pagination`) have occasionally been failing due to worker timeout. This was because the test case creates huge number (6001!) routes and breached timeout for Gunicorn workers which is 30 sec by default. This PR adds a new env variable `MLFLOW_DEPLOYMENT_SERVER_START_TIMEOUT` to configure the timeout and fix the broken test.

**Note**: Initially I was thinking of adding `--timeout` to the CLI command `mlflow deployment start-server`, but switched to env var considering the low likelihood of users need to change it. Also it might be confusing with prediction timeout.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.


#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
