### PR TITLE
Improve error message when code_path includes Databricks notebook

### DIFF
--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -302,7 +302,7 @@ def _save_model_with_class_artifacts_params(
             shutil.move(tmp_artifacts_dir.path(), os.path.join(path, saved_artifacts_dir_subpath))
         custom_model_config_kwargs[CONFIG_KEY_ARTIFACTS] = saved_artifacts_config
 
-    saved_code_subpath = _validate_and_copy_code_paths(src=code_paths, dst=path)
+    saved_code_subpath = _validate_and_copy_code_paths(code_paths, path)
 
     mlflow.pyfunc.add_to_model(
         model=mlflow_model,

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -32,8 +32,8 @@ from mlflow.utils.environment import (
     _process_pip_requirements,
     _PythonEnv,
 )
-from mlflow.utils.file_utils import TempDir, _copy_file_or_tree, get_total_file_size, write_to
-from mlflow.utils.model_utils import _get_flavor_configuration
+from mlflow.utils.file_utils import TempDir, get_total_file_size, write_to
+from mlflow.utils.model_utils import _get_flavor_configuration, _validate_and_copy_code_paths
 from mlflow.utils.requirements_utils import _get_pinned_requirement
 
 CONFIG_KEY_ARTIFACTS = "artifacts"
@@ -302,11 +302,7 @@ def _save_model_with_class_artifacts_params(
             shutil.move(tmp_artifacts_dir.path(), os.path.join(path, saved_artifacts_dir_subpath))
         custom_model_config_kwargs[CONFIG_KEY_ARTIFACTS] = saved_artifacts_config
 
-    saved_code_subpath = None
-    if code_paths is not None:
-        saved_code_subpath = "code"
-        for code_path in code_paths:
-            _copy_file_or_tree(src=code_path, dst=path, dst_dir=saved_code_subpath)
+    saved_code_subpath = _validate_and_copy_code_paths(src=code_paths, dst=path)
 
     mlflow.pyfunc.add_to_model(
         model=mlflow_model,

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from unittest import mock
 
 import pytest
 import sklearn.neighbors as knn
@@ -12,6 +13,7 @@ from mlflow.mleap import FLAVOR_NAME as MLEAP_FLAVOR_NAME
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode
 from mlflow.utils.file_utils import TempDir
+from mlflow.utils.model_utils import _validate_and_copy_code_paths
 
 
 @pytest.fixture(scope="module")
@@ -104,3 +106,14 @@ def test_add_code_to_system_path(sklearn_knn_model, model_path):
     assert "dummy_package" in sys.modules
     assert "pandas" in sys.modules
     assert "site-packages" in sys.modules["pandas"].__file__
+
+
+@mock.patch("builtins.open", side_effect=OSError("[Errno 95] Operation not supported"))
+def test_add_code_to_system_path_not_copyable_file(sklearn_knn_model, model_path):
+
+    with pytest.raises(MlflowException, match=r"Failed to copy the specified code path"):
+        mlflow.sklearn.save_model(
+            sk_model=sklearn_knn_model,
+            path=model_path,
+            code_paths=["tests/utils/test_resources/dummy_module.py"],
+        )

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -13,7 +13,6 @@ from mlflow.mleap import FLAVOR_NAME as MLEAP_FLAVOR_NAME
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode
 from mlflow.utils.file_utils import TempDir
-from mlflow.utils.model_utils import _validate_and_copy_code_paths
 
 
 @pytest.fixture(scope="module")
@@ -110,7 +109,6 @@ def test_add_code_to_system_path(sklearn_knn_model, model_path):
 
 @mock.patch("builtins.open", side_effect=OSError("[Errno 95] Operation not supported"))
 def test_add_code_to_system_path_not_copyable_file(sklearn_knn_model, model_path):
-
     with pytest.raises(MlflowException, match=r"Failed to copy the specified code path"):
         mlflow.sklearn.save_model(
             sk_model=sklearn_knn_model,


### PR DESCRIPTION
### What changes are proposed in this pull request?

When an user saves a model with `code_paths` that includes Databricks notebooks, it will raise an OS error during file copy with `shutil.copyfile`. This is because DB notebooks cannot be read as normal files e.g. `open()` (general `.ipynb` file works). Currently this error is surfaced like `[Errno 95] Operation not supported: 'my_module/Notebook'"`, which doesn't really help. This PR adds more user-friendly error messages indicating the path includes non-copyable file(s).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

On Databricks notebook:

![Screenshot 2024-01-19 at 23 08 44](https://github.com/mlflow/mlflow/assets/31463517/13633ee8-10c5-46e6-8aeb-8a3b041cddf0)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
