### PR TITLE
Add support for retrieving license files for transformers models

### DIFF
--- a/docs/source/llms/transformers/guide/index.rst
+++ b/docs/source/llms/transformers/guide/index.rst
@@ -397,6 +397,15 @@ the stored model object.
 In addition to the ``ModelCard``, the components that comprise any Pipeline (or the individual components if saving a dictionary of named components) will have their source types
 stored. The model type, pipeline type, task, and classes of any supplementary component (such as a ``Tokenizer`` or ``ImageProcessor``) will be stored in the ``MLmodel`` file as well.
 
+In order to preserve any attached legal requirements to the usage of any  model that is hosted on the huggingface hub, a "best effort" attempt
+is made when logging a transformers model to retrieve and persist any license information. A file will be generated (``LICENSE.txt``) within the root of
+the model directory. Within this file you will either find a copy of a declared license, the name of a common license type that applies to the model's use (i.e., 'apache-2.0', 'mit'),
+or, in the event that license information was never submitted to the huggingface hub when uploading a model repository, a link to the repository for you to use
+in order to determine what restrictions exist regarding the use of the model.
+
+.. note::
+  Model license information was introduced in **MLflow 2.10.0**. Previous versions do not include license information for models.
+
 Automatic Signature inference
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -93,6 +93,8 @@ _IMAGE_PROCESSOR_KEY = "image_processor"
 _IMAGE_PROCESSOR_TYPE_KEY = "image_processor_type"
 _INFERENCE_CONFIG_BINARY_KEY = "inference_config.txt"
 _INSTANCE_TYPE_KEY = "instance_type"
+_LICENSE_FILE_NAME = "LICENSE.txt"
+_LICENSE_FILE_NAMES = ["LICENSE.txt", "LICENSE", "LICENSE.md", "LICENSE.yml"]
 _MODEL_KEY = "model"
 _MODEL_BINARY_KEY = "model_binary"
 _MODEL_BINARY_FILE_NAME = "model"
@@ -532,11 +534,19 @@ def save_model(
             inference_config=inference_config,
         )
 
+    model_name = transformers_model.model.name_or_path
+
     # Get the model card from either the argument or the HuggingFace marketplace
-    card_data = model_card if model_card is not None else _fetch_model_card(transformers_model)
+    card_data = model_card if model_card is not None else _fetch_model_card(model_name)
 
     # If the card data can be acquired, save the text and the data separately
     _write_card_data(card_data, path)
+
+    # Retrieve license information from the huggingface_hub repository if it exists
+    license_text = _fetch_license(model_name, card_data)
+
+    # Write the license information (or guidance) along with the model
+    _write_license_information(license_text, path)
 
     model_bin_kwargs = {_MODEL_BINARY_KEY: _MODEL_BINARY_FILE_NAME}
 
@@ -1096,7 +1106,7 @@ def _deserialize_torch_dtype_if_exists(flavor_config):
     return _torch_dype_mapping()[flavor_config["torch_dtype"]]
 
 
-def _fetch_model_card(model_or_pipeline):
+def _fetch_model_card(model_name):
     """
     Attempts to retrieve the model card for the specified model architecture iff the
     `huggingface_hub` library is installed. If a card cannot be found in the registry or
@@ -1112,19 +1122,58 @@ def _fetch_model_card(model_or_pipeline):
         )
         return
 
-    model = model_or_pipeline.model
-
     if hasattr(hub, "ModelCard"):
         try:
-            return hub.ModelCard.load(model.name_or_path)
+            return hub.ModelCard.load(model_name)
         except Exception as e:
             _logger.warning(f"The model card could not be retrieved from the hub due to {e}")
     else:
         _logger.warning(
-            f"The version of huggingface_hub that is installed does not provide "
+            "The version of huggingface_hub that is installed does not provide "
             f"ModelCard functionality. You have version {hub.__version__} installed. "
-            f"Update huggingface_hub to >= '0.10.0' to retrieve the ModelCard data."
+            "Update huggingface_hub to >= '0.10.0' to retrieve the ModelCard data."
         )
+
+
+def _fetch_license(model_name, card_data):
+    """
+    Attempts to retrieve a license document from the underlying model repository iff the
+    `huggingface_hub` library is installed. If the library is available and a license file
+    is present, return the contents as text. If the license file does not exist, return
+    instructions for a user to investigate what the underlying usage restrictions that
+    exist.
+    """
+
+    fallback = f"A license file could not be found for the '{model_name}' repository. \n"
+    "To ensure that you are in compliance with the license requirements for this "
+    f"model, please visit the model repository here:\n https://huggingface.co/{model_name}"
+
+    def _get_license_file_as_text(repo_id):
+        for license_name in _LICENSE_FILE_NAMES:
+            try:
+                license_file_local_location = hub.hf_hub_download(
+                    repo_id=repo_id, filename=license_name
+                )
+                return pathlib.Path(license_file_local_location).read_text()
+            except Exception as e:
+                _logger.info(f"A license file could not be obtained due to {e}")
+
+    try:
+        import huggingface_hub as hub
+    except ImportError:
+        _logger.warning(
+            f"Unable to retrieve license information for the model repo {model_name}. In order "
+            "to enable retrieval of license information, please install the huggingface_hub "
+            "package by running `pip install huggingface_hub>0.10.0"
+        )
+
+    if lic := _get_license_file_as_text(model_name):
+        return lic
+
+    if (cd := card_data) and cd.data.license != "other":
+        return f"{fallback}\nThe declared license type is: '{cd.data.license}'"
+
+    return fallback
 
 
 def _write_card_data(card_data, path):
@@ -1141,6 +1190,20 @@ def _write_card_data(card_data, path):
             yaml.safe_dump(
                 card_data.data.to_dict(), stream=file, default_flow_style=False, encoding="utf-8"
             )
+
+
+def _write_license_information(license_text, path):
+    """Writes the license file or instructions to retrieve license information"""
+    if license_text:
+        try:
+            path.joinpath(_LICENSE_FILE_NAME).write_text(license_text, encoding="utf-8")
+        except UnicodeError as e:
+            _logger.warning(f"Unable to save the license data due to: {e}")
+    else:
+        _logger.warning(
+            "Unable to find license information for this model. Please verify "
+            "permissible usage for the model you are storing prior to use."
+        )
 
 
 def _build_pipeline_from_model_input(model, task: str):

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1144,9 +1144,11 @@ def _fetch_license(model_name, card_data):
     exist.
     """
 
-    fallback = f"A license file could not be found for the '{model_name}' repository. \n"
-    "To ensure that you are in compliance with the license requirements for this "
-    f"model, please visit the model repository here:\n https://huggingface.co/{model_name}"
+    fallback = (
+        f"A license file could not be found for the '{model_name}' repository. \n"
+        "To ensure that you are in compliance with the license requirements for this "
+        f"model, please visit the model repository here:\n https://huggingface.co/{model_name}"
+    )
 
     def _get_license_file_as_text(repo_id):
         for license_name in _LICENSE_FILE_NAMES:
@@ -1156,7 +1158,7 @@ def _fetch_license(model_name, card_data):
                 )
                 return pathlib.Path(license_file_local_location).read_text()
             except Exception as e:
-                _logger.info(f"A license file could not be obtained due to {e}")
+                _logger.debug(f"A license file could not be obtained due to {e}")
 
     try:
         import huggingface_hub as hub

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -317,20 +317,20 @@ def test_model_card_acquisition_vision_model(small_vision_model):
 
 
 @pytest.mark.parametrize(
-    ("repo_id", "license_file", "file_end"),
+    ("repo_id", "license_file"),
     [
-        ("google/mobilenet_v2_1.0_224", "LICENSE.txt", "_224"),  # no license declared
-        ("csarron/mobilebert-uncased-squad-v2", "LICENSE.txt", "'mit'"),  # mit license
-        ("codellama/CodeLlama-34b-hf", "LICENSE", "this Agreement."),  # custom license
-        ("openai/whisper-tiny", "LICENSE.txt", "'apache-2.0'"),  # apache license
-        ("stabilityai/stable-code-3b", "LICENSE", "principles."),  # custom
-        ("mistralai/Mixtral-8x7B-Instruct-v0.1", "LICENSE.txt", "'apache-2.0'"),  # apache
+        ("google/mobilenet_v2_1.0_224", "LICENSE.txt"),  # no license declared
+        ("csarron/mobilebert-uncased-squad-v2", "LICENSE.txt"),  # mit license
+        ("codellama/CodeLlama-34b-hf", "LICENSE"),  # custom license
+        ("openai/whisper-tiny", "LICENSE.txt"),  # apache license
+        ("stabilityai/stable-code-3b", "LICENSE"),  # custom
+        ("mistralai/Mixtral-8x7B-Instruct-v0.1", "LICENSE.txt"),  # apache
     ],
 )
-def test_license_acquisition(repo_id, license_file, file_end, tmp_path):
+def test_license_acquisition(repo_id, license_file, tmp_path):
     card_data = _fetch_model_card(repo_id)
     _write_license_information(repo_id, card_data, tmp_path)
-    assert tmp_path.joinpath(license_file).read_text().rstrip().endswith(file_end)
+    assert tmp_path.joinpath(license_file).stat().st_size > 0
 
 
 def test_license_fallback(tmp_path):

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -311,7 +311,7 @@ def test_saving_with_invalid_dict_as_model(model_path):
 
 
 def test_model_card_acquisition_vision_model(small_vision_model):
-    model_provided_card = _fetch_model_card(small_vision_model)
+    model_provided_card = _fetch_model_card(small_vision_model.model.name_or_path)
     assert model_provided_card.data.to_dict()["tags"] == ["vision", "image-classification"]
     assert len(model_provided_card.text) > 0
 
@@ -327,8 +327,8 @@ def test_model_card_acquisition_vision_model(small_vision_model):
 )
 def test_license_acquisition(repo_id, file_end):
     card_data = _fetch_model_card(repo_id)
-
-    assert _fetch_license(repo_id, card_data).rstrip().endswith(file_end)
+    license_text = _fetch_license(repo_id, card_data).rstrip()
+    assert license_text.endswith(file_end)
 
 
 def test_license_fallback():
@@ -3856,7 +3856,7 @@ def test_qa_model_model_size_bytes(small_qa_pipeline, tmp_path):
     expected_size = 0
     for folder in [model_dir, tokenizer_dir]:
         expected_size += _calculate_expected_size(folder)
-    other_files = ["model_card.md", "model_card_data.yaml"]
+    other_files = ["model_card.md", "model_card_data.yaml", "LICENSE.txt"]
     for file in other_files:
         path = tmp_path.joinpath(file)
         expected_size += _calculate_expected_size(path)

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -323,6 +323,8 @@ def test_model_card_acquisition_vision_model(small_vision_model):
         ("csarron/mobilebert-uncased-squad-v2", "LICENSE.txt", "'mit'"),  # mit license
         ("codellama/CodeLlama-34b-hf", "LICENSE", "this Agreement."),  # custom license
         ("openai/whisper-tiny", "LICENSE.txt", "'apache-2.0'"),  # apache license
+        ("stabilityai/stable-code-3b", "LICENSE", "principles."),  # custom
+        ("mistralai/Mixtral-8x7B-Instruct-v0.1", "LICENSE.txt", "'apache-2.0'"),  # apache
     ],
 )
 def test_license_acquisition(repo_id, license_file, file_end, tmp_path):
@@ -333,11 +335,7 @@ def test_license_acquisition(repo_id, license_file, file_end, tmp_path):
 
 def test_license_fallback(tmp_path):
     _write_license_information("not a real repo", None, tmp_path)
-    assert (
-        tmp_path.joinpath("LICENSE.txt")
-        .read_text()
-        .startswith("A license file could not be found for the")
-    )
+    assert tmp_path.joinpath("LICENSE.txt").stat().st_size > 0
 
 
 def test_vision_model_save_pipeline_with_defaults(small_vision_model, model_path):
@@ -959,16 +957,13 @@ def test_huggingface_hub_not_installed(small_seq2seq_pipeline, model_path):
 
         assert result is None
 
-        license = mlflow.transformers._fetch_license(
-            small_seq2seq_pipeline.model.name_or_path, result
-        )
-        assert license.startswith("A license file could not be found for")
-
         mlflow.transformers.save_model(transformers_model=small_seq2seq_pipeline, path=model_path)
 
         contents = {item.name for item in model_path.iterdir()}
         assert not contents.intersection({"model_card.txt", "model_card_data.yaml"})
-        assert "LICENSE.txt" in contents
+
+        license_data = model_path.joinpath("LICENSE.txt").read_text()
+        assert license_data.rstrip().endswith("mobilebert")
 
 
 def test_save_pipeline_without_defined_components(small_conversational_model, model_path):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/10871?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10871/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10871
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add support for a 'best effort' retrieval of model license information from the huggingface hub for transformers models.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [X] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
