### PR TITLE
Fix recipe card display format

### DIFF
--- a/mlflow/recipes/cards/__init__.py
+++ b/mlflow/recipes/cards/__init__.py
@@ -298,8 +298,11 @@ class FailureCard(BaseCard):
         )
         self.add_tab(
             "Stacktrace",
-            "<div class='stacktrace-container'><p style='margin-top:0px'><code>{{ STACKTRACE|e }}</code></p></div>"
-        ).add_html("STACKTRACE", f'{failure_traceback}')
+            (
+                "<div class='stacktrace-container'><p style='margin-top:0px'><code>"
+                "{{ STACKTRACE|e }}</code></p></div>"
+            ),
+        ).add_html("STACKTRACE", f"{failure_traceback}")
         warning_output_path = os.path.join(output_directory, "warning_logs.txt")
         if os.path.exists(warning_output_path):
             with open(warning_output_path) as f:

--- a/mlflow/recipes/cards/__init__.py
+++ b/mlflow/recipes/cards/__init__.py
@@ -239,7 +239,6 @@ class BaseCard:
         """
         import pandas as pd
         from pandas.io.formats.style import Styler
-        import html
 
         if not isinstance(table, Styler):
             table = pd.DataFrame(table, columns=columns)
@@ -247,7 +246,14 @@ class BaseCard:
             # javascript code injection
             # Note that `pandas_df.style.to_html(escape=True) does not work
             # So that we have to manually escape values in dataframe cells.
-            table = table.map(lambda x: html.escape(str(x)))
+
+            def escape_value(x):
+                return html.escape(str(x))
+
+            if hasattr(table, "map"):
+                table = table.map(escape_value)
+            else:
+                table = table.applymap(escape_value)
             table = table.style
 
         pandas_version = Version(pd.__version__)

--- a/mlflow/recipes/cards/__init__.py
+++ b/mlflow/recipes/cards/__init__.py
@@ -308,7 +308,7 @@ class FailureCard(BaseCard):
                 "<div class='stacktrace-container'><p style='margin-top:0px'><code>"
                 "{{ STACKTRACE|e }}</code></p></div>"
             ),
-        ).add_html("STACKTRACE", f"{failure_traceback}")
+        ).add_html("STACKTRACE", str(failure_traceback))
         warning_output_path = os.path.join(output_directory, "warning_logs.txt")
         if os.path.exists(warning_output_path):
             with open(warning_output_path) as f:

--- a/mlflow/recipes/steps/ingest/__init__.py
+++ b/mlflow/recipes/steps/ingest/__init__.py
@@ -171,7 +171,7 @@ class BaseIngestStep(BaseStep, metaclass=abc.ABCMeta):
             )
         # Tab #2 -- Ingested dataset schema.
         schema_html = BaseCard.render_table(schema["fields"])
-        card.add_tab("Data Schema", "{{SCHEMA|e}}").add_html("SCHEMA", schema_html)
+        card.add_tab("Data Schema", "{{SCHEMA}}").add_html("SCHEMA", schema_html)
 
         if data_preview is not None:
             # Tab #3 -- Ingested dataset preview.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/10893?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10893/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10893
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
The security fix https://github.com/mlflow/mlflow/pull/10873 causes Recipe card display format broken.
This PR fixes it.

### How is this PR tested?

Manually test:
<img width="462" alt="image" src="https://github.com/mlflow/mlflow/assets/19235986/74141a73-0626-4674-987c-d4d0a2516e73">

<img width="1028" alt="image" src="https://github.com/mlflow/mlflow/assets/19235986/fec18b0d-cdb2-4545-83a6-e02ee359baa8">



- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
