### PR TITLE
Fix azure openai and docs

### DIFF
--- a/docs/source/llms/openai/guide/index.rst
+++ b/docs/source/llms/openai/guide/index.rst
@@ -109,7 +109,7 @@ To successfully log a model targeting Azure OpenAI Service, specific environment
 - **OPENAI_API_BASE**: The base endpoint for your Azure OpenAI resource (e.g., ``https://<your-service-name>.openai.azure.com/``). Within the Azure OpenAI documentation and guides, this key is referred to as ``AZURE_OPENAI_ENDPOINT`` or simply ``ENDPOINT``.
 - **OPENAI_API_VERSION**: The API version to use for the Azure OpenAI Service. More information can be found in the `Azure OpenAI documentation <https://learn.microsoft.com/en-us/azure/ai-services/openai/reference>`_, including up-to-date lists of supported versions.
 - **OPENAI_API_TYPE**: If using Azure OpenAI endpoints, this value should be set to ``"azure"``.
-- **DEPLOYMENT_ID**: The deployment name that you chose when you deployed the model in Azure. To learn more, visit the `Azure OpenAI deployment documentation <https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/create-resource?pivots=web-portal>`_.
+- **OPENAI_DEPLOYMENT_NAME**: The deployment name that you chose when you deployed the model in Azure. To learn more, visit the `Azure OpenAI deployment documentation <https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/create-resource?pivots=web-portal>`_.
 
 Azure OpenAI Service in MLflow
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/openai/azure_openai.py
+++ b/examples/openai/azure_openai.py
@@ -1,5 +1,3 @@
-import os
-
 import openai
 import pandas as pd
 
@@ -14,7 +12,7 @@ export OPENAI_API_BASE="<AZURE OPENAI BASE>"
 # OPENAI_API_VERSION e.g. 2023-05-15
 export OPENAI_API_VERSION="<AZURE OPENAI API VERSION>"
 export OPENAI_API_TYPE="azure"
-export DEPLOYMENT_ID="<AZURE OPENAI DEPLOYMENT ID OR NAME>"
+export OPENAI_DEPLOYMENT_NAME="<AZURE OPENAI DEPLOYMENT ID OR NAME>"
 """
 
 with mlflow.start_run():
@@ -24,7 +22,6 @@ with mlflow.start_run():
         task=openai.ChatCompletion,
         artifact_path="model",
         messages=[{"role": "user", "content": "Tell me a joke about {animal}."}],
-        deployment_id=os.environ["DEPLOYMENT_ID"],
     )
 
 # Load native OpenAI model

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -656,7 +656,7 @@ class _OpenAIWrapper:
         self.request_configs = {}
         for x in ["api_base", "api_version", "api_type", "engine", "deployment_id"]:
             if x in self.model:
-                self.request_configs[x] = self.model[x]
+                self.request_configs[x] = self.model.pop(x)
             elif value := getattr(self.api_config, x):
                 self.request_configs[x] = value
 

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -653,15 +653,16 @@ class _OpenAIWrapper:
         self.api_token = _OAITokenHolder(self.api_config.api_type)
         # If the same parameter exists in self.model & self.api_config,
         # we use the parameter from self.model
-        self.envs = {
-            x: getattr(self.api_config, x)
-            for x in ["api_base", "api_version", "api_type", "engine", "deployment_id"]
-            if getattr(self.api_config, x) is not None and x not in self.model
-        }
-        api_type = self.model.get("api_type") or self.envs.get("api_type")
-        if api_type in ("azure", "azure_ad", "azuread"):
-            deployment_id = self.model.get("deployment_id") or self.envs.get("deployment_id")
-            if self.model.get("engine") or self.envs.get("engine"):
+        self.request_configs = {}
+        for x in ["api_base", "api_version", "api_type", "engine", "deployment_id"]:
+            if x in self.model:
+                self.request_configs[x] = self.model[x]
+            elif value := getattr(self.api_config, x):
+                self.request_configs[x] = value
+
+        if self.request_configs.get("api_type") in ("azure", "azure_ad", "azuread"):
+            deployment_id = self.request_configs.get("deployment_id")
+            if self.request_configs.get("engine"):
                 # Avoid using both parameters as they serve the same purpose
                 # Invalid inputs:
                 #   - Wrong engine + correct/wrong deployment_id
@@ -704,11 +705,11 @@ class _OpenAIWrapper:
             return data[self.formater.variables].to_dict(orient="records")
 
     def _construct_request_url(self, task_url, default_url):
-        api_type = self.model.get("api_type") or self.envs.get("api_type")
+        api_type = self.request_configs.get("api_type")
         if api_type in ("azure", "azure_ad", "azuread"):
-            api_base = self.envs.get("api_base")
-            api_version = self.envs.get("api_version")
-            deployment_id = self.envs.get("deployment_id")
+            api_base = self.request_configs.get("api_base")
+            api_version = self.request_configs.get("api_version")
+            deployment_id = self.request_configs.get("deployment_id")
 
             return (
                 f"{api_base}/openai/deployments/{deployment_id}/"

--- a/mlflow/utils/openai_utils.py
+++ b/mlflow/utils/openai_utils.py
@@ -211,11 +211,6 @@ def _validate_model_params(task, model, params):
         )
 
 
-def _exclude_params_from_envs(params, envs):
-    """Params passed at inference time should override envs."""
-    return {k: v for k, v in envs.items() if k not in params} if params else envs
-
-
 class _OAITokenHolder:
     def __init__(self, api_type):
         self._api_token = None

--- a/tests/openai/test_openai_model_export.py
+++ b/tests/openai/test_openai_model_export.py
@@ -1,6 +1,5 @@
 import importlib
 import json
-from copy import deepcopy
 from unittest import mock
 
 import numpy as np
@@ -17,7 +16,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.models.signature import ModelSignature
 from mlflow.types.schema import ColSpec, ParamSchema, ParamSpec, Schema, TensorSpec
 from mlflow.utils.openai_utils import (
-    _exclude_params_from_envs,
     _mock_chat_completion_response,
     _mock_models_retrieve_response,
     _mock_request,
@@ -668,20 +666,3 @@ def test_engine_and_deployment_id_for_azure_openai(tmp_path, monkeypatch):
         MlflowException, match=r"Either engine or deployment_id must be set for Azure OpenAI API"
     ):
         mlflow.pyfunc.load_model(tmp_path)
-
-
-@pytest.mark.parametrize(
-    ("params", "envs"),
-    [
-        ({"a": None, "b": "b"}, {"a": "a", "c": "c"}),
-        ({"a": "a", "b": "b"}, {"a": "a", "d": "d"}),
-        ({}, {"a": "a", "b": "b"}),
-        ({"a": "a"}, {"b": "b"}),
-    ],
-)
-def test_exclude_params_from_envs(params, envs):
-    original_envs = deepcopy(envs)
-    result = _exclude_params_from_envs(params, envs)
-    assert envs == original_envs
-    assert not any(key in params for key in result)
-    assert all(key in envs for key in result)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10894?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10894/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10894
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #10883

This should be a regression introduced by https://github.com/mlflow/mlflow/pull/10615

### What changes are proposed in this pull request?
Fix params saved within azure openai model not used when constructing request url

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
