### PR TITLE
Fix promptflow test

### DIFF
--- a/examples/promptflow/basic/requirements.txt
+++ b/examples/promptflow/basic/requirements.txt
@@ -1,3 +1,2 @@
 promptflow[azure]
-promptflow-tools
 python-dotenv

--- a/examples/promptflow/basic/requirements.txt
+++ b/examples/promptflow/basic/requirements.txt
@@ -1,2 +1,3 @@
 promptflow[azure]
 python-dotenv
+propmtflow-tools

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -629,3 +629,17 @@ johnsnowlabs:
       else
         echo "Skipping tests due to missing license key"
       fi
+
+promptflow:
+  package_info:
+    pip_release: "promptflow"
+  models:
+    minimum: "1.1.0"
+    maximum: "1.4.1"
+    requirements:
+      ">= 0.0.0": [
+        "pyspark",
+        "promptflow-tools",
+      ]
+    run: |
+      pytest tests/promptflow/test_promptflow_model_export.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -639,6 +639,7 @@ promptflow:
     requirements:
       ">= 0.0.0": [
         "pyspark",
+        "promptflow-tools",
       ]
     run: |
       pytest tests/promptflow/test_promptflow_model_export.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -639,7 +639,6 @@ promptflow:
     requirements:
       ">= 0.0.0": [
         "pyspark",
-        "promptflow-tools",
       ]
     run: |
       pytest tests/promptflow/test_promptflow_model_export.py

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -253,15 +253,6 @@ _ML_PACKAGE_VERSIONS = {
             "maximum": "0.1.0"
         }
     },
-    "promptflow": {
-        "package_info": {
-            "pip_release": "promptflow"
-        },
-        "models": {
-            "minimum": "1.1.0",
-            "maximum": "1.3.0"
-        }
-    },
     "sentence_transformers": {
         "package_info": {
             "pip_release": "sentence-transformers"

--- a/tests/promptflow/flow_with_additional_includes/requirements.txt
+++ b/tests/promptflow/flow_with_additional_includes/requirements.txt
@@ -1,3 +1,2 @@
 promptflow[azure]
-promptflow-tools
 python-dotenv

--- a/tests/promptflow/flow_with_additional_includes/requirements.txt
+++ b/tests/promptflow/flow_with_additional_includes/requirements.txt
@@ -1,2 +1,3 @@
 promptflow[azure]
 python-dotenv
+promptflow-tools

--- a/tests/promptflow/test_promptflow_model_export.py
+++ b/tests/promptflow/test_promptflow_model_export.py
@@ -36,8 +36,8 @@ def test_promptflow_log_and_load_model():
 
     assert "promptflow" in logged_model.flavors
     assert logged_model.signature is not None
-    assert str(logged_model.signature.inputs) == "['text': string]"
-    assert str(logged_model.signature.outputs) == "['output': string]"
+    assert str(logged_model.signature.inputs) == "['text': string (required)]"
+    assert str(logged_model.signature.outputs) == "['output': string (required)]"
     assert isinstance(loaded_model, Flow)
 
 

--- a/tests/promptflow/test_promptflow_model_export.py
+++ b/tests/promptflow/test_promptflow_model_export.py
@@ -98,7 +98,7 @@ def test_promptflow_model_serve_predict():
     }
 
 
-def test_promptflow_model_sparkudf_predict():
+def test_promptflow_model_sparkudf_predict(spark):
     # Assert predict with promptflow model
     logged_model = log_promptflow_example_model()
     # Assert predict with spark udf
@@ -116,7 +116,7 @@ def test_promptflow_model_sparkudf_predict():
 def test_unsupported_class():
     mock_model = object()
     with pytest.raises(
-        MlflowException, match="only supports instances loaded by ~promptflow.load_flow"
+        MlflowException, match="MLflow promptflow flavor only supports instance defined with"
     ):
         with mlflow.start_run():
             mlflow.promptflow.log_model(mock_model, "mock_model_path")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10900?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10900/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10900
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix promptflow tests. The tests were not run as a part of CI in [the original PR](https://github.com/mlflow/mlflow/pull/10104) because the model version config was added to wrong place (`ml_model_versions.py` instead of `ml-model-versions.yml`). 

### How is this PR tested?

- [x Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
