### PR TITLE
Simplify spark session fixture usage

### DIFF
--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -58,6 +58,8 @@ from mlflow.tracking.artifact_utils import get_artifact_uri
 from mlflow.utils import insecure_hash
 from mlflow.utils.file_utils import TempDir
 
+from tests.utils.test_file_utils import spark_session  # noqa: F401
+
 
 def get_iris():
     iris = sklearn.datasets.load_iris()
@@ -106,12 +108,6 @@ def get_raw_tag(run_id, tag_name):
 
 def get_local_artifact_path(run_id, artifact_path):
     return get_artifact_uri(run_id, artifact_path).replace("file://", "")
-
-
-@pytest.fixture(scope="module")
-def spark_session():
-    with SparkSession.builder.master("local[*]").getOrCreate() as session:
-        yield session
 
 
 @pytest.fixture(scope="module")

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -27,7 +27,6 @@ from pyspark.ml.feature import HashingTF, IndexToString, StringIndexer, Tokenize
 from pyspark.ml.linalg import Vectors
 from pyspark.ml.regression import LinearRegression, LinearRegressionModel
 from pyspark.ml.tuning import CrossValidator, ParamGridBuilder, TrainValidationSplit
-from pyspark.sql import SparkSession
 
 import mlflow
 from mlflow import MlflowClient
@@ -52,15 +51,10 @@ from mlflow.utils.validation import (
 )
 
 from tests.helper_functions import AnyStringWith
+from tests.utils.test_file_utils import spark_session  # noqa: F401
 
 MODEL_DIR = "model"
 MLFLOW_PARENT_RUN_ID = "mlflow.parentRunId"
-
-
-@pytest.fixture(scope="module")
-def spark_session():
-    with SparkSession.builder.master("local[*]").getOrCreate() as session:
-        yield session
 
 
 @pytest.fixture(scope="module")

--- a/tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py
+++ b/tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py
@@ -30,6 +30,7 @@ from tests.helper_functions import (
     expect_status_code,
     pyfunc_serve_and_score_model,
 )
+from tests.utils.test_file_utils import spark_session  # noqa: F401
 
 IS_TENSORFLOW_AVAILABLE = _is_available_on_pypi("tensorflow")
 EXTRA_PYFUNC_SERVING_TEST_ARGS = [] if IS_TENSORFLOW_AVAILABLE else ["--env-manager", "local"]
@@ -49,14 +50,6 @@ def data():
     y = data["target"]
     x = data.drop("target", axis=1)
     return x, y
-
-
-@pytest.fixture(scope="module")
-def spark_session():
-    from pyspark.sql import SparkSession
-
-    with SparkSession.builder.master("local[2]").getOrCreate() as session:
-        yield session
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Cokral/mlflow/pull/10915?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10915/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10915
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #10045

### What changes are proposed in this pull request?

Remove the duplicated definitions of `spark_session` constructor in the following files:
 - [X] tests.spark.autologging.ml.test_pyspark_ml_autologging
 - [X] tests.evaluate.test_evaluation
 - [X] tests.tensorflow.test_keras_pyfunc_model_works_with_all_input_types
 
Instead, use the defined `spark_session` constructor already present in `tests.utils.test_file_utils`.

I had to use `# noqa: F401` to ensure that the import doesn't get removed by the linter. 
Do you know any better way to do this?
I imagine we could also work with the `conftest.py` files to do the imports instead of doing it directly in the test file.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
