### PR TITLE
Handle unrecognized response error code

### DIFF
--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -136,8 +136,8 @@ class RestException(MlflowException):
             except ValueError or KeyError:
                 _logger.warning(
                     f"Received error code not recognized by MLflow: {error_code}, this may "
-                    "indicate your request hits error outside the MLflow server, e.g., proxy "
-                    "server, IP blocker or so."
+                    "indicate your request encountered an error before reaching MLflow server, "
+                    "e.g., within a proxy server or authentication / authorization service."
                 )
                 super().__init__(message)
 

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -117,22 +117,29 @@ class RestException(MlflowException):
     """Exception thrown on non 200-level responses from the REST API"""
 
     def __init__(self, json):
+        self.json = json
+
         error_code = json.get("error_code", ErrorCode.Name(INTERNAL_ERROR))
         message = "{}: {}".format(
             error_code,
             json["message"] if "message" in json else "Response: " + str(json),
         )
+
         try:
             super().__init__(message, error_code=ErrorCode.Value(error_code))
         except ValueError:
-            _logger.warning(
-                f"Received error code not recognized by MLflow: {error_code}, this may indicate "
-                "your request hits error outside the MLflow server, e.g., proxy server, IP blocker "
-                "or so."
-            )
-            super().__init__(message)
-
-        self.json = json
+            try:
+                # The `error_code` can be an http error code, in which case we convert it to the
+                # corresponding `ErrorCode`.
+                error_code = HTTP_STATUS_TO_ERROR_CODE[int(error_code)]
+                super().__init__(message, error_code=ErrorCode.Value(error_code))
+            except ValueError or KeyError:
+                _logger.warning(
+                    f"Received error code not recognized by MLflow: {error_code}, this may "
+                    "indicate your request hits error outside the MLflow server, e.g., proxy "
+                    "server, IP blocker or so."
+                )
+                super().__init__(message)
 
 
 class ExecutionException(MlflowException):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -53,7 +53,13 @@ def test_rest_exception():
 
 
 def test_rest_exception_with_unrecognized_error_code():
+    # Test that we can create a RestException with a convertible error code.
+    exception = RestException({"error_code": "403", "messages": "something important."})
+    assert "something important." in str(exception)
+    assert exception.error_code == "PERMISSION_DENIED"
+    json.loads(exception.serialize_as_json())
+
     # Test that we can create a RestException with an unrecognized error code.
-    exc = RestException({"error_code": "403", "messages": "something important."})
-    assert "something important." in str(exc)
-    json.loads(exc.serialize_as_json())
+    exception = RestException({"error_code": "weird error", "messages": "something important."})
+    assert "something important." in str(exception)
+    json.loads(exception.serialize_as_json())

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -50,3 +50,10 @@ def test_rest_exception():
     deserialized_rest_exception = RestException(json.loads(json_exception))
     assert deserialized_rest_exception.error_code == "RESOURCE_ALREADY_EXISTS"
     assert "test" in deserialized_rest_exception.message
+
+
+def test_rest_exception_with_unrecognized_error_code():
+    # Test that we can create a RestException with an unrecognized error code.
+    exc = RestException({"error_code": "403", "messages": "something important."})
+    assert "something important." in str(exc)
+    json.loads(exc.serialize_as_json())


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/10918?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10918/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10918
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Currently we assume every response should have a error code defined in `databricks.proto`, however it's possible that the request fails without reaching MLflow service, e.g., IP blacklist. In this scenario, we shouldn't throw a vague ValueError, but instead we can report the error code as it is to an `MlflowException`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
