### PR TITLE
Replace `pytest.warns(None)` with `warnings.catch_warnings`

### DIFF
--- a/tests/autologging/test_autologging_behaviors_unit.py
+++ b/tests/autologging/test_autologging_behaviors_unit.py
@@ -178,6 +178,7 @@ def test_silent_mode_is_respected_in_multithreaded_environments(
 
     executions = []
     with warnings.catch_warnings(record=True) as warnings_record:
+        warnings.simplefilter("always")
         with ThreadPoolExecutor(max_workers=50) as executor:
             for _ in range(100):
                 executions.append(executor.submit(parallel_fn))

--- a/tests/autologging/test_autologging_behaviors_unit.py
+++ b/tests/autologging/test_autologging_behaviors_unit.py
@@ -81,7 +81,7 @@ def test_autologging_warnings_are_redirected_as_expected(
     stream = StringIO()
     sys.stderr = stream
 
-    with pytest.warns(None) as warnings_record:
+    with warnings.catch_warnings(record=True) as warnings_record:
         autolog_function(silent=False)
         patch_destination.fn()
 
@@ -121,7 +121,7 @@ def test_autologging_event_logging_and_warnings_respect_silent_mode(
     stream = StringIO()
     sys.stderr = stream
 
-    with pytest.warns(None) as silent_warnings_record:
+    with warnings.catch_warnings(record=True) as silent_warnings_record:
         autolog_function(silent=True)
         patch_destination.fn()
 
@@ -137,7 +137,7 @@ def test_autologging_event_logging_and_warnings_respect_silent_mode(
 
     stream.truncate(0)
 
-    with pytest.warns(None) as noisy_warnings_record:
+    with warnings.catch_warnings(record=True) as noisy_warnings_record:
         autolog_function(silent=False)
         patch_destination.fn()
 
@@ -177,7 +177,7 @@ def test_silent_mode_is_respected_in_multithreaded_environments(
         return True
 
     executions = []
-    with pytest.warns(None) as warnings_record:
+    with warnings.catch_warnings(record=True) as warnings_record:
         with ThreadPoolExecutor(max_workers=50) as executor:
             for _ in range(100):
                 executions.append(executor.submit(parallel_fn))
@@ -228,7 +228,8 @@ def test_silent_mode_restores_warning_and_event_logging_behavior_correctly_if_er
     with pytest.raises(Exception, match="enablement error"):
         test_autolog(silent=True)
 
-    with pytest.warns(None):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         with ThreadPoolExecutor(max_workers=50) as executor:
             for _ in range(100):
                 executor.submit(parallel_fn)
@@ -265,7 +266,7 @@ def test_silent_mode_operates_independently_across_integrations(patch_destinatio
         logger.info("event_autolog2")
         safe_patch("integration2", patch_destination, "fn2", patch_impl2)
 
-    with pytest.warns(None) as warnings_record:
+    with warnings.catch_warnings(record=True) as warnings_record:
         autolog1(silent=True)
         autolog2(silent=False)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10924?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10924/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10924
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Replace `pytest.warns(None)` to fix the following error:

https://github.com/mlflow/mlflow/actions/runs/7691119289/job/20955937120

```
>           warnings.warn(WARNS_NONE_ARG, stacklevel=4)
E           pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
E           See https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests for alternatives in common use cases.
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
