### PR TITLE
Fix `test_client_can_be_serialized_with_pickle`

### DIFF
--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -209,6 +209,10 @@ def _register_tracking_stores():
     _tracking_store_registry.register_entrypoints()
 
 
+def _register(scheme, builder):
+    _tracking_store_registry.register(scheme, builder)
+
+
 _register_tracking_stores()
 
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -664,6 +664,7 @@ def test_client_can_be_serialized_with_pickle(tmp_path):
     with pytest.raises(AttributeError, match="<locals>.MockUnpickleableModelRegistryStore'"):
         pickle.dumps(mock_model_registry_store)
 
+    reg = _tracking_store_registry
     _tracking_store_registry.register("pickle", lambda *args, **kwargs: mock_tracking_store)
     _get_model_registry_store_registry().register(
         "pickle", lambda *args, **kwargs: mock_model_registry_store

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -20,7 +20,7 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking._model_registry.utils import (
     _get_store_registry as _get_model_registry_store_registry,
 )
-from mlflow.tracking._tracking_service.utils import _tracking_store_registry
+from mlflow.tracking._tracking_service.utils import _register
 from mlflow.utils.databricks_utils import _construct_databricks_run_url, get_databricks_runtime
 from mlflow.utils.mlflow_tags import (
     MLFLOW_GIT_COMMIT,
@@ -664,8 +664,7 @@ def test_client_can_be_serialized_with_pickle(tmp_path):
     with pytest.raises(AttributeError, match="<locals>.MockUnpickleableModelRegistryStore'"):
         pickle.dumps(mock_model_registry_store)
 
-    reg = _tracking_store_registry
-    _tracking_store_registry.register("pickle", lambda *args, **kwargs: mock_tracking_store)
+    _register("pickle", lambda *args, **kwargs: mock_tracking_store)
     _get_model_registry_store_registry().register(
         "pickle", lambda *args, **kwargs: mock_model_registry_store
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10927?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10927/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10927
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fixes this error https://github.com/mlflow/mlflow/actions/runs/7691119289/job/20955938381/


It looks like `_tracking_store_registry` is somehow copied (by pytest?), the original `_tracking_store_registry` doesn't know about pickle and complains "I don't know pickle":

Code:

```
        _tracking_store_registry.register("pickle", lambda *args, **kwargs: mock_tracking_store)
        _get_model_registry_store_registry().register(
            "pickle", lambda *args, **kwargs: mock_model_registry_store
        )
    
        # Create an MlflowClient with the store that cannot be pickled, perform
        # tracking & model registry operations, and verify that the client can still be pickled
>       client = MlflowClient("pickle://foo")
```

Error:

```
E           mlflow.tracking.registry.UnsupportedModelRegistryStoreURIException:  Model registry functionality is unavailable; got unsupported URI 'pickle://foo' for model registry data storage. Supported URI schemes are: ['', 'file', 'databricks', 'databricks-uc', 'http', 'https', 'postgresql', 'mysql', 'sqlite', 'mssql', 'file-plugin']. See https://www.mlflow.org/docs/latest/tracking.html#storage for how to run an MLflow server against one of the supported backend storage locations.
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
