### PR TITLE
Improve langchain autologging doc

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -376,6 +376,7 @@ nitpick_ignore = [
     ("py:class", "pydantic.main.BaseModel"),
     ("py:class", "ConfigDict"),
     ("py:class", "FieldInfo"),
+    ("py:class", "ComputedFieldInfo"),
     ("py:class", "keras_core.src.callbacks.callback.Callback"),
 ]
 

--- a/docs/source/llms/langchain/guide/index.rst
+++ b/docs/source/llms/langchain/guide/index.rst
@@ -255,14 +255,14 @@ MLflow `langchain` flavor supports autologging of LangChain models, which provid
 - **Automated Input and Output Logging**: Autologging takes care of logging inputs and outputs of the LangChain model during inference. The recorded results are neatly organized into an inference_inputs_outputs.json file, providing a comprehensive overview of the model's inference history.
 
 .. note::
-    To use MLflow LangChain autologging, please upgrade langchain to version 0.1.0 or higher.
-    Currently you might need to manually install langchain_community>=0.0.16 to enable autologging artifacts and metrics. (we're working on improvements in the meantime)
-    If autologging doesn't log artifacts as expected, please check the warning messages in stdout logs. 
-    For langchain_community==0.0.16, please try to install textstat and spacy libraries manually, and restart your python environment.
+    To use MLflow LangChain autologging, please upgrade langchain to **version 0.1.0** or higher.
+    Depending on your existing environment, you may need to manually install langchain_community>=0.0.16 in order to enable the automatic logging of artifacts and metrics. (this behavior will be modified in the future to be an optional import)
+    If autologging doesn't log artifacts as expected, please check the warning messages in `stdout` logs. 
+    For langchain_community==0.0.16, you will need to install the `textstat` and `spacy` libraries manually, as well as restarting any active interactive environment (i.e., a notebook environment). On Databricks, you can achieve this via executing `dbutils.library.restartPython()` to force the Python REPL to restart, allowing the newly installed libraries to be available.
 
-MLflow langchain autologging injects `MlflowCallbackHandler <https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/callbacks/mlflow_callback.py>`_ into the langchain model inference process, to log
-metrics and artifacts automatically. We log the model if `log_models` is set to True when calling :py:func:`mlflow.langchain.autolog`, supported model types are `Chain`, `AgentExecutor`, `BaseRetriever`, `RunnableSequence`, `RunnableParallel`, `RunnableBranch`, `SimpleChatModel`, `ChatPromptTemplate`,
-`RunnableLambda`, `RunnablePassthrough`, and more model types will be supported in the future.
+MLflow langchain autologging injects `MlflowCallbackHandler <https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/callbacks/mlflow_callback.py>`_ into the langchain model inference process to log
+metrics and artifacts automatically. We will only log the model if both `log_models` is set to `True` when calling :py:func:`mlflow.langchain.autolog` and the objects being invoked are within the supported model types: `Chain`, `AgentExecutor`, `BaseRetriever`, `RunnableSequence`, `RunnableParallel`, `RunnableBranch`, `SimpleChatModel`, `ChatPromptTemplate`,
+`RunnableLambda`, `RunnablePassthrough`. Additional model types will be supported in the future.
 
 .. note::
     We patch `invoke` function for all supported langchain models, `__call__` function for Chains, AgentExecutors models, and `get_relevant_documents` function for BaseRetrievers, so only when those functions are called MLflow autologs metrics and artifacts.
@@ -330,6 +330,10 @@ Metrics:
   |                                               | (they're the text analysis metrics of the generation text if `textstat`   |
   |                                               | library is installed)                                                     |
   +-----------------------------------------------+---------------------------------------------------------------------------+
+
+.. note::
+    Each inference call logs those artifacts into a separate directory named `artifacts-<session_id>-<idx>`, where `session_id` is randomly generated uuid, and `idx` is the index of the inference call.
+    `session_id` is also preserved in the `inference_inputs_outputs.json` file, so you can easily find the corresponding artifacts for each inference call.
 
 If you encounter any issues unexpected, please feel free to open an issue in `MLflow Github repo <https://github.com/mlflow/mlflow/issues>`_.
 

--- a/docs/source/llms/langchain/guide/index.rst
+++ b/docs/source/llms/langchain/guide/index.rst
@@ -254,6 +254,85 @@ MLflow `langchain` flavor supports autologging of LangChain models, which provid
 - **Seamless Metrics Recording**: Autologging effortlessly captures metrics for evaluating generated texts, as well as key objects such as llms and agents employed during inference.
 - **Automated Input and Output Logging**: Autologging takes care of logging inputs and outputs of the LangChain model during inference. The recorded results are neatly organized into an inference_inputs_outputs.json file, providing a comprehensive overview of the model's inference history.
 
+.. note::
+    To use MLflow LangChain autologging, please upgrade langchain to version 0.1.0 or higher.
+    Currently you might need to manually install langchain_community>=0.0.16 to enable autologging artifacts and metrics. (we're working on improvements in the meantime)
+    If autologging doesn't log artifacts as expected, please check the warning messages in stdout logs. 
+    For langchain_community==0.0.16, please try to install textstat and spacy libraries manually, and restart your python environment.
+
+MLflow langchain autologging injects `MlflowCallbackHandler <https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/callbacks/mlflow_callback.py>`_ into the langchain model inference process, to log
+metrics and artifacts automatically. We log the model if `log_models` is set to True when calling :py:func:`mlflow.langchain.autolog`, supported model types are `Chain`, `AgentExecutor`, `BaseRetriever`, `RunnableSequence`, `RunnableParallel`, `RunnableBranch`, `SimpleChatModel`, `ChatPromptTemplate`,
+`RunnableLambda`, `RunnablePassthrough`, and more model types will be supported in the future.
+
+.. note::
+    We patch `invoke` function for all supported langchain models, `__call__` function for Chains, AgentExecutors models, and `get_relevant_documents` function for BaseRetrievers, so only when those functions are called MLflow autologs metrics and artifacts.
+    If the model contains retrievers, we don't support autologging the model because it requires saving `loader_fn` and `persist_dir` in order to load the model. Please log the model manually if you want to log the model with retrievers.
+
+The following metrics and artifacts are logged by default (depending on the models involved):
+
+Artifacts:
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | Artifact name                                 | Explanation                                                               |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | table_action_records.html                     | Each action's details, including chains, tools, llms, agents, retrievers. |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | table_session_analysis.html                   | Details about prompt and output for each prompt step; token usages;       |
+  |                                               | text analysis metrics                                                     |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | chat_html.html                                | LLM input and output details                                              |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | llm_start_x_prompt_y.json                     | Includes prompt and kwargs passed during llm `generate` call              |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | llm_end_x_generation_y.json                   | Includes llm_output of the LLM result                                     |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | ent-<hash string of generation.text>.html     | Visualization of the generation text using spacy "en_core_web_sm" model   |
+  |                                               | with style ent (if spacy is installed and the model is downloaded)        | 
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | dep-<hash string of generation.text>.html     | Visualization of the generation text using spacy "en_core_web_sm" model   |
+  |                                               | with style dep (if spacy is installed and the model is downloaded)        |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | llm_new_tokens_x.json                         | Records new tokens added to the LLM during inference                      |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | chain_start_x.json                            | Records the inputs and chain related information during inference         |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | chain_end_x.json                              | Records the chain outputs                                                 |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | tool_start_x.json                             | Records the tool's name, descriptions information during inference        |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | tool_end_x.json                               | Records observation of the tool                                           |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | retriever_start_x.json                        | Records the retriever's information during inference                      |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | retriever_end_x.json                          | Records the retriever's result documents                                  |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | agent_finish_x.json                           | Records final return value of the ActionAgent, including output and log   |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | agent_action_x.json                           | Records the ActionAgent's action details                                  |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | on_text_x.json                                | Records the text during inference                                         |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | inference_inputs_outputs.json                 | Input and output details for each inference call (logged by default, can  |
+  |                                               | be turned off by setting `log_inputs_outputs=False` when turn on autolog) |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+
+Metrics:
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | Metric types                                  | Details                                                                   |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | Basic Metrics                                 | step, starts, ends, errors, text_ctr, chain_starts, chain_ends, llm_starts|
+  |                                               | llm_ends, llm_streams, tool_starts, tool_ends, agent_ends, retriever_ends |
+  |                                               | retriever_starts (they're the count number of each component invocation)  |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+  | Text Analysis Metrics                         | flesch_reading_ease, flesch_kincaid_grade, smog_index, coleman_liau_index |
+  |                                               | automated_readability_index, dale_chall_readability_score,                |
+  |                                               | difficult_words, linsear_write_formula, gunning_fog, fernandez_huerta,    |
+  |                                               | szigriszt_pazos, gutierrez_polini, crawford, gulpease_index, osman        |
+  |                                               | (they're the text analysis metrics of the generation text if `textstat`   |
+  |                                               | library is installed)                                                     |
+  +-----------------------------------------------+---------------------------------------------------------------------------+
+
+If you encounter any issues unexpected, please feel free to open an issue in `MLflow Github repo <https://github.com/mlflow/mlflow/issues>`_.
+
 An example of MLflow langchain autologging
 """"""""""""""""""""""""""""""""""""""""""
 

--- a/examples/langchain/chain_autolog.py
+++ b/examples/langchain/chain_autolog.py
@@ -8,6 +8,11 @@ from langchain.schema.runnable import RunnableLambda
 
 import mlflow
 
+# Uncomment the following to use the full abilities of langchain autologgin
+# %pip install `langchain_community>=0.0.16`
+# These two libraries enable autologging to log text analysis related artifacts
+# %pip install textstat spacy
+
 assert "OPENAI_API_KEY" in os.environ, "Please set the OPENAI_API_KEY environment variable."
 
 # Enable mlflow langchain autologging


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10930?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10930/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10930
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
https://output.circle-artifacts.com/output/job/869ff71b-7d45-4778-a001-cd3dd3b73935/artifacts/0/docs/build/html/llms/langchain/guide/index.html#mlflow-langchain-autologging

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
