### PR TITLE
Fix flakiness in spark autolog tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -372,7 +372,8 @@ spark:
 
       # NB: Running each .py file individually is important (instead of
       # 'pytest tests/spark/autologging') not to share SparkSession across tests
-      find tests/spark/autologging -name 'test*.py' | xargs -L 1 pytest
+      pytest tests/spark/autologging/datasource/test_spark_datasource_autologging_crossframework.py
+      for file in $(find tests/spark/autologging -name 'test*.py' | grep -v crossframework | xargs -L 1 pytest
 
 mleap:
   package_info:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -373,7 +373,7 @@ spark:
       # NB: Running each .py file individually is important (instead of
       # 'pytest tests/spark/autologging') not to share SparkSession across tests
       pytest tests/spark/autologging/datasource/test_spark_datasource_autologging_crossframework.py
-      for file in $(find tests/spark/autologging -name 'test*.py' | grep -v crossframework | xargs -L 1 pytest
+      find tests/spark/autologging -name 'test*.py' | grep -v crossframework | xargs -L 1 pytest
 
 mleap:
   package_info:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -372,6 +372,7 @@ spark:
 
       # NB: Running each .py file individually is important (instead of
       # 'pytest tests/spark/autologging') not to share SparkSession across tests
+      # `test_spark_datasource_autologging_crossframework.py` fails when run with other tests
       pytest tests/spark/autologging/datasource/test_spark_datasource_autologging_crossframework.py
       find tests/spark/autologging -name 'test*.py' | grep -v crossframework | xargs -L 1 pytest
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10932?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10932/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10932
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fixes https://github.com/mlflow-automation/mlflow/actions/runs/7741843653/job/21120216355#step:15:1191:

```
tests/spark/autologging/datasource/test_spark_datasource_autologging_crossframework.py::test_spark_autologging_with_sklearn_autologging FAILED | MEM 1.5/15.6 GB | DISK 58.6/83.2 GB [ 33%]
tests/spark/autologging/datasource/test_spark_datasource_autologging_crossframework.py::test_spark_sklearn_autologging_context_provider FAILED | MEM 1.5/15.6 GB | DISK 58.6/83.2 GB [ 66%]
tests/spark/autologging/datasource/test_spark_datasource_autologging_crossframework.py::test_spark_and_sklearn_autologging_all_runs_managed FAILED | MEM 1.5/15.6 GB | DISK 58.6/83.2 GB [100%]
```

<details><summary>Stacktrace</summary>
<p>

```
mlflow/utils/autologging_utils/__init__.py:434: in autolog
    return _autolog(*args, **kwargs)
        _autolog   = <function autolog at 0x7fa67ddf40d0>
        args       = ()
        config_to_store = {'disable': False, 'silent': False}
        default_params = {'disable': False, 'silent': False}
        is_silent_mode = False
        kwargs     = {}
        name       = 'spark'
        param_spec = mappingproxy(OrderedDict([('disable', <Parameter "disable=False">), ('silent', <Parameter "silent=False">)]))
mlflow/spark/__init__.py:1148: in autolog
    _listen_for_spark_activity(sc)
        SparkSession = <class 'pyspark.sql.session.SparkSession'>
        __init__   = <function autolog.<locals>.__init__ at 0x7fa6a273fc10>
        _get_active_spark_session = <function _get_active_spark_session at 0x7fa6a2[946](https://github.com/mlflow-automation/mlflow/actions/runs/7741843653/job/21120216355#step:15:947)940>
        _listen_for_spark_activity = <function _listen_for_spark_activity at 0x7fa67ddf4790>
        _stop_listen_for_spark_activity = <function _stop_listen_for_spark_activity at 0x7fa67ddf4700>
        active_session = <pyspark.sql.session.SparkSession object at 0x7fa6a26d6b80>
        disable    = False
        patched_session_stop = <function autolog.<locals>.patched_session_stop at 0x7fa6a2677ee0>
        pyspark_version = '3.1.3'
        sc         = <SparkContext master=local[*] appName=pyspark-shell>
        silent     = False
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

spark_context = <SparkContext master=local[*] appName=pyspark-shell>

    def _listen_for_spark_activity(spark_context):
        global _spark_table_info_listener
        if _get_current_listener() is not None:
            return
    
        if _get_spark_major_version(spark_context) < 3:
            raise MlflowException("Spark autologging unsupported for Spark versions < 3")
    
        gw = spark_context._gateway
        params = gw.callback_server_parameters
        callback_server_params = CallbackServerParameters(
            address=params.address,
            port=params.port,
            daemonize=True,
            daemonize_connections=True,
            eager_load=params.eager_load,
            ssl_context=params.ssl_context,
            accept_timeout=params.accept_timeout,
            read_timeout=params.read_timeout,
            auth_token=params.auth_token,
        )
        callback_server_started = gw.start_callback_server(callback_server_params)
    
        try:
            event_publisher = _get_jvm_event_publisher(spark_context)
            event_publisher.init(1)
            _spark_table_info_listener = PythonSubscriber()
            event_publisher.register(_spark_table_info_listener)
        except Exception as e:
            if callback_server_started:
                try:
                    gw.shutdown_callback_server()
                except Exception as e:
                    _logger.warning(
                        "Failed to shut down Spark callback server for autologging: %s", str(e)
                    )
            _spark_table_info_listener = None
>           raise MlflowException(
                "Exception while attempting to initialize JVM-side state for Spark datasource "
                "autologging. Note that Spark datasource autologging only works with Spark 3.0 "
                "and above. Please create a new Spark session with required Spark version and "
                "ensure you have the mlflow-spark JAR attached to your Spark session as described "
                "in https://mlflow.org/docs/latest/tracking/autolog.html#spark Exception:\n%s" % e
            )
E           mlflow.exceptions.MlflowException: Exception while attempting to initialize JVM-side state for Spark datasource autologging. Note that Spark datasource autologging only works with Spark 3.0 and above. Please create a new Spark session with required Spark version and ensure you have the mlflow-spark JAR attached to your Spark session as described in https://mlflow.org/docs/latest/tracking/autolog.html#spark Exception:
E           An error occurred while calling z:org.mlflow.spark.autologging.MlflowAutologEventPublisher.register.
E           : java.net.ConnectException: Connection refused (Connection refused)
E           	at java.base/java.net.PlainSocketImpl.socketConnect(Native Method)
E           	at java.base/java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:412)
E           	at java.base/java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:255)
E           	at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:237)
E           	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
E           	at java.base/java.net.Socket.connect(Socket.java:609)
E           	at java.base/java.net.Socket.connect(Socket.java:558)
E           	at java.base/java.net.Socket.<init>(Socket.java:454)
E           	at java.base/java.net.Socket.<init>(Socket.java:264)
E           	at java.base/javax.net.DefaultSocketFactory.createSocket(SocketFactory.java:277)
E           	at py4j.CallbackConnection.start(CallbackConnection.java:226)
E           	at py4j.CallbackClient.getConnection(CallbackClient.java:238)
E           	at py4j.CallbackClient.getConnectionLock(CallbackClient.java:250)
E           	at py4j.CallbackClient.sendCommand(CallbackClient.java:377)
E           	at py4j.CallbackClient.sendCommand(CallbackClient.java:356)
E           	at py4j.reflection.PythonProxyHandler.invoke(PythonProxyHandler.java:106)
E           	at com.sun.proxy.$Proxy22.replId(Unknown Source)
E           	at org.mlflow.spark.autologging.MlflowAutologEventPublisherImpl.register(MlflowAutologEventPublisher.scala:116)
E           	at org.mlflow.spark.autologging.MlflowAutologEventPublisherImpl.register$(MlflowAutologEventPublisher.scala:112)
E           	at org.mlflow.spark.autologging.MlflowAutologEventPublisher$.register(MlflowAutologEventPublisher.scala:20)
E           	at org.mlflow.spark.autologging.MlflowAutologEventPublisher.register(MlflowAutologEventPublisher.scala)
E           	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
E           	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
E           	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
E           	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
E           	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
E           	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
E           	at py4j.Gateway.invoke(Gateway.java:282)
E           	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
E           	at py4j.commands.CallCommand.execute(CallCommand.java:79)
E           	at py4j.GatewayConnection.run(GatewayConnection.java:238)
E           	at java.base/java.lang.Thread.run(Thread.java:829)

callback_server_params = <py4j.java_gateway.CallbackServerParameters object at 0x7fa69f1e9b80>
callback_server_started = False
event_publisher = <py4j.java_gateway.JavaClass object at 0x7fa69f1e9c70>
gw         = <py4j.java_gateway.JavaGateway object at 0x7fa67aecbe80>
params     = <py4j.java_gateway.CallbackServerParameters object at 0x7fa67aecbf40>
spark_context = <SparkContext master=local[*] appName=pyspark-shell>
```

</p>
</details> 

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
