### PR TITLE
Split JS CI job

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -32,6 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        option: [--testPathPattern, --testPathIgnorePattern]
         include:
           - os: ubuntu-latest
             shell: bash
@@ -73,7 +74,7 @@ jobs:
           yarn i18n:check
       - name: Run tests
         run: |
-          yarn test --silent
+          yarn test --silent ${{ matrix.option }}=src/experiment-tracking
       - name: Run build
         if: runner.os == 'Linux'
         env:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -74,7 +74,7 @@ jobs:
           yarn i18n:check
       - name: Run tests
         run: |
-          yarn test --silent ${{ matrix.option }} src/experiment-tracking/components
+          yarn test --silent ${{ matrix.option }} src/experiment-tracking/components --logHeapUsage
       - name: Run build
         if: runner.os == 'Linux'
         env:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -74,7 +74,7 @@ jobs:
           yarn i18n:check
       - name: Run tests
         run: |
-          yarn test --silent ${{ matrix.option }} src/experiment-tracking/components --logHeapUsage
+          yarn test --silent ${{ matrix.option }} src/experiment-tracking/components
       - name: Run build
         if: runner.os == 'Linux'
         env:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        option: [--testPathPattern, --testPathIgnorePattern]
+        option: [--testPathPattern, --testPathIgnorePatterns]
         include:
           - os: ubuntu-latest
             shell: bash
@@ -74,7 +74,7 @@ jobs:
           yarn i18n:check
       - name: Run tests
         run: |
-          yarn test --silent ${{ matrix.option }}=src/experiment-tracking
+          yarn test --silent ${{ matrix.option }} src/experiment-tracking/components
       - name: Run build
         if: runner.os == 'Linux'
         env:


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

This PR splits the JS job, hopefully resulting in [less flaky runs](https://github.com/mlflow/mlflow/actions/workflows/js.yml).

The `src/experiment-tracking/components/` directory contains roughly half of all JS tests, so i split the job by running `yarn test [--testPathPattern | --testPathIgnorePatterns] src/experiment-tracking/components`.

I ran the JS job 3 times on this PR and it passed every time, so it should probably be more stable now.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
