### PR TITLE
Fix ag-grid source map

### DIFF
--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -19,9 +19,9 @@
     "i18n:check": "yarn i18n --lint"
   },
   "dependencies": {
-    "@ag-grid-community/client-side-row-model": "28.2.1",
-    "@ag-grid-community/core": "28.2.1",
-    "@ag-grid-community/react": "28.2.1",
+    "@ag-grid-community/client-side-row-model": "^28.2.1",
+    "@ag-grid-community/core": "^28.2.1",
+    "@ag-grid-community/react": "^28.2.1",
     "@apollo/client": "^3.6.9",
     "@craco/craco": "7.0.0-alpha.0",
     "@databricks/design-system": "file:./vendor/design-system",

--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -19,9 +19,9 @@
     "i18n:check": "yarn i18n --lint"
   },
   "dependencies": {
-    "@ag-grid-community/client-side-row-model": "^27.2.1",
-    "@ag-grid-community/core": "^27.2.1",
-    "@ag-grid-community/react": "^27.2.1",
+    "@ag-grid-community/client-side-row-model": "28.2.1",
+    "@ag-grid-community/core": "28.2.1",
+    "@ag-grid-community/react": "28.2.1",
     "@apollo/client": "^3.6.9",
     "@craco/craco": "7.0.0-alpha.0",
     "@databricks/design-system": "file:./vendor/design-system",

--- a/mlflow/server/js/yarn.lock
+++ b/mlflow/server/js/yarn.lock
@@ -23,7 +23,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ag-grid-community/client-side-row-model@npm:28.2.1":
+"@ag-grid-community/client-side-row-model@npm:^28.2.1":
   version: 28.2.1
   resolution: "@ag-grid-community/client-side-row-model@npm:28.2.1"
   dependencies:
@@ -32,14 +32,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ag-grid-community/core@npm:28.2.1, @ag-grid-community/core@npm:~28.2.1":
+"@ag-grid-community/core@npm:^28.2.1, @ag-grid-community/core@npm:~28.2.1":
   version: 28.2.1
   resolution: "@ag-grid-community/core@npm:28.2.1"
   checksum: da64f8412f33b7b76067f169a1dc867f3641e10e9b3344edec3f26dc792ba2245dd4afca0fe1788c71c6c96ffac04ca4ea30ec43551b77bfab178c9b68b761ec
   languageName: node
   linkType: hard
 
-"@ag-grid-community/react@npm:28.2.1":
+"@ag-grid-community/react@npm:^28.2.1":
   version: 28.2.1
   resolution: "@ag-grid-community/react@npm:28.2.1"
   dependencies:
@@ -4925,9 +4925,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mlflow/mlflow@workspace:."
   dependencies:
-    "@ag-grid-community/client-side-row-model": 28.2.1
-    "@ag-grid-community/core": 28.2.1
-    "@ag-grid-community/react": 28.2.1
+    "@ag-grid-community/client-side-row-model": ^28.2.1
+    "@ag-grid-community/core": ^28.2.1
+    "@ag-grid-community/react": ^28.2.1
     "@apollo/client": ^3.6.9
     "@babel/core": ^7.23.0
     "@babel/eslint-parser": ^7.22.15

--- a/mlflow/server/js/yarn.lock
+++ b/mlflow/server/js/yarn.lock
@@ -23,32 +23,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ag-grid-community/client-side-row-model@npm:^27.2.1":
-  version: 27.3.0
-  resolution: "@ag-grid-community/client-side-row-model@npm:27.3.0"
+"@ag-grid-community/client-side-row-model@npm:28.2.1":
+  version: 28.2.1
+  resolution: "@ag-grid-community/client-side-row-model@npm:28.2.1"
   dependencies:
-    "@ag-grid-community/core": ~27.3.0
-  checksum: 11a3f29a721f3a39d130cc1bcd79e6280ff2c39ea680e8dc59edae30dbc14966337898da856c9b271903d79a0fd049807872a8d8ca4a42007239dedac804433e
+    "@ag-grid-community/core": ~28.2.1
+  checksum: cdd6c74b6a5b44ace07da0cc1797f5f38646cf25ef51d43d3c02aa0ccd702437490a4ce9fd9db2dfcbeefd1edd4e48bd82052e2596e2cfbe8618df8bdcd90b27
   languageName: node
   linkType: hard
 
-"@ag-grid-community/core@npm:^27.2.1, @ag-grid-community/core@npm:~27.3.0":
-  version: 27.3.0
-  resolution: "@ag-grid-community/core@npm:27.3.0"
-  checksum: 915a3eb560c06baffa18ba98462ffb4562c2c898752e87c1f303de75fd77e2356cdceda11bf5b80687ea9fe4c856ea2a9907235dc19b637b109f52340ae2e1fc
+"@ag-grid-community/core@npm:28.2.1, @ag-grid-community/core@npm:~28.2.1":
+  version: 28.2.1
+  resolution: "@ag-grid-community/core@npm:28.2.1"
+  checksum: da64f8412f33b7b76067f169a1dc867f3641e10e9b3344edec3f26dc792ba2245dd4afca0fe1788c71c6c96ffac04ca4ea30ec43551b77bfab178c9b68b761ec
   languageName: node
   linkType: hard
 
-"@ag-grid-community/react@npm:^27.2.1":
-  version: 27.3.0
-  resolution: "@ag-grid-community/react@npm:27.3.0"
+"@ag-grid-community/react@npm:28.2.1":
+  version: 28.2.1
+  resolution: "@ag-grid-community/react@npm:28.2.1"
   dependencies:
     prop-types: ^15.8.1
   peerDependencies:
-    "@ag-grid-community/core": ~27.3.0
+    "@ag-grid-community/core": ~28.2.1
     react: ^16.3.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.3.0 || ^17.0.0 || ^18.0.0
-  checksum: a7215edead31eb7c1d2fea8e1f6a3e3b8173639a240435e08186db833dc1ef507824db212be16c64655adceb84a12172fa721c4eb5db8643151bca04d2267ac9
+  checksum: cbdb6886f2e295723f64874b517dd914d0b75f99a0d9229a636bff2764263ac49aff38ea7e63a7142557d55249122393f8116246b91dfcde60099fdfd8c56a97
   languageName: node
   linkType: hard
 
@@ -4925,9 +4925,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mlflow/mlflow@workspace:."
   dependencies:
-    "@ag-grid-community/client-side-row-model": ^27.2.1
-    "@ag-grid-community/core": ^27.2.1
-    "@ag-grid-community/react": ^27.2.1
+    "@ag-grid-community/client-side-row-model": 28.2.1
+    "@ag-grid-community/core": 28.2.1
+    "@ag-grid-community/react": 28.2.1
     "@apollo/client": ^3.6.9
     "@babel/core": ^7.23.0
     "@babel/eslint-parser": ^7.22.15


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/minkj1992/mlflow/pull/10946?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10946/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10946
```

</p>
</details>

### Related Issues/PRs

- #10942 

### What changes are proposed in this pull request?

https://github.com/ag-grid/ag-grid/issues/5039

As link above @ag-grid-community ^27.2.1 has a source map issue, so I did yarn up ag-grid version to ^28.2.1. 


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
