### PR TITLE
Use merge ref instead of head ref in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,13 @@ jobs:
 
     steps:
       - checkout
-      - run: |
-          if [ -n "$CIRCLE_PR_NUMBER" ]; then
-            git fetch origin refs/pull/$CIRCLE_PR_NUMBER/merge
-            git checkout FETCH_HEAD
-          fi
+      - run:
+          name: Fetch merge ref
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              git fetch origin refs/pull/$CIRCLE_PR_NUMBER/merge
+              git checkout FETCH_HEAD
+            fi
       - run:
           name: Build documentation
           working_directory: docs
@@ -31,11 +33,13 @@ jobs:
 
     steps:
       - checkout
-      - run: |
-          if [ -n "$CIRCLE_PR_NUMBER" ]; then
-            git fetch origin refs/pull/$CIRCLE_PR_NUMBER/merge
-            git checkout FETCH_HEAD
-          fi
+      - run:
+          name: Fetch merge ref
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              git fetch origin refs/pull/$CIRCLE_PR_NUMBER/merge
+              git checkout FETCH_HEAD
+            fi
       - run:
           name: Install Java
           command: |
@@ -81,11 +85,13 @@ jobs:
 
     steps:
       - checkout
-      - run: |
-          if [ -n "$CIRCLE_PR_NUMBER" ]; then
-            git fetch origin refs/pull/$CIRCLE_PR_NUMBER/merge
-            git checkout FETCH_HEAD
-          fi
+      - run:
+          name: Fetch merge ref
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              git fetch origin refs/pull/$CIRCLE_PR_NUMBER/merge
+              git checkout FETCH_HEAD
+            fi
       - run:
           name: Pull submodule
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,10 @@ version: 2.1
 orbs:
   win: circleci/windows@5.0.0
 
-jobs:
-  build_doc_r:
-    machine:
-      image: ubuntu-2004:202111-01
-
+commands:
+  fetch_merge_ref:
+    description: "Fetch the merge ref for a pull request"
     steps:
-      - checkout
       - run:
           name: Fetch merge ref
           command: |
@@ -17,6 +14,15 @@ jobs:
               git fetch origin refs/pull/$CIRCLE_PR_NUMBER/merge
               git checkout FETCH_HEAD
             fi
+
+jobs:
+  build_doc_r:
+    machine:
+      image: ubuntu-2004:202111-01
+
+    steps:
+      - checkout
+      - fetch_merge_ref
       - run:
           name: Build documentation
           working_directory: docs
@@ -33,13 +39,7 @@ jobs:
 
     steps:
       - checkout
-      - run:
-          name: Fetch merge ref
-          command: |
-            if [ -n "$CIRCLE_PR_NUMBER" ]; then
-              git fetch origin refs/pull/$CIRCLE_PR_NUMBER/merge
-              git checkout FETCH_HEAD
-            fi
+      - fetch_merge_ref
       - run:
           name: Install Java
           command: |
@@ -85,13 +85,7 @@ jobs:
 
     steps:
       - checkout
-      - run:
-          name: Fetch merge ref
-          command: |
-            if [ -n "$CIRCLE_PR_NUMBER" ]; then
-              git fetch origin refs/pull/$CIRCLE_PR_NUMBER/merge
-              git checkout FETCH_HEAD
-            fi
+      - fetch_merge_ref
       - run:
           name: Pull submodule
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,11 @@ jobs:
 
     steps:
       - checkout
+      - run: |
+          if [ -n "$CIRCLE_PR_NUMBER" ]; then
+            git fetch origin refs/pull/$CIRCLE_PR_NUMBER/merge
+            git checkout FETCH_HEAD
+          fi
       - run:
           name: Install Java
           command: |
@@ -76,6 +81,11 @@ jobs:
 
     steps:
       - checkout
+      - run: |
+          if [ -n "$CIRCLE_PR_NUMBER" ]; then
+            git fetch origin refs/pull/$CIRCLE_PR_NUMBER/merge
+            git checkout FETCH_HEAD
+          fi
       - run:
           name: Pull submodule
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,11 @@ jobs:
 
     steps:
       - checkout
+      - run: |
+          if [ -n "$CIRCLE_PR_NUMBER" ]; then
+            git fetch origin refs/pull/$CIRCLE_PR_NUMBER/merge
+            git checkout FETCH_HEAD
+          fi
       - run:
           name: Build documentation
           working_directory: docs


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10949?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10949/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10949
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

CircleCI uses the head ref by default when a PR is filed but this is not ideal. For example, if I have a PR branch that's 30 commits behind master. Just because sphinx works fine on this branch doesn't mean it does when the PR is merged into master. We can prevent this "works fine on my branch but doesn't on master" issue by using the merge ref. GitHub Actions use the merge ref by default. See https://stackoverflow.com/a/63595981 for more details.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
