### PR TITLE
List changed pages in docs preview

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
           command: |
             make rsthtml
             make javadocs
+            python changed_pages.py
       - run:
           name: Check for broken links
           working_directory: docs

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -97,12 +97,15 @@ Failed to find a documentation preview for {args.commit_sha}.
     workflow = session.get(f"https://circleci.com/api/v2/workflow/{workflow_id}/job")
     build_doc_job = next(filter(lambda s: s["name"] == build_doc_job_name, workflow["items"]))
     build_doc_job_id = build_doc_job["id"]
-    artifact_url = f"https://output.circle-artifacts.com/output/job/{build_doc_job_id}/artifacts/0/docs/build/html/index.html"
-    print(f"Artifact URL: {artifact_url}")
+    top_page = f"https://output.circle-artifacts.com/output/job/{build_doc_job_id}/artifacts/0/docs/build/html/index.html"
+    changed_pages = f"https://output.circle-artifacts.com/output/job/{build_doc_job_id}/artifacts/0/docs/build/html/diff.html"
 
     # Post the artifact URL as a comment
     comment_body = f"""
-Documentation preview for {args.commit_sha} will be available [here]({artifact_url}) when [this CircleCI job]({job_url}) completes successfully.
+Documentation preview for {args.commit_sha} will be available when [this CircleCI job]({job_url}) completes successfully.
+
+- [Top page]({top_page})
+- [Changed pages]({changed_pages})
 
 <details>
 <summary>More info</summary>

--- a/docs/changed_pages.py
+++ b/docs/changed_pages.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+
+import requests
+
+
+def fetch_changed_files(pr: str) -> list[str]:
+    pr_num = pr.rsplit("/", 1)[-1]
+    url = f"https://api.github.com/repos/mlflow/mlflow/pulls/{pr_num}/files"
+    per_page = 100
+    changed_files = []
+    for page in range(1, 100):
+        r = requests.get(url, params={"page": page, "per_page": per_page})
+        r.raise_for_status()
+        files = r.json()
+        changed_files.extend(f["filename"] for f in files)
+        if len(files) < per_page:
+            return changed_files
+
+
+def main() -> None:
+    pr = os.environ.get("CIRCLE_PULL_REQUEST")
+    if pr is None:
+        return
+
+    SOURCE_REGEX = re.compile(r"<!-- source: (.+) -->")
+    BUILD_DIR = pathlib.Path("build/html")
+    changed_files = fetch_changed_files(pr)
+    changed_pages: list[str] = []
+    for p in BUILD_DIR.rglob("**/*.html"):
+        if m := SOURCE_REGEX.search(p.read_text()):
+            source = m.group(1)
+            if source in changed_files:
+                changed_pages.append(p.relative_to(BUILD_DIR))
+
+    links = "".join(f'<li><a href="{p}"><h2>{p}</h2></a></li>' for p in changed_pages)
+    diff_html = f"""
+<h1>Changed Pages</h1>
+<ul>{links}</ul>
+"""
+    BUILD_DIR.joinpath("diff.html").write_text(diff_html)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/theme/mlflow/layout.html
+++ b/docs/theme/mlflow/layout.html
@@ -12,6 +12,7 @@
 {%- endif %}
 
 <!DOCTYPE html>
+<!-- source: docs/source/{{ pagename }}{{ page_source_suffix }} -->
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/10951?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10951/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10951
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

List changed pages in docs preview for convenience.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
