### PR TITLE
Fix inputs & outputs log for langchain autologging

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -745,8 +745,8 @@ def autolog(
 
         classes = lc_runnables_types() + (AgentExecutor, Chain)
         for cls in classes:
-            # IF runnable also contains loader_fn and persist_dir, warn
-            # BaseRetrievalQA, BaseREtriever, ...
+            # If runnable also contains loader_fn and persist_dir, warn
+            # BaseRetrievalQA, BaseRetriever, ...
             safe_patch(FLAVOR_NAME, cls, "invoke", functools.partial(patched_inference, "invoke"))
 
         for cls in [AgentExecutor, Chain]:

--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -72,6 +72,8 @@ def _combine_input_and_output(input, output, session_id, func_name):
     """
     if func_name == "get_relevant_documents" and output is not None:
         output = [{"page_content": doc.page_content, "metadata": doc.metadata} for doc in output]
+        # to make sure output is inside a single row when converted into pandas DataFrame
+        output = [output]
     result = {"session_id": [session_id]}
     input = _convert_data_to_dict(input, "input") if input else {}
     output = _convert_data_to_dict(output, "output") if output else {}

--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -300,7 +300,13 @@ def patched_inference(func_name, original, self, *args, **kwargs):
                 _logger.info("Input data gathering failed, only log inference results.")
         else:
             input_data = input_example
-        data_dict = _combine_input_and_output(input_data, result, self.session_id, func_name)
+        try:
+            data_dict = _combine_input_and_output(input_data, result, self.session_id, func_name)
+        except Exception as e:
+            _logger.warning(
+                "Failed to log inputs and outputs into `inference_inputs_outputs.json` "
+                f"file due to error {e}."
+            )
         mlflow.log_table(
             data_dict, "inference_inputs_outputs.json", run_id=mlflow_callback.mlflg.run_id
         )

--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -192,8 +192,6 @@ def patched_inference(func_name, original, self, *args, **kwargs):
     """
 
     import langchain
-
-    # import from langchain_community for test purpose
     from langchain_community.callbacks import MlflowCallbackHandler
 
     class _MLflowLangchainCallback(MlflowCallbackHandler, metaclass=ExceptionSafeAbstractClass):

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -607,8 +607,8 @@ langchain:
     run: |
       pytest tests/langchain/test_langchain_model_export.py
   autologging:
-    minimum: "0.1.0"
-    maximum: "0.1.3"
+    minimum: "0.1.4"
+    maximum: "0.1.5"
     requirements:
       ">= 0.0.0":
         [

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2116,7 +2116,7 @@ def autolog(
         "pytorch_lightning": "mlflow.pytorch",
         "setfit": "mlflow.transformers",
         "transformers": "mlflow.transformers",
-        "langchain": "mlflow.langchain",
+        # do not enable langchain autologging by default
     }
 
     def get_autologging_params(autolog_fn):

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -4,7 +4,6 @@ from io import StringIO
 from unittest import mock
 
 import fastai
-import langchain
 import lightgbm
 import pyspark
 import pyspark.ml
@@ -41,7 +40,6 @@ library_to_mlflow_module_without_spark_datasource = {
     pytorch_lightning: mlflow.pytorch,
     transformers: mlflow.transformers,
     setfit: mlflow.transformers,
-    langchain: mlflow.langchain,
 }
 
 library_to_mlflow_module = {
@@ -145,10 +143,6 @@ def test_universal_autolog_calls_specific_autologs_correctly(library, mlflow_mod
         "disable_for_unsupported_versions": True,
         "silent": True,
     }
-    if library == langchain:
-        # not supported yet
-        args_to_test.pop("log_datasets")
-        args_to_test.update({"log_input_examples": False, "log_model_signatures": False})
     if library in integrations_with_additional_config:
         args_to_test.update({"log_input_examples": True, "log_model_signatures": True})
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/10952?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10952/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10952
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix errors when input and output has different length.
The improvement in this PR is to flatten the input & output such that if the data is a dictionary, each key will correspond to a column in the pandas dataframe. Then we log the combined result into inference_inputs_outputs.json file.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
