### PR TITLE
Automatic model checkpointing for keras model training

### DIFF
--- a/mlflow/tensorflow/_autolog.py
+++ b/mlflow/tensorflow/_autolog.py
@@ -1,4 +1,7 @@
+import os
+import shutil
 import warnings
+import time
 from typing import Dict, Union
 
 import numpy as np
@@ -6,6 +9,7 @@ import tensorflow
 from tensorflow.keras.callbacks import Callback, TensorBoard
 
 import mlflow
+from mlflow.utils.file_utils import create_tmp_dir
 from mlflow.utils.autologging_utils import (
     INPUT_EXAMPLE_SAMPLE_ROWS,
     ExceptionSafeClass,
@@ -97,8 +101,9 @@ class __MLflowModelCheckpointCallback(Callback, metaclass=ExceptionSafeClass):
 
         assert False, "Illegal __MLflowModelCheckpoint config."
 
-    def on_epoch_end(self, epoch, logs=None):
-        metric_dict = {k: float(v) for k, v in trainer.callback_metrics.items()}
+    def on_epoch_end(self, epoch, metrics=None):
+        metrics = metrics or {}
+        metric_dict = {k: float(v) for k, v in metrics.items()}
 
         should_checkpoint = False
         if self.every_n_epochs and (epoch % self.every_n_epochs == 0):
@@ -129,16 +134,16 @@ class __MLflowModelCheckpointCallback(Callback, metaclass=ExceptionSafeClass):
 
         if self.save_best_only:
             if self.save_weights_only:
-                checkpoint_model_filename = "latest_checkpoint_model.weights.pth"
+                checkpoint_model_filename = "latest_checkpoint_model.weights.h5"
             else:
-                checkpoint_model_filename = "latest_checkpoint_model.pth"
+                checkpoint_model_filename = "latest_checkpoint_model.h5"
             checkpoint_metrics_filename = "latest_checkpoint_metrics.json"
             checkpoint_artifact_dir = ""
         else:
             if self.save_weights_only:
-                checkpoint_model_filename = f"checkpoint_model_epoch_{epoch}.weights.pth"
+                checkpoint_model_filename = f"checkpoint_model_epoch_{epoch}.weights.h5"
             else:
-                checkpoint_model_filename = f"checkpoint_model_epoch_{epoch}.pth"
+                checkpoint_model_filename = f"checkpoint_model_epoch_{epoch}.h5"
             checkpoint_metrics_filename = f"checkpoint_metrics_epoch_{epoch}.json"
             checkpoint_artifact_dir = "checkpoints"
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/10955?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10955/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10955
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Automatic model checkpointing for keras model training,

Design doc: https://docs.google.com/document/d/1Ke7-8og_KzV3WE5xOS4XKSLZsISdTsVLlol14vJ3S70/edit

Demo:
https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/175288875337509

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
