### PR TITLE
Allow completions (`prompt`), embeddings (`input`) format inputs to scoring server

### DIFF
--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -202,10 +202,10 @@ def _serialize_input_data(input_data, content_type):
 
 def _serialize_to_json(input_data):
     # imported inside function to avoid circular import
-    from mlflow.pyfunc.scoring_server import SUPPORTED_FORMATS, SUPPORTED_LLM_FORMAT
+    from mlflow.pyfunc.scoring_server import SUPPORTED_FORMATS, SUPPORTED_LLM_FORMATS
 
     if isinstance(input_data, dict) and any(
-        key in input_data for key in SUPPORTED_FORMATS | {SUPPORTED_LLM_FORMAT}
+        key in input_data for key in SUPPORTED_FORMATS | SUPPORTED_LLM_FORMATS
     ):
         return json.dumps(input_data)
     else:

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -74,8 +74,8 @@ INPUTS = "inputs"
 
 SUPPORTED_FORMATS = {DF_RECORDS, DF_SPLIT, INSTANCES, INPUTS}
 
-# TODO: Support other input keys like "prmopt", "input", for other endpoint types like Embedding
-SUPPORTED_LLM_FORMAT = "messages"
+# Support unwrapped JSON with these keys for LLM use cases of Chat, Completions, Embeddings tasks
+SUPPORTED_LLM_FORMATS = ["messages", "prompt", "input"]
 
 REQUIRED_INPUT_FORMAT = (
     f"The input must be a JSON dictionary with exactly one of the input fields {SUPPORTED_FORMATS}"
@@ -328,7 +328,7 @@ def invocations(data, content_type, model, input_schema):
         params = None
     elif mime_type == CONTENT_TYPE_JSON:
         json_input = _decode_json_input(data)
-        should_parse_as_unified_llm_input = SUPPORTED_LLM_FORMAT in json_input
+        should_parse_as_unified_llm_input = any(x in json_input for x in SUPPORTED_LLM_FORMATS)
         if should_parse_as_unified_llm_input:
             # Unified LLM input format
             if hasattr(model.metadata, "get_params_schema"):

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -75,7 +75,10 @@ INPUTS = "inputs"
 SUPPORTED_FORMATS = {DF_RECORDS, DF_SPLIT, INSTANCES, INPUTS}
 
 # Support unwrapped JSON with these keys for LLM use cases of Chat, Completions, Embeddings tasks
-SUPPORTED_LLM_FORMATS = ["messages", "prompt", "input"]
+LLM_CHAT_KEY = "messages"
+LLM_COMPLETIONS_KEY = "prompt"
+LLM_EMBEDDINGS_KEY = "input"
+SUPPORTED_LLM_FORMATS = {LLM_CHAT_KEY, LLM_COMPLETIONS_KEY, LLM_EMBEDDINGS_KEY}
 
 REQUIRED_INPUT_FORMAT = (
     f"The input must be a JSON dictionary with exactly one of the input fields {SUPPORTED_FORMATS}"

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -992,7 +992,7 @@ _LLM_EMBEDDINGS_INPUT_SCHEMA = Schema(
             },
             {},
         ),
-        # Test case: signature with params, split params and data
+        # Test case: signature with no params accepted, ignores params
         (
             ModelSignature(
                 inputs=_LLM_EMBEDDINGS_INPUT_SCHEMA,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/es94129/mlflow/pull/10958?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10958/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10958
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

On top of https://github.com/mlflow/mlflow/pull/10742, allow input dicts with keys `prompt` and `input` to be parsed without wrapping in `"dataframe_records" | "dataframe_split" | "instances" | "inputs"`, and return without the `predictions` key.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<details><summary>Manual test</summary>

Run `log_completions_model.py`:
```python
_LLM_COMPLETIONS_INPUT_SCHEMA = Schema(
    [
        ColSpec(
            DataType.string,
            name="prompt",
        )
    ]
)

signature = ModelSignature(
    inputs=_LLM_COMPLETIONS_INPUT_SCHEMA,
    params=ParamSchema(
        [
            ParamSpec("temperature", DataType.double, default=0.1),
            ParamSpec("max_tokens", DataType.integer, default=20),
        ]
    ),
)

print("SIGNATURE", signature)

class Mod(mlflow.pyfunc.PythonModel):
    def predict(self, ctx, inp: List[Dict[str, str]], params):
        print("INP", inp)
        print("PARAMS", params)
        return {
            "some_key": "some_value"
        }

print(
    mlflow.pyfunc.log_model(
        python_model=Mod(),
        artifact_path="model",
        signature=signature
    ).model_uri
)
```

Run the `mlflow models serve` and query the port:
```sh
> mlflow models serve -m runs:/d6b6cc86244d476385d1304956419adf/model -p 9000 --env-manager local
INP [{'prompt': 'Hello'}]
PARAMS {'temperature': 0.6, 'max_tokens': 20}
```
```sh
> curl http://127.0.0.1:9000/invocations -H
 'Content-Type: application/json' -d '{
                                            "prompt": "Hello",
                                            "temperature": 0.6
                                        }' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    75  100    26  100    49   2906   5478 --:--:-- --:--:-- --:--:-- 18750
{
  "some_key": "some_value"
}
```

</details>

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Querying `mlflow models serve` allows input dictionaries that contains the key `prompt` or `input`, without the need of being wrapped into one of `"dataframe_records" | "dataframe_split" | "instances" | "inputs"`. The returned dictionary when this kind of input is given would not be wrapped in `predictions`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
