### PR TITLE
Extract databricks info from langchain flavor

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -27,13 +27,15 @@ from mlflow.langchain._langchain_autolog import (
     _update_langchain_model_config,
     patched_inference,
 )
+from mlflow.langchain.databricks_dependencies import (
+    _DATABRICKS_DEPENDENCY_KEY,
+    _detect_databricks_dependencies,
+)
 from mlflow.langchain.runnables import _load_runnables, _save_runnables
 from mlflow.langchain.utils import (
     _BASE_LOAD_KEY,
-    _DATABRICKS_DEPENDENCY_KEY,
     _MODEL_LOAD_KEY,
     _RUNNABLE_LOAD_KEY,
-    _detect_databricks_dependencies,
     _load_base_lcs,
     _save_base_lcs,
     _validate_and_wrap_lc_model,

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 import yaml
+from packaging.version import Version
 
 import mlflow
 from mlflow import pyfunc
@@ -275,8 +276,9 @@ def save_model(
         **model_data_kwargs,
     }
 
-    if databricks_dependency := _detect_databricks_dependencies(lc_model):
-        flavor_conf[_DATABRICKS_DEPENDENCY_KEY] = databricks_dependency
+    if Version(langchain.__version__) >= Version("0.0.311"):
+        if databricks_dependency := _detect_databricks_dependencies(lc_model):
+            flavor_conf[_DATABRICKS_DEPENDENCY_KEY] = databricks_dependency
 
     mlflow_model.add_flavor(
         FLAVOR_NAME,

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -1,0 +1,172 @@
+from typing import Dict, Optional, Set
+
+_DATABRICKS_DEPENDENCY_KEY = "databricks_dependency"
+_DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY = "databricks_vector_search_index_name"
+_DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY = "databricks_vector_search_endpoint_name"
+_DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY = "databricks_embeddings_endpoint_name"
+_DATABRICKS_LLM_ENDPOINT_NAME_KEY = "databricks_llm_endpoint_name"
+_DATABRICKS_CHAT_ENDPOINT_NAME_KEY = "databricks_chat_endpoint_name"
+
+
+def _assign_value_or_append_to_list(d, key, value):
+    if key in d:
+        if isinstance(d[key], list):
+            d[key].append(value)
+        else:
+            d[key] = [d[key], value]
+    else:
+        d[key] = value
+    return d
+
+
+def _extract_databricks_dependencies_from_retriever(retriever, dependency_dict) -> Dict[str, str]:
+    import langchain
+
+    if hasattr(retriever, "vectorstore") and hasattr(retriever.vectorstore, "embeddings"):
+        vectorstore = retriever.vectorstore
+        embeddings = vectorstore.embeddings
+
+        if isinstance(vectorstore, langchain.vectorstores.DatabricksVectorSearch):
+            index = vectorstore.index
+            _assign_value_or_append_to_list(
+                dependency_dict, _DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY, index.name
+            )
+            _assign_value_or_append_to_list(
+                dependency_dict, _DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY, index.endpoint_name
+            )
+
+        if isinstance(embeddings, langchain.embeddings.DatabricksEmbeddings):
+            _assign_value_or_append_to_list(
+                dependency_dict, _DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY, embeddings.endpoint
+            )
+        elif (
+            hasattr(vectorstore, "_is_databricks_managed_embeddings")
+            and callable(getattr(vectorstore, "_is_databricks_managed_embeddings"))
+            and vectorstore._is_databricks_managed_embeddings()
+        ):
+            _assign_value_or_append_to_list(
+                dependency_dict,
+                _DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY,
+                "_is_databricks_managed_embeddings",
+            )
+
+    return dependency_dict
+
+
+def _extract_databricks_dependencies_from_llm(llm, dependency_dict) -> Dict[str, str]:
+    import langchain
+
+    if isinstance(llm, langchain.llms.Databricks):
+        _assign_value_or_append_to_list(
+            dependency_dict, _DATABRICKS_LLM_ENDPOINT_NAME_KEY, llm.endpoint_name
+        )
+    return dependency_dict
+
+
+def _extract_databricks_dependencies_from_chat_model(chat_model, dependency_dict) -> Dict[str, str]:
+    import langchain
+
+    if isinstance(chat_model, langchain.chat_models.ChatDatabricks):
+        _assign_value_or_append_to_list(
+            dependency_dict, _DATABRICKS_CHAT_ENDPOINT_NAME_KEY, chat_model.endpoint
+        )
+    return dependency_dict
+
+
+def _extract_dpendency_dict_from_lc_model(lc_model, dependency_dict) -> Dict[str, str]:
+    if hasattr(lc_model, "retriever"):
+        dependency_dict = _extract_databricks_dependencies_from_retriever(
+            lc_model.retriever, dependency_dict
+        )
+
+    if hasattr(
+        lc_model, "llm_chain"
+    ):  # StuffDocumentsChain, MapRerankDocumentsChain, MapReduceDocumentsChain
+        dependency_dict = _extract_databricks_dependencies_from_llm(
+            lc_model.llm_chain.llm, dependency_dict
+        )
+    if hasattr(lc_model, "question_generator"):  # BaseConversationalRetrievalChain
+        dependency_dict = _extract_databricks_dependencies_from_llm(
+            lc_model.question_generator.llm, dependency_dict
+        )
+
+    if hasattr(lc_model, "initial_llm_chain") and hasattr(
+        lc_model, "refine_llm_chain"
+    ):  # RefineDocumentsChain
+        dependency_dict = _extract_databricks_dependencies_from_llm(
+            lc_model.initial_llm_chain.llm, dependency_dict
+        )
+        dependency_dict = _extract_databricks_dependencies_from_llm(
+            lc_model.refine_llm_chain.llm, dependency_dict
+        )
+
+    if hasattr(lc_model, "combine_documents_chain"):  # RetrievalQA, ReduceDocumentsChain
+        dependency_dict = _extract_dpendency_dict_from_lc_model(
+            lc_model.combine_documents_chain, dependency_dict
+        )
+    if hasattr(lc_model, "combine_docs_chain"):  # BaseConversationalRetrievalChain
+        dependency_dict = _extract_dpendency_dict_from_lc_model(
+            lc_model.combine_docs_chain, dependency_dict
+        )
+
+    if (
+        hasattr(lc_model, "collapse_documents_chain")
+        and lc_model.collapse_documents_chain is not None
+    ):  # ReduceDocumentsChain
+        dependency_dict = _extract_dpendency_dict_from_lc_model(
+            lc_model.collapse_documents_chain, dependency_dict
+        )
+
+    if hasattr(lc_model, "chat_model"):
+        dependency_dict = _extract_databricks_dependencies_from_chat_model(
+            lc_model.chat_model, dependency_dict
+        )
+    return dependency_dict
+
+
+def _traverse_runnable(
+    lc_model, dependency_dict: Dict[str, str], visited: Set[str]
+) -> (Dict[str, str], Set[str]):
+    import langchain_core
+
+    current_object_id = id(lc_model)
+    if current_object_id in visited:
+        return dependency_dict, visited
+
+    # Visit the current object
+    visited.add(current_object_id)
+    dependency_dict = _extract_dpendency_dict_from_lc_model(lc_model, dependency_dict)
+
+    if isinstance(lc_model, langchain_core.runnables.RunnableSerializable):
+        # Visit the returned graph
+        for node in lc_model.get_graph().nodes.values():
+            dependency_dict, visited = _traverse_runnable(node.data, dependency_dict, visited)
+    else:
+        # This is a leaf node
+        pass
+    return dependency_dict, visited
+
+
+def _detect_databricks_dependencies(lc_model, visited: Optional[Set[str]] = None) -> Dict[str, str]:
+    """
+    Detects the databricks dependencies of a langchain model and returns a dictionary of
+    detected endpoint names and index names.
+
+    lc_model can be an arbirary [chain that is built with LCEL](https://python.langchain.com
+    /docs/modules/chains#lcel-chains), which is a langchain_core.runnables.RunnableSerializable.
+    If a [legacy chain constructed by subclassing from a legacy Chain
+    class](https://python.langchain.com/docs/modules/chains#legacy-chains) is also a
+    langchain_core.runnables.RunnableSerializable, it is also supported.
+
+    For an LCEL chain, all the langchain_core.runnables.RunnableSerializable nodes will be
+    traversed.
+
+    If a retriever is found, it will be used to extract the databricks vector search and embeddings
+    dependencies. If an llm is found, it will be used to extract the databricks llm dependencies.
+    If a chat_model is found, it will be used to extract the databricks chat dependencies.
+    """
+    if visited is None:
+        visited = set()
+    dependency_dict = {}
+    visited = set()
+    return _traverse_runnable(lc_model, dependency_dict, visited)[0]

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -98,7 +98,7 @@ def _traverse_runnable(lc_model, dependency_dict: DefaultDict[str, List[Any]], v
     visited.add(current_object_id)
     _extract_dependency_dict_from_lc_model(lc_model, dependency_dict)
 
-    if isinstance(lc_model, langchain_core.runnables.RunnableSerializable):
+    if isinstance(lc_model, langchain_core.runnables.Runnable):
         # Visit the returned graph
         for node in lc_model.get_graph().nodes.values():
             _traverse_runnable(node.data, dependency_dict, visited)

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -103,7 +103,7 @@ def _traverse_runnable(lc_model, dependency_dict: DefaultDict[str, List[Any]], v
         for node in lc_model.get_graph().nodes.values():
             _traverse_runnable(node.data, dependency_dict, visited)
     else:
-        # This is a leaf node
+        # No-op for non-runnable, if any
         pass
     return
 

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -73,7 +73,7 @@ def _extract_databricks_dependencies_from_chat_model(chat_model, dependency_dict
     return dependency_dict
 
 
-def _extract_dpendency_dict_from_lc_model(lc_model, dependency_dict) -> Dict[str, str]:
+def _extract_dependency_dict_from_lc_model(lc_model, dependency_dict) -> Dict[str, str]:
     if hasattr(lc_model, "retriever"):
         dependency_dict = _extract_databricks_dependencies_from_retriever(
             lc_model.retriever, dependency_dict
@@ -101,11 +101,11 @@ def _extract_dpendency_dict_from_lc_model(lc_model, dependency_dict) -> Dict[str
         )
 
     if hasattr(lc_model, "combine_documents_chain"):  # RetrievalQA, ReduceDocumentsChain
-        dependency_dict = _extract_dpendency_dict_from_lc_model(
+        dependency_dict = _extract_dependency_dict_from_lc_model(
             lc_model.combine_documents_chain, dependency_dict
         )
     if hasattr(lc_model, "combine_docs_chain"):  # BaseConversationalRetrievalChain
-        dependency_dict = _extract_dpendency_dict_from_lc_model(
+        dependency_dict = _extract_dependency_dict_from_lc_model(
             lc_model.combine_docs_chain, dependency_dict
         )
 
@@ -113,7 +113,7 @@ def _extract_dpendency_dict_from_lc_model(lc_model, dependency_dict) -> Dict[str
         hasattr(lc_model, "collapse_documents_chain")
         and lc_model.collapse_documents_chain is not None
     ):  # ReduceDocumentsChain
-        dependency_dict = _extract_dpendency_dict_from_lc_model(
+        dependency_dict = _extract_dependency_dict_from_lc_model(
             lc_model.collapse_documents_chain, dependency_dict
         )
 
@@ -135,7 +135,7 @@ def _traverse_runnable(
 
     # Visit the current object
     visited.add(current_object_id)
-    dependency_dict = _extract_dpendency_dict_from_lc_model(lc_model, dependency_dict)
+    dependency_dict = _extract_dependency_dict_from_lc_model(lc_model, dependency_dict)
 
     if isinstance(lc_model, langchain_core.runnables.RunnableSerializable):
         # Visit the returned graph

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -166,7 +166,7 @@ def _detect_databricks_dependencies(lc_model) -> Dict[str, str]:
     Detects the databricks dependencies of a langchain model and returns a dictionary of
     detected endpoint names and index names.
 
-    lc_model can be an arbirary [chain that is built with LCEL](https://python.langchain.com
+    lc_model can be an arbitrary [chain that is built with LCEL](https://python.langchain.com
     /docs/modules/chains#lcel-chains), which is a langchain_core.runnables.RunnableSerializable.
     [Legacy chains](https://python.langchain.com/docs/modules/chains#legacy-chains) have limited
     support. Only RetrievalQA, StuffDocumentsChain, ReduceDocumentsChain, RefineDocumentsChain,

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -14,10 +14,8 @@ def _extract_databricks_dependencies_from_retriever(
 ):
     import langchain
 
-    if hasattr(retriever, "vectorstore") and hasattr(retriever.vectorstore, "embeddings"):
-        vectorstore = retriever.vectorstore
-        embeddings = vectorstore.embeddings
-
+    vectorstore = getattr(retriever, "vectorstore", None)
+    if vectorstore and (embeddings := getattr(vectorstore, "embeddings", None)):
         if isinstance(vectorstore, langchain.vectorstores.DatabricksVectorSearch):
             index = vectorstore.index
             dependency_dict[_DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY].append(index.name)
@@ -26,8 +24,7 @@ def _extract_databricks_dependencies_from_retriever(
         if isinstance(embeddings, langchain.embeddings.DatabricksEmbeddings):
             dependency_dict[_DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY].append(embeddings.endpoint)
         elif (
-            hasattr(vectorstore, "_is_databricks_managed_embeddings")
-            and callable(getattr(vectorstore, "_is_databricks_managed_embeddings"))
+            callable(getattr(vectorstore, "_is_databricks_managed_embeddings", None))
             and vectorstore._is_databricks_managed_embeddings()
         ):
             dependency_dict[_DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY].append(

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -6,7 +6,7 @@ import shutil
 import types
 from functools import lru_cache
 from importlib.util import find_spec
-from typing import Dict, NamedTuple, Optional, Set
+from typing import NamedTuple
 
 import cloudpickle
 import yaml
@@ -35,12 +35,6 @@ _RUNNABLE_LOAD_KEY = "runnable_load"
 _BASE_LOAD_KEY = "base_load"
 _CONFIG_LOAD_KEY = "config_load"
 _MODEL_LOAD_KEY = "model_load"
-_DATABRICKS_DEPENDENCY_KEY = "databricks_dependency"
-_DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY = "databricks_vector_search_index_name"
-_DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY = "databricks_vector_search_endpoint_name"
-_DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY = "databricks_embeddings_endpoint_name"
-_DATABRICKS_LLM_ENDPOINT_NAME_KEY = "databricks_llm_endpoint_name"
-_DATABRICKS_CHAT_ENDPOINT_NAME_KEY = "databricks_chat_endpoint_name"
 _UNSUPPORTED_MODEL_ERROR_MESSAGE = (
     "MLflow langchain flavor only supports subclasses of "
     "langchain.chains.base.Chain, langchain.agents.agent.AgentExecutor, "
@@ -477,127 +471,3 @@ def _load_base_lcs(
 
         model = initialize_agent(tools=tools, llm=llm, agent_path=agent_path, **kwargs)
     return model
-
-
-def _assign_value_or_append_to_list(d, key, value):
-    if key in d:
-        if isinstance(d[key], list):
-            d[key].append(value)
-        else:
-            d[key] = [d[key], value]
-    else:
-        d[key] = value
-    return d
-
-
-def _extract_databricks_dependencies_from_retriever(retriever, dependency_dict) -> Dict[str, str]:
-    import langchain
-
-    if hasattr(retriever, "vectorstore") and hasattr(retriever.vectorstore, "embeddings"):
-        vectorstore = retriever.vectorstore
-        embeddings = vectorstore.embeddings
-
-        if isinstance(vectorstore, langchain.vectorstores.DatabricksVectorSearch):
-            index = vectorstore.index
-            _assign_value_or_append_to_list(
-                dependency_dict, _DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY, index.name
-            )
-            _assign_value_or_append_to_list(
-                dependency_dict, _DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY, index.endpoint_name
-            )
-
-        if isinstance(embeddings, langchain.embeddings.DatabricksEmbeddings):
-            _assign_value_or_append_to_list(
-                dependency_dict, _DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY, embeddings.endpoint
-            )
-        elif (
-            hasattr(vectorstore, "_is_databricks_managed_embeddings")
-            and callable(getattr(vectorstore, "_is_databricks_managed_embeddings"))
-            and vectorstore._is_databricks_managed_embeddings()
-        ):
-            _assign_value_or_append_to_list(
-                dependency_dict,
-                _DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY,
-                "_is_databricks_managed_embeddings",
-            )
-
-    return dependency_dict
-
-
-def _extract_databricks_dependencies_from_llm(llm, dependency_dict) -> Dict[str, str]:
-    import langchain
-
-    if isinstance(llm, langchain.llms.Databricks):
-        _assign_value_or_append_to_list(
-            dependency_dict, _DATABRICKS_LLM_ENDPOINT_NAME_KEY, llm.endpoint_name
-        )
-    return dependency_dict
-
-
-def _extract_databricks_dependencies_from_chat_model(chat_model, dependency_dict) -> Dict[str, str]:
-    import langchain
-
-    if isinstance(chat_model, langchain.chat_models.ChatDatabricks):
-        _assign_value_or_append_to_list(
-            dependency_dict, _DATABRICKS_CHAT_ENDPOINT_NAME_KEY, chat_model.endpoint
-        )
-    return dependency_dict
-
-
-def _traverse_node(
-    lc_model, dependency_dict: Dict[str, str], visited: Set[str]
-) -> (Dict[str, str], Set[str]):
-    import langchain_core
-
-    # Do not use langchain node id since it's dynamically generated
-    # Use id() to compare the identical reference of the node
-    current_node_id = id(lc_model)
-    if current_node_id in visited:
-        return dependency_dict, visited
-
-    # Visit the current node
-    visited.add(current_node_id)
-    if hasattr(lc_model, "retriever"):
-        dependency_dict = _extract_databricks_dependencies_from_retriever(
-            lc_model.retriever, dependency_dict
-        )
-    if hasattr(lc_model, "llm"):
-        dependency_dict = _extract_databricks_dependencies_from_llm(lc_model.llm, dependency_dict)
-    if hasattr(lc_model, "chat_model"):
-        dependency_dict = _extract_databricks_dependencies_from_chat_model(
-            lc_model.chat_model, dependency_dict
-        )
-
-    if isinstance(lc_model, langchain_core.runnables.RunnableSerializable):
-        # Visit the returned graph
-        for node in lc_model.get_graph().nodes.values():
-            dependency_dict, visited = _traverse_node(node, dependency_dict, visited)
-    else:
-        # This is a leaf node
-        pass
-    return dependency_dict, visited
-
-
-def _detect_databricks_dependencies(lc_model, visited: Optional[Set[str]] = None) -> Dict[str, str]:
-    """
-    Detects the databricks dependencies of a langchain model and returns a dictionary of
-    detected endpoint names and index names.
-
-    lc_model can be an arbirary [chain that is built with LCEL](https://python.langchain.com
-    /docs/modules/chains#lcel-chains), which is a langchain_core.runnables.RunnableSerializable.
-    If a [legacy chain constructed by subclassing from a legacy Chain
-    class](https://python.langchain.com/docs/modules/chains#legacy-chains) is also a
-    langchain_core.runnables.RunnableSerializable, it is also supported.
-
-    For an LCEL chain, all the langchain_core.runnables.RunnableSerializable nodes will be
-    traversed.
-
-    If a retriever is found, it will be used to extract the databricks vector search and embeddings
-    dependencies. If an llm is found, it will be used to extract the databricks llm dependencies.
-    If a chat_model is found, it will be used to extract the databricks chat dependencies.
-    """
-    if visited is None:
-        visited = set()
-    dependency_dict = {}
-    visited = set()
-    return _traverse_node(lc_model, dependency_dict, visited)[0]

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -6,7 +6,7 @@ import shutil
 import types
 from functools import lru_cache
 from importlib.util import find_spec
-from typing import NamedTuple
+from typing import Dict, NamedTuple, Optional, Set
 
 import cloudpickle
 import yaml
@@ -35,6 +35,12 @@ _RUNNABLE_LOAD_KEY = "runnable_load"
 _BASE_LOAD_KEY = "base_load"
 _CONFIG_LOAD_KEY = "config_load"
 _MODEL_LOAD_KEY = "model_load"
+_DATABRICKS_DEPENDENCY_KEY = "databricks_dependency"
+_DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY = "databricks_vector_search_index_name"
+_DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY = "databricks_vector_search_endpoint_name"
+_DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY = "databricks_embeddings_endpoint_name"
+_DATABRICKS_LLM_ENDPOINT_NAME_KEY = "databricks_llm_endpoint_name"
+_DATABRICKS_CHAT_ENDPOINT_NAME_KEY = "databricks_chat_endpoint_name"
 _UNSUPPORTED_MODEL_ERROR_MESSAGE = (
     "MLflow langchain flavor only supports subclasses of "
     "langchain.chains.base.Chain, langchain.agents.agent.AgentExecutor, "
@@ -471,3 +477,127 @@ def _load_base_lcs(
 
         model = initialize_agent(tools=tools, llm=llm, agent_path=agent_path, **kwargs)
     return model
+
+
+def _assign_value_or_append_to_list(d, key, value):
+    if key in d:
+        if isinstance(d[key], list):
+            d[key].append(value)
+        else:
+            d[key] = [d[key], value]
+    else:
+        d[key] = value
+    return d
+
+
+def _extract_databricks_dependencies_from_retriever(retriever, dependency_dict) -> Dict[str, str]:
+    import langchain
+
+    if hasattr(retriever, "vectorstore") and hasattr(retriever.vectorstore, "embeddings"):
+        vectorstore = retriever.vectorstore
+        embeddings = vectorstore.embeddings
+
+        if isinstance(vectorstore, langchain.vectorstores.DatabricksVectorSearch):
+            index = vectorstore.index
+            _assign_value_or_append_to_list(
+                dependency_dict, _DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY, index.name
+            )
+            _assign_value_or_append_to_list(
+                dependency_dict, _DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY, index.endpoint_name
+            )
+
+        if isinstance(embeddings, langchain.embeddings.DatabricksEmbeddings):
+            _assign_value_or_append_to_list(
+                dependency_dict, _DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY, embeddings.endpoint
+            )
+        elif (
+            hasattr(vectorstore, "_is_databricks_managed_embeddings")
+            and callable(getattr(vectorstore, "_is_databricks_managed_embeddings"))
+            and vectorstore._is_databricks_managed_embeddings()
+        ):
+            _assign_value_or_append_to_list(
+                dependency_dict,
+                _DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY,
+                "_is_databricks_managed_embeddings",
+            )
+
+    return dependency_dict
+
+
+def _extract_databricks_dependencies_from_llm(llm, dependency_dict) -> Dict[str, str]:
+    import langchain
+
+    if isinstance(llm, langchain.llms.Databricks):
+        _assign_value_or_append_to_list(
+            dependency_dict, _DATABRICKS_LLM_ENDPOINT_NAME_KEY, llm.endpoint_name
+        )
+    return dependency_dict
+
+
+def _extract_databricks_dependencies_from_chat_model(chat_model, dependency_dict) -> Dict[str, str]:
+    import langchain
+
+    if isinstance(chat_model, langchain.chat_models.ChatDatabricks):
+        _assign_value_or_append_to_list(
+            dependency_dict, _DATABRICKS_CHAT_ENDPOINT_NAME_KEY, chat_model.endpoint
+        )
+    return dependency_dict
+
+
+def _traverse_node(
+    lc_model, dependency_dict: Dict[str, str], visited: Set[str]
+) -> (Dict[str, str], Set[str]):
+    import langchain_core
+
+    # Do not use langchain node id since it's dynamically generated
+    # Use id() to compare the identical reference of the node
+    current_node_id = id(lc_model)
+    if current_node_id in visited:
+        return dependency_dict, visited
+
+    # Visit the current node
+    visited.add(current_node_id)
+    if hasattr(lc_model, "retriever"):
+        dependency_dict = _extract_databricks_dependencies_from_retriever(
+            lc_model.retriever, dependency_dict
+        )
+    if hasattr(lc_model, "llm"):
+        dependency_dict = _extract_databricks_dependencies_from_llm(lc_model.llm, dependency_dict)
+    if hasattr(lc_model, "chat_model"):
+        dependency_dict = _extract_databricks_dependencies_from_chat_model(
+            lc_model.chat_model, dependency_dict
+        )
+
+    if isinstance(lc_model, langchain_core.runnables.RunnableSerializable):
+        # Visit the returned graph
+        for node in lc_model.get_graph().nodes.values():
+            dependency_dict, visited = _traverse_node(node, dependency_dict, visited)
+    else:
+        # This is a leaf node
+        pass
+    return dependency_dict, visited
+
+
+def _detect_databricks_dependencies(lc_model, visited: Optional[Set[str]] = None) -> Dict[str, str]:
+    """
+    Detects the databricks dependencies of a langchain model and returns a dictionary of
+    detected endpoint names and index names.
+
+    lc_model can be an arbirary [chain that is built with LCEL](https://python.langchain.com
+    /docs/modules/chains#lcel-chains), which is a langchain_core.runnables.RunnableSerializable.
+    If a [legacy chain constructed by subclassing from a legacy Chain
+    class](https://python.langchain.com/docs/modules/chains#legacy-chains) is also a
+    langchain_core.runnables.RunnableSerializable, it is also supported.
+
+    For an LCEL chain, all the langchain_core.runnables.RunnableSerializable nodes will be
+    traversed.
+
+    If a retriever is found, it will be used to extract the databricks vector search and embeddings
+    dependencies. If an llm is found, it will be used to extract the databricks llm dependencies.
+    If a chat_model is found, it will be used to extract the databricks chat dependencies.
+    """
+    if visited is None:
+        visited = set()
+    dependency_dict = {}
+    visited = set()
+    return _traverse_node(lc_model, dependency_dict, visited)[0]

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -48,7 +48,6 @@ import mlflow
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.deployments import PredictionsResponse
 from mlflow.exceptions import MlflowException
-from mlflow.langchain.databricks_dependencies import _assign_value_or_append_to_list
 from mlflow.models.signature import ModelSignature, Schema, infer_signature
 from mlflow.types.schema import Array, ColSpec, DataType, Object, Property
 from mlflow.utils.openai_utils import (
@@ -1568,9 +1567,7 @@ def test_chat_with_history(spark, fake_chat_model):
 
 def _extract_endpoint_name_from_lc_model(lc_model, dependency_dict: DefaultDict[str, List[Any]]):
     if type(lc_model).__name__ == type(get_fake_chat_model()).__name__:
-        _assign_value_or_append_to_list(
-            dependency_dict, "fake_chat_model_endpoint_name", lc_model.endpoint_name
-        )
+        dependency_dict["fake_chat_model_endpoint_name"].append(lc_model.endpoint_name)
 
 
 @pytest.mark.skipif(
@@ -1614,20 +1611,15 @@ def _extract_databricks_dependencies_from_retriever(
         embeddings = vectorstore.embeddings
 
         if isinstance(vectorstore, langchain_community.vectorstores.faiss.FAISS):
-            _assign_value_or_append_to_list(dependency_dict, "fake_index", "faiss-index")
+            dependency_dict["fake_index"].append("faiss-index")
 
         if isinstance(embeddings, FakeEmbeddings):
-            _assign_value_or_append_to_list(
-                dependency_dict, "fake_embeddings_size", embeddings.size
-            )
+            dependency_dict["fake_embeddings_size"].append(embeddings.size)
 
 
 def _extract_databricks_dependencies_from_llm(llm, dependency_dict: DefaultDict[str, List[Any]]):
     if isinstance(llm, FakeLLM):
-        _assign_value_or_append_to_list(
-            dependency_dict, "fake_llm_endpoint_name", llm.endpoint_name
-        )
-    return dependency_dict
+        dependency_dict["fake_llm_endpoint_name"].append(llm.endpoint_name)
 
 
 @pytest.mark.skipif(

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1606,10 +1606,8 @@ def _extract_databricks_dependencies_from_retriever(
 ):
     import langchain_community
 
-    if hasattr(retriever, "vectorstore") and hasattr(retriever.vectorstore, "embeddings"):
-        vectorstore = retriever.vectorstore
-        embeddings = vectorstore.embeddings
-
+    vectorstore = getattr(retriever, "vectorstore", None)
+    if vectorstore and (embeddings := getattr(vectorstore, "embeddings", None)):
         if isinstance(vectorstore, langchain_community.vectorstores.faiss.FAISS):
             dependency_dict["fake_index"].append("faiss-index")
 

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1578,7 +1578,7 @@ def _extract_endpoint_name_from_lc_model(lc_model, dependency_dict) -> Dict[str,
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
 @mock.patch(
-    "mlflow.langchain.databricks_dependencies._extract_dpendency_dict_from_lc_model",
+    "mlflow.langchain.databricks_dependencies._extract_dependency_dict_from_lc_model",
     _extract_endpoint_name_from_lc_model,
 )
 def test_databricks_dependency_extraction_from_lcel_chain():

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -5,7 +5,7 @@ import shutil
 import sqlite3
 from contextlib import contextmanager
 from operator import itemgetter
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, DefaultDict, Dict, List, Mapping, Optional
 from unittest import mock
 
 import langchain
@@ -1566,12 +1566,11 @@ def test_chat_with_history(spark, fake_chat_model):
     }
 
 
-def _extract_endpoint_name_from_lc_model(lc_model, dependency_dict) -> Dict[str, str]:
+def _extract_endpoint_name_from_lc_model(lc_model, dependency_dict: DefaultDict[str, List[Any]]):
     if type(lc_model).__name__ == type(get_fake_chat_model()).__name__:
         _assign_value_or_append_to_list(
             dependency_dict, "fake_chat_model_endpoint_name", lc_model.endpoint_name
         )
-    return dependency_dict
 
 
 @pytest.mark.skipif(
@@ -1605,7 +1604,9 @@ def test_databricks_dependency_extraction_from_lcel_chain():
     }
 
 
-def _extract_databricks_dependencies_from_retriever(retriever, dependency_dict) -> Dict[str, str]:
+def _extract_databricks_dependencies_from_retriever(
+    retriever, dependency_dict: DefaultDict[str, List[Any]]
+):
     import langchain_community
 
     if hasattr(retriever, "vectorstore") and hasattr(retriever.vectorstore, "embeddings"):
@@ -1620,10 +1621,8 @@ def _extract_databricks_dependencies_from_retriever(retriever, dependency_dict) 
                 dependency_dict, "fake_embeddings_size", embeddings.size
             )
 
-    return dependency_dict
 
-
-def _extract_databricks_dependencies_from_llm(llm, dependency_dict) -> Dict[str, str]:
+def _extract_databricks_dependencies_from_llm(llm, dependency_dict: DefaultDict[str, List[Any]]):
     if isinstance(llm, FakeLLM):
         _assign_value_or_append_to_list(
             dependency_dict, "fake_llm_endpoint_name", llm.endpoint_name
@@ -1671,9 +1670,9 @@ def test_databricks_dependency_extraction_from_retrieval_qa_chain(tmp_path):
         )
     langchain_flavor = logged_model.flavors["langchain"]
     assert langchain_flavor["databricks_dependency"] == {
-        "fake_llm_endpoint_name": "fake-llm-endpoint",
-        "fake_index": "faiss-index",
-        "fake_embeddings_size": 5,
+        "fake_llm_endpoint_name": ["fake-llm-endpoint"],
+        "fake_index": ["faiss-index"],
+        "fake_embeddings_size": [5],
     }
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/liangz1/mlflow/pull/10969?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10969/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10969
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
mlflow.langchain.log_model detects the databricks dependencies of a langchain model and saves a dictionary of detected endpoint names and index names in the MLmodel file under "langchain" flavor.

#### What information do we extract?
```python
from langchain_community.embeddings import DatabricksEmbeddings
# from DatabricksEmbeddings, extract databricks_embeddings_endpoint_name

from langchain.vectorstores import DatabricksVectorSearch
# from DatabricksVectorSearch, extract databricks_vector_search_index_name and databricks_vector_search_endpoint_name

from langchain_community.llms import Databricks
# from Databricks, extract databricks_llm_endpoint_name

from langchain.chat_models import ChatDatabricks
# from ChatDatabricks, extract databricks_chat_endpoint_name
```

#### What Chain do we support?
Arbitrary LCEL chains. [Legacy chains](https://python.langchain.com/docs/modules/chains#legacy-chains) have limited
    support. Only RetrievalQA, StuffDocumentsChain, ReduceDocumentsChain, RefineDocumentsChain,
    MapRerankDocumentsChain, MapReduceDocumentsChain, BaseConversationalRetrievalChain are
    supported. If you need to support a custom chain, you need to monkey patch
    the function mlflow.langchain.databricks_dependencies._extract_dependency_dict_from_lc_model().

Reference: Here is a list of all built-in LCEL chains and legacy chains in langchain: https://python.langchain.com/docs/modules/chains.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Manual tests code and results: [notebook link](https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/2868607934344885)

<details>

LCEL chain:
Code:
```python
prompt = PromptTemplate(
  input_variables = ["question"],
  template = "You are an assistant. Give a short answer to this question: {question}"
)
chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens = 500)

chain = (
  prompt
  | chat_model
  | StrOutputParser()
)
with mlflow.start_run():
    logged_model = mlflow.langchain.log_model(
        chain,
        "lcel_chain_basic",
    )
```
MLmodel file:
```
artifact_path: lcel_chain_basic
databricks_runtime: 14.2.x-cpu-ml-scala2.12
flavors:
  langchain:
    code: null
    databricks_dependency:
      databricks_chat_endpoint_name: databricks-llama-2-70b-chat
    langchain_version: 0.1.4
    model_data: model
    model_load: runnable_load
    model_type: RunnableSequence
  python_function:
    env:
      conda: conda.yaml
      virtualenv: python_env.yaml
    loader_module: mlflow.langchain
    model_data: model
    model_load: runnable_load
    python_version: 3.10.12
mlflow_version: 2.10.1.dev0
model_size_bytes: 677
model_uuid: 4a42ef5ce9464c2498c73d40eb7a8ee5
run_id: 3d642a7205fd440da558cd7e601c2536
utc_time_created: '2024-02-03 00:34:34.758090'
```

RetrievalQA chain:
Code:
```python
def get_retriever(persist_dir: str = None):
    host = "https://e2-dogfood.staging.cloud.databricks.com"
    os.environ["DATABRICKS_HOST"] = host
    os.environ["DATABRICKS_TOKEN"] = "dapiad213418cd36856a0c4dde7e3268768b"
    # Get the vector search index
    vsc = VectorSearchClient(workspace_url=host, personal_access_token=os.environ["DATABRICKS_TOKEN"])
    vs_index = vsc.get_index(
        endpoint_name="dbdemos_vs_endpoint",
        index_name="aakrati.rag_chatbot.databricks_documentation_vs_index"
    )

    # Create the retriever
    vectorstore = DatabricksVectorSearch(
        vs_index, text_column="content", embedding=DatabricksEmbeddings(endpoint="databricks-bge-large-en")
    )
    return vectorstore.as_retriever()


def transform_input(**request):
  request["messages"] = [
    {
      "role": "user",
      "content": request["prompt"]
    }
  ]
  del request["prompt"]
  return request

retriever = get_retriever()
llm = Databricks(endpoint_name="databricks-mixtral-8x7b-instruct", transform_input_fn=transform_input)
retrievalQA = RetrievalQA.from_llm(llm=llm, retriever=retriever)

with mlflow.start_run():
    logged_model = mlflow.langchain.log_model(
        retrievalQA,
        "retrieval_qa_chain",
        loader_fn=get_retriever,
    )
```
MLmodel file:
```
artifact_path: retrieval_qa_chain
databricks_runtime: 14.2.x-cpu-ml-scala2.12
flavors:
  langchain:
    code: null
    databricks_dependency:
      databricks_embeddings_endpoint_name: _is_databricks_managed_embeddings
      databricks_llm_endpoint_name: databricks-mixtral-8x7b-instruct
      databricks_vector_search_endpoint_name: dbdemos_vs_endpoint
      databricks_vector_search_index_name: aakrati.rag_chatbot.databricks_documentation_vs_index
    langchain_version: 0.1.4
    loader_arg: retriever
    loader_fn: loader_fn.pkl
    model_data: model.yaml
    model_load: base_load
    model_type: RetrievalQA
  python_function:
    env:
      conda: conda.yaml
      virtualenv: python_env.yaml
    loader_arg: retriever
    loader_fn: loader_fn.pkl
    loader_module: mlflow.langchain
    model_data: model.yaml
    model_load: base_load
    python_version: 3.10.12
mlflow_version: 2.10.1.dev0
model_size_bytes: 3477
model_uuid: 38fec0ebbaa242e48413f43ec8702003
run_id: b54dce07d6a14ba9bb712e94e05d5120
signature:
  inputs: '[{"type": "string", "name": "query", "required": true}]'
  outputs: '[{"type": "string", "name": "result", "required": true}]'
  params: null
utc_time_created: '2024-02-03 00:34:25.692498'
```
</details>
<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
