### PR TITLE
Fix indentation

### DIFF
--- a/docs/source/llms/deployments/guides/step1-create-deployments.rst
+++ b/docs/source/llms/deployments/guides/step1-create-deployments.rst
@@ -45,36 +45,37 @@ configuration file that is defined at server start, permitting dynamic route cre
 
         endpoints:
         - name: completions
-            endpoint_type: llm/v1/completions
-            model:
-                provider: openai
-                name: gpt-3.5-turbo
-                config:
-                    openai_api_key: $OPENAI_API_KEY
+          endpoint_type: llm/v1/completions
+          model:
+              provider: openai
+              name: gpt-3.5-turbo
+              config:
+                  openai_api_key: $OPENAI_API_KEY
 
         - name: chat
-            endpoint_type: llm/v1/chat
-            model:
-                provider: openai
-                name: gpt-4
-                config:
-                    openai_api_key: $OPENAI_API_KEY
+          endpoint_type: llm/v1/chat
+          model:
+              provider: openai
+              name: gpt-4
+              config:
+                  openai_api_key: $OPENAI_API_KEY
 
         - name: chat_3.5
-            endpoint_type: llm/v1/chat
-            model:
-                provider: openai
-                name: gpt-3.5-turbo
-                config:
-                    openai_api_key: $OPENAI_API_KEY
+          endpoint_type: llm/v1/chat
+          model:
+              provider: openai
+              name: gpt-3.5-turbo
+              config:
+                  openai_api_key: $OPENAI_API_KEY
 
         - name: embeddings
-            endpoint_type: llm/v1/embeddings
-            model:
-                provider: openai
-                name: text-embedding-ada-002
-                config:
-                    openai_api_key: $OPENAI_API_KEY
+          endpoint_type: llm/v1/embeddings
+          model:
+              provider: openai
+              name: text-embedding-ada-002
+              config:
+                  openai_api_key: $OPENAI_API_KEY
+
 
 
 Step 4: Start the Server


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/bmuskalla/mlflow/pull/10972?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10972/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10972
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #10971

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fixes the indentation of the examplar configuration file for OpenAI.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Fixes the example configuration for an LLM Deployments Server.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
