### PR TITLE
Implement chat & chat streaming for Cohere

### DIFF
--- a/docs/source/llms/deployments/index.rst
+++ b/docs/source/llms/deployments/index.rst
@@ -240,8 +240,8 @@ below can be used as a helpful guide when configuring a given endpoint for any n
 |                          | - claude-1.3-100k        |                          |                          |
 |                          | - claude-2               |                          |                          |
 +--------------------------+--------------------------+--------------------------+--------------------------+
-| Cohere                   | - command                | N/A                      | - embed-english-v2.0     |
-|                          | - command-light-nightly  |                          | - embed-multilingual-v2.0|
+| Cohere                   | - command                | - command                | - embed-english-v2.0     |
+|                          | - command-light          | - command-light          | - embed-multilingual-v2.0|
 +--------------------------+--------------------------+--------------------------+--------------------------+
 | Azure OpenAI             | - text-davinci-003       | - gpt-35-turbo           | - text-embedding-ada-002 |
 |                          | - gpt-35-turbo           | - gpt-4                  |                          |
@@ -885,7 +885,7 @@ generated before receiving it. Streaming responses are supported by the followin
 +============+=====================+==============+
 | OpenAI     | ✓                   | ✓            |
 +------------+---------------------+--------------+
-| Cohere     | ✓                   | ✘            |
+| Cohere     | ✓                   | ✓            |
 +------------+---------------------+--------------+
 
 To enable streaming responses, set the ``stream`` parameter to ``true`` in your request. For example:

--- a/docs/source/llms/deployments/index.rst
+++ b/docs/source/llms/deployments/index.rst
@@ -824,7 +824,7 @@ In addition to the :ref:`standard_query_parameters`, you can pass any additional
 - ``top_k`` (supported by MosaicML, Anthropic, PaLM, Cohere)
 - ``frequency_penalty`` (supported by OpenAI, Cohere, AI21 Labs)
 - ``presence_penalty`` (supported by OpenAI, Cohere, AI21 Labs)
-- ``stream`` (supported by OpenAI)
+- ``stream`` (supported by OpenAI, Cohere)
 
 Below is an example of submitting a query request to an MLflow Deployments Server endpoint using additional parameters:
 

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -97,6 +97,22 @@ class ProviderAdapter(ABC):
         raise NotImplementedError
 
     @classmethod
+    def model_to_chat(cls, resp, config):
+        raise NotImplementedError
+
+    @classmethod
+    def model_to_chat_streaming(cls, resp, config):
+        raise NotImplementedError
+
+    @classmethod
+    def chat_to_model(cls, payload, config):
+        raise NotImplementedError
+
+    @classmethod
+    def chat_streaming_to_model(cls, payload, config):
+        raise NotImplementedError
+
+    @classmethod
     @abstractmethod
     def embeddings_to_model(cls, payload, config):
         raise NotImplementedError

--- a/mlflow/gateway/providers/cohere.py
+++ b/mlflow/gateway/providers/cohere.py
@@ -204,7 +204,15 @@ class CohereAdapter(ProviderAdapter):
             )
         payload["message"] = last_message["content"]
 
+        # Cohere uses `preamble_override` to set the system message
+        # we only pass the first system message to Cohere
+        system_message = [m for m in messages if m["role"] == "system"]
+        if len(system_message) > 0:
+            payload["preamble_override"] = system_message[0]["content"]
+
         # remaining messages are chat history
+        # we want to include only user and assistant messages
+        messages = [m for m in messages if m["role"] in ("user", "assistant")]
         if messages:
             payload["chat_history"] = [
                 {

--- a/mlflow/gateway/providers/cohere.py
+++ b/mlflow/gateway/providers/cohere.py
@@ -187,12 +187,14 @@ class CohereAdapter(ProviderAdapter):
                 detail=f"Parameter n must be 1 for Cohere chat, got {payload['n']}.",
             )
         del payload["n"]
+
         if "stop" in payload:
             raise HTTPException(
                 status_code=422,
                 detail="Parameter stop is not supported for Cohere chat.",
             )
         payload = cls._scale_temperature(payload)
+
         last_message = payload["messages"][-1]
         if last_message["role"] != "user":
             raise HTTPException(
@@ -200,6 +202,7 @@ class CohereAdapter(ProviderAdapter):
                 detail=f"Last message must be from user, got {last_message['role']}.",
             )
         payload["message"] = last_message["content"]
+
         if len(payload["messages"]) > 1:
             payload["chat_history"] = [
                 {

--- a/mlflow/gateway/providers/cohere.py
+++ b/mlflow/gateway/providers/cohere.py
@@ -235,6 +235,7 @@ class CohereAdapter(ProviderAdapter):
         #   },
         #   "tool_inputs": null
         # }
+        # ```
         return chat.ResponsePayload(
             id=resp["response_id"],
             object="chat.completion",

--- a/mlflow/gateway/providers/cohere.py
+++ b/mlflow/gateway/providers/cohere.py
@@ -186,6 +186,7 @@ class CohereAdapter(ProviderAdapter):
                 status_code=422,
                 detail=f"Parameter n must be 1 for Cohere chat, got {payload['n']}.",
             )
+        del payload["n"]
         if "stop" in payload:
             raise HTTPException(
                 status_code=422,

--- a/mlflow/gateway/providers/cohere.py
+++ b/mlflow/gateway/providers/cohere.py
@@ -8,10 +8,17 @@ from fastapi.encoders import jsonable_encoder
 from mlflow.gateway.config import CohereConfig, RouteConfig
 from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
 from mlflow.gateway.providers.utils import rename_payload_keys, send_request, send_stream_request
-from mlflow.gateway.schemas import completions, embeddings
+from mlflow.gateway.schemas import completions, embeddings, chat
 
 
 class CohereAdapter(ProviderAdapter):
+    @staticmethod
+    def _scale_temperature(payload):
+        # The range of Cohere's temperature is 0-5, but ours is 0-2, so we scale it.
+        if "temperature" in payload:
+            payload["temperature"] = 2.5 * payload["temperature"]
+        return payload
+
     @classmethod
     def model_to_completions(cls, resp, config):
         # Response example (https://docs.cohere.com/reference/generate)
@@ -155,9 +162,7 @@ class CohereAdapter(ProviderAdapter):
             "n": "num_generations",
         }
         cls.check_keys_against_mapping(key_mapping, payload)
-        # The range of Cohere's temperature is 0-5, but ours is 0-2, so we scale it.
-        if "temperature" in payload:
-            payload["temperature"] = 2.5 * payload["temperature"]
+        payload = cls._scale_temperature(payload)
         return rename_payload_keys(payload, key_mapping)
 
     @classmethod
@@ -173,6 +178,84 @@ class CohereAdapter(ProviderAdapter):
                     status_code=422, detail=f"Invalid parameter {k2}. Use {k1} instead."
                 )
         return rename_payload_keys(payload, key_mapping)
+
+    @classmethod
+    def chat_to_model(cls, payload, config):
+        if payload["n"] != 1:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Parameter n must be 1 for Cohere chat, got {payload['n']}.",
+            )
+        if "stop" in payload:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Parameter stop is not supported for Cohere chat.",
+            )
+        payload = cls._scale_temperature(payload)
+        last_message = payload["messages"][-1]
+        if last_message["role"] != "user":
+            raise HTTPException(
+                status_code=422,
+                detail=f"Last message must be from user, got {last_message['role']}.",
+            )
+        payload["message"] = last_message["content"]
+        if len(payload["messages"]) > 1:
+            payload["chat_history"] = [
+                {
+                    "role": "USER" if m["role"] == "user" else "CHATBOT",
+                    "message": m["content"],
+                }
+                for m in payload["messages"][:-1]
+            ]
+        del payload["messages"]
+        return payload
+
+    @classmethod
+    def model_to_chat(cls, resp, config):
+        # Response example (https://docs.cohere.com/reference/chat)
+        # ```
+        # {
+        #   "response_id": "string",
+        #   "text": "string",
+        #   "generation_id": "string",
+        #   "token_count": {
+        #     "prompt_tokens": 0,
+        #     "response_tokens": 0,
+        #     "total_tokens": 0,
+        #     "billed_tokens": 0
+        #   },
+        #   "meta": {
+        #     "api_version": {
+        #       "version": "1"
+        #     },
+        #     "billed_units": {
+        #       "input_tokens": 0,
+        #       "output_tokens": 0
+        #     }
+        #   },
+        #   "tool_inputs": null
+        # }
+        return chat.ResponsePayload(
+            id=resp["response_id"],
+            object="chat.completion",
+            created=int(time.time()),
+            model=config.model.name,
+            choices=[
+                chat.Choice(
+                    index=0,
+                    message=chat.ResponseMessage(
+                        role="assistant",
+                        content=resp["text"],
+                    ),
+                    finish_reason=None,
+                ),
+            ],
+            usage=chat.ChatUsage(
+                prompt_tokens=resp["token_count"]["prompt_tokens"],
+                completion_tokens=resp["token_count"]["response_tokens"],
+                total_tokens=resp["token_count"]["total_tokens"],
+            ),
+        )
 
 
 class CohereProvider(BaseProvider):
@@ -207,6 +290,18 @@ class CohereProvider(BaseProvider):
             path=path,
             payload=payload,
         )
+
+    async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        payload = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload)
+        resp = await self._request(
+            "chat",
+            {
+                "model": self.config.model.name,
+                **CohereAdapter.chat_to_model(payload, self.config),
+            },
+        )
+        return CohereAdapter.model_to_chat(resp, self.config)
 
     async def completions_stream(
         self, payload: completions.RequestPayload

--- a/mlflow/gateway/providers/cohere.py
+++ b/mlflow/gateway/providers/cohere.py
@@ -205,10 +205,10 @@ class CohereAdapter(ProviderAdapter):
         payload["message"] = last_message["content"]
 
         # Cohere uses `preamble_override` to set the system message
-        # we only pass the first system message to Cohere
-        system_message = [m for m in messages if m["role"] == "system"]
-        if len(system_message) > 0:
-            payload["preamble_override"] = system_message[0]["content"]
+        # we concatenate all system messages from the user with a newline
+        system_messages = [m for m in messages if m["role"] == "system"]
+        if len(system_messages) > 0:
+            payload["preamble_override"] = "\n".join(m["content"] for m in system_messages)
 
         # remaining messages are chat history
         # we want to include only user and assistant messages

--- a/mlflow/gateway/providers/cohere.py
+++ b/mlflow/gateway/providers/cohere.py
@@ -8,7 +8,7 @@ from fastapi.encoders import jsonable_encoder
 from mlflow.gateway.config import CohereConfig, RouteConfig
 from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
 from mlflow.gateway.providers.utils import rename_payload_keys, send_request, send_stream_request
-from mlflow.gateway.schemas import completions, embeddings, chat
+from mlflow.gateway.schemas import chat, completions, embeddings
 
 
 class CohereAdapter(ProviderAdapter):
@@ -189,7 +189,7 @@ class CohereAdapter(ProviderAdapter):
         if "stop" in payload:
             raise HTTPException(
                 status_code=422,
-                detail=f"Parameter stop is not supported for Cohere chat.",
+                detail="Parameter stop is not supported for Cohere chat.",
             )
         payload = cls._scale_temperature(payload)
         last_message = payload["messages"][-1]

--- a/mlflow/gateway/schemas/chat.py
+++ b/mlflow/gateway/schemas/chat.py
@@ -121,7 +121,7 @@ _STREAM_RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
 
 
 class StreamResponsePayload(ResponseModel):
-    id: str
+    id: Optional[str] = None
     object: Literal["chat.completion.chunk"] = "chat.completion.chunk"
     created: int
     model: str


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/gabrielfu/mlflow/pull/10976?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10976/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10976
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Implement chat & chat streaming for Cohere

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

```yaml
# config.yaml
routes:
  - name: cohere
    route_type: llm/v1/chat
    model:
      provider: cohere
      name: command
      config:
        cohere_api_key: <key>
```

```shell
mlflow deployments start-server --config-path config.yaml --workers 1
```

Non-streaming:
```shell
curl -X POST http://127.0.0.1:5000/endpoints/cohere/invocations \
  -H "Content-Type: application/json" \
  -d '{"messages": [{"role": "user","content": "Hi"},{"role": "assistant","content": "Hi"},{"role": "user","content": "Tell me something fun."}]}'
```

Streaming:
```shell
curl -X POST http://127.0.0.1:5000/endpoints/cohere/invocations \
  -H "Content-Type: application/json" \
  -d '{"messages": [{"role": "user","content": "Hi"},{"role": "assistant","content": "Hi"},{"role": "user","content": "Tell me something fun."}], "stream": true}'
```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [X] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add support for Cohere chat streaming and non-streaming endpoints

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
