### PR TITLE
Enrich documentations for docker deployment

### DIFF
--- a/docs/source/deployment/deploy-model-to-kubernetes/index.rst
+++ b/docs/source/deployment/deploy-model-to-kubernetes/index.rst
@@ -10,9 +10,50 @@ as a core Python inference server in Kubernetes-native frameworks like `Seldon C
 of Kubernetes to serve your model at scale. See :ref:`Serving Framework <serving_frameworks>` for the detailed comparison between Flask and MLServer,
 and why MLServer is a better choice for ML production use cases.
 
+
+.. _build-docker-for-deployment:
+
+Building a Docker Image for MLflow Model
+----------------------------------------
+The essential step to deploy an MLflow model to Kubernetes is to build a Docker image that contains the MLflow model and the inference server. This can be done via 
+``build-docker`` CLI command or Python API.
+
+.. tabs::
+
+    .. tab:: CLI
+
+        .. code-block:: bash
+
+            mlflow models build-docker -m runs:/<run_id>/model -n <image_name> --enable-mlserver
+
+        If you want to use the bare-bones Flask server instead of MLServer, remove the ``--enable-mlserver`` flag. For other options, see the
+        `build-docker <../../cli.html#mlflow-models-build-docker>`_ command documentation.
+
+    .. tab:: Python
+
+        .. code-block:: python
+
+            import mlflow
+
+            mlflow.models.build_docker(
+                model_uri=f"runs:/{run_id}/model",
+                name="<image_name>",
+                enable_mlserver=True,
+            )
+
+        If you want to use the bare-bones Flask server instead of MLServer, remove ``enable_mlserver=True``. For other options, see the
+        `mlflow.models.build_docker <../../python_api/mlflow.models.html#mlflow.models.build_docker>`_ function documentation.
+
+.. important::
+
+    Since MLflow 2.10.1, the Docker image spec has been changed to reduce the image size and improve the performance.
+    Most notably, Java is no longer installed in the image except for the Java model flavor such as ``spark``.
+    If you need to install Java for other flavors, e.g. custom Python model that uses SparkML, please specify the ``--install-java`` flag to enforce Java installation.
+
+
 Deployment Steps
 ----------------
-Please refer to the following partner documentations for deploying MLflow Models to Kubernetes using MLServer:
+Please refer to the following partner documentations for deploying MLflow Models to Kubernetes using MLServer. You can also follow the tutorial below to learn the end-to-end process including environment setup, model training, and deployment.
 
 - `Deploy MLflow models with KServe InferenceService <https://kserve.github.io/website/latest/modelserving/v1beta1/mlflow/v2/>`_
 - `Deploy MLflow models to Seldon Core <https://docs.seldon.io/projects/seldon-core/en/latest/servers/mlflow.html>`_

--- a/docs/source/deployment/index.rst
+++ b/docs/source/deployment/index.rst
@@ -33,8 +33,8 @@ To use MLflow deployment, you must first create a model.
 Container
 ~~~~~~~~~
 Container plays a critical role for simplifying and standardizing the model deployment process. MLflow uses Docker containers to package models with their dependencies,
-enabling deployment to various destinations without environment compatibility issues.
-If you're new to Docker, you can learn more at `"What is a Container" <https://www.docker.com/resources/what-container//>`_.
+enabling deployment to various destinations without environment compatibility issues. See `Building a Docker Image for MLflow Model <build-docker-for-deployment>`_ for more details on how to deploy your model as a container.
+If you're new to Docker, you can start learning at `"What is a Container" <https://www.docker.com/resources/what-container//>`_.
 
 Deployment Target
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/deployment/index.rst
+++ b/docs/source/deployment/index.rst
@@ -33,7 +33,7 @@ To use MLflow deployment, you must first create a model.
 Container
 ~~~~~~~~~
 Container plays a critical role for simplifying and standardizing the model deployment process. MLflow uses Docker containers to package models with their dependencies,
-enabling deployment to various destinations without environment compatibility issues. See `Building a Docker Image for MLflow Model <build-docker-for-deployment>`_ for more details on how to deploy your model as a container.
+enabling deployment to various destinations without environment compatibility issues. See :ref:`Building a Docker Image for MLflow Model <build-docker-for-deployment>` for more details on how to deploy your model as a container.
 If you're new to Docker, you can start learning at `"What is a Container" <https://www.docker.com/resources/what-container//>`_.
 
 Deployment Target

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -246,6 +246,13 @@ def build_docker(**kwargs):
         # Mount the model stored in '/local/path/to/artifacts/model' and serve it
         docker run --rm -p 5001:8080 -v /local/path/to/artifacts/model:/opt/ml/model "my-image-name"
 
+    .. important::
+
+        Since MLflow 2.10.1, the Docker image built with ``--model-uri`` does **not install Java**
+        for improved performance, unless the model flavor is one of ``["johnsnowlabs", "h2o",
+        "mleap", "spark"]``. If you need to install Java for other flavors, e.g. custom Python model
+        that uses SparkML, please specify the ``--install-java`` flag to enforce Java installation.
+
     .. warning::
 
         The image built without ``--model-uri`` doesn't support serving models with RFunc / Java

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -35,6 +35,7 @@ def build_docker(
         for improved performance, unless the model flavor is one of ``["johnsnowlabs", "h2o",
         "mleap", "spark"]``. If you need to install Java for other flavors, e.g. custom Python model
         that uses SparkML, please specify ``install-java=True`` to enforce Java installation.
+        For earlier versions, Java is always installed to the image.
 
 
     .. warning::
@@ -53,37 +54,27 @@ def build_docker(
     See https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html for more information on the
     'python_function' flavor.
 
+    Args:
+        model_uri: URI to the model. A local path, a 'runs:/' URI, or a remote storage URI (e.g.,
+            an 's3://' URI). For more information about supported remote URIs for model artifacts,
+            see https://mlflow.org/docs/latest/tracking.html#artifact-stores"
+        name: Name of the Docker image to build. Defaults to 'mlflow-pyfunc'.
+        install_java: If specified, install Java in the image. Default is False in order to
+            reduce both the image size and the build time. Model flavors requiring Java will enable
+            this setting automatically, such as the Spark flavor. (This argument is only available
+            in MLflow 2.10.1 and later. In earlier versions, Java is always installed to the image.)
 
-    :param model_uri: URI to the model. A local path, a 'runs:/' URI, or a remote storage URI (e.g.,
-        an 's3://' URI). For more information about supported remote URIs for model artifacts, see
-        https://mlflow.org/docs/latest/tracking.html#artifact-stores"
+        enable_mlserver: If specified, the image will be built with the Seldon MLserver as backend.
+        env_manager: If specified, create an environment for MLmodel using the specified environment
+            manager. The following values are supported: (1) virtualenv (default): use virtualenv
+            and pyenv for Python version management (2) conda: use conda (3) local: use the local
+            environment without creating a new one.
 
-    :param name: Name of the Docker image to build. Defaults to 'mlflow-pyfunc'.
+        install_mlflow: If specified and there is a conda or virtualenv environment to be activated
+            mlflow will be installed into the environment after it has been activated.
+            The version of installed mlflow will be the same as the one used to invoke this command.
 
-    :param install_java: If specified, install Java in the image. Default is False in order to
-        reduce both the image size and the build time. Model flavors requiring Java will enable
-        this setting automatically, such as the Spark flavor.
-
-        .. note::
-
-            This option is only available for MLflow > 2.10.1. For earlier versions, Java is
-            always installed to the image.
-
-    :param enable_mlserver: If specified, the image will be built with
-        `MLserver <https://mlserver.readthedocs.io/en/latest/index.html>`_ as a serving backend.
-
-    :param env_manager: If specified, create an environment for MLmodel using the specified
-        environment manager. The following values are supported:
-        - local: use the local environment
-        - virtualenv: use virtualenv (and pyenv for Python version management)
-        - conda: use conda
-        If unspecified, default to virtualenv.
-
-    :param mlflow_home: Path to local clone of MLflow project. Use for development only.
-    :param install_mlflow: "If specified and there is a conda or virtualenv environment to be
-        activated mlflow will be installed into the environment after it has been activated.
-        The version of installed mlflow will be the same as the one used to invoke this command.
-
+        mlflow_home: Path to local clone of MLflow project. Use for development only.
     """
     get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager).build_image(
         model_uri,
@@ -114,23 +105,24 @@ def predict(
     data formats accepted by this function, see the following documentation:
     https://www.mlflow.org/docs/latest/models.html#built-in-deployment-tools.
 
-    :param model_uri: URI to the model. A local path, a local or remote URI e.g. runs:/, s3://.
-    :param input_data: Input data for prediction. Must be valid input for the PyFunc model.
-    :param input_path: Path to a file containing input data. If provided, 'input_data' must be None.
-    :param content_type: Content type of the input data. Can be one of {‘json’, ‘csv’}.
-    :param output_path: File to output results to as json. If not provided, output to stdout.
-    :param env_manager: Specify a way to create an environment for MLmodel inference:
+    Args:
+        model_uri: URI to the model. A local path, a local or remote URI e.g. runs:/, s3://.
+        input_data: Input data for prediction. Must be valid input for the PyFunc model.
+        input_path: Path to a file containing input data. If provided, 'input_data' must be None.
+        content_type: Content type of the input data. Can be one of {‘json’, ‘csv’}.
+        output_path: File to output results to as json. If not provided, output to stdout.
+        env_manager: Specify a way to create an environment for MLmodel inference:
 
-        - virtualenv (default): use virtualenv (and pyenv for Python version management)
-        - local: use the local environment
-        - conda: use conda
+            - virtualenv (default): use virtualenv (and pyenv for Python version management)
+            - local: use the local environment
+            - conda: use conda
 
-    :param install_mlflow: If specified and there is a conda or virtualenv environment to be
-        activated mlflow will be installed into the environment after it has been activated.
-        The version of installed mlflow will be the same as the one used to invoke this command.
-    :param pip_requirements_override: If specified, install the specified python dependencies to
-        the model inference environment. This is particularly useful when you want to add extra
-        dependencies or try different versions of the dependencies defined in the logged model.
+        install_mlflow: If specified and there is a conda or virtualenv environment to be activated
+            mlflow will be installed into the environment after it has been activated. The version
+            of installed mlflow will be the same as the one used to invoke this command.
+        pip_requirements_override: If specified, install the specified python dependencies to the
+            model inference environment. This is particularly useful when you want to add extra
+            dependencies or try different versions of the dependencies defined in the logged model.
 
     Code example:
 

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -29,6 +29,14 @@ def build_docker(
     specified. If ``model_uri`` is not specified, an MLflow Model directory must be mounted as a
     volume into the /opt/ml/model directory in the container.
 
+    .. important::
+
+        Since MLflow 2.10.1, the Docker image built with ``--model-uri`` does **not install Java**
+        for improved performance, unless the model flavor is one of ``["johnsnowlabs", "h2o",
+        "mleap", "spark"]``. If you need to install Java for other flavors, e.g. custom Python model
+        that uses SparkML, please specify ``install-java=True`` to enforce Java installation.
+
+
     .. warning::
 
         If ``model_uri`` is unspecified, the resulting image doesn't support serving models with
@@ -44,6 +52,38 @@ def build_docker(
 
     See https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html for more information on the
     'python_function' flavor.
+
+
+    :param model_uri: URI to the model. A local path, a 'runs:/' URI, or a remote storage URI (e.g.,
+        an 's3://' URI). For more information about supported remote URIs for model artifacts, see
+        https://mlflow.org/docs/latest/tracking.html#artifact-stores"
+
+    :param name: Name of the Docker image to build. Defaults to 'mlflow-pyfunc'.
+
+    :param install_java: If specified, install Java in the image. Default is False in order to
+        reduce both the image size and the build time. Model flavors requiring Java will enable
+        this setting automatically, such as the Spark flavor.
+
+        .. note::
+
+            This option is only available for MLflow > 2.10.1. For earlier versions, Java is
+            always installed to the image.
+
+    :param enable_mlserver: If specified, the image will be built with
+        `MLserver <https://mlserver.readthedocs.io/en/latest/index.html>`_ as a serving backend.
+
+    :param env_manager: If specified, create an environment for MLmodel using the specified
+        environment manager. The following values are supported:
+        - local: use the local environment
+        - virtualenv: use virtualenv (and pyenv for Python version management)
+        - conda: use conda
+        If unspecified, default to virtualenv.
+
+    :param mlflow_home: Path to local clone of MLflow project. Use for development only.
+    :param install_mlflow: "If specified and there is a conda or virtualenv environment to be
+        activated mlflow will be installed into the environment after it has been activated.
+        The version of installed mlflow will be the same as the one used to invoke this command.
+
     """
     get_flavor_backend(model_uri, docker_build=True, env_manager=env_manager).build_image(
         model_uri,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/10983?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10983/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10983
```

</p>
</details>

### Related Issues/PRs

Follow-up for #10954 

### What changes are proposed in this pull request?

Add documentation for the new ``--install-java`` flag and warning box for the default behavior change.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
