### PR TITLE
Fix typo in EnvironmentUtils.java

### DIFF
--- a/mlflow/java/scoring/src/main/java/org/mlflow/utils/EnvironmentUtils.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/utils/EnvironmentUtils.java
@@ -1,6 +1,6 @@
 package org.mlflow.utils;
 
-/** Utilities for reading from / writing to the system enviroment */
+/** Utilities for reading from / writing to the system environment */
 public class EnvironmentUtils {
   public static int getIntegerValue(String varName, int defaultValue) {
     String rawValue = System.getenv(varName);


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/eltociear/mlflow/pull/10984?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10984/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10984
```

</p>
</details>

Fixed typo.
enviroment -> environment

