### PR TITLE
fix: update dev dependency error

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -75,7 +75,7 @@ gateway-api-docs:
 # Builds only the RST-based documentation (i.e., everything but Java & R docs)
 .PHONY: rsthtml
 rsthtml: gateway-api-docs
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -T
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 	@echo "Use 'make view' to preview docs."

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -75,7 +75,7 @@ gateway-api-docs:
 # Builds only the RST-based documentation (i.e., everything but Java & R docs)
 .PHONY: rsthtml
 rsthtml: gateway-api-docs
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -T
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 	@echo "Use 'make view' to preview docs."

--- a/requirements/doc-min-requirements.txt
+++ b/requirements/doc-min-requirements.txt
@@ -10,3 +10,10 @@ sphinx-click
 sphinx-tabs==3.2.0
 # redirect handling
 sphinx-reredirects==0.1.3
+# https://github.com/sphinx-doc/sphinx/issues/11890
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5

--- a/requirements/doc-requirements.txt
+++ b/requirements/doc-requirements.txt
@@ -1,5 +1,5 @@
 -r doc-min-requirements.txt
-tensorflow-cpu<=2.12.0
+tensorflow<=2.15.0
 pyspark
 datasets
 # nbsphinx and ipython are required for jupyter notebook rendering

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -9,7 +9,7 @@ fastai>=2.4.1
 # Required by mlflow.spacy
 spacy>=3.3.0
 # Required by mlflow.tensorflow
-tensorflow-cpu>=2.8.0
+tensorflow>=2.8.0
 # Required by mlflow.pytorch
 torch>=1.11.0
 torchvision>=0.12.0

--- a/requirements/lint-requirements.txt
+++ b/requirements/lint-requirements.txt
@@ -1,5 +1,6 @@
 pylint==2.14.4
 ruff==0.1.3
+rstcheck-core==1.0.3
 rstcheck==6.1.1
 black[jupyter]==23.7.0
 blacken-docs==1.16.0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/minkj1992/mlflow/pull/10998?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/10998/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 10998
```

</p>
</details>

### Related Issues/PRs

 #10990 

### What changes are proposed in this pull request?

1. Revert #9754 (cc @harupy)

```
ERROR: Could not find a version that satisfies the requirement tensorflow-cpu<=2.12.0 (from versions: none)
ERROR: No matching distribution found for tensorflow-cpu<=2.12.0
```


2. Pinned sphinx version, [sphinx-issue](https://github.com/sphinx-doc/sphinx/issues/11890#issuecomment-1912282968) (#10559  cc @B-Step62 )

```
> make rsthtml
/Users/minwook/code/personal/mlflow/mlflow/gateway/config.py:493: FutureWarning: The 'routes' configuration key has been deprecated and will be removed in an upcoming release. Use 'endpoints' instead.
  check_configuration_deprecated_fields(configuration)
/Users/minwook/code/personal/mlflow/mlflow/gateway/config.py:493: FutureWarning: The 'route_type' configuration key has been deprecated and will be removed in an upcoming release. Use 'endpoint_type' instead.
  check_configuration_deprecated_fields(configuration)
sphinx-build -b html -d build/doctrees  -W --keep-going -n -T source build/html
Running Sphinx v3.5.4

Traceback (most recent call last):
  File "/Users/minwook/code/personal/mlflow/.venvs/mlflow-dev/lib/python3.9/site-packages/sphinx/registry.py", line 430, in load_extension
    metadata = setup(app)
  File "/Users/minwook/code/personal/mlflow/.venvs/mlflow-dev/lib/python3.9/site-packages/sphinxcontrib/applehelp/__init__.py", line 230, in setup
    app.require_sphinx('5.0')
  File "/Users/minwook/code/personal/mlflow/.venvs/mlflow-dev/lib/python3.9/site-packages/sphinx/application.py", line 415, in require_sphinx
    raise VersionRequirementError(version)
sphinx.errors.VersionRequirementError: 5.0

```

3. Set `rstcheck-core`==1.0.3 to fix pydantic version conflicts

```
Collecting pydantic>=2 (from rstcheck-core<2.0.0,>=1.0.2->rstcheck==6.1.1->-r /Users/minwook/code/personal/mlflow/requirements/lint-requirements.txt (line 3))
  Using cached pydantic-2.6.0-py3-none-any.whl.metadata (81 kB)
```


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
