### PR TITLE
Add weekly cron job for running slow docker tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -277,9 +277,8 @@ jobs:
         run: |
           pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} --durations=30 \
             tests/pyfunc --ignore tests/pyfunc/test_spark_connect.py \
-            --ignore tests/pyfunc/docker/test_docker_flavors.py
 
-          # test_spark_connect.py fails if it's run with ohter tests, so run it separately.
+          # test_spark_connect.py fails if it's run with other tests, so run it separately.
           pytest tests/pyfunc/test_spark_connect.py
 
   sagemaker:

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -2,6 +2,11 @@
 name: MLflow Slow Tests
 
 on:
+  pull_request:
+    paths:
+      # Run this workflow in PR when relevant files change
+      - 'slow-tests.yml'
+      - 'tests/pyfunc/docker/test_docker.py'
   workflow_dispatch:
     inputs:
       repository:

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
     paths:
       # Run this workflow in PR when relevant files change
-      - '.github/workflows/slow-tests.yml'
-      - 'tests/pyfunc/docker/test_docker.py'
+      - ".github/workflows/slow-tests.yml"
+      - "tests/pyfunc/docker/test_docker.py"
   workflow_dispatch:
     inputs:
       repository:
@@ -46,7 +46,7 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    if: (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       # Run this workflow in PR when relevant files change
-      - 'slow-tests.yml'
+      - '.github/workflows/slow-tests.yml'
       - 'tests/pyfunc/docker/test_docker.py'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -51,6 +51,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/untracked
       - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-pyenv

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -60,6 +60,7 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           source ./dev/install-common-deps.sh --ml
+          python -m pip install langchain_experimental
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -1,0 +1,62 @@
+# A daily job to run slow tests with MLFLOW_RUN_SLOW_TESTS environment variable set to true.
+name: MLflow Slow Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: >
+          [Optional] Repository name with owner. For example, mlflow/mlflow.
+           Defaults to the repository that triggered a workflow.
+        required: false
+        default: ""
+      ref:
+        description: >
+          [Optional] The branch, tag or SHA to checkout. When checking out the repository that
+           triggered a workflow, this defaults to the reference or SHA for that event. Otherwise,
+           uses the default branch.
+        required: false
+        default: ""
+  schedule:
+    # Run this workflow daily at 13:00 UTC
+    - cron: "0 13 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -exo pipefail {0}
+
+env:
+  MLFLOW_RUN_SLOW_TESTS: "true"
+  MLFLOW_HOME: /home/runner/work/mlflow/mlflow
+  PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    if: (github.event_name == 'schedule' && github.repository == 'mlflow-automation/mlflow') || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          source ./dev/install-common-deps.sh --ml
+      - uses: ./.github/actions/pipdeptree
+      - name: Run tests
+        run: |
+          source .venv/bin/activate
+          pytest tests/pyfunc/docker

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -525,3 +525,7 @@ MLFLOW_CONFIGURE_LOGGING = _BooleanEnvironmentVariable("MLFLOW_LOGGING_CONFIGURE
 #: length.
 #: (default: ``True``)
 MLFLOW_TRUNCATE_LONG_VALUES = _BooleanEnvironmentVariable("MLFLOW_TRUNCATE_LONG_VALUES", True)
+
+# Whether to run slow tests with pytest. Default to False in normal runs,
+# but set to True in the weekly slow test jobs.
+MLFLOW_RUN_SLOW_TESTS = _BooleanEnvironmentVariable("MLFLOW_RUN_SLOW_TESTS", False)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -528,4 +528,4 @@ MLFLOW_TRUNCATE_LONG_VALUES = _BooleanEnvironmentVariable("MLFLOW_TRUNCATE_LONG_
 
 # Whether to run slow tests with pytest. Default to False in normal runs,
 # but set to True in the weekly slow test jobs.
-MLFLOW_RUN_SLOW_TESTS = _BooleanEnvironmentVariable("MLFLOW_RUN_SLOW_TESTS", False)
+_MLFLOW_RUN_SLOW_TESTS = _BooleanEnvironmentVariable("MLFLOW_RUN_SLOW_TESTS", False)

--- a/tests/pyfunc/docker/conftest.py
+++ b/tests/pyfunc/docker/conftest.py
@@ -1,4 +1,6 @@
+import logging
 import os
+import subprocess
 from functools import lru_cache
 
 import pytest
@@ -14,9 +16,11 @@ RESOURCE_DIR = os.path.join(MLFLOW_ROOT, "tests", "resources", "dockerfile")
 
 docker_client = docker.from_env()
 
+_logger = logging.getLogger(__name__)
+
 
 @pytest.fixture(autouse=True)
-def clean_up_docker_image():
+def clean_up_docker():
     yield
 
     # Get all containers using the test image
@@ -29,6 +33,12 @@ def clean_up_docker_image():
         docker_client.images.remove(TEST_IMAGE_NAME, force=True)
     except docker.errors.ImageNotFound:
         pass
+
+    # Clean up the build cache and volumes
+    try:
+        subprocess.run(["docker", "builder", "prune", "-a", "-f"], check=True)
+    except subprocess.CalledProcessError as e:
+        _logger.warning("Failed to clean up docker system: %s", e)
 
 
 @lru_cache(maxsize=1)

--- a/tests/pyfunc/docker/conftest.py
+++ b/tests/pyfunc/docker/conftest.py
@@ -17,6 +17,8 @@ docker_client = docker.from_env()
 
 @pytest.fixture(autouse=True)
 def clean_up_docker_image():
+    yield
+
     # Get all containers using the test image
     containers = docker_client.containers.list(filters={"ancestor": TEST_IMAGE_NAME})
     for container in containers:

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -45,7 +45,7 @@ if _MLFLOW_RUN_SLOW_TESTS.get():
     from tests.prophet.test_prophet_model_export import (
         prophet_model as prophet_raw_model,  # noqa: F401
     )
-    from tests.pyfunc.docker.conftest import (  # noqa: F401
+    from tests.pyfunc.docker.conftest import (
         MLFLOW_ROOT,
         TEST_IMAGE_NAME,
         docker_client,

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -19,11 +19,11 @@ import pytest
 import requests
 
 import mlflow
-from mlflow.environment_variables import MLFLOW_RUN_SLOW_TESTS
+from mlflow.environment_variables import _MLFLOW_RUN_SLOW_TESTS
 from mlflow.models.flavor_backend_registry import get_flavor_backend
 
 # Only import model fixtures if when MLFLOW_RUN_SLOW_TESTS environment variable is set to true
-if MLFLOW_RUN_SLOW_TESTS.get():
+if _MLFLOW_RUN_SLOW_TESTS.get():
     from tests.catboost.test_catboost_model_export import reg_model  # noqa: F401
     from tests.diviner.test_diviner_model_export import (  # noqa: F401
         diviner_data,
@@ -61,7 +61,7 @@ if MLFLOW_RUN_SLOW_TESTS.get():
     from tests.transformers.helper import load_small_qa_pipeline, load_small_seq2seq_pipeline
 
 @pytest.mark.skipif(
-    not MLFLOW_RUN_SLOW_TESTS.get(),
+    not _MLFLOW_RUN_SLOW_TESTS.get(),
     reason="Skip slow tests. Set MLFLOW_RUN_SLOW_TESTS environment variable to run them.",
 )
 @pytest.mark.parametrize(

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -11,6 +11,7 @@ To run this test, run the following command manually
 
 import json
 import os
+import shutil
 import time
 from operator import itemgetter
 
@@ -60,10 +61,26 @@ if _MLFLOW_RUN_SLOW_TESTS.get():
     from tests.tensorflow.test_tensorflow2_core_model_export import tf2_toy_model  # noqa: F401
     from tests.transformers.helper import load_small_qa_pipeline, load_small_seq2seq_pipeline
 
-@pytest.mark.skipif(
+
+pytestmark = pytest.mark.skipif(
     not _MLFLOW_RUN_SLOW_TESTS.get(),
     reason="Skip slow tests. Set MLFLOW_RUN_SLOW_TESTS environment variable to run them.",
 )
+
+
+@pytest.fixture
+def model_path(tmp_path):
+    model_path = tmp_path.joinpath("model")
+
+    yield model_path
+
+    # Pytest keeps the temporary directory created by `tmp_path` fixture for 3 recent test sessions
+    # by default. This is useful for debugging during local testing, but in CI it just wastes the
+    # disk space.
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        shutil.rmtree(model_path, ignore_errors=True)
+
+
 @pytest.mark.parametrize(
     ("flavor"),
     [
@@ -142,8 +159,7 @@ def test_build_image_and_serve(flavor, request):
 
 
 @pytest.fixture
-def catboost_model(tmp_path, reg_model):
-    model_path = str(tmp_path / "catboost_model")
+def catboost_model(model_path, reg_model):
     save_model_with_latest_mlflow_version(
         flavor="catboost",
         cb_model=reg_model.model,
@@ -154,9 +170,7 @@ def catboost_model(tmp_path, reg_model):
 
 
 @pytest.fixture
-def diviner_model(tmp_path, grouped_prophet, diviner_groups):
-    model_path = str(tmp_path / "diviner_model")
-
+def diviner_model(model_path, grouped_prophet, diviner_groups):
     save_model_with_latest_mlflow_version(
         flavor="diviner",
         diviner_model=grouped_prophet,
@@ -169,8 +183,7 @@ def diviner_model(tmp_path, grouped_prophet, diviner_groups):
 
 
 @pytest.fixture
-def fastai_model(tmp_path, fastai_model_raw):
-    model_path = str(tmp_path / "fastai_model")
+def fastai_model(model_path, fastai_model_raw):
     save_model_with_latest_mlflow_version(
         flavor="fastai",
         fastai_learner=fastai_model_raw.model,
@@ -181,8 +194,7 @@ def fastai_model(tmp_path, fastai_model_raw):
 
 
 @pytest.fixture
-def h2o_model(tmp_path, h2o_iris_model):
-    model_path = str(tmp_path / "h2o_model")
+def h2o_model(model_path, h2o_iris_model):
     save_model_with_latest_mlflow_version(
         flavor="h2o",
         h2o_model=h2o_iris_model.model,
@@ -193,12 +205,10 @@ def h2o_model(tmp_path, h2o_iris_model):
 
 
 @pytest.fixture
-def keras_model(tmp_path, iris_data):
+def keras_model(model_path, iris_data):
     from sklearn import datasets
     from tensorflow.keras.layers import Dense
     from tensorflow.keras.models import Sequential
-
-    model_path = str(tmp_path / "keras_model")
 
     model = Sequential()
     model.add(Dense(3, input_dim=4))
@@ -215,11 +225,10 @@ def keras_model(tmp_path, iris_data):
 
 
 @pytest.fixture
-def langchain_model(tmp_path):
+def langchain_model(model_path):
     from langchain.schema.runnable import RunnablePassthrough
 
     chain = RunnablePassthrough() | itemgetter("messages")
-    model_path = str(tmp_path / "langchain_model")
     save_model_with_latest_mlflow_version(
         flavor="langchain", lc_model=chain, path=model_path, input_example={"messages": "Hi"}
     )
@@ -227,8 +236,7 @@ def langchain_model(tmp_path):
 
 
 @pytest.fixture
-def lightgbm_model(tmp_path, lgb_model):
-    model_path = str(tmp_path / "lightgbm_model")
+def lightgbm_model(model_path, lgb_model):
     save_model_with_latest_mlflow_version(
         flavor="lightgbm",
         lgb_model=lgb_model.model,
@@ -239,7 +247,7 @@ def lightgbm_model(tmp_path, lgb_model):
 
 
 @pytest.fixture
-def onnx_model(tmp_path):
+def onnx_model(tmp_path, model_path):
     import numpy as np
     import onnx
     import torch
@@ -267,8 +275,7 @@ def onnx_model(tmp_path):
 
 
 @pytest.fixture
-def paddle_model(tmp_path, pd_model):
-    model_path = str(tmp_path / "paddle_model")
+def paddle_model(model_path, pd_model):
     save_model_with_latest_mlflow_version(
         flavor="paddle",
         pd_model=pd_model.model,
@@ -279,8 +286,7 @@ def paddle_model(tmp_path, pd_model):
 
 
 @pytest.fixture
-def pmdarima_model(tmp_path, auto_arima_object_model):
-    model_path = str(tmp_path / "pmdarima_model")
+def pmdarima_model(model_path, auto_arima_object_model):
     save_model_with_latest_mlflow_version(
         flavor="pmdarima",
         pmdarima_model=auto_arima_object_model,
@@ -291,8 +297,7 @@ def pmdarima_model(tmp_path, auto_arima_object_model):
 
 
 @pytest.fixture
-def prophet_model(tmp_path, prophet_raw_model):
-    model_path = str(tmp_path / "prophet_model")
+def prophet_model(model_path, prophet_raw_model):
     save_model_with_latest_mlflow_version(
         flavor="prophet",
         pr_model=prophet_raw_model.model,
@@ -303,7 +308,7 @@ def prophet_model(tmp_path, prophet_raw_model):
 
 
 @pytest.fixture
-def pyfunc_model(tmp_path):
+def pyfunc_model(model_path):
     class CustomModel(mlflow.pyfunc.PythonModel):
         def __init__(self):
             pass
@@ -311,7 +316,6 @@ def pyfunc_model(tmp_path):
         def predict(self, context, model_input):
             return model_input
 
-    model_path = str(tmp_path / "pyfunc_model")
     save_model_with_latest_mlflow_version(
         flavor="pyfunc",
         python_model=CustomModel(),
@@ -322,11 +326,10 @@ def pyfunc_model(tmp_path):
 
 
 @pytest.fixture
-def pytorch_model(tmp_path):
+def pytorch_model(model_path):
     from torch import nn, randn
 
     model = nn.Sequential(nn.Linear(4, 3), nn.ReLU(), nn.Linear(3, 1))
-    model_path = str(tmp_path / "pytorch_model")
     save_model_with_latest_mlflow_version(
         flavor="pytorch",
         pytorch_model=model,
@@ -337,8 +340,7 @@ def pytorch_model(tmp_path):
 
 
 @pytest.fixture
-def sklearn_model(tmp_path, sklearn_knn_model, iris_data):
-    model_path = str(tmp_path / "sklearn_model")
+def sklearn_model(model_path, sklearn_knn_model, iris_data):
     save_model_with_latest_mlflow_version(
         flavor="sklearn",
         sk_model=sklearn_knn_model,
@@ -349,8 +351,7 @@ def sklearn_model(tmp_path, sklearn_knn_model, iris_data):
 
 
 @pytest.fixture
-def spacy_model(tmp_path, spacy_model_with_data):
-    model_path = str(tmp_path / "spacy_model")
+def spacy_model(model_path, spacy_model_with_data):
     save_model_with_latest_mlflow_version(
         flavor="spacy",
         spacy_model=spacy_model_with_data.model,
@@ -361,8 +362,7 @@ def spacy_model(tmp_path, spacy_model_with_data):
 
 
 @pytest.fixture
-def spark_model(tmp_path, spark_model_iris):
-    model_path = str(tmp_path / "spark_model")
+def spark_model(model_path, spark_model_iris):
     save_model_with_latest_mlflow_version(
         flavor="spark",
         spark_model=spark_model_iris.model,
@@ -373,9 +373,8 @@ def spark_model(tmp_path, spark_model_iris):
 
 
 @pytest.fixture
-def statsmodels_model(tmp_path):
+def statsmodels_model(model_path):
     model = ols_model()
-    model_path = str(tmp_path / "statsmodels_model")
     save_model_with_latest_mlflow_version(
         flavor="statsmodels",
         statsmodels_model=model.model,
@@ -386,8 +385,7 @@ def statsmodels_model(tmp_path):
 
 
 @pytest.fixture
-def tensorflow_model(tmp_path, tf2_toy_model):
-    model_path = str(tmp_path / "tensorflow_model")
+def tensorflow_model(model_path, tf2_toy_model):
     save_model_with_latest_mlflow_version(
         flavor="tensorflow",
         model=tf2_toy_model.model,
@@ -398,9 +396,8 @@ def tensorflow_model(tmp_path, tf2_toy_model):
 
 
 @pytest.fixture
-def transformers_pt_model(tmp_path):
+def transformers_pt_model(model_path):
     pipeline = load_small_seq2seq_pipeline()
-    model_path = str(tmp_path / "transformers_model")
     save_model_with_latest_mlflow_version(
         flavor="transformers",
         transformers_model=pipeline,
@@ -411,9 +408,8 @@ def transformers_pt_model(tmp_path):
 
 
 @pytest.fixture
-def transformers_tf_model(tmp_path):
+def transformers_tf_model(model_path):
     pipeline = load_small_qa_pipeline()
-    model_path = str(tmp_path / "transformers_model")
     save_model_with_latest_mlflow_version(
         flavor="transformers",
         transformers_model=pipeline,

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -110,7 +110,7 @@ def model_path(tmp_path):
     ],
 )
 def test_build_image_and_serve(flavor, request):
-    model_path = request.getfixturevalue(f"{flavor}_model")
+    model_path = str(request.getfixturevalue(f"{flavor}_model"))
     flavor = flavor.split("_")[0]  # Remove _pt or _tf from the flavor name
 
     # Build an image

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -19,44 +19,51 @@ import pytest
 import requests
 
 import mlflow
+from mlflow.environment_variables import MLFLOW_RUN_SLOW_TESTS
 from mlflow.models.flavor_backend_registry import get_flavor_backend
 
-from tests.catboost.test_catboost_model_export import reg_model  # noqa: F401
-from tests.diviner.test_diviner_model_export import (  # noqa: F401
-    diviner_data,
-    diviner_groups,
-    grouped_prophet,
-)
-from tests.fastai.test_fastai_model_export import fastai_model as fastai_model_raw  # noqa: F401
-from tests.h2o.test_h2o_model_export import h2o_iris_model  # noqa: F401
-from tests.helper_functions import get_safe_port
-from tests.langchain.test_langchain_model_export import fake_chat_model  # noqa: F401
-from tests.lightgbm.test_lightgbm_model_export import lgb_model  # noqa: F401
-from tests.models.test_model import iris_data, sklearn_knn_model  # noqa: F401
-from tests.paddle.test_paddle_model_export import pd_model  # noqa: F401
-from tests.pmdarima.test_pmdarima_model_export import (  # noqa: F401
-    auto_arima_object_model,
-    test_data,
-)
-from tests.prophet.test_prophet_model_export import prophet_model as prophet_raw_model  # noqa: F401
-from tests.pyfunc.docker.conftest import (
-    MLFLOW_ROOT,
-    TEST_IMAGE_NAME,
-    docker_client,
-    save_model_with_latest_mlflow_version,
-)
-from tests.spacy.test_spacy_model_export import spacy_model_with_data  # noqa: F401
-from tests.spark.test_spark_model_export import (  # noqa: F401
-    iris_df,
-    spark,
-    spark_model_iris,
-)
-from tests.statsmodels.model_fixtures import ols_model
-from tests.tensorflow.test_tensorflow2_core_model_export import tf2_toy_model  # noqa: F401
-from tests.transformers.helper import load_small_qa_pipeline, load_small_seq2seq_pipeline
+# Only import model fixtures if when MLFLOW_RUN_SLOW_TESTS environment variable is set to true
+if MLFLOW_RUN_SLOW_TESTS.get():
+    from tests.catboost.test_catboost_model_export import reg_model  # noqa: F401
+    from tests.diviner.test_diviner_model_export import (  # noqa: F401
+        diviner_data,
+        diviner_groups,
+        grouped_prophet,
+    )
+    from tests.fastai.test_fastai_model_export import fastai_model as fastai_model_raw  # noqa: F401
+    from tests.h2o.test_h2o_model_export import h2o_iris_model  # noqa: F401
+    from tests.helper_functions import get_safe_port
+    from tests.langchain.test_langchain_model_export import fake_chat_model  # noqa: F401
+    from tests.lightgbm.test_lightgbm_model_export import lgb_model  # noqa: F401
+    from tests.models.test_model import iris_data, sklearn_knn_model  # noqa: F401
+    from tests.paddle.test_paddle_model_export import pd_model  # noqa: F401
+    from tests.pmdarima.test_pmdarima_model_export import (  # noqa: F401
+        auto_arima_object_model,
+        test_data,
+    )
+    from tests.prophet.test_prophet_model_export import (
+        prophet_model as prophet_raw_model,  # noqa: F401
+    )
+    from tests.pyfunc.docker.conftest import (  # noqa: F401
+        MLFLOW_ROOT,
+        TEST_IMAGE_NAME,
+        docker_client,
+        save_model_with_latest_mlflow_version,
+    )
+    from tests.spacy.test_spacy_model_export import spacy_model_with_data  # noqa: F401
+    from tests.spark.test_spark_model_export import (  # noqa: F401
+        iris_df,
+        spark,
+        spark_model_iris,
+    )
+    from tests.statsmodels.model_fixtures import ols_model
+    from tests.tensorflow.test_tensorflow2_core_model_export import tf2_toy_model  # noqa: F401
+    from tests.transformers.helper import load_small_qa_pipeline, load_small_seq2seq_pipeline
 
-
-@pytest.mark.skipif(os.getenv("GITHUB_ACTIONS") == "true", reason="Time consuming tests")
+@pytest.mark.skipif(
+    not MLFLOW_RUN_SLOW_TESTS.get(),
+    reason="Skip slow tests. Set MLFLOW_RUN_SLOW_TESTS environment variable to run them.",
+)
 @pytest.mark.parametrize(
     ("flavor"),
     [


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11004?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11004/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11004
```

</p>
</details>

### Related Issues/PRs

Follow-up for #10954

### What changes are proposed in this pull request?

Scheduling a weekly cron job for testing docker image building and querying with flavors.

**Note**
Using environment variable `MLFLOW_RUN_SLOW_TESTS` to control whether or not to run slow tests, instead of pytest CLI option. The latter is a bit tricky when we want to use the flag outside the test functions scope. For example, in `test_docker_flavors`, we have many import statements for accessing fixtures defined in other files. We don't want to import them when the tests are skipped, but we can't lazily import it inside test functions, because pytest fixture visibility is determined before running tests. Hence we have to check whether or not to run slow tests in global scope, which is trickly to do with pytest CLI option.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

**Question**: I tested the functionality of skipping slow tests via env var, but don't know how to test the new workflow. Is there any good way to test Github action before merging the PR?

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
