### PR TITLE
Add _unity_catalog back to mlflow.store namespace

### DIFF
--- a/mlflow/store/__init__.py
+++ b/mlflow/store/__init__.py
@@ -1,3 +1,4 @@
+import mlflow.store._unity_catalog  # noqa: F401
 from mlflow.store.artifact import artifact_repo
 from mlflow.store.tracking import abstract_store
 

--- a/mlflow/store/__init__.py
+++ b/mlflow/store/__init__.py
@@ -1,4 +1,4 @@
-import mlflow.store._unity_catalog  # noqa: F401
+from mlflow.store import _unity_catalog  # noqa: F401
 from mlflow.store.artifact import artifact_repo
 from mlflow.store.tracking import abstract_store
 

--- a/mlflow/store/_unity_catalog/__init__.py
+++ b/mlflow/store/_unity_catalog/__init__.py
@@ -1,0 +1,1 @@
+from mlflow.store._unity_catalog import registry  # noqa: F401

--- a/mlflow/store/_unity_catalog/registry/__init__.py
+++ b/mlflow/store/_unity_catalog/registry/__init__.py
@@ -1,0 +1,3 @@
+from mlflow.store._unity_catalog.registry.rest_store import (
+    get_feature_dependencies,  # noqa: F401
+)

--- a/mlflow/store/_unity_catalog/registry/__init__.py
+++ b/mlflow/store/_unity_catalog/registry/__init__.py
@@ -1,3 +1,1 @@
-from mlflow.store._unity_catalog.registry.rest_store import (
-    get_feature_dependencies,  # noqa: F401
-)
+from mlflow.store._unity_catalog.registry import rest_store  # noqa: F401

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -6,7 +6,6 @@ import shutil
 from contextlib import contextmanager
 
 import mlflow
-from mlflow.data.delta_dataset_source import DeltaDatasetSource
 from mlflow.entities import Run
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_uc_registry_messages_pb2 import (
@@ -462,6 +461,8 @@ class UcModelRegistryStore(BaseRestStore):
         return run.data.tags.get(MLFLOW_DATABRICKS_JOB_RUN_ID, None)
 
     def _get_lineage_input_sources(self, run):
+        from mlflow.data.delta_dataset_source import DeltaDatasetSource
+
         if run is None:
             return None
         securable_list = []

--- a/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
+++ b/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
@@ -271,7 +271,7 @@ def test_uc_models_artifact_repo_list_artifacts_uses_temporary_creds():
         )
 
 
-def test_get_feature_dependencies():
+def test_get_feature_dependencies_doesnt_throw():
     import mlflow
 
     class MyModel(mlflow.pyfunc.PythonModel):

--- a/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
+++ b/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
@@ -269,3 +269,21 @@ def test_uc_models_artifact_repo_list_artifacts_uses_temporary_creds():
             method="POST",
             json={"name": "MyModel", "version": "12", "operation": "MODEL_VERSION_OPERATION_READ"},
         )
+
+
+def test_get_feature_dependencies():
+    import mlflow
+
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input):
+            return model_input
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(artifact_path="model", python_model=MyModel())
+
+    assert (
+        mlflow.store._unity_catalog.registry.rest_store.get_feature_dependencies(
+            model_info.model_uri
+        )
+        == ""
+    )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11006?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11006/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11006
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This is a weird one. It looks like the removal of the `mlflow.store._unity_catalog` [import in this PR](https://github.com/mlflow/mlflow/pull/10796/files#diff-a6cf2ed01732ba770f75a494aae9a06140868dfa11a859f89227783616eb138fL9-L12) caused `_unity_catalog` to be unimportable from `mlflow.store`, which is causing a test failure.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
