### PR TITLE
Add support for listing artifacts within the `mlflow.artifacts` API

### DIFF
--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -26,6 +26,23 @@ def run_with_artifact(tmp_path):
     return (run, artifact_path, artifact_content)
 
 
+@pytest.fixture
+def run_with_artifacts(tmp_path):
+    artifact_path = "test"
+    artifact_content = "content"
+
+    local_dir = tmp_path / "dir"
+    local_dir.mkdir()
+    local_dir.joinpath("file.txt").write_text(artifact_content)
+    local_dir.joinpath("subdir").mkdir()
+    local_dir.joinpath("subdir").joinpath("text.txt").write_text(artifact_content)
+
+    with mlflow.start_run() as run:
+        mlflow.log_artifact(local_dir, artifact_path)
+
+    return (run, artifact_path)
+
+
 def test_download_artifacts_with_uri(run_with_artifact):
     run, artifact_path, artifact_content = run_with_artifact
     run_uri = f"runs:/{run.info.run_id}/{artifact_path}"
@@ -247,3 +264,51 @@ def test_log_artifact_windows_path_with_hostname(text_artifact):
                 rf"{experiment_test_1_artifact_location}\{run.info.run_id}"
                 rf"\artifacts\{text_artifact.artifact_name}" == local_path
             )
+
+
+def test_list_artifacts_with_artifact_uri(run_with_artifacts):
+    run, artifact_path = run_with_artifacts
+    run_uri = f"runs:/{run.info.run_id}/{artifact_path}"
+    actual_uri = str(pathlib.PurePosixPath(run.info.artifact_uri) / artifact_path)
+    for uri in (run_uri, actual_uri):
+        artifacts = mlflow.artifacts.list_artifacts(artifact_uri=uri)
+        assert len(artifacts) == 1
+        assert artifacts[0].path == f"{artifact_path}/dir"
+
+        artifacts = mlflow.artifacts.list_artifacts(artifact_uri=f"{uri}/dir")
+        assert len(artifacts) == 2
+        assert artifacts[0].path == "dir/file.txt"
+        assert artifacts[1].path == "dir/subdir"
+
+        artifacts = mlflow.artifacts.list_artifacts(artifact_uri=f"{uri}/dir/subdir")
+        assert len(artifacts) == 1
+        assert artifacts[0].path == "subdir/text.txt"
+
+        artifacts = mlflow.artifacts.list_artifacts(artifact_uri=f"{uri}/non-exist-path")
+        assert len(artifacts) == 0
+
+
+def test_list_artifacts_with_run_id(run_with_artifacts):
+    run, artifact_path = run_with_artifacts
+    artifacts = mlflow.artifacts.list_artifacts(run_id=run.info.run_id)
+    assert len(artifacts) == 1
+    assert artifacts[0].path == artifact_path
+
+    artifacts = mlflow.artifacts.list_artifacts(run_id=run.info.run_id, artifact_path=artifact_path)
+    assert len(artifacts) == 1
+    assert artifacts[0].path == f"{artifact_path}/dir"
+
+
+def test_list_artifacts_throws_for_invalid_arguments():
+    with pytest.raises(MlflowException, match="Exactly one of"):
+        mlflow.artifacts.list_artifacts(
+            artifact_uri="uri",
+            run_id="run_id",
+            artifact_path="path",
+        )
+
+    with pytest.raises(MlflowException, match="Exactly one of"):
+        mlflow.artifacts.list_artifacts()
+
+    with pytest.raises(MlflowException, match="`artifact_path` cannot be specified"):
+        mlflow.artifacts.list_artifacts(artifact_uri="uri", artifact_path="path")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/11008?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11008/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11008
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Add `mlflow.artifacts.list_artifacts` API for easier listing artifacts

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Tested UC: https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/2531914303105515/command/2531914303105632

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
