### PR TITLE
Fix non-idempotent prediction due to in-place update to model-config

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1851,7 +1851,7 @@ def generate_signature_output(pipeline, data, model_config=None, params=None, fl
         flavor_config=flavor_config,
         model_config=model_config,
     )
-    pyfunc_model.predict(data, params=params)
+    return pyfunc_model.predict(data, params=params)
 
 
 class _TransformersWrapper:

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -15,6 +15,7 @@ import shutil
 import string
 import sys
 from functools import lru_cache
+from types import MappingProxyType
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
 from urllib.parse import urlparse
 
@@ -572,7 +573,10 @@ def save_model(
         # from the input_example if provided, otherwise, apply a generic signature.
         if mlflow_model.signature is None:
             mlflow_model.signature = _get_default_pipeline_signature(
-                built_pipeline, input_example, model_config or inference_config
+                pipeline=built_pipeline,
+                example=input_example,
+                model_config=model_config or inference_config,
+                flavor_config=flavor_conf,
             )
 
         # if pipeline is text-generation and a prompt template is specified,
@@ -1554,7 +1558,9 @@ def _format_input_example_for_special_cases(input_example, pipeline):
     return input_data if not isinstance(input_example, tuple) else (input_data, input_example[1])
 
 
-def _get_default_pipeline_signature(pipeline, example=None, model_config=None) -> ModelSignature:
+def _get_default_pipeline_signature(
+    pipeline, example=None, model_config=None, flavor_config=None
+) -> ModelSignature:
     """
     Assigns a default ModelSignature for a given Pipeline type that has pyfunc support. These
     default signatures should only be generated and assigned when saving a model iff the user
@@ -1571,7 +1577,13 @@ def _get_default_pipeline_signature(pipeline, example=None, model_config=None) -
             if _contains_params(example):
                 example, params = example
             example = _format_input_example_for_special_cases(example, pipeline)
-            prediction = generate_signature_output(pipeline, example, model_config, params)
+            prediction = generate_signature_output(
+                pipeline=pipeline,
+                data=example,
+                model_config=model_config,
+                params=params,
+                flavor_config=flavor_config,
+            )
             return infer_signature(example, prediction, params)
         except Exception as e:
             _logger.warning(
@@ -1807,7 +1819,7 @@ def _load_pyfunc(path, model_config: Optional[Dict[str, Any]] = None):
 
 
 @experimental
-def generate_signature_output(pipeline, data, model_config=None, params=None):
+def generate_signature_output(pipeline, data, model_config=None, params=None, flavor_config=None):
     """
     Utility for generating the response output for the purposes of extracting an output signature
     for model saving and logging. This function simulates loading of a saved model or pipeline
@@ -1820,6 +1832,7 @@ def generate_signature_output(pipeline, data, model_config=None, params=None):
         model_config: Any additional model configuration, provided as kwargs, to inform
             the format of the output type from a pipeline inference call.
         params: A dictionary of additional parameters to pass to the pipeline for inference.
+        flavor_config: The flavor configuration for the model.
 
     Returns:
         The output from the ``pyfunc`` pipeline wrapper's ``predict`` method
@@ -1833,16 +1846,24 @@ def generate_signature_output(pipeline, data, model_config=None, params=None):
             error_code=INVALID_PARAMETER_VALUE,
         )
 
-    return _TransformersWrapper(pipeline=pipeline, model_config=model_config).predict(
-        data, params=params
+    pyfunc_model = _TransformersWrapper(
+        pipeline=pipeline,
+        flavor_config=flavor_config,
+        model_config=model_config,
     )
+    pyfunc_model.predict(data, params=params)
 
 
 class _TransformersWrapper:
     def __init__(self, pipeline, flavor_config=None, model_config=None, prompt_template=None):
         self.pipeline = pipeline
         self.flavor_config = flavor_config
-        self.model_config = model_config or {}
+        # The predict method updates the model_config several times. This should be done over a
+        # deep copy of the original model_config that was specified by the user, otherwise the
+        # prediction won't be idempotent. Hence we creates an immutable dictionary of the original
+        # model config here and enforce creating a deep copy at every predict call.
+        self.model_config = MappingProxyType(model_config or {})
+
         self.prompt_template = prompt_template
         self._conversation = None
         # NB: Current special-case custom pipeline types that have not been added to
@@ -1883,21 +1904,21 @@ class _TransformersWrapper:
                     )
             return parsed
 
-    def _override_model_config(self, params):
+    def _merge_model_config_with_params(self, model_config, params):
         if params:
             _logger.warning(
                 "params provided to the `predict` method will override the inference "
                 "configuration saved with the model. If the params provided are not "
                 "valid for the pipeline, MlflowException will be raised."
             )
-
             # Override the inference configuration with any additional kwargs provided by the user.
-            self.model_config.update(params)
+            return {**model_config, **params}
+        else:
+            return model_config
 
-    def _validate_model_config_and_return_output(self, data, return_tensors=False):
+    def _validate_model_config_and_return_output(self, data, model_config, return_tensors=False):
         import transformers
 
-        model_config = copy.deepcopy(self.model_config)
         if return_tensors:
             model_config["return_tensors"] = True
 
@@ -1943,7 +1964,12 @@ class _TransformersWrapper:
         Returns:
             Model predictions.
         """
-        self._override_model_config(params)
+        # NB: This `predict` method updates the model_config several times. To make the predict
+        # call idempotent, we keep the original self.model_config immutable and creates a deep
+        # copy of it at every predict call.
+        model_config = copy.deepcopy(dict(self.model_config))
+
+        model_config = self._merge_model_config_with_params(model_config, params)
 
         if isinstance(data, pd.DataFrame):
             input_data = self._convert_pandas_to_dict(data)
@@ -1975,10 +2001,9 @@ class _TransformersWrapper:
                 _validate_input_dictionary_contains_only_strings_and_lists_of_strings(x)
                 for x in input_data
             )
+        return self._predict(input_data, model_config)
 
-        return self._predict(input_data)
-
-    def _predict(self, data):
+    def _predict(self, data, model_config):
         import transformers
 
         # NB: the ordering of these conditional statements matters. TranslationPipeline and
@@ -2032,7 +2057,7 @@ class _TransformersWrapper:
             self._validate_str_or_list_str(data)
             output_key = "generated_text"
         elif isinstance(self.pipeline, transformers.AutomaticSpeechRecognitionPipeline):
-            if self.model_config.get("return_timestamps", None) in ["word", "char"]:
+            if model_config.get("return_timestamps", None) in ["word", "char"]:
                 output_key = None
             else:
                 output_key = "text"
@@ -2051,9 +2076,9 @@ class _TransformersWrapper:
         # formatting output), but if `include_prompt` is set to False in the `model_config`
         # option during model saving, excess newline characters and the fed-in prompt will be
         # trimmed out from the start of the response.
-        include_prompt = self.model_config.pop("include_prompt", True)
+        include_prompt = model_config.pop("include_prompt", True)
         # Optional stripping out of `\n` for specific generator pipelines.
-        collapse_whitespace = self.model_config.pop("collapse_whitespace", False)
+        collapse_whitespace = model_config.pop("collapse_whitespace", False)
 
         data = self._convert_cast_lists_from_np_back_to_list(data)
 
@@ -2069,7 +2094,7 @@ class _TransformersWrapper:
                 output_key = "generated_token_ids"
 
             raw_output = self._validate_model_config_and_return_output(
-                data, return_tensors=return_tensors
+                data, model_config=model_config, return_tensors=return_tensors
             )
 
         # Handle the pipeline outputs
@@ -2087,7 +2112,7 @@ class _TransformersWrapper:
 
             if self.llm_inference_task:
                 output = postprocess_output_for_llm_inference_task(
-                    data, output, self.pipeline, self.model_config, self.llm_inference_task
+                    data, output, self.pipeline, model_config, self.llm_inference_task
                 )
 
         elif isinstance(self.pipeline, transformers.FeatureExtractionPipeline):
@@ -2100,7 +2125,7 @@ class _TransformersWrapper:
             output = self._parse_tokenizer_output(raw_output, output_key)
         elif isinstance(
             self.pipeline, transformers.AutomaticSpeechRecognitionPipeline
-        ) and self.model_config.get("return_timestamps", None) in ["word", "char"]:
+        ) and model_config.get("return_timestamps", None) in ["word", "char"]:
             output = json.dumps(raw_output)
         elif isinstance(
             self.pipeline,

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3965,3 +3965,25 @@ def test_text_generation_task_completions_serve(text_generation_pipeline):
     assert output_dict["text"] is not None
     assert output_dict["finish_reason"] == "stop"
     assert output_dict["usage"]["prompt_tokens"] < 20
+
+
+def test_model_config_is_not_mutated_after_prediction(text2text_generation_pipeline):
+    model_config = {
+        "top_k": 2,
+        "num_beams": 5,
+        "max_length": 30,
+    }
+    # Params will be used to override the values of model_config but should not mutate it
+    params = {
+        "top_k": 3,
+        "max_length": 50,
+    }
+
+    pyfunc_model = _TransformersWrapper(text2text_generation_pipeline, model_config=model_config)
+    assert pyfunc_model.model_config["top_k"] == 2
+
+    pyfunc_model.predict("How to learn Python in 3 weeks?", params=params)
+
+    assert pyfunc_model.model_config["top_k"] == 2
+    assert pyfunc_model.model_config["num_beams"] == 5
+    assert pyfunc_model.model_config["max_length"] == 30

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3972,18 +3972,24 @@ def test_model_config_is_not_mutated_after_prediction(text2text_generation_pipel
         "top_k": 2,
         "num_beams": 5,
         "max_length": 30,
+        "max_new_tokens": 500,
     }
     # Params will be used to override the values of model_config but should not mutate it
     params = {
-        "top_k": 3,
-        "max_length": 50,
+        "top_k": 30,
+        "max_length": 500,
+        "max_new_tokens": 5,
     }
 
     pyfunc_model = _TransformersWrapper(text2text_generation_pipeline, model_config=model_config)
     assert pyfunc_model.model_config["top_k"] == 2
 
-    pyfunc_model.predict("How to learn Python in 3 weeks?", params=params)
+    prediction_output = pyfunc_model.predict(
+        "rocket moon ship astronaut space gravity", params=params
+    )
 
     assert pyfunc_model.model_config["top_k"] == 2
     assert pyfunc_model.model_config["num_beams"] == 5
     assert pyfunc_model.model_config["max_length"] == 30
+    assert pyfunc_model.model_config["max_new_tokens"] == 500
+    assert len(prediction_output[0].split(" ")) <= 5

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3968,18 +3968,24 @@ def test_text_generation_task_completions_serve(text_generation_pipeline):
 
 
 def test_model_config_is_not_mutated_after_prediction(text2text_generation_pipeline):
+    # max_length and max_new_tokens cannot be used together in Transformers earlier than 4.27
+    validate_max_new_tokens = Version(transformers.__version__) > Version("4.26.1")
+
     model_config = {
         "top_k": 2,
         "num_beams": 5,
         "max_length": 30,
-        "max_new_tokens": 500,
     }
+    if validate_max_new_tokens:
+        model_config["max_new_tokens"] = 500
+
     # Params will be used to override the values of model_config but should not mutate it
     params = {
         "top_k": 30,
         "max_length": 500,
-        "max_new_tokens": 5,
     }
+    if validate_max_new_tokens:
+        params["max_new_tokens"] = 5
 
     pyfunc_model = _TransformersWrapper(text2text_generation_pipeline, model_config=model_config)
     assert pyfunc_model.model_config["top_k"] == 2
@@ -3991,5 +3997,6 @@ def test_model_config_is_not_mutated_after_prediction(text2text_generation_pipel
     assert pyfunc_model.model_config["top_k"] == 2
     assert pyfunc_model.model_config["num_beams"] == 5
     assert pyfunc_model.model_config["max_length"] == 30
-    assert pyfunc_model.model_config["max_new_tokens"] == 500
-    assert len(prediction_output[0].split(" ")) <= 5
+    if validate_max_new_tokens:
+        assert pyfunc_model.model_config["max_new_tokens"] == 500
+        assert len(prediction_output[0].split(" ")) <= 5


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11014?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11014/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11014
```

</p>
</details>

### What changes are proposed in this pull request?

In `predict()` method of `_TransformersWrapper`, `self.model_config` is modified in-place for a few times, e.g. (1) params overrides model config values (2) some `pop()` operations to remove our custom keys like `include_prompt` before actual pipeline inference. These updates directly change the original model config, so as a result, the next prediction uses the different model config tweaked by the first call. 

E.g. 
```
model_config = {
    "top_k": 2,
    "num_beams": 5,
    "max_length": 30,
}
    
pyfunc_model = _TransformersWrapper(text2text_generation_pipeline, model_config=model_config)
assert pyfunc_model.model_config["top_k"] == 2

# Params will be used to override the values of model_config
params = {
    "top_k": 3,
    "max_length": 50,
}
pyfunc_model.predict("How to learn Python in 3 weeks?", params=params)
    
>       assert pyfunc_model.model_config["top_k"] == 2
E       assert 3 == 2
```

This also cause another issue in model logging, where incorrect model config is saved. This is because we run sometimes multiple prediction during model saving e.g. when user specified `input_example` we generate model output to infer signature from it. Then the saved model config is the one tweaked by these predictions.

**Note**: I hit this issue while development for another issue and running `test_instructional_pipeline_no_prompt_in_output` test, which is skipped in CI (due to large model size). Other CI tests didn't catch this, because most of them specify signature manually + not giving input example so only single prediction call only in the test case. 

### How is this PR tested?
- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

We probably need to update some document to warn users for this model config issue, as we suggest users to use the option ([example](https://mlflow.org/docs/latest/llms/transformers/guide/index.html#using-model-config-and-model-signature-params-for-transformers-inference)). I can do that as a follow-up.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix idempotent prediction issue due to in-place update to model_config, which can also cause incorrect metadata to be saved.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
