### PR TITLE
Add Mistral AI as a new provider in LLM Deployment

### DIFF
--- a/docs/source/llms/deployments/index.rst
+++ b/docs/source/llms/deployments/index.rst
@@ -259,6 +259,9 @@ below can be used as a helpful guide when configuring a given endpoint for any n
 | AWS Bedrock              | - Amazon Titan           | N/A                      | N/A                      |
 |                          | - Third-party providers  |                          |                          |
 +--------------------------+--------------------------+--------------------------+--------------------------+
+| Mistral                  | - mistral-tiny           | N/A                      |  - mistral-embed         |
+|                          | - mistral-small          |                          |                          |
++--------------------------+--------------------------+--------------------------+--------------------------+
 
 
 † Llama 2 is licensed under the `LLAMA 2 Community License <https://ai.meta.com/llama/license/>`_, Copyright © Meta Platforms, Inc. All Rights Reserved.
@@ -303,6 +306,7 @@ As of now, the MLflow Deployments Server supports the following providers:
 * **huggingface text generation inference**: This is used for models deployed using `Huggingface Text Generation Inference <https://huggingface.co/docs/text-generation-inference/index>`_.
 * **ai21labs**: This is used for models offered by `AI21 Labs <https://studio.ai21.com/foundation-models>`_.
 * **bedrock**: This is used for models offered by `AWS Bedrock <https://aws.amazon.com/bedrock/>`_.
+* **mistral**: This is used for models offered by `Mistral <https://docs.mistral.ai/>`_.
 
 More providers are being added continually. Check the latest version of the MLflow Deployments Server Docs for the
 most up-to-date list of supported providers.
@@ -511,6 +515,7 @@ Each endpoint has the following configuration parameters:
     - "huggingface-text-generation-inference"
     - "ai21labs"
     - "bedrock"
+    - "mistral"
 
   - **name**: This is an optional field to specify the name of the model.
   - **config**: This contains provider-specific configuration details.
@@ -680,6 +685,16 @@ To match your user's interaction and security access requirements, adjust the ``
 +----------------------------+----------+---------+-----------------------------------------------------------------------------------------------+
 | **openai_organization**    | No       |         | This is an optional field to specify the organization in OpenAI.                              |
 +----------------------------+----------+---------+-----------------------------------------------------------------------------------------------+
+
+
+Mistral
+++++++
+
++--------------------------+----------+--------------------------+-------------------------------------------------------+
+| Configuration Parameter  | Required | Default                  | Description                                           |
++==========================+==========+==========================+=======================================================+
+| **mistral_api_key**       | Yes      | N/A                      | This is the API key for the Mistral service.         |
++--------------------------+----------+--------------------------+-------------------------------------------------------+
 
 
 An example configuration for Azure OpenAI is:

--- a/docs/source/llms/deployments/index.rst
+++ b/docs/source/llms/deployments/index.rst
@@ -688,7 +688,7 @@ To match your user's interaction and security access requirements, adjust the ``
 
 
 Mistral
-++++++
++++++++
 
 +--------------------------+----------+--------------------------+-------------------------------------------------------+
 | Configuration Parameter  | Required | Default                  | Description                                           |

--- a/docs/source/llms/gateway/index.rst
+++ b/docs/source/llms/gateway/index.rst
@@ -302,6 +302,9 @@ below can be used as a helpful guide when configuring a given route for any newl
 | AWS Bedrock              | - Amazon Titan           | N/A                      | N/A                      |
 |                          | - Third-party providers  |                          |                          |
 +--------------------------+--------------------------+--------------------------+--------------------------+
+| Mistral                  | - mistral-tiny           | N/A                      |  - mistral-embed         |
+|                          | - mistral-small          |                          |                          |
++--------------------------+--------------------------+--------------------------+--------------------------+
 
 
 † Llama 2 is licensed under the `LLAMA 2 Community License <https://ai.meta.com/llama/license/>`_, Copyright © Meta Platforms, Inc. All Rights Reserved.
@@ -343,6 +346,7 @@ As of now, the MLflow AI Gateway supports the following providers:
 * **huggingface text generation inference**: This is used for models deployed using `Huggingface Text Generation Inference <https://huggingface.co/docs/text-generation-inference/index>`_.
 * **ai21labs**: This is used for models offered by `AI21 Labs <https://studio.ai21.com/foundation-models>`_.
 * **bedrock**: This is used for models offered by `AWS Bedrock <https://aws.amazon.com/bedrock/>`_.
+* **mistral**: This is used for models offered by `Mistral <https://docs.mistral.ai/>`_.
 
 More providers are being added continually. Check the latest version of the MLflow AI Gateway Docs for the
 most up-to-date list of supported providers.
@@ -540,6 +544,7 @@ Each route has the following configuration parameters:
     - "huggingface-text-generation-inference"
     - "ai21labs"
     - "bedrock"
+    - "mistral"
 
   - **name**: This is an optional field to specify the name of the model.
   - **config**: This contains provider-specific configuration details.
@@ -637,6 +642,16 @@ Top-level model configuration for AWS Bedrock routes must be one of the followin
 | **aws_config**           | No       |                              | An object with either the key-based or role-based     |
 |                          |          |                              | schema below.                                         |
 +--------------------------+----------+------------------------------+-------------------------------------------------------+
+
+
+Mistral
+++++++
+
++--------------------------+----------+--------------------------+-------------------------------------------------------+
+| Configuration Parameter  | Required | Default                  | Description                                           |
++==========================+==========+==========================+=======================================================+
+| **mistral_api_key**       | Yes      | N/A                      | This is the API key for the Mistral service.         |
++--------------------------+----------+--------------------------+-------------------------------------------------------+
 
 
 To use key-based authentication, define an AWS Bedrock route with the required fields below.

--- a/docs/source/llms/gateway/index.rst
+++ b/docs/source/llms/gateway/index.rst
@@ -645,7 +645,7 @@ Top-level model configuration for AWS Bedrock routes must be one of the followin
 
 
 Mistral
-++++++
++++++++
 
 +--------------------------+----------+--------------------------+-------------------------------------------------------+
 | Configuration Parameter  | Required | Default                  | Description                                           |

--- a/examples/deployments/deployments_server/README.md
+++ b/examples/deployments/deployments_server/README.md
@@ -47,6 +47,7 @@ For full examples of configurations and supported endpoint types, see:
 - [AI21 Labs](ai21labs/config.yaml)
 - [PaLM](palm/config.yaml)
 - [AzureOpenAI](azure_openai/config.yaml)
+- [Mistral](mistral/config.yaml)
 
 ## Step 3: Setting Access Keys
 

--- a/examples/deployments/deployments_server/mistral/README.md
+++ b/examples/deployments/deployments_server/mistral/README.md
@@ -1,0 +1,13 @@
+## Example endpoint configuration for Mistral
+
+To see an example of specifying both the completions and the embeddings endpoints for Mistral, see [the configuration](config.yaml) YAML file.
+
+This configuration file specifies two endpoints: 'completions' and 'embeddings', both using Mistral's models 'mistral-tiny' and 'mistral-embed', respectively.
+
+## Setting a Mistral API Key
+
+This example requires a [Mistral API key](https://docs.mistral.ai/):
+
+```sh
+export MISTRAL_API_KEY=...
+```

--- a/examples/deployments/deployments_server/mistral/config.yaml
+++ b/examples/deployments/deployments_server/mistral/config.yaml
@@ -1,0 +1,16 @@
+endpoints:
+  - name: completions
+    endpoint_type: llm/v1/completions
+    model:
+      provider: mistral
+      name: mistral-tiny
+      config:
+        mistral_api_key: $MISTRAL_API_KEY
+
+  - name: embeddings
+    endpoint_type: llm/v1/embeddings
+    model:
+      provider: mistral
+      name: mistral-embed
+      config:
+        mistral_api_key: $MISTRAL_API_KEY

--- a/examples/deployments/deployments_server/mistral/example.py
+++ b/examples/deployments/deployments_server/mistral/example.py
@@ -1,0 +1,34 @@
+from mlflow.deployments import get_deploy_client
+
+
+def main():
+    client = get_deploy_client("http://localhost:7000")
+
+    print(f"Mistral endpoints: {client.list_endpoints()}\n")
+    print(f"Mistral completions endpoint info: {client.get_endpoint(endpoint='completions')}\n")
+
+    # Completions request
+    response_completions = client.predict(
+        endpoint="completions",
+        inputs={
+            "prompt": "How many average size European ferrets can fit inside a standard olympic?",
+            "temperature": 0.1,
+        },
+    )
+    print(f"Mistral response for completions: {response_completions}")
+
+    # Embeddings request
+    response_embeddings = client.predict(
+        endpoint="embeddings",
+        inputs={
+            "input": [
+                "How does your culture celebrate the New Year, and how does it differ from other countries’ "
+                "celebrations?"
+            ]
+        },
+    )
+    print(f"Mistral response for embeddings: {response_embeddings}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -46,6 +46,7 @@ class Provider(str, Enum):
     # Note: The following providers are only supported on Databricks
     DATABRICKS_MODEL_SERVING = "databricks-model-serving"
     DATABRICKS = "databricks"
+    MISTRAL = "mistral"
 
     @classmethod
     def values(cls):
@@ -215,6 +216,15 @@ class AWSBedrockConfig(ConfigModel):
     aws_config: Union[AWSRole, AWSIdAndKey, AWSBaseConfig]
 
 
+class MistralConfig(ConfigModel):
+    mistral_api_key: str
+
+    # pylint: disable=no-self-argument
+    @validator("mistral_api_key", pre=True)
+    def validate_mistral_api_key(cls, value):
+        return _resolve_api_key_from_input(value)
+
+
 config_types = {
     Provider.COHERE: CohereConfig,
     Provider.OPENAI: OpenAIConfig,
@@ -225,6 +235,7 @@ config_types = {
     Provider.MLFLOW_MODEL_SERVING: MlflowModelServingConfig,
     Provider.PALM: PaLMConfig,
     Provider.HUGGINGFACE_TEXT_GENERATION_INFERENCE: HuggingFaceTextGenerationInferenceConfig,
+    Provider.MISTRAL: MistralConfig,
 }
 
 
@@ -284,6 +295,7 @@ class Model(ConfigModel):
             MlflowModelServingConfig,
             HuggingFaceTextGenerationInferenceConfig,
             PaLMConfig,
+            MistralConfig,
         ]
     ] = None
 

--- a/mlflow/gateway/providers/__init__.py
+++ b/mlflow/gateway/providers/__init__.py
@@ -11,6 +11,7 @@ def get_provider(provider: Provider) -> Type[BaseProvider]:
     from mlflow.gateway.providers.bedrock import AWSBedrockProvider
     from mlflow.gateway.providers.cohere import CohereProvider
     from mlflow.gateway.providers.huggingface import HFTextGenerationInferenceServerProvider
+    from mlflow.gateway.providers.mistral import MistralProvider
     from mlflow.gateway.providers.mlflow import MlflowModelServingProvider
     from mlflow.gateway.providers.mosaicml import MosaicMLProvider
     from mlflow.gateway.providers.openai import OpenAIProvider
@@ -26,6 +27,7 @@ def get_provider(provider: Provider) -> Type[BaseProvider]:
         Provider.MLFLOW_MODEL_SERVING: MlflowModelServingProvider,
         Provider.HUGGINGFACE_TEXT_GENERATION_INFERENCE: HFTextGenerationInferenceServerProvider,
         Provider.BEDROCK: AWSBedrockProvider,
+        Provider.MISTRAL: MistralProvider,
     }
     if prov := provider_to_class.get(provider):
         return prov

--- a/mlflow/gateway/providers/mistral.py
+++ b/mlflow/gateway/providers/mistral.py
@@ -1,0 +1,164 @@
+import time
+from typing import Any, Dict
+
+from fastapi.encoders import jsonable_encoder
+
+from mlflow.gateway.config import MistralConfig, RouteConfig
+from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
+from mlflow.gateway.providers.utils import send_request
+from mlflow.gateway.schemas import completions, embeddings
+
+
+class MistralAdapter(ProviderAdapter):
+    @classmethod
+    def model_to_completions(cls, resp, config):
+        # Response example (https://docs.mistral.ai/api/#operation/createChatCompletion)
+        # ```
+        # {
+        #   "id": "string",
+        #   "object": "string",
+        #   "created": "integer",
+        #   "model": "string",
+        #   "choices": [
+        #     {
+        #       "index": "integer",
+        #       "message": {
+        #           "role": "string",
+        #           "content": "string"
+        #       },
+        #       "finish_reason": "string",
+        #     }
+        #   ],
+        #   "usage":
+        #   {
+        #       "prompt_tokens": "integer",
+        #       "completion_tokens": "integer",
+        #       "total_tokens": "integer",
+        #   }
+        # }
+        # ```
+        return completions.ResponsePayload(
+            created=int(time.time()),
+            object="text_completion",
+            model=config.model.name,
+            choices=[
+                completions.Choice(
+                    index=idx,
+                    text=c["message"]["content"],
+                    finish_reason=c["finish_reason"],
+                )
+                for idx, c in enumerate(resp["choices"])
+            ],
+            usage=completions.CompletionsUsage(
+                prompt_tokens=resp["usage"]["prompt_tokens"],
+                completion_tokens=resp["usage"]["completion_tokens"],
+                total_tokens=resp["usage"]["total_tokens"],
+            ),
+        )
+
+    @classmethod
+    def model_to_embeddings(cls, resp, config):
+        # Response example (https://docs.mistral.ai/api/#operation/createEmbedding):
+        # ```
+        # {
+        #   "id": "string",
+        #   "object": "string",
+        #   "data": [
+        #     {
+        #       "object": "string",
+        #       "embedding":
+        #       [
+        #           float,
+        #           float
+        #       ]
+        #       "index": "integer",
+        #     }
+        #   ],
+        #   "model": "string",
+        #   "usage":
+        #   {
+        #       "prompt_tokens": "integer",
+        #       "total_tokens": "integer",
+        #   }
+        # }
+        # ```
+        return embeddings.ResponsePayload(
+            data=[
+                embeddings.EmbeddingObject(
+                    embedding=data["embedding"],
+                    index=data["index"],
+                )
+                for data in resp["data"]
+            ],
+            model=config.model.name,
+            usage=embeddings.EmbeddingsUsage(
+                prompt_tokens=resp["usage"]["prompt_tokens"],
+                total_tokens=resp["usage"]["total_tokens"],
+            ),
+        )
+
+    @classmethod
+    def completions_to_model(cls, payload, config):
+        payload.pop("stop", None)
+        payload.pop("n", None)
+        payload["messages"] = [{"role": "user", "content": payload.pop("prompt")}]
+
+        # The range of Mistral's temperature is 0-1, but ours is 0-2, so we scale it.
+        if "temperature" in payload:
+            payload["temperature"] = 0.5 * payload["temperature"]
+
+        return payload
+
+    @classmethod
+    def embeddings_to_model(cls, payload, config):
+        return payload
+
+
+class MistralProvider(BaseProvider):
+    NAME = "Mistral"
+
+    def __init__(self, config: RouteConfig) -> None:
+        super().__init__(config)
+        if config.model.config is None or not isinstance(config.model.config, MistralConfig):
+            raise TypeError(f"Unexpected config type {config.model.config}")
+        self.mistral_config: MistralConfig = config.model.config
+
+    @property
+    def auth_headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {self.mistral_config.mistral_api_key}"}
+
+    @property
+    def base_url(self) -> str:
+        return "https://api.mistral.ai/v1/"
+
+    async def _request(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return await send_request(
+            headers=self.auth_headers,
+            base_url=self.base_url,
+            path=path,
+            payload=payload,
+        )
+
+    async def completions(self, payload: completions.RequestPayload) -> completions.ResponsePayload:
+        payload = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload)
+        resp = await self._request(
+            "chat/completions",
+            {
+                "model": self.config.model.name,
+                **MistralAdapter.completions_to_model(payload, self.config),
+            },
+        )
+        return MistralAdapter.model_to_completions(resp, self.config)
+
+    async def embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
+        payload = jsonable_encoder(payload, exclude_none=True)
+        self.check_for_model_field(payload)
+        resp = await self._request(
+            "embeddings",
+            {
+                "model": self.config.model.name,
+                **MistralAdapter.embeddings_to_model(payload, self.config),
+            },
+        )
+        return MistralAdapter.model_to_embeddings(resp, self.config)

--- a/tests/gateway/providers/test_mistral.py
+++ b/tests/gateway/providers/test_mistral.py
@@ -1,0 +1,282 @@
+import math
+from unittest import mock
+
+import pytest
+from aiohttp import ClientTimeout
+from fastapi import HTTPException
+from fastapi.encoders import jsonable_encoder
+from pydantic import ValidationError
+
+from mlflow.gateway.config import RouteConfig
+from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
+from mlflow.gateway.providers.mistral import MistralProvider
+from mlflow.gateway.schemas import completions, embeddings
+
+from tests.gateway.tools import MockAsyncResponse
+
+TEST_STRING = "This is a test"
+CONTENT_TYPE = "application/json"
+TARGET = "aiohttp.ClientSession.post"
+
+
+def completions_config():
+    return {
+        "name": "completions",
+        "route_type": "llm/v1/completions",
+        "model": {
+            "provider": "mistral",
+            "name": "mistral-tiny",
+            "config": {
+                "mistral_api_key": "key",
+            },
+        },
+    }
+
+
+def completions_response():
+    return {
+        "id": "string",
+        "object": "string",
+        "create": "integer",
+        "model": "string",
+        "choices": [
+            {
+                "index": "integer",
+                "message": {"role": "user", "content": TEST_STRING},
+                "finish_reason": "length",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 9,
+            "completion_tokens": 9,
+            "total_tokens": 18,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_completions():
+    resp = completions_response()
+    config = completions_config()
+    with mock.patch("time.time", return_value=1677858242), mock.patch(
+        TARGET, return_value=MockAsyncResponse(resp)
+    ) as mock_post:
+        provider = MistralProvider(RouteConfig(**config))
+        payload = {
+            "prompt": TEST_STRING,
+            "n": 1,
+            "stop": ["foobar"],
+        }
+        response = await provider.completions(completions.RequestPayload(**payload))
+        assert jsonable_encoder(response) == {
+            "id": None,
+            "object": "text_completion",
+            "created": 1677858242,
+            "model": "mistral-tiny",
+            "choices": [
+                {
+                    "text": TEST_STRING,
+                    "index": 0,
+                    "finish_reason": "length",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 9,
+                "total_tokens": 18,
+            },
+        }
+        mock_post.assert_called_once_with(
+            "https://api.mistral.ai/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": TEST_STRING}],
+                "model": "mistral-tiny",
+                "temperature": 0.0,
+            },
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
+        )
+
+
+@pytest.mark.asyncio
+async def test_completions_temperature_is_scaled_correctly():
+    resp = completions_response()
+    config = completions_config()
+    with mock.patch(TARGET, return_value=MockAsyncResponse(resp)) as mock_post:
+        provider = MistralProvider(RouteConfig(**config))
+        payload = {
+            "prompt": TEST_STRING,
+            "temperature": 0.5,
+        }
+        await provider.completions(completions.RequestPayload(**payload))
+        assert math.isclose(
+            mock_post.call_args[1]["json"]["temperature"], 0.5 * 0.5, rel_tol=1e-09, abs_tol=1e-09
+        )
+
+
+def embeddings_config():
+    return {
+        "name": "embeddings",
+        "route_type": "llm/v1/embeddings",
+        "model": {
+            "provider": "mistral",
+            "name": "mistral-embed",
+            "config": {
+                "mistral_api_key": "key",
+            },
+        },
+    }
+
+
+def embeddings_response():
+    return {
+        "id": "bc57846a-3e56-4327-8acc-588ca1a37b8a",
+        "object": "list",
+        "data": [
+            {
+                "object": "embedding",
+                "embedding": [
+                    3.25,
+                    0.7685547,
+                    2.65625,
+                    -0.30126953,
+                    -2.3554688,
+                    1.2597656,
+                ],
+                "index": 0,
+            }
+        ],
+        "model": "mistral-embed",
+        "usage": {"prompt_tokens": None, "total_tokens": None},
+    }
+
+
+def embeddings_batch_response():
+    return {
+        "id": "bc57846a-3e56-4327-8acc-588ca1a37b8a",
+        "object": "list",
+        "data": [
+            {
+                "object": "embedding",
+                "embedding": [
+                    3.25,
+                    0.7685547,
+                    2.65625,
+                    -0.30126953,
+                    -2.3554688,
+                    1.2597656,
+                ],
+                "index": 0,
+            },
+            {
+                "object": "embedding",
+                "embedding": [
+                    7.25,
+                    0.7685547,
+                    4.65625,
+                    -0.30126953,
+                    -2.3554688,
+                    8.2597656,
+                ],
+                "index": 1,
+            },
+        ],
+        "model": "mistral-embed",
+        "usage": {"prompt_tokens": None, "total_tokens": None},
+    }
+
+
+@pytest.mark.asyncio
+async def test_embeddings():
+    resp = embeddings_response()
+    config = embeddings_config()
+    with mock.patch(TARGET, return_value=MockAsyncResponse(resp)) as mock_post:
+        provider = MistralProvider(RouteConfig(**config))
+        payload = {"input": TEST_STRING}
+        response = await provider.embeddings(embeddings.RequestPayload(**payload))
+        assert jsonable_encoder(response) == {
+            "object": "list",
+            "data": [
+                {
+                    "object": "embedding",
+                    "embedding": [
+                        3.25,
+                        0.7685547,
+                        2.65625,
+                        -0.30126953,
+                        -2.3554688,
+                        1.2597656,
+                    ],
+                    "index": 0,
+                }
+            ],
+            "model": "mistral-embed",
+            "usage": {"prompt_tokens": None, "total_tokens": None},
+        }
+        mock_post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_batch_embeddings():
+    resp = embeddings_batch_response()
+    config = embeddings_config()
+    with mock.patch(TARGET, return_value=MockAsyncResponse(resp)) as mock_post:
+        provider = MistralProvider(RouteConfig(**config))
+        payload = {"input": ["This is a", "batch test"]}
+        response = await provider.embeddings(embeddings.RequestPayload(**payload))
+        assert jsonable_encoder(response) == {
+            "object": "list",
+            "data": [
+                {
+                    "object": "embedding",
+                    "embedding": [
+                        3.25,
+                        0.7685547,
+                        2.65625,
+                        -0.30126953,
+                        -2.3554688,
+                        1.2597656,
+                    ],
+                    "index": 0,
+                },
+                {
+                    "object": "embedding",
+                    "embedding": [
+                        7.25,
+                        0.7685547,
+                        4.65625,
+                        -0.30126953,
+                        -2.3554688,
+                        8.2597656,
+                    ],
+                    "index": 1,
+                },
+            ],
+            "model": "mistral-embed",
+            "usage": {"prompt_tokens": None, "total_tokens": None},
+        }
+        mock_post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_param_model_is_not_permitted():
+    config = embeddings_config()
+    provider = MistralProvider(RouteConfig(**config))
+    payload = {
+        "prompt": "This should fail",
+        "max_tokens": 5000,
+        "model": "something-else",
+    }
+    with pytest.raises(HTTPException, match=r".*") as e:
+        await provider.completions(completions.RequestPayload(**payload))
+    assert "The parameter 'model' is not permitted" in e.value.detail
+    assert e.value.status_code == 422
+
+
+@pytest.mark.parametrize("prompt", [{"set1", "set2"}, ["list1"], [1], ["list1", "list2"], [1, 2]])
+@pytest.mark.asyncio
+async def test_completions_throws_if_prompt_contains_non_string(prompt):
+    config = completions_config()
+    provider = MistralProvider(RouteConfig(**config))
+    payload = {"prompt": prompt}
+    with pytest.raises(ValidationError, match=r"prompt"):
+        await provider.completions(completions.RequestPayload(**payload))

--- a/tests/gateway/test_integration.py
+++ b/tests/gateway/test_integration.py
@@ -14,6 +14,7 @@ from mlflow.gateway.providers.anthropic import AnthropicProvider
 from mlflow.gateway.providers.bedrock import AWSBedrockProvider
 from mlflow.gateway.providers.cohere import CohereProvider
 from mlflow.gateway.providers.huggingface import HFTextGenerationInferenceServerProvider
+from mlflow.gateway.providers.mistral import MistralProvider
 from mlflow.gateway.providers.mlflow import MlflowModelServingProvider
 from mlflow.gateway.providers.mosaicml import MosaicMLProvider
 from mlflow.gateway.providers.openai import OpenAIProvider
@@ -219,6 +220,28 @@ def basic_config_dict():
                     "config": {"aws_config": {"aws_region": "us-east-1"}},
                 },
             },
+            {
+                "name": "completions-mistral",
+                "route_type": "llm/v1/completions",
+                "model": {
+                    "provider": "mistral",
+                    "name": "mistral-tiny",
+                    "config": {
+                        "mistral_api_key": "$MISTRAL_API_KEY",
+                    },
+                },
+            },
+            {
+                "name": "embeddings-mistral",
+                "route_type": "llm/v1/embeddings",
+                "model": {
+                    "provider": "mistral",
+                    "name": "mistral-embed",
+                    "config": {
+                        "mistral_api_key": "$MISTRAL_API_KEY",
+                    },
+                },
+            },
         ]
     }
 
@@ -244,6 +267,7 @@ def env_setup(monkeypatch):
     monkeypatch.setenv("AI21LABS_API_KEY", "test_ai21labs_key")
     monkeypatch.setenv("MOSAICML_API_KEY", "test_mosaicml_key")
     monkeypatch.setenv("PALM_API_KEY", "test_palm_key")
+    monkeypatch.setenv("MISTRAL_API_KEY", "test_mistral_key")
 
 
 @pytest.fixture
@@ -959,4 +983,62 @@ def test_bedrock_completions(gateway):
     with patch.object(AWSBedrockProvider, "completions", mock_completions):
         response = query(route=route.name, data=data)
 
+    assert response == expected_output
+
+
+def test_mistral_completions(gateway):
+    client = MlflowGatewayClient(gateway_uri=gateway.url)
+    route = client.get_route("completions-mistral")
+    expected_output = {
+        "id": None,
+        "object": "text_completion",
+        "created": 1677858242,
+        "model": "mistral-tiny",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "user", "content": "mock using MagicMock please"},
+                "finish_reason": "length",
+            }
+        ],
+        "usage": {"prompt_tokens": None, "completion_tokens": None, "total_tokens": None},
+    }
+
+    data = {"prompt": "mock my test", "max_tokens": 50}
+
+    async def mock_completions(self, payload):
+        return expected_output
+
+    with patch.object(MistralProvider, "completions", mock_completions):
+        response = client.query(route=route.name, data=data)
+    assert response == expected_output
+
+
+def test_mistral_embeddings(gateway):
+    client = MlflowGatewayClient(gateway_uri=gateway.url)
+    route = client.get_route("embeddings-mistral")
+    expected_output = {
+        "object": "list",
+        "data": [
+            {
+                "object": "embedding",
+                "embedding": [
+                    0.1,
+                    0.2,
+                    0.3,
+                ],
+                "index": 0,
+            }
+        ],
+        "model": "mistral-embed",
+        "usage": {"prompt_tokens": None, "total_tokens": None},
+    }
+
+    data = {"input": "mock me and my test"}
+
+    async def mock_embeddings(self, payload):
+        return expected_output
+
+    with patch.object(MistralProvider, "embeddings", mock_embeddings):
+        response = client.query(route=route.name, data=data)
     assert response == expected_output

--- a/tests/gateway/test_integration.py
+++ b/tests/gateway/test_integration.py
@@ -291,7 +291,7 @@ def test_create_gateway_client_with_declared_url(gateway):
     assert gateway_client.gateway_uri == gateway.url
     assert isinstance(gateway_client.get_route("chat-openai"), Route)
     routes = gateway_client.search_routes()
-    assert len(routes) == 18
+    assert len(routes) == 20
     assert all(isinstance(route, Route) for route in routes)
 
 
@@ -997,7 +997,7 @@ def test_mistral_completions(gateway):
         "choices": [
             {
                 "index": 0,
-                "message": {"role": "user", "content": "mock using MagicMock please"},
+                "text": "mock using MagicMock please",
                 "finish_reason": "length",
             }
         ],


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/thnguyendn/mlflow/pull/11020?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11020/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11020
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #10948

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Though MLFlow has already proposed Mistral AI as part of Hugging Face TGI, this PR is created to fill the need of having Mistral AI as a new LLM Provider, that could be easier to manage by the centralized endpoint of MLFlow LLM Deployment.

In terms of functionality, the new provider provides an endpoint for completion and another one for embedding, those which correspond to the Mistral AI completion (https://docs.mistral.ai/api/#operation/createChatCompletion) and embedding APIs (https://docs.mistral.ai/api/#operation/createEmbedding).

Technically, the changes in this Pull Request can be found in the following places:
- Creation of the MistralConfig in the config.py file
- Creation of the MistralProvider and MistralAdapter to adapt the request and the corresponding response from the Mistral APIs (mistral.py)
- Creation of a unit test to test MistralProvider (test_mistral.py)

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
