### PR TITLE
Add node id to system metrics to support logging system metrics in multi-node setup

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -97,6 +97,7 @@ from mlflow.projects import run
 from mlflow.system_metrics import (
     disable_system_metrics_logging,
     enable_system_metrics_logging,
+    set_system_metrics_node_id,
     set_system_metrics_samples_before_logging,
     set_system_metrics_sampling_interval,
 )
@@ -203,6 +204,7 @@ __all__ = [
     "set_experiment_tag",
     "set_experiment_tags",
     "set_registry_uri",
+    "set_system_metrics_node_id",
     "set_system_metrics_samples_before_logging",
     "set_system_metrics_sampling_interval",
     "set_tag",

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -457,6 +457,11 @@ MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING = _EnvironmentVariable(
     "MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING", int, None
 )
 
+#: Specifies the node id of system metrics logging. This is useful in multi-node (distributed
+#: training) setup.
+MLFLOW_SYSTEM_METRICS_NODE_ID = _EnvironmentVariable("MLFLOW_SYSTEM_METRICS_NODE_ID", str, None)
+
+
 # Private environment variable to specify the number of chunk download retries for multipart
 # download.
 _MLFLOW_MPD_NUM_RETRIES = _EnvironmentVariable("_MLFLOW_MPD_NUM_RETRIES", int, 3)

--- a/mlflow/system_metrics/__init__.py
+++ b/mlflow/system_metrics/__init__.py
@@ -2,6 +2,7 @@
 
 from mlflow.environment_variables import (
     MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING,
+    MLFLOW_SYSTEM_METRICS_NODE_ID,
     MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING,
     MLFLOW_SYSTEM_METRICS_SAMPLING_INTERVAL,
 )
@@ -51,3 +52,16 @@ def set_system_metrics_samples_before_logging(samples):
         MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING.unset()
     else:
         MLFLOW_SYSTEM_METRICS_SAMPLES_BEFORE_LOGGING.set(samples)
+
+
+@experimental
+def set_system_metrics_node_id(node_id):
+    """Set the system metrics node id.
+
+    node_id is the identifier of the machine where the metrics are collected. This is useful in
+    multi-node (distributed training) setup.
+    """
+    if node_id is None:
+        MLFLOW_SYSTEM_METRICS_NODE_ID.unset()
+    else:
+        MLFLOW_SYSTEM_METRICS_NODE_ID.set(node_id)

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -14,6 +14,7 @@ def disable_system_metrics_logging():
     mlflow.disable_system_metrics_logging()
     mlflow.set_system_metrics_sampling_interval(None)
     mlflow.set_system_metrics_samples_before_logging(None)
+    mlflow.set_system_metrics_node_id(None)
 
 
 def test_manual_system_metrics_monitor():
@@ -141,3 +142,26 @@ def test_automatic_system_metrics_monitor_resume_existing_run():
         run.info.run_id, "system/cpu_utilization_percentage"
     )
     assert metrics_history[-1].step > last_step
+
+
+def test_system_metrics_monitor_with_multi_node():
+    mlflow.enable_system_metrics_logging()
+    mlflow.set_system_metrics_sampling_interval(0.2)
+    mlflow.set_system_metrics_samples_before_logging(2)
+
+    mlflow_run = mlflow.start_run()
+    run_id = mlflow_run.info.run_id
+    mlflow.end_run()
+
+    node_ids = ["0", "1", "2", "3"]
+    for node_id in node_ids:
+        mlflow.set_system_metrics_node_id(node_id)
+        with mlflow.start_run(run_id=run_id, log_system_metrics=True):
+            time.sleep(1)
+
+    mlflow_run = mlflow.get_run(run_id)
+    metrics = mlflow_run.data.metrics
+
+    for node_id in node_ids:
+        expected_metric_name = f"system/{node_id}/cpu_utilization_percentage"
+        assert expected_metric_name in metrics.keys()

--- a/tests/system_metrics/test_system_metrics_logging.py
+++ b/tests/system_metrics/test_system_metrics_logging.py
@@ -149,9 +149,8 @@ def test_system_metrics_monitor_with_multi_node():
     mlflow.set_system_metrics_sampling_interval(0.2)
     mlflow.set_system_metrics_samples_before_logging(2)
 
-    mlflow_run = mlflow.start_run()
-    run_id = mlflow_run.info.run_id
-    mlflow.end_run()
+    with mlflow.start_run() as run:
+        run_id = run.info.run_id
 
     node_ids = ["0", "1", "2", "3"]
     for node_id in node_ids:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/11021?quickstart=1)


#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11021/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11021
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> 
Resolve #10994 

### What changes are proposed in this pull request?

Add node id to system metrics to support logging system metrics in multi-node setup. Previously users need to override the system metrics to do so.

Verified that logging to the same run from two machines separately can successfully display system metrics from two nodes:
<img width="1020" alt="image" src="https://github.com/mlflow/mlflow/assets/22925031/b5134d2f-10eb-4173-bace-33a23783092d">


### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
