### PR TITLE
Support OpenAI python SDK v1

### DIFF
--- a/docs/source/llms/openai/notebooks/openai-embeddings-generation.ipynb
+++ b/docs/source/llms/openai/notebooks/openai-embeddings-generation.ipynb
@@ -94,7 +94,7 @@
     "with mlflow.start_run():\n",
     "    model_info = mlflow.openai.log_model(\n",
     "        model=\"text-embedding-ada-002\",\n",
-    "        task=openai.Embedding,\n",
+    "        task=openai.embeddings,\n",
     "        artifact_path=\"model\",\n",
     "        signature=ModelSignature(\n",
     "            inputs=Schema([ColSpec(type=\"string\", name=None)]),\n",

--- a/examples/evaluation/evaluate_with_custom_code_metrics.py
+++ b/examples/evaluation/evaluate_with_custom_code_metrics.py
@@ -49,7 +49,7 @@ with mlflow.start_run() as run:
     )
     logged_model = mlflow.openai.log_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=openai.chat.completions,
         artifact_path="model",
         messages=[
             {"role": "system", "content": system_prompt},

--- a/examples/evaluation/evaluate_with_llm_judge.py
+++ b/examples/evaluation/evaluate_with_llm_judge.py
@@ -48,7 +48,7 @@ with mlflow.start_run() as run:
     system_prompt = "Answer the following question in two sentences"
     logged_model = mlflow.openai.log_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=openai.chat.completions,
         artifact_path="model",
         messages=[
             {"role": "system", "content": system_prompt},

--- a/examples/evaluation/evaluate_with_qa_metrics.py
+++ b/examples/evaluation/evaluate_with_qa_metrics.py
@@ -22,7 +22,7 @@ with mlflow.start_run() as run:
     system_prompt = "Answer the following question in two sentences"
     logged_model = mlflow.openai.log_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=openai.chat.completions,
         artifact_path="model",
         messages=[
             {"role": "system", "content": system_prompt},

--- a/examples/llms/question_answering/question_answering.py
+++ b/examples/llms/question_answering/question_answering.py
@@ -18,7 +18,7 @@ def build_and_evalute_model_with_prompt(system_prompt):
     # to MLflow Tracking
     logged_model = mlflow.openai.log_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=openai.chat.completions,
         artifact_path="model",
         messages=[
             {"role": "system", "content": system_prompt},

--- a/examples/openai/azure_openai.py
+++ b/examples/openai/azure_openai.py
@@ -19,14 +19,14 @@ with mlflow.start_run():
     model_info = mlflow.openai.log_model(
         # Your Azure OpenAI model e.g. gpt-3.5-turbo
         model="<YOUR AZURE OPENAI MODEL>",
-        task=openai.ChatCompletion,
+        task=openai.chat.completions,
         artifact_path="model",
         messages=[{"role": "user", "content": "Tell me a joke about {animal}."}],
     )
 
 # Load native OpenAI model
 native_model = mlflow.openai.load_model(model_info.model_uri)
-completion = openai.ChatCompletion.create(
+completion = openai.chat.completions.create(
     deployment_id=native_model["deployment_id"],
     messages=native_model["messages"],
 )

--- a/examples/openai/chat_completions.py
+++ b/examples/openai/chat_completions.py
@@ -27,7 +27,7 @@ print(
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=openai.chat.completions,
         artifact_path="model",
         messages=[{"role": "user", "content": "Tell me a joke about {animal}."}],
     )
@@ -65,7 +65,7 @@ print(
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=openai.chat.completions,
         artifact_path="model",
         messages=[{"role": "user", "content": "Tell me a {adjective} joke about {animal}."}],
     )
@@ -97,7 +97,7 @@ print(
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=openai.chat.completions,
         artifact_path="model",
         messages=[
             {"role": "system", "content": "You are {person}"},
@@ -132,7 +132,7 @@ print(
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=openai.chat.completions,
         artifact_path="model",
         messages=[{"role": "system", "content": "You are Elon Musk"}],
     )
@@ -173,7 +173,7 @@ print(
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=openai.chat.completions,
         artifact_path="model",
         messages=[{"role": "user", "content": "Tell me a joke about {animal}."}],
         signature=ModelSignature(

--- a/examples/openai/completions.py
+++ b/examples/openai/completions.py
@@ -19,7 +19,7 @@ print(
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
         model="text-davinci-002",
-        task=openai.Completion,
+        task=openai.completions,
         artifact_path="model",
         prompt="Clasify the following tweet's sentiment: '{tweet}'.",
     )
@@ -38,7 +38,7 @@ print(
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
         model="text-davinci-002",
-        task=openai.Completion,
+        task=openai.completions,
         artifact_path="model",
         prompt="Clasify the following tweet's sentiment: '{tweet}'.",
         signature=ModelSignature(

--- a/examples/openai/embeddings.py
+++ b/examples/openai/embeddings.py
@@ -21,7 +21,7 @@ print(
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
         model="text-embedding-ada-002",
-        task=openai.Embedding,
+        task=openai.embeddings,
         artifact_path="model",
     )
 
@@ -40,7 +40,7 @@ print(
 with mlflow.start_run():
     mlflow.openai.log_model(
         model="text-embedding-ada-002",
-        task=openai.Embedding,
+        task=openai.embeddings,
         artifact_path="model",
         signature=ModelSignature(
             inputs=Schema([ColSpec(type="string", name=None)]),

--- a/examples/openai/spark_udf.py
+++ b/examples/openai/spark_udf.py
@@ -10,7 +10,7 @@ assert "OPENAI_API_KEY" in os.environ, "Please set the OPENAI_API_KEY environmen
 with mlflow.start_run():
     model_info = mlflow.openai.log_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=openai.chat.completions,
         messages=[{"role": "user", "content": "Tell me a {adjective} joke about {animal}."}],
         artifact_path="model",
     )

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -575,7 +575,7 @@ openai:
     # install_dev: |
     #   pip install git+https://github.com/openai/openai-python
   models:
-    minimum: "0.27.5"
+    minimum: "0.27.2"
     maximum: "1.11.1"
     requirements:
       ">= 0.0.0": ["pyspark", "tiktoken", "aiohttp", "tenacity"]

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -575,8 +575,8 @@ openai:
     # install_dev: |
     #   pip install git+https://github.com/openai/openai-python
   models:
-    minimum: "0.27.2"
-    maximum: "0.28.1"
+    minimum: "0.27.5"
+    maximum: "1.11.1"
     requirements:
       ">= 0.0.0": ["pyspark", "tiktoken", "aiohttp", "tenacity"]
     run: |

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -31,6 +31,7 @@ When the logged model is served on Databricks, each secret will be resolved and 
 corresponding environment variable. See https://docs.databricks.com/security/secrets/index.html
 for how to set up secrets on Databricks.
 """
+
 import itertools
 import logging
 import os
@@ -39,10 +40,11 @@ from string import Formatter
 from typing import Any, Dict, Optional, Set
 
 import yaml
+from packaging.version import Version
 
 import mlflow
 from mlflow import pyfunc
-from mlflow.environment_variables import _MLFLOW_TESTING, MLFLOW_OPENAI_SECRET_SCOPE
+from mlflow.environment_variables import MLFLOW_OPENAI_SECRET_SCOPE
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelInputExample, ModelSignature
 from mlflow.models.model import MLMODEL_FILE_NAME
@@ -114,47 +116,39 @@ def get_default_conda_env():
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
 
-def _get_class_to_task_mapping():
-    from openai.api_resources import (
-        Audio,
-        ChatCompletion,
-        Completion,
-        Deployment,
-        Edit,
-        Embedding,
-        Engine,
-        File,
-        FineTune,
-        Image,
-        Moderation,
-    )
-    from openai.api_resources import (
-        Model as OpenAIModel,
-    )
+def _get_obj_to_task_mapping():
+    import openai
 
-    return {
-        Audio: Audio.OBJECT_NAME,
-        ChatCompletion: ChatCompletion.OBJECT_NAME,
-        Completion: Completion.OBJECT_NAME,
-        Edit: Edit.OBJECT_NAME,
-        Deployment: Deployment.OBJECT_NAME,
-        Embedding: Embedding.OBJECT_NAME,
-        Engine: Engine.OBJECT_NAME,
-        File: File.OBJECT_NAME,
-        Image: Image.OBJECT_NAME,
-        FineTune: FineTune.OBJECT_NAME,
-        OpenAIModel: OpenAIModel.OBJECT_NAME,
-        Moderation: "moderations",
-    }
+    if Version(_get_openai_package_version()).major < 1:
+        from openai import api_resources as ar
 
-
-def _class_to_task(cls):
-    task = _get_class_to_task_mapping().get(cls)
-    if task is None:
-        raise mlflow.MlflowException(
-            f"Unsupported class: {cls}", error_code=INVALID_PARAMETER_VALUE
-        )
-    return task
+        return {
+            ar.Audio: ar.Audio.OBJECT_NAME,
+            ar.ChatCompletion: ar.ChatCompletion.OBJECT_NAME,
+            ar.Completion: ar.Completion.OBJECT_NAME,
+            ar.Edit: ar.Edit.OBJECT_NAME,
+            ar.Deployment: ar.Deployment.OBJECT_NAME,
+            ar.Embedding: ar.Embedding.OBJECT_NAME,
+            ar.Engine: ar.Engine.OBJECT_NAME,
+            ar.File: ar.File.OBJECT_NAME,
+            ar.Image: ar.Image.OBJECT_NAME,
+            ar.FineTune: ar.FineTune.OBJECT_NAME,
+            ar.Model: ar.Model.OBJECT_NAME,
+            ar.Moderation: "moderations",
+        }
+    else:
+        return {
+            openai.audio: "audio",
+            openai.chat.completions: "chat.completions",
+            openai.completions: "completions",
+            openai.images.edit: "images.edit",
+            openai.embeddings: "embeddings",
+            openai.files: "files",
+            openai.images: "images",
+            openai.fine_tuning: "fine_tuning",
+            openai.moderations: "moderations",
+            openai.models: "models",
+        }
 
 
 def _get_model_name(model):
@@ -162,23 +156,30 @@ def _get_model_name(model):
 
     if isinstance(model, str):
         return model
-    elif isinstance(model, openai.Model):
+
+    if Version(_get_openai_package_version()).major < 1 and isinstance(model, openai.Model):
         return model.id
-    else:
-        raise mlflow.MlflowException(
-            f"Unsupported model type: {type(model)}", error_code=INVALID_PARAMETER_VALUE
-        )
+
+    raise mlflow.MlflowException(
+        f"Unsupported model type: {type(model)}", error_code=INVALID_PARAMETER_VALUE
+    )
 
 
 def _get_task_name(task):
+    mapping = _get_obj_to_task_mapping()
     if isinstance(task, str):
+        if task not in mapping.values():
+            raise mlflow.MlflowException(
+                f"Unsupported task: {task}", error_code=INVALID_PARAMETER_VALUE
+            )
         return task
-    elif isinstance(task, type):
-        return _class_to_task(task)
     else:
-        raise mlflow.MlflowException(
-            f"Unsupported task type: {type(task)}", error_code=INVALID_PARAMETER_VALUE
-        )
+        task_name = mapping.get(task)
+        if task_name is None:
+            raise mlflow.MlflowException(
+                f"Unsupported task object: {task}", error_code=INVALID_PARAMETER_VALUE
+            )
+    return task_name
 
 
 def _get_api_config() -> _OpenAIApiConfig:
@@ -266,9 +267,8 @@ def save_model(
     Save an OpenAI model to a path on the local file system.
 
     Args:
-        model: The OpenAI model name or reference instance, e.g.,
-            ``openai.Model.retrieve("gpt-3.5-turbo")``.
-        task: The task the model is performing, e.g., ``openai.ChatCompletion`` or
+        model: The OpenAI model name.
+        task: The task the model is performing, e.g., ``openai.chat.completions`` or
             ``'chat.completions'``.
         path: Local path where the model is to be saved.
         conda_env: {{ conda_env }}
@@ -310,7 +310,7 @@ def save_model(
         # Chat
         mlflow.openai.save_model(
             model="gpt-3.5-turbo",
-            task=openai.ChatCompletion,
+            task=openai.chat.completions,
             messages=[{"role": "user", "content": "Tell me a joke."}],
             path="model",
         )
@@ -318,7 +318,7 @@ def save_model(
         # Completions
         mlflow.openai.save_model(
             model="text-davinci-002",
-            task=openai.Completion,
+            task=openai.completions,
             prompt="{text}. The general sentiment of the text is",
             path="model",
         )
@@ -326,7 +326,7 @@ def save_model(
         # Embeddings
         mlflow.openai.save_model(
             model="text-embedding-ada-002",
-            task=openai.Embedding,
+            task=openai.embeddings,
             path="model",
         )
     """
@@ -468,7 +468,7 @@ def log_model(
     Args:
         model: The OpenAI model name or reference instance, e.g.,
             ``openai.Model.retrieve("gpt-3.5-turbo")``.
-        task: The task the model is performing, e.g., ``openai.ChatCompletion`` or
+        task: The task the model is performing, e.g., ``openai.chat.completions`` or
             ``'chat.completions'``.
         artifact_path: Run-relative artifact path.
         conda_env: {{ conda_env }}
@@ -521,7 +521,7 @@ def log_model(
         with mlflow.start_run():
             info = mlflow.openai.log_model(
                 model="gpt-3.5-turbo",
-                task=openai.ChatCompletion,
+                task=openai.chat.completions,
                 messages=[{"role": "user", "content": "Tell me a joke about {animal}."}],
                 artifact_path="model",
             )
@@ -533,7 +533,7 @@ def log_model(
         with mlflow.start_run():
             info = mlflow.openai.log_model(
                 model="text-embedding-ada-002",
-                task=openai.Embedding,
+                task=openai.embeddings,
                 artifact_path="embeddings",
             )
             model = mlflow.pyfunc.load_model(info.model_uri)
@@ -706,8 +706,8 @@ class _OpenAIWrapper:
 
     def _construct_request_url(self, task_url, default_url):
         api_type = self.request_configs.get("api_type")
+        api_base = self.request_configs.get("api_base")
         if api_type in ("azure", "azure_ad", "azuread"):
-            api_base = self.request_configs.get("api_base")
             api_version = self.request_configs.get("api_version")
             deployment_id = self.request_configs.get("deployment_id")
 
@@ -715,8 +715,8 @@ class _OpenAIWrapper:
                 f"{api_base}/openai/deployments/{deployment_id}/"
                 f"{task_url}?api-version={api_version}"
             )
-        else:
-            return default_url
+
+        return f"{api_base}/{task_url}" if api_base else default_url
 
     def _predict_chat(self, data, params):
         from mlflow.openai.api_request_parallel_processor import process_api_requests
@@ -812,39 +812,13 @@ class _OpenAIWrapper:
             return self._predict_embeddings(data, params or {})
 
 
-class _TestOpenAIWrapper(_OpenAIWrapper):
-    """A wrapper class that should be used for testing purposes only."""
-
-    def predict(
-        self,
-        data,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
-    ):
-        """
-        Args:
-            data: Model input data.
-            params: Additional parameters to pass to the model for inference.
-
-                .. Note:: Experimental: This parameter may change or be removed in a future
-                           release without warning.
-
-        Returns:
-            Model predictions.
-        """
-        from mlflow.utils.openai_utils import _mock_openai_request
-
-        with _mock_openai_request():
-            return super().predict(data)
-
-
 def _load_pyfunc(path):
     """Loads PyFunc implementation. Called by ``pyfunc.load_model``.
 
     Args:
         path: Local filesystem path to the MLflow Model with the ``openai`` flavor.
     """
-    wrapper_cls = _TestOpenAIWrapper if _MLFLOW_TESTING.get() else _OpenAIWrapper
-    return wrapper_cls(_load_model(path))
+    return _OpenAIWrapper(_load_model(path))
 
 
 @experimental

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -178,7 +178,7 @@ def _get_task_name(task):
             raise mlflow.MlflowException(
                 f"Unsupported task object: {task}", error_code=INVALID_PARAMETER_VALUE
             )
-    return task_name
+        return task_name
 
 
 def _get_api_config() -> _OpenAIApiConfig:

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -31,7 +31,6 @@ When the logged model is served on Databricks, each secret will be resolved and 
 corresponding environment variable. See https://docs.databricks.com/security/secrets/index.html
 for how to set up secrets on Databricks.
 """
-
 import itertools
 import logging
 import os

--- a/tests/openai/mock_openai.py
+++ b/tests/openai/mock_openai.py
@@ -1,0 +1,103 @@
+import json
+from typing import List, Union
+
+import fastapi
+from pydantic import BaseModel
+
+app = fastapi.FastAPI()
+
+
+@app.get("/health")
+def health():
+    return {"status": "healthy"}
+
+
+class Message(BaseModel):
+    role: str
+    content: str
+
+
+class ChatPayload(BaseModel):
+    messages: List[Message]
+
+
+@app.post("/chat/completions")
+async def chat(payload: ChatPayload):
+    return {
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "created": 1677652288,
+        "model": "gpt-3.5-turbo-0613",
+        "system_fingerprint": "fp_44709d6fcb",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": json.dumps([m.dict() for m in payload.messages]),
+                },
+                "logprobs": None,
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 9,
+            "completion_tokens": 12,
+            "total_tokens": 21,
+        },
+    }
+
+
+class CompletionsPayload(BaseModel):
+    prompt: Union[str, List[str]]
+
+
+@app.post("/completions")
+def completions(payload: CompletionsPayload):
+    return {
+        "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
+        "object": "text_completion",
+        "created": 1589478378,
+        "model": "gpt-3.5-turbo",
+        "choices": [
+            {
+                "text": text,
+                "index": 0,
+                "logprobs": None,
+                "finish_reason": "length",
+            }
+            for text in ([payload.prompt] if isinstance(payload.prompt, str) else payload.prompt)
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+    }
+
+
+class EmbeddingsPayload(BaseModel):
+    input: Union[str, List[str]]
+
+
+@app.post("/embeddings")
+def embeddings(payload: EmbeddingsPayload):
+    return {
+        "object": "list",
+        "data": [
+            {
+                "object": "embedding",
+                "embedding": list(range(1536)),
+                "index": 0,
+            }
+            for _ in range(1 if isinstance(payload.input, str) else len(payload.input))
+        ],
+        "model": "text-embedding-ada-002",
+        "usage": {"prompt_tokens": 8, "total_tokens": 8},
+    }
+
+
+@app.get("/models/{model}")
+def get_model(model: str):
+    return {
+        "id": model,
+        "object": "model",
+        "created": 1686935002,
+        "owned_by": "openai",
+    }

--- a/tests/openai/mock_openai.py
+++ b/tests/openai/mock_openai.py
@@ -94,7 +94,7 @@ def embeddings(payload: EmbeddingsPayload):
 
 
 @app.get("/models/{model}")
-def get_model(model: str):
+def models(model: str):
     return {
         "id": model,
         "object": "model",

--- a/tests/openai/test_openai_model_export.py
+++ b/tests/openai/test_openai_model_export.py
@@ -29,7 +29,7 @@ def spark():
         yield s
 
 
-is_v1 = Version(openai.__version__).major >= 1
+is_v1 = Version(mlflow.openai._get_openai_package_version()).major >= 1
 
 
 def chat_completions():

--- a/tests/openai/test_openai_model_export.py
+++ b/tests/openai/test_openai_model_export.py
@@ -1,12 +1,17 @@
 import importlib
 import json
+import subprocess
+import sys
+import time
 from unittest import mock
 
 import numpy as np
 import openai
 import pandas as pd
 import pytest
+import requests
 import yaml
+from packaging.version import Version
 from pyspark.sql import SparkSession
 
 import mlflow
@@ -14,13 +19,8 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.exceptions import MlflowException
 from mlflow.models.signature import ModelSignature
 from mlflow.types.schema import ColSpec, ParamSchema, ParamSpec, Schema, TensorSpec
-from mlflow.utils.openai_utils import (
-    _mock_chat_completion_response,
-    _mock_models_retrieve_response,
-    _mock_request,
-)
 
-from tests.helper_functions import pyfunc_serve_and_score_model
+from tests.helper_functions import get_safe_port, pyfunc_serve_and_score_model
 
 
 @pytest.fixture(scope="module")
@@ -29,15 +29,65 @@ def spark():
         yield s
 
 
+is_v1 = Version(openai.__version__).major >= 1
+
+
+def chat_completions():
+    return openai.chat.completions if is_v1 else openai.ChatCompletion
+
+
+def completions():
+    return openai.completions if is_v1 else openai.Completion
+
+
+def embeddings():
+    return openai.embeddings if is_v1 else openai.Embedding
+
+
+@pytest.fixture(scope="module", autouse=True)
+def mock_openai():
+    port = get_safe_port()
+    with subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "tests.openai.mock_openai:app",
+            "--host",
+            "localhost",
+            "--port",
+            str(port),
+        ]
+    ) as proc:
+        base_url = f"http://localhost:{port}"
+        for _ in range(3):
+            try:
+                resp = requests.get(f"{base_url}/health")
+            except requests.ConnectionError:
+                time.sleep(1)
+                continue
+            if resp.ok:
+                break
+        else:
+            raise RuntimeError("Failed to start mock OpenAI server")
+
+        yield base_url
+        proc.kill()
+
+
 @pytest.fixture(autouse=True)
-def set_envs(monkeypatch):
+def set_envs(monkeypatch, mock_openai):
     monkeypatch.setenvs(
         {
             "MLFLOW_TESTING": "true",
             "OPENAI_API_KEY": "test",
+            "OPENAI_API_BASE": mock_openai,
         }
     )
-    importlib.reload(openai)
+    if is_v1:
+        openai.base_url = mock_openai
+    else:
+        importlib.reload(openai)
 
 
 def test_log_model():
@@ -55,20 +105,12 @@ def test_log_model():
     assert loaded_model["task"] == "chat.completions"
     assert loaded_model["temperature"] == 0.9
     assert loaded_model["messages"] == [{"role": "system", "content": "You are an MLflow expert."}]
-    with _mock_request(return_value=_mock_chat_completion_response(content="foo")) as mock:
-        completion = openai.ChatCompletion.create(
-            model=loaded_model["model"],
-            messages=loaded_model["messages"],
-            temperature=loaded_model["temperature"],
-        )
-        assert completion.choices[0].message.content == "foo"
-        mock.assert_called_once()
 
 
 def test_chat_single_variable(tmp_path):
     mlflow.openai.save_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=chat_completions(),
         path=tmp_path,
         messages=[{"role": "user", "content": "{x}"}],
     )
@@ -104,7 +146,7 @@ def test_chat_single_variable(tmp_path):
 def test_completion_single_variable(tmp_path):
     mlflow.openai.save_model(
         model="text-davinci-003",
-        task=openai.Completion,
+        task=completions(),
         path=tmp_path,
         prompt="Say {text}",
     )
@@ -118,26 +160,26 @@ def test_completion_single_variable(tmp_path):
             ]
         }
     )
-    expected_output = [["Say this is a test", "Say this is another test"]]
-    assert list(map(json.loads, model.predict(data))) == expected_output
+    expected_output = ["Say this is a test", "Say this is another test"]
+    assert model.predict(data) == expected_output
 
     data = [
         {"x": "this is a test"},
         {"x": "this is another test"},
     ]
-    assert list(map(json.loads, model.predict(data))) == expected_output
+    assert model.predict(data) == expected_output
 
     data = [
         "this is a test",
         "this is another test",
     ]
-    assert list(map(json.loads, model.predict(data))) == expected_output
+    assert model.predict(data) == expected_output
 
 
 def test_chat_multiple_variables(tmp_path):
     mlflow.openai.save_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=chat_completions(),
         path=tmp_path,
         messages=[{"role": "user", "content": "{x} {y}"}],
     )
@@ -179,7 +221,7 @@ def test_chat_multiple_variables(tmp_path):
 def test_chat_role_content(tmp_path):
     mlflow.openai.save_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=chat_completions(),
         path=tmp_path,
         messages=[{"role": "{role}", "content": "{content}"}],
     )
@@ -215,7 +257,7 @@ def test_chat_role_content(tmp_path):
 def test_completion_multiple_variables(tmp_path):
     mlflow.openai.save_model(
         model="text-davinci-003",
-        task=openai.Completion,
+        task=completions(),
         path=tmp_path,
         prompt="Say {x} and {y}",
     )
@@ -241,20 +283,20 @@ def test_completion_multiple_variables(tmp_path):
             ],
         }
     )
-    expected_output = [["Say a and c", "Say b and d"]]
-    assert list(map(json.loads, model.predict(data))) == expected_output
+    expected_output = ["Say a and c", "Say b and d"]
+    assert model.predict(data) == expected_output
 
     data = [
         {"x": "a", "y": "c"},
         {"x": "b", "y": "d"},
     ]
-    assert list(map(json.loads, model.predict(data))) == expected_output
+    assert model.predict(data) == expected_output
 
 
 def test_chat_multiple_messages(tmp_path):
     mlflow.openai.save_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=chat_completions(),
         path=tmp_path,
         messages=[
             {"role": "user", "content": "{x}"},
@@ -299,7 +341,7 @@ def test_chat_multiple_messages(tmp_path):
 def test_chat_no_variables(tmp_path):
     mlflow.openai.save_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=chat_completions(),
         path=tmp_path,
         messages=[{"role": "user", "content": "a"}],
     )
@@ -339,7 +381,7 @@ def test_chat_no_variables(tmp_path):
 def test_completion_no_variable(tmp_path):
     mlflow.openai.save_model(
         model="text-davinci-003",
-        task=openai.Completion,
+        task=completions(),
         path=tmp_path,
     )
 
@@ -352,26 +394,26 @@ def test_completion_no_variable(tmp_path):
             ]
         }
     )
-    expected_output = [["this is a test", "this is another test"]]
-    assert list(map(json.loads, model.predict(data))) == expected_output
+    expected_output = ["this is a test", "this is another test"]
+    assert model.predict(data) == expected_output
 
     data = [
         {"x": "this is a test"},
         {"x": "this is another test"},
     ]
-    assert list(map(json.loads, model.predict(data))) == expected_output
+    assert model.predict(data) == expected_output
 
     data = [
         "this is a test",
         "this is another test",
     ]
-    assert list(map(json.loads, model.predict(data))) == expected_output
+    assert model.predict(data) == expected_output
 
 
 def test_chat_no_messages(tmp_path):
     mlflow.openai.save_model(
         model="gpt-3.5-turbo",
-        task=openai.ChatCompletion,
+        task=chat_completions(),
         path=tmp_path,
     )
     model = mlflow.models.Model.load(tmp_path)
@@ -421,23 +463,22 @@ def test_invalid_messages(tmp_path, messages):
     ):
         mlflow.openai.save_model(
             model="gpt-3.5-turbo",
-            task=openai.ChatCompletion,
+            task=chat_completions(),
             path=tmp_path,
             messages=messages,
         )
 
 
 def test_task_argument_accepts_class(tmp_path):
-    mlflow.openai.save_model(model="gpt-3.5-turbo", task=openai.ChatCompletion, path=tmp_path)
+    mlflow.openai.save_model(model="gpt-3.5-turbo", task=chat_completions(), path=tmp_path)
     loaded_model = mlflow.openai.load_model(tmp_path)
     assert loaded_model["task"] == "chat.completions"
 
 
+@pytest.mark.skipif(is_v1, reason="Requires OpenAI SDK v0")
 def test_model_argument_accepts_retrieved_model(tmp_path):
-    with _mock_request(return_value=_mock_models_retrieve_response()) as mock:
-        model = openai.Model.retrieve("gpt-3.5-turbo")
-        mock.assert_called_once()
-    mlflow.openai.save_model(model=model, task=openai.ChatCompletion, path=tmp_path)
+    model = openai.Model.retrieve("gpt-3.5-turbo")
+    mlflow.openai.save_model(model=model, task=chat_completions(), path=tmp_path)
     loaded_model = mlflow.openai.load_model(tmp_path)
     assert loaded_model["model"] == "gpt-3.5-turbo"
 
@@ -491,7 +532,7 @@ def test_spark_udf_chat(tmp_path, spark):
 
 class ChatCompletionModel(mlflow.pyfunc.PythonModel):
     def predict(self, context, model_input, params=None):
-        completion = openai.ChatCompletion.create(
+        completion = chat_completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": "What is MLflow?"}],
         )
@@ -501,7 +542,7 @@ class ChatCompletionModel(mlflow.pyfunc.PythonModel):
 def test_embeddings(tmp_path):
     mlflow.openai.save_model(
         model="text-embedding-ada-002",
-        task=openai.Embedding,
+        task=embeddings(),
         path=tmp_path,
     )
 
@@ -514,11 +555,11 @@ def test_embeddings(tmp_path):
     model = mlflow.pyfunc.load_model(tmp_path)
     data = pd.DataFrame({"text": ["a", "b"]})
     preds = model.predict(data)
-    assert preds == [[0.0], [0.0]]
+    assert list(map(len, preds)) == [1536, 1536]
 
     data = pd.DataFrame({"text": ["a"] * 100})
     preds = model.predict(data)
-    assert preds == [[0.0]] * 100
+    assert list(map(len, preds)) == [1536] * 100
 
 
 def test_embeddings_batch_size_azure(tmp_path, monkeypatch):
@@ -526,7 +567,7 @@ def test_embeddings_batch_size_azure(tmp_path, monkeypatch):
     monkeypatch.setenv("OPENAI_ENGINE", "test_engine")
     mlflow.openai.save_model(
         model="text-embedding-ada-002",
-        task=openai.Embedding,
+        task=embeddings(),
         path=tmp_path,
     )
     model = mlflow.pyfunc.load_model(tmp_path)
@@ -537,7 +578,7 @@ def test_embeddings_batch_size_azure(tmp_path, monkeypatch):
 def test_embeddings_pyfunc_server_and_score(tmp_path):
     mlflow.openai.save_model(
         model="text-embedding-ada-002",
-        task=openai.Embedding,
+        task=embeddings(),
         path=tmp_path,
     )
     df = pd.DataFrame({"text": ["a", "b"]})
@@ -555,7 +596,7 @@ def test_embeddings_pyfunc_server_and_score(tmp_path):
 def test_spark_udf_embeddings(tmp_path, spark):
     mlflow.openai.save_model(
         model="text-embedding-ada-002",
-        task=openai.Embedding,
+        task=embeddings(),
         path=tmp_path,
     )
     udf = mlflow.pyfunc.spark_udf(spark, tmp_path, result_type="array<double>")
@@ -567,13 +608,13 @@ def test_spark_udf_embeddings(tmp_path, spark):
         ["x"],
     )
     df = df.withColumn("z", udf("x")).toPandas()
-    assert df["z"].tolist() == [[0.0], [0.0]]
+    assert list(map(len, df["z"])) == [1536, 1536]
 
 
 def test_inference_params(tmp_path):
     mlflow.openai.save_model(
         model="text-embedding-ada-002",
-        task=openai.Embedding,
+        task=embeddings(),
         path=tmp_path,
         signature=ModelSignature(
             inputs=Schema([ColSpec(type="string", name=None)]),
@@ -591,14 +632,14 @@ def test_inference_params(tmp_path):
     model = mlflow.pyfunc.load_model(tmp_path)
     data = pd.DataFrame({"text": ["a", "b"]})
     preds = model.predict(data, params={"batch_size": 5})
-    assert preds == [[0.0], [0.0]]
+    assert list(map(len, preds)) == [1536, 1536]
 
 
 def test_inference_params_overlap(tmp_path):
     with pytest.raises(mlflow.MlflowException, match=r"any of \['prefix'\] as parameters"):
         mlflow.openai.save_model(
             model="text-davinci-003",
-            task=openai.Completion,
+            task=completions(),
             path=tmp_path,
             prefix="Classify the following text's sentiment:",
             signature=ModelSignature(
@@ -613,7 +654,7 @@ def test_engine_and_deployment_id_for_azure_openai(tmp_path, monkeypatch):
     monkeypatch.setenv("OPENAI_API_TYPE", "azure")
     mlflow.openai.save_model(
         model="text-embedding-ada-002",
-        task=openai.Embedding,
+        task=embeddings(),
         path=tmp_path,
     )
     with pytest.raises(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11034?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11034/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11034
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #10793
Resolve #10810

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Summary

- Legacy OpenAI objects were updated:
  - `openai.Embedding` -> `openai.emebeddings`
  - `openai.ChatCompletions` -> `openai.chat.completions`
  - `openai.Comletions` -> `openai.completions`
- Created a fake OpenAI service. v0 uses `requests` for making HTTP requests while v1 uses `httpx`. Creating a fake OpenAI service is easier and cleaner than monkey-patching both `requests` and `httpx` during tests.
- No updates in the prediction logic.
- Both v1 and v0 are supported.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
