### PR TITLE
Upgrade ruff to 0.2.1

### DIFF
--- a/dev/ruff.py
+++ b/dev/ruff.py
@@ -5,7 +5,7 @@ import re
 import subprocess
 import sys
 
-RUFF = [sys.executable, "-m", "ruff"]
+RUFF = [sys.executable, "-m", "ruff", "check"]
 MESSAGE_REGEX = re.compile(r"^.+:\d+:\d+: ([A-Z0-9]+) (\[\*\] )?.+$")
 
 

--- a/mlflow/utils/import_hooks/__init__.py
+++ b/mlflow/utils/import_hooks/__init__.py
@@ -208,7 +208,7 @@ def discover_post_import_hooks(group):
 @synchronized(_post_import_hooks_lock)
 def notify_module_loaded(module):
     name = getattr(module, "__name__", None)
-    hooks = _post_import_hooks.get(name, None)
+    hooks = _post_import_hooks.get(name)
 
     if hooks:
         _post_import_hooks[name] = []
@@ -219,7 +219,7 @@ def notify_module_loaded(module):
 
 @synchronized(_import_error_hooks_lock)
 def notify_module_import_error(module_name):
-    hooks = _import_error_hooks.get(module_name, None)
+    hooks = _import_error_hooks.get(module_name)
 
     if hooks:
         # Error hooks differ from post import hooks, in that we don't clear the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,21 @@ force-exclude = '''
 [tool.ruff]
 line-length = 100
 target-version = "py38"
+force-exclude = true
+extend-include = ["*.ipynb"]
+extend-exclude = [
+  "setup.py",
+  "docs/source",
+  "examples/recipes",
+  "mlflow/protos",
+  "mlflow/ml_package_versions.py",
+  "mlflow/server/js",
+  "mlflow/store/db_migrations",
+  "mlflow/temporary_db_migrations_for_pre_1_users",
+  "tests/protos",
+]
+
+[tool.ruff.lint]
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 select = [
   "B006",
@@ -63,7 +78,6 @@ select = [
   "TID251",
   "W",
 ]
-force-exclude = true
 ignore = [
   "E721",  # type-comparison
   "E402",  # module-import-not-at-top-of-file
@@ -71,35 +85,23 @@ ignore = [
   "E741",  # ambiguous-variable-name
   "F811",  # redefined-while-unused
 ]
-extend-include = ["*.ipynb"]
-extend-exclude = [
-  "setup.py",
-  "docs/source",
-  "examples/recipes",
-  "mlflow/protos",
-  "mlflow/ml_package_versions.py",
-  "mlflow/server/js",
-  "mlflow/store/db_migrations",
-  "mlflow/temporary_db_migrations_for_pre_1_users",
-  "tests/protos",
-]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "dev/*" = ["T201", "PT018"]
 "examples/*" = ["T20"]
 "docs/broken_links.py" = ["T20"]
 "mlflow/*" = ["PT018"]
 
-[tool.ruff.flake8-pytest-style]
+[tool.ruff.lint.flake8-pytest-style]
 mark-parentheses = false
 fixture-parentheses = false
 raises-require-match-for = ["*"]
 
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 forced-separate = ["tests"]
 
-[tool.ruff.flake8-tidy-imports.banned-api]
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
 "pkg_resources".msg = "We're migrating away from pkg_resources. Please use importlib.resources or importlib.metadata instead."

--- a/requirements/lint-requirements.txt
+++ b/requirements/lint-requirements.txt
@@ -1,5 +1,5 @@
 pylint==2.14.4
-ruff==0.1.3
+ruff==0.2.1
 rstcheck==6.1.1
 black[jupyter]==23.7.0
 blacken-docs==1.16.0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11044?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11044/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11044
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Upgrade ruff to 0.2.1 (the latest version).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
