### PR TITLE
Simplify `dev/ruff.py`

### DIFF
--- a/dev/ruff.py
+++ b/dev/ruff.py
@@ -19,7 +19,7 @@ def transform(stdout: str, is_maintainer: bool) -> str:
                 )
                 line = f"{line}. Run {command} to fix this error."
             else:
-                line = f"{line}. See https://docs.astral.sh/ruff/rules//{m.group(1)} for how to fix this error."
+                line = f"{line}. See https://docs.astral.sh/ruff/rules/{m.group(1)} for how to fix this error."
         transformed.append(line)
     return "\n".join(transformed)
 

--- a/dev/ruff.py
+++ b/dev/ruff.py
@@ -1,5 +1,3 @@
-import functools
-import json
 import os
 import re
 import subprocess
@@ -7,12 +5,6 @@ import sys
 
 RUFF = [sys.executable, "-m", "ruff"]
 MESSAGE_REGEX = re.compile(r"^.+:\d+:\d+: ([A-Z0-9]+) (\[\*\] )?.+$")
-
-
-@functools.lru_cache
-def get_rule_name(code: str) -> str:
-    out = subprocess.check_output([*RUFF, "rule", "--format", "json", code], text=True).strip()
-    return json.loads(out)["name"]
 
 
 def transform(stdout: str, is_maintainer: bool) -> str:
@@ -27,10 +19,7 @@ def transform(stdout: str, is_maintainer: bool) -> str:
                 )
                 line = f"{line}. Run {command} to fix this error."
             else:
-                name = get_rule_name(m.group(1))
-                line = (
-                    f"{line}. See https://beta.ruff.rs/docs/rules/{name} for how to fix this error."
-                )
+                line = f"{line}. See https://docs.astral.sh/ruff/rules//{m.group(1)} for how to fix this error."
         transformed.append(line)
     return "\n".join(transformed)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11045?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11045/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11045
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Simplify `dev/ruff.py`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
