### PR TITLE
Remove `testcode` directive and use `:test:` option instead

### DIFF
--- a/docs/source/testcode_block.py
+++ b/docs/source/testcode_block.py
@@ -62,7 +62,7 @@ class TestCodeBlockDirective(CodeBlock):
     Dumps code blocks marked with the `:test:` option to files for testing.
 
     ```
-    .. code-block:: ...
+    .. code-block:: python
         :test:
 
         print("Hello, world!")

--- a/docs/source/testcode_block.py
+++ b/docs/source/testcode_block.py
@@ -40,7 +40,8 @@ def _func():           # <- obj_line
 
     Docstring            <- obj_line + offset + extra_offset
 
-    .. testcode:: <- obj_line + offset + extra_offset + lineno_in_docstring
+    .. code-block::      <- obj_line + offset + extra_offset + lineno_in_docstring
+        :test:
         ...
     """
     pass

--- a/docs/source/testcode_block.py
+++ b/docs/source/testcode_block.py
@@ -5,6 +5,7 @@ import functools
 import re
 from pathlib import Path
 
+from docutils.parsers.rst import directives
 from sphinx.directives.code import CodeBlock
 
 
@@ -56,6 +57,11 @@ def get_code_block_location(obj_path, lineno_in_docstring, repo_root):
 
 
 class TestCodeBlockDirective(CodeBlock):
+    option_spec = {
+        **CodeBlock.option_spec,
+        "test": directives.flag
+    }
+
     def _dump_code_block(self):
         docs_dir = Path.cwd()
         repo_root = docs_dir.parent
@@ -87,12 +93,13 @@ class TestCodeBlockDirective(CodeBlock):
         directory.joinpath(filename).write_text(code)
 
     def run(self):
-        self._dump_code_block()
+        if "test" in self.options:
+            self._dump_code_block()
         return super().run()
 
 
 def setup(app):
-    app.add_directive("testcode", TestCodeBlockDirective)
+    app.add_directive("code-block", TestCodeBlockDirective, override=True)
     return {
         "version": "builtin",
         "parallel_read_safe": False,

--- a/docs/source/testcode_block.py
+++ b/docs/source/testcode_block.py
@@ -59,7 +59,8 @@ def get_code_block_location(obj_path, lineno_in_docstring, repo_root):
 
 class TestCodeBlockDirective(CodeBlock):
     """
-    Dumps code blocks marked with the `:test:` option to files for testing.
+    Overrides the `code-block` directive to dump code blocks marked with the `:test:` option
+    to files for testing.
 
     ```
     .. code-block:: python

--- a/docs/source/testcode_block.py
+++ b/docs/source/testcode_block.py
@@ -57,6 +57,16 @@ def get_code_block_location(obj_path, lineno_in_docstring, repo_root):
 
 
 class TestCodeBlockDirective(CodeBlock):
+    """
+    Dumps code blocks marked with the `:test:` option to files for testing.
+
+    ```
+    .. code-block:: ...
+        :test:
+
+        print("Hello, world!")
+    ```
+    """
     option_spec = {
         **CodeBlock.option_spec,
         "test": directives.flag

--- a/mlflow/data/numpy_dataset.py
+++ b/mlflow/data/numpy_dataset.py
@@ -181,7 +181,8 @@ def from_numpy(
         name: The name of the dataset. If unspecified, a name is generated.
         digest: The dataset digest (hash). If unspecified, a digest is computed automatically.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Basic Example
 
         import mlflow
@@ -191,7 +192,8 @@ def from_numpy(
         y = np.random.randint(2, size=[2])
         dataset = mlflow.data.from_numpy(x, targets=y)
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Dict Example
 
         import mlflow

--- a/mlflow/data/pandas_dataset.py
+++ b/mlflow/data/pandas_dataset.py
@@ -196,7 +196,8 @@ def from_pandas(
         predictions: An optional predictions column name for model evaluation. This column
             must be present in the dataframe (``df``).
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -125,7 +125,8 @@ def make_genai_metric(
 
     :return: A metric object.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example for creating a genai metric
 
         from mlflow.metrics.genai import EvaluationExample, make_genai_metric

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -503,7 +503,8 @@ class PyFuncModel:
 
         :return: The underlying wrapped model object
 
-        .. testcode:: python
+        .. code-block:: python
+        :test:
             :caption: Example
 
             import mlflow

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -504,7 +504,7 @@ class PyFuncModel:
         :return: The underlying wrapped model object
 
         .. code-block:: python
-        :test:
+            :test:
             :caption: Example
 
             import mlflow

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -956,7 +956,8 @@ def autolog(
             created if it does not already exist.
         extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import os

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -45,7 +45,8 @@ def register_model(
         Single :py:class:`mlflow.entities.model_registry.ModelVersion` object created by
         backend.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow.sklearn
@@ -158,7 +159,8 @@ def search_registered_models(
         A list of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
         that satisfy the search expressions.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -270,7 +272,8 @@ def search_model_versions(
         A list of :py:class:`mlflow.entities.model_registry.ModelVersion` objects
             that satisfy the search expressions.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -52,7 +52,8 @@ def set_tracking_uri(uri: Union[str, Path]) -> None:
               "databricks://<profileName>".
             - A :py:class:`pathlib.Path` instance
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -196,7 +196,7 @@ class MlflowClient:
             returns None.
 
         .. code-block:: python
-        :test:
+            :test:
             :caption: Example
 
             import mlflow
@@ -1586,7 +1586,7 @@ class MlflowClient:
                 the table is saved (e.g. "dir/file.json").
 
         .. code-block:: python
-        :test:
+            :test:
             :caption: Dictionary Example
 
             import mlflow
@@ -1604,7 +1604,7 @@ class MlflowClient:
             )
 
         .. code-block:: python
-        :test:
+            :test:
             :caption: Pandas DF Example
 
             import mlflow
@@ -1701,7 +1701,7 @@ class MlflowClient:
             or else throw a MlflowException.
 
          .. code-block:: python
-        :test:
+            :test:
             :caption: Example with passing run_ids
 
             import mlflow
@@ -1728,7 +1728,7 @@ class MlflowClient:
             )
 
         .. code-block:: python
-        :test:
+            :test:
             :caption: Example with passing no run_ids
 
             # Loads the table with the specified name for all runs in the given

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -195,7 +195,8 @@ class MlflowClient:
             A single :py:class:`mlflow.entities.Run` object, if the parent run exists. Otherwise,
             returns None.
 
-        .. testcode:: python
+        .. code-block:: python
+        :test:
             :caption: Example
 
             import mlflow
@@ -1584,7 +1585,8 @@ class MlflowClient:
             artifact_file: The run-relative artifact file path in posixpath format to which
                 the table is saved (e.g. "dir/file.json").
 
-        .. testcode:: python
+        .. code-block:: python
+        :test:
             :caption: Dictionary Example
 
             import mlflow
@@ -1601,7 +1603,8 @@ class MlflowClient:
                 run.info.run_id, data=table_dict, artifact_file="qabot_eval_results.json"
             )
 
-        .. testcode:: python
+        .. code-block:: python
+        :test:
             :caption: Pandas DF Example
 
             import mlflow
@@ -1697,7 +1700,8 @@ class MlflowClient:
             pandas.DataFrame containing the loaded table if the artifact exists
             or else throw a MlflowException.
 
-         .. testcode:: python
+         .. code-block:: python
+        :test:
             :caption: Example with passing run_ids
 
             import mlflow
@@ -1723,7 +1727,8 @@ class MlflowClient:
                 extra_columns=["run_id"],
             )
 
-        .. testcode:: python
+        .. code-block:: python
+        :test:
             :caption: Example with passing no run_ids
 
             # Loads the table with the specified name for all runs in the given

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -106,7 +106,8 @@ def set_experiment(
         An instance of :py:class:`mlflow.entities.Experiment` representing the new active
         experiment.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -248,7 +249,8 @@ def start_run(
         :py:class:`mlflow.ActiveRun` object that acts as a context manager wrapping the
         run's state.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -415,7 +417,8 @@ def end_run(status: str = RunStatus.to_string(RunStatus.FINISHED)) -> None:
     """
     End an active MLflow run (if there is one).
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -470,7 +473,8 @@ def active_run() -> Optional[ActiveRun]:
     (parameters, metrics, etc.) through the run returned by ``mlflow.active_run``. In order
     to access such attributes, use the :py:class:`mlflow.client.MlflowClient` as follows:
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -493,7 +497,8 @@ def last_active_run() -> Optional[Run]:
 
     Examples:
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: To retrieve the most recent autologged run:
 
         import mlflow
@@ -515,7 +520,8 @@ def last_active_run() -> Optional[Run]:
         predictions = rf.predict(X_test)
         autolog_run = mlflow.last_active_run()
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: To get the most recently active run that ended:
 
         import mlflow
@@ -524,7 +530,8 @@ def last_active_run() -> Optional[Run]:
         mlflow.end_run()
         run = mlflow.last_active_run()
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: To retrieve the currently active run:
 
         import mlflow
@@ -560,7 +567,8 @@ def get_run(run_id: str) -> Run:
     Returns:
         A single Run object, if the run exists. Otherwise, raises an exception.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -590,7 +598,8 @@ def get_parent_run(run_id: str) -> Optional[Run]:
         A single :py:class:`mlflow.entities.Run` object, if the parent run exists. Otherwise,
         returns None.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -634,7 +643,8 @@ def log_param(key: str, value: Any, synchronous: bool = True) -> Any:
         :py:class:`mlflow.utils.async_logging.run_operations.RunOperations` instance that represents
         future for logging operation.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -664,7 +674,8 @@ def set_experiment_tag(key: str, value: Any) -> None:
         value: Tag value, but will be string-ified if not. All backend stores will support values
             up to length 5000, but some may support larger values.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -695,7 +706,8 @@ def set_tag(key: str, value: Any, synchronous: bool = True) -> Optional[RunOpera
         :py:class:`mlflow.utils.async_logging.run_operations.RunOperations` instance that
         represents future for logging operation.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -720,7 +732,8 @@ def delete_tag(key: str) -> None:
     Args:
         key: Name of the tag
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -770,7 +783,8 @@ def log_metric(
         When `synchronous=False`, returns `RunOperations` that represents future for
         logging operation.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -820,7 +834,8 @@ def log_metrics(
         :py:class:`mlflow.utils.async_logging.run_operations.RunOperations` instance that
         represents future for logging operation.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -860,7 +875,8 @@ def log_params(params: Dict[str, Any], synchronous: bool = True) -> Optional[Run
         :py:class:`mlflow.utils.async_logging.run_operations.RunOperations` instance that
         represents future for logging operation.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -895,7 +911,8 @@ def log_input(
             This will be set as an input tag with key `mlflow.data.context`.
         tags: Tags to be associated with the dataset. Dictionary of tag_key -> tag_value.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import numpy as np
@@ -927,7 +944,8 @@ def set_experiment_tags(tags: Dict[str, Any]) -> None:
     Args:
         tags: Dictionary containing tag names and corresponding values.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -962,7 +980,8 @@ def set_tags(tags: Dict[str, Any], synchronous: bool = True) -> Optional[RunOper
         :py:class:`mlflow.utils.async_logging.run_operations.RunOperations` instance that
         represents future for logging operation.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -999,7 +1018,8 @@ def log_artifact(
         local_path: Path to the file to write.
         artifact_path: If provided, the directory in ``artifact_uri`` to write to.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -1028,7 +1048,8 @@ def log_artifacts(
         local_dir: Path to the directory of files to write.
         artifact_path: If provided, the directory in ``artifact_uri`` to write to.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import json
@@ -1061,7 +1082,8 @@ def log_text(text: str, artifact_file: str, run_id: Optional[str] = None) -> Non
         artifact_file: The run-relative artifact file path in posixpath format to which
             the text is saved (e.g. "dir/file.txt").
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -1093,7 +1115,8 @@ def log_dict(dictionary: Dict[str, Any], artifact_file: str, run_id: Optional[st
         artifact_file: The run-relative artifact file path in posixpath format to which
             the dictionary is saved (e.g. "dir/data.json").
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -1141,7 +1164,8 @@ def log_figure(
             the figure is saved (e.g. "dir/file.png").
         save_kwargs: Additional keyword arguments passed to the method that saves the figure.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Matplotlib Example
 
         import mlflow
@@ -1153,7 +1177,8 @@ def log_figure(
         with mlflow.start_run():
             mlflow.log_figure(fig, "figure.png")
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Plotly Example
 
         import mlflow
@@ -1206,7 +1231,8 @@ def log_image(image: Union["numpy.ndarray", "PIL.Image.Image"], artifact_file: s
         artifact_file: The run-relative artifact file path in posixpath format to which
             the image is saved (e.g. "dir/image.png").
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Numpy Example
 
         import mlflow
@@ -1217,7 +1243,8 @@ def log_image(image: Union["numpy.ndarray", "PIL.Image.Image"], artifact_file: s
         with mlflow.start_run():
             mlflow.log_image(image, "image.png")
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Pillow Example
 
         import mlflow
@@ -1247,7 +1274,8 @@ def log_table(
         artifact_file: The run-relative artifact file path in posixpath format to which
             the table is saved (e.g. "dir/file.json").
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Dictionary Example
 
         import mlflow
@@ -1261,7 +1289,8 @@ def log_table(
             # Log the dictionary as a table
             mlflow.log_table(data=table_dict, artifact_file="qabot_eval_results.json")
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Pandas DF Example
 
         import mlflow
@@ -1305,7 +1334,8 @@ def load_table(
         pandas.DataFrame containing the loaded table if the artifact exists
         or else throw a MlflowException.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example with passing run_ids
 
         import mlflow
@@ -1328,7 +1358,8 @@ def load_table(
             extra_columns=["run_id"],
         )
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example with passing no run_ids
 
         # Loads the table with the specified name for all runs in the given
@@ -1369,7 +1400,8 @@ def get_experiment(experiment_id: str) -> Experiment:
     Returns:
         :py:class:`mlflow.entities.Experiment`
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -1404,7 +1436,8 @@ def get_experiment_by_name(name: str) -> Optional[Experiment]:
         An instance of :py:class:`mlflow.entities.Experiment`
         if an experiment with the specified name exists, otherwise None.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -1485,7 +1518,8 @@ def search_experiments(
     Returns:
         A list of :py:class:`Experiment <mlflow.entities.Experiment>` objects.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -1559,7 +1593,8 @@ def create_experiment(
     Returns:
         String ID of the created experiment.
 
-     .. testcode:: python
+     .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -1599,7 +1634,8 @@ def delete_experiment(experiment_id: str) -> None:
     Args:
         experiment_id: The string-ified experiment ID returned from ``create_experiment``.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -1633,7 +1669,8 @@ def delete_run(run_id: str) -> None:
     Args:
         run_id: Unique identifier for the run to delete.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -1679,7 +1716,8 @@ def get_artifact_uri(artifact_path: Optional[str] = None) -> str:
         is not provided and the currently active run uses an S3-backed store, this may be a
         URI of the form ``s3://<bucket_name>/path/to/artifact/root``.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -1757,7 +1795,8 @@ def search_runs(
         the value for the corresponding column is (NumPy) ``Nan``, ``None``, or ``None``
         respectively.
 
-     .. testcode:: python
+     .. code-block:: python
+        :test:
         :caption: Example
 
         import mlflow
@@ -1989,7 +2028,8 @@ def autolog(
     Note that framework-specific configurations set at any point will take precedence over
     any configurations set by this function. For example:
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
 
         import mlflow
 
@@ -1999,7 +2039,8 @@ def autolog(
     would enable autologging for `sklearn` with `log_models=False` and `exclusive=True`,
     but
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
 
         import mlflow
 
@@ -2046,7 +2087,8 @@ def autolog(
             autologging setup and training execution.
         extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
 
-    .. testcode:: python
+    .. code-block:: python
+        :test:
         :caption: Example
 
         import numpy as np


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11058?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11058/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11058
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Related to https://github.com/astral-sh/ruff/discussions/9871. Removes `testcode` directives and use `code-block` with `:test:`. Once this PR is merged, we can format everything using ruff.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
