### PR TITLE
Support converting pandas Dataframe containing dicts into EvaluationDataset

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -432,6 +432,7 @@ def _hash_dict_as_bytes(data_dict):
     result = _hash_ndarray_as_bytes(list(data_dict.keys()))
     try:
         result += _hash_ndarray_as_bytes(list(data_dict.values()))
+    # If the values containing non-hashable objects, we will hash the values recursively.
     except Exception:
         for value in data_dict.values():
             result += _hash_data_as_bytes(value)

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -411,9 +411,31 @@ def _hash_uint64_ndarray_as_bytes(array):
 
 
 def _hash_ndarray_as_bytes(nd_array):
+    if not isinstance(nd_array, np.ndarray):
+        nd_array = np.array(nd_array)
     return _hash_uint64_ndarray_as_bytes(
         pd.util.hash_array(nd_array.flatten(order="C"))
     ) + _hash_uint64_ndarray_as_bytes(np.array(nd_array.shape, dtype="uint64"))
+
+
+def _hash_data_as_bytes(data):
+    if isinstance(data, (list, np.ndarray)):
+        return _hash_ndarray_as_bytes(data)
+    if isinstance(data, dict):
+        return _hash_dict_as_bytes(data)
+    if np.isscalar(data):
+        return _hash_uint64_ndarray_as_bytes(pd.util.hash_array(np.array([data])))
+    raise MlflowException(f"Unsupported data type for hashing: `{type(data)}`")
+
+
+def _hash_dict_as_bytes(data_dict):
+    result = _hash_ndarray_as_bytes(list(data_dict.keys()))
+    try:
+        result += _hash_ndarray_as_bytes(list(data_dict.values()))
+    except Exception:
+        for value in data_dict.values():
+            result += _hash_data_as_bytes(value)
+    return result
 
 
 def _hash_array_like_obj_as_bytes(data):
@@ -433,10 +455,8 @@ def _hash_array_like_obj_as_bytes(data):
             if spark_vector_type is not None:
                 if isinstance(v, spark_vector_type):
                     return _hash_ndarray_as_bytes(v.toArray())
-            if isinstance(v, np.ndarray):
-                return _hash_ndarray_as_bytes(v)
-            if isinstance(v, list):
-                return _hash_ndarray_as_bytes(np.array(v))
+            if isinstance(v, (dict, list, np.ndarray)):
+                return _hash_data_as_bytes(v)
             return v
 
         data = data.applymap(_hash_array_like_element_as_bytes)

--- a/tests/data/test_pandas_dataset.py
+++ b/tests/data/test_pandas_dataset.py
@@ -258,3 +258,24 @@ def test_df_hashing_with_strings():
     )
 
     assert dataset1.digest != dataset2.digest
+
+
+def test_df_hashing_with_dicts():
+    source_uri = "test:/my/test/uri"
+    source = TestDatasetSource._resolve(source_uri)
+
+    df = pd.DataFrame(
+        [
+            {"a": [1, 2, 3], "b": {"b": "b", "c": {"c": "c"}}, "c": 3, "d": "d"},
+            {"a": [2, 3], "b": {"b": "b"}, "c": 3, "d": "d"},
+        ]
+    )
+    dataset1 = PandasDataset(df=df, source=source, name="testname")
+    dataset2 = PandasDataset(df=df, source=source, name="testname")
+    assert dataset1.digest == dataset2.digest
+
+    evaluation_dataset = dataset1.to_evaluation_dataset()
+    assert isinstance(evaluation_dataset, EvaluationDataset)
+    assert evaluation_dataset.features_data.equals(df)
+    evaluation_dataset2 = dataset2.to_evaluation_dataset()
+    assert evaluation_dataset.hash == evaluation_dataset2.hash


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/11059?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11059/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11059
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Before this PR:
```
import pandas as pd
from mlflow.models.evaluation.base import _convert_data_to_mlflow_dataset

df = pd.DataFrame([{"input": {"text": "text"}, "output": "some_string"}])
data = _convert_data_to_mlflow_dataset(data=df, targets="output")
data.to_evaluation_dataset() <--- error
```
This is because dictionaries can not be hashed. This PR supports it.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
