### PR TITLE
Add CLI tool for updating requirements

### DIFF
--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -277,15 +277,15 @@ def build_docker(**kwargs):
 @commands.command("update-pip-requirements")
 @cli_args.MODEL_URI
 @click.argument("operation", type=click.Choice(["add", "remove"]))
-@click.argument("requirement_string", type=str)
-def update_pip_requirements(model_uri, operation, requirement_string):
+@click.argument("requirement_strings", type=str, nargs=-1)
+def update_pip_requirements(model_uri, operation, requirement_strings):
     """
     Add or remove requirements from a model's conda.yaml and requirements.txt files.
     If using a remote tracking server, please make sure to set the MLFLOW_TRACKING_URI
     environment variable to the URL of the desired server.
 
-    REQUIREMENT_STRING is a comma-separated string of pip requirements,
-    e.g. "pandas==1.0.0, scikit-learn".
+    REQUIREMENT_STRINGS is a list of pip requirements specifiers.
+    See below for examples.
 
     Sample usage:
 
@@ -294,12 +294,12 @@ def update_pip_requirements(model_uri, operation, requirement_string):
         # Add requirements using the model's "runs:/" URI
 
         mlflow models update-pip-requirements -m runs:/<run_id>/<model_path> \\
-            add "pandas==1.0.0, scikit-learn"
+            add "pandas==1.0.0" "scikit-learn" "mlflow >= 2.8, != 2.9.0"
 
         # Remove requirements from a local model
 
         mlflow models update-pip-requirements -m /path/to/local/model \\
-            remove "torchvision, pydantic"
+            remove "torchvision" "pydantic"
 
     Note that model registry URIs (i.e. URIs in the form ``models:/``) are not
     supported, as artifacts in the model registry are intended to be read-only.
@@ -313,7 +313,7 @@ def update_pip_requirements(model_uri, operation, requirement_string):
     found in the existing files will be ignored.
     """
     try:
-        requirements = [Requirement(s.strip().lower()) for s in requirement_string.split(",")]
+        requirements = [Requirement(s.strip().lower()) for s in requirement_strings]
     except InvalidRequirement as e:
         raise click.BadArgumentUsage(f"Invalid requirement: {e}")
 

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -714,6 +714,8 @@ def get_model_info(model_uri: str) -> ModelInfo:
 
 
 def get_model_requirements_files(resolved_uri: str) -> Dict[str, str]:
+    requirements_txt_file = None
+    conda_yaml_file = None
     try:
         requirements_txt_file = _download_artifact_from_uri(
             artifact_uri=append_to_uri_path(resolved_uri, _REQUIREMENTS_FILE_NAME)
@@ -722,8 +724,11 @@ def get_model_requirements_files(resolved_uri: str) -> Dict[str, str]:
             artifact_uri=append_to_uri_path(resolved_uri, _CONDA_ENV_FILE_NAME)
         )
     except Exception as ex:
+        file_name = (
+            _REQUIREMENTS_FILE_NAME if requirements_txt_file is None else _CONDA_ENV_FILE_NAME
+        )
         raise MlflowException(
-            f'Failed to download a model file from "{resolved_uri}"',
+            f'Failed to download "{file_name}" from "{resolved_uri}"',
             RESOURCE_DOES_NOT_EXIST,
         ) from ex
 

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -792,7 +792,7 @@ def _get_requirements_from_file(
         reqs = _get_pip_deps(conda_env)
     else:
         reqs = data.splitlines()
-    return [Requirement(req) for req in reqs]
+    return [Requirement(req) for req in reqs if req]
 
 
 def _write_requirements_to_file(
@@ -829,7 +829,7 @@ def _remove_requirements(
     old_reqs_dict = {req.name: str(req) for req in old_reqs}
     for req in reqs_to_remove:
         if req.name in old_reqs_dict:
-            _logger.info(f'"{req.name}" not found in requirements, ignoring')
+            _logger.warning(f'"{req.name}" not found in requirements, ignoring')
         old_reqs_dict.pop(req.name, None)
     return list(old_reqs_dict.values())
 

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -828,7 +828,7 @@ def _remove_requirements(
 ) -> List[str]:
     old_reqs_dict = {req.name: str(req) for req in old_reqs}
     for req in reqs_to_remove:
-        if req.name in old_reqs_dict:
+        if req.name not in old_reqs_dict:
             _logger.warning(f'"{req.name}" not found in requirements, ignoring')
         old_reqs_dict.pop(req.name, None)
     return list(old_reqs_dict.values())

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -15,6 +15,7 @@ import sklearn
 import sklearn.datasets
 import sklearn.neighbors
 from click.testing import CliRunner
+from packaging.requirements import Requirement
 
 import mlflow
 import mlflow.models.cli as models_cli
@@ -22,16 +23,23 @@ import mlflow.sklearn
 from mlflow.environment_variables import MLFLOW_DISABLE_ENV_MANAGER_CONDA_WARNING
 from mlflow.exceptions import MlflowException
 from mlflow.models.flavor_backend_registry import get_flavor_backend
+from mlflow.models.model import get_model_requirements_files
 from mlflow.protos.databricks_pb2 import BAD_REQUEST, ErrorCode
 from mlflow.pyfunc.backend import PyFuncBackend
 from mlflow.pyfunc.scoring_server import (
     CONTENT_TYPE_CSV,
     CONTENT_TYPE_JSON,
 )
+from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.utils import PYTHON_VERSION
 from mlflow.utils import env_manager as _EnvManager
 from mlflow.utils.conda import _get_conda_env_name
-from mlflow.utils.environment import _mlflow_conda_env
+from mlflow.utils.environment import (
+    _CONDA_ENV_FILE_NAME,
+    _REQUIREMENTS_FILE_NAME,
+    _get_requirements_from_file,
+    _mlflow_conda_env,
+)
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.process import ShellCommandException
 
@@ -844,3 +852,100 @@ def test_signature_enforcement_with_model_serving(input_schema, output_schema, p
 
     # Assert the prediction result
     assert json.loads(scoring_result.content)["predictions"] == ["test"]
+
+
+def assert_base_model_reqs():
+    """
+    Helper function for testing model requirements. Asserts that the
+    contents of requirements.txt and conda.yaml are as expected, then
+    returns their filepaths so mutations can be performed.
+    """
+    import cloudpickle
+
+    class MyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input, params=None):
+            return ["test"]
+
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(artifact_path="model", python_model=MyModel())
+
+    resolved_uri = RunsArtifactRepository.get_underlying_uri(model_info.model_uri)
+    local_paths = get_model_requirements_files(resolved_uri)
+
+    requirements_txt_file = local_paths[_REQUIREMENTS_FILE_NAME]
+    conda_env_file = local_paths[_CONDA_ENV_FILE_NAME]
+
+    reqs = _get_requirements_from_file(requirements_txt_file)
+    assert Requirement(f"mlflow=={mlflow.__version__}") in reqs
+    assert Requirement(f"cloudpickle=={cloudpickle.__version__}") in reqs
+
+    reqs = _get_requirements_from_file(conda_env_file)
+    assert Requirement(f"mlflow=={mlflow.__version__}") in reqs
+    assert Requirement(f"cloudpickle=={cloudpickle.__version__}") in reqs
+
+    return model_info.model_uri
+
+
+def test_update_requirements_cli_adds_reqs_successfully():
+    import cloudpickle
+
+    model_uri = assert_base_model_reqs()
+
+    CliRunner().invoke(
+        models_cli.update_pip_requirements,
+        ["-m", f"{model_uri}", "add", "mlflow==1.0.0, coolpackage==8.8.8"],
+        catch_exceptions=False,
+    )
+
+    resolved_uri = RunsArtifactRepository.get_underlying_uri(model_uri)
+    local_paths = get_model_requirements_files(resolved_uri)
+
+    # the tool should overwrite mlflow, add coolpackage, and leave cloudpickle alone
+    reqs = _get_requirements_from_file(local_paths[_REQUIREMENTS_FILE_NAME])
+    assert Requirement("mlflow==1.0.0") in reqs
+    assert Requirement("coolpackage==8.8.8") in reqs
+    assert Requirement(f"cloudpickle=={cloudpickle.__version__}") in reqs
+
+    reqs = _get_requirements_from_file(local_paths[_CONDA_ENV_FILE_NAME])
+    assert Requirement("mlflow==1.0.0") in reqs
+    assert Requirement("coolpackage==8.8.8") in reqs
+    assert Requirement(f"cloudpickle=={cloudpickle.__version__}") in reqs
+
+
+def test_update_requirements_cli_removes_reqs_successfully():
+    import cloudpickle
+
+    model_uri = assert_base_model_reqs()
+
+    CliRunner().invoke(
+        models_cli.update_pip_requirements,
+        ["-m", f"{model_uri}", "remove", "mlflow"],
+        catch_exceptions=False,
+    )
+
+    resolved_uri = RunsArtifactRepository.get_underlying_uri(model_uri)
+    local_paths = get_model_requirements_files(resolved_uri)
+
+    # the tool should remove mlflow and leave cloudpickle alone
+    reqs = _get_requirements_from_file(local_paths[_REQUIREMENTS_FILE_NAME])
+    assert len(reqs) == 1
+    assert Requirement(f"mlflow=={mlflow.__version__}") not in reqs
+    assert Requirement(f"cloudpickle=={cloudpickle.__version__}") in reqs
+
+    reqs = _get_requirements_from_file(local_paths[_CONDA_ENV_FILE_NAME])
+    assert len(reqs) == 1
+    assert Requirement(f"mlflow=={mlflow.__version__}") not in reqs
+    assert Requirement(f"cloudpickle=={cloudpickle.__version__}") in reqs
+
+
+def test_update_requirements_cli_throws_on_incompatible_input():
+    model_uri = assert_base_model_reqs()
+
+    with pytest.raises(
+        MlflowException, match="The specified requirements versions are incompatible"
+    ):
+        CliRunner().invoke(
+            models_cli.update_pip_requirements,
+            ["-m", f"{model_uri}", "add", "mlflow<2.6, mlflow>2.7"],
+            catch_exceptions=False,
+        )

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -891,7 +891,7 @@ def test_update_requirements_cli_adds_reqs_successfully():
 
     CliRunner().invoke(
         models_cli.update_pip_requirements,
-        ["-m", f"{model_uri}", "add", "mlflow>=2.9, !=2.9.0" "coolpackage[extra]==8.8.8"],
+        ["-m", f"{model_uri}", "add", "mlflow>=2.9, !=2.9.0", "coolpackage[extra]==8.8.8"],
         catch_exceptions=False,
     )
 

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -942,6 +942,6 @@ def test_update_requirements_cli_throws_on_incompatible_input():
     ):
         CliRunner().invoke(
             models_cli.update_pip_requirements,
-            ["-m", f"{model_uri}", "add", "mlflow<2.6, mlflow>2.7"],
+            ["-m", f"{model_uri}", "add", "mlflow<2.6", "mlflow>2.7"],
             catch_exceptions=False,
         )

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -926,9 +926,7 @@ def test_update_requirements_cli_removes_reqs_successfully():
 
     # the tool should remove mlflow and leave cloudpickle alone
     reqs = _get_requirements_from_file(local_paths.requirements)
-    assert len(reqs) == 1
-    assert Requirement(f"mlflow=={mlflow.__version__}") not in reqs
-    assert Requirement(f"cloudpickle=={cloudpickle.__version__}") in reqs
+    assert reqs == [Requirement(f"cloudpickle=={cloudpickle.__version__}")]
 
     reqs = _get_requirements_from_file(local_paths.conda)
     assert reqs == [Requirement(f"cloudpickle=={cloudpickle.__version__}")]


### PR DESCRIPTION
### Related Issues/PRs

### What changes are proposed in this pull request?

This PR adds a CLI tool to update `conda.yaml` and `requirements.txt` files programmatically. It works for both local and remote URIs, using existing utils to fetch and upload artifacts. I mainly modelled the implementation after [set_signature](https://github.com/mlflow/mlflow/blob/2f6928954e627bd6f86675e4cd172fefc358efda/mlflow/models/signature.py#L377), which does pretty much the same thing for signatures.

You can call the tool like this:
```bash
$ mlflow models update-pip-requirements -m runs:/<run-id>/<artifact-path> add "pytorch" "pydantic>=2.1"

$ mlflow models update-pip-requirements -m path/to/local/model remove "torchvision" "tensorflow"
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added a CLI tool to update `conda.yaml` and `requirements.txt` files, eliminating the need to edit these files manually.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
