### PR TITLE
Bump python versions used in CI to latest

### DIFF
--- a/.github/actions/setup-pyenv/action.yml
+++ b/.github/actions/setup-pyenv/action.yml
@@ -18,9 +18,6 @@ runs:
       shell: bash
       run: |
         git clone https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
-        cd $HOME/.pyenv
-        # Checkout cb5da5e831fb50ce0ac44fc13617965b2309a482 to avoid https://github.com/pyenv/pyenv/commit/ca1593c80eae0b84349ca163699b71b04ea8b9fa that broke tests for virtualenv project execution
-        git checkout cb5da5e831fb50ce0ac44fc13617965b2309a482
     - name: Setup environment variables
       if: runner.os == 'Linux'
       shell: bash

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -28,10 +28,10 @@ runs:
             # GitHub Actions does not have a Python 3.8.12 binary for Windows as of Oct. 27 2022
             python_version="3.8.10"
           else
-            python_version="3.8.12"
+            python_version="3.8.18"
           fi
         elif [[ "$python_version" == "3.9" ]]; then
-          python_version="3.9.13"
+          python_version="3.9.18"
         else
           echo "Invalid python version: '$python_version'. Must be '3.8'"
           exit 1

--- a/examples/virtualenv/project/entrypoint.py
+++ b/examples/virtualenv/project/entrypoint.py
@@ -20,7 +20,7 @@ parser.add_argument(
 args = parser.parse_args()
 if args.test:
     assert "VIRTUAL_ENV" in os.environ
-    assert sys.version_info[:3] == (3, 8, 13), sys.version_info
+    assert sys.version_info[:3] == (3, 8, 18), sys.version_info
     assert sklearn.__version__ == "1.0.2", sklearn.__version__
 
 X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1]])

--- a/tests/resources/example_virtualenv_conda_project/entrypoint.py
+++ b/tests/resources/example_virtualenv_conda_project/entrypoint.py
@@ -20,7 +20,7 @@ parser.add_argument(
 args = parser.parse_args()
 if args.test:
     assert "VIRTUAL_ENV" in os.environ
-    assert sys.version_info[:3] == (3, 8, 13), sys.version_info
+    assert sys.version_info[:3] == (3, 8, 18), sys.version_info
     assert sklearn.__version__ == "1.0.2", sklearn.__version__
 
 X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1]])

--- a/tests/resources/example_virtualenv_no_python_env/entrypoint.py
+++ b/tests/resources/example_virtualenv_no_python_env/entrypoint.py
@@ -20,7 +20,7 @@ parser.add_argument(
 args = parser.parse_args()
 if args.test:
     assert "VIRTUAL_ENV" in os.environ
-    assert sys.version_info[:3] == (3, 8, 13), sys.version_info
+    assert sys.version_info[:3] == (3, 8, 18), sys.version_info
     assert sklearn.__version__ == "1.0.2", sklearn.__version__
 
 X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1]])

--- a/tests/resources/example_virtualenv_project/entrypoint.py
+++ b/tests/resources/example_virtualenv_project/entrypoint.py
@@ -20,7 +20,7 @@ parser.add_argument(
 args = parser.parse_args()
 if args.test:
     assert "VIRTUAL_ENV" in os.environ
-    assert sys.version_info[:3] == (3, 8, 13), sys.version_info
+    assert sys.version_info[:3] == (3, 8, 18), sys.version_info
     assert sklearn.__version__ == "1.0.2", sklearn.__version__
 
 X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1]])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11070?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11070/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11070
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Bumps the python versions used in CI to the latest.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
