### PR TITLE
Turn `PytestCollectionWarning` into error

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2171,9 +2171,7 @@ def log_model(
 
 
                 with mlflow.start_run():
-                    model_info = mlflow.pyfunc.log_model(
-                        artifact_path="model", python_model=MyModel()
-                    )  # pylint: disable=line-too-long
+                    model_info = mlflow.pyfunc.log_model(artifact_path="model", python_model=MyModel())  # pylint: disable=line-too-long
 
 
                 loaded_model = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2171,7 +2171,9 @@ def log_model(
 
 
                 with mlflow.start_run():
-                    model_info = mlflow.pyfunc.log_model(artifact_path="model", python_model=MyModel())  # pylint: disable=line-too-long
+                    model_info = mlflow.pyfunc.log_model(
+                        artifact_path="model", python_model=MyModel()
+                    )  # pylint: disable=line-too-long
 
 
                 loaded_model = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,7 @@ filterwarnings =
   # Prevent deprecated numpy type aliases from being used
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:mlflow
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:tests
-  error::PytestCollectionWarning
+  error::pytest.PytestCollectionWarning
 markers =
   skipcacheclean: skip cleaning the HuggingFace cache directory after test run, only used for Transformers flavor tests
 timeout = 1200

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,7 @@ filterwarnings =
   # Prevent deprecated numpy type aliases from being used
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:mlflow
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:tests
+  error::PytestCollectionWarning
 markers =
   skipcacheclean: skip cleaning the HuggingFace cache directory after test run, only used for Transformers flavor tests
 timeout = 1200

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -2,14 +2,14 @@ import json
 
 from mlflow.types.schema import Schema
 
-from tests.resources.data.dataset import TestDataset
-from tests.resources.data.dataset_source import TestDatasetSource
+from tests.resources.data.dataset import SampleDataset
+from tests.resources.data.dataset_source import SampleDatasetSource
 
 
 def test_conversion_to_json():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
-    dataset = TestDataset(data_list=[1, 2, 3], source=source, name="testname")
+    source = SampleDatasetSource._resolve(source_uri)
+    dataset = SampleDataset(data_list=[1, 2, 3], source=source, name="testname")
 
     dataset_json = dataset.to_json()
     parsed_json = json.loads(dataset_json)
@@ -26,17 +26,17 @@ def test_conversion_to_json():
 
 def test_digest_property_has_expected_value():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
-    dataset = TestDataset(data_list=[1, 2, 3], source=source, name="testname")
+    source = SampleDatasetSource._resolve(source_uri)
+    dataset = SampleDataset(data_list=[1, 2, 3], source=source, name="testname")
     assert dataset.digest == dataset._compute_digest()
 
 
 def test_expected_name_is_used():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
 
-    dataset_without_name = TestDataset(data_list=[1, 2, 3], source=source)
+    dataset_without_name = SampleDataset(data_list=[1, 2, 3], source=source)
     assert dataset_without_name.name == "dataset"
 
-    dataset_with_name = TestDataset(data_list=[1, 2, 3], source=source, name="testname")
+    dataset_with_name = SampleDataset(data_list=[1, 2, 3], source=source, name="testname")
     assert dataset_with_name.name == "testname"

--- a/tests/data/test_dataset_registry.py
+++ b/tests/data/test_dataset_registry.py
@@ -9,8 +9,8 @@ from mlflow.data.dataset_registry import DatasetRegistry, register_constructor
 from mlflow.data.dataset_source_registry import DatasetSourceRegistry, resolve_dataset_source
 from mlflow.exceptions import MlflowException
 
-from tests.resources.data.dataset import TestDataset
-from tests.resources.data.dataset_source import TestDatasetSource
+from tests.resources.data.dataset import SampleDataset
+from tests.resources.data.dataset_source import SampleDatasetSource
 
 
 @pytest.fixture
@@ -116,37 +116,37 @@ def test_register_constructor_from_entrypoints_and_call(dataset_registry, tmp_pa
 
 
 def test_register_constructor_and_call(dataset_registry, dataset_source_registry, tmp_path):  # pylint: disable=unused-argument
-    dataset_source_registry.register(TestDatasetSource)
+    dataset_source_registry.register(SampleDatasetSource)
 
-    def from_test(data_list, source, name=None, digest=None) -> TestDataset:
-        resolved_source: TestDatasetSource = resolve_dataset_source(
-            source, candidate_sources=[TestDatasetSource]
+    def from_test(data_list, source, name=None, digest=None) -> SampleDataset:
+        resolved_source: SampleDatasetSource = resolve_dataset_source(
+            source, candidate_sources=[SampleDatasetSource]
         )
-        return TestDataset(data_list=data_list, source=resolved_source, name=name, digest=digest)
+        return SampleDataset(data_list=data_list, source=resolved_source, name=name, digest=digest)
 
     register_constructor(constructor_fn=from_test)
     register_constructor(constructor_name="from_test_2", constructor_fn=from_test)
 
     dataset1 = mlflow.data.from_test(
         data_list=[1, 2, 3],
-        # Use a TestDatasetSourceURI
+        # Use a SampleDatasetSourceURI
         source="test:" + str(tmp_path),
         name="name1",
         digest="digest1",
     )
-    assert isinstance(dataset1, TestDataset)
+    assert isinstance(dataset1, SampleDataset)
     assert dataset1.data_list == [1, 2, 3]
     assert dataset1.name == "name1"
     assert dataset1.digest == "digest1"
 
     dataset2 = mlflow.data.from_test_2(
         data_list=[4, 5, 6],
-        # Use a TestDatasetSourceURI
+        # Use a SampleDatasetSourceURI
         source="test:" + str(tmp_path),
         name="name2",
         digest="digest2",
     )
-    assert isinstance(dataset2, TestDataset)
+    assert isinstance(dataset2, SampleDataset)
     assert dataset2.data_list == [4, 5, 6]
     assert dataset2.name == "name2"
     assert dataset2.digest == "digest2"

--- a/tests/data/test_dataset_source.py
+++ b/tests/data/test_dataset_source.py
@@ -6,19 +6,19 @@ import pytest
 import mlflow.data
 from mlflow.exceptions import MlflowException
 
-from tests.resources.data.dataset_source import TestDatasetSource
+from tests.resources.data.dataset_source import SampleDatasetSource
 
 
 def test_load(tmp_path):
-    assert TestDatasetSource("test:" + str(tmp_path)).load() == str(tmp_path)
+    assert SampleDatasetSource("test:" + str(tmp_path)).load() == str(tmp_path)
 
 
 def test_conversion_to_json_and_back():
     uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(uri)
+    source = SampleDatasetSource._resolve(uri)
     source_json = source.to_json()
     assert json.loads(source_json)["uri"] == uri
-    reloaded_source = TestDatasetSource.from_json(source_json)
+    reloaded_source = SampleDatasetSource.from_json(source_json)
     assert reloaded_source.uri == source.uri
 
 

--- a/tests/data/test_dataset_source_registry.py
+++ b/tests/data/test_dataset_source_registry.py
@@ -6,7 +6,7 @@ import pytest
 from mlflow.data.dataset_source_registry import DatasetSourceRegistry
 from mlflow.exceptions import MlflowException
 
-from tests.resources.data.dataset_source import TestDatasetSource
+from tests.resources.data.dataset_source import SampleDatasetSource
 
 
 def test_register_entrypoints_and_resolve(tmp_path):
@@ -26,18 +26,18 @@ def test_register_entrypoints_and_resolve(tmp_path):
 
 def test_register_dataset_source_and_resolve(tmp_path):
     registry = DatasetSourceRegistry()
-    registry.register(TestDatasetSource)
+    registry.register(SampleDatasetSource)
 
     uri = "test:" + str(tmp_path)
     resolved_source = registry.resolve(uri)
-    assert isinstance(resolved_source, TestDatasetSource)
-    # Verify that the TestDatasetSource is constructed with the correct URI
+    assert isinstance(resolved_source, SampleDatasetSource)
+    # Verify that the SampleDatasetSource is constructed with the correct URI
     assert resolved_source.uri == uri
 
 
 def test_register_dataset_source_and_load_from_json(tmp_path):
     registry = DatasetSourceRegistry()
-    registry.register(TestDatasetSource)
+    registry.register(SampleDatasetSource)
     resolved_source = registry.resolve("test:" + str(tmp_path))
     resolved_source_json = resolved_source.to_json()
     source_from_json = registry.get_source_from_json(
@@ -48,12 +48,12 @@ def test_register_dataset_source_and_load_from_json(tmp_path):
 
 def test_load_from_json_throws_for_unrecognized_source_type(tmp_path):
     registry = DatasetSourceRegistry()
-    registry.register(TestDatasetSource)
+    registry.register(SampleDatasetSource)
 
     with pytest.raises(MlflowException, match="unrecognized source type: foo"):
         registry.get_source_from_json(source_json='{"bar": "123"}', source_type="foo")
 
-    class CandidateDatasetSource1(TestDatasetSource):
+    class CandidateDatasetSource1(SampleDatasetSource):
         @staticmethod
         def _get_source_type() -> str:
             return "candidate1"
@@ -72,25 +72,25 @@ def test_load_from_json_throws_for_unrecognized_source_type(tmp_path):
             return raw_source.startswith("candidate2")
 
     registry = DatasetSourceRegistry()
-    registry.register(TestDatasetSource)
+    registry.register(SampleDatasetSource)
     registry.register(CandidateDatasetSource1)
     registry.register(CandidateDatasetSource2)
 
     registry.resolve("test:" + str(tmp_path))
-    registry.resolve("test:" + str(tmp_path), candidate_sources=[TestDatasetSource])
+    registry.resolve("test:" + str(tmp_path), candidate_sources=[SampleDatasetSource])
     with pytest.raises(MlflowException, match="Could not find a source information resolver"):
-        # TestDatasetSource is the only source that can resolve raw sources with scheme "test",
-        # and TestDatasetSource is not a subclass of CandidateDatasetSource1
+        # SampleDatasetSource is the only source that can resolve raw sources with scheme "test",
+        # and SampleDatasetSource is not a subclass of CandidateDatasetSource1
         registry.resolve("test:" + str(tmp_path), candidate_sources=[CandidateDatasetSource1])
 
     registry.resolve("candidate1:" + str(tmp_path))
     registry.resolve("candidate1:" + str(tmp_path), candidate_sources=[CandidateDatasetSource1])
-    # CandidateDatasetSource1 is a subclass of TestDatasetSource and is therefore considered
+    # CandidateDatasetSource1 is a subclass of SampleDatasetSource and is therefore considered
     # as a candidate for resolution
-    registry.resolve("candidate1:" + str(tmp_path), candidate_sources=[TestDatasetSource])
+    registry.resolve("candidate1:" + str(tmp_path), candidate_sources=[SampleDatasetSource])
     with pytest.raises(MlflowException, match="Could not find a source information resolver"):
         # CandidateDatasetSource2 is not a superclass of CandidateDatasetSource1 or
-        # TestDatasetSource and cannot resolve raw sources with scheme "candidate1"
+        # SampleDatasetSource and cannot resolve raw sources with scheme "candidate1"
         registry.resolve("candidate1:" + str(tmp_path), candidate_sources=[CandidateDatasetSource2])
 
 
@@ -99,31 +99,31 @@ def test_resolve_dataset_source_maintains_consistent_order_and_uses_last_registe
 
     from mlflow_test_plugin.dummy_dataset_source import DummyDatasetSource
 
-    class TestDatasetSourceCopy1(TestDatasetSource):
+    class SampleDatasetSourceCopy1(SampleDatasetSource):
         pass
 
-    class TestDatasetSourceCopy2(TestDatasetSource):
+    class SampleDatasetSourceCopy2(SampleDatasetSource):
         pass
 
     registry1 = DatasetSourceRegistry()
-    registry1.register(TestDatasetSource)
-    registry1.register(TestDatasetSourceCopy1)
-    registry1.register(TestDatasetSourceCopy2)
+    registry1.register(SampleDatasetSource)
+    registry1.register(SampleDatasetSourceCopy1)
+    registry1.register(SampleDatasetSourceCopy2)
     source1 = registry1.resolve("test:/" + str(tmp_path))
-    assert isinstance(source1, TestDatasetSourceCopy2)
+    assert isinstance(source1, SampleDatasetSourceCopy2)
 
     registry2 = DatasetSourceRegistry()
-    registry2.register(TestDatasetSource)
-    registry2.register(TestDatasetSourceCopy2)
-    registry2.register(TestDatasetSourceCopy1)
+    registry2.register(SampleDatasetSource)
+    registry2.register(SampleDatasetSourceCopy2)
+    registry2.register(SampleDatasetSourceCopy1)
     source2 = registry2.resolve("test:/" + str(tmp_path))
-    assert isinstance(source2, TestDatasetSourceCopy1)
+    assert isinstance(source2, SampleDatasetSourceCopy1)
 
     # Verify that a different matching dataset source can still be resolved via `candidates`
     source3 = registry2.resolve(
-        "test:/" + str(tmp_path), candidate_sources=[TestDatasetSourceCopy2]
+        "test:/" + str(tmp_path), candidate_sources=[SampleDatasetSourceCopy2]
     )
-    assert isinstance(source3, TestDatasetSourceCopy2)
+    assert isinstance(source3, SampleDatasetSourceCopy2)
 
     # Verify that last registered order applies to entrypoints too
     class DummyDatasetSourceCopy(DummyDatasetSource):
@@ -139,16 +139,16 @@ def test_resolve_dataset_source_maintains_consistent_order_and_uses_last_registe
 
 
 def test_resolve_dataset_source_warns_when_multiple_matching_sources_found(tmp_path):
-    class TestDatasetSourceCopy1(TestDatasetSource):
+    class SampleDatasetSourceCopy1(SampleDatasetSource):
         pass
 
-    class TestDatasetSourceCopy2(TestDatasetSource):
+    class SampleDatasetSourceCopy2(SampleDatasetSource):
         pass
 
     registry1 = DatasetSourceRegistry()
-    registry1.register(TestDatasetSource)
-    registry1.register(TestDatasetSourceCopy1)
-    registry1.register(TestDatasetSourceCopy2)
+    registry1.register(SampleDatasetSource)
+    registry1.register(SampleDatasetSourceCopy1)
+    registry1.register(SampleDatasetSourceCopy2)
 
     with mock.patch("mlflow.data.dataset_source_registry.warnings.warn") as mock_warn:
         registry1.resolve("test:/" + str(tmp_path))
@@ -159,11 +159,12 @@ def test_resolve_dataset_source_warns_when_multiple_matching_sources_found(tmp_p
             "The specified dataset source can be interpreted in multiple ways" in multiple_match_msg
         )
         assert (
-            "TestDatasetSource, TestDatasetSourceCopy1, TestDatasetSourceCopy2"
+            "SampleDatasetSource, SampleDatasetSourceCopy1, SampleDatasetSourceCopy2"
             in multiple_match_msg
         )
         assert (
-            "MLflow will assume that this is a TestDatasetSourceCopy2 source" in multiple_match_msg
+            "MLflow will assume that this is a SampleDatasetSourceCopy2 source"
+            in multiple_match_msg
         )
 
 

--- a/tests/data/test_numpy_dataset.py
+++ b/tests/data/test_numpy_dataset.py
@@ -13,12 +13,12 @@ from mlflow.data.schema import TensorDatasetSchema
 from mlflow.models.evaluation.base import EvaluationDataset
 from mlflow.types.utils import _infer_schema
 
-from tests.resources.data.dataset_source import TestDatasetSource
+from tests.resources.data.dataset_source import SampleDatasetSource
 
 
 def test_conversion_to_json():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = NumpyDataset(features=np.array([1, 2, 3]), source=source, name="testname")
 
     dataset_json = dataset.to_json()
@@ -65,7 +65,7 @@ def test_conversion_to_json():
 )
 def test_conversion_to_json_with_multi_tensor_features_and_targets(features, targets):
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = NumpyDataset(features=features, targets=targets, source=source)
 
     dataset_json = dataset.to_json()
@@ -111,7 +111,7 @@ def test_conversion_to_json_with_multi_tensor_features_and_targets(features, tar
 )
 def test_schema_and_profile_with_multi_tensor_features_and_targets(features, targets):
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = NumpyDataset(features=features, targets=targets, source=source)
 
     assert isinstance(dataset.schema, TensorDatasetSchema)
@@ -147,7 +147,7 @@ def test_schema_and_profile_with_multi_tensor_features_and_targets(features, tar
 
 def test_digest_property_has_expected_value():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     features = np.array([1, 2, 3])
     targets = np.array([4, 5, 6])
     dataset_with_features = NumpyDataset(features=features, source=source, name="testname")
@@ -165,7 +165,7 @@ def test_digest_property_has_expected_value():
 
 def test_features_property():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     features = np.array([1, 2, 3])
     dataset = NumpyDataset(features=features, source=source, name="testname")
     assert np.array_equal(dataset.features, features)
@@ -173,7 +173,7 @@ def test_features_property():
 
 def test_targets_property():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     features = np.array([1, 2, 3])
     targets = np.array([4, 5, 6])
     dataset_with_targets = NumpyDataset(
@@ -186,7 +186,7 @@ def test_targets_property():
 
 def test_to_pyfunc():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     features = np.array([1, 2, 3])
     dataset = NumpyDataset(features=features, source=source, name="testname")
     assert isinstance(dataset.to_pyfunc(), PyFuncInputsOutputs)
@@ -194,7 +194,7 @@ def test_to_pyfunc():
 
 def test_to_evaluation_dataset():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     features = np.array([[1, 2], [3, 4]])
     targets = np.array([0, 1])
     dataset = NumpyDataset(features=features, targets=targets, source=source, name="testname")

--- a/tests/data/test_pandas_dataset.py
+++ b/tests/data/test_pandas_dataset.py
@@ -15,7 +15,7 @@ from mlflow.models.evaluation.base import EvaluationDataset
 from mlflow.types.schema import Schema
 from mlflow.types.utils import _infer_schema
 
-from tests.resources.data.dataset_source import TestDatasetSource
+from tests.resources.data.dataset_source import SampleDatasetSource
 
 
 @pytest.fixture(scope="module")
@@ -36,7 +36,7 @@ def spark_session():
 
 def test_conversion_to_json():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
 
     dataset = PandasDataset(
         df=pd.DataFrame([1, 2, 3], columns=["Numbers"]),
@@ -59,7 +59,7 @@ def test_conversion_to_json():
 
 def test_digest_property_has_expected_value():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = PandasDataset(
         df=pd.DataFrame([1, 2, 3], columns=["Numbers"]),
         source=source,
@@ -71,7 +71,7 @@ def test_digest_property_has_expected_value():
 
 def test_df_property():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     df = pd.DataFrame([1, 2, 3], columns=["Numbers"])
     dataset = PandasDataset(
         df=df,
@@ -83,7 +83,7 @@ def test_df_property():
 
 def test_targets_property():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     df_no_targets = pd.DataFrame([1, 2, 3], columns=["Numbers"])
     dataset_no_targets = PandasDataset(
         df=df_no_targets,
@@ -103,7 +103,7 @@ def test_targets_property():
 
 def test_with_invalid_targets():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     df = pd.DataFrame([[1, 2, 3], [1, 2, 3]], columns=["a", "b", "c"])
     with pytest.raises(
         MlflowException,
@@ -119,7 +119,7 @@ def test_with_invalid_targets():
 
 def test_to_pyfunc():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     df = pd.DataFrame([1, 2, 3], columns=["Numbers"])
     dataset = PandasDataset(
         df=df,
@@ -131,7 +131,7 @@ def test_to_pyfunc():
 
 def test_to_pyfunc_with_outputs():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     df = pd.DataFrame([[1, 2, 3], [1, 2, 3]], columns=["a", "b", "c"])
     dataset = PandasDataset(
         df=df,
@@ -227,7 +227,7 @@ def test_to_evaluation_dataset():
     import numpy as np
 
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     df = pd.DataFrame([[1, 2, 3], [1, 2, 3]], columns=["a", "b", "c"])
     dataset = PandasDataset(
         df=df,
@@ -243,7 +243,7 @@ def test_to_evaluation_dataset():
 
 def test_df_hashing_with_strings():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
 
     dataset1 = PandasDataset(
         df=pd.DataFrame([["a", 2, 3], ["a", 2, 3]], columns=["text_column", "b", "c"]),
@@ -262,7 +262,7 @@ def test_df_hashing_with_strings():
 
 def test_df_hashing_with_dicts():
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
 
     df = pd.DataFrame(
         [

--- a/tests/data/test_tensorflow_dataset.py
+++ b/tests/data/test_tensorflow_dataset.py
@@ -13,7 +13,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models.evaluation.base import EvaluationDataset
 from mlflow.types.utils import _infer_schema
 
-from tests.resources.data.dataset_source import TestDatasetSource
+from tests.resources.data.dataset_source import SampleDatasetSource
 
 
 def test_dataset_construction_validates_features_and_targets():
@@ -80,7 +80,7 @@ def test_conversion_to_json():
     source_uri = "test:/my/test/uri"
     x = np.random.sample((100, 2))
     tf_dataset = tf.data.Dataset.from_tensors(x)
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = TensorFlowDataset(features=tf_dataset, source=source, name="testname")
 
     dataset_json = dataset.to_json()
@@ -145,7 +145,7 @@ def test_conversion_to_json():
 )
 def test_conversion_to_json_with_multi_tensor_datasets(features, targets):
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = TensorFlowDataset(features=features, targets=targets, source=source, name="testname")
 
     dataset_json = dataset.to_json()
@@ -175,7 +175,7 @@ def test_schema_and_profile_with_multi_tensor_tuple_datasets():
         )
     )
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = TensorFlowDataset(
         features=features_dataset, targets=targets_dataset, source=source, name="testname"
     )
@@ -209,7 +209,7 @@ def test_schema_and_profile_with_multi_tensor_dict_datasets():
         {"c": np.random.sample((100, 1)), "d": np.random.sample((100,))}
     )
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = TensorFlowDataset(
         features=features_dataset, targets=targets_dataset, source=source, name="testname"
     )
@@ -239,7 +239,7 @@ def test_digest_property_has_expected_value():
     source_uri = "test:/my/test/uri"
     x = [[1, 2, 3], [4, 5, 6]]
     tf_dataset = tf.data.Dataset.from_tensors(x)
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = TensorFlowDataset(features=tf_dataset, source=source, name="testname")
     assert dataset.digest == dataset._compute_digest()
     assert dataset.digest == "666a9820"
@@ -249,7 +249,7 @@ def test_data_property_has_expected_value():
     source_uri = "test:/my/test/uri"
     x = [[1, 2, 3], [4, 5, 6]]
     tf_dataset = tf.data.Dataset.from_tensors(x)
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = TensorFlowDataset(features=tf_dataset, source=source, name="testname")
     assert dataset.data == tf_dataset
 
@@ -258,7 +258,7 @@ def test_source_property_has_expected_value():
     source_uri = "test:/my/test/uri"
     x = [[1, 2, 3], [4, 5, 6]]
     tf_dataset = tf.data.Dataset.from_tensors(x)
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = TensorFlowDataset(features=tf_dataset, source=source, name="testname")
     assert dataset.source == source
 
@@ -267,7 +267,7 @@ def test_profile_property_has_expected_value_dataset():
     source_uri = "test:/my/test/uri"
     x = [[1, 2, 3], [4, 5, 6]]
     tf_dataset = tf.data.Dataset.from_tensors(x)
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = TensorFlowDataset(features=tf_dataset, source=source, name="testname")
     assert dataset.profile == {
         "features_cardinality": tf_dataset.cardinality().numpy(),
@@ -278,7 +278,7 @@ def test_profile_property_has_expected_value_tensors():
     source_uri = "test:/my/test/uri"
     x = [[1, 2, 3], [4, 5, 6]]
     tf_tensor = tf.convert_to_tensor(x)
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = TensorFlowDataset(features=tf_tensor, source=source, name="testname")
     assert dataset.profile == {
         "features_cardinality": tf.size(tf_tensor).numpy(),
@@ -289,7 +289,7 @@ def test_to_pyfunc():
     source_uri = "test:/my/test/uri"
     x = np.random.sample((100, 2))
     tf_dataset = tf.data.Dataset.from_tensors(x)
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = TensorFlowDataset(features=tf_dataset, source=source, name="testname")
     assert isinstance(dataset.to_pyfunc(), PyFuncInputsOutputs)
 
@@ -300,7 +300,7 @@ def test_to_evaluation_dataset():
     y = np.random.sample((2, 1))
     x_tensors = tf.convert_to_tensor(x)
     y_tensors = tf.convert_to_tensor(y)
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = TensorFlowDataset(
         features=x_tensors, source=source, targets=y_tensors, name="testname"
     )
@@ -316,7 +316,7 @@ def test_to_evaluation_dataset_with_tensorflow_dataset_data():
     y = np.random.sample((2, 1))
     x_tf_data = tf.data.Dataset.from_tensors(x)
     y_tf_data = tf.data.Dataset.from_tensors(y)
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     dataset = TensorFlowDataset(
         features=x_tf_data, source=source, targets=y_tf_data, name="testname"
     )

--- a/tests/protos/test_message.proto
+++ b/tests/protos/test_message.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 
 package mlflow;
 
-message TestMessage {
+message SampleMessage {
   optional int32 field_int32 = 1;
   optional int64 field_int64 = 2;
   optional uint32 field_uint32 = 3;
@@ -21,21 +21,21 @@ message TestMessage {
 
   repeated int64 field_repeated_int64 = 15;
 
-  enum TestEnum {
+  enum SampleEnum {
     NONE = 0;
     ENUM_VALUE1 = 1;
     ENUM_VALUE2 = 2;
   }
-  optional TestEnum field_enum = 16;
+  optional SampleEnum field_enum = 16;
 
-  message TestInnerMessage {
+  message SampleInnerMessage {
     optional int64 field_inner_int64 = 1;
     repeated int64 field_inner_repeated_int64 = 2;
     optional string field_inner_string = 3;
   }
-  repeated TestInnerMessage field_inner_message = 17;
+  repeated SampleInnerMessage field_inner_message = 17;
 
-  oneof test_oneof {
+  oneof sample_oneof {
     int64 oneof1 = 18;
     int64 oneof2 = 19;
   }
@@ -43,13 +43,13 @@ message TestMessage {
   map<int64, string> field_map1 = 20;
   map<string, int64> field_map2 = 21;
   map<int64, int64> field_map3 = 22;
-  map<int64, TestInnerMessage> field_map4 = 23;
+  map<int64, SampleInnerMessage> field_map4 = 23;
 
   extensions 1000 to 1999;
 }
 
 message ExtensionMessage {
-  extend TestMessage {
+  extend SampleMessage {
     optional int64 field_extended_int64 = 1001;
   }
 }

--- a/tests/protos/test_message_pb2.py
+++ b/tests/protos/test_message_pb2.py
@@ -14,64 +14,64 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12test_message.proto\x12\x06mlflow\"\x9d\t\n\x0bTestMessage\x12\x13\n\x0b\x66ield_int32\x18\x01 \x01(\x05\x12\x13\n\x0b\x66ield_int64\x18\x02 \x01(\x03\x12\x14\n\x0c\x66ield_uint32\x18\x03 \x01(\r\x12\x14\n\x0c\x66ield_uint64\x18\x04 \x01(\x04\x12\x14\n\x0c\x66ield_sint32\x18\x05 \x01(\x11\x12\x14\n\x0c\x66ield_sint64\x18\x06 \x01(\x12\x12\x15\n\rfield_fixed32\x18\x07 \x01(\x07\x12\x15\n\rfield_fixed64\x18\x08 \x01(\x06\x12\x16\n\x0e\x66ield_sfixed32\x18\t \x01(\x0f\x12\x16\n\x0e\x66ield_sfixed64\x18\n \x01(\x10\x12\x12\n\nfield_bool\x18\x0b \x01(\x08\x12\x14\n\x0c\x66ield_string\x18\x0c \x01(\t\x12 \n\x13\x66ield_with_default1\x18\r \x01(\x03:\x03\x31\x30\x30\x12 \n\x13\x66ield_with_default2\x18\x0e \x01(\x03:\x03\x32\x30\x30\x12\x1c\n\x14\x66ield_repeated_int64\x18\x0f \x03(\x03\x12\x30\n\nfield_enum\x18\x10 \x01(\x0e\x32\x1c.mlflow.TestMessage.TestEnum\x12\x41\n\x13\x66ield_inner_message\x18\x11 \x03(\x0b\x32$.mlflow.TestMessage.TestInnerMessage\x12\x10\n\x06oneof1\x18\x12 \x01(\x03H\x00\x12\x10\n\x06oneof2\x18\x13 \x01(\x03H\x00\x12\x36\n\nfield_map1\x18\x14 \x03(\x0b\x32\".mlflow.TestMessage.FieldMap1Entry\x12\x36\n\nfield_map2\x18\x15 \x03(\x0b\x32\".mlflow.TestMessage.FieldMap2Entry\x12\x36\n\nfield_map3\x18\x16 \x03(\x0b\x32\".mlflow.TestMessage.FieldMap3Entry\x12\x36\n\nfield_map4\x18\x17 \x03(\x0b\x32\".mlflow.TestMessage.FieldMap4Entry\x1am\n\x10TestInnerMessage\x12\x19\n\x11\x66ield_inner_int64\x18\x01 \x01(\x03\x12\"\n\x1a\x66ield_inner_repeated_int64\x18\x02 \x03(\x03\x12\x1a\n\x12\x66ield_inner_string\x18\x03 \x01(\t\x1a\x30\n\x0e\x46ieldMap1Entry\x12\x0b\n\x03key\x18\x01 \x01(\x03\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x30\n\x0e\x46ieldMap2Entry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\x1a\x30\n\x0e\x46ieldMap3Entry\x12\x0b\n\x03key\x18\x01 \x01(\x03\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\x1aV\n\x0e\x46ieldMap4Entry\x12\x0b\n\x03key\x18\x01 \x01(\x03\x12\x33\n\x05value\x18\x02 \x01(\x0b\x32$.mlflow.TestMessage.TestInnerMessage:\x02\x38\x01\"6\n\x08TestEnum\x12\x08\n\x04NONE\x10\x00\x12\x0f\n\x0b\x45NUM_VALUE1\x10\x01\x12\x0f\n\x0b\x45NUM_VALUE2\x10\x02*\x06\x08\xe8\x07\x10\xd0\x0f\x42\x0c\n\ntest_oneof\"F\n\x10\x45xtensionMessage22\n\x14\x66ield_extended_int64\x12\x13.mlflow.TestMessage\x18\xe9\x07 \x01(\x03')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12test_message.proto\x12\x06mlflow\"\xb9\t\n\rSampleMessage\x12\x13\n\x0b\x66ield_int32\x18\x01 \x01(\x05\x12\x13\n\x0b\x66ield_int64\x18\x02 \x01(\x03\x12\x14\n\x0c\x66ield_uint32\x18\x03 \x01(\r\x12\x14\n\x0c\x66ield_uint64\x18\x04 \x01(\x04\x12\x14\n\x0c\x66ield_sint32\x18\x05 \x01(\x11\x12\x14\n\x0c\x66ield_sint64\x18\x06 \x01(\x12\x12\x15\n\rfield_fixed32\x18\x07 \x01(\x07\x12\x15\n\rfield_fixed64\x18\x08 \x01(\x06\x12\x16\n\x0e\x66ield_sfixed32\x18\t \x01(\x0f\x12\x16\n\x0e\x66ield_sfixed64\x18\n \x01(\x10\x12\x12\n\nfield_bool\x18\x0b \x01(\x08\x12\x14\n\x0c\x66ield_string\x18\x0c \x01(\t\x12 \n\x13\x66ield_with_default1\x18\r \x01(\x03:\x03\x31\x30\x30\x12 \n\x13\x66ield_with_default2\x18\x0e \x01(\x03:\x03\x32\x30\x30\x12\x1c\n\x14\x66ield_repeated_int64\x18\x0f \x03(\x03\x12\x34\n\nfield_enum\x18\x10 \x01(\x0e\x32 .mlflow.SampleMessage.SampleEnum\x12\x45\n\x13\x66ield_inner_message\x18\x11 \x03(\x0b\x32(.mlflow.SampleMessage.SampleInnerMessage\x12\x10\n\x06oneof1\x18\x12 \x01(\x03H\x00\x12\x10\n\x06oneof2\x18\x13 \x01(\x03H\x00\x12\x38\n\nfield_map1\x18\x14 \x03(\x0b\x32$.mlflow.SampleMessage.FieldMap1Entry\x12\x38\n\nfield_map2\x18\x15 \x03(\x0b\x32$.mlflow.SampleMessage.FieldMap2Entry\x12\x38\n\nfield_map3\x18\x16 \x03(\x0b\x32$.mlflow.SampleMessage.FieldMap3Entry\x12\x38\n\nfield_map4\x18\x17 \x03(\x0b\x32$.mlflow.SampleMessage.FieldMap4Entry\x1ao\n\x12SampleInnerMessage\x12\x19\n\x11\x66ield_inner_int64\x18\x01 \x01(\x03\x12\"\n\x1a\x66ield_inner_repeated_int64\x18\x02 \x03(\x03\x12\x1a\n\x12\x66ield_inner_string\x18\x03 \x01(\t\x1a\x30\n\x0e\x46ieldMap1Entry\x12\x0b\n\x03key\x18\x01 \x01(\x03\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x30\n\x0e\x46ieldMap2Entry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\x1a\x30\n\x0e\x46ieldMap3Entry\x12\x0b\n\x03key\x18\x01 \x01(\x03\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\x1aZ\n\x0e\x46ieldMap4Entry\x12\x0b\n\x03key\x18\x01 \x01(\x03\x12\x37\n\x05value\x18\x02 \x01(\x0b\x32(.mlflow.SampleMessage.SampleInnerMessage:\x02\x38\x01\"8\n\nSampleEnum\x12\x08\n\x04NONE\x10\x00\x12\x0f\n\x0b\x45NUM_VALUE1\x10\x01\x12\x0f\n\x0b\x45NUM_VALUE2\x10\x02*\x06\x08\xe8\x07\x10\xd0\x0f\x42\x0e\n\x0csample_oneof\"H\n\x10\x45xtensionMessage24\n\x14\x66ield_extended_int64\x12\x15.mlflow.SampleMessage\x18\xe9\x07 \x01(\x03')
 
 
 
-_TESTMESSAGE = DESCRIPTOR.message_types_by_name['TestMessage']
-_TESTMESSAGE_TESTINNERMESSAGE = _TESTMESSAGE.nested_types_by_name['TestInnerMessage']
-_TESTMESSAGE_FIELDMAP1ENTRY = _TESTMESSAGE.nested_types_by_name['FieldMap1Entry']
-_TESTMESSAGE_FIELDMAP2ENTRY = _TESTMESSAGE.nested_types_by_name['FieldMap2Entry']
-_TESTMESSAGE_FIELDMAP3ENTRY = _TESTMESSAGE.nested_types_by_name['FieldMap3Entry']
-_TESTMESSAGE_FIELDMAP4ENTRY = _TESTMESSAGE.nested_types_by_name['FieldMap4Entry']
+_SAMPLEMESSAGE = DESCRIPTOR.message_types_by_name['SampleMessage']
+_SAMPLEMESSAGE_SAMPLEINNERMESSAGE = _SAMPLEMESSAGE.nested_types_by_name['SampleInnerMessage']
+_SAMPLEMESSAGE_FIELDMAP1ENTRY = _SAMPLEMESSAGE.nested_types_by_name['FieldMap1Entry']
+_SAMPLEMESSAGE_FIELDMAP2ENTRY = _SAMPLEMESSAGE.nested_types_by_name['FieldMap2Entry']
+_SAMPLEMESSAGE_FIELDMAP3ENTRY = _SAMPLEMESSAGE.nested_types_by_name['FieldMap3Entry']
+_SAMPLEMESSAGE_FIELDMAP4ENTRY = _SAMPLEMESSAGE.nested_types_by_name['FieldMap4Entry']
 _EXTENSIONMESSAGE = DESCRIPTOR.message_types_by_name['ExtensionMessage']
-_TESTMESSAGE_TESTENUM = _TESTMESSAGE.enum_types_by_name['TestEnum']
-TestMessage = _reflection.GeneratedProtocolMessageType('TestMessage', (_message.Message,), {
+_SAMPLEMESSAGE_SAMPLEENUM = _SAMPLEMESSAGE.enum_types_by_name['SampleEnum']
+SampleMessage = _reflection.GeneratedProtocolMessageType('SampleMessage', (_message.Message,), {
 
-  'TestInnerMessage' : _reflection.GeneratedProtocolMessageType('TestInnerMessage', (_message.Message,), {
-    'DESCRIPTOR' : _TESTMESSAGE_TESTINNERMESSAGE,
+  'SampleInnerMessage' : _reflection.GeneratedProtocolMessageType('SampleInnerMessage', (_message.Message,), {
+    'DESCRIPTOR' : _SAMPLEMESSAGE_SAMPLEINNERMESSAGE,
     '__module__' : 'test_message_pb2'
-    # @@protoc_insertion_point(class_scope:mlflow.TestMessage.TestInnerMessage)
+    # @@protoc_insertion_point(class_scope:mlflow.SampleMessage.SampleInnerMessage)
     })
   ,
 
   'FieldMap1Entry' : _reflection.GeneratedProtocolMessageType('FieldMap1Entry', (_message.Message,), {
-    'DESCRIPTOR' : _TESTMESSAGE_FIELDMAP1ENTRY,
+    'DESCRIPTOR' : _SAMPLEMESSAGE_FIELDMAP1ENTRY,
     '__module__' : 'test_message_pb2'
-    # @@protoc_insertion_point(class_scope:mlflow.TestMessage.FieldMap1Entry)
+    # @@protoc_insertion_point(class_scope:mlflow.SampleMessage.FieldMap1Entry)
     })
   ,
 
   'FieldMap2Entry' : _reflection.GeneratedProtocolMessageType('FieldMap2Entry', (_message.Message,), {
-    'DESCRIPTOR' : _TESTMESSAGE_FIELDMAP2ENTRY,
+    'DESCRIPTOR' : _SAMPLEMESSAGE_FIELDMAP2ENTRY,
     '__module__' : 'test_message_pb2'
-    # @@protoc_insertion_point(class_scope:mlflow.TestMessage.FieldMap2Entry)
+    # @@protoc_insertion_point(class_scope:mlflow.SampleMessage.FieldMap2Entry)
     })
   ,
 
   'FieldMap3Entry' : _reflection.GeneratedProtocolMessageType('FieldMap3Entry', (_message.Message,), {
-    'DESCRIPTOR' : _TESTMESSAGE_FIELDMAP3ENTRY,
+    'DESCRIPTOR' : _SAMPLEMESSAGE_FIELDMAP3ENTRY,
     '__module__' : 'test_message_pb2'
-    # @@protoc_insertion_point(class_scope:mlflow.TestMessage.FieldMap3Entry)
+    # @@protoc_insertion_point(class_scope:mlflow.SampleMessage.FieldMap3Entry)
     })
   ,
 
   'FieldMap4Entry' : _reflection.GeneratedProtocolMessageType('FieldMap4Entry', (_message.Message,), {
-    'DESCRIPTOR' : _TESTMESSAGE_FIELDMAP4ENTRY,
+    'DESCRIPTOR' : _SAMPLEMESSAGE_FIELDMAP4ENTRY,
     '__module__' : 'test_message_pb2'
-    # @@protoc_insertion_point(class_scope:mlflow.TestMessage.FieldMap4Entry)
+    # @@protoc_insertion_point(class_scope:mlflow.SampleMessage.FieldMap4Entry)
     })
   ,
-  'DESCRIPTOR' : _TESTMESSAGE,
+  'DESCRIPTOR' : _SAMPLEMESSAGE,
   '__module__' : 'test_message_pb2'
-  # @@protoc_insertion_point(class_scope:mlflow.TestMessage)
+  # @@protoc_insertion_point(class_scope:mlflow.SampleMessage)
   })
-_sym_db.RegisterMessage(TestMessage)
-_sym_db.RegisterMessage(TestMessage.TestInnerMessage)
-_sym_db.RegisterMessage(TestMessage.FieldMap1Entry)
-_sym_db.RegisterMessage(TestMessage.FieldMap2Entry)
-_sym_db.RegisterMessage(TestMessage.FieldMap3Entry)
-_sym_db.RegisterMessage(TestMessage.FieldMap4Entry)
+_sym_db.RegisterMessage(SampleMessage)
+_sym_db.RegisterMessage(SampleMessage.SampleInnerMessage)
+_sym_db.RegisterMessage(SampleMessage.FieldMap1Entry)
+_sym_db.RegisterMessage(SampleMessage.FieldMap2Entry)
+_sym_db.RegisterMessage(SampleMessage.FieldMap3Entry)
+_sym_db.RegisterMessage(SampleMessage.FieldMap4Entry)
 
 ExtensionMessage = _reflection.GeneratedProtocolMessageType('ExtensionMessage', (_message.Message,), {
   'DESCRIPTOR' : _EXTENSIONMESSAGE,
@@ -81,31 +81,31 @@ ExtensionMessage = _reflection.GeneratedProtocolMessageType('ExtensionMessage', 
 _sym_db.RegisterMessage(ExtensionMessage)
 
 if _descriptor._USE_C_DESCRIPTORS == False:
-  TestMessage.RegisterExtension(_EXTENSIONMESSAGE.extensions_by_name['field_extended_int64'])
+  SampleMessage.RegisterExtension(_EXTENSIONMESSAGE.extensions_by_name['field_extended_int64'])
 
   DESCRIPTOR._options = None
-  _TESTMESSAGE_FIELDMAP1ENTRY._options = None
-  _TESTMESSAGE_FIELDMAP1ENTRY._serialized_options = b'8\001'
-  _TESTMESSAGE_FIELDMAP2ENTRY._options = None
-  _TESTMESSAGE_FIELDMAP2ENTRY._serialized_options = b'8\001'
-  _TESTMESSAGE_FIELDMAP3ENTRY._options = None
-  _TESTMESSAGE_FIELDMAP3ENTRY._serialized_options = b'8\001'
-  _TESTMESSAGE_FIELDMAP4ENTRY._options = None
-  _TESTMESSAGE_FIELDMAP4ENTRY._serialized_options = b'8\001'
-  _TESTMESSAGE._serialized_start=31
-  _TESTMESSAGE._serialized_end=1212
-  _TESTMESSAGE_TESTINNERMESSAGE._serialized_start=787
-  _TESTMESSAGE_TESTINNERMESSAGE._serialized_end=896
-  _TESTMESSAGE_FIELDMAP1ENTRY._serialized_start=898
-  _TESTMESSAGE_FIELDMAP1ENTRY._serialized_end=946
-  _TESTMESSAGE_FIELDMAP2ENTRY._serialized_start=948
-  _TESTMESSAGE_FIELDMAP2ENTRY._serialized_end=996
-  _TESTMESSAGE_FIELDMAP3ENTRY._serialized_start=998
-  _TESTMESSAGE_FIELDMAP3ENTRY._serialized_end=1046
-  _TESTMESSAGE_FIELDMAP4ENTRY._serialized_start=1048
-  _TESTMESSAGE_FIELDMAP4ENTRY._serialized_end=1134
-  _TESTMESSAGE_TESTENUM._serialized_start=1136
-  _TESTMESSAGE_TESTENUM._serialized_end=1190
-  _EXTENSIONMESSAGE._serialized_start=1214
-  _EXTENSIONMESSAGE._serialized_end=1284
+  _SAMPLEMESSAGE_FIELDMAP1ENTRY._options = None
+  _SAMPLEMESSAGE_FIELDMAP1ENTRY._serialized_options = b'8\001'
+  _SAMPLEMESSAGE_FIELDMAP2ENTRY._options = None
+  _SAMPLEMESSAGE_FIELDMAP2ENTRY._serialized_options = b'8\001'
+  _SAMPLEMESSAGE_FIELDMAP3ENTRY._options = None
+  _SAMPLEMESSAGE_FIELDMAP3ENTRY._serialized_options = b'8\001'
+  _SAMPLEMESSAGE_FIELDMAP4ENTRY._options = None
+  _SAMPLEMESSAGE_FIELDMAP4ENTRY._serialized_options = b'8\001'
+  _SAMPLEMESSAGE._serialized_start=31
+  _SAMPLEMESSAGE._serialized_end=1240
+  _SAMPLEMESSAGE_SAMPLEINNERMESSAGE._serialized_start=805
+  _SAMPLEMESSAGE_SAMPLEINNERMESSAGE._serialized_end=916
+  _SAMPLEMESSAGE_FIELDMAP1ENTRY._serialized_start=918
+  _SAMPLEMESSAGE_FIELDMAP1ENTRY._serialized_end=966
+  _SAMPLEMESSAGE_FIELDMAP2ENTRY._serialized_start=968
+  _SAMPLEMESSAGE_FIELDMAP2ENTRY._serialized_end=1016
+  _SAMPLEMESSAGE_FIELDMAP3ENTRY._serialized_start=1018
+  _SAMPLEMESSAGE_FIELDMAP3ENTRY._serialized_end=1066
+  _SAMPLEMESSAGE_FIELDMAP4ENTRY._serialized_start=1068
+  _SAMPLEMESSAGE_FIELDMAP4ENTRY._serialized_end=1158
+  _SAMPLEMESSAGE_SAMPLEENUM._serialized_start=1160
+  _SAMPLEMESSAGE_SAMPLEENUM._serialized_end=1216
+  _EXTENSIONMESSAGE._serialized_start=1242
+  _EXTENSIONMESSAGE._serialized_end=1314
 # @@protoc_insertion_point(module_scope)

--- a/tests/resources/data/dataset.py
+++ b/tests/resources/data/dataset.py
@@ -10,14 +10,14 @@ from mlflow.types import Schema
 from mlflow.types.utils import _infer_schema
 from mlflow.utils import insecure_hash
 
-from tests.resources.data.dataset_source import TestDatasetSource
+from tests.resources.data.dataset_source import SampleDatasetSource
 
 
-class TestDataset(Dataset):
+class SampleDataset(Dataset):
     def __init__(
         self,
         data_list: List[int],
-        source: TestDatasetSource,
+        source: SampleDatasetSource,
         name: Optional[str] = None,
         digest: Optional[str] = None,
     ):
@@ -54,7 +54,7 @@ class TestDataset(Dataset):
         return self._data_list
 
     @property
-    def source(self) -> TestDatasetSource:
+    def source(self) -> SampleDatasetSource:
         return self._source
 
     @property

--- a/tests/resources/data/dataset_source.py
+++ b/tests/resources/data/dataset_source.py
@@ -7,7 +7,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
 
-class TestDatasetSource(DatasetSource):
+class SampleDatasetSource(DatasetSource):
     def __init__(self, uri):
         self._uri = uri
 

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -83,7 +83,7 @@ from mlflow.utils.mlflow_tags import (
 from mlflow.utils.proto_json_utils import message_to_json
 
 from tests.helper_functions import mock_http_200
-from tests.resources.data.dataset_source import TestDatasetSource
+from tests.resources.data.dataset_source import SampleDatasetSource
 from tests.store._unity_catalog.conftest import (
     _REGISTRY_HOST_CREDS,
     _TRACKING_HOST_CREDS,
@@ -1033,7 +1033,7 @@ def test_input_source_truncation(num_inputs, expected_truncation_size, store):
         "lifecycle_stage",
     )
     source_uri = "test:/my/test/uri"
-    source = TestDatasetSource._resolve(source_uri)
+    source = SampleDatasetSource._resolve(source_uri)
     df = pd.DataFrame([1, 2, 3], columns=["Numbers"])
     input_list = []
     for count in range(num_inputs):

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -32,7 +32,7 @@ def reset_logging_level():
     logger.setLevel(level_before)
 
 
-class TestStream:
+class SampleStream:
     def __init__(self):
         self.content = None
         self.flush_count = 0
@@ -50,8 +50,8 @@ class TestStream:
 
 @pytest.mark.parametrize("logging_fn", LOGGING_FNS_TO_TEST)
 def test_event_logging_apis_respect_stderr_reassignment(logging_fn):
-    stream1 = TestStream()
-    stream2 = TestStream()
+    stream1 = SampleStream()
+    stream2 = SampleStream()
     message_content = "test message"
 
     sys.stderr = stream1
@@ -70,7 +70,7 @@ def test_event_logging_apis_respect_stderr_reassignment(logging_fn):
 
 @pytest.mark.parametrize("logging_fn", LOGGING_FNS_TO_TEST)
 def test_event_logging_apis_respect_stream_disablement_enablement(logging_fn):
-    stream = TestStream()
+    stream = SampleStream()
     sys.stderr = stream
     message_content = "test message"
 
@@ -91,7 +91,7 @@ def test_event_logging_apis_respect_stream_disablement_enablement(logging_fn):
 
 
 def test_event_logging_stream_flushes_properly():
-    stream = TestStream()
+    stream = SampleStream()
     sys.stderr = stream
 
     eprint("foo", flush=True)
@@ -100,7 +100,7 @@ def test_event_logging_stream_flushes_properly():
 
 
 def test_debug_logs_emitted_correctly_when_configured():
-    stream = TestStream()
+    stream = SampleStream()
     sys.stderr = stream
 
     logger.setLevel(logging.DEBUG)

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -28,10 +28,7 @@ from mlflow.utils.proto_json_utils import (
     parse_tf_serving_input,
 )
 
-from tests.protos.test_message_pb2 import TestMessage
-
-# Prevent pytest from trying to collect TestMessage as a test class:
-TestMessage.__test__ = False
+from tests.protos.test_message_pb2 import SampleMessage
 
 
 def test_message_to_json():
@@ -154,7 +151,7 @@ def test_message_to_json():
                               field_inner_repeated_int64: 83
                               field_inner_string: "str2"}}]
     """,
-        TestMessage(),
+        SampleMessage(),
     )
     json_out = message_to_json(test_message)
     json_dict = json.loads(json_out)
@@ -197,7 +194,7 @@ def test_message_to_json():
         },
         "[mlflow.ExtensionMessage.field_extended_int64]": "100",
     }
-    new_test_message = TestMessage()
+    new_test_message = SampleMessage()
     parse_dict(json_dict, new_test_message)
     assert new_test_message == test_message
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11071?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11071/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11071
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

We sometimes create a class whose name looks like `TestXxx` for testing purposes, but this confuses pytest and results in the following warning. To avoid this warning, this PR enables a setting to turn PytestCollectionWarning into an error.

https://github.com/mlflow/mlflow/actions/runs/7841106885/job/21396850440#step:12:270

```
tests/resources/data/dataset.py:16
  /home/runner/work/mlflow/mlflow/tests/resources/data/dataset.py:16: PytestCollectionWarning: cannot collect test class 'TestDataset' because it has a __init__ constructor (from: tests/data/test_dataset.py)
    class TestDataset(Dataset):

tests/resources/data/dataset_source.py:10
  /home/runner/work/mlflow/mlflow/tests/resources/data/dataset_source.py:10: PytestCollectionWarning: cannot collect test class 'TestDatasetSource' because it has a __init__ constructor (from: tests/data/test_dataset.py)
    class TestDatasetSource(DatasetSource):

```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
