### PR TITLE
Enable Transformers weight-less model saving

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -29,8 +29,6 @@ from mlflow import pyfunc
 from mlflow.environment_variables import (
     MLFLOW_DEFAULT_PREDICTION_DEVICE,
     MLFLOW_HUGGINGFACE_DEVICE_MAP_STRATEGY,
-    MLFLOW_HUGGINGFACE_DISABLE_ACCELERATE_FEATURES,
-    MLFLOW_HUGGINGFACE_MODEL_MAX_SHARD_SIZE,
     MLFLOW_HUGGINGFACE_USE_DEVICE_MAP,
     MLFLOW_HUGGINGFACE_USE_LOW_CPU_MEM_USAGE,
 )
@@ -48,6 +46,15 @@ from mlflow.protos.databricks_pb2 import (
     RESOURCE_DOES_NOT_EXIST,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+from mlflow.transformers.flavor_config import FlavorKey, build_flavor_config
+from mlflow.transformers.hub_utils import is_valid_hf_repo_id
+from mlflow.transformers.model_io import (
+    _COMPONENTS_BINARY_DIR_NAME,
+    load_model_and_components_from_huggingface_hub,
+    load_model_and_components_from_local,
+    save_pipeline_pretrained_weights,
+)
+from mlflow.transformers.torch_utils import _TORCH_DTYPE_KEY, _deserialize_torch_dtype
 from mlflow.types.utils import _validate_input_dictionary_contains_only_strings_and_lists_of_strings
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
@@ -106,7 +113,6 @@ if IS_TRANSFORMERS_AVAILABLE:
 
 # The following import is only used for type hinting
 if TYPE_CHECKING:
-    import torch
     from transformers import Pipeline
 
 
@@ -114,40 +120,21 @@ FLAVOR_NAME = "transformers"
 
 _CARD_TEXT_FILE_NAME = "model_card.md"
 _CARD_DATA_FILE_NAME = "model_card_data.yaml"
-_COMPONENTS_BINARY_KEY = "components"
-_FEATURE_EXTRACTOR_KEY = "feature_extractor"
-_FEATURE_EXTRACTOR_TYPE_KEY = "feature_extractor_type"
-_FRAMEWORK_KEY = "framework"
-_IMAGE_PROCESSOR_KEY = "image_processor"
-_IMAGE_PROCESSOR_TYPE_KEY = "image_processor_type"
 _INFERENCE_CONFIG_BINARY_KEY = "inference_config.txt"
-_INSTANCE_TYPE_KEY = "instance_type"
 _LICENSE_FILE_NAME = "LICENSE.txt"
 _LICENSE_FILE_PATTERN = re.compile(r"license(\.[a-z]+|$)", re.IGNORECASE)
-_MODEL_KEY = "model"
-_MODEL_BINARY_KEY = "model_binary"
-_MODEL_BINARY_FILE_NAME = "model"
-_MODEL_PATH_OR_NAME_KEY = "source_model_name"
-_PIPELINE_MODEL_TYPE_KEY = "pipeline_model_type"
-_PROCESSOR_KEY = "processor"
-_PROCESSOR_TYPE_KEY = "processor_type"
-_PROMPT_TEMPLATE_KEY = "prompt_template"
+
 _SUPPORTED_RETURN_TYPES = {"pipeline", "components"}
 # The default device id for CPU is -1 and GPU IDs are ordinal starting at 0, as documented here:
 # https://huggingface.co/transformers/v4.7.0/main_classes/pipelines.html
 _TRANSFORMERS_DEFAULT_CPU_DEVICE_ID = -1
 _TRANSFORMERS_DEFAULT_GPU_DEVICE_ID = 0
-_TASK_KEY = "task"
-_TOKENIZER_KEY = "tokenizer"
-_TOKENIZER_TYPE_KEY = "tokenizer_type"
-_TORCH_DTYPE_KEY = "torch_dtype"
-_METADATA_PIPELINE_SCALAR_CONFIG_KEYS = {_FRAMEWORK_KEY}
 _SUPPORTED_SAVE_KEYS = {
-    _MODEL_KEY,
-    _TOKENIZER_KEY,
-    _FEATURE_EXTRACTOR_KEY,
-    _IMAGE_PROCESSOR_KEY,
-    _TORCH_DTYPE_KEY,
+    FlavorKey.MODEL,
+    FlavorKey.TOKENIZER,
+    FlavorKey.FEATURE_EXTRACTOR,
+    FlavorKey.IMAGE_PROCESSOR,
+    FlavorKey.TORCH_DTYPE,
 }
 
 _SUPPORTED_PROMPT_TEMPLATING_TASK_TYPES = {
@@ -163,6 +150,9 @@ _PROMPT_TEMPLATE_RETURN_FULL_TEXT_INFO = (
     "pipeline kwarg set to False by default. To override this behavior, provide a "
     "`model_config` dict with `return_full_text` set to `True` when saving the model."
 )
+
+#
+_MLFLOW_VERSION_SAVE_PRETRAINED_PARAM_ADDED = Version("2.11.0")
 
 _logger = logging.getLogger(__name__)
 
@@ -244,12 +234,12 @@ def _validate_transformers_model_dict(transformers_model):
                 f"{_SUPPORTED_SAVE_KEYS}",
                 error_code=INVALID_PARAMETER_VALUE,
             )
-        if _MODEL_KEY not in transformers_model:
+        if FlavorKey.MODEL not in transformers_model:
             raise MlflowException(
-                f"The 'transformers_model' dictionary must have an entry for {_MODEL_KEY}",
+                f"The 'transformers_model' dictionary must have an entry for {FlavorKey.MODEL}",
                 error_code=INVALID_PARAMETER_VALUE,
             )
-        model = transformers_model[_MODEL_KEY]
+        model = transformers_model[FlavorKey.MODEL]
     else:
         model = transformers_model.model
     if not hasattr(model, "name_or_path"):
@@ -293,6 +283,7 @@ def save_model(
     model_config: Optional[Dict[str, Any]] = None,
     example_no_conversion: bool = False,
     prompt_template: Optional[str] = None,
+    save_pretrained: bool = True,
     **kwargs,  # pylint: disable=unused-argument
 ) -> None:
     """
@@ -471,6 +462,7 @@ def save_model(
                                     release without warning.
         example_no_conversion: {{ example_no_conversion }}
         prompt_template: {{ prompt_template }}
+        save_pretrained: {{ save_pretrained }}
         kwargs: Optional additional configurations for transformers serialization.
 
     """
@@ -544,47 +536,55 @@ def save_model(
 
         _validate_prompt_template(prompt_template)
         if mlflow_model.metadata:
-            mlflow_model.metadata[_PROMPT_TEMPLATE_KEY] = prompt_template
+            mlflow_model.metadata[FlavorKey.PROMPT_TEMPLATE] = prompt_template
         else:
-            mlflow_model.metadata = {_PROMPT_TEMPLATE_KEY: prompt_template}
+            mlflow_model.metadata = {FlavorKey.PROMPT_TEMPLATE: prompt_template}
 
-    flavor_conf = _generate_base_flavor_configuration(built_pipeline)
+    if not save_pretrained and not is_valid_hf_repo_id(built_pipeline.model.name_or_path):
+        _logger.warning(
+            "The save_pretrained parameter is set to False, but the specified model does not "
+            "have a valid HuggingFace Hub repository identifier. Therefore, the weights will "
+            "be saved to disk anyway."
+        )
+        save_pretrained = True
 
-    components = _record_pipeline_components(built_pipeline)
-
-    if components:
-        flavor_conf.update(**components)
-
-    if processor:
-        flavor_conf.update({_PROCESSOR_TYPE_KEY: _get_instance_type(processor)})
+    # Create the flavor configuration
+    flavor_conf = build_flavor_config(built_pipeline, processor, save_pretrained)
 
     if llm_inference_task:
-        flavor_conf.update({_LLM_INFERENCE_TASK_KEY: task})
+        flavor_conf.update({_LLM_INFERENCE_TASK_KEY: llm_inference_task})
         if mlflow_model.metadata:
-            mlflow_model.metadata[_METADATA_LLM_INFERENCE_TASK_KEY] = task
+            mlflow_model.metadata[_METADATA_LLM_INFERENCE_TASK_KEY] = llm_inference_task
         else:
-            mlflow_model.metadata = {_METADATA_LLM_INFERENCE_TASK_KEY: task}
+            mlflow_model.metadata = {_METADATA_LLM_INFERENCE_TASK_KEY: llm_inference_task}
 
-    # Save the model object
-    built_pipeline.model.save_pretrained(
-        save_directory=path.joinpath(_MODEL_BINARY_FILE_NAME),
-        max_shard_size=MLFLOW_HUGGINGFACE_MODEL_MAX_SHARD_SIZE.get(),
+    mlflow_model.add_flavor(
+        FLAVOR_NAME,
+        transformers_version=transformers.__version__,
+        code=code_dir_subpath,
+        **flavor_conf,
     )
 
-    if model_config and inference_config:
-        raise MlflowException(
-            "Using both `model_config` and `inference_config` is not allowed. Use `model_config` "
-            "to indicate any model configuration you need to use for inference."
+    # Flavor config should not be mutated after being added to MLModel
+    flavor_conf = MappingProxyType(flavor_conf)
+
+    # Save pipeline model and components weights
+    if save_pretrained:
+        save_pipeline_pretrained_weights(path, built_pipeline, flavor_conf, processor)
+    else:
+        repo = built_pipeline.model.name_or_path
+        _logger.info(
+            "Skipping saving pretrained model weights to disk as the save_pretrained is set to "
+            f"False. The reference to HuggingFace Hub repository {repo} will be logged instead."
         )
 
-    # Save the components explicitly to the components directory
-    if components:
-        _save_components(
-            root_path=path.joinpath(_COMPONENTS_BINARY_KEY),
-            component_config=components,
-            pipeline=built_pipeline,
-            processor=processor,
-            inference_config=inference_config,
+    if inference_config:
+        _logger.warning(
+            "Indicating `inference_config` is deprecated and will be removed in a future version "
+            "of MLflow. Use `model_config` instead."
+        )
+        path.joinpath(_INFERENCE_CONFIG_BINARY_KEY).write_text(
+            json.dumps(inference_config, indent=2)
         )
 
     model_name = built_pipeline.model.name_or_path
@@ -597,8 +597,6 @@ def save_model(
 
     # Write the license information (or guidance) along with the model
     _write_license_information(model_name, card_data, path)
-
-    model_bin_kwargs = {_MODEL_BINARY_KEY: _MODEL_BINARY_FILE_NAME}
 
     # Only allow a subset of task types to have a pyfunc definition.
     # Currently supported types are NLP-based language tasks which have a pipeline definition
@@ -629,7 +627,6 @@ def save_model(
             python_env=_PYTHON_ENV_FILE_NAME,
             code=code_dir_subpath,
             model_config=model_config,
-            **model_bin_kwargs,
         )
     else:
         if processor:
@@ -643,15 +640,10 @@ def save_model(
             f"This model is unable to be used for pyfunc prediction because {reason} "
             f"The pyfunc flavor will not be added to the Model."
         )
-    flavor_conf.update(**model_bin_kwargs)
-    mlflow_model.add_flavor(
-        FLAVOR_NAME,
-        transformers_version=transformers.__version__,
-        code=code_dir_subpath,
-        **flavor_conf,
-    )
+
     if size := get_total_file_size(path):
         mlflow_model.model_size_bytes = size
+
     mlflow_model.save(str(path.joinpath(MLMODEL_FILE_NAME)))
 
     if conda_env is None:
@@ -703,6 +695,7 @@ def log_model(
     model_config: Optional[Dict[str, Any]] = None,
     example_no_conversion: bool = False,
     prompt_template: Optional[str] = None,
+    save_pretrained: bool = True,
     **kwargs,
 ):
     """
@@ -887,6 +880,7 @@ def log_model(
                                     release without warning.
         example_no_conversion: {{ example_no_conversion }}
         prompt_template: {{ prompt_template }}
+        save_pretrained: {{ save_pretrained }}
         kwargs: Additional arguments for :py:class:`mlflow.models.model.Model`
     """
     return Model.log(
@@ -909,6 +903,7 @@ def log_model(
         model_config=model_config,
         example_no_conversion=example_no_conversion,
         prompt_template=prompt_template,
+        save_pretrained=save_pretrained,
         **kwargs,
     )
 
@@ -980,7 +975,7 @@ def load_model(
 
     flavor_config = _get_flavor_configuration_from_uri(model_uri, FLAVOR_NAME, _logger)
 
-    if return_type == "pipeline" and _PROCESSOR_TYPE_KEY in flavor_config:
+    if return_type == "pipeline" and FlavorKey.PROCESSOR_TYPE in flavor_config:
         raise MlflowException(
             "This model has been saved with a processor. Processor objects are "
             "not compatible with Pipelines. Please load this model by specifying "
@@ -1027,41 +1022,17 @@ def is_gpu_available():
     return is_gpu
 
 
-def _try_load_model_with_device(model_instance, model_path, device, conf):
-    load_model_conf = {}
-    # Assume if torch_dtype was specified in the conf, then it must be with a
-    # pipeline for which it's compatible.
-    if _TORCH_DTYPE_KEY in conf:
-        load_model_conf[_TORCH_DTYPE_KEY] = conf[_TORCH_DTYPE_KEY]
-
-    try:
-        load_model_conf["device"] = device
-        model = model_instance.from_pretrained(model_path, **load_model_conf)
-    except (ValueError, TypeError, NotImplementedError):
-        _logger.warning("Could not specify device parameter for this pipeline type")
-        load_model_conf.pop("device", None)
-        model = model_instance.from_pretrained(model_path, **load_model_conf)
-    return model
-
-
 def _load_model(path: str, flavor_config, return_type: str, device=None, **kwargs):
     """
     Loads components from a locally serialized ``Pipeline`` object.
     """
     import transformers
 
-    model_instance = getattr(transformers, flavor_config[_PIPELINE_MODEL_TYPE_KEY])
-    local_path = pathlib.Path(path)
-    # NB: Path resolution for models that were saved prior to 2.4.1 release when the pathing for
-    #     the saved pipeline or component artifacts was handled by duplicate entries for components
-    #     (artifacts/pipeline/* and artifacts/components/*) and pipelines were saved via the
-    #     "artifacts/pipeline/*" path. In order to load the older formats after the change, the
-    #     presence of the new path key is checked.
-    model_path = local_path.joinpath(flavor_config.get(_MODEL_BINARY_KEY, "pipeline"))
-
     conf = {
-        "task": flavor_config[_TASK_KEY],
+        "task": flavor_config[FlavorKey.TASK],
     }
+    if framework := flavor_config.get(FlavorKey.FRAMEWORK):
+        conf["framework"] = framework
 
     if device is None:
         if MLFLOW_DEFAULT_PREDICTION_DEVICE.get():
@@ -1085,75 +1056,36 @@ def _load_model(path: str, flavor_config, return_type: str, device=None, **kwarg
         conf["device"] = device
         accelerate_model_conf["device"] = device
 
-    if _TORCH_DTYPE_KEY in flavor_config or _TORCH_DTYPE_KEY in kwargs:
-        if _TORCH_DTYPE_KEY in kwargs:
-            dtype_val = kwargs[_TORCH_DTYPE_KEY]
-        else:
-            dtype_val = _deserialize_torch_dtype(flavor_config[_TORCH_DTYPE_KEY])
+    if dtype_val := kwargs.get(_TORCH_DTYPE_KEY) or flavor_config.get(FlavorKey.TORCH_DTYPE):
+        if isinstance(dtype_val, str):
+            dtype_val = _deserialize_torch_dtype(dtype_val)
         conf[_TORCH_DTYPE_KEY] = dtype_val
         accelerate_model_conf[_TORCH_DTYPE_KEY] = dtype_val
 
     accelerate_model_conf["low_cpu_mem_usage"] = MLFLOW_HUGGINGFACE_USE_LOW_CPU_MEM_USAGE.get()
 
-    if not MLFLOW_HUGGINGFACE_DISABLE_ACCELERATE_FEATURES.get():
-        try:
-            model = model_instance.from_pretrained(model_path, **accelerate_model_conf)
-        except (ValueError, TypeError, NotImplementedError, ImportError):
-            # NB: ImportError is caught here in the event that `accelerate` is not installed
-            # on the system, which will raise if `low_cpu_mem_usage` is set or the argument
-            # `device_map` is set and accelerate is not installed.
-            model = _try_load_model_with_device(model_instance, model_path, device, conf)
+    # Load model and components either from local or from HuggingFace Hub. We check for the
+    # presence of the model revision (a commit hash of the hub repository) that is only present
+    # in the model logged with `save_pretrained=False
+    if FlavorKey.MODEL_REVISION not in flavor_config:
+        model_and_components = load_model_and_components_from_local(
+            path=pathlib.Path(path),
+            flavor_conf=flavor_config,
+            accelerate_conf=accelerate_model_conf,
+            device=device,
+        )
     else:
-        model = _try_load_model_with_device(model_instance, model_path, device, conf)
-
-    conf["model"] = model
-
-    if _PROCESSOR_TYPE_KEY in flavor_config:
-        conf[_PROCESSOR_KEY] = _load_component(
-            local_path, _PROCESSOR_KEY, flavor_config[_PROCESSOR_TYPE_KEY]
+        model_and_components = load_model_and_components_from_huggingface_hub(
+            flavor_conf=flavor_config, accelerate_conf=accelerate_model_conf, device=device
         )
 
-    for component_key in flavor_config[_COMPONENTS_BINARY_KEY]:
-        component_type_key = f"{component_key}_type"
-        component_type = flavor_config[component_type_key]
-        conf[component_key] = _load_component(local_path, component_key, component_type)
-
-    for key in _METADATA_PIPELINE_SCALAR_CONFIG_KEYS:
-        if key in flavor_config:
-            conf[key] = flavor_config[key]
+    conf = {**conf, **model_and_components}
 
     if return_type == "pipeline":
         conf.update(**kwargs)
         return transformers.pipeline(**conf)
     elif return_type == "components":
         return conf
-
-
-def _deserialize_torch_dtype(dtype_str: str) -> torch.dtype:
-    """
-    Convert the string-encoded `torch_dtype` pipeline argument back to the correct `torch.dtype`
-    instance value for applying to a loaded pipeline instance.
-    """
-    try:
-        import torch
-    except ImportError as e:
-        raise MlflowException(
-            "Unable to determine if the value supplied by the argument "
-            "torch_dtype is valid since torch is not installed.",
-            error_code=INVALID_PARAMETER_VALUE,
-        ) from e
-
-    if dtype_str.startswith("torch."):
-        dtype_str = dtype_str[6:]
-
-    dtype = getattr(torch, dtype_str, None)
-    if isinstance(dtype, torch.dtype):
-        return dtype
-
-    raise MlflowException(
-        f"The value '{dtype_str}' is not a valid torch.dtype",
-        error_code=INVALID_PARAMETER_VALUE,
-    )
 
 
 def _fetch_model_card(model_name):
@@ -1281,129 +1213,6 @@ def _build_pipeline_from_model_input(model_dict: Dict[str, Any], task: Optional[
         ) from e
 
 
-def _record_pipeline_components(pipeline) -> Dict[str, Any]:
-    """
-    Utility for recording which components are present in either the generated pipeline iff the
-    supplied save object is not a pipeline or the components of the supplied pipeline object.
-    """
-    components_conf = {}
-    components = []
-    for attr, key in [
-        ("feature_extractor", _FEATURE_EXTRACTOR_TYPE_KEY),
-        ("tokenizer", _TOKENIZER_TYPE_KEY),
-        ("image_processor", _IMAGE_PROCESSOR_TYPE_KEY),
-    ]:
-        component = getattr(pipeline, attr, None)
-        if component is not None:
-            components_conf.update({key: _get_instance_type(component)})
-            components.append(attr)
-    if components:
-        components_conf.update({_COMPONENTS_BINARY_KEY: components})
-    return components_conf
-
-
-def _save_components(
-    root_path: pathlib.Path,
-    component_config: Dict[str, Any],
-    pipeline,
-    processor,
-    inference_config=None,
-):
-    """
-    Saves non-model pipeline components.
-    """
-    component_types = component_config.get(_COMPONENTS_BINARY_KEY, [])
-    for component_name in component_types:
-        component = getattr(pipeline, component_name)
-        component.save_pretrained(root_path.joinpath(component_name))
-    if processor:
-        processor.save_pretrained(root_path.joinpath(_PROCESSOR_KEY))
-    if inference_config:
-        _logger.warning(
-            "Indicating `inference_config` is deprecated and will be removed in a future version "
-            "of MLflow. Use `model_config` instead."
-        )
-        root_path.joinpath(_INFERENCE_CONFIG_BINARY_KEY).write_text(json.dumps(inference_config))
-
-
-def _load_component(root_path: pathlib.Path, component_key: str, component_type):
-    """
-    Loads an individual component object from local disk.
-    """
-    import transformers
-
-    components_dir = root_path.joinpath(_COMPONENTS_BINARY_KEY)
-    component_path = components_dir.joinpath(component_key)
-    component_instance = getattr(transformers, component_type)
-    return component_instance.from_pretrained(component_path)
-
-
-def _generate_base_flavor_configuration(pipeline: Pipeline) -> Dict[str, str]:
-    """
-    Generates the base flavor metadata needed for reconstructing a pipeline from saved
-    components. This is important because the ``Pipeline`` class does not have a loader
-    functionality. The serialization of a Pipeline saves the model, configurations, and
-    metadata for ``FeatureExtractor``s, ``Processor``s, and ``Tokenizer``s exclusively.
-    This function extracts key information from the submitted model object so that the precise
-    instance types can be loaded correctly.
-    """
-    flavor_configuration = {
-        _TASK_KEY: pipeline.task,
-        _INSTANCE_TYPE_KEY: _get_instance_type(pipeline),
-        _MODEL_PATH_OR_NAME_KEY: pipeline.model.name_or_path,
-        _PIPELINE_MODEL_TYPE_KEY: _get_instance_type(pipeline.model),
-    }
-
-    # Extract and add to the configuration the scalar serializable arguments for pipeline args
-    for arg_key in _METADATA_PIPELINE_SCALAR_CONFIG_KEYS:
-        if entry := _get_scalar_argument_from_pipeline(pipeline, arg_key):
-            flavor_configuration[arg_key] = entry
-
-    # Extract a serialized representation of torch_dtype if provided
-    if torch_dtype := _extract_torch_dtype_if_set(pipeline):
-        # Convert the torch dtype and back to standardize the string representation
-        flavor_configuration[_TORCH_DTYPE_KEY] = str(torch_dtype)
-
-    return flavor_configuration
-
-
-def _get_scalar_argument_from_pipeline(pipeline, arg_key):
-    """
-    Retrieve provided pipeline arguments for the purposes of instantiating a pipeline object upon
-    loading.
-    """
-
-    return getattr(pipeline, arg_key, None)
-
-
-def _extract_torch_dtype_if_set(pipeline) -> Optional[torch.dtype]:
-    """
-    Extract the torch datatype argument if set and return as a string encoded value.
-    """
-    if torch_dtype := getattr(pipeline, _TORCH_DTYPE_KEY, None):
-        # Torch dtype value may be a string or a torch.dtype instance
-        if isinstance(torch_dtype, str):
-            torch_dtype = _deserialize_torch_dtype(torch_dtype)
-        return torch_dtype
-
-    try:
-        import torch
-    except ImportError:
-        # If torch is not installed, safe to assume the model doesn't have a custom torch_dtype
-        return None
-
-    # Transformers pipeline doesn't inherit underlying model's dtype, so we have to also check
-    # the model's dtype.
-    model = pipeline.model
-    model_dtype = getattr(model.config, _TORCH_DTYPE_KEY, None) or getattr(model, "dtype", None)
-
-    # However, we should not extract dtype from parameters if it's default one (float32),
-    # to avoid setting torch_dtype for the model that doesn't support it.
-    if isinstance(model_dtype, str):
-        model_dtype = _deserialize_torch_dtype(model_dtype)
-    return model_dtype if model_dtype != torch.float32 else None
-
-
 def _validate_llm_inference_task_type(llm_inference_task: str, pipeline: Pipeline) -> None:
     """
     Validates that an ``inference_task`` type is supported by ``transformers`` pipeline type.
@@ -1511,7 +1320,7 @@ def _load_pyfunc(path, model_config: Optional[Dict[str, Any]] = None):
     """
     local_path = pathlib.Path(path)
     flavor_configuration = _get_flavor_configuration(local_path, FLAVOR_NAME)
-    model_config = _get_model_config(local_path.joinpath(_COMPONENTS_BINARY_KEY), model_config)
+    model_config = _get_model_config(local_path.joinpath(_COMPONENTS_BINARY_DIR_NAME), model_config)
     prompt_template = _get_prompt_template(local_path)
 
     return _TransformersWrapper(
@@ -2186,7 +1995,7 @@ class _TransformersWrapper:
             # that can be set for these generator pipelines. It is off by default (False).
             if (
                 not include_prompt
-                and flavor_config[_INSTANCE_TYPE_KEY] in self._supported_custom_generator_types
+                and flavor_config[FlavorKey.INSTANCE_TYPE] in self._supported_custom_generator_types
                 and data_out.startswith(data_in + "\n\n")
             ):
                 # If the user has indicated to not preserve the prompt input in the response,
@@ -2839,7 +2648,7 @@ def _get_prompt_template(model_path):
 
     model_conf = Model.load(model_path)
     if model_conf.metadata:
-        return model_conf.metadata.get(_PROMPT_TEMPLATE_KEY)
+        return model_conf.metadata.get(FlavorKey.PROMPT_TEMPLATE)
 
     return None
 

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -151,8 +151,6 @@ _PROMPT_TEMPLATE_RETURN_FULL_TEXT_INFO = (
     "`model_config` dict with `return_full_text` set to `True` when saving the model."
 )
 
-#
-_MLFLOW_VERSION_SAVE_PRETRAINED_PARAM_ADDED = Version("2.11.0")
 
 _logger = logging.getLogger(__name__)
 
@@ -1200,7 +1198,7 @@ def _build_pipeline_from_model_input(model_dict: Dict[str, Any], task: Optional[
     if task is None or task.startswith(_LLM_INFERENCE_TASK_PREFIX):
         from transformers.pipelines import get_task
 
-        task = get_task(model_dict[_MODEL_KEY].name_or_path)
+        task = get_task(model_dict[FlavorKey.MODEL].name_or_path)
 
     try:
         return pipeline(task=task, **model_dict)

--- a/mlflow/transformers/flavor_config.py
+++ b/mlflow/transformers/flavor_config.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict
+
+from mlflow.transformers.hub_utils import get_latest_commit_for_repo
+from mlflow.transformers.torch_utils import _extract_torch_dtype_if_set
+
+if TYPE_CHECKING:
+    import transformers
+
+
+# Flavor configuration keys
+class FlavorKey:
+    TASK = "task"
+    INSTANCE_TYPE = "instance_type"
+    TORCH_DTYPE = "torch_dtype"
+    FRAMEWORK = "framework"
+
+    MODEL = "model"
+    MODEL_TYPE = "pipeline_model_type"
+    MODEL_BINARY = "model_binary"
+    MODEL_NAME = "source_model_name"
+    MODEL_REVISION = "source_model_revision"
+
+    COMPONENTS = "components"
+    COMPONENT_NAME = "{}_name"  # e.g. tokenizer_name
+    COMPONENT_REVISION = "{}_revision"
+    COMPONENT_TYPE = "{}_type"
+    TOKENIZER = "tokenizer"
+    FEATURE_EXTRACTOR = "feature_extractor"
+    IMAGE_PROCESSOR = "image_processor"
+    PROCESSOR = "processor"
+    PROCESSOR_TYPE = "processor_type"
+
+    PROMPT_TEMPLATE = "prompt_template"
+
+
+def build_flavor_config(
+    pipeline: transformers.Pipeline, processor=None, save_pretrained=True
+) -> Dict[str, Any]:
+    """
+    Generates the base flavor metadata needed for reconstructing a pipeline from saved
+    components. This is important because the ``Pipeline`` class does not have a loader
+    functionality. The serialization of a Pipeline saves the model, configurations, and
+    metadata for ``FeatureExtractor``s, ``Processor``s, and ``Tokenizer``s exclusively.
+    This function extracts key information from the submitted model object so that the precise
+    instance types can be loaded correctly.
+
+    Args:
+        pipeline: Transformer pipeline to generate the flavor configuration for.
+        processor: Optional processor instance to save alongside the pipeline.
+        save_pretrained: Whether to save the pipeline and components weights to local disk.
+
+    Returns:
+        A dictionary containing the flavor configuration for the pipeline and its components,
+        i.e. the configurations stored in "transformers" key in the MLModel YAML file.
+    """
+    flavor_conf = _generate_base_config(pipeline)
+    flavor_conf.update(_get_model_config(pipeline.model, save_pretrained))
+
+    components = _get_components_from_pipeline(pipeline, processor)
+    for key, instance in components.items():
+        # Some components don't have name_or_path, then we fallback to the one from the model.
+        flavor_conf.update(
+            _get_component_config(
+                instance, key, save_pretrained, default_repo=pipeline.model.name_or_path
+            )
+        )
+
+    # "components" field doesn't include processor
+    components.pop(FlavorKey.PROCESSOR, None)
+    flavor_conf[FlavorKey.COMPONENTS] = list(components.keys())
+
+    return flavor_conf
+
+
+def _generate_base_config(pipeline):
+    flavor_conf = {
+        FlavorKey.TASK: pipeline.task,
+        FlavorKey.INSTANCE_TYPE: _get_instance_type(pipeline),
+    }
+
+    if framework := getattr(pipeline, "framework", None):
+        flavor_conf[FlavorKey.FRAMEWORK] = framework
+
+    # Extract a serialized representation of torch_dtype if provided
+    if torch_dtype := _extract_torch_dtype_if_set(pipeline):
+        # Convert the torch dtype and back to standardize the string representation
+        flavor_conf[FlavorKey.TORCH_DTYPE] = str(torch_dtype)
+
+    return flavor_conf
+
+
+def _get_model_config(model, save_pretrained=True):
+    conf = {
+        FlavorKey.MODEL_TYPE: _get_instance_type(model),
+        FlavorKey.MODEL_NAME: model.name_or_path,
+    }
+
+    if save_pretrained:
+        # log local path to model binary file
+        from mlflow.transformers.model_io import _MODEL_BINARY_FILE_NAME
+
+        conf[FlavorKey.MODEL_BINARY] = _MODEL_BINARY_FILE_NAME
+    else:
+        # log HuggingFace repo name and commit hash
+        conf[FlavorKey.MODEL_REVISION] = get_latest_commit_for_repo(model.name_or_path)
+
+    return conf
+
+
+def _get_component_config(component, key, save_pretrained=True, default_repo=None):
+    conf = {FlavorKey.COMPONENT_TYPE.format(key): _get_instance_type(component)}
+
+    # Log source repo name and commit sha for the component
+    if not save_pretrained:
+        repo = getattr(component, "name_or_path", default_repo)
+        revision = get_latest_commit_for_repo(repo)
+        conf[FlavorKey.COMPONENT_NAME.format(key)] = repo
+        conf[FlavorKey.COMPONENT_REVISION.format(key)] = revision
+
+    return conf
+
+
+def _get_components_from_pipeline(pipeline, processor=None):
+    supported_component_names = [
+        FlavorKey.FEATURE_EXTRACTOR,
+        FlavorKey.TOKENIZER,
+        FlavorKey.IMAGE_PROCESSOR,
+    ]
+
+    components = {}
+    for name in supported_component_names:
+        if instance := getattr(pipeline, name, None):
+            components[name] = instance
+
+    if processor:
+        components[FlavorKey.PROCESSOR] = processor
+
+    return components
+
+
+def _get_instance_type(obj):
+    """
+    Utility for extracting the saved object type or, if the `base` argument is set to `True`,
+    the base ABC type of the model.
+    """
+    return obj.__class__.__name__

--- a/mlflow/transformers/hub_utils.py
+++ b/mlflow/transformers/hub_utils.py
@@ -1,0 +1,55 @@
+import functools
+import logging
+import os
+from typing import Optional
+
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+
+_logger = logging.getLogger(__name__)
+
+
+# NB: The maxsize=1 is added for encouraging the cache refresh so the user doesn't get stale
+#    commit hash from the cache. This doesn't work perfectly because it only updates cache
+#    when the user calls it with a different repo name, but it's better than nothing.
+@functools.lru_cache(maxsize=1)
+def get_latest_commit_for_repo(repo: str) -> str:
+    """
+    Fetches the latest commit hash for a repository from the HuggingFace model hub.
+    """
+    try:
+        import huggingface_hub as hub
+    except ImportError:
+        raise MlflowException(
+            "Unable to fetch model commit hash from the HuggingFace model hub. "
+            "This is required for saving Transformer model without base model "
+            "weights, while ensuring the version consistency of the model. "
+            "Please install the `huggingface-hub` package and retry.",
+            error_code=RESOURCE_DOES_NOT_EXIST,
+        )
+    return hub.HfApi().model_info(repo).sha
+
+
+def is_valid_hf_repo_id(maybe_repo_id: Optional[str]) -> bool:
+    """
+    Check if the given string is a valid HuggingFace repo identifier e.g. "username/repo_id".
+    """
+
+    if not maybe_repo_id or os.path.isdir(maybe_repo_id):
+        return False
+
+    try:
+        from huggingface_hub.utils import HFValidationError, validate_repo_id
+    except ImportError:
+        raise MlflowException(
+            "Unable to validate the repository identifier for the HuggingFace model hub "
+            "because the `huggingface-hub` package is not installed. Please install the "
+            "package with `pip install huggingface-hub` command and retry."
+        )
+
+    try:
+        validate_repo_id(maybe_repo_id)
+        return True
+    except HFValidationError as e:
+        _logger.warning(f"The repository identified {maybe_repo_id} is invalid: {e}")
+        return False

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -1,0 +1,183 @@
+import logging
+
+from mlflow.environment_variables import (
+    MLFLOW_HUGGINGFACE_DISABLE_ACCELERATE_FEATURES,
+    MLFLOW_HUGGINGFACE_MODEL_MAX_SHARD_SIZE,
+)
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_STATE
+from mlflow.transformers.flavor_config import FlavorKey
+
+_logger = logging.getLogger(__name__)
+
+# File/directory names for saved artifacts
+_MODEL_BINARY_FILE_NAME = "model"
+_COMPONENTS_BINARY_DIR_NAME = "components"
+_PROCESSOR_BINARY_DIR_NAME = "processor"
+
+
+def save_pipeline_pretrained_weights(path, pipeline, flavor_conf, processor=None):
+    """
+    Save the binary artifacts of the pipeline to the specified local path.
+
+    Args:
+        path: The local path to save the pipeline
+        pipeline: Transformers pipeline instance
+        flavor_config: The flavor configuration constructed for the pipeline
+        processor: Optional processor instance to save alongside the pipeline
+    """
+    pipeline.model.save_pretrained(
+        save_directory=path.joinpath(_MODEL_BINARY_FILE_NAME),
+        max_shard_size=MLFLOW_HUGGINGFACE_MODEL_MAX_SHARD_SIZE.get(),
+    )
+
+    component_dir = path.joinpath(_COMPONENTS_BINARY_DIR_NAME)
+    for name in flavor_conf.get(FlavorKey.COMPONENTS, []):
+        getattr(pipeline, name).save_pretrained(component_dir.joinpath(name))
+
+    if processor:
+        processor.save_pretrained(component_dir.joinpath(_PROCESSOR_BINARY_DIR_NAME))
+
+
+def load_model_and_components_from_local(path, flavor_conf, accelerate_conf, device=None):
+    """
+    Load the model and components of a Transformer pipeline from the specified local path.
+
+    Args:
+        path: The local path contains MLflow model artifacts
+        flavor_conf: The flavor configuration
+        accelerate_conf: The configuration for the accelerate library
+        device: The device to load the model onto
+    """
+    loaded = {}
+
+    # NB: Path resolution for models that were saved prior to 2.4.1 release when the patching for
+    #     the saved pipeline or component artifacts was handled by duplicate entries for components
+    #     (artifacts/pipeline/* and artifacts/components/*) and pipelines were saved via the
+    #     "artifacts/pipeline/*" path. In order to load the older formats after the change, the
+    #     presence of the new path key is checked.
+    model_path = path.joinpath(flavor_conf.get(FlavorKey.MODEL_BINARY, "pipeline"))
+    loaded[FlavorKey.MODEL] = _load_model(model_path, flavor_conf, accelerate_conf, device)
+
+    components = flavor_conf.get(FlavorKey.COMPONENTS, [])
+    if FlavorKey.PROCESSOR_TYPE in flavor_conf:
+        components.append("processor")
+
+    for component_key in components:
+        loaded[component_key] = _load_component(flavor_conf, component_key, local_path=path)
+
+    return loaded
+
+
+def load_model_and_components_from_huggingface_hub(flavor_conf, accelerate_conf, device=None):
+    """
+    Load the model and components of a Transformer pipeline from HuggingFace Hub.
+
+    Args:
+        flavor_conf: The flavor configuration
+        accelerate_conf: The configuration for the accelerate library
+        device: The device to load the model onto
+    """
+    loaded = {}
+
+    model_repo = flavor_conf[FlavorKey.MODEL_NAME]
+    model_revision = flavor_conf.get(FlavorKey.MODEL_REVISION)
+
+    if not model_revision:
+        raise MlflowException(
+            "The model was saved with 'save_pretrained' set to False, but the commit hash is not "
+            "found in the saved metadata. Loading the model with the different version may cause "
+            "inconsistency issue and security risk.",
+            error_code=INVALID_STATE,
+        )
+
+    loaded[FlavorKey.MODEL] = _load_model(
+        model_repo, flavor_conf, accelerate_conf, device, revision=model_revision
+    )
+
+    components = flavor_conf.get(FlavorKey.COMPONENTS, [])
+    if FlavorKey.PROCESSOR_TYPE in flavor_conf:
+        components.append("processor")
+
+    for name in components:
+        loaded[name] = _load_component(flavor_conf, name)
+
+    return loaded
+
+
+def _load_component(flavor_conf, name, local_path=None):
+    import transformers
+
+    cls = getattr(transformers, flavor_conf[FlavorKey.COMPONENT_TYPE.format(name)])
+
+    if local_path is not None:
+        # Load component from local file
+        path = local_path.joinpath(_COMPONENTS_BINARY_DIR_NAME, name)
+        return cls.from_pretrained(str(path))
+    else:
+        # Load component from HuggingFace Hub
+        repo = flavor_conf[FlavorKey.COMPONENT_NAME.format(name)]
+        revision = flavor_conf.get(FlavorKey.COMPONENT_REVISION.format(name))
+        return cls.from_pretrained(repo, revision=revision)
+
+
+def _load_model(model_name_or_path, flavor_conf, accelerate_conf, device, revision=None):
+    """
+    Try to load a model with various loading strategies.
+      1. Try to load the model with accelerate
+      2. Try to load the model with the specified device
+      3. Load the model without the device
+    """
+    import transformers
+
+    cls = getattr(transformers, flavor_conf[FlavorKey.MODEL_TYPE])
+
+    load_kwargs = {"revision": revision} if revision else {}
+
+    if model := _try_load_model_with_accelerate(
+        cls, model_name_or_path, {**accelerate_conf, **load_kwargs}
+    ):
+        return model
+
+    load_kwargs["device"] = device
+    if torch_dtype := flavor_conf.get(FlavorKey.TORCH_DTYPE):
+        load_kwargs[FlavorKey.TORCH_DTYPE] = torch_dtype
+
+    if model := _try_load_model_with_device(cls, model_name_or_path, load_kwargs):
+        return model
+    _logger.warning(
+        "Could not specify device parameter for this pipeline type."
+        "Falling back to loading the model with the default device."
+    )
+
+    load_kwargs.pop("device", None)
+    return cls.from_pretrained(model_name_or_path, **load_kwargs)
+
+
+def _try_load_model_with_accelerate(model_class, model_name_or_path, load_kwargs):
+    if MLFLOW_HUGGINGFACE_DISABLE_ACCELERATE_FEATURES.get():
+        return None
+
+    try:
+        return model_class.from_pretrained(model_name_or_path, **load_kwargs)
+    except (ValueError, TypeError, NotImplementedError, ImportError):
+        # NB: ImportError is caught here in the event that `accelerate` is not installed
+        # on the system, which will raise if `low_cpu_mem_usage` is set or the argument
+        # `device_map` is set and accelerate is not installed.
+        pass
+
+
+def _try_load_model_with_device(model_class, model_name_or_path, load_kwargs):
+    try:
+        return model_class.from_pretrained(model_name_or_path, **load_kwargs)
+    except OSError as e:
+        revision = load_kwargs.get("revision")
+        if f"{revision} is not a valid git identifier" in str(e):
+            raise MlflowException(
+                f"The model was saved with a HuggingFace Hub repository name '{model_name_or_path}'"
+                f"and a commit hash '{revision}', but the commit is not found in the repository. "
+            )
+        else:
+            raise e
+    except (ValueError, TypeError, NotImplementedError):
+        pass

--- a/mlflow/transformers/torch_utils.py
+++ b/mlflow/transformers/torch_utils.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+
+if TYPE_CHECKING:
+    import torch
+
+_TORCH_DTYPE_KEY = "torch_dtype"
+
+
+def _extract_torch_dtype_if_set(pipeline) -> Optional[torch.dtype]:
+    """
+    Extract the torch datatype argument if set and return as a string encoded value.
+    """
+    if torch_dtype := getattr(pipeline, _TORCH_DTYPE_KEY, None):
+        # Torch dtype value may be a string or a torch.dtype instance
+        if isinstance(torch_dtype, str):
+            torch_dtype = _deserialize_torch_dtype(torch_dtype)
+        return torch_dtype
+
+    try:
+        import torch
+    except ImportError:
+        # If torch is not installed, safe to assume the model doesn't have a custom torch_dtype
+        return None
+
+    # Transformers pipeline doesn't inherit underlying model's dtype, so we have to also check
+    # the model's dtype.
+    model = pipeline.model
+    model_dtype = getattr(model.config, _TORCH_DTYPE_KEY, None) or getattr(model, "dtype", None)
+
+    # However, we should not extract dtype from parameters if it's default one (float32),
+    # to avoid setting torch_dtype for the model that doesn't support it.
+    if isinstance(model_dtype, str):
+        model_dtype = _deserialize_torch_dtype(model_dtype)
+    return model_dtype if model_dtype != torch.float32 else None
+
+
+def _deserialize_torch_dtype(dtype_str: str) -> torch.dtype:
+    """
+    Convert the string-encoded `torch_dtype` pipeline argument back to the correct `torch.dtype`
+    instance value for applying to a loaded pipeline instance.
+    """
+    try:
+        import torch
+    except ImportError as e:
+        raise MlflowException(
+            "Unable to determine if the value supplied by the argument "
+            "torch_dtype is valid since torch is not installed.",
+            error_code=INVALID_PARAMETER_VALUE,
+        ) from e
+
+    if dtype_str.startswith("torch."):
+        dtype_str = dtype_str[6:]
+
+    dtype = getattr(torch, dtype_str, None)
+    if isinstance(dtype, torch.dtype):
+        return dtype
+
+    raise MlflowException(
+        f"The value '{dtype_str}' is not a valid torch.dtype",
+        error_code=INVALID_PARAMETER_VALUE,
+    )

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -269,6 +269,29 @@ Currently, only the following pipeline types are supported:
 - `text-generation <https://huggingface.co/transformers/main_classes/pipelines.html#transformers.TextGenerationPipeline>`_
 """
         ),
+        "save_pretrained": (
+            """If set to ``False``, MLflow will not save the Transformer model weight files,
+instead only saving the reference to the HuggingFace Hub model repository and its commit hash.
+This is useful when you load the pretrained model from HuggingFace Hub and want to log or save
+it to MLflow without modifying the model weights. In such case, specifying this flag to
+``False`` will save the storage space and reduce time to save the model.
+
+.. warning::
+
+    If the model is saved with ``save_pretrained`` set to ``False``, the model cannot be
+    registered to the MLflow Model Registry. In order to convert the model to the one that
+    can be registered, you can use mlflow.transformers.download_pretrained_model() to download
+    the model weights from the HuggingFace Hub and save it in the existing model artifacts.
+
+    .. code-block:: python
+
+        import mlflow.transformers
+
+        model_uri = "YOUR_MODEL_URI_LOGGED_WITH_SAVE_PRETRAINED_FALSE"
+        model = mlflow.transformers.download_pretrained_model(model_uri)
+        mlflow.register_model(model_uri, "model_name")
+"""
+        ),
     }
 )
 

--- a/tests/transformers/test_flavor_configs.py
+++ b/tests/transformers/test_flavor_configs.py
@@ -1,0 +1,107 @@
+import pytest
+
+from mlflow.transformers import _build_pipeline_from_model_input
+from mlflow.transformers.flavor_config import build_flavor_config
+from mlflow.transformers.hub_utils import is_valid_hf_repo_id
+
+from tests.transformers.helper import IS_NEW_FEATURE_EXTRACTION_API
+
+
+@pytest.fixture
+def multi_modal_pipeline(component_multi_modal):
+    task = "image-classification"
+    pipeline = _build_pipeline_from_model_input(component_multi_modal, task)
+
+    if IS_NEW_FEATURE_EXTRACTION_API:
+        processor = pipeline.image_processor
+        components = {
+            "tokenizer": "BertTokenizerFast",
+            "image_processor": "ViltImageProcessor",
+            "processor": "ViltImageProcessor",
+        }
+    else:
+        processor = pipeline.feature_extractor
+        components = {
+            "tokenizer": "BertTokenizerFast",
+            "feature_extractor": "ViltProcessor",
+            "processor": "ViltProcessor",
+        }
+
+    return pipeline, task, processor, components
+
+
+def test_flavor_config_tf(small_seq2seq_pipeline):
+    expected = {
+        "task": "text-classification",
+        "instance_type": "TextClassificationPipeline",
+        "pipeline_model_type": "TFMobileBertForSequenceClassification",
+        "source_model_name": "lordtt13/emo-mobilebert",
+        "model_binary": "model",
+        "framework": "tf",
+        "components": ["tokenizer"],
+        "tokenizer_type": "MobileBertTokenizerFast",
+    }
+    conf = build_flavor_config(small_seq2seq_pipeline)
+    assert conf == expected
+
+
+def test_flavor_config_pt_save_pretrained_false(small_qa_pipeline):
+    expected = {
+        "task": "question-answering",
+        "instance_type": "QuestionAnsweringPipeline",
+        "pipeline_model_type": "MobileBertForQuestionAnswering",
+        "source_model_name": "csarron/mobilebert-uncased-squad-v2",
+        # "source_model_revision": "SOME_COMMIT_SHA",
+        "framework": "pt",
+        "components": ["tokenizer"],
+        "tokenizer_type": "MobileBertTokenizerFast",
+        "tokenizer_name": "csarron/mobilebert-uncased-squad-v2",
+        # "tokenizer_revision": "SOME_COMMIT_SHA",
+    }
+    conf = build_flavor_config(small_qa_pipeline, save_pretrained=False)
+    assert len(conf.pop("source_model_revision")) == 40
+    assert len(conf.pop("tokenizer_revision")) == 40
+    assert conf == expected
+
+
+def test_flavor_config_component_multi_modal(multi_modal_pipeline):
+    pipeline, task, processor, expected_components = multi_modal_pipeline
+
+    # 1. Test with save_pretrained = True
+    conf = build_flavor_config(pipeline, processor)
+
+    assert "model_binary" in conf
+    assert conf["pipeline_model_type"] == "ViltForQuestionAnswering"
+    assert conf["source_model_name"] == "dandelin/vilt-b32-finetuned-vqa"
+    assert "source_model_revision" not in conf
+
+    assert set(conf["components"]) == set(expected_components.keys()) - {"processor"}
+    for component in expected_components:
+        assert conf[f"{component}_type"] == expected_components[component]
+        assert f"{component}_revision" not in conf
+        assert f"{component}_revision" not in conf
+
+
+def test_flavor_config_component_multi_modal_save_pretrained_false(multi_modal_pipeline):
+    pipeline, task, processor, expected_components = multi_modal_pipeline
+
+    conf = build_flavor_config(pipeline, processor, False)
+
+    assert "model_binary" not in conf
+    assert conf["pipeline_model_type"] == "ViltForQuestionAnswering"
+    assert conf["source_model_name"] == pipeline.model.name_or_path
+    assert len(conf["source_model_revision"]) == 40
+
+    assert set(conf["components"]) == set(expected_components.keys()) - {"processor"}
+
+    for component in expected_components:
+        assert conf[f"{component}_type"] == expected_components[component]
+        assert conf[f"{component}_name"] == pipeline.model.name_or_path
+        assert len(conf[f"{component}_revision"]) == 40
+
+
+def test_is_valid_hf_repo_id(tmp_path):
+    assert is_valid_hf_repo_id(None) is False
+    assert is_valid_hf_repo_id(str(tmp_path)) is False
+    assert is_valid_hf_repo_id("invalid/repo/name") is False
+    assert is_valid_hf_repo_id("google-t5/t5-small") is True

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -2,9 +2,9 @@ import base64
 import gc
 import importlib.util
 import json
-import logging
 import os
 import pathlib
+import re
 import textwrap
 from unittest import mock
 
@@ -31,17 +31,9 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.transformers import (
     _CARD_DATA_FILE_NAME,
     _CARD_TEXT_FILE_NAME,
-    _FRAMEWORK_KEY,
-    _INSTANCE_TYPE_KEY,
-    _MODEL_PATH_OR_NAME_KEY,
-    _PIPELINE_MODEL_TYPE_KEY,
-    _TASK_KEY,
     _build_pipeline_from_model_input,
     _fetch_model_card,
-    _generate_base_flavor_configuration,
-    _get_instance_type,
     _is_model_distributed_in_memory,
-    _record_pipeline_components,
     _should_add_pyfunc_to_model,
     _TransformersWrapper,
     _validate_llm_inference_task_type,
@@ -62,10 +54,11 @@ from tests.helper_functions import (
     assert_register_model_called_with_local_model_path,
     pyfunc_serve_and_score_model,
 )
-from tests.transformers.helper import IS_NEW_FEATURE_EXTRACTION_API, flaky
+from tests.transformers.helper import (
+    IS_NEW_FEATURE_EXTRACTION_API,
+    flaky,
+)
 
-transformers_version = Version(transformers.__version__)
-_IMAGE_PROCESSOR_API_CHANGE_VERSION = "4.26.0"
 _IS_PIPELINE_DTYPE_SUPPORTED_VERSION = Version(transformers.__version__) >= Version("4.26.1")
 
 # NB: Some pipelines under test in this suite come very close or outright exceed the
@@ -82,8 +75,6 @@ image_file_path = pathlib.Path(pathlib.Path(__file__).parent.parent, "datasets",
 # - TextClassifier pipeline tests
 # - Text2TextGeneration pipeline tests
 # - Conversational pipeline tests
-
-_logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(autouse=True)
@@ -129,6 +120,10 @@ def sound_file_for_test():
 
 @pytest.fixture
 def raw_audio_file():
+    return read_raw_audio_file()
+
+
+def read_raw_audio_file():
     datasets_path = pathlib.Path(__file__).resolve().parent.parent.joinpath("datasets")
 
     return datasets_path.joinpath("apollo11_launch.wav").read_bytes()
@@ -176,11 +171,6 @@ def test_inference_task_validation(small_seq2seq_pipeline, text_generation_pipel
     _validate_llm_inference_task_type("llm/v1/completions", text_generation_pipeline)
 
 
-def test_instance_extraction(small_qa_pipeline):
-    assert _get_instance_type(small_qa_pipeline) == "QuestionAnsweringPipeline"
-    assert _get_instance_type(small_qa_pipeline.model) == "MobileBertForQuestionAnswering"
-
-
 @pytest.mark.parametrize(
     ("model", "result"),
     [
@@ -199,27 +189,6 @@ def test_component_multi_modal_model_ineligible_for_pyfunc(component_multi_modal
     task = transformers.pipelines.get_task(component_multi_modal["model"].name_or_path)
     pipeline = _build_pipeline_from_model_input(component_multi_modal, task)
     assert not _should_add_pyfunc_to_model(pipeline)
-
-
-def test_base_flavor_configuration_generation(small_seq2seq_pipeline, small_qa_pipeline):
-    expected_seq_pipeline_conf = {
-        _TASK_KEY: "text-classification",
-        _INSTANCE_TYPE_KEY: "TextClassificationPipeline",
-        _PIPELINE_MODEL_TYPE_KEY: "TFMobileBertForSequenceClassification",
-        _MODEL_PATH_OR_NAME_KEY: "lordtt13/emo-mobilebert",
-        _FRAMEWORK_KEY: "tf",
-    }
-    expected_qa_pipeline_conf = {
-        _TASK_KEY: "question-answering",
-        _INSTANCE_TYPE_KEY: "QuestionAnsweringPipeline",
-        _PIPELINE_MODEL_TYPE_KEY: "MobileBertForQuestionAnswering",
-        _MODEL_PATH_OR_NAME_KEY: "csarron/mobilebert-uncased-squad-v2",
-        _FRAMEWORK_KEY: "pt",
-    }
-    conf = _generate_base_flavor_configuration(small_seq2seq_pipeline)
-    assert conf == expected_seq_pipeline_conf
-    conf = _generate_base_flavor_configuration(small_qa_pipeline)
-    assert conf == expected_qa_pipeline_conf
 
 
 def test_pipeline_construction_from_base_nlp_model(small_qa_pipeline):
@@ -429,54 +398,6 @@ def test_basic_save_model_and_load_text_pipeline(small_seq2seq_pipeline, model_p
     result = loaded("MLflow is a really neat tool!")
     assert result[0]["label"] == "happy"
     assert result[0]["score"] > 0.5
-
-
-def test_component_saving_multi_modal(component_multi_modal, model_path):
-    if IS_NEW_FEATURE_EXTRACTION_API:
-        processor = component_multi_modal["image_processor"]
-        expected = {"tokenizer", "processor", "image_processor"}
-    else:
-        processor = component_multi_modal["feature_extractor"]
-        expected = {"tokenizer", "processor", "feature_extractor"}
-
-    mlflow.transformers.save_model(
-        transformers_model=component_multi_modal,
-        path=model_path,
-        processor=processor,
-    )
-    components_dir = model_path.joinpath("components")
-    contents = {item.name for item in components_dir.iterdir()}
-    assert contents.intersection(expected) == expected
-
-    mlmodel = yaml.safe_load(model_path.joinpath("MLmodel").read_bytes())
-    flavor_config = mlmodel["flavors"]["transformers"]
-    assert set(flavor_config["components"]).issubset(expected)
-
-
-def test_extract_pipeline_components(small_vision_model, small_qa_pipeline):
-    components_vision = _record_pipeline_components(small_vision_model)
-    if IS_NEW_FEATURE_EXTRACTION_API:
-        component_list = ["feature_extractor", "image_processor"]
-    else:
-        component_list = ["feature_extractor"]
-
-    assert components_vision["components"] == component_list
-    components_qa = _record_pipeline_components(small_qa_pipeline)
-    assert components_qa["tokenizer_type"] == "MobileBertTokenizerFast"
-    assert components_qa["components"] == ["tokenizer"]
-
-
-def test_extract_multi_modal_components(small_multi_modal_pipeline):
-    components_multi = _record_pipeline_components(small_multi_modal_pipeline)
-    if IS_NEW_FEATURE_EXTRACTION_API:
-        assert components_multi["image_processor_type"] == "ViltImageProcessor"
-        assert components_multi["components"] == ["tokenizer", "image_processor"]
-    elif transformers_version >= Version(_IMAGE_PROCESSOR_API_CHANGE_VERSION):
-        assert components_multi["feature_extractor_type"] == "ViltFeatureExtractor"
-        assert components_multi["components"] == ["feature_extractor", "tokenizer"]
-    else:
-        assert components_multi["feature_extractor_type"] == "ViltImageProcessor"
-        assert components_multi["components"] == ["feature_extractor", "tokenizer"]
 
 
 def test_basic_save_model_and_load_vision_pipeline(small_vision_model, model_path, image_for_test):
@@ -2468,195 +2389,6 @@ def test_instructional_pipeline_with_prompt_in_output(model_path):
     assert "\n\n" in inference[0]
 
 
-@pytest.mark.parametrize(
-    "dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64, torch.int32, torch.int64]
-)
-@pytest.mark.skipif(not _IS_PIPELINE_DTYPE_SUPPORTED_VERSION, reason="Feature does not exist")
-@flaky()
-def test_extraction_of_torch_dtype_from_pipeline(dtype):
-    pipe = transformers.pipeline(
-        task="translation_en_to_fr",
-        model=transformers.T5ForConditionalGeneration.from_pretrained("t5-small"),
-        tokenizer=transformers.T5TokenizerFast.from_pretrained("t5-small", model_max_length=100),
-        framework="pt",
-        torch_dtype=dtype,
-    )
-
-    parsed = mlflow.transformers._extract_torch_dtype_if_set(pipe)
-
-    assert parsed == dtype
-
-
-@flaky()
-def test_extraction_of_torch_dtype_from_model():
-    model = transformers.T5ForConditionalGeneration.from_pretrained(
-        "t5-small", torch_dtype=torch.float16
-    )
-    tokenizer = transformers.T5TokenizerFast.from_pretrained("t5-small", model_max_length=100)
-    pipe = transformers.pipeline(
-        task="translation_en_to_fr",
-        model=model,
-        tokenizer=tokenizer,
-        framework="pt",
-    )
-
-    # Pipeline doesn't inherit model's dtype (or doesn't have dtype attribute prior to 4.26.1)
-    if _IS_PIPELINE_DTYPE_SUPPORTED_VERSION:
-        assert pipe.torch_dtype is None
-
-    # If Pytorch is not installed, return None
-    with mock.patch.dict("sys.modules", {"torch": None}):
-        parsed = mlflow.transformers._extract_torch_dtype_if_set(pipe)
-        assert parsed is None
-
-    # Extract it from model config if available
-    model.config.torch_dtype = torch.bfloat16
-    parsed = mlflow.transformers._extract_torch_dtype_if_set(pipe)
-    assert parsed == torch.bfloat16
-
-    # Extract it from param if model config is not available
-    model.config.torch_dtype = None
-    parsed = mlflow.transformers._extract_torch_dtype_if_set(pipe)
-    assert parsed == torch.float16
-
-
-@flaky()
-def test_extraction_of_torch_dtype_returns_none_if_default():
-    model = transformers.T5ForConditionalGeneration.from_pretrained("t5-small")
-    assert model.dtype == torch.float32
-    assert model.config.torch_dtype is None
-
-    pipe = transformers.pipeline(
-        task="translation_en_to_fr",
-        model=model,
-        tokenizer=transformers.T5TokenizerFast.from_pretrained("t5-small", model_max_length=100),
-        framework="pt",
-    )
-
-    parsed = mlflow.transformers._extract_torch_dtype_if_set(pipe)
-    assert parsed is None
-
-
-@flaky()
-def test_extraction_of_torch_dtype_return_none_when_pytorch_is_not_installed():
-    model = transformers.T5ForConditionalGeneration.from_pretrained(
-        "t5-small", torch_dtype=torch.float16
-    )
-    tokenizer = transformers.T5TokenizerFast.from_pretrained("t5-small", model_max_length=100)
-    pipe = transformers.pipeline(
-        task="translation_en_to_fr",
-        model=model,
-        tokenizer=tokenizer,
-        framework="pt",
-    )
-
-    with mock.patch.dict("sys.modules", {"torch": None}):
-        parsed = mlflow.transformers._extract_torch_dtype_if_set(pipe)
-        assert parsed is None
-
-
-@pytest.mark.parametrize(
-    "dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64, torch.float]
-)
-@pytest.mark.skipif(not _IS_PIPELINE_DTYPE_SUPPORTED_VERSION, reason="Feature does not exist")
-def test_extraction_of_torch_dtype_from_components(dtype, model_path):
-    components = {
-        "model": transformers.T5ForConditionalGeneration.from_pretrained("t5-small"),
-        "tokenizer": transformers.T5TokenizerFast.from_pretrained("t5-small", model_max_length=100),
-        "torch_dtype": dtype,
-    }
-
-    mlflow.transformers.save_model(transformers_model=components, path=model_path)
-
-    base_loaded = mlflow.transformers.load_model(model_path)
-    assert base_loaded.torch_dtype == dtype
-    assert base_loaded.framework == "pt"
-    assert base_loaded.model.dtype == dtype
-
-
-@pytest.mark.parametrize(
-    ("dtype", "expected"),
-    [
-        ("torch.float16", torch.float16),
-        ("torch.bfloat16", torch.bfloat16),
-        ("torch.float32", torch.float32),
-        ("torch.float64", torch.float64),
-        ("torch.int32", torch.int32),
-        ("torch.int64", torch.int64),
-        ("float16", torch.float16),
-        ("bfloat16", torch.bfloat16),
-        ("float32", torch.float32),
-        ("float64", torch.float64),
-        ("int32", torch.int32),
-        ("int64", torch.int64),
-        ("float", torch.float32),
-        ("double", torch.float64),
-        ("int", torch.int32),
-    ],
-)
-def test_deserialize_torch_dtype(dtype, expected):
-    parsed = mlflow.transformers._deserialize_torch_dtype(dtype)
-    assert isinstance(parsed, torch.dtype)
-    assert parsed == expected
-
-
-@mock.patch.dict("sys.modules", {"torch": None})
-def test_deserialize_torch_dtype_torch_not_installed_raise():
-    with pytest.raises(MlflowException, match="Unable to determine if the value"):
-        mlflow.transformers._deserialize_torch_dtype("torch.float16")
-
-
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        "torch.float128",
-        "torch.",
-        "numpy.float32",
-        "string",
-    ],
-)
-def test_deserialize_torch_dtype_invalid_value(dtype):
-    with pytest.raises(MlflowException, match="The value '"):
-        mlflow.transformers._deserialize_torch_dtype(dtype)
-
-
-@pytest.mark.parametrize(
-    "dtype", [torch.bfloat16, torch.float16, torch.float64, torch.float, torch.cfloat]
-)
-@pytest.mark.skipif(not _IS_PIPELINE_DTYPE_SUPPORTED_VERSION, reason="Feature does not exist")
-@flaky()
-def test_extraction_of_base_flavor_config(dtype):
-    task = "translation_en_to_fr"
-
-    # Many of the 'full configuration' arguments specified are not stored as instance arguments
-    # for a pipeline; rather, they are only used when acquiring the pipeline components from
-    # the huggingface hub at initial pipeline creation. If a pipeline is specified, it is
-    # irrelevant to store these.
-    full_config_pipeline = transformers.pipeline(
-        task=task,
-        model=transformers.T5ForConditionalGeneration.from_pretrained("t5-small"),
-        tokenizer=transformers.T5TokenizerFast.from_pretrained("t5-small", model_max_length=100),
-        framework="pt",
-        torch_dtype=dtype,
-        device_map="auto",
-        use_auth_token=True,
-        trust_remote_code=True,
-        revision="main",
-        use_fast=True,
-    )
-
-    parsed = mlflow.transformers._generate_base_flavor_configuration(full_config_pipeline)
-
-    assert parsed == {
-        "task": "translation_en_to_fr",
-        "instance_type": "TranslationPipeline",
-        "source_model_name": "t5-small",
-        "pipeline_model_type": "T5ForConditionalGeneration",
-        "framework": "pt",
-        "torch_dtype": str(dtype),
-    }
-
-
 @pytest.mark.skipif(not _IS_PIPELINE_DTYPE_SUPPORTED_VERSION, reason="Feature does not exist")
 @flaky()
 def test_load_as_pipeline_preserves_framework_and_dtype(model_path):
@@ -3814,3 +3546,65 @@ def test_text_generation_task_chat_serve(text_generation_pipeline):
         and output_dict["usage"]["completion_tokens"] < 10
     )
     assert output_dict["usage"]["prompt_tokens"] < 20
+
+
+HF_COMMIT_HASH_PATTERN = re.compile(r"[a-z0-9]{40}")
+
+
+@pytest.mark.parametrize(
+    ("model_fixture", "input_example", "components"),
+    [
+        ("text2text_generation_pipeline", "What is MLflow?", {"tokenizer"}),
+        ("text_generation_pipeline", "What is MLflow?", {"tokenizer"}),
+        (
+            "small_vision_model",
+            image_url,
+            {"feature_extractor", "image_processor"}
+            if IS_NEW_FEATURE_EXTRACTION_API
+            else {"feature_extractor"},
+        ),
+        (
+            "component_multi_modal",
+            {"text": "What is MLflow?", "image": image_url},
+            {"image_processor", "tokenizer"}
+            if IS_NEW_FEATURE_EXTRACTION_API
+            else {"feature_extractor", "tokenizer"},
+        ),
+        ("fill_mask_pipeline", "The quick brown <mask> jumps over the lazy dog.", {"tokenizer"}),
+        ("whisper_pipeline", read_raw_audio_file, {"feature_extractor", "tokenizer"}),
+        ("feature_extraction_pipeline", "What is MLflow?", {"tokenizer"}),
+    ],
+)
+def test_save_and_load_pipeline_without_save_pretrained_false(
+    model_fixture, input_example, components, model_path, request
+):
+    pipeline = request.getfixturevalue(model_fixture)
+    model = pipeline["model"] if isinstance(pipeline, dict) else pipeline.model
+
+    mlflow.transformers.save_model(
+        transformers_model=pipeline,
+        path=model_path,
+        save_pretrained=False,
+    )
+
+    # No weights should be saved
+    assert not model_path.joinpath("model").exists()
+    assert not model_path.joinpath("components").exists()
+
+    # Validate the contents of MLModel file
+    mlmodel = yaml.safe_load(model_path.joinpath("MLmodel").read_bytes())
+    flavor_conf = mlmodel["flavors"]["transformers"]
+    assert "model_binary" not in flavor_conf
+    assert flavor_conf["source_model_name"] == model.name_or_path
+    assert HF_COMMIT_HASH_PATTERN.match(flavor_conf["source_model_revision"])
+    assert set(flavor_conf["components"]) == components
+    for c in components:
+        component = pipeline[c] if isinstance(pipeline, dict) else getattr(pipeline, c)
+        assert flavor_conf[f"{c}_name"] == getattr(component, "name_or_path", model.name_or_path)
+        assert HF_COMMIT_HASH_PATTERN.match(flavor_conf[f"{c}_revision"])
+
+    # Validate pyfunc load and prediction (if pyfunc supported)
+    if "python_function" in mlmodel["flavors"]:
+        if callable(input_example):
+            input_example = input_example()
+        mlflow.pyfunc.load_model(model_path).predict(input_example)

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3548,7 +3548,7 @@ def test_text_generation_task_chat_serve(text_generation_pipeline):
     assert output_dict["usage"]["prompt_tokens"] < 20
 
 
-HF_COMMIT_HASH_PATTERN = re.compile(r"[a-z0-9]{40}")
+HF_COMMIT_HASH_PATTERN = re.compile(r"^[a-z0-9]{40}$")
 
 
 @pytest.mark.parametrize(

--- a/tests/transformers/test_transformers_prompt_templating.py
+++ b/tests/transformers/test_transformers_prompt_templating.py
@@ -1,17 +1,15 @@
 from unittest.mock import MagicMock
 
 import pytest
+import transformers
 import yaml
-from transformers import pipeline
+from packaging.version import Version
 
 import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.models.model import MLMODEL_FILE_NAME
-from mlflow.transformers import (
-    _PROMPT_TEMPLATE_KEY,
-    _SUPPORTED_PROMPT_TEMPLATING_TASK_TYPES,
-    _validate_prompt_template,
-)
+from mlflow.transformers import _SUPPORTED_PROMPT_TEMPLATING_TASK_TYPES, _validate_prompt_template
+from mlflow.transformers.flavor_config import FlavorKey
 
 # session fixtures to prevent saving and loading a ~400mb model every time
 TEST_PROMPT_TEMPLATE = "Answer the following question like a pirate:\nQ: {prompt}\nA: "
@@ -43,13 +41,15 @@ UNSUPPORTED_PIPELINES = [
     "depth-estimation",
     "video-classification",
     "mask-generation",
-    "image-to-image",
 ]
+
+if Version(transformers.__version__) >= Version("4.34.1"):
+    UNSUPPORTED_PIPELINES.append("image-to-image")
 
 
 @pytest.fixture(scope="session")
 def small_text_generation_model():
-    return pipeline("text-generation", model="distilgpt2")
+    return transformers.pipeline("text-generation", model="distilgpt2")
 
 
 @pytest.fixture(scope="session")
@@ -103,7 +103,7 @@ def test_prompt_save_and_load(saved_transformers_model_path):
     with open(mlmodel_path) as f:
         mlmodel_dict = yaml.safe_load(f)
 
-    assert mlmodel_dict["metadata"][_PROMPT_TEMPLATE_KEY] == TEST_PROMPT_TEMPLATE
+    assert mlmodel_dict["metadata"][FlavorKey.PROMPT_TEMPLATE] == TEST_PROMPT_TEMPLATE
 
     model = mlflow.pyfunc.load_model(saved_transformers_model_path)
     assert model._model_impl.prompt_template == TEST_PROMPT_TEMPLATE
@@ -122,7 +122,7 @@ def test_model_save_override_return_full_text(tmp_path, small_text_generation_mo
 
 
 def test_saving_prompt_throws_on_unsupported_task():
-    model = pipeline("text-generation", model="distilgpt2")
+    model = transformers.pipeline("text-generation", model="distilgpt2")
 
     for pipeline_type in UNSUPPORTED_PIPELINES:
         # mock the task by setting it explicitly


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11075?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11075/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11075
```

</p>
</details>

### What changes are proposed in this pull request?


Introducing `save_pretrained` flag to Transformers flavor model saving and logging, which allows *weight-less* model logging that is more efficient in terms of disk usage and latency. If it is set to `False`, MLflow doesn't save weight files of the model and components in pipeline, instead, only saves reference to the HuggingFace Hub model repository (repo_id and commit hash). When loading the model, MLflow will download the weights from the hub repository to initiate the pipeline.

Please read [the design doc](https://docs.google.com/document/d/1j7fcF5LGNp5Z4g0VbKIpqIqClzwkuOqxXbGNEl_IAUs/edit) for the detailed context and motivation behind this change.

### Tracker

This PR is the first change for enabling the weight-less saving feature. More PRs will be created before merging the feature branch as follows:

- [x] [**This PR**] Introduce `save_pretrained` flag and implement saving/loading logic.
- [ ] Support PEFT model.
- [ ] Implement an API to download the weight files to the existing *weight-less* model (so it can be registered without re-logging).
- [ ] Block registering model to MLflow Model Registry (OSS Model Registry, Databricks Workspace Model Registry, UC Model Registry)
- [ ] Update documentation and examples

### Example
Here is a sample difference of `MLModel` file when logged with `save_pretrained = False`, comparing to the normal one.

```
# Only showing transformers flavor config, no change to the rest
  transformers:
    code: null
    components:
    - tokenizer
    framework: tf
    instance_type: TextClassificationPipeline
--  model_binary: model
    pipeline_model_type: TFMobileBertForSequenceClassification
    source_model_name: lordtt13/emo-mobilebert
++  source_model_revision: 26d8fcb41762ae83cc9fa03005cb63cde06ef340
    task: text-classification
++  tokenizer_name: lordtt13/emo-mobilebert
++  tokenizer_revision: 26d8fcb41762ae83cc9fa03005cb63cde06ef340
    tokenizer_type: MobileBertTokenizerFast
    transformers_version: 4.34.1
```

1. `model_binary` is deducted.
2. `source_model_revision` is added, which is the latest commit hash of the HuggingFace Hub repository. 
3. `tokenizer_name` and `tokenizer_revision` are added. Similar changes are applied for other components like `image_processor`.

### Other changes
This PR includes some refactoring to make this extension easier.
1. Flavor config construction logic is extracted to `mlflow/transformers/flavor_config.py`. 
2. The model weight saving logic is extracted to `mlflow/transformers/model_io.py`.
3. Added some utility files.

### How is this PR tested?

- [x] Existing unit/integration tests (including Docker flavor tests)
- [x] New unit/integration tests
- [x] Manual tests (WIP: Parity test for the default behavior `save_pretrained = True`)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

Document update is a follow-up.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introducing `save_pretrained` flag to Transformers flavor model saving and logging, which allows *weight-less* model logging that is more efficient in terms of disk usage and latency. If it is set to `False`, MLflow doesn't save weight files of the model and components in pipeline, instead, only saves reference to the HuggingFace Hub model repository (repo_id and commit hash).
#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
