### PR TITLE
Enforce google style docstring

### DIFF
--- a/pylint_plugins/__init__.py
+++ b/pylint_plugins/__init__.py
@@ -1,7 +1,9 @@
 from pylint_plugins.assign_checker import AssignChecker
 from pylint_plugins.import_checker import ImportChecker
+from pylint_plugins.no_rst import NoRstChecker
 
 
 def register(linter):
     linter.register_checker(ImportChecker(linter))
     linter.register_checker(AssignChecker(linter))
+    linter.register_checker(NoRstChecker(linter))

--- a/pylint_plugins/errors.py
+++ b/pylint_plugins/errors.py
@@ -29,3 +29,10 @@ USELESS_ASSIGNMENT = Message(
     message="Useless assignment. Use immediate return instead.",
     reason="For simplicity and readability",
 )
+
+NO_RST = Message(
+    id="W0009",
+    name="no-rst",
+    message="Do not use RST style. Use Google style instead.",
+    reason="For readability",
+)

--- a/pylint_plugins/no_rst.py
+++ b/pylint_plugins/no_rst.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from astroid import nodes
+from pylint import checkers
+from pylint.interfaces import IAstroidChecker
+
+from pylint_plugins.errors import NO_RST, to_msgs
+
+PARAM_REGEX = re.compile(r"\s+:param\s+\w+:", re.MULTILINE)
+RETURN_REGEX = re.compile(r"\s+:returns?:", re.MULTILINE)
+
+# TODO: Remove this once all docstrings are updated
+IGNORE = {
+    str(Path(p).resolve())
+    for p in [
+        "dev/set-mlflow-spark-scala-version.py",
+        "mlflow/gateway/client.py",
+        "mlflow/gateway/providers/utils.py",
+        "mlflow/keras/callback.py",
+        "mlflow/legacy_databricks_cli/configure/provider.py",
+        "mlflow/metrics/base.py",
+        "mlflow/metrics/genai/base.py",
+        "mlflow/mleap/__init__.py",
+        "mlflow/models/evaluation/default_evaluator.py",
+        "mlflow/projects/databricks.py",
+        "mlflow/projects/kubernetes.py",
+        "mlflow/store/_unity_catalog/registry/rest_store.py",
+        "mlflow/store/artifact/azure_data_lake_artifact_repo.py",
+        "mlflow/store/artifact/gcs_artifact_repo.py",
+        "mlflow/store/model_registry/rest_store.py",
+        "mlflow/store/tracking/rest_store.py",
+        "mlflow/utils/docstring_utils.py",
+        "tests/conftest.py",
+        "tests/evaluate/test_validation.py",
+        "tests/helper_functions.py",
+        "tests/projects/test_project_spec.py",
+        "tests/resources/data/dataset.py",
+        "tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_dataset.py",
+        "tests/sagemaker/mock/__init__.py",
+        "tests/store/artifact/test_cli.py",
+        "tests/tracking/fluent/test_fluent.py",
+        "tests/transformers/helper.py",
+        "tests/utils/test_docstring_utils.py",
+    ]
+}
+
+
+class NoRstChecker(checkers.BaseChecker):
+    __implements__ = IAstroidChecker
+
+    name = "no-rst"
+    msgs = to_msgs(NO_RST)
+    priority = -1
+
+    def visit_classdef(self, node: nodes.ClassDef) -> None:
+        self._check_docstring(node)
+
+    def visit_functiondef(self, node: nodes.FunctionDef) -> None:
+        self._check_docstring(node)
+
+    visit_asyncfunctiondef = visit_functiondef
+
+    def _check_docstring(self, node: nodes.Module | nodes.ClassDef | nodes.FunctionDef) -> None:
+        if (
+            node.root().file not in IGNORE
+            and node.doc_node
+            and (doc := node.doc_node.value)
+            and (PARAM_REGEX.search(doc) or RETURN_REGEX.search(doc))
+        ):
+            self.add_message(NO_RST.name, node=node.doc_node)

--- a/pylint_plugins/no_rst.py
+++ b/pylint_plugins/no_rst.py
@@ -33,6 +33,7 @@ IGNORE = {
         "mlflow/store/model_registry/rest_store.py",
         "mlflow/store/tracking/rest_store.py",
         "mlflow/utils/docstring_utils.py",
+        "mlflow/utils/rest_utils.py",
         "tests/conftest.py",
         "tests/evaluate/test_validation.py",
         "tests/helper_functions.py",

--- a/pylintrc
+++ b/pylintrc
@@ -81,6 +81,7 @@ enable=signature-differs,
        # Custom rules
        lazy-builtin-import,
        useless-assignment,
+       no-rst,
 
 [REPORTS]
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11078?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11078/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11078
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Title

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
