### PR TITLE
Fix duplicate `pytest_configure`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -56,6 +56,9 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "notrackingurimock")
     config.addinivalue_line("markers", "allow_infer_pip_requirements_fallback")
     config.addinivalue_line(
+        "markers", "do_not_disable_new_import_hook_firing_if_module_already_exists"
+    )
+    config.addinivalue_line(
         "markers",
         (
             "skipcacheclean: "

--- a/conftest.py
+++ b/conftest.py
@@ -58,6 +58,7 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "do_not_disable_new_import_hook_firing_if_module_already_exists"
     )
+    config.addinivalue_line("markers", "classification")
     config.addinivalue_line(
         "markers",
         (

--- a/conftest.py
+++ b/conftest.py
@@ -52,10 +52,21 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    # Register markers to suppress `PytestUnknownMarkWarning`
     config.addinivalue_line("markers", "requires_ssh")
     config.addinivalue_line("markers", "notrackingurimock")
     config.addinivalue_line("markers", "allow_infer_pip_requirements_fallback")
+    config.addinivalue_line(
+        "markers",
+        (
+            "skipcacheclean: "
+            "skip cleaning the HuggingFace cache directory after test run, "
+            "only used for Transformers flavor tests"
+        ),
+    )
+
+    labels = fetch_pr_labels() or []
+    if "fail-fast" in labels:
+        config.option.maxfail = 1
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -113,12 +124,6 @@ def fetch_pr_labels():
     with open(os.environ["GITHUB_EVENT_PATH"]) as f:
         pr_data = json.load(f)
         return [label["name"] for label in pr_data["pull_request"]["labels"]]
-
-
-def pytest_configure(config):
-    labels = fetch_pr_labels() or []
-    if "fail-fast" in labels:
-        config.option.maxfail = 1
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,8 @@
 [pytest]
-addopts = -p no:legacypath --color=yes --durations=10 --showlocals -v
+addopts = -p no:legacypath --strict-markers --color=yes --durations=10 --showlocals -v
 filterwarnings =
   # Prevent deprecated numpy type aliases from being used
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:mlflow
   error:^`np\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:tests
   error::pytest.PytestCollectionWarning
-markers =
-  skipcacheclean: skip cleaning the HuggingFace cache directory after test run, only used for Transformers flavor tests
 timeout = 1200

--- a/tests/recipes/test_evaluate_step.py
+++ b/tests/recipes/test_evaluate_step.py
@@ -103,6 +103,7 @@ def weighted_mean_squared_error_func(eval_df, builtin_metrics):
     assert model_validation_status_path.read_text() == expected_status
 
 
+@pytest.mark.classification
 @pytest.mark.usefixtures("clear_custom_metrics_module_cache")
 def test_evaluate_produces_expected_step_card(
     tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path

--- a/tests/recipes/test_evaluate_step.py
+++ b/tests/recipes/test_evaluate_step.py
@@ -103,7 +103,6 @@ def weighted_mean_squared_error_func(eval_df, builtin_metrics):
     assert model_validation_status_path.read_text() == expected_status
 
 
-@pytest.mark.classification
 @pytest.mark.usefixtures("clear_custom_metrics_module_cache")
 def test_evaluate_produces_expected_step_card(
     tmp_recipe_root_path: Path, tmp_recipe_exec_path: Path


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11079?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11079/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11079
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`conftest.py` in the repository root has two `pytest_configure`. The second one overwrites the first one. This PR fixes it.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
