### PR TITLE
Set `require_serial` to `true` to disable parallel execution of pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: prettier
         files: '^(?!CHANGELOG.md|mlflow/pypi_package_index.json|docs/|mlflow/server/js/).+\.(js|md|json|ya?ml)$'
         args: ["--no-config", "--print-width", "100"]
+        require_serial: true
   - repo: local
     hooks:
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
         language: system
         types_or: [python, jupyter]
         stages: [commit]
+        require_serial: true
 
       - id: format
         name: format
@@ -20,6 +21,7 @@ repos:
         language: system
         types_or: [python, jupyter]
         stages: [commit]
+        require_serial: true
 
       - id: blacken-docs
         name: blacken-docs
@@ -27,6 +29,7 @@ repos:
         language: system
         types_or: [rst, markdown]
         stages: [commit]
+        require_serial: true
 
       - id: pylint
         name: pylint
@@ -35,6 +38,7 @@ repos:
         types: [python]
         args: ["--rcfile=pylintrc"]
         stages: [commit]
+        require_serial: true
 
       - id: disallow-rule-ids
         name: disallow-rule-ids
@@ -42,6 +46,7 @@ repos:
         language: system
         types: [python]
         stages: [commit]
+        require_serial: true
 
       - id: rstcheck
         name: rstcheck
@@ -49,15 +54,18 @@ repos:
         language: system
         files: README.rst
         stages: [commit]
+        require_serial: true
 
       - id: must-have-signoff
         name: must-have-signoff
         entry: 'grep "Signed-off-by:"'
         language: system
         stages: [prepare-commit-msg]
+        require_serial: true
 
       - id: mlflow-typo
         name: mlflow-typo
         entry: dev/mlflow-typo.sh
         language: system
         stages: [commit]
+        require_serial: true


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11082?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11082/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11082
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`require_serial` is a flag to enable/disable parallel execution of a pre-commit hook.
I found `require_serial=true` is faster than `require_serial=true` (default) as shown below:

```
### this PR ###

(mlflow) @ mlflow [require_serial] -- INSERT --
% time pre-commit run --all-files
prettier.................................................................Passed
ruff.....................................................................Passed
format...................................................................Passed
blacken-docs.............................................................Passed
pylint...................................................................Passed
disallow-rule-ids........................................................Passed
rstcheck.................................................................Passed
mlflow-typo..............................................................Passed
pre-commit run --all-files  190.26s user 36.39s system 647% cpu 34.994 total
                                                                                                           

### master branch ###
                                                                                                           
(mlflow) @ mlflow [master] -- INSERT --
% time pre-commit run --all-files
prettier.................................................................Passed
ruff.....................................................................Passed
format...................................................................Passed
blacken-docs.............................................................Passed
pylint...................................................................Passed
disallow-rule-ids........................................................Passed
rstcheck.................................................................Passed
mlflow-typo..............................................................Passed
pre-commit run --all-files  418.54s user 49.15s system 913% cpu 51.197 total
```

pylint only

```
### this PR ### 

(mlflow) @ mlflow [require_serial] -- INSERT --
% time pre-commit run pylint --all-files
pylint...................................................................Passed
pre-commit run pylint --all-files  188.64s user 35.15s system 808% cpu 27.694 total

### master branch ###
                                                                                                                   
(mlflow) @ mlflow [master] -- INSERT --
% time pre-commit run pylint --all-files
pylint...................................................................Passed
pre-commit run pylint --all-files  426.09s user 40.96s system 958% cpu 48.716 total
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
