### PR TITLE
Feature/user defined evaluation prompt template

### DIFF
--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -126,9 +126,9 @@ def make_genai_metric(
         greater_is_better: (Optional) Whether the metric is better when it is greater.
         max_workers: (Optional) The maximum number of workers to use for judge scoring.
             Defaults to 10 workers.
-        grading_system_prompt_template: (Optional) The grading system prompt template for the GenAI metric. Other
-            parameters such as name, definition, grading_prompt and examples will be passed to it, and can be included
-            in the prompt template with {}.
+        grading_system_prompt_template: (Optional) The grading system prompt template for the GenAI
+            metric. Other parameters such as name, definition, grading_prompt and examples will be
+            passed to it, and can be included in the prompt template with {}.
     Returns:
         A metric object.
 

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -9,6 +9,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.metrics.base import MetricValue
 from mlflow.metrics.genai import model_utils
 from mlflow.metrics.genai.base import EvaluationExample
+from mlflow.metrics.genai.prompt_template import PromptTemplate
 from mlflow.metrics.genai.utils import _get_default_model, _get_latest_metric_version
 from mlflow.models import EvaluationMetric, make_metric
 from mlflow.protos.databricks_pb2 import (
@@ -92,6 +93,7 @@ def make_genai_metric(
     aggregations: Optional[List[str]] = ["mean", "variance", "p90"],  # noqa: B006
     greater_is_better: bool = True,
     max_workers: int = 10,
+    grading_system_prompt_template: Optional[List[str]] = None,
 ) -> EvaluationMetric:
     """
     Create a genai metric used to evaluate LLM using LLM as a judge in MLflow. The full grading
@@ -124,7 +126,9 @@ def make_genai_metric(
         greater_is_better: (Optional) Whether the metric is better when it is greater.
         max_workers: (Optional) The maximum number of workers to use for judge scoring.
             Defaults to 10 workers.
-
+        grading_system_prompt_template: (Optional) The grading system prompt template for the GenAI metric. Other
+            parameters such as name, definition, grading_prompt and examples will be passed to it, and can be included
+            in the prompt template with {}.
     Returns:
         A metric object.
 
@@ -245,6 +249,11 @@ def make_genai_metric(
         examples,
         model,
         *(parameters,) if parameters is not None else (),
+        grading_system_prompt_template=(
+            PromptTemplate(grading_system_prompt_template)
+            if isinstance(grading_system_prompt_template, list)
+            else None
+        ),
     ).to_dict()
 
     def eval_fn(

--- a/mlflow/metrics/genai/prompts/v1.py
+++ b/mlflow/metrics/genai/prompts/v1.py
@@ -72,6 +72,11 @@ class EvaluationModel:
     examples: List[EvaluationExample] = None
     model: str = default_model
     parameters: Dict[str, Any] = field(default_factory=lambda: default_parameters)
+    grading_system_prompt_template: PromptTemplate = grading_system_prompt_template
+
+    def __post_init__(self):
+        if self.grading_system_prompt_template is None:
+            self.grading_system_prompt_template = grading_system_prompt_template
 
     def to_dict(self):
         examples_str = (
@@ -82,7 +87,7 @@ class EvaluationModel:
 
         return {
             "model": self.model,
-            "eval_prompt": grading_system_prompt_template.partial_fill(
+            "eval_prompt": self.grading_system_prompt_template.partial_fill(
                 name=self.name,
                 definition=self.definition,
                 grading_prompt=self.grading_prompt,

--- a/tests/metrics/genai/prompts/test_v1.py
+++ b/tests/metrics/genai/prompts/test_v1.py
@@ -3,6 +3,7 @@ import re
 import pytest
 
 from mlflow.metrics.genai import EvaluationExample
+from mlflow.metrics.genai.prompt_template import PromptTemplate
 from mlflow.metrics.genai.prompts.v1 import EvaluationModel
 
 
@@ -264,3 +265,88 @@ def test_no_examples(examples):
         input="This is an input", output="This is an output", grading_context_columns=args_string
     )
     assert re.sub(r"\s+", "", prompt2) == re.sub(r"\s+", "", expected_prompt2)
+
+
+def test_custom_grading_system_prompt_template_output():
+    grading_system_prompt_template = PromptTemplate(
+        [
+            """
+            Task:
+            Custom task defined by the user""",
+                    """
+            
+            Input:
+            {input}""",
+                    """
+            
+            Output:
+            {output}
+            
+            {grading_context_columns}
+            
+            Metric definition:
+            {definition}
+            
+            Grading rubric:
+            {grading_prompt}
+            
+            {examples}
+            
+            Custom text defined by the user.
+            """,
+        ]
+    )
+    model = EvaluationModel(
+        name = "correctness",
+        definition = "definition",
+        grading_prompt = "grading prompt",
+        examples = [
+            EvaluationExample(
+                input="This is an input",
+                output="This is an output",
+                score=4,
+                justification="This is a justification",
+                grading_context={"ground_truth": "This is an output"},
+            ),
+        ],
+        grading_system_prompt_template = grading_system_prompt_template
+    ).to_dict()
+    args_string = ""
+    expected_prompt2 = """
+        Task:
+        Custom task defined by the user
+        
+        Input:
+        This is an input
+        
+        Output:
+        This is an output
+
+        Metric definition:
+        definition
+
+        Grading rubric:
+        grading prompt
+        
+        Examples:
+            Example Input:
+            This is an input
+    
+            Example Output:
+            This is an output
+    
+            Additional information used by the model:
+            key: ground_truth
+            value:
+            This is an output
+    
+            Example score: 4
+            Example justification: This is a justification
+            
+        Custom text defined by the user.
+    """
+    prompt2 = model["eval_prompt"].format(
+        input="This is an input", output="This is an output", grading_context_columns=args_string
+    )
+    assert re.sub(r"\s+", "", prompt2) == re.sub(r"\s+", "", expected_prompt2)
+

--- a/tests/metrics/genai/prompts/test_v1.py
+++ b/tests/metrics/genai/prompts/test_v1.py
@@ -273,34 +273,34 @@ def test_custom_grading_system_prompt_template_output():
             """
             Task:
             Custom task defined by the user""",
-                    """
-            
+            """
+
             Input:
             {input}""",
-                    """
-            
+            """
+
             Output:
             {output}
-            
+
             {grading_context_columns}
-            
+
             Metric definition:
             {definition}
-            
+
             Grading rubric:
             {grading_prompt}
-            
+
             {examples}
-            
+
             Custom text defined by the user.
             """,
         ]
     )
     model = EvaluationModel(
-        name = "correctness",
-        definition = "definition",
-        grading_prompt = "grading prompt",
-        examples = [
+        name="correctness",
+        definition="definition",
+        grading_prompt="grading prompt",
+        examples=[
             EvaluationExample(
                 input="This is an input",
                 output="This is an output",
@@ -309,16 +309,16 @@ def test_custom_grading_system_prompt_template_output():
                 grading_context={"ground_truth": "This is an output"},
             ),
         ],
-        grading_system_prompt_template = grading_system_prompt_template
+        grading_system_prompt_template=grading_system_prompt_template,
     ).to_dict()
     args_string = ""
     expected_prompt2 = """
         Task:
         Custom task defined by the user
-        
+
         Input:
         This is an input
-        
+
         Output:
         This is an output
 
@@ -327,26 +327,25 @@ def test_custom_grading_system_prompt_template_output():
 
         Grading rubric:
         grading prompt
-        
+
         Examples:
             Example Input:
             This is an input
-    
+
             Example Output:
             This is an output
-    
+
             Additional information used by the model:
             key: ground_truth
             value:
             This is an output
-    
+
             Example score: 4
             Example justification: This is a justification
-            
+
         Custom text defined by the user.
     """
     prompt2 = model["eval_prompt"].format(
         input="This is an input", output="This is an output", grading_context_columns=args_string
     )
     assert re.sub(r"\s+", "", prompt2) == re.sub(r"\s+", "", expected_prompt2)
-

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -1025,3 +1025,49 @@ def test_make_genai_metric_without_example():
         greater_is_better=True,
         aggregations=["mean", "variance", "p90"],
     )
+
+
+def test_custom_grading_system_prompt_template():
+    custom_system_prompt_template = [
+        """
+Task:
+Custom task defined by the user""",
+        """
+
+Input:
+{input}""",
+        """
+
+Output:
+{output}
+
+{grading_context_columns}
+
+Metric definition:
+{definition}
+
+Grading rubric:
+{grading_prompt}
+
+Custom text defined by the user.
+""",
+    ]
+    custom_metric = make_genai_metric(
+        name="correctness",
+        version="v1",
+        definition=example_definition,
+        grading_prompt=example_grading_prompt,
+        examples=[],
+        grading_system_prompt_template=custom_system_prompt_template
+    )
+
+    # pylint: disable=line-too-long
+    expected_metric_details = "\nTask:\nCustom task defined by the user\n\nInput:\n{input}\n\nOutput:\n{output}\n\n{grading_context_columns}\n\nMetric definition:\nCorrectness refers to how well the generated output matches or aligns with the reference or ground truth text that is considered accurate and appropriate for the given input. The ground truth serves as a benchmark against which the provided output is compared to determine the level of accuracy and fidelity.\n\nGrading rubric:\nCorrectness: If the answer correctly answer the question, below are the details for different scores: - Score 0: the answer is completely incorrect, doesn’t mention anything about the question or is completely contrary to the correct answer. - Score 1: the answer provides some relevance to the question and answer one aspect of the question correctly. - Score 2: the answer mostly answer the question but is missing or hallucinating on one critical aspect. - Score 4: the answer correctly answer the question and not missing any major aspect\n\nCustom text defined by the user.\n"
+
+    assert custom_metric.metric_details == expected_metric_details
+
+    assert (
+        custom_metric.__str__()
+        == f"EvaluationMetric(name=correctness, greater_is_better=True, long_name=correctness, version=v1, metric_details={expected_metric_details})"
+    )
+    # pylint: enable=line-too-long

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -1058,7 +1058,7 @@ Custom text defined by the user.
         definition=example_definition,
         grading_prompt=example_grading_prompt,
         examples=[],
-        grading_system_prompt_template=custom_system_prompt_template
+        grading_system_prompt_template=custom_system_prompt_template,
     )
 
     # pylint: disable=line-too-long


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Cokral/mlflow/pull/11085?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11085/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11085
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #10808

### What changes are proposed in this pull request?

Provide a way for users to override the `grading_system_prompt_template` used in the genai prompt v1. 
- Add parameter `grading_system_prompt_template` parameter in `make_genai_metric` which replaces the default value
- Update `EvaluationModel` accordingly

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions 
 - [X] Unsure -- maybe the docstring is sufficient as this will not be used massively.

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
