### PR TITLE
Add logging frequency control to tensorflow flavor for consistency with Keras flavor

### DIFF
--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -7,13 +7,11 @@ TensorFlow (native) format
 :py:mod:`mlflow.pyfunc`
     Produced for use by generic pyfunc-based deployment tools and batch inference.
 """
-import atexit
 import importlib
 import logging
 import os
 import shutil
 import tempfile
-import warnings
 from typing import Any, Dict, NamedTuple, Optional
 
 import numpy as np
@@ -40,16 +38,11 @@ from mlflow.utils import is_iterator
 from mlflow.utils.autologging_utils import (
     PatchFunction,
     autologging_integration,
-    batch_metrics_logger,
     get_autologging_config,
     log_fn_args_as_params,
     picklable_exception_safe_function,
     resolve_input_example_and_signature,
     safe_patch,
-)
-from mlflow.utils.autologging_utils.metrics_queue import (
-    add_to_metrics_queue,
-    flush_metrics_queue,
 )
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
@@ -71,13 +64,10 @@ from mlflow.utils.model_utils import (
     _validate_and_prepare_target_save_path,
 )
 from mlflow.utils.requirements_utils import _get_pinned_requirement
-from mlflow.utils.time import get_current_time_millis
 
 FLAVOR_NAME = "tensorflow"
 
 _logger = logging.getLogger(__name__)
-
-_LOG_EVERY_N_STEPS = 1
 
 # For tracking if the run was started by autologging.
 _AUTOLOG_RUN_ID = None
@@ -427,7 +417,7 @@ def save_model(
         # it only supports saving model in .h5 or .keras format
         if save_format == "h5":
             file_extension = ".h5"
-        elif Version(tf.__version__).release >= (2, 16):
+        elif Version(tf.__version__).release >= (2, 15):
             file_extension = ".keras"
         else:
             file_extension = ""
@@ -914,28 +904,6 @@ def _assoc_list_to_map(lst):
     return d
 
 
-def _log_event(event):
-    """
-    Extracts metric information from the event protobuf
-    """
-    if event.WhichOneof("what") == "summary":
-        summary = event.summary
-        for v in summary.value:
-            if v.HasField("simple_value"):
-                # NB: Most TensorFlow APIs use one-indexing for epochs, while tf.Keras
-                # uses zero-indexing. Accordingly, the modular arithmetic used here is slightly
-                # different from the arithmetic used in `__MLflowTfKeras2Callback.on_epoch_end`,
-                # which provides metric logging hooks for tf.Keras
-                if (event.step - 1) % _LOG_EVERY_N_STEPS == 0:
-                    add_to_metrics_queue(
-                        key=v.tag,
-                        value=v.simple_value,
-                        step=event.step,
-                        time=get_current_time_millis(),
-                        run_id=mlflow.active_run().info.run_id,
-                    )
-
-
 @picklable_exception_safe_function
 def _get_tensorboard_callback(lst):
     import tensorflow as tf
@@ -955,13 +923,14 @@ class _TensorBoardLogDir(NamedTuple):
     is_temp: bool
 
 
-def _setup_callbacks(callbacks, metrics_logger):
+def _setup_callbacks(callbacks, log_every_epoch, log_every_n_steps):
     """
     Adds TensorBoard and MlfLowTfKeras callbacks to the
     input list, and returns the new list and appropriate log directory.
     """
     # pylint: disable=no-name-in-module
-    from mlflow.tensorflow._autolog import __MLflowTfKeras2Callback, _TensorBoard
+    from mlflow.tensorflow.autologging import _TensorBoard
+    from mlflow.tensorflow.callback import MLflowCallback
 
     tb = _get_tensorboard_callback(callbacks)
     for callback in callbacks:
@@ -977,7 +946,12 @@ def _setup_callbacks(callbacks, metrics_logger):
         callbacks.append(_TensorBoard(log_dir.location))
     else:
         log_dir = _TensorBoardLogDir(location=tb.log_dir, is_temp=False)
-    callbacks.append(__MLflowTfKeras2Callback(metrics_logger, _LOG_EVERY_N_STEPS))
+    callbacks.append(
+        MLflowCallback(
+            log_every_epoch=log_every_epoch,
+            log_every_n_steps=log_every_n_steps,
+        )
+    )
     return callbacks, log_dir
 
 
@@ -996,6 +970,8 @@ def autolog(
     saved_model_kwargs=None,
     keras_model_kwargs=None,
     extra_tags=None,
+    log_every_epoch=True,
+    log_every_n_steps=None,
 ):  # pylint: disable=unused-argument
     # pylint: disable=no-name-in-module
     """
@@ -1038,8 +1014,8 @@ def autolog(
     autologging by calling `mlflow.tensorflow.autolog(disable=True)`.
 
     Args:
-        every_n_iter: The frequency with which metrics should be logged. For example, a value of
-            100 will log metrics at step 0, 100, 200, etc.
+        every_n_iter: deprecated, please use ``log_every_epoch`` instead. Per ``every_n_iter``
+            steps, metrics will be logged.
         log_models: If ``True``, trained models are logged as MLflow model artifacts.
             If ``False``, trained models are not logged.
         log_datasets: If ``True``, dataset information is logged to MLflow Tracking.
@@ -1075,16 +1051,25 @@ def autolog(
         saved_model_kwargs: a dict of kwargs to pass to ``tensorflow.saved_model.save`` method.
         keras_model_kwargs: a dict of kwargs to pass to ``keras_model.save`` method.
         extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
+        log_every_epoch: If True, training metrics will be logged at the end of each epoch.
+        log_every_n_steps: If set, training metrics will be logged every `n` training steps.
+            `log_every_n_steps` must be `None` when `log_every_epoch=True`.
     """
     import tensorflow as tf
 
-    global _LOG_EVERY_N_STEPS
-    _LOG_EVERY_N_STEPS = every_n_iter
-
-    atexit.register(flush_metrics_queue)
+    if every_n_iter != 1:
+        _logger.warning(
+            "The `every_n_iter` parameter is deprecated, please use `log_every_epoch` and "
+            "`log_every_n_steps` instead. Automatically set `log_every_n_steps` to `every_n_iter`."
+        )
+        log_every_epoch = False
+        log_every_n_steps = every_n_iter
 
     if Version(tf.__version__) < Version("2.3"):
-        warnings.warn("Could not log to MLflow. TensorFlow versions below 2.3 are not supported.")
+        _logger.error(
+            "Could not log to MLflow because your Tensorflow version is below 2.3, detected "
+            f"version: {tf.__version__}."
+        )
         return
 
     @picklable_exception_safe_function
@@ -1114,7 +1099,9 @@ def autolog(
         except Exception:
             return None
 
-    def _log_early_stop_callback_metrics(callback, history, metrics_logger):
+    def _log_early_stop_callback_metrics(callback, history):
+        from mlflow import log_metrics
+
         if callback is None or not callback.model.stop_training:
             return
 
@@ -1123,7 +1110,7 @@ def autolog(
             return
 
         stopped_epoch, restore_best_weights, _ = callback_attrs
-        metrics_logger.record_metrics({"stopped_epoch": stopped_epoch})
+        log_metrics({"stopped_epoch": stopped_epoch}, synchronous=False)
 
         if not restore_best_weights or callback.best_weights is None:
             return
@@ -1138,7 +1125,7 @@ def autolog(
         # the best epoch. In keras > 2.6.0, the best epoch can be obtained via the `best_epoch`
         # attribute of an `EarlyStopping` instance: https://github.com/keras-team/keras/pull/15197
         restored_epoch = initial_epoch + monitored_metric.index(callback.best)
-        metrics_logger.record_metrics({"restored_epoch": restored_epoch})
+        log_metrics({"restored_epoch": restored_epoch}, synchronous=False)
         restored_index = history.epoch.index(restored_epoch)
         restored_metrics = {
             key: metrics[restored_index] for key, metrics in history.history.items()
@@ -1146,7 +1133,7 @@ def autolog(
         # Checking that a metric history exists
         metric_key = next(iter(history.history), None)
         if metric_key is not None:
-            metrics_logger.record_metrics(restored_metrics, stopped_epoch + 1)
+            log_metrics(restored_metrics, stopped_epoch + 1, synchronous=False)
 
     def _log_keras_model(history, args):
         def _infer_model_signature(input_data_slice):
@@ -1157,7 +1144,7 @@ def autolog(
             history.model.stop_training = original_stop_training
             return infer_signature(input_data_slice, model_output)
 
-        from mlflow.tensorflow._autolog import extract_tf_keras_input_example
+        from mlflow.tensorflow.autologging import extract_tf_keras_input_example
 
         def _get_tf_keras_input_example_slice():
             input_training_data = args[0]
@@ -1242,76 +1229,83 @@ def autolog(
             log_fn_args_as_params(original, args, kwargs, unlogged_params)
 
             run_id = mlflow.active_run().info.run_id
-            with batch_metrics_logger(run_id) as metrics_logger:
-                # Check if the 'callback' argument of fit() is set positionally
-                if len(args) >= 6:
-                    # Convert the positional training function arguments to a list in order to
-                    # mutate the contents
-                    args = list(args)
-                    # Make a shallow copy of the preexisting callbacks to avoid permanently
-                    # modifying their contents for future training invocations. Introduce
-                    # TensorBoard & tf.keras callbacks if necessary
-                    callbacks = list(args[5])
-                    callbacks, self.log_dir = _setup_callbacks(callbacks, metrics_logger)
-                    # Replace the callbacks positional entry in the copied arguments and convert
-                    # the arguments back to tuple form for usage in the training function
-                    args[5] = callbacks
-                    args = tuple(args)
-                else:
-                    # Make a shallow copy of the preexisting callbacks and introduce TensorBoard
-                    # & tf.keras callbacks if necessary
-                    callbacks = list(kwargs.get("callbacks") or [])
-                    kwargs["callbacks"], self.log_dir = _setup_callbacks(callbacks, metrics_logger)
-
-                early_stop_callback = _get_early_stop_callback(callbacks)
-                _log_early_stop_callback_params(early_stop_callback)
-
-                if log_datasets:
-                    try:
-                        context_tags = context_registry.resolve_tags()
-                        source = CodeDatasetSource(tags=context_tags)
-
-                        x = kwargs["x"] if "x" in kwargs else args[0]
-                        if "y" in kwargs:
-                            y = kwargs["y"]
-                        elif len(args) >= 2:
-                            y = args[1]
-                        else:
-                            y = None
-
-                        if "validation_data" in kwargs:
-                            validation_data = kwargs["validation_data"]
-                        elif len(args) >= 8:
-                            validation_data = args[7]
-                        else:
-                            validation_data = None
-                        _log_tensorflow_dataset(x, source, "train", targets=y)
-                        if validation_data is not None:
-                            _log_tensorflow_dataset(validation_data, source, "eval")
-
-                    except Exception as e:
-                        _logger.warning(
-                            "Failed to log training dataset information to "
-                            "MLflow Tracking. Reason: %s",
-                            e,
-                        )
-
-                history = original(inst, *args, **kwargs)
-
-                if log_models:
-                    _log_keras_model(history, args)
-
-                _log_early_stop_callback_metrics(
-                    callback=early_stop_callback,
-                    history=history,
-                    metrics_logger=metrics_logger,
+            # Check if the 'callback' argument of fit() is set positionally
+            if len(args) >= 6:
+                # Convert the positional training function arguments to a list in order to
+                # mutate the contents
+                args = list(args)
+                # Make a shallow copy of the preexisting callbacks to avoid permanently
+                # modifying their contents for future training invocations. Introduce
+                # TensorBoard & tf.keras callbacks if necessary
+                callbacks = list(args[5])
+                callbacks, self.log_dir = _setup_callbacks(
+                    callbacks,
+                    log_every_epoch=log_every_epoch,
+                    log_every_n_steps=log_every_n_steps,
+                )
+                # Replace the callbacks positional entry in the copied arguments and convert
+                # the arguments back to tuple form for usage in the training function
+                args[5] = callbacks
+                args = tuple(args)
+            else:
+                # Make a shallow copy of the preexisting callbacks and introduce TensorBoard
+                # & tf.keras callbacks if necessary
+                callbacks = list(kwargs.get("callbacks") or [])
+                kwargs["callbacks"], self.log_dir = _setup_callbacks(
+                    callbacks,
+                    log_every_epoch=log_every_epoch,
+                    log_every_n_steps=log_every_n_steps,
                 )
 
-                flush_metrics_queue()
-                mlflow.log_artifacts(
-                    local_dir=self.log_dir.location,
-                    artifact_path="tensorboard_logs",
-                )
+            early_stop_callback = _get_early_stop_callback(callbacks)
+            _log_early_stop_callback_params(early_stop_callback)
+
+            if log_datasets:
+                try:
+                    context_tags = context_registry.resolve_tags()
+                    source = CodeDatasetSource(tags=context_tags)
+
+                    x = kwargs["x"] if "x" in kwargs else args[0]
+                    if "y" in kwargs:
+                        y = kwargs["y"]
+                    elif len(args) >= 2:
+                        y = args[1]
+                    else:
+                        y = None
+
+                    if "validation_data" in kwargs:
+                        validation_data = kwargs["validation_data"]
+                    elif len(args) >= 8:
+                        validation_data = args[7]
+                    else:
+                        validation_data = None
+                    _log_tensorflow_dataset(x, source, "train", targets=y)
+                    if validation_data is not None:
+                        _log_tensorflow_dataset(validation_data, source, "eval")
+
+                except Exception as e:
+                    _logger.warning(
+                        "Failed to log training dataset information to "
+                        "MLflow Tracking. Reason: %s",
+                        e,
+                    )
+
+            history = original(inst, *args, **kwargs)
+
+            if log_models:
+                _log_keras_model(history, args)
+
+            _log_early_stop_callback_metrics(
+                callback=early_stop_callback,
+                history=history,
+            )
+            # Ensure all data are logged.
+            mlflow.flush_async_logging()
+
+            mlflow.log_artifacts(
+                local_dir=self.log_dir.location,
+                artifact_path="tensorboard_logs",
+            )
             if self.log_dir.is_temp:
                 shutil.rmtree(self.log_dir.location)
             return history

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -1185,7 +1185,9 @@ def autolog(
         def __init__(self):
             self.log_dir = None
 
-        def _patch_implementation(self, original, inst, *args, **kwargs):  # pylint: disable=arguments-differ
+        def _patch_implementation(
+            self, original, inst, *args, **kwargs
+        ):  # pylint: disable=arguments-differ
             unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
 
             batch_size = None
@@ -1228,7 +1230,6 @@ def autolog(
 
             log_fn_args_as_params(original, args, kwargs, unlogged_params)
 
-            run_id = mlflow.active_run().info.run_id
             # Check if the 'callback' argument of fit() is set positionally
             if len(args) >= 6:
                 # Convert the positional training function arguments to a list in order to

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -417,7 +417,7 @@ def save_model(
         # it only supports saving model in .h5 or .keras format
         if save_format == "h5":
             file_extension = ".h5"
-        elif Version(tf.__version__).release >= (2, 15):
+        elif Version(tf.__version__).release >= (2, 16):
             file_extension = ".keras"
         else:
             file_extension = ""
@@ -1185,9 +1185,7 @@ def autolog(
         def __init__(self):
             self.log_dir = None
 
-        def _patch_implementation(
-            self, original, inst, *args, **kwargs
-        ):  # pylint: disable=arguments-differ
+        def _patch_implementation(self, original, inst, *args, **kwargs):  # pylint: disable=arguments-differ
             unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
 
             batch_size = None

--- a/mlflow/tensorflow/autologging.py
+++ b/mlflow/tensorflow/autologging.py
@@ -1,11 +1,9 @@
-import warnings
 from typing import Dict, Union
 
 import numpy as np
 import tensorflow
-from tensorflow.keras.callbacks import Callback, TensorBoard
+from tensorflow.keras.callbacks import TensorBoard
 
-import mlflow
 from mlflow.utils.autologging_utils import (
     INPUT_EXAMPLE_SAMPLE_ROWS,
     ExceptionSafeClass,

--- a/mlflow/tensorflow/autologging.py
+++ b/mlflow/tensorflow/autologging.py
@@ -16,52 +16,6 @@ class _TensorBoard(TensorBoard, metaclass=ExceptionSafeClass):
     pass
 
 
-class __MLflowTfKeras2Callback(Callback, metaclass=ExceptionSafeClass):
-    """
-    Callback for auto-logging parameters and metrics in TensorFlow >= 2.0.0.
-    Records model structural information as params when training starts.
-    """
-
-    def __init__(self, metrics_logger, log_every_n_steps):
-        super().__init__()
-        self.metrics_logger = metrics_logger
-        self.log_every_n_steps = log_every_n_steps
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
-
-    def on_train_begin(self, logs=None):  # pylint: disable=unused-argument
-        config = self.model.optimizer.get_config()
-        for attribute in config:
-            mlflow.log_param("opt_" + attribute, config[attribute])
-
-        model_summary = []
-
-        def print_fn(line, *args, **kwargs):
-            model_summary.append(line)
-
-        try:
-            self.model.summary(print_fn=print_fn)
-            summary = "\n".join(model_summary)
-            mlflow.log_text(summary, artifact_file="model_summary.txt")
-        except ValueError as ex:
-            if "This model has not yet been built" in str(ex):
-                warnings.warn(str(ex))
-            else:
-                raise ex
-
-    def on_epoch_end(self, epoch, logs=None):
-        # NB: tf.Keras uses zero-indexing for epochs, while other TensorFlow Estimator
-        # APIs (e.g., tf.Estimator) use one-indexing. Accordingly, the modular arithmetic
-        # used here is slightly different from the arithmetic used in `_log_event`, which
-        # provides  metric logging hooks for TensorFlow Estimator & other TensorFlow APIs
-        if epoch % self.log_every_n_steps == 0:
-            self.metrics_logger.record_metrics(logs, epoch)
-
-
 def _extract_input_example_from_tensor_or_ndarray(
     input_features: Union[tensorflow.Tensor, np.ndarray],
 ) -> np.ndarray:

--- a/mlflow/tensorflow/callback.py
+++ b/mlflow/tensorflow/callback.py
@@ -1,17 +1,16 @@
 from tensorflow import keras
 
-from mlflow import log_params, log_text
-from mlflow.utils.autologging_utils import BatchMetricsLogger
+from mlflow import log_metrics, log_params, log_text
+from mlflow.utils.autologging_utils import ExceptionSafeClass
 
 
-class MLflowCallback(keras.callbacks.Callback):
+class MLflowCallback(keras.callbacks.Callback, metaclass=ExceptionSafeClass):
     """Callback for logging Tensorflow training metrics to MLflow.
 
     This callback logs model information at training start, and logs training metrics every epoch or
     every n steps (defined by the user) to MLflow.
 
     Args:
-        run: an `mlflow.entities.run.Run` instance, the MLflow run.
         log_every_epoch: bool, If True, log metrics every epoch. If False, log metrics every n
             steps.
         log_every_n_steps: int, log metrics every n steps. If None, log metrics every epoch.
@@ -52,8 +51,7 @@ class MLflowCallback(keras.callbacks.Callback):
             )
     """
 
-    def __init__(self, run, log_every_epoch=True, log_every_n_steps=None):
-        self.metrics_logger = BatchMetricsLogger(run.info.run_id)
+    def __init__(self, log_every_epoch=True, log_every_n_steps=None):
         self.log_every_epoch = log_every_epoch
         self.log_every_n_steps = log_every_n_steps
 
@@ -71,7 +69,7 @@ class MLflowCallback(keras.callbacks.Callback):
     def on_train_begin(self, logs=None):
         """Log model architecture and optimizer configuration when training begins."""
         config = self.model.optimizer.get_config()
-        log_params({f"optimizer_{k}": v for k, v in config.items()})
+        log_params({f"opt_{k}": v for k, v in config.items()})
 
         model_summary = []
 
@@ -84,20 +82,22 @@ class MLflowCallback(keras.callbacks.Callback):
 
     def on_epoch_end(self, epoch, logs=None):
         """Log metrics at the end of each epoch."""
-        if not self.log_every_epoch:
+        if not self.log_every_epoch or logs is None:
             return
-        self.metrics_logger.record_metrics(logs, epoch)
+        log_metrics(logs, step=epoch, synchronous=False)
 
     def on_batch_end(self, batch, logs=None):
         """Log metrics at the end of each batch with user specified frequency."""
-        if self.log_every_n_steps is None:
+        if self.log_every_n_steps is None or logs is None:
             return
-        if (batch + 1) % self.log_every_n_steps == 0:
-            self.metrics_logger.record_metrics(logs, batch)
+        current_iteration = int(self.model.optimizer.iterations.numpy())
+
+        if current_iteration % self.log_every_n_steps == 0:
+            log_metrics(logs, step=current_iteration, synchronous=False)
 
     def on_test_end(self, logs=None):
         """Log validation metrics at validation end."""
         if logs is None:
             return
         metrics = {"validation_" + k: v for k, v in logs.items()}
-        self.metrics_logger.record_metrics(metrics)
+        log_metrics(metrics, synchronous=False)

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -21,12 +21,11 @@ from mlflow import MlflowClient
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.models.utils import _read_example
-from mlflow.tensorflow._autolog import __MLflowTfKeras2Callback, _TensorBoard
+from mlflow.tensorflow.autologging import _TensorBoard
 from mlflow.tensorflow.callback import MLflowCallback
 from mlflow.types.utils import _infer_schema
 from mlflow.utils.autologging_utils import (
     AUTOLOGGING_INTEGRATIONS,
-    BatchMetricsLogger,
     autologging_is_disabled,
 )
 from mlflow.utils.process import _exec_cmd
@@ -110,7 +109,9 @@ def fashion_mnist_tf_dataset_eval():
 
 
 def _create_fashion_mnist_model():
-    model = tf.keras.Sequential([tf.keras.layers.Flatten(), tf.keras.layers.Dense(10)])
+    model = tf.keras.Sequential(
+        [tf.keras.Input((28, 28)), tf.keras.layers.Flatten(), tf.keras.layers.Dense(10)]
+    )
     model.compile(
         optimizer=tf.keras.optimizers.Adam(),
         loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
@@ -579,7 +580,9 @@ def test_tf_keras_autolog_implicit_batch_size_works_multi_input(generate_data, b
         pytest.param(
             __GeneratorClass,
             marks=pytest.mark.skipif(
-                Version(tf.__version__).release >= (2, 16), reason="does not support"
+                Version(tf.__version__).release >= (2, 15)
+                and "TF_USE_LEGACY_KERAS" not in os.environ,
+                reason="does not support",
             ),
         ),
     ],
@@ -641,9 +644,8 @@ def test_tf_keras_autolog_succeeds_for_tf_datasets_lacking_batch_size_info():
 
 
 def test_tf_keras_autolog_records_metrics_for_last_epoch(random_train_data, random_one_hot_labels):
-    every_n_iter = 5
     num_training_epochs = 17
-    mlflow.tensorflow.autolog(every_n_iter=every_n_iter)
+    mlflow.tensorflow.autolog(log_every_epoch=True)
 
     model = create_tf_keras_model()
     with mlflow.start_run() as run:
@@ -658,7 +660,7 @@ def test_tf_keras_autolog_records_metrics_for_last_epoch(random_train_data, rand
     run_metrics = client.get_run(run.info.run_id).data.metrics
     assert "accuracy" in run_metrics
     all_epoch_acc = client.get_metric_history(run.info.run_id, "accuracy")
-    assert {metric.step for metric in all_epoch_acc} == {0, 5, 10, 15}
+    assert len(all_epoch_acc) == num_training_epochs
 
 
 def test_tf_keras_autolog_logs_metrics_for_single_epoch_training(
@@ -671,7 +673,7 @@ def test_tf_keras_autolog_logs_metrics_for_single_epoch_training(
     produced in the boundary case where a model is trained for a single epoch, ensuring
     that we don't miss the zero index in the tf.Keras case.
     """
-    mlflow.tensorflow.autolog(every_n_iter=5)
+    mlflow.tensorflow.autolog()
 
     model = create_tf_keras_model()
     with mlflow.start_run() as run:
@@ -686,7 +688,7 @@ def test_tf_keras_autolog_logs_metrics_for_single_epoch_training(
 def test_tf_keras_autolog_names_positional_parameters_correctly(
     random_train_data, random_one_hot_labels
 ):
-    mlflow.tensorflow.autolog(every_n_iter=5)
+    mlflow.tensorflow.autolog()
 
     data = random_train_data
     labels = random_one_hot_labels
@@ -813,52 +815,6 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
 
     artifacts = [f.path for f in client.list_artifacts(run.info.run_id)]
     assert "tensorboard_logs" in artifacts
-
-
-@pytest.mark.parametrize("restore_weights", [True])
-@pytest.mark.parametrize("callback", ["early"])
-@pytest.mark.parametrize("patience", [0, 1, 5])
-@pytest.mark.parametrize("initial_epoch", [0, 10])
-def test_tf_keras_autolog_batch_metrics_logger_logs_expected_metrics(
-    callback,
-    restore_weights,
-    patience,
-    initial_epoch,
-    random_train_data,
-    random_one_hot_labels,
-):
-    patched_metrics_data = []
-
-    # Mock patching BatchMetricsLogger.record_metrics()
-    # to ensure that expected metrics are being logged.
-    original = BatchMetricsLogger.record_metrics
-
-    with patch(
-        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics", autospec=True
-    ) as record_metrics_mock:
-
-        def record_metrics_side_effect(self, metrics, step=None):
-            patched_metrics_data.extend(metrics.items())
-            original(self, metrics, step)
-
-        record_metrics_mock.side_effect = record_metrics_side_effect
-        run, _, callback = get_tf_keras_random_data_run_with_callback(
-            random_train_data,
-            random_one_hot_labels,
-            callback,
-            restore_weights,
-            patience,
-            initial_epoch,
-            log_models=False,
-        )
-    patched_metrics_data = dict(patched_metrics_data)
-    original_metrics = run.data.metrics
-
-    for metric_name in original_metrics:
-        assert metric_name in patched_metrics_data
-
-    restored_epoch = int(patched_metrics_data["restored_epoch"])
-    assert restored_epoch == initial_epoch
 
 
 @pytest.mark.parametrize("log_models", [False])
@@ -1105,9 +1061,7 @@ def test_fluent_autolog_with_tf_keras_logs_expected_content(
 
 
 def test_callback_is_picklable():
-    cb = __MLflowTfKeras2Callback(
-        metrics_logger=BatchMetricsLogger(run_id="1234"), log_every_n_steps=5
-    )
+    cb = MLflowCallback()
     pickle.dumps(cb)
 
     tb = _TensorBoard()
@@ -1128,29 +1082,6 @@ def test_tf_keras_autolog_distributed_training(random_train_data, random_one_hot
         model.fit(random_train_data, random_one_hot_labels, **fit_params)
     client = MlflowClient()
     assert client.get_run(run.info.run_id).data.params.keys() >= fit_params.keys()
-
-
-@pytest.mark.skipif(
-    Version(tf.__version__) < Version("2.6.0"),
-    reason=("TensorFlow only has a hard dependency on Keras in version >= 2.6.0"),
-)
-def test_fluent_autolog_with_tf_keras_preserves_v2_model_reference():
-    """
-    Verifies that, in TensorFlow >= 2.6.0, `tensorflow.keras.Model` refers to the correct class in
-    the correct module after `mlflow.autolog()` is called, guarding against previously identified
-    compatibility issues between recent versions of TensorFlow and MLflow's internal utility for
-    setting up autologging import hooks.
-    """
-    mlflow.autolog()
-
-    import tensorflow.keras
-
-    if Version(tf.__version__).release < (2, 16):
-        from keras.api._v2.keras import Model as ModelV2
-    else:
-        from keras import Model as ModelV2
-
-    assert tensorflow.keras.Model is ModelV2
 
 
 def test_import_tensorflow_with_fluent_autolog_enables_tensorflow_autologging():
@@ -1337,7 +1268,7 @@ def test_keras_autolog_logs_model_signature_by_default(keras_data_gen_sequence):
 
 
 def test_extract_tf_keras_input_example_unsupported_type_returns_None():
-    from mlflow.tensorflow._autolog import extract_tf_keras_input_example
+    from mlflow.tensorflow.autologging import extract_tf_keras_input_example
 
     extracted_data = extract_tf_keras_input_example([1, 2, 4, 5])
     assert extracted_data is None, (
@@ -1347,7 +1278,7 @@ def test_extract_tf_keras_input_example_unsupported_type_returns_None():
 
 
 def test_extract_input_example_from_tf_input_fn_unsupported_type_returns_None():
-    from mlflow.tensorflow._autolog import extract_tf_keras_input_example
+    from mlflow.tensorflow.autologging import extract_tf_keras_input_example
 
     extracted_data = extract_tf_keras_input_example(lambda: [1, 2, 4, 5])
     assert extracted_data is None, (
@@ -1383,3 +1314,22 @@ def test_autolog_throw_error_on_explicit_mlflow_callback(keras_data_gen_sequence
     with mlflow.start_run() as run:
         with pytest.raises(MlflowException, match="MLflow autologging must be turned off*"):
             model.fit(keras_data_gen_sequence, callbacks=[MLflowCallback(run)])
+
+
+def test_autolog_correct_logging_frequency(random_train_data, random_one_hot_labels):
+    logging_freq = 5
+    num_epochs = 2
+    batch_size = 10
+    mlflow.tensorflow.autolog(log_every_epoch=False, log_every_n_steps=logging_freq)
+    initial_model = create_tf_keras_model()
+    with mlflow.start_run() as run:
+        initial_model.fit(
+            random_train_data,
+            random_one_hot_labels,
+            batch_size=batch_size,
+            epochs=num_epochs,
+        )
+
+    client = MlflowClient()
+    loss_history = client.get_metric_history(run.info.run_id, "loss")
+    assert len(loss_history) == num_epochs * (len(random_train_data) // batch_size) // logging_freq


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/11094?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11094/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11094
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The odd argument `every_n_iter` was confusingly wrong - it actually means logging per n epochs, but takes the name `n_iter`. This PR aligns the tensorflow flavor with keras flavor, which unblocks aligning the version control for Keras 3 and Keras 2.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
