### PR TITLE
Use `tempfile` in `mlflow.log_artifact` example

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1212,7 +1212,7 @@ class MlflowClient:
                 tmp_dir = Path(tmp_dir)
                 with (tmp_dir / "data.json").open("w") as f:
                     json.dump(data, f, indent=2)
-                with (tmpdir / "features.json").open("w") as f:
+                with (tmp_dir / "features.json").open("w") as f:
                     f.write(features)
 
                 # Create a run under the default experiment (whose id is '0'), and log

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1158,11 +1158,10 @@ class MlflowClient:
         .. code-block:: python
             :caption: Example
 
-            from mlflow import MlflowClient
+            import tempfile
+            from pathlib import Path
 
-            features = "rooms, zipcode, median_price, school_rating, transport"
-            with open("features.txt", "w") as f:
-                f.write(features)
+            from mlflow import MlflowClient
 
             # Create a run under the default experiment (whose id is '0').
             client = MlflowClient()
@@ -1170,7 +1169,11 @@ class MlflowClient:
             run = client.create_run(experiment_id)
 
             # log and fetch the artifact
-            client.log_artifact(run.info.run_id, "features.txt")
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                path = Path(tmp_dir, "features.txt")
+                path.write_text(features)
+                client.log_artifact(run.info.run_id, path)
+
             artifacts = client.list_artifacts(run.info.run_id)
             for artifact in artifacts:
                 print(f"artifact: {artifact.path}")
@@ -1198,26 +1201,27 @@ class MlflowClient:
         .. code-block:: python
             :caption: Example
 
-            import os
             import json
+            import tempfile
+            from pathlib import Path
 
             # Create some artifacts data to preserve
             features = "rooms, zipcode, median_price, school_rating, transport"
             data = {"state": "TX", "Available": 25, "Type": "Detached"}
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                tmp_dir = Path(tmp_dir)
+                with (tmp_dir / "data.json").open("w") as f:
+                    json.dump(data, f, indent=2)
+                with (tmpdir / "features.json").open("w") as f:
+                    f.write(features)
 
-            # Create couple of artifact files under the local directory "data"
-            os.makedirs("data", exist_ok=True)
-            with open("data/data.json", "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
-            with open("data/features.txt", "w") as f:
-                f.write(features)
+                # Create a run under the default experiment (whose id is '0'), and log
+                # all files in "data" to root artifact_uri/states
+                client = MlflowClient()
+                experiment_id = "0"
+                run = client.create_run(experiment_id)
+                client.log_artifacts(run.info.run_id, tmp_dir, artifact_path="states")
 
-            # Create a run under the default experiment (whose id is '0'), and log
-            # all files in "data" to root artifact_uri/states
-            client = MlflowClient()
-            experiment_id = "0"
-            run = client.create_run(experiment_id)
-            client.log_artifacts(run.info.run_id, "data", artifact_path="states")
             artifacts = client.list_artifacts(run.info.run_id)
             for artifact in artifacts:
                 print(f"artifact: {artifact.path}")

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1071,9 +1071,9 @@ def log_artifacts(
                 json.dump(data, f, indent=2)
             with (tmp_dir / "features.json").open("w") as f:
                 f.write(features)
-        # Write all files in "data" to root artifact_uri/states
+        # Write all files in `tmp_dir` to root artifact_uri/states
         with mlflow.start_run():
-            mlflow.log_artifacts(path, artifact_path="states")
+            mlflow.log_artifacts(tmp_dir, artifact_path="states")
     """
     run_id = run_id or _get_or_start_run().info.run_id
     MlflowClient().log_artifacts(run_id, local_dir, artifact_path)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1030,13 +1030,12 @@ def log_artifact(
         # Create a features.txt artifact file
         features = "rooms, zipcode, median_price, school_rating, transport"
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with Path(tmp_dir, "features.txt").open("w") as f:
-                f.write(features)
-
+            path = Path(tmp_dir, "features.txt")
+            path.write_text(features)
             # With artifact_path=None write features.txt under
             # root artifact_uri/artifacts directory
             with mlflow.start_run():
-                mlflow.log_artifact("features.txt")
+                mlflow.log_artifact(path)
     """
     run_id = run_id or _get_or_start_run().info.run_id
     MlflowClient().log_artifact(run_id, local_path, artifact_path)
@@ -1058,7 +1057,8 @@ def log_artifacts(
         :caption: Example
 
         import json
-        import os
+        import tempfile
+        from pathlib import Path
         import mlflow
 
         # Create some files to preserve as artifacts
@@ -1066,13 +1066,15 @@ def log_artifacts(
         data = {"state": "TX", "Available": 25, "Type": "Detached"}
         # Create couple of artifact files under the directory "data"
         os.makedirs("data", exist_ok=True)
-        with open("data/data.json", "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2)
-        with open("data/features.txt", "w") as f:
-            f.write(features)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            with (tmp_dir / "data.json").open("w") as f:
+                json.dump(data, f, indent=2)
+            with (tmpdir / "features.json").open("w") as f:
+                f.write(features)
         # Write all files in "data" to root artifact_uri/states
         with mlflow.start_run():
-            mlflow.log_artifacts("data", artifact_path="states")
+            mlflow.log_artifacts(path, artifact_path="states")
     """
     run_id = run_id or _get_or_start_run().info.run_id
     MlflowClient().log_artifacts(run_id, local_dir, artifact_path)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1071,9 +1071,9 @@ def log_artifacts(
                 json.dump(data, f, indent=2)
             with (tmp_dir / "features.json").open("w") as f:
                 f.write(features)
-        # Write all files in `tmp_dir` to root artifact_uri/states
-        with mlflow.start_run():
-            mlflow.log_artifacts(tmp_dir, artifact_path="states")
+            # Write all files in `tmp_dir` to root artifact_uri/states
+            with mlflow.start_run():
+                mlflow.log_artifacts(tmp_dir, artifact_path="states")
     """
     run_id = run_id or _get_or_start_run().info.run_id
     MlflowClient().log_artifacts(run_id, local_dir, artifact_path)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1069,7 +1069,7 @@ def log_artifacts(
             tmp_dir = Path(tmp_dir)
             with (tmp_dir / "data.json").open("w") as f:
                 json.dump(data, f, indent=2)
-            with (tmpdir / "features.json").open("w") as f:
+            with (tmp_dir / "features.json").open("w") as f:
                 f.write(features)
         # Write all files in "data" to root artifact_uri/states
         with mlflow.start_run():

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1022,16 +1022,21 @@ def log_artifact(
         :test:
         :caption: Example
 
+        from pathlib import Path
+        import tempfile
+
         import mlflow
 
         # Create a features.txt artifact file
         features = "rooms, zipcode, median_price, school_rating, transport"
-        with open("features.txt", "w") as f:
-            f.write(features)
-        # With artifact_path=None write features.txt under
-        # root artifact_uri/artifacts directory
-        with mlflow.start_run():
-            mlflow.log_artifact("features.txt")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with Path(tmp_dir, "features.txt").open("w") as f:
+                f.write(features)
+
+            # With artifact_path=None write features.txt under
+            # root artifact_uri/artifacts directory
+            with mlflow.start_run():
+                mlflow.log_artifact("features.txt")
     """
     run_id = run_id or _get_or_start_run().info.run_id
     MlflowClient().log_artifact(run_id, local_path, artifact_path)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1022,8 +1022,8 @@ def log_artifact(
         :test:
         :caption: Example
 
-        from pathlib import Path
         import tempfile
+        from pathlib import Path
 
         import mlflow
 
@@ -1059,13 +1059,12 @@ def log_artifacts(
         import json
         import tempfile
         from pathlib import Path
+
         import mlflow
 
         # Create some files to preserve as artifacts
         features = "rooms, zipcode, median_price, school_rating, transport"
         data = {"state": "TX", "Available": 25, "Type": "Detached"}
-        # Create couple of artifact files under the directory "data"
-        os.makedirs("data", exist_ok=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_dir = Path(tmp_dir)
             with (tmp_dir / "data.json").open("w") as f:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11095?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11095/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11095
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Resolve #11093

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
