### PR TITLE
Return dict-like object in `MlflowDeploymentClient.get_endpoint`

### DIFF
--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -114,11 +114,14 @@ def _call_openai_api(openai_uri, payload, eval_parameters):
 
 
 def _call_deployments_api(deployment_uri, payload, eval_parameters):
+    from pydantic import BaseModel
+
     from mlflow.deployments import get_deploy_client
 
     client = get_deploy_client()
 
     endpoint = client.get_endpoint(deployment_uri)
+    endpoint = endpoint.dict() if isinstance(endpoint, BaseModel) else endpoint
     endpoint_type = endpoint.get("task", endpoint.get("endpoint_type"))
 
     if endpoint_type == "llm/v1/completions":

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -121,6 +121,7 @@ def _call_deployments_api(deployment_uri, payload, eval_parameters):
     client = get_deploy_client()
 
     endpoint = client.get_endpoint(deployment_uri)
+    # TODO: Standardize the return type of `get_endpoint` and remove this check
     endpoint = endpoint.dict() if isinstance(endpoint, BaseModel) else endpoint
     endpoint_type = endpoint.get("task", endpoint.get("endpoint_type"))
 


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Resolve #11087.
Resolve #10804.
Return dict-like object in `MlflowDeploymentClient.get_endpoint` to fix the following error. This error is swallowed by try-catch and results in `answer_similarity=NaN`.

```
2024/02/13 13:18:53 INFO mlflow.models.evaluation.base: Evaluating the model with the default evaluator.
2024/02/13 13:18:53 INFO mlflow.models.evaluation.default_evaluator: Computing model predictions.
2024/02/13 13:19:00 INFO mlflow.models.evaluation.default_evaluator: Testing metrics on first row...
  0%|                                                          | 0/1 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "a.py", line 79, in <module>
    ev = mlflow.evaluate(
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/models/evaluation/base.py", line 1946, in evaluate
    evaluate_result = _evaluate(
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/models/evaluation/base.py", line 1181, in _evaluate
    eval_result = evaluator.evaluate(
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/models/evaluation/default_evaluator.py", line 1956, in evaluate
    evaluation_result = self._evaluate(model, is_baseline_model=False)
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/models/evaluation/default_evaluator.py", line 1845, in _evaluate
    self._evaluate_metrics(eval_df)
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/models/evaluation/default_evaluator.py", line 1639, in _evaluate_metrics
    self._test_first_row(eval_df)
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/models/evaluation/default_evaluator.py", line 1630, in _test_first_row
    raise MlflowException("\n".join(exceptions))
mlflow.exceptions.MlflowException: Metric 'answer_similarity': Error:
AttributeError("'Endpoint' object has no attribute 'get'")
Traceback (most recent call last):
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/models/evaluation/default_evaluator.py", line 1610, in _test_first_row
    metric_value = _evaluate_metric(metric_tuple, eval_fn_args)
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/models/evaluation/default_evaluator.py", line 598, in _evaluate_metric
    metric = metric_tuple.function(*eval_fn_args)
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/metrics/genai/genai_metric.py", line 349, in eval_fn
    score, justification = future.result()
  File "/Users/harutaka.kawamura/.pyenv/versions/miniconda3-latest/envs/mlflow/lib/python3.8/concurrent/futures/_base.py", line 437, in result
    return self.__get_result()
  File "/Users/harutaka.kawamura/.pyenv/versions/miniconda3-latest/envs/mlflow/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
  File "/Users/harutaka.kawamura/.pyenv/versions/miniconda3-latest/envs/mlflow/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/metrics/genai/genai_metric.py", line 307, in score_model_on_one_payload
    raw_result = model_utils.score_model_on_payload(
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/metrics/genai/model_utils.py", line 25, in score_model_on_payload
    return _call_deployments_api(suffix, payload, eval_parameters)
  File "/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlflow/metrics/genai/model_utils.py", line 122, in _call_deployments_api
    endpoint_type = endpoint.get("task", endpoint.get("endpoint_type"))
  File "/Users/harutaka.kawamura/.pyenv/versions/miniconda3-latest/envs/mlflow/lib/python3.8/site-packages/pydantic/main.py", line 767, in __getattr__
    raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
AttributeError: 'Endpoint' object has no attribute 'get'
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```python
from datasets import load_dataset

dataset = load_dataset("squad")
eval_df = dataset["train"].to_pandas().sample(n=10, random_state=0)


def get_answer(row):
    answers = row["answers"]["text"]
    return answers[0]


eval_df["answer"] = eval_df.apply(get_answer, axis=1)
eval_df = eval_df.drop(columns=["answers", "id", "title"])

import mlflow

mlflow.set_tracking_uri("http://127.0.0.1:5000")
mlflow.set_experiment("test-deployment")


from langchain_core.output_parsers import StrOutputParser
from langchain_core.prompts import ChatPromptTemplate
from langchain_core.runnables import RunnablePassthrough
from langchain_openai import ChatOpenAI

template = """Answer the question based only on the following context:
{context}

Question: {question}
"""
prompt = ChatPromptTemplate.from_template(template)

llm = ChatOpenAI()
chain = RunnablePassthrough() | prompt | llm | StrOutputParser()
chain.invoke({"question": "What is 1 + 1?", "context": "1 + 1 is 3"})

from mlflow.metrics.genai import EvaluationExample, answer_similarity

# Create an example to describe what answer_similarity means like for this problem.
example = EvaluationExample(
    input="What is MLflow?",
    output="MLflow is an open-source platform for managing machine "
    "learning workflows, including experiment tracking, model packaging, "
    "versioning, and deployment, simplifying the ML lifecycle.",
    score=4,
    justification="The definition effectively explains what MLflow is "
    "its purpose, and its developer. It could be more concise for a 5-score.",
    grading_context={
        "targets": "MLflow is an open-source platform for managing "
        "the end-to-end machine learning (ML) lifecycle. It was developed by Databricks, "
        "a company that specializes in big data and machine learning solutions. MLflow is "
        "designed to address the challenges that data scientists and machine learning "
        "engineers face when developing, training, and deploying machine learning models."
    },
)

import mlflow.deployments

# Construct the metric using OpenAI GPT-4 as the judge
mlflow.deployments.set_deployments_target("http://localhost:7000")

judge_model = "endpoints:/chat"
# judge_model = "openai:/gpt-4"

answer_similarity_metric = answer_similarity(model=judge_model, examples=[example])

mlflow.deployments.get_deployments_target()  # wasn't set even if in env variable


def model(input_df):
    answers = []
    for _, row in input_df.iterrows():
        answer = chain.invoke({"question": row["question"], "context": row["context"]})
        answers.append(answer)
    return answers


with mlflow.start_run():
    ev = mlflow.evaluate(
        model,
        eval_df,
        # model_type="question-answering",
        # evaluators="default",
        targets="answer",
        extra_metrics=[answer_similarity_metric],  # faithfulness_metric, relevance_metric],
        evaluator_config={
            "col_mapping": {
                "inputs": "question",
            }
        },
    )
    print(ev.metrics)

```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
