### PR TITLE
Remove extra validation for model types when constructing Transformers pipeline

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -519,12 +519,6 @@ def save_model(
     if task and task.startswith(_LLM_INFERENCE_TASK_PREFIX):
         llm_inference_task = task
         _validate_llm_inference_task_type(llm_inference_task, built_pipeline)
-
-        flavor_conf.update({_LLM_INFERENCE_TASK_KEY: task})
-        if mlflow_model.metadata:
-            mlflow_model.metadata[_METADATA_LLM_INFERENCE_TASK_KEY] = task
-        else:
-            mlflow_model.metadata = {_METADATA_LLM_INFERENCE_TASK_KEY: task}
     else:
         llm_inference_task = None
 
@@ -563,6 +557,13 @@ def save_model(
 
     if processor:
         flavor_conf.update({_PROCESSOR_TYPE_KEY: _get_instance_type(processor)})
+
+    if llm_inference_task:
+        flavor_conf.update({_LLM_INFERENCE_TASK_KEY: task})
+        if mlflow_model.metadata:
+            mlflow_model.metadata[_METADATA_LLM_INFERENCE_TASK_KEY] = task
+        else:
+            mlflow_model.metadata = {_METADATA_LLM_INFERENCE_TASK_KEY: task}
 
     # Save the model object
     built_pipeline.model.save_pretrained(
@@ -1266,6 +1267,7 @@ def _build_pipeline_from_model_input(model_dict: Dict[str, Any], task: Optional[
 
     if task is None or task.startswith(_LLM_INFERENCE_TASK_PREFIX):
         from transformers.pipelines import get_task
+
         task = get_task(model_dict[_MODEL_KEY].name_or_path)
 
     try:

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -17,7 +17,7 @@ import shutil
 import string
 import sys
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 import numpy as np
@@ -90,6 +90,7 @@ if IS_TRANSFORMERS_AVAILABLE:
     from mlflow.transformers.llm_inference_utils import (
         _LLM_INFERENCE_TASK_CHAT,
         _LLM_INFERENCE_TASK_KEY,
+        _LLM_INFERENCE_TASK_PREFIX,
         _METADATA_LLM_INFERENCE_TASK_KEY,
         _SUPPORTED_LLM_INFERENCE_TASK_TYPES_BY_PIPELINE_TASK,
         convert_data_messages_with_chat_template,
@@ -106,6 +107,7 @@ if IS_TRANSFORMERS_AVAILABLE:
 # The following import is only used for type hinting
 if TYPE_CHECKING:
     import torch
+    from transformers import Pipeline
 
 
 FLAVOR_NAME = "transformers"
@@ -474,11 +476,6 @@ def save_model(
     """
     import transformers
 
-    _validate_transformers_model_dict(transformers_model)
-
-    if isinstance(transformers_model, dict):
-        transformers_model = _TransformersModel.from_dict(**transformers_model)
-
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
 
     path = pathlib.Path(path).absolute()
@@ -487,12 +484,18 @@ def save_model(
 
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, str(path))
 
-    transformers_task, llm_inference_task = _get_or_infer_task_type(transformers_model, task)
+    _validate_transformers_model_dict(transformers_model)
 
-    if not isinstance(transformers_model, transformers.Pipeline):
-        built_pipeline = _build_pipeline_from_model_input(transformers_model, transformers_task)
-    else:
+    if isinstance(transformers_model, transformers.Pipeline):
         built_pipeline = transformers_model
+    elif isinstance(transformers_model, dict):
+        built_pipeline = _build_pipeline_from_model_input(transformers_model, task=task)
+    else:
+        raise MlflowException(
+            "The `transformers_model` must be a Transformers Pipeline or a dictionary, "
+            f"received: {type(transformers_model)}",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
 
     # Verify that the model has not been loaded to distributed memory
     # NB: transformers does not correctly save a model whose weights have been loaded
@@ -512,6 +515,18 @@ def save_model(
 
     if mlflow_model is None:
         mlflow_model = Model()
+
+    if task and task.startswith(_LLM_INFERENCE_TASK_PREFIX):
+        llm_inference_task = task
+        _validate_llm_inference_task_type(llm_inference_task, built_pipeline)
+
+        flavor_conf.update({_LLM_INFERENCE_TASK_KEY: task})
+        if mlflow_model.metadata:
+            mlflow_model.metadata[_METADATA_LLM_INFERENCE_TASK_KEY] = task
+        else:
+            mlflow_model.metadata = {_METADATA_LLM_INFERENCE_TASK_KEY: task}
+    else:
+        llm_inference_task = None
 
     if llm_inference_task:
         mlflow_model.signature = infer_signature_from_llm_inference_task(
@@ -539,7 +554,7 @@ def save_model(
         else:
             mlflow_model.metadata = {_PROMPT_TEMPLATE_KEY: prompt_template}
 
-    flavor_conf = _generate_base_flavor_configuration(built_pipeline, transformers_task)
+    flavor_conf = _generate_base_flavor_configuration(built_pipeline)
 
     components = _record_pipeline_components(built_pipeline)
 
@@ -548,13 +563,6 @@ def save_model(
 
     if processor:
         flavor_conf.update({_PROCESSOR_TYPE_KEY: _get_instance_type(processor)})
-
-    if llm_inference_task:
-        flavor_conf.update({_LLM_INFERENCE_TASK_KEY: task})
-        if mlflow_model.metadata:
-            mlflow_model.metadata[_METADATA_LLM_INFERENCE_TASK_KEY] = task
-        else:
-            mlflow_model.metadata = {_METADATA_LLM_INFERENCE_TASK_KEY: task}
 
     # Save the model object
     built_pipeline.model.save_pretrained(
@@ -578,7 +586,7 @@ def save_model(
             inference_config=inference_config,
         )
 
-    model_name = transformers_model.model.name_or_path
+    model_name = built_pipeline.model.name_or_path
 
     # Get the model card from either the argument or the HuggingFace marketplace
     card_data = model_card or _fetch_model_card(model_name)
@@ -647,7 +655,7 @@ def save_model(
 
     if conda_env is None:
         if pip_requirements is None:
-            default_reqs = get_default_pip_requirements(transformers_model.model)
+            default_reqs = get_default_pip_requirements(built_pipeline.model)
             # Infer the pip requirements with a timeout to avoid hanging indefinitely at prediction
             inferred_reqs = infer_pip_requirements_with_timeout(
                 str(path), FLAVOR_NAME, fallback=default_reqs
@@ -1248,7 +1256,7 @@ def _write_license_information(model_name, card_data, path):
     path.joinpath(_LICENSE_FILE_NAME).write_text(fallback, encoding="utf-8")
 
 
-def _build_pipeline_from_model_input(model, task: str):
+def _build_pipeline_from_model_input(model_dict: Dict[str, Any], task: Optional[str]) -> Pipeline:
     """
     Utility for generating a pipeline from component parts. If required components are not
     specified, use the transformers library pipeline component validation to force raising an
@@ -1256,10 +1264,12 @@ def _build_pipeline_from_model_input(model, task: str):
     """
     from transformers import pipeline
 
-    pipeline_config = model.to_dict()
-    pipeline_config.update({"task": task})
+    if task is None or task.startswith(_LLM_INFERENCE_TASK_PREFIX):
+        from transformers.pipelines import get_task
+        task = get_task(model_dict[_MODEL_KEY].name_or_path)
+
     try:
-        return pipeline(**pipeline_config)
+        return pipeline(task=task, **model_dict)
     except Exception as e:
         raise MlflowException(
             "The provided model configuration cannot be created as a Pipeline. "
@@ -1326,10 +1336,7 @@ def _load_component(root_path: pathlib.Path, component_key: str, component_type)
     return component_instance.from_pretrained(component_path)
 
 
-def _generate_base_flavor_configuration(
-    pipeline,
-    task: str,
-) -> Dict[str, str]:
+def _generate_base_flavor_configuration(pipeline: Pipeline) -> Dict[str, str]:
     """
     Generates the base flavor metadata needed for reconstructing a pipeline from saved
     components. This is important because the ``Pipeline`` class does not have a loader
@@ -1338,13 +1345,10 @@ def _generate_base_flavor_configuration(
     This function extracts key information from the submitted model object so that the precise
     instance types can be loaded correctly.
     """
-
-    _validate_transformers_task_type(task)
-
     flavor_configuration = {
-        _TASK_KEY: task,
+        _TASK_KEY: pipeline.task,
         _INSTANCE_TYPE_KEY: _get_instance_type(pipeline),
-        _MODEL_PATH_OR_NAME_KEY: _get_base_model_architecture(pipeline),
+        _MODEL_PATH_OR_NAME_KEY: pipeline.model.name_or_path,
         _PIPELINE_MODEL_TYPE_KEY: _get_instance_type(pipeline.model),
     }
 
@@ -1398,107 +1402,19 @@ def _extract_torch_dtype_if_set(pipeline) -> Optional[torch.dtype]:
     return model_dtype if model_dtype != torch.float32 else None
 
 
-def _get_or_infer_task_type(model, task: Optional[str] = None) -> Tuple[str, str]:
-    """
-    From the ``task`` parameter, determine the appropriate ``transformers`` task type and
-    MLflow LLM inference task type if possible.
-    1. If ``task`` is not provided, infer the ``transformers`` task type from the model.
-    2. If ``task`` is provided and a valid ``transformers`` task type, use it.
-    3. If ``task`` is provided and not a valid ``transformers`` task type, assume it's an MLflow
-    LLM inference task type, and infer the ``transformers`` task type.
-    """
-    transformers_task, llm_inference_task = None, None
-
-    if not task:
-        transformers_task = _infer_transformers_task_type(model)
-    elif _is_transformers_task_type(task):
-        transformers_task = task
-    else:
-        transformers_task = _infer_transformers_task_type(model)
-        llm_inference_task = task
-        _validate_llm_inference_task_type(llm_inference_task, transformers_task)
-
-    return transformers_task, llm_inference_task
-
-
-def _infer_transformers_task_type(model) -> str:
-    """
-    Performs inference of the task type, used in generating a pipeline object based on the
-    underlying model's intended use case. This utility relies on the definitions within the
-    transformers pipeline construction utility functions.
-
-    Args:
-        model: Either the model or the Pipeline object that the task will be extracted or
-            inferred from
-
-    Returns:
-        The task type string
-    """
-    from transformers import Pipeline
-    from transformers.pipelines import get_task
-
-    if isinstance(model, Pipeline):
-        return model.task
-    elif isinstance(model, _TransformersModel):
-        try:
-            return get_task(model.model.name_or_path)
-        except Exception as e:
-            raise MlflowException(
-                "The task type cannot be inferred from the submitted Pipeline or dictionary of "
-                "model components. Please provide the task type explicitly when saving or logging "
-                "this submitted Pipeline or dictionary of components.",
-                error_code=BAD_REQUEST,
-            ) from e
-    else:
-        raise MlflowException(
-            f"The provided model type: {type(model)} is not supported. "
-            "Supported model types are: Pipeline or a dictionary with specific named keys. "
-            "Run `help(mlflow.transformers.save_model)` to see details of supported types.",
-            error_code=BAD_REQUEST,
-        )
-
-
-def _is_transformers_task_type(task: str) -> bool:
-    from transformers.pipelines import get_supported_tasks
-
-    valid_tasks = get_supported_tasks()
-
-    return task in valid_tasks or task.startswith("translation")
-
-
-def _validate_transformers_task_type(transformers_task: str) -> None:
-    """
-    Validates that a ``transformers_task`` type is supported by the ``transformers`` library
-    and has been registered in the hub.
-    """
-    from transformers.pipelines import get_supported_tasks
-
-    valid_tasks = get_supported_tasks()
-
-    if not _is_transformers_task_type(transformers_task):
-        raise MlflowException(
-            f"The task provided is invalid. '{transformers_task}' is not a supported task. "
-            f"Must be one of the registered transformers tasks: {valid_tasks}, or one of the "
-            f"supported MLflow inference tasks",
-            error_code=BAD_REQUEST,
-        )
-
-
-def _validate_llm_inference_task_type(llm_inference_task: str, transformers_task: str) -> None:
+def _validate_llm_inference_task_type(llm_inference_task: str, pipeline: Pipeline) -> None:
     """
     Validates that an ``inference_task`` type is supported by ``transformers`` pipeline type.
     """
     supported_llm_inference_tasks = _SUPPORTED_LLM_INFERENCE_TASK_TYPES_BY_PIPELINE_TASK.get(
-        transformers_task, []
+        pipeline.task, []
     )
 
     if llm_inference_task not in supported_llm_inference_tasks:
         raise MlflowException(
-            f"The task provided is invalid. '{llm_inference_task}' is not a supported task. "
-            f"Must be one of the registered MLflow inference tasks supported for "
-            f"the {transformers_task} pipeline: {supported_llm_inference_tasks}, or one of the "
-            f"registered transformers tasks",
-            error_code=BAD_REQUEST,
+            f"The task provided is invalid. '{llm_inference_task}' is not a supported task for "
+            f"the {pipeline.task} pipeline. Must be one of {supported_llm_inference_tasks}",
+            error_code=INVALID_PARAMETER_VALUE,
         )
 
 
@@ -1516,18 +1432,6 @@ def _get_engine_type(model):
             return "torch"
         elif issubclass(cls, FlaxPreTrainedModel):
             return "flax"
-
-
-def _get_base_model_architecture(model_or_pipeline):
-    """
-    Extracts the base model architecture type from a submitted model.
-    """
-    from transformers import Pipeline
-
-    if isinstance(model_or_pipeline, Pipeline):
-        return model_or_pipeline.model.name_or_path
-    else:
-        return model_or_pipeline[_MODEL_KEY].name_or_path
 
 
 def _get_instance_type(obj):
@@ -1581,109 +1485,6 @@ def _should_add_pyfunc_to_model(pipeline) -> bool:
     if type(pipeline).__name__ in exclusion_pipeline_types:
         return False
     return True
-
-
-class _TransformersModel(NamedTuple):
-    """
-    Type validator class for models that are submitted as a dictionary for saving and logging.
-    Usage of this class should always leverage the type-checking from the class method
-    'from_dict()' instead of the instance-based configuration that is utilized with instantiating
-    a NamedTuple instance (it uses '__new__()' instead of an '__init__()'  dunder method, making
-    type validation on instantiation overly complex if we were to support that approach).
-    """
-
-    # NB: Assigning Any type here to eliminate local imports. Type validation is performed when
-    # calling the `from_dict` class method.
-    model: Any
-    tokenizer: Any = None
-    feature_extractor: Any = None
-    image_processor: Any = None
-    processor: Any = None
-    torch_dtype: Any = None
-
-    def to_dict(self):
-        dict_repr = self._asdict()
-        # NB: due to breaking changes in APIs, newer pipeline-supported argument keys are not
-        # backwards compatible. If there isn't an instance present, do not return an empty
-        # key to value mapping.
-        return {name: obj for name, obj in dict_repr.items() if obj}
-
-    @staticmethod
-    def _build_exception_msg(obj, obj_name, valid_types):
-        type_msg = (
-            "one of: " + ", ".join([valid_type.__name__ for valid_type in valid_types])
-            if isinstance(valid_types, tuple)
-            else valid_types.__name__
-        )
-        return (
-            f"The {obj_name} type submitted is not compatible with the transformers flavor: "
-            f"'{type(obj).__name__}'. "
-            f"The allowed types must inherit from {type_msg}."
-        )
-
-    @classmethod
-    def _validate_submitted_types(
-        cls, model, tokenizer, feature_extractor, image_processor, processor, torch_dtype
-    ):
-        from transformers import (
-            FeatureExtractionMixin,
-            FlaxPreTrainedModel,
-            ImageFeatureExtractionMixin,
-            ImageProcessingMixin,
-            PreTrainedModel,
-            PreTrainedTokenizerBase,
-            ProcessorMixin,
-            TFPreTrainedModel,
-        )
-
-        validation = [
-            (model, "model", (PreTrainedModel, TFPreTrainedModel, FlaxPreTrainedModel)),
-            (tokenizer, "tokenizer", PreTrainedTokenizerBase),
-            (
-                feature_extractor,
-                "feature_extractor",
-                (
-                    FeatureExtractionMixin,
-                    ImageFeatureExtractionMixin,
-                    ProcessorMixin,
-                    ImageProcessingMixin,
-                ),
-            ),
-            (image_processor, "image_processor", ImageProcessingMixin),
-            (processor, "processor", ProcessorMixin),
-        ]
-        invalid_types = []
-
-        for arg, name, types in validation:
-            if arg and not isinstance(arg, types):
-                invalid_types.append(cls._build_exception_msg(arg, name, types))
-        # only import torch when torch_dtype is not None
-        if torch_dtype is not None:
-            from torch import dtype
-
-            if not isinstance(torch_dtype, dtype):
-                invalid_types.append(cls._build_exception_msg(torch_dtype, "torch_dtype", dtype))
-        if invalid_types:
-            raise MlflowException("\n".join(invalid_types), error_code=BAD_REQUEST)
-
-    @classmethod
-    def from_dict(
-        cls,
-        model,
-        tokenizer=None,
-        feature_extractor=None,
-        image_processor=None,
-        processor=None,
-        torch_dtype=None,
-        **kwargs,  # pylint: disable=unused-argument
-    ):
-        cls._validate_submitted_types(
-            model, tokenizer, feature_extractor, image_processor, processor, torch_dtype
-        )
-
-        return _TransformersModel(
-            model, tokenizer, feature_extractor, image_processor, processor, torch_dtype
-        )
 
 
 def _get_model_config(local_path, pyfunc_config):

--- a/mlflow/transformers/llm_inference_utils.py
+++ b/mlflow/transformers/llm_inference_utils.py
@@ -20,8 +20,10 @@ _LLM_INFERENCE_TASK_KEY = "inference_task"
 # future Databricks Provisioned Throughput support of more model architectures for inference.
 _METADATA_LLM_INFERENCE_TASK_KEY = "task"
 
-_LLM_INFERENCE_TASK_COMPLETIONS = "llm/v1/completions"
-_LLM_INFERENCE_TASK_CHAT = "llm/v1/chat"
+_LLM_INFERENCE_TASK_PREFIX = "llm/v1"
+_LLM_INFERENCE_TASK_COMPLETIONS = f"{_LLM_INFERENCE_TASK_PREFIX}/completions"
+_LLM_INFERENCE_TASK_CHAT = f"{_LLM_INFERENCE_TASK_PREFIX}/chat"
+
 
 _LLM_INFERENCE_OBJECT_NAME = {
     _LLM_INFERENCE_TASK_COMPLETIONS: "text_completion",

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -39,17 +39,12 @@ from mlflow.transformers import (
     _build_pipeline_from_model_input,
     _fetch_model_card,
     _generate_base_flavor_configuration,
-    _get_base_model_architecture,
     _get_instance_type,
-    _get_or_infer_task_type,
-    _infer_transformers_task_type,
     _is_model_distributed_in_memory,
     _record_pipeline_components,
     _should_add_pyfunc_to_model,
-    _TransformersModel,
     _TransformersWrapper,
     _validate_llm_inference_task_type,
-    _validate_transformers_task_type,
     _write_card_data,
     _write_license_information,
     get_default_conda_env,
@@ -169,36 +164,16 @@ def test_dependencies_tensorflow(small_seq2seq_pipeline):
     assert pip_in_conda.intersection(expected_conda) == expected_conda
 
 
-def test_task_inference(small_seq2seq_pipeline):
-    expected_task = "text-classification"
-    assert _infer_transformers_task_type(small_seq2seq_pipeline) == expected_task
-
-    assert (
-        _infer_transformers_task_type(
-            _TransformersModel.from_dict(**{"model": small_seq2seq_pipeline.model})
-        )
-        == expected_task
-    )
-    with pytest.raises(MlflowException, match="The provided model type"):
-        _infer_transformers_task_type(small_seq2seq_pipeline.tokenizer)
-
-
-def test_transformers_task_validation():
-    with pytest.raises(MlflowException, match="The task provided is invalid. 'fake-task' is not"):
-        _validate_transformers_task_type("fake-task")
-    _validate_transformers_task_type("image-classification")
-
-
-def test_inference_task_validation():
+def test_inference_task_validation(small_seq2seq_pipeline, text_generation_pipeline):
     with pytest.raises(
         MlflowException, match="The task provided is invalid. 'llm/v1/invalid' is not"
     ):
-        _validate_llm_inference_task_type("llm/v1/invalid", "text-generation")
+        _validate_llm_inference_task_type("llm/v1/invalid", text_generation_pipeline)
     with pytest.raises(
         MlflowException, match="The task provided is invalid. 'llm/v1/completions' is not"
     ):
-        _validate_llm_inference_task_type("llm/v1/completions", "text-classification")
-    _validate_llm_inference_task_type("llm/v1/completions", "text-generation")
+        _validate_llm_inference_task_type("llm/v1/completions", small_seq2seq_pipeline)
+    _validate_llm_inference_task_type("llm/v1/completions", text_generation_pipeline)
 
 
 def test_instance_extraction(small_qa_pipeline):
@@ -221,19 +196,9 @@ def test_pipeline_eligibility_for_pyfunc_registration(model, result, request):
 
 
 def test_component_multi_modal_model_ineligible_for_pyfunc(component_multi_modal):
-    components = _TransformersModel.from_dict(**component_multi_modal)
-    task = _infer_transformers_task_type(components)
-
-    pipeline = _build_pipeline_from_model_input(components, task=task)
+    task = transformers.pipelines.get_task(component_multi_modal["model"].name_or_path)
+    pipeline = _build_pipeline_from_model_input(component_multi_modal, task)
     assert not _should_add_pyfunc_to_model(pipeline)
-
-
-def test_model_architecture_extraction(small_seq2seq_pipeline):
-    assert _get_base_model_architecture(small_seq2seq_pipeline) == "lordtt13/emo-mobilebert"
-    assert (
-        _get_base_model_architecture({"model": small_seq2seq_pipeline.model})
-        == "lordtt13/emo-mobilebert"
-    )
 
 
 def test_base_flavor_configuration_generation(small_seq2seq_pipeline, small_qa_pipeline):
@@ -251,31 +216,17 @@ def test_base_flavor_configuration_generation(small_seq2seq_pipeline, small_qa_p
         _MODEL_PATH_OR_NAME_KEY: "csarron/mobilebert-uncased-squad-v2",
         _FRAMEWORK_KEY: "pt",
     }
-    seq_conf_infer_task = _generate_base_flavor_configuration(
-        small_seq2seq_pipeline, _get_or_infer_task_type(small_seq2seq_pipeline)[0]
-    )
-    assert seq_conf_infer_task == expected_seq_pipeline_conf
-    seq_conf_specify_task = _generate_base_flavor_configuration(
-        small_seq2seq_pipeline, "text-classification"
-    )
-    assert seq_conf_specify_task == expected_seq_pipeline_conf
-    qa_conf_infer_task = _generate_base_flavor_configuration(
-        small_qa_pipeline, _get_or_infer_task_type(small_qa_pipeline)[0]
-    )
-    assert qa_conf_infer_task == expected_qa_pipeline_conf
-    qa_conf_specify_task = _generate_base_flavor_configuration(
-        small_qa_pipeline, "question-answering"
-    )
-    assert qa_conf_specify_task == expected_qa_pipeline_conf
-    with pytest.raises(MlflowException, match="The task provided is invalid. 'magic' is not"):
-        _generate_base_flavor_configuration(small_qa_pipeline, "magic")
+    conf = _generate_base_flavor_configuration(small_seq2seq_pipeline)
+    assert conf == expected_seq_pipeline_conf
+    conf = _generate_base_flavor_configuration(small_qa_pipeline)
+    assert conf == expected_qa_pipeline_conf
 
 
 def test_pipeline_construction_from_base_nlp_model(small_qa_pipeline):
-    generated = _build_pipeline_from_model_input(
-        _TransformersModel.from_dict(
-            **{"model": small_qa_pipeline.model, "tokenizer": small_qa_pipeline.tokenizer}
-        ),
+    generated = _build_pipeline_from_model_input({
+        "model": small_qa_pipeline.model,
+        "tokenizer": small_qa_pipeline.tokenizer
+        },
         "question-answering",
     )
     assert isinstance(generated, type(small_qa_pipeline))
@@ -288,10 +239,7 @@ def test_pipeline_construction_from_base_vision_model(small_vision_model):
         model.update({"image_processor": small_vision_model.feature_extractor})
     else:
         model.update({"feature_extractor": small_vision_model.feature_extractor})
-    generated = _build_pipeline_from_model_input(
-        _TransformersModel.from_dict(**model),
-        "image-classification",
-    )
+    generated = _build_pipeline_from_model_input(model, task="image-classification")
     assert isinstance(generated, type(small_vision_model))
     assert isinstance(generated.tokenizer, type(small_vision_model.tokenizer))
     if IS_NEW_FEATURE_EXTRACTION_API:
@@ -299,14 +247,6 @@ def test_pipeline_construction_from_base_vision_model(small_vision_model):
     else:
         compare_type = generated.feature_extractor
     assert isinstance(compare_type, transformers.MobileNetV2ImageProcessor)
-
-
-def test_pipeline_construction_fails_with_invalid_type(small_vision_model):
-    with pytest.raises(
-        MlflowException,
-        match="The model type submitted is not compatible with the transformers flavor: ",
-    ):
-        _TransformersModel.from_dict(**{"model": small_vision_model.feature_extractor})
 
 
 def test_saving_with_invalid_dict_as_model(model_path):
@@ -1000,54 +940,6 @@ def test_invalid_model_type_without_registered_name_does_not_save(model_path):
 
     with pytest.raises(MlflowException, match="The submitted model type"):
         mlflow.transformers.save_model(transformers_model=invalid_pipeline, path=model_path)
-
-
-@flaky()
-def test_invalid_task_inference_raises_error(model_path):
-    from transformers import Pipeline
-
-    def softmax(outputs):
-        maxes = np.max(outputs, axis=-1, keepdims=True)
-        shifted_exp = np.exp(outputs - maxes)
-        return shifted_exp / shifted_exp.sum(axis=-1, keepdims=True)
-
-    class PairClassificationPipeline(Pipeline):
-        def _sanitize_parameters(self, **kwargs):
-            preprocess_kwargs = {}
-            if "second_text" in kwargs:
-                preprocess_kwargs["second_text"] = kwargs["second_text"]
-            return preprocess_kwargs, {}, {}
-
-        # pylint: disable=arguments-renamed,arguments-differ
-        def preprocess(self, text, second_text=None):
-            return self.tokenizer(text, text_pair=second_text, return_tensors=self.framework)
-
-        # pylint: disable=arguments-differ,arguments-renamed
-        def _forward(self, model_inputs):
-            return self.model(**model_inputs)
-
-        # pylint: disable=arguments-differ
-        def postprocess(self, model_outputs):
-            logits = model_outputs.logits[0].numpy()
-            probabilities = softmax(logits)
-
-            best_class = np.argmax(probabilities)
-            label = self.model.config.id2label[best_class]
-            score = probabilities[best_class].item()
-            logits = logits.tolist()
-            return {"label": label, "score": score, "logits": logits}
-
-    model = transformers.AutoModelForSequenceClassification.from_pretrained(
-        "sgugger/finetuned-bert-mrpc"
-    )
-    dummy_pipeline = PairClassificationPipeline(model=model)
-
-    with pytest.raises(
-        MlflowException, match="The task provided is invalid. '' is not a supported"
-    ):
-        mlflow.transformers.save_model(transformers_model=dummy_pipeline, path=model_path)
-    dummy_pipeline.task = "text-classification"
-    mlflow.transformers.save_model(transformers_model=dummy_pipeline, path=model_path)
 
 
 def test_invalid_input_to_pyfunc_signature_output_wrapper_raises(component_multi_modal):
@@ -2755,7 +2647,7 @@ def test_extraction_of_base_flavor_config(dtype):
         use_fast=True,
     )
 
-    parsed = mlflow.transformers._generate_base_flavor_configuration(full_config_pipeline, task)
+    parsed = mlflow.transformers._generate_base_flavor_configuration(full_config_pipeline)
 
     assert parsed == {
         "task": "translation_en_to_fr",

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -223,10 +223,8 @@ def test_base_flavor_configuration_generation(small_seq2seq_pipeline, small_qa_p
 
 
 def test_pipeline_construction_from_base_nlp_model(small_qa_pipeline):
-    generated = _build_pipeline_from_model_input({
-        "model": small_qa_pipeline.model,
-        "tokenizer": small_qa_pipeline.tokenizer
-        },
+    generated = _build_pipeline_from_model_input(
+        {"model": small_qa_pipeline.model, "tokenizer": small_qa_pipeline.tokenizer},
         "question-answering",
     )
     assert isinstance(generated, type(small_qa_pipeline))


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11099?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11099/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11099
```

</p>
</details>

### Related Issues/PRs

ML-37991

### What changes are proposed in this pull request?

When users tries to log/save Transformers model with dictionary format like `mlflow.transformers.save_model({"model": my_model, "tokenizer": my_tokenizer, ...}, ...)`, we cast that dict into our custom [_TransformersModel](https://github.com/mlflow/mlflow/blob/master/mlflow/transformers/__init__.py#L1624-L1667) class to apply some validation on its contents such as model, tokenizer, etc. This class is purely for validation purpose, as we [convert it back to dictionary](https://github.com/mlflow/mlflow/blob/master/mlflow/transformers/__init__.py#L1259) right away to build Transformers pipeline.

However, the validation is based on a static allowlist which can be out-of-date and cause confusion to users. For example, [PeftModel](https://huggingface.co/docs/peft/v0.8.2/en/package_reference/peft_model#peft.PeftModel) works as a valid model for a pipeline, but the allowlist doesn't include it, so using PeftModel will cause an validation error. (**Note**: PeftModel itself is not yet fully supported in MLflow, but will be added in this quarter).

This PR removes that custom validation logic and let Transformers to validate it i.e. just try pipeline construction. This also helps simplifying some downstream logic.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
