### PR TITLE
Add warning when requirements files are edited

### DIFF
--- a/.github/workflows/require-core-maintainer-approval.js
+++ b/.github/workflows/require-core-maintainer-approval.js
@@ -1,0 +1,24 @@
+const CORE_MAINTAINERS = new Set([
+  "B-Step62",
+  "BenWilson2",
+  "daniellok-db",
+  "harupy",
+  "serena-ruan",
+  "WeichenXu123",
+]);
+
+module.exports = async ({ github, context, core }) => {
+  const { data: reviews } = await github.rest.pulls.listReviews({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.issue.number,
+  });
+
+  const maintainerApprovals = reviews.filter(
+    (review) => review.state === "APPROVED" && CORE_MAINTAINERS.has(review.user.login)
+  );
+
+  if (maintainerApprovals.length === 0) {
+    core.setFailed("No core maintainers have approved this pull request");
+  }
+};

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -1,7 +1,7 @@
 name: Warn on editing requirements
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - setup.py
       - requirements/skinny-requirements.yaml

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -1,26 +1,23 @@
-name: Warn on editing requirements
+name: Require core maintainer approval when editing requirements
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - setup.py
       - requirements/skinny-requirements.yaml
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
   warn:
     runs-on: ubuntu-latest
     steps:
-      - name: Post warning if file is edited
+      - name: Fail without core maintainer approval
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "⚠️ Warning: It looks like you're editing requirements for MLflow. Please ensure that this doesn't cause any dependency conflicts with downstream tasks that depend on MLflow (e.g. image building).",
-            });
+            script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/require-core-maintainer-approval.js`);
+            script({ context, github, core });

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -1,21 +1,18 @@
 name: Warn on editing requirements
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - setup.py
       - requirements/skinny-requirements.yaml
 
 permissions:
-  contents: read
-  issues: write
   pull-requests: write
 
 jobs:
   warn:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - name: Post warning if file is edited
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -19,4 +19,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/require-core-maintainer-approval.js`);
-            script({ context, github, core });
+            await script({ context, github, core });

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Post warning if file is edited
         uses: actions/github-script@v7
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   warn:

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -14,9 +14,6 @@ permissions:
 jobs:
   warn:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Post warning if file is edited

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -1,0 +1,32 @@
+name: Warn on editing requirements
+
+on:
+  pull_request:
+    paths:
+      - setup.py
+      - requirements/skinny-requirements.yaml
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  warn:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Post warning if file is edited
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "⚠️ Warning: It looks like you're editing requirements for MLflow. Please ensure that this doesn't cause any dependency conflicts with downstream tasks that depend on MLflow (e.g. image building).",
+            });

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.rest.issues.createComment({
+            github.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -1,7 +1,7 @@
 name: Warn on editing requirements
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - setup.py
       - requirements/skinny-requirements.yaml

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -11,7 +11,7 @@ click:
 
 cloudpickle:
   pip_release: cloudpickle
-  max_major_version: 3
+  max_major_version: 4
 
 entrypoints:
   pip_release: entrypoints

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -11,7 +11,7 @@ click:
 
 cloudpickle:
   pip_release: cloudpickle
-  max_major_version: 4
+  max_major_version: 3
 
 entrypoints:
   pip_release: entrypoints


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11118?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11118/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11118
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

As title, this job will comment on a PR with a warning if the PR edits `setup.py` or `skinny-requirements.yaml`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


I merged a PR into a branch, then opened a PR from that branch:
https://github.com/mlflow/mlflow/pull/11101

<img width="959" alt="Screenshot 2024-02-14 at 11 36 59 AM" src="https://github.com/mlflow/mlflow/assets/148037680/84c38d89-27ff-4ded-8896-41f82277720b">

Replaced this PR with `pull_request_target` so it can have write permissions


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
