### PR TITLE
Support PEFT models in Transformers flavor

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -530,6 +530,7 @@ transformers:
           "torch",
           "torchvision",
           "tensorflow",
+          "peft", # optimized fine-tuning library developed by Hugging Face
           "accelerate", # required for large torch models where weights will not fit in RAM
           "librosa", # required for transformers audio pipelines for bitrate conversion
           "ffmpeg", # required for transformers audio pipelines for audio byte to numpy conversion

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -6,7 +6,7 @@ from mlflow.environment_variables import (
 )
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_STATE
-from mlflow.transformers.flavor_config import FlavorKey
+from mlflow.transformers.flavor_config import FlavorKey, get_peft_base_model, is_peft_model
 
 _logger = logging.getLogger(__name__)
 
@@ -26,7 +26,9 @@ def save_pipeline_pretrained_weights(path, pipeline, flavor_conf, processor=None
         flavor_config: The flavor configuration constructed for the pipeline
         processor: Optional processor instance to save alongside the pipeline
     """
-    pipeline.model.save_pretrained(
+    model = get_peft_base_model(pipeline.model) if is_peft_model(pipeline.model) else pipeline.model
+
+    model.save_pretrained(
         save_directory=path.joinpath(_MODEL_BINARY_FILE_NAME),
         max_shard_size=MLFLOW_HUGGINGFACE_MODEL_MAX_SHARD_SIZE.get(),
     )

--- a/mlflow/transformers/peft.py
+++ b/mlflow/transformers/peft.py
@@ -1,0 +1,58 @@
+"""
+PEFT (Parameter-Efficient Fine-Tuning) is a library for efficiently adapting large pretrained
+models without fine-tuning all of model parameters but only a small number of (extra) parameters.
+Users can define a PEFT model that wraps a Transformer model to apply a thin adapter layer on
+top of the base model. The PEFT model provides almost the same APIs as the original model such
+as from_pretrained(), save_pretrained().
+"""
+_PEFT_ADAPTOR_DIR_NAME = "peft"
+
+
+def is_peft_model(model) -> bool:
+    try:
+        from peft import PeftModel
+    except ImportError:
+        return False
+
+    return isinstance(model, PeftModel)
+
+
+def get_peft_base_model(model):
+    """Extract the base model from a PEFT model."""
+    peft_config_map = model.peft_config or {}
+
+    # PEFT usually wraps the base model with two additional classes, one is PeftModel class
+    # and the other is the adaptor specific class, like LoraModel class, so the class hierarchy
+    # looks like PeftModel -> LoraModel -> BaseModel
+    # However, when the PEFT config is the one for "prompt learning", there is not adaptor class
+    # and the PeftModel class directly wraps the base model.
+    if peft_config := peft_config_map.get(model.active_adapter):
+        if not peft_config.is_prompt_learning:
+            return model.base_model.model
+
+    return model.base_model
+
+
+def save_peft_adaptor(path, model):
+    if not is_peft_model(model):
+        raise ValueError("The provided model is not a PEFT model.")
+
+    model.save_pretrained(path.joinpath(_PEFT_ADAPTOR_DIR_NAME))
+
+
+def get_model_with_peft_adapter(base_model, peft_adapter_path):
+    """
+    Apply the PEFT adapter to the base model to create a PEFT model.
+
+    NB: The alternative way to load PEFT adapter is to use load_adapter API like
+    `base_model.load_adapter(peft_adapter_path)`, as it injects the adapter weights
+    into the model in-place hence reducing the memory footprint. However, doing so
+    returns the base model class and not the PEFT model, loosing some properties
+    such as peft_config. This is not preferable because load_model API should
+    return the exact same object that was saved. Hence we construct the PEFT model
+    instead of in-place injection, for consistency over the memory saving which
+    should be small in most cases.
+    """
+    from peft import PeftModel
+
+    return PeftModel.from_pretrained(base_model, peft_adapter_path)

--- a/mlflow/transformers/peft.py
+++ b/mlflow/transformers/peft.py
@@ -19,25 +19,17 @@ def is_peft_model(model) -> bool:
 
 def get_peft_base_model(model):
     """Extract the base model from a PEFT model."""
-    peft_config_map = model.peft_config or {}
+    peft_config = model.peft_config.get(model.active_adapter) if model.peft_config else None
 
     # PEFT usually wraps the base model with two additional classes, one is PeftModel class
     # and the other is the adaptor specific class, like LoraModel class, so the class hierarchy
     # looks like PeftModel -> LoraModel -> BaseModel
     # However, when the PEFT config is the one for "prompt learning", there is not adaptor class
     # and the PeftModel class directly wraps the base model.
-    if peft_config := peft_config_map.get(model.active_adapter):
-        if not peft_config.is_prompt_learning:
-            return model.base_model.model
+    if peft_config and not peft_config.is_prompt_learning:
+        return model.base_model.model
 
     return model.base_model
-
-
-def save_peft_adaptor(path, model):
-    if not is_peft_model(model):
-        raise ValueError("The provided model is not a PEFT model.")
-
-    model.save_pretrained(path.joinpath(_PEFT_ADAPTOR_DIR_NAME))
 
 
 def get_model_with_peft_adapter(base_model, peft_adapter_path):

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -290,6 +290,13 @@ it to MLflow without modifying the model weights. In such case, specifying this 
         model_uri = "YOUR_MODEL_URI_LOGGED_WITH_SAVE_PRETRAINED_FALSE"
         model = mlflow.transformers.download_pretrained_model(model_uri)
         mlflow.register_model(model_uri, "model_name")
+
+.. important::
+
+    When you save the `PEFT <https://huggingface.co/docs/peft/en/index>` model, MLflow will
+    overrides the `save_pretrained` flag to `False` and only the PEFT adapter weights. The
+    base model weights are not saved but the reference to the HuggingFace repository and
+    its commit hash are logged instead.
 """
         ),
     }

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -293,8 +293,8 @@ it to MLflow without modifying the model weights. In such case, specifying this 
 
 .. important::
 
-    When you save the `PEFT <https://huggingface.co/docs/peft/en/index>` model, MLflow will
-    overrides the `save_pretrained` flag to `False` and only the PEFT adapter weights. The
+    When you save the `PEFT <https://huggingface.co/docs/peft/en/index>`_ model, MLflow will
+    override the `save_pretrained` flag to `False` and only store the PEFT adapter weights. The
     base model weights are not saved but the reference to the HuggingFace repository and
     its commit hash are logged instead.
 """

--- a/tests/transformers/conftest.py
+++ b/tests/transformers/conftest.py
@@ -8,6 +8,7 @@ from tests.transformers.helper import (
     load_fill_mask_pipeline,
     load_ner_pipeline,
     load_ner_pipeline_aggregation,
+    load_peft_pipeline,
     load_small_conversational_model,
     load_small_multi_modal_pipeline,
     load_small_qa_pipeline,
@@ -122,3 +123,8 @@ def audio_classification_pipeline():
 @pytest.fixture
 def feature_extraction_pipeline():
     return load_feature_extraction_pipeline()
+
+
+@pytest.fixture
+def peft_pipeline():
+    return load_peft_pipeline()

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3592,8 +3592,8 @@ def test_save_and_load_pipeline_without_save_pretrained_false(
     assert not model_path.joinpath("components").exists()
 
     # Validate the contents of MLModel file
-    mlmodel = yaml.safe_load(model_path.joinpath("MLmodel").read_bytes())
-    flavor_conf = mlmodel["flavors"]["transformers"]
+    mlmodel = Model.load(str(model_path.joinpath("MLmodel")))
+    flavor_conf = mlmodel.flavors["transformers"]
     assert "model_binary" not in flavor_conf
     assert flavor_conf["source_model_name"] == model.name_or_path
     assert HF_COMMIT_HASH_PATTERN.match(flavor_conf["source_model_revision"])

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3604,7 +3604,7 @@ def test_save_and_load_pipeline_without_save_pretrained_false(
         assert HF_COMMIT_HASH_PATTERN.match(flavor_conf[f"{c}_revision"])
 
     # Validate pyfunc load and prediction (if pyfunc supported)
-    if "python_function" in mlmodel["flavors"]:
+    if "python_function" in mlmodel.flavors:
         if callable(input_example):
             input_example = input_example()
         mlflow.pyfunc.load_model(model_path).predict(input_example)

--- a/tests/transformers/test_transformers_peft_model.py
+++ b/tests/transformers/test_transformers_peft_model.py
@@ -1,0 +1,90 @@
+import importlib
+
+import pytest
+
+import mlflow
+from mlflow.models import Model
+from mlflow.transformers.peft import get_peft_base_model, is_peft_model
+
+from tests.transformers.test_transformers_model_export import (
+    HF_COMMIT_HASH_PATTERN,
+    model_path,  # noqa: F401
+)
+
+peft_not_installed_cond = {
+    "condition": importlib.util.find_spec("peft") is None,
+    "reason": "PEFT is not installed",
+}
+
+
+@pytest.mark.skipif(**peft_not_installed_cond)
+def test_is_peft_model(peft_pipeline, small_qa_pipeline):
+    assert is_peft_model(peft_pipeline.model)
+    assert not is_peft_model(small_qa_pipeline.model)
+
+
+@pytest.mark.skipif(**peft_not_installed_cond)
+def test_get_peft_base_model(peft_pipeline):
+    base_model = get_peft_base_model(peft_pipeline.model)
+    assert base_model.__class__.__name__ == "OPTForCausalLM"
+    assert base_model.name_or_path == "facebook/opt-350m"
+
+
+@pytest.mark.skipif(**peft_not_installed_cond)
+def test_get_peft_base_model_prompt_learning(small_qa_pipeline):
+    from peft import PeftModel, PromptTuningConfig
+
+    peft_config = PromptTuningConfig(
+        task_type="question-answering",
+        num_virtual_tokens=10,
+        peft_type="PROMPT_TUNING",
+    )
+    peft_model = PeftModel(small_qa_pipeline.model, peft_config)
+
+    base_model = get_peft_base_model(peft_model)
+    assert base_model.__class__.__name__ == "MobileBertForQuestionAnswering"
+    assert base_model.name_or_path == "csarron/mobilebert-uncased-squad-v2"
+
+
+@pytest.mark.skipif(**peft_not_installed_cond)
+def test_save_and_load_peft_pipeline(peft_pipeline, model_path):
+    from peft import PeftModel
+
+    mlflow.transformers.save_model(
+        transformers_model=peft_pipeline,
+        path=model_path,
+    )
+
+    # For PEFT, only the adapter model should be saved
+    assert model_path.joinpath("peft").exists()
+    assert not model_path.joinpath("model").exists()
+    assert not model_path.joinpath("components").exists()
+
+    # Validate the contents of MLModel file
+    flavor_conf = Model.load(str(model_path.joinpath("MLmodel"))).flavors["transformers"]
+    assert "model_binary" not in flavor_conf
+    assert HF_COMMIT_HASH_PATTERN.match(flavor_conf["source_model_revision"])
+    assert flavor_conf["peft_adaptor"] == "peft"
+
+    loaded_pipeline = mlflow.transformers.load_model(model_path)
+    assert isinstance(loaded_pipeline.model, PeftModel)
+
+    loaded_pipeline.predict("Hi")
+
+
+@pytest.mark.skipif(**peft_not_installed_cond)
+def test_save_and_load_peft_components(peft_pipeline, model_path):
+    from peft import PeftModel
+
+    mlflow.transformers.save_model(
+        transformers_model={
+            "model": peft_pipeline.model,
+            "tokenizer": peft_pipeline.tokenizer,
+        },
+        path=model_path,
+    )
+
+    loaded_pipeline = mlflow.transformers.load_model(model_path)
+    assert isinstance(loaded_pipeline.model, PeftModel)
+
+    loaded_pipeline.predict("Hi")

--- a/tests/transformers/test_transformers_peft_model.py
+++ b/tests/transformers/test_transformers_peft_model.py
@@ -1,6 +1,8 @@
 import importlib
 
 import pytest
+import transformers
+from packaging.version import Version
 
 import mlflow
 from mlflow.models import Model
@@ -12,8 +14,11 @@ from tests.transformers.test_transformers_model_export import (
 )
 
 peft_not_installed_cond = {
-    "condition": importlib.util.find_spec("peft") is None,
-    "reason": "PEFT is not installed",
+    "condition": (
+        importlib.util.find_spec("peft") is None
+        or Version(transformers.__version__) <= Version("4.25.1")
+    ),
+    "reason": "PEFT is not installed or Transformer version is too old",
 }
 
 

--- a/tests/transformers/test_transformers_peft_model.py
+++ b/tests/transformers/test_transformers_peft_model.py
@@ -8,34 +8,28 @@ import mlflow
 from mlflow.models import Model
 from mlflow.transformers.peft import get_peft_base_model, is_peft_model
 
-from tests.transformers.test_transformers_model_export import (
-    HF_COMMIT_HASH_PATTERN,
-    model_path,  # noqa: F401
-)
+from tests.transformers.test_transformers_model_export import HF_COMMIT_HASH_PATTERN
 
-peft_not_installed_cond = {
-    "condition": (
+pytestmark = pytest.mark.skipif(
+    (
         importlib.util.find_spec("peft") is None
         or Version(transformers.__version__) <= Version("4.25.1")
     ),
-    "reason": "PEFT is not installed or Transformer version is too old",
-}
+    reason="PEFT is not installed or Transformer version is too old",
+)
 
 
-@pytest.mark.skipif(**peft_not_installed_cond)
 def test_is_peft_model(peft_pipeline, small_qa_pipeline):
     assert is_peft_model(peft_pipeline.model)
     assert not is_peft_model(small_qa_pipeline.model)
 
 
-@pytest.mark.skipif(**peft_not_installed_cond)
 def test_get_peft_base_model(peft_pipeline):
     base_model = get_peft_base_model(peft_pipeline.model)
-    assert base_model.__class__.__name__ == "OPTForCausalLM"
-    assert base_model.name_or_path == "facebook/opt-350m"
+    assert base_model.__class__.__name__ == "BertForSequenceClassification"
+    assert base_model.name_or_path == "Elron/bleurt-tiny-512"
 
 
-@pytest.mark.skipif(**peft_not_installed_cond)
 def test_get_peft_base_model_prompt_learning(small_qa_pipeline):
     from peft import PeftModel, PromptTuningConfig
 
@@ -51,34 +45,35 @@ def test_get_peft_base_model_prompt_learning(small_qa_pipeline):
     assert base_model.name_or_path == "csarron/mobilebert-uncased-squad-v2"
 
 
-@pytest.mark.skipif(**peft_not_installed_cond)
-def test_save_and_load_peft_pipeline(peft_pipeline, model_path):
-    from peft import PeftModel
+def test_save_and_load_peft_pipeline(peft_pipeline, tmp_path):
+    import peft
 
     mlflow.transformers.save_model(
         transformers_model=peft_pipeline,
-        path=model_path,
+        path=tmp_path,
     )
 
     # For PEFT, only the adapter model should be saved
-    assert model_path.joinpath("peft").exists()
-    assert not model_path.joinpath("model").exists()
-    assert not model_path.joinpath("components").exists()
+    assert tmp_path.joinpath("peft").exists()
+    assert not tmp_path.joinpath("model").exists()
+    assert not tmp_path.joinpath("components").exists()
 
     # Validate the contents of MLModel file
-    flavor_conf = Model.load(str(model_path.joinpath("MLmodel"))).flavors["transformers"]
+    flavor_conf = Model.load(str(tmp_path.joinpath("MLmodel"))).flavors["transformers"]
     assert "model_binary" not in flavor_conf
     assert HF_COMMIT_HASH_PATTERN.match(flavor_conf["source_model_revision"])
     assert flavor_conf["peft_adaptor"] == "peft"
 
-    loaded_pipeline = mlflow.transformers.load_model(model_path)
-    assert isinstance(loaded_pipeline.model, PeftModel)
+    # Validate peft is recorded to requirements.txt
+    with open(tmp_path.joinpath("requirements.txt")) as f:
+        assert f"peft=={peft.__version__}" in f.read()
 
+    loaded_pipeline = mlflow.transformers.load_model(tmp_path)
+    assert isinstance(loaded_pipeline.model, peft.PeftModel)
     loaded_pipeline.predict("Hi")
 
 
-@pytest.mark.skipif(**peft_not_installed_cond)
-def test_save_and_load_peft_components(peft_pipeline, model_path):
+def test_save_and_load_peft_components(peft_pipeline, tmp_path):
     from peft import PeftModel
 
     mlflow.transformers.save_model(
@@ -86,10 +81,24 @@ def test_save_and_load_peft_components(peft_pipeline, model_path):
             "model": peft_pipeline.model,
             "tokenizer": peft_pipeline.tokenizer,
         },
-        path=model_path,
+        path=tmp_path,
     )
 
-    loaded_pipeline = mlflow.transformers.load_model(model_path)
+    loaded_pipeline = mlflow.transformers.load_model(tmp_path)
     assert isinstance(loaded_pipeline.model, PeftModel)
+    loaded_pipeline.predict("Hi")
 
+
+def test_log_peft_pipeline(peft_pipeline):
+    from peft import PeftModel
+
+    with mlflow.start_run():
+        model_info = mlflow.transformers.log_model(
+            transformers_model=peft_pipeline,
+            artifact_path="model",
+            input_example="hi",
+        )
+
+    loaded_pipeline = mlflow.transformers.load_model(model_info.model_uri)
+    assert isinstance(loaded_pipeline.model, PeftModel)
     loaded_pipeline.predict("Hi")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11120?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11120/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11120
```

</p>
</details>

### Related Issues/PRs

#9256 

### What changes are proposed in this pull request?

Add support for [PEFT](https://huggingface.co/docs/peft/en/index) models in the Transformer flavor, on top of the recent `save_pretrained` feature. Basically, when PEFT model is used for the pipeline, we only save the PEFT adapter weight and ignore base model weights. 

### Tracker

This PR is filed for the PEFT feature branch. More changes are needed be done before merging the feature branch to master:

- [x] Introduce `save_pretrained` flag and implement saving/loading logic ([PR](https://github.com/mlflow/mlflow/pull/11075)).
- [ ] Block registering model to MLflow Model Registry (OSS Model Registry, Databricks Workspace Model Registry, UC Model Registry)
- [ ] Implement an API to download the weight files to the existing *weight-less* model (so it can be registered without re-logging).
- [x] [**This PR**] Support PEFT model.
- [ ] Update documentation and examples

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

A sample PEFT pipeline is added to the test suite. More comprehensive tests will be conducted as a part of final bug-bash before merging the faeture branch.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

Documentation and Tutorials will be updated as a follow-up in next sprint.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support [Parameter-Efficient Fine-Tuning (PEFT)](https://huggingface.co/docs/peft/en/index) models in Transformers flavor.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
