### PR TITLE
Add workflow that requires core maintainer approval when editing requirements paths

### DIFF
--- a/.github/workflows/require-core-maintainer-approval.js
+++ b/.github/workflows/require-core-maintainer-approval.js
@@ -7,7 +7,7 @@ const CORE_MAINTAINERS = new Set([
   "WeichenXu123",
 ]);
 
-module.exports = async ({ github, context, core }) => {
+module.exports = async ({ github, context, core, reason }) => {
   const { data: reviews } = await github.rest.pulls.listReviews({
     owner: context.repo.owner,
     repo: context.repo.repo,
@@ -19,6 +19,6 @@ module.exports = async ({ github, context, core }) => {
   );
 
   if (maintainerApprovals.length === 0) {
-    core.setFailed("No core maintainers have approved this pull request");
+    core.setFailed(`This PR requires an approval from a core maintainer. Reason: ${reason}`);
   }
 };

--- a/.github/workflows/require-core-maintainer-approval.js
+++ b/.github/workflows/require-core-maintainer-approval.js
@@ -1,0 +1,24 @@
+const CORE_MAINTAINERS = new Set([
+  "B-Step62",
+  "BenWilson2",
+  "daniellok-db",
+  "harupy",
+  "serena-ruan",
+  "WeichenXu123",
+]);
+
+module.exports = async ({ github, context, core }) => {
+  const { data: reviews } = await github.rest.pulls.listReviews({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.issue.number,
+  });
+
+  const maintainerApprovals = reviews.filter(
+    (review) => review.state === "APPROVED" && CORE_MAINTAINERS.has(review.user.login)
+  );
+
+  if (maintainerApprovals.length === 0) {
+    core.setFailed("No core maintainers have approved this pull request");
+  }
+};

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -1,4 +1,4 @@
-name: Require core maintainer approval when editing requirements
+name: Maintainer approval for requirement edits
 
 on:
   pull_request:
@@ -19,5 +19,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/require-core-maintainer-approval.js`);
-            await script({ context, github, core });
+            const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/require-core-maintainer-approval.js`);
+            const reason = (
+              "Editing requirements files can cause conflicts in downstream processes " +
+              "that depend on MLflow. Please ensure that one of the MLflow Core Maintainers " +
+              "has a chance to review this PR."
+            );
+            await script({ context, github, core, reason });

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -1,4 +1,4 @@
-name: Warn on editing requirements
+name: Require core maintainer approval when editing requirements
 
 on:
   pull_request:
@@ -13,14 +13,10 @@ jobs:
   warn:
     runs-on: ubuntu-latest
     steps:
-      - name: Post warning if file is edited
+      - name: Fail without core maintainer approval
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "⚠️ Warning: It looks like you're editing requirements for MLflow. Please ensure that this doesn't cause any dependency conflicts with downstream tasks that depend on MLflow (e.g. image building).",
-            });
+            script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/require-core-maintainer-approval.js`);
+            await script({ context, github, core });

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -1,7 +1,7 @@
 name: Maintainer approval for requirement edits
 
 on:
-  pull_request_review:
+  pull_request:
     paths:
       - setup.py
       - requirements/skinny-requirements.yaml
@@ -11,8 +11,6 @@ permissions:
 
 jobs:
   warn:
-    if: context.
-
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -13,6 +13,7 @@ jobs:
   warn:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Fail without core maintainer approval
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -18,13 +18,12 @@ jobs:
           script: |
             const prNumber = context.payload.pull_request.number;
             const repo = context.repo;
-            const files = await github.rest.pulls.listFiles({
+            const { data: files } = await github.rest.pulls.listFiles({
               owner: repo.owner,
               repo: repo.repo,
               pull_number: prNumber,
             });
 
-            console.log(files)
             const editedPaths = files.map(file => file.filename);
             const protectedPaths = new Set([
               "setup.py",

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -5,7 +5,7 @@ on:
     types: [submitted]
 
 permissions:
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   check:

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -2,9 +2,6 @@ name: Maintainer approval for requirement edits
 
 on:
   pull_request:
-    paths:
-      - setup.py
-      - requirements/skinny-requirements.yaml
 
 permissions:
   pull-requests: write
@@ -19,12 +16,26 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            console.log(JSON.stringify(context.payload.pull_request, null, 2))
+            const prNumber = context.payload.pull_request.number;
+            const repo = context.repo;
+            const files = await github.rest.pulls.listFiles({
+              owner: repo.owner,
+              repo: repo.repo,
+              pull_number: prNumber,
+            });
 
-            const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/require-core-maintainer-approval.js`);
-            const reason = (
-              "Editing requirements files can cause conflicts in downstream processes " +
-              "that depend on MLflow. Please ensure that one of the MLflow Core Maintainers " +
-              "has a chance to review this PR."
-            );
-            await script({ context, github, core, reason });
+            const editedPaths = files.map(file => file.filename);
+            const protectedPaths = new Set([
+              "setup.py",
+              "requirements/skinny-requirements.yaml",
+            ]);
+
+            if (editedPaths.some(path => protectedPaths.has(path))) {
+              const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/require-core-maintainer-approval.js`);
+              const reason = (
+                "Editing requirements files can cause conflicts in downstream processes " +
+                "that depend on MLflow. Please ensure that one of the MLflow Core Maintainers " +
+                "has a chance to review this PR."
+              );
+              await script({ context, github, core, reason });
+            }

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -1,7 +1,7 @@
 name: Maintainer approval for requirement edits
 
 on:
-  pull_request:
+  pull_request_review:
     paths:
       - setup.py
       - requirements/skinny-requirements.yaml
@@ -11,6 +11,8 @@ permissions:
 
 jobs:
   warn:
+    if: context.
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,6 +21,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            console.log(JSON.stringify(context.payload.pull_request, null, 2))
+
             const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/require-core-maintainer-approval.js`);
             const reason = (
               "Editing requirements files can cause conflicts in downstream processes " +

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -1,0 +1,26 @@
+name: Warn on editing requirements
+
+on:
+  pull_request:
+    paths:
+      - setup.py
+      - requirements/skinny-requirements.yaml
+
+permissions:
+  pull-requests: write
+
+jobs:
+  warn:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post warning if file is edited
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "⚠️ Warning: It looks like you're editing requirements for MLflow. Please ensure that this doesn't cause any dependency conflicts with downstream tasks that depend on MLflow (e.g. image building).",
+            });

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -24,6 +24,7 @@ jobs:
               pull_number: prNumber,
             });
 
+            console.log(files)
             const editedPaths = files.map(file => file.filename);
             const protectedPaths = new Set([
               "setup.py",

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -1,13 +1,15 @@
 name: Maintainer approval for requirement edits
 
 on:
-  pull_request:
+  pull_request_review:
+    types: [submitted]
 
 permissions:
   pull-requests: write
 
 jobs:
-  warn:
+  check:
+    if: github.event.review.state == 'APPROVED'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -11,7 +11,7 @@ click:
 
 cloudpickle:
   pip_release: cloudpickle
-  max_major_version: 3
+  max_major_version: 4
 
 entrypoints:
   pip_release: entrypoints

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -11,7 +11,7 @@ click:
 
 cloudpickle:
   pip_release: cloudpickle
-  max_major_version: 4
+  max_major_version: 3
 
 entrypoints:
   pip_release: entrypoints


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11125?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11125/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11125
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds a workflow that fails if a non-core maintainer tries to approve a PR that touches the `skinny-requirements.txt` or `setup.py` files. The reason for this is because dependency conflicts can be hard to manage with downstream tasks, so it's important for us to at least be aware of potential incompatibilities.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Example failure: https://github.com/mlflow/mlflow/actions/runs/7898767754/job/21556841255
Example success: hopefully it happens when someone approves this PR

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
