### PR TITLE
Modify Databricks Utils to Fetch Dependency Token in Model Serving Environment 

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -479,9 +479,6 @@ def get_databricks_host_creds(server_uri=None, get_creds_for_model_serving_dep=F
                     config = DatabricksConfig.from_token(host=host, token=token, insecure=False)
         if not config or not config.host:
             _fail_malformed_databricks_auth(profile)
-
-
-
         if config.username is not None and config.password is not None:
             return MlflowHostCreds(
                 config.host,
@@ -492,6 +489,7 @@ def get_databricks_host_creds(server_uri=None, get_creds_for_model_serving_dep=F
         elif config.token:
             return MlflowHostCreds(config.host, token=config.token, ignore_tls_verification=insecure)
         _fail_malformed_databricks_auth(profile)
+
 
     if is_in_databricks_serving_environment() and get_creds_for_model_serving_dep:
         try:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -433,8 +433,8 @@ def _fail_malformed_databricks_auth(profile):
 def _fail_model_serving_creds_env(exception):
     raise MlflowException(
         "Unable to read Oauth credentials from file mount for Databricks "
-        f"Model Serving dependency, failed with exception: {exception}"
-    )
+        f"Model Serving dependency failed"
+    ) from exception
 
 
 # Helper function to attempt to read OAuth Token from

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -433,7 +433,7 @@ def _fail_malformed_databricks_auth(profile):
 def _fail_model_serving_creds_env(exception):
     raise MlflowException(
         "Unable to read Oauth credentials from file mount for Databricks "
-        f"Model Serving dependency failed"
+        "Model Serving dependency failed"
     ) from exception
 
 
@@ -491,7 +491,7 @@ def _model_serving_env_databricks_host_creds():
     # Since we do not record OAuth expiration time in OAuth file, perform periodic refresh
     # of OAuth environment variable cache here. As currently configured (02/24) OAuth token
     # in model serving environment is guaranteed to have at least 30 min remaining on TTL
-    # at any point in time but refresh at higher rate of every 10 min here to be safe 
+    # at any point in time but refresh at higher rate of every 10 min here to be safe
     # and in case those values change in the future.
     OAUTH_CACHE_REFRESH_DURATION_SEC = 10 * 60
     OAUTH_CACHE_ENV_VAR = "DATABRICKS_DEPENDENCY_OAUTH_CACHE"
@@ -512,13 +512,13 @@ def _model_serving_env_databricks_host_creds():
         os.environ[OAUTH_CACHE_EXPIRATION_ENV_VAR] = str(
             time.time() + OAUTH_CACHE_REFRESH_DURATION_SEC
         )
-        
+
     return MlflowHostCreds(
         os.environ[MODEL_SERVING_HOST_ENV_VAR],
-        token=oauth_token, 
+        token=oauth_token,
         ignore_tls_verification=True
     )
-    
+
 
 def get_databricks_host_creds(server_uri=None):
     """
@@ -530,8 +530,8 @@ def get_databricks_host_creds(server_uri=None):
     Databricks Secret Manager, we will query for a secret in the scope "<scope>" for secrets with
     keys of the form "<prefix>-host" and "<prefix>-token". Note that this prefix *cannot* be empty
     if trying to authenticate with this method. If found, those host credentials will be used. This
-    method will throw an exception if sufficient auth cannot be found. If called, within a Databricks
-    Model Serving environment, this method will attempt to read the OAuth token from where it would 
+    method will throw an exception if sufficient auth cannot be found. If called, within Databricks
+    Model Serving environment, this method will attempt to read the OAuth token from where it would
     expect to find it in the serving environment.
 
     Args:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -481,9 +481,9 @@ def _model_serving_env_databricks_host_creds():
     # Since we do not record OAuth expiration time in OAuth file, perform periodic refresh
     # of OAuth environment variable cache here. As currently configured (02/24) OAuth token
     # in model serving environment is guaranteed to have at least 30 min remaining on TTL
-    # at any point in time but refresh at higher rate of every 10 min here to be safe
-    # and in case those values change in the future.
-    OAUTH_CACHE_REFRESH_DURATION_SEC = 10 * 60
+    # at any point in time but refresh at higher rate of every 5 min here to be safe
+    # and conform with refresh logic for Brickstore tables.
+    OAUTH_CACHE_REFRESH_DURATION_SEC = 5 * 60
     OAUTH_CACHE_ENV_VAR = "DATABRICKS_DEPENDENCY_OAUTH_CACHE"
     OAUTH_CACHE_EXPIRATION_ENV_VAR = "DATABRICKS_DEPENDENCY_OAUTH_CACHE_EXIRY_TS"
     MODEL_SERVING_HOST_ENV_VAR = "DATABRICKS_MODEL_SERVING_HOST_URL"

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -169,7 +169,6 @@ def is_in_databricks_serving_environment():
     return "MODEL_SERVING_CONTAINER_EXPOSED_IP" in os.environ and "MAX_MODEL_LOADING_TIMEOUT" in os.environ
 
 
-
 def is_in_databricks_repo():
     try:
         return get_git_repo_relative_path() is not None
@@ -480,8 +479,6 @@ def get_databricks_host_creds(server_uri=None):
     config = ProfileConfigProvider(profile).get_config() if profile else get_config()
     insecure = hasattr(config, "insecure") and config.insecure
 
-
-
     # helper method for
     if is_in_databricks_serving_environment():
         # check if dependency is cached in env var before reading from file
@@ -498,7 +495,7 @@ def get_databricks_host_creds(server_uri=None):
                 _fail_model_serving_creds_env(e)
         return MlflowHostCreds(
             config.host, 
-            token=_oauth_token,
+            token=oauth_token,
             ignore_tls_verification=insecure
         )
      # default host creds behavior if not fetching OAuth token for model serving dependency

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -440,6 +440,7 @@ def _fail_model_serving_creds_env(exception):
 # constant defined outside function for testing override
 _MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH = "/var/credentials-secret/model-dependencies-oauth-token"
 
+
 # Helper function to attempt to read OAuth Token from
 # mounted file in Databricks Model Serving environment
 def _get_model_dependency_oauth_token(should_retry=True):
@@ -481,9 +482,7 @@ def _default_databricks_host_creds(server_uri):
             ignore_tls_verification=insecure,
         )
     elif config.token:
-        return MlflowHostCreds(
-            config.host, token=config.token, ignore_tls_verification=insecure
-        )
+        return MlflowHostCreds(config.host, token=config.token, ignore_tls_verification=insecure)
     _fail_malformed_databricks_auth(profile)
 
 
@@ -514,9 +513,7 @@ def _model_serving_env_databricks_host_creds():
         )
 
     return MlflowHostCreds(
-        os.environ[MODEL_SERVING_HOST_ENV_VAR],
-        token=oauth_token,
-        ignore_tls_verification=True
+        os.environ[MODEL_SERVING_HOST_ENV_VAR], token=oauth_token, ignore_tls_verification=True
     )
 
 
@@ -544,7 +541,7 @@ def get_databricks_host_creds(server_uri=None):
     """
     # if in model serving environment databricks attempt to fetch model dependency OAuth token
     if is_in_databricks_model_serving_environment():
-      return  _model_serving_env_databricks_host_creds()
+        return _model_serving_env_databricks_host_creds()
     # default host creds behavior if not fetching OAuth token for model serving dependency
     else:
         return _default_databricks_host_creds(server_uri)

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -5,6 +5,7 @@ import subprocess
 from sys import stderr
 from typing import Optional, TypeVar
 
+import json
 import mlflow.utils
 from mlflow.environment_variables import MLFLOW_TRACKING_URI
 from mlflow.exceptions import MlflowException
@@ -22,7 +23,7 @@ from mlflow.utils.uri import get_db_info_from_uri, is_databricks_uri
 
 _logger = logging.getLogger(__name__)
 
-DEPENDENCY_OAUTH_ENV_VAR = "DEPENDENCY_OAUTH_TOKEN"
+MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH = "/var/credentials-secret/model-dependency-token"
 
 def _use_repl_context_if_available(name):
     """Creates a decorator to insert a short circuit that returns the specified REPL context
@@ -163,7 +164,7 @@ def is_in_databricks_job():
         return False
 
 def is_in_databricks_serving_environment():
-    return "DATABRICKS_MODEL_SERVING" in os.environ
+    return "MODEL_VERSION_ID" in os.environ
 
 
 def is_in_databricks_repo():
@@ -422,8 +423,23 @@ def _fail_malformed_databricks_auth(profile):
         "https://github.com/databricks/databricks-cli." % profile
     )
 
+# Helper function to attempt to read OAuth Token from
+# mounted file in Databricks Model Serving environment
+def _get_model_dependency_oauth_token(should_retry=True):
+    try:
+        with open(MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH, "r") as f:
+            json_data = f.read()
+            oauth_dict = json.loads(json_data)
+            return oauth_dict["OAUTH_TOKEN"][0]["oauthTokenValue"]
+    except Exception as e:
+        if should_retry:
+            return _get_model_dependency_oauth_token(should_retry=False)
+        else:
+            raise e
 
-def get_databricks_host_creds(server_uri=None):
+
+
+def get_databricks_host_creds(server_uri=None, get_creds_for_model_serving_dep=False):
     """
     Reads in configuration necessary to make HTTP requests to a Databricks server. This
     uses the Databricks CLI's ConfigProvider interface to load the DatabricksConfig object.
@@ -443,15 +459,14 @@ def get_databricks_host_creds(server_uri=None):
         MlflowHostCreds which includes the hostname and authentication information necessary to
         talk to the Databricks server.
     """
+    
     profile, path = get_db_info_from_uri(server_uri)
     config = ProfileConfigProvider(profile).get_config() if profile else get_config()
-    if is_in_databricks_serving_environment():
-        try:
-            return MlflowHostCreds(config.host, token=os.environ[DEPENDENCY_OAUTH_ENV_VAR], ignore_tls_verification=insecure)
-        except Exception:
-            _fail_malformed_databricks_auth(profile)
-    else:
-        # if a path is specified, that implies a Databricks tracking URI of the form:
+    insecure = hasattr(config, "insecure") and config.insecure
+
+    # helper method for default host creds behavior if not fetching OAuth token for model serving dependency
+    def _get_databricks_host_creds():
+     # if a path is specified, that implies a Databricks tracking URI of the form:
         # databricks://profile-name/path-specifier
         if (not config or not config.host) and path:
             dbutils = _get_dbutils()
@@ -465,7 +480,7 @@ def get_databricks_host_creds(server_uri=None):
         if not config or not config.host:
             _fail_malformed_databricks_auth(profile)
 
-        insecure = hasattr(config, "insecure") and config.insecure
+
 
         if config.username is not None and config.password is not None:
             return MlflowHostCreds(
@@ -477,6 +492,23 @@ def get_databricks_host_creds(server_uri=None):
         elif config.token:
             return MlflowHostCreds(config.host, token=config.token, ignore_tls_verification=insecure)
         _fail_malformed_databricks_auth(profile)
+
+    if is_in_databricks_serving_environment() and get_creds_for_model_serving_dep:
+        try:
+            
+            return MlflowHostCreds(
+                config.host, 
+                token=_get_model_dependency_oauth_token(),
+                ignore_tls_verification=insecure
+            )
+        except Exception as e :
+            _logger.warning("Unable to read Oauth credentials from file mount for Databricks Model Serving dependency, "
+                "defaulting to fetching PAT token. ")
+            return _get_databricks_host_creds()
+    else:
+       return _get_databricks_host_creds()
+
+
 
 
 @_use_repl_context_if_available("mlflowGitRepoUrl")

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -460,7 +460,7 @@ def _get_model_dependency_oauth_token(should_retry=True):
 def _default_databricks_host_creds(server_uri):
     profile, path = get_db_info_from_uri(server_uri)
     config = ProfileConfigProvider(profile).get_config() if profile else get_config()
-    insecure = hasattr(config, "insecure") and config.insecure
+    insecure = getattr(config, "insecure", False)
     # if a path is specified, that implies a Databricks tracking URI of the form:
     # databricks://profile-name/path-specifier
     if (not config or not config.host) and path:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1,11 +1,12 @@
 import functools
+import json
 import logging
 import os
 import subprocess
+import time
 from sys import stderr
 from typing import Optional, TypeVar
 
-import json
 import mlflow.utils
 from mlflow.environment_variables import MLFLOW_TRACKING_URI
 from mlflow.exceptions import MlflowException
@@ -17,8 +18,6 @@ from mlflow.legacy_databricks_cli.configure.provider import (
     get_config,
     set_config_provider,
 )
-
-import time
 from mlflow.utils._spark_utils import _get_active_spark_session
 from mlflow.utils.rest_utils import MlflowHostCreds
 from mlflow.utils.uri import get_db_info_from_uri, is_databricks_uri
@@ -476,9 +475,10 @@ def get_databricks_host_creds(server_uri=None):
         MlflowHostCreds which includes the hostname and authentication information necessary to
         talk to the Databricks server.
     """
-    # Since we do not record OAuth expiration time in OAuth file, perform periodic refresh of OAuth cache here.
-    # As currently configured (02/24) OAuth token in model serving environment guaranteed to have at least 30 min
-    # remaining on TTL at any point in time but refresh at higher rate here to be safe and in case those values change in the future.
+    # Since we do not record OAuth expiration time in OAuth file, perform periodic refresh
+    # of OAuth cache here. As currently configured (02/24) OAuth token in model serving environment
+    # guaranteed to have at least 30 min remaining on TTL at any point in time but refresh at higher
+    # rate here to be safe and in case those values change in the future.
     OAUTH_CACHE_REFRESH_DURATION = 10 * 60
     OAUTH_CACHE_ENV_VAR = "DATABRICKS_DEPENDENCY_OAUTH_CACHE"
     OAUTH_CACHE_EXPIRATION_ENV_VAR = "DATABRICKS_DEPENDENCY_OAUTH_CACHE_EXIRY_TS"

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -167,6 +167,7 @@ def is_in_databricks_job():
 def is_in_databricks_model_serving_environment():
     return "DATABRICKS_MODEL_SERVING_ENV" in os.environ
 
+
 def is_in_databricks_repo():
     try:
         return get_git_repo_relative_path() is not None
@@ -424,7 +425,6 @@ def _fail_malformed_databricks_auth(profile):
     )
 
 
-
 # constant defined outside function for testing override
 _MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH = "/var/credentials-secret/model-dependencies-oauth-token"
 
@@ -445,7 +445,7 @@ def _get_model_dependency_oauth_token(should_retry=True):
             raise MlflowException(
                 "Unable to read Oauth credentials from file mount for Databricks "
                 "Model Serving dependency failed"
-            ) from e 
+            ) from e
 
 
 def _default_databricks_host_creds(server_uri):

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -106,7 +106,7 @@ def test_databricks_model_serving_throws(get_config, monkeypatch):
     monkeypatch.setenv("MODEL_SERVING_CONTAINER_EXPOSED_IP", "127.0.0.1")
     monkeypatch.setenv("MAX_MODEL_LOADING_TIMEOUT", "600")
     get_config.return_value = DatabricksConfig.from_password("host", "user", "pass", insecure=False)
-    with pytest.raises(MlflowException, match ="Unable to read Oauth credentials"):
+    with pytest.raises(MlflowException, match="Unable to read Oauth credentials"):
         databricks_utils.get_databricks_host_creds()
 
 

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -212,6 +212,7 @@ def test_databricks_params_throws_errors(ProfileConfigProvider):
         "host", None, None, insecure=True
     )
     ProfileConfigProvider.return_value = mock_provider
+    result = databricks_utils.get_databricks_host_creds()
     with pytest.raises(Exception, match="You haven't configured the CLI yet"):
         databricks_utils.get_databricks_host_creds()
 

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -102,6 +102,15 @@ def test_databricks_single_slash_in_uri_scheme_throws(get_config):
 
 
 @mock.patch("mlflow.utils.databricks_utils.get_config")
+def test_databricks_model_serving_throws(get_config, monkeypatch):
+    monkeypatch.setenv("MODEL_SERVING_CONTAINER_EXPOSED_IP", "127.0.0.1")
+    monkeypatch.setenv("MAX_MODEL_LOADING_TIMEOUT", "600")
+    get_config.return_value = DatabricksConfig.from_password("host", "user", "pass", insecure=False)
+    with pytest.raises(MlflowException, match ="Unable to read Oauth credentials"):
+        databricks_utils.get_databricks_host_creds()
+
+
+@mock.patch("mlflow.utils.databricks_utils.get_config")
 def test_databricks_params_model_serving_oauth_cache(get_config, monkeypatch):
     monkeypatch.setenv("MODEL_SERVING_CONTAINER_EXPOSED_IP", "127.0.0.1")
     monkeypatch.setenv("MAX_MODEL_LOADING_TIMEOUT", "600")

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -102,16 +102,14 @@ def test_databricks_single_slash_in_uri_scheme_throws(get_config):
 
 
 def test_databricks_model_serving_throws(monkeypatch):
-    monkeypatch.setenv("MODEL_SERVING_CONTAINER_EXPOSED_IP", "127.0.0.1")
-    monkeypatch.setenv("MAX_MODEL_LOADING_TIMEOUT", "600")
+    monkeypatch.setenv("DATABRICKS_MODEL_SERVING_ENV", "true")
     monkeypatch.setenv("DATABRICKS_MODEL_SERVING_HOST_URL", "host")
     with pytest.raises(MlflowException, match="Unable to read Oauth credentials"):
         databricks_utils.get_databricks_host_creds()
 
 
 def test_databricks_params_model_serving_oauth_cache(monkeypatch):
-    monkeypatch.setenv("MODEL_SERVING_CONTAINER_EXPOSED_IP", "127.0.0.1")
-    monkeypatch.setenv("MAX_MODEL_LOADING_TIMEOUT", "600")
+    monkeypatch.setenv("DATABRICKS_MODEL_SERVING_ENV", "true")
     monkeypatch.setenv("DATABRICKS_DEPENDENCY_OAUTH_CACHE", "token")
     monkeypatch.setenv("DATABRICKS_DEPENDENCY_OAUTH_CACHE_EXIRY_TS", str(time.time() + 5))
     monkeypatch.setenv("DATABRICKS_MODEL_SERVING_HOST_URL", "host")
@@ -131,8 +129,7 @@ def oauth_file(tmp_path):
 
 
 def test_databricks_params_model_serving_read_oauth(monkeypatch, oauth_file):
-    monkeypatch.setenv("MODEL_SERVING_CONTAINER_EXPOSED_IP", "127.0.0.1")
-    monkeypatch.setenv("MAX_MODEL_LOADING_TIMEOUT", "600")
+    monkeypatch.setenv("DATABRICKS_MODEL_SERVING_ENV", "true")
     monkeypatch.setenv("DATABRICKS_MODEL_SERVING_HOST_URL", "host")
     with mock.patch(
         "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
@@ -271,12 +268,10 @@ def test_is_in_databricks_runtime(monkeypatch):
 
 
 def test_is_in_databricks_model_serving_environment(monkeypatch):
-    monkeypatch.setenv("MODEL_SERVING_CONTAINER_EXPOSED_IP", "127.0.0.1")
-    monkeypatch.setenv("MAX_MODEL_LOADING_TIMEOUT", "600")
+    monkeypatch.setenv("DATABRICKS_MODEL_SERVING_ENV", "true")
     assert databricks_utils.is_in_databricks_model_serving_environment()
 
-    # both environment variables needed to verify environment
-    monkeypatch.delenv("MAX_MODEL_LOADING_TIMEOUT")
+    monkeypatch.delenv("DATABRICKS_MODEL_SERVING_ENV")
     assert not databricks_utils.is_in_databricks_model_serving_environment()
 
 

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -101,7 +101,6 @@ def test_databricks_single_slash_in_uri_scheme_throws(get_config):
         databricks_utils.get_databricks_host_creds("databricks:/profile:path")
 
 
-
 @mock.patch("mlflow.utils.databricks_utils.get_config")
 def test_databricks_params_model_serving_oauth_cache(get_config, monkeypatch):
     monkeypatch.setenv("MODEL_SERVING_CONTAINER_EXPOSED_IP", "127.0.0.1")
@@ -114,15 +113,15 @@ def test_databricks_params_model_serving_oauth_cache(get_config, monkeypatch):
     assert params.host == "host"
     assert params.token == "token"
 
+
 @pytest.fixture
 def oauth_file(tmp_path):
-    token_contents = {
-        "OAUTH_TOKEN": [{"oauthTokenValue": "token"}]
-    }
+    token_contents = {"OAUTH_TOKEN": [{"oauthTokenValue": "token"}]}
     oauth_file = tmp_path.joinpath("model-dependencies-oauth-token")
-    with open(oauth_file, 'w') as f:
+    with open(oauth_file, "w") as f:
         json.dump(token_contents, f)
     return oauth_file
+
 
 @mock.patch("mlflow.utils.databricks_utils.get_config")
 def test_databricks_params_model_serving_read_oauth(get_config, monkeypatch, oauth_file):
@@ -130,13 +129,14 @@ def test_databricks_params_model_serving_read_oauth(get_config, monkeypatch, oau
     monkeypatch.setenv("MAX_MODEL_LOADING_TIMEOUT", "600")
     get_config.return_value = DatabricksConfig.from_password("host", "user", "pass", insecure=False)
     print("TESTTT", databricks_utils.MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH)
-    with mock.patch("mlflow.utils.databricks_utils.MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)):
+    with mock.patch(
+        "mlflow.utils.databricks_utils.MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
+    ):
         params = databricks_utils.get_databricks_host_creds()
         assert os.environ["DATABRICKS_DEPENDENCY_OAUTH_CACHE"] == "token"
         assert float(os.environ["DATABRICKS_DEPENDENCY_OAUTH_CACHE_EXIRY_TS"]) > time.time()
         assert params.host == "host"
         assert params.token == "token"
-
 
 
 def test_get_workspace_info_from_databricks_secrets():

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -1,5 +1,8 @@
 import builtins
+import json
+import os
 import sys
+import time
 from unittest import mock
 
 import pytest
@@ -18,9 +21,6 @@ from mlflow.utils.databricks_utils import (
 from mlflow.utils.uri import construct_db_uri_from_profile
 
 from tests.helper_functions import mock_method_chain
-import time
-import os
-import json
 
 
 def test_no_throw():
@@ -128,7 +128,6 @@ def test_databricks_params_model_serving_read_oauth(get_config, monkeypatch, oau
     monkeypatch.setenv("MODEL_SERVING_CONTAINER_EXPOSED_IP", "127.0.0.1")
     monkeypatch.setenv("MAX_MODEL_LOADING_TIMEOUT", "600")
     get_config.return_value = DatabricksConfig.from_password("host", "user", "pass", insecure=False)
-    print("TESTTT", databricks_utils.MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH)
     with mock.patch(
         "mlflow.utils.databricks_utils.MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
     ):
@@ -253,7 +252,6 @@ def test_databricks_params_throws_errors(ProfileConfigProvider):
         "host", None, None, insecure=True
     )
     ProfileConfigProvider.return_value = mock_provider
-    result = databricks_utils.get_databricks_host_creds()
     with pytest.raises(Exception, match="You haven't configured the CLI yet"):
         databricks_utils.get_databricks_host_creds()
 

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -140,9 +140,8 @@ def test_databricks_params_model_serving_oauth_cache_expired(monkeypatch, oauth_
         assert os.environ["DATABRICKS_DEPENDENCY_OAUTH_CACHE"] == "token2"
         assert float(os.environ["DATABRICKS_DEPENDENCY_OAUTH_CACHE_EXIRY_TS"]) > time.time()
         assert params.host == "host"
-        # should use token2 from oauthfile, rather than token from cache 
+        # should use token2 from oauthfile, rather than token from cache
         assert params.token == "token2"
-
 
 
 def test_databricks_params_model_serving_read_oauth(monkeypatch, oauth_file):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/victorsun123/mlflow/pull/11129?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11129/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11129
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Support fetching OAuth Token in Databricks Model Serving Environment

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [X] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
