### PR TITLE
Fix add environment variable to disable mlflow configuring logging on import

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -32,7 +32,6 @@ import contextlib
 from mlflow.version import VERSION
 
 __version__ = VERSION
-
 from mlflow import (
     artifacts,  # noqa: F401
     client,  # noqa: F401
@@ -42,6 +41,7 @@ from mlflow import (
     projects,  # noqa: F401
     tracking,  # noqa: F401
 )
+from mlflow.environment_variables import MLFLOW_CONFIGURE_LOGGING
 from mlflow.utils.lazy_load import LazyLoader
 from mlflow.utils.logging_utils import _configure_mlflow_loggers
 
@@ -82,7 +82,8 @@ tensorflow = LazyLoader("mlflow.tensorflow", globals(), "mlflow.tensorflow")
 transformers = LazyLoader("mlflow.transformers", globals(), "mlflow.transformers")
 xgboost = LazyLoader("mlflow.xgboost", globals(), "mlflow.xgboost")
 
-_configure_mlflow_loggers(root_module_name=__name__)
+if MLFLOW_CONFIGURE_LOGGING.get() is True:
+    _configure_mlflow_loggers(root_module_name=__name__)
 
 from mlflow.client import MlflowClient
 from mlflow.exceptions import MlflowException

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -511,3 +511,9 @@ MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT = _EnvironmentVariable(
 MLFLOW_GATEWAY_RATE_LIMITS_STORAGE_URI = _EnvironmentVariable(
     "MLFLOW_GATEWAY_RATE_LIMITS_STORAGE_URI", str, None
 )
+
+#: Specifies whether or not to have mlflow configure logging on import.
+#: If set to True, mlflow will configure ``mlflow.<module_name>`` loggers with
+#: logging handlers and formatters.
+#: (default: ``True``)
+MLFLOW_CONFIGURE_LOGGING = _BooleanEnvironmentVariable("MLFLOW_LOGGING_CONFIGURE_LOGGING", True)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jmahlik/mlflow/pull/11137?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11137/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11137
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #11132

### What changes are proposed in this pull request?
Setting MLFLOW_LOGGING_CONFIGURE_LOGGING to false disables mlflow from configuring logging on import, which may not be desired.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?
Bit hard to write a unit test for this one since it requires importing mlflow again after it's imported so logging has already been configured globally.

Here's an example to test it out:

```python
import os
import logging

# Set this to False to disable logging config from happening on import
os.environ["MLFLOW_LOGGING_CONFIGURE_LOGGING"] = "True"

import mlflow

# The default for mlflow is INFO, but we should be able to override this
logging.basicConfig(level=logging.DEBUG)

mlflow_logger = logging.getLogger("mlflow")
root_logger = logging.getLogger()

# Will have no handlers with False
print(mlflow_logger.handlers)

# Mlflow ignores the logging config so this won't show
mlflow_logger.debug("hello from mlflow")

# But all other loggers pick up the logging config
root_logger.debug("hello from root")
```

Output with True
```console
[<StreamHandler (NOTSET)>]
DEBUG:root:hello from root
```

Output with False
```console
[]
DEBUG:mlflow:hello from mlflow
DEBUG:root:hello from root

```

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
See PR description.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
