### PR TITLE
Remove `python setup.py dependencies` command

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Build
         run: |
           ./tests/db/compose.sh pull -q postgresql mysql mssql
-          ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)"
+          ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(cat requirements/skinny-requirements.txt requirements/core-requirements.txt | grep -Ev '^(#|$)')"
       - name: Run tests
         run: |
           set +e

--- a/setup.py
+++ b/setup.py
@@ -76,27 +76,6 @@ with open(os.path.join("requirements", "gateway-requirements.txt")) as f:
 _is_mlflow_skinny = bool(os.environ.get(_MLFLOW_SKINNY_ENV_VAR))
 logging.debug("{} env var is set: {}".format(_MLFLOW_SKINNY_ENV_VAR, _is_mlflow_skinny))
 
-
-class ListDependencies(Command):
-    # `python setup.py <command name>` prints out "running <command name>" by default.
-    # This logging message must be hidden by specifying `--quiet` (or `-q`) when piping the output
-    # of this command to `pip install`.
-    description = "List mlflow dependencies"
-    user_options = [
-        ("skinny", None, "List mlflow-skinny dependencies"),
-    ]
-
-    def initialize_options(self):
-        self.skinny = False
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        dependencies = SKINNY_REQUIREMENTS if self.skinny else CORE_REQUIREMENTS
-        print("\n".join(dependencies))
-
-
 MINIMUM_SUPPORTED_PYTHON_VERSION = Path("requirements", "python-version.txt").read_text().strip()
 
 skinny_package_data = [
@@ -180,9 +159,6 @@ setup(
         https=mlflow.deployments.mlflow
         openai=mlflow.deployments.openai
     """,
-    cmdclass={
-        "dependencies": ListDependencies,
-    },
     zip_safe=False,
     author="Databricks",
     description="MLflow: A Platform for ML Development and Productionization",

--- a/tests/db/README.md
+++ b/tests/db/README.md
@@ -17,10 +17,10 @@ This directory contains files to test MLflow tracking operations using the follo
 ```bash
 # Build a service
 service=mlflow-sqlite
-./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)" $service
+./tests/db/compose.sh build --build-arg DEPENDENCIES="$(cat requirements/skinny-requirements.txt requirements/core-requirements.txt | grep -Ev '^(#|$)')" $service
 
 # Build all services
-./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)"
+./tests/db/compose.sh build --build-arg DEPENDENCIES="$(cat requirements/skinny-requirements.txt requirements/core-requirements.txt | grep -Ev '^(#|$)')"
 ```
 
 ## Run Services

--- a/tests/db/update_schemas.sh
+++ b/tests/db/update_schemas.sh
@@ -4,7 +4,7 @@ set -ex
 python tests/store/dump_schema.py tests/resources/db/latest_schema.sql
 
 ./tests/db/compose.sh down --volumes --remove-orphans
-./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python setup.py -q dependencies)"
+./tests/db/compose.sh build --build-arg DEPENDENCIES="$(cat requirements/skinny-requirements.txt requirements/core-requirements.txt | grep -Ev '^(#|$)')"
 for service in $(./tests/db/compose.sh config --services | grep '^mlflow-')
 do
   ./tests/db/compose.sh run --rm $service python tests/db/test_schema.py


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11143?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11143/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11143
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Remove `python setup.py dependencies` command for migration to `pyproject.toml`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
