### PR TITLE
Add pull_request_target trigger to maintainer approval workflow

### DIFF
--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   check:
     if: |
-      github.event_name === 'pull_request'
+      github.event_name == 'pull_request'
       || github.event.review?.state == 'APPROVED'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -1,10 +1,7 @@
 name: Maintainer approval for requirement edits
 
 on:
-  pull_request_target:
-    paths:
-      - setup.py
-      - requirements/skinny-requirements.yaml
+  pull_request:
   pull_request_review:
     types: [submitted]
 
@@ -13,9 +10,7 @@ permissions:
 
 jobs:
   check:
-    if: |
-      github.event_name == 'pull_request_target'
-      || github.event.review.state == 'APPROVED'
+    if: github.event_name == 'pull_request' || github.event.review.state == 'APPROVED'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -15,7 +15,7 @@ jobs:
   check:
     if: |
       github.event_name == 'pull_request'
-      || github.event.review?.state == 'APPROVED'
+      || github.event.review.state == 'APPROVED'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -2,15 +2,12 @@ name: Maintainer approval for requirement edits
 
 on:
   pull_request:
-  pull_request_review:
-    types: [submitted]
 
 permissions:
   pull-requests: read
 
 jobs:
   check:
-    if: github.event_name == 'pull_request' || github.event.review.state == 'APPROVED'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -35,7 +35,7 @@ jobs:
               const reason = (
                 "Editing requirements files can cause conflicts in downstream processes " +
                 "that depend on MLflow. Please ensure that one of the MLflow Core Maintainers " +
-                "has a chance to review this PR."
+                "has a chance to review this PR, and rerun this workflow once approved."
               );
               await script({ context, github, core, reason });
             }

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -1,7 +1,7 @@
 name: Maintainer approval for requirement edits
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - setup.py
       - requirements/skinny-requirements.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   check:
     if: |
-      github.event_name == 'pull_request'
+      github.event_name == 'pull_request_target'
       || github.event.review.state == 'APPROVED'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/warn-on-editing-requirements.yml
+++ b/.github/workflows/warn-on-editing-requirements.yml
@@ -1,6 +1,10 @@
 name: Maintainer approval for requirement edits
 
 on:
+  pull_request:
+    paths:
+      - setup.py
+      - requirements/skinny-requirements.yaml
   pull_request_review:
     types: [submitted]
 
@@ -9,7 +13,9 @@ permissions:
 
 jobs:
   check:
-    if: github.event.review.state == 'APPROVED'
+    if: |
+      github.event_name === 'pull_request'
+      || github.event.review?.state == 'APPROVED'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ version = (
     SourceFileLoader("mlflow.version", os.path.join("mlflow", "version.py")).load_module().VERSION
 )
 
+
 # Get a list of all files in the directory to include in our module
 def package_files(directory):
     """

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ version = (
     SourceFileLoader("mlflow.version", os.path.join("mlflow", "version.py")).load_module().VERSION
 )
 
-
+# add a comment to test workflow
 # Get a list of all files in the directory to include in our module
 def package_files(directory):
     """

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ version = (
     SourceFileLoader("mlflow.version", os.path.join("mlflow", "version.py")).load_module().VERSION
 )
 
-# add a comment to test workflow
 # Get a list of all files in the directory to include in our module
 def package_files(directory):
     """


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11145?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11145/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11145
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

As title, add `pull_request_target` so people can be informed earlier that they need approval.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

I got a failure here without approval:
https://github.com/mlflow/mlflow/actions/runs/7910901686

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
