### PR TITLE
Clean tmp path instantly in Transformers CI test

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -109,7 +109,6 @@ if TYPE_CHECKING:
     import torch
     from transformers import Pipeline
 
-
 FLAVOR_NAME = "transformers"
 
 _CARD_TEXT_FILE_NAME = "model_card.md"

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -2,9 +2,9 @@ import base64
 import gc
 import importlib.util
 import json
-import logging
 import os
 import pathlib
+import shutil
 import textwrap
 from unittest import mock
 
@@ -83,8 +83,6 @@ image_file_path = pathlib.Path(pathlib.Path(__file__).parent.parent, "datasets",
 # - Text2TextGeneration pipeline tests
 # - Conversational pipeline tests
 
-_logger = logging.getLogger(__name__)
-
 
 @pytest.fixture(autouse=True)
 def force_gc():
@@ -98,7 +96,14 @@ def force_gc():
 
 @pytest.fixture
 def model_path(tmp_path):
-    return tmp_path.joinpath("model")
+    model_path = tmp_path.joinpath("model")
+    yield model_path
+
+    # Pytest keeps the temporary directory created by `tmp_path` fixture for 3 recent test sessions
+    # by default. This is useful for debugging during local testing, but in CI it just wastes the
+    # disk space.
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        shutil.rmtree(model_path, ignore_errors=True)
 
 
 @pytest.fixture
@@ -1106,7 +1111,7 @@ def test_text2text_generation_pipeline_with_model_configs(
 
 
 def test_text2text_generation_pipeline_with_model_config_and_params(
-    text2text_generation_pipeline, tmp_path
+    text2text_generation_pipeline, model_path
 ):
     data = "muppet keyboard type"
     model_config = {
@@ -1126,7 +1131,6 @@ def test_text2text_generation_pipeline_with_model_config_and_params(
         parameters,
     )
 
-    model_path = tmp_path / "model"
     mlflow.transformers.save_model(
         text2text_generation_pipeline,
         path=model_path,
@@ -1148,7 +1152,9 @@ def test_text2text_generation_pipeline_with_model_config_and_params(
     assert res == pyfunc_loaded.predict(data, {"extra_param": "extra_value"})
 
 
-def test_text2text_generation_pipeline_with_params_success(text2text_generation_pipeline, tmp_path):
+def test_text2text_generation_pipeline_with_params_success(
+    text2text_generation_pipeline, model_path
+):
     data = "muppet keyboard type"
     parameters = {"top_k": 2, "num_beams": 5, "do_sample": True}
     generated_output = mlflow.transformers.generate_signature_output(
@@ -1160,7 +1166,6 @@ def test_text2text_generation_pipeline_with_params_success(text2text_generation_
         parameters,
     )
 
-    model_path = tmp_path / "model"
     mlflow.transformers.save_model(
         text2text_generation_pipeline,
         path=model_path,
@@ -1175,7 +1180,7 @@ def test_text2text_generation_pipeline_with_params_success(text2text_generation_
 
 
 def test_text2text_generation_pipeline_with_params_with_errors(
-    text2text_generation_pipeline, tmp_path
+    text2text_generation_pipeline, model_path
 ):
     data = "muppet keyboard type"
     parameters = {"top_k": 2, "num_beams": 5, "invalid_param": "invalid_param", "do_sample": True}
@@ -1183,7 +1188,6 @@ def test_text2text_generation_pipeline_with_params_with_errors(
         text2text_generation_pipeline, data
     )
 
-    model_path = tmp_path / "model"
     mlflow.transformers.save_model(
         text2text_generation_pipeline,
         path=model_path,
@@ -3533,7 +3537,7 @@ def test_model_on_single_device():
     assert not _is_model_distributed_in_memory(mock_model)
 
 
-def test_basic_model_with_accelerate_device_mapping_fails_save(tmp_path):
+def test_basic_model_with_accelerate_device_mapping_fails_save(tmp_path, model_path):
     task = "translation_en_to_de"
     architecture = "t5-small"
     model = transformers.T5ForConditionalGeneration.from_pretrained(
@@ -3552,10 +3556,10 @@ def test_basic_model_with_accelerate_device_mapping_fails_save(tmp_path):
         MlflowException,
         match="The model that is attempting to be saved has been loaded into memory",
     ):
-        mlflow.transformers.save_model(transformers_model=pipeline, path=str(tmp_path / "model"))
+        mlflow.transformers.save_model(transformers_model=pipeline, path=model_path)
 
 
-def test_basic_model_with_accelerate_homogeneous_mapping_works(tmp_path):
+def test_basic_model_with_accelerate_homogeneous_mapping_works(model_path):
     task = "translation_en_to_de"
     architecture = "t5-small"
     model = transformers.T5ForConditionalGeneration.from_pretrained(
@@ -3569,9 +3573,9 @@ def test_basic_model_with_accelerate_homogeneous_mapping_works(tmp_path):
     )
     pipeline = transformers.pipeline(task=task, model=model, tokenizer=tokenizer)
 
-    mlflow.transformers.save_model(transformers_model=pipeline, path=str(tmp_path / "model"))
+    mlflow.transformers.save_model(transformers_model=pipeline, path=model_path)
 
-    loaded = mlflow.transformers.load_model(str(tmp_path / "model"))
+    loaded = mlflow.transformers.load_model(model_path)
     text = "Apples are delicious"
     assert loaded(text) == pipeline(text)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11148?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11148/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11148
```

</p>
</details>

### Related Issues/PRs

Follow-up for https://github.com/mlflow/mlflow/pull/11120#issuecomment-1945431570

### What changes are proposed in this pull request?

Pytest keeps a temporary directory created by `tmp_path` fixture for 3 recent sessions by default (ref). This is useful for debugging during local testing, but just wastes disk space in CI test. This PR changes the `model_path` fixture to clean up itself after each test run.

**Note**: Initially I tried to add the clean up to global pytest configuration, but it seems some tests depend on the original behavior of long-living tmp dirs. Solving them look like a rabbit hole and we only have the disk space issue in Transformers model test, so just modified `model_path` fixture instead.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Good amount of disk space is freed up.

![Screenshot 2024-02-15 at 18 13 28](https://github.com/mlflow/mlflow/assets/31463517/96f14e9c-9e69-4ec3-aa19-29e86df01884)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
