### PR TITLE
Update hardcoded "io.delta:delta-spark_2.12:3.0.0" dependency to correct scala version

### DIFF
--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -1,9 +1,9 @@
 import contextlib
+import multiprocessing
 import os
 import shutil
 import tempfile
 import zipfile
-import multiprocessing
 
 
 def _get_active_spark_session():

--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -51,8 +51,7 @@ def _get_spark_scala_version():
     if is_in_databricks_runtime():
         return os.environ["SPARK_SCALA_VERSION"]
 
-    spark = _get_active_spark_session()
-    if spark is not None:
+    if spark := _get_active_spark_session():
         return _get_spark_scala_version_from_spark_session(spark)
 
     try:
@@ -72,7 +71,11 @@ def _create_local_spark_session_for_recipes():
         # Return None if user doesn't have PySpark installed
         return None
     _prepare_subprocess_environ_for_creating_local_spark_session()
-    spark_scala_version = _get_spark_scala_version()
+
+    try:
+        spark_scala_version = _get_spark_scala_version()
+    except Exception as e:
+        raise RuntimeError("Getting spark scala version failed.") from e
     return (
         SparkSession.builder.master("local[*]")
         .config("spark.jars.packages", f"io.delta:delta-spark_{spark_scala_version}:3.0.0")

--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import tempfile
 import zipfile
+
 from packaging.version import Version
 
 
@@ -43,8 +44,9 @@ def _get_spark_scala_version_from_spark_session(spark):
 
 
 def _get_spark_scala_version():
-    from mlflow.utils.databricks_utils import is_in_databricks_runtime
     from pyspark.sql import SparkSession
+
+    from mlflow.utils.databricks_utils import is_in_databricks_runtime
 
     if is_in_databricks_runtime():
         return os.environ["SPARK_SCALA_VERSION"]

--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -68,8 +68,7 @@ def _get_spark_scala_version():
     # after terminating the temporal spark session, creating another spark session
     # with "spark.jars.packages" configuration doesn't work.
     proc = multiprocessing.Process(
-        target=_get_spark_scala_version_child_proc_target,
-        args=(result_queue,)
+        target=_get_spark_scala_version_child_proc_target, args=(result_queue,)
     )
     proc.start()
     proc.join()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/11149?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11149/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11149
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Update hardcoded "io.delta:delta-spark_2.12:3.0.0" dependency to correct scala version

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
