### PR TITLE
Call load_context() when enforcing ChatModel output

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -257,7 +257,7 @@ from mlflow.protos.databricks_pb2 import (
 from mlflow.pyfunc.model import (
     ChatModel,
     PythonModel,
-    PythonModelContext,  # noqa: F401
+    PythonModelContext,
     _log_warning_if_params_not_in_predict_signature,
     _PythonModelPyfuncWrapper,
     get_default_conda_env,  # noqa: F401
@@ -2068,7 +2068,7 @@ def save_model(
             _logger.info("Predicting on input example to validate output")
             context = PythonModelContext(artifacts, model_config)
             python_model.load_context(context)
-            output = python_model.predict(None, messages, params)
+            output = python_model.predict(context, messages, params)
             if not isinstance(output, ChatResponse):
                 raise MlflowException(
                     "Failed to save ChatModel. Please ensure that the model's predict() method "

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2063,6 +2063,11 @@ def save_model(
             # output is not coercable to ChatResponse
             messages = [ChatMessage(**m) for m in input_example["messages"]]
             params = ChatParams(**{k: v for k, v in input_example.items() if k != "messages"})
+
+            # call load_context() first, as predict may depend on it
+            _logger.info("Predicting on input example to validate output")
+            context = PythonModelContext(artifacts, model_config)
+            python_model.load_context(context)
             output = python_model.predict(None, messages, params)
             if not isinstance(output, ChatResponse):
                 raise MlflowException(

--- a/tests/pyfunc/test_chat_model.py
+++ b/tests/pyfunc/test_chat_model.py
@@ -1,4 +1,6 @@
 import json
+import pathlib
+import pickle
 from typing import List
 
 import pytest
@@ -26,36 +28,50 @@ DEFAULT_PARAMS = {
 }
 
 
+def get_mock_response(messages, params):
+    return {
+        "id": "123",
+        "model": "MyChatModel",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": json.dumps([m.to_dict() for m in messages]),
+                },
+                "finish_reason": "stop",
+            },
+            {
+                "index": 1,
+                "message": {
+                    "role": "user",
+                    "content": json.dumps(params.to_dict()),
+                },
+                "finish_reason": "stop",
+            },
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 10,
+            "total_tokens": 20,
+        },
+    }
+
+
 class TestChatModel(mlflow.pyfunc.ChatModel):
     def predict(self, context, messages: List[ChatMessage], params: ChatParams) -> ChatResponse:
-        mock_response = {
-            "id": "123",
-            "model": "MyChatModel",
-            "choices": [
-                {
-                    "index": 0,
-                    "message": {
-                        "role": "assistant",
-                        "content": json.dumps([m.to_dict() for m in messages]),
-                    },
-                    "finish_reason": "stop",
-                },
-                {
-                    "index": 1,
-                    "message": {
-                        "role": "user",
-                        "content": json.dumps(params.to_dict()),
-                    },
-                    "finish_reason": "stop",
-                },
-            ],
-            "usage": {
-                "prompt_tokens": 10,
-                "completion_tokens": 10,
-                "total_tokens": 20,
-            },
-        }
+        mock_response = get_mock_response(messages, params)
         return ChatResponse(**mock_response)
+
+
+class ChatModelWithContext(mlflow.pyfunc.ChatModel):
+    def load_context(self, context):
+        predict_path = pathlib.Path(context.artifacts["predict_fn"])
+        self.predict_fn = pickle.loads(predict_path.read_bytes())
+
+    def predict(self, context, messages: List[ChatMessage], params: ChatParams) -> ChatResponse:
+        message = ChatMessage(role="assistant", content=self.predict_fn())
+        return ChatResponse(**get_mock_response([message], params))
 
 
 def test_chat_model_save_load(tmp_path):
@@ -82,6 +98,30 @@ def test_chat_model_save_throws_with_signature(tmp_path):
                 Schema([ColSpec(name="test", type=DataType.string)]),
             ),
         )
+
+
+def mock_predict():
+    return "hello"
+
+
+def test_chat_model_with_context_saves_successfully(tmp_path_factory):
+    model_path = tmp_path_factory.mktemp("model")
+    predict_path = tmp_path_factory.mktemp("predict") / "predict.pkl"
+    predict_path.write_bytes(pickle.dumps(mock_predict))
+
+    model = ChatModelWithContext()
+    mlflow.pyfunc.save_model(
+        python_model=model,
+        path=model_path,
+        artifacts={"predict_fn": str(predict_path)},
+    )
+
+    loaded_model = mlflow.pyfunc.load_model(model_path)
+    messages = [{"role": "user", "content": "test"}]
+
+    response = loaded_model.predict({"messages": messages})
+    expected_response = json.dumps([{"role": "assistant", "content": "hello"}])
+    assert response["choices"][0]["message"]["content"] == expected_response
 
 
 @pytest.mark.parametrize(

--- a/tests/pyfunc/test_chat_model.py
+++ b/tests/pyfunc/test_chat_model.py
@@ -104,9 +104,9 @@ def mock_predict():
     return "hello"
 
 
-def test_chat_model_with_context_saves_successfully(tmp_path_factory):
-    model_path = tmp_path_factory.mktemp("model")
-    predict_path = tmp_path_factory.mktemp("predict") / "predict.pkl"
+def test_chat_model_with_context_saves_successfully(tmp_path):
+    model_path = tmp_path / "model"
+    predict_path = tmp_path / "predict.pkl"
     predict_path.write_bytes(pickle.dumps(mock_predict))
 
     model = ChatModelWithContext()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11150?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11150/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11150
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

I discovered a bug while working on a notebook for ChatModel. If the user has some logic in `predict()` that depends on `load_model()` (e.g. setting something like `self.model`), then prediction will fail. This is actually a problem in normal pyfuncs as well if they're logged with an input example, however in normal pyfuncs we don't enforce outputs, so we just catch the exception and tell the user to save the signature manually.

This PR simply calls `load_context()` with the artifacts that the user saves before performing predict. I would imagine that most users will need to load some context if they're using ChatModel, so this should unblock a lot of people.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
