### PR TITLE
Add an API to download and save model weights and use it for UC registration

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 import mlflow
 from mlflow.entities import Run
 from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INTERNAL_ERROR
 from mlflow.protos.databricks_uc_registry_messages_pb2 import (
     MODEL_VERSION_OPERATION_READ_WRITE,
     CreateModelVersionRequest,
@@ -531,18 +532,7 @@ class UcModelRegistryStore(BaseRestStore):
         # Import Model here instead of in the top level, to avoid circular import; the
         # mlflow.models.model module imports from MLflow tracking, which triggers an import of
         # this file during store registry initialization
-        from mlflow.models.model import Model
-
-        try:
-            model = Model.load(local_model_path)
-        except Exception as e:
-            raise MlflowException(
-                "Unable to load model metadata. Ensure the source path of the model "
-                "being registered points to a valid MLflow model directory "
-                "(see https://mlflow.org/docs/latest/models.html#storage-format) containing a "
-                "model signature (https://mlflow.org/docs/latest/models.html#model-signature) "
-                "specifying both input and output type specifications."
-            ) from e
+        model = _load_model(local_model_path)
         signature_required_explanation = (
             "All models in the Unity Catalog must be logged with a "
             "model signature containing both input and output "
@@ -560,6 +550,46 @@ class UcModelRegistryStore(BaseRestStore):
                 "Model passed for registration contained a signature that includes only inputs. "
                 f"{signature_required_explanation}"
             )
+
+    def _download_model_weights_if_not_saved(self, local_model_path):
+        """
+        Transformers models can be saved without the base model weights by setting
+        `save_pretrained=False` when saving or logging the model. Such 'weight-less'
+        model cannot be directly deployed to model serving, so here we download the
+        weights proactively from the HuggingFace hub and save them to the model directory.
+        """
+        model = _load_model(local_model_path)
+        flavor_conf = model.flavors.get("transformers")
+
+        if not flavor_conf:
+            return
+
+        from mlflow.transformers.flavor_config import FlavorKey
+        from mlflow.transformers.model_io import _MODEL_BINARY_FILE_NAME
+
+        if (
+            FlavorKey.MODEL_BINARY in flavor_conf
+            and os.path.exists(os.path.join(local_model_path, _MODEL_BINARY_FILE_NAME))
+            and FlavorKey.MODEL_REVISION not in flavor_conf
+        ):
+            # Model weights are already saved
+            return
+
+        _logger.info(
+            "It appears that the specified Transformers model was saved without the base model "
+            "weights, but such model cannot be directly registered in the Unity Catalog. "
+            "Attempting to download the model weights from the HuggingFace hub and save them to "
+            "the model directory for enabling model registration."
+        )
+        try:
+            mlflow.transformers.persist_pretrained_model(local_model_path)
+        except Exception as e:
+            raise MlflowException(
+                "Failed to download the model weights from the HuggingFace hub and cannot register "
+                "the model in the Unity Catalog. Please ensure that the model was saved with the "
+                "correct reference to the HuggingFace hub repository and you have access to it.",
+                error_code=INTERNAL_ERROR,
+            ) from e
 
     @contextmanager
     def _local_model_dir(self, source, local_model_path):
@@ -638,6 +668,7 @@ class UcModelRegistryStore(BaseRestStore):
         full_name = get_full_name_from_sc(name, self.spark)
         with self._local_model_dir(source, local_model_path) as local_model_dir:
             self._validate_model_signature(local_model_dir)
+            self._download_model_weights_if_not_saved(local_model_dir)
             feature_deps = get_feature_dependencies(local_model_dir)
             req_body = message_to_json(
                 CreateModelVersionRequest(

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -576,10 +576,9 @@ class UcModelRegistryStore(BaseRestStore):
             return
 
         _logger.info(
-            "It appears that the specified Transformers model was saved without the base model "
-            "weights, but such model cannot be directly registered in the Unity Catalog. "
-            "Attempting to download the model weights from the HuggingFace hub and save them to "
-            "the model directory for enabling model registration."
+            "You are attempting to register a transformers model that does not have persisted "
+            "model weights. Attempting to fetch the weights so that the model can be registered "
+            "within Unity Catalog."
         )
         try:
             mlflow.transformers.persist_pretrained_model(local_model_path)
@@ -587,7 +586,8 @@ class UcModelRegistryStore(BaseRestStore):
             raise MlflowException(
                 "Failed to download the model weights from the HuggingFace hub and cannot register "
                 "the model in the Unity Catalog. Please ensure that the model was saved with the "
-                "correct reference to the HuggingFace hub repository and you have access to it.",
+                "correct reference to the HuggingFace hub repository and that you have access to "
+                "fetch model weights from the defined repository.",
                 error_code=INTERNAL_ERROR,
             ) from e
 

--- a/mlflow/transformers/flavor_config.py
+++ b/mlflow/transformers/flavor_config.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict
 
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import ALREADY_EXISTS
 from mlflow.transformers.hub_utils import get_latest_commit_for_repo
 from mlflow.transformers.peft import _PEFT_ADAPTOR_DIR_NAME, get_peft_base_model, is_peft_model
 from mlflow.transformers.torch_utils import _extract_torch_dtype_if_set
@@ -154,3 +156,36 @@ def _get_instance_type(obj):
     the base ABC type of the model.
     """
     return obj.__class__.__name__
+
+
+def update_flavor_conf_to_persist_pretrained_model(
+    original_flavor_conf: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Updates the flavor configuration that was saved with save_pretrained=False to the one that
+    includes the local path to the model binary file.
+    """
+    flavor_conf = original_flavor_conf.copy()
+
+    # Replace model commit path with local path
+    if FlavorKey.MODEL_BINARY in original_flavor_conf:
+        raise MlflowException(
+            "It appears that the pretrained model weight is already saved to the artifact path.",
+            error_code=ALREADY_EXISTS,
+        )
+
+    from mlflow.transformers.model_io import _MODEL_BINARY_FILE_NAME
+
+    flavor_conf[FlavorKey.MODEL_BINARY] = _MODEL_BINARY_FILE_NAME
+    flavor_conf.pop(FlavorKey.MODEL_REVISION, None)
+
+    # Remove component repo name and commit hash
+    components = original_flavor_conf.get(FlavorKey.COMPONENTS, [])
+    if FlavorKey.PROCESSOR_TYPE in original_flavor_conf:
+        components.append(FlavorKey.PROCESSOR)
+
+    for component in components:
+        flavor_conf.pop(FlavorKey.COMPONENT_NAME.format(component), None)
+        flavor_conf.pop(FlavorKey.COMPONENT_REVISION.format(component), None)
+
+    return flavor_conf

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -233,15 +233,17 @@ def test_create_model_version_missing_python_deps(store, local_model_dir):
         store.create_model_version(name=model_name, source=str(local_model_dir))
 
 
+_TEST_SIGNATURE = ModelSignature(
+    inputs=Schema([ColSpec(DataType.double)]), outputs=Schema([ColSpec(DataType.double)])
+)
+
+
 @pytest.fixture
 def feature_store_local_model_dir(tmp_path):
-    fake_signature = ModelSignature(
-        inputs=Schema([ColSpec(DataType.double)]), outputs=Schema([ColSpec(DataType.double)])
-    )
     fake_mlmodel_contents = {
         "artifact_path": "some-artifact-path",
         "run_id": "abc123",
-        "signature": fake_signature.to_dict(),
+        "signature": _TEST_SIGNATURE.to_dict(),
         "flavors": {"python_function": {"loader_module": "databricks.feature_store.mlflow_model"}},
     }
     with open(tmp_path.joinpath(MLMODEL_FILE_NAME), "w") as handle:
@@ -286,6 +288,63 @@ def test_create_model_version_missing_output_signature(store, tmp_path):
         match="Model passed for registration contained a signature that includes only inputs",
     ):
         store.create_model_version(name="mymodel", source=str(tmp_path))
+
+
+@pytest.mark.parametrize(
+    ("flavor_config", "should_persist_api_called"),
+    [
+        # persist_pretrained_model should NOT be called for non-transformer models
+        (
+            {
+                "python_function": {},
+                "scikit-learn": {},
+            },
+            False,
+        ),
+        # persist_pretrained_model should be NOT called if model weights are saved locally
+        (
+            {
+                "transformers": {
+                    "model_binary": "model",
+                    "source_model_name": "SOME_REPO",
+                }
+            },
+            False,
+        ),
+        # persist_pretrained_model should be called if model weights are not saved locally
+        (
+            {
+                "transformers": {
+                    "source_model_name": "SOME_REPO",
+                    "source_model_revision": "SOME_COMMIT_HASH",
+                }
+            },
+            True,
+        ),
+    ],
+)
+def test_download_model_weights_if_not_saved(
+    flavor_config, should_persist_api_called, store, tmp_path
+):
+    fake_mlmodel_contents = {
+        "artifact_path": "some-artifact-path",
+        "run_id": "abc123",
+        "flavors": flavor_config,
+        "signature": _TEST_SIGNATURE.to_dict(),
+    }
+    with open(tmp_path.joinpath(MLMODEL_FILE_NAME), "w") as handle:
+        yaml.dump(fake_mlmodel_contents, handle)
+
+    if model_binary_path := flavor_config.get("transformers", {}).get("model_binary"):
+        tmp_path.joinpath(model_binary_path).mkdir()
+
+    with mock.patch("mlflow.transformers") as transformers_mock:
+        store._download_model_weights_if_not_saved(str(tmp_path))
+
+        if should_persist_api_called:
+            transformers_mock.persist_pretrained_model.assert_called_once_with(str(tmp_path))
+        else:
+            transformers_mock.persist_pretrained_model.assert_not_called()
 
 
 @mock_http_200

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -301,7 +301,7 @@ def test_create_model_version_missing_output_signature(store, tmp_path):
             },
             False,
         ),
-        # persist_pretrained_model should be NOT called if model weights are saved locally
+        # persist_pretrained_model should NOT be called if model weights are saved locally
         (
             {
                 "transformers": {
@@ -332,7 +332,7 @@ def test_download_model_weights_if_not_saved(
         "flavors": flavor_config,
         "signature": _TEST_SIGNATURE.to_dict(),
     }
-    with open(tmp_path.joinpath(MLMODEL_FILE_NAME), "w") as handle:
+    with tmp_path.joinpath(MLMODEL_FILE_NAME).open("w") as handle:
         yaml.dump(fake_mlmodel_contents, handle)
 
     if model_binary_path := flavor_config.get("transformers", {}).get("model_binary"):

--- a/tests/transformers/test_flavor_configs.py
+++ b/tests/transformers/test_flavor_configs.py
@@ -105,3 +105,65 @@ def test_is_valid_hf_repo_id(tmp_path):
     assert is_valid_hf_repo_id(str(tmp_path)) is False
     assert is_valid_hf_repo_id("invalid/repo/name") is False
     assert is_valid_hf_repo_id("google-t5/t5-small") is True
+
+
+_COMMON_CONF = {
+    "task": "text-classification",
+    "instance_type": "TextClassificationPipeline",
+    "pipeline_model_type": "TFMobileBertForSequenceClassification",
+    "source_model_name": "lordtt13/emo-mobilebert",
+    "framework": "tf",
+    "components": ["tokenizer"],
+    "tokenizer_type": "MobileBertTokenizerFast",
+    "transformers_version": "4.37.1",
+}
+_COMMIT_HASH = "26d8fcb41762ae83cc9fa03005cb63cde06ef340"
+
+
+def test_update_flavor_conf_to_persist_pretrained_model():
+    flavor_conf = {
+        **_COMMON_CONF,
+        "components": ["tokenizer"],
+        "source_model_revision": _COMMIT_HASH,
+        "tokenizer_name": "lordtt13/emo-mobilebert",
+        "tokenizer_revision": _COMMIT_HASH,
+    }
+    updated_flavor_conf = update_flavor_conf_to_persist_pretrained_model(flavor_conf)
+
+    assert updated_flavor_conf["model_binary"] == "model"
+    assert "source_model_revision" not in updated_flavor_conf
+    assert "tokenizer_revision" not in updated_flavor_conf
+    assert "tokenizer_name" not in updated_flavor_conf
+
+
+def test_update_flavor_conf_to_persist_pretrained_model_multi_modal():
+    flavor_conf = {
+        **_COMMON_CONF,
+        "components": ["tokenizer", "image_processor"],
+        "source_model_revision": _COMMIT_HASH,
+        "tokznier_revision": _COMMIT_HASH,
+        "image-processor_type": "ViltImageProcessor",
+        "image_processor_name": "dandelin/vilt-b32-finetuned-vqa",
+        "image_processor_revision": _COMMIT_HASH,
+        "processor_type": "ViltImageProcessor",
+        "processor_name": "dandelin/vilt-b32-finetuned-vqa",
+        "processor_revision": _COMMIT_HASH,
+    }
+    updated_flavor_conf = update_flavor_conf_to_persist_pretrained_model(flavor_conf)
+
+    assert updated_flavor_conf["model_binary"] == "model"
+    assert "source_model_revision" not in updated_flavor_conf
+    for component in ["tokenizer", "image_processor", "processor"]:
+        assert f"{component}_revision" not in updated_flavor_conf
+        assert f"{component}_name" not in updated_flavor_conf
+
+
+def test_update_flavor_conf_to_persist_pretrained_model_raise_if_already_persisted():
+    flavor_conf = {
+        **_COMMON_CONF,
+        "components": ["tokenizer"],
+        "model_binary": "model",
+    }
+
+    with pytest.raises(MlflowException, match="It appears that the pretrained model weight"):
+        update_flavor_conf_to_persist_pretrained_model(flavor_conf)

--- a/tests/transformers/test_flavor_configs.py
+++ b/tests/transformers/test_flavor_configs.py
@@ -1,7 +1,11 @@
 import pytest
 
+from mlflow.exceptions import MlflowException
 from mlflow.transformers import _build_pipeline_from_model_input
-from mlflow.transformers.flavor_config import build_flavor_config
+from mlflow.transformers.flavor_config import (
+    build_flavor_config,
+    update_flavor_conf_to_persist_pretrained_model,
+)
 from mlflow.transformers.hub_utils import is_valid_hf_repo_id
 
 from tests.transformers.helper import IS_NEW_FEATURE_EXTRACTION_API


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11157?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11157/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11157
```

</p>
</details>

### What changes are proposed in this pull request?

This PR includes two (related) changes:

**1. Introduce new `persist_pretrained_model` API.**
Transformer "weigth-less" models cannot be deployed to Databricks model-serving as it is. This is because otherwise we need to download the weights from HuggingFace Hub in our control plane, which might impact service availability. Therefore, we block customers to register a model to DB Workspace Model Registry, but there should be a way to convert such weigth-less models to be the ones that can be registered.

Thus, this PR adds a new API `mlflow.transformers.persist_pretrained_model(model_uri)`, with which users can download the model weight from the HF Hub and save into the existing weight-less model. 

**2. Handle UC registration**
Initially, we also planned to block customers from registering weight-less models to UC. However, it turns out that the UC registration process is always done in the users notebook not our control plane, meaning that the download from the HF Hub is not harmful. We can simply use the new API to make the model registrable on behalf of users for avoid frustrating experience.


**Note**: For OSS Model Registry, we need no change i.e. not blocking registration. This is because the model weight is downloaded (on users' side) when they deploy the model to deployment target. This provides consistent non-blocking experience across OSS and UC, and since the Workspace Model Registry is considered as legacy, I think it's reasonable to have limitation there.

### Tracker

This PR is filed for the PEFT feature branch. More changes are needed be done before merging the feature branch to master:

- [x] Introduce `save_pretrained` flag and implement saving/loading logic ([PR](https://github.com/mlflow/mlflow/pull/11075)).
- [ ] Block registering model to Databricks Workspace Model Registry (WIP)
- [ ] [**This PR**] Implement an API to download the weight files to the existing *weight-less* model (so it can be registered without re-logging).
- [x] Support PEFT model. ([PR](https://github.com/mlflow/mlflow/pull/11120))
- [ ] Update documentation and examples

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


https://github.com/mlflow/mlflow/assets/31463517/30a95ed8-67cd-44e5-aa50-25d8a2decc70

Steps:
1. Log Transformers model with `save_pretrained=False`
2. Check the logged model doesn't contain model weight.
3. Click "Register Model" button and see code snippet for UC registration
4. Go back to notebook and run registration code.
5. Check the model weight is persisted in the model artifact and MLModel file is updated properly.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

Documentation update will be done in a follow-up PR planned before the release.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introduce a new API `mlflow.transformers.persist_pretrained_model` to download and save model weights, so that the Transformers "weight-less" model can be registered to Databricks Workspace Model Registry.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
