### PR TITLE
Rename AWS Bedrock to Amazon Bedrock

### DIFF
--- a/docs/source/llms/deployments/index.rst
+++ b/docs/source/llms/deployments/index.rst
@@ -256,7 +256,7 @@ below can be used as a helpful guide when configuring a given endpoint for any n
 |                          | - j2-mid                 |                          |                          |
 |                          | - j2-light               |                          |                          |
 +--------------------------+--------------------------+--------------------------+--------------------------+
-| AWS Bedrock              | - Amazon Titan           | N/A                      | N/A                      |
+| Amazon Bedrock           | - Amazon Titan           | N/A                      | N/A                      |
 |                          | - Third-party providers  |                          |                          |
 +--------------------------+--------------------------+--------------------------+--------------------------+
 | Mistral                  | - mistral-tiny           | N/A                      |  - mistral-embed         |
@@ -306,7 +306,7 @@ As of now, the MLflow Deployments Server supports the following providers:
 * **palm**: This is used for models offered by `PaLM <https://developers.generativeai.google/api/rest/generativelanguage/models/>`_.
 * **huggingface text generation inference**: This is used for models deployed using `Huggingface Text Generation Inference <https://huggingface.co/docs/text-generation-inference/index>`_.
 * **ai21labs**: This is used for models offered by `AI21 Labs <https://studio.ai21.com/foundation-models>`_.
-* **bedrock**: This is used for models offered by `AWS Bedrock <https://aws.amazon.com/bedrock/>`_.
+* **bedrock**: This is used for models offered by `Amazon Bedrock <https://aws.amazon.com/bedrock/>`_.
 * **mistral**: This is used for models offered by `Mistral <https://docs.mistral.ai/>`_.
 
 More providers are being added continually. Check the latest version of the MLflow Deployments Server Docs for the
@@ -603,10 +603,10 @@ Anthropic
 | **anthropic_api_key**   | Yes      | N/A                      | This is the API key for the Anthropic service.        |
 +-------------------------+----------+--------------------------+-------------------------------------------------------+
 
-AWS Bedrock
+Amazon Bedrock
 +++++++++++
 
-Top-level model configuration for AWS Bedrock endpoints must be one of the following two supported authentication modes: `key-based` or `role-based`.
+Top-level model configuration for Amazon Bedrock endpoints must be one of the following two supported authentication modes: `key-based` or `role-based`.
 
 +--------------------------+----------+------------------------------+-------------------------------------------------------+
 | Configuration Parameter  | Required | Default                      | Description                                           |
@@ -616,7 +616,7 @@ Top-level model configuration for AWS Bedrock endpoints must be one of the follo
 +--------------------------+----------+------------------------------+-------------------------------------------------------+
 
 
-To use key-based authentication, define an AWS Bedrock endpoint with the required fields below.
+To use key-based authentication, define an Amazon Bedrock endpoint with the required fields below.
 .. note::
 
   If using a configured endpoint purely for development or testing, utilizing an IAM User role or a temporary short-lived standard IAM role are recommended; while for production deployments, a standard long-expiry IAM role is recommended to ensure that the endpoint is capable of handling authentication for a long period. If the authentication expires and a new set of keys need to be supplied, the endpoint must be recreated in order to persist the new keys.
@@ -636,7 +636,7 @@ To use key-based authentication, define an AWS Bedrock endpoint with the require
 | **aws_session_token**    | No       | None                         | Optional session token, if required                   |
 +--------------------------+----------+------------------------------+-------------------------------------------------------+
 
-Alternatively, for role-based authentication, an AWS Bedrock endpoint can be defined and initialized with an a IAM Role  ARN that is authorized to access Bedrock.  The MLflow Deployments Server will attempt to assume this role with using the standard credential provider chain and will renew the role credentials if they have expired.
+Alternatively, for role-based authentication, an Amazon Bedrock endpoint can be defined and initialized with an a IAM Role  ARN that is authorized to access Bedrock.  The MLflow Deployments Server will attempt to assume this role with using the standard credential provider chain and will renew the role credentials if they have expired.
 
 +--------------------------+----------+------------------------------+-------------------------------------------------------+
 | Configuration Parameter  | Required | Default                      | Description                                           |

--- a/docs/source/llms/deployments/index.rst
+++ b/docs/source/llms/deployments/index.rst
@@ -604,7 +604,7 @@ Anthropic
 +-------------------------+----------+--------------------------+-------------------------------------------------------+
 
 Amazon Bedrock
-+++++++++++
+++++++++++++++
 
 Top-level model configuration for Amazon Bedrock endpoints must be one of the following two supported authentication modes: `key-based` or `role-based`.
 

--- a/docs/source/llms/gateway/index.rst
+++ b/docs/source/llms/gateway/index.rst
@@ -632,7 +632,7 @@ Anthropic
 +-------------------------+----------+--------------------------+-------------------------------------------------------+
 
 Amazon Bedrock
-+++++++++++
+++++++++++++++
 
 Top-level model configuration for Amazon Bedrock routes must be one of the following two supported authentication modes: `key-based` or `role-based`.
 

--- a/docs/source/llms/gateway/index.rst
+++ b/docs/source/llms/gateway/index.rst
@@ -299,7 +299,7 @@ below can be used as a helpful guide when configuring a given route for any newl
 |                          | - j2-mid                 |                          |                          |
 |                          | - j2-light               |                          |                          |
 +--------------------------+--------------------------+--------------------------+--------------------------+
-| AWS Bedrock              | - Amazon Titan           | N/A                      | N/A                      |
+| Amazon Bedrock           | - Amazon Titan           | N/A                      | N/A                      |
 |                          | - Third-party providers  |                          |                          |
 +--------------------------+--------------------------+--------------------------+--------------------------+
 | Mistral                  | - mistral-tiny           | N/A                      |  - mistral-embed         |
@@ -345,7 +345,7 @@ As of now, the MLflow AI Gateway supports the following providers:
 * **palm**: This is used for models offered by `PaLM <https://developers.generativeai.google/api/rest/generativelanguage/models/>`_.
 * **huggingface text generation inference**: This is used for models deployed using `Huggingface Text Generation Inference <https://huggingface.co/docs/text-generation-inference/index>`_.
 * **ai21labs**: This is used for models offered by `AI21 Labs <https://studio.ai21.com/foundation-models>`_.
-* **bedrock**: This is used for models offered by `AWS Bedrock <https://aws.amazon.com/bedrock/>`_.
+* **bedrock**: This is used for models offered by `Amazon Bedrock <https://aws.amazon.com/bedrock/>`_.
 * **mistral**: This is used for models offered by `Mistral <https://docs.mistral.ai/>`_.
 
 More providers are being added continually. Check the latest version of the MLflow AI Gateway Docs for the
@@ -631,10 +631,10 @@ Anthropic
 | **anthropic_api_key**   | Yes      | N/A                      | This is the API key for the Anthropic service.        |
 +-------------------------+----------+--------------------------+-------------------------------------------------------+
 
-AWS Bedrock
+Amazon Bedrock
 +++++++++++
 
-Top-level model configuration for AWS Bedrock routes must be one of the following two supported authentication modes: `key-based` or `role-based`.
+Top-level model configuration for Amazon Bedrock routes must be one of the following two supported authentication modes: `key-based` or `role-based`.
 
 +--------------------------+----------+------------------------------+-------------------------------------------------------+
 | Configuration Parameter  | Required | Default                      | Description                                           |
@@ -654,7 +654,7 @@ Mistral
 +--------------------------+----------+--------------------------+-------------------------------------------------------+
 
 
-To use key-based authentication, define an AWS Bedrock route with the required fields below.
+To use key-based authentication, define an Amazon Bedrock route with the required fields below.
 .. note::
 
   If using a configured route purely for development or testing, utilizing an IAM User role or a temporary short-lived standard IAM role are recommended; while for production deployments, a standard long-expiry IAM role is recommended to ensure that the route is capable of handling authentication for a long period. If the authentication expires and a new set of keys need to be supplied, the route must be recreated in order to persist the new keys.
@@ -674,7 +674,7 @@ To use key-based authentication, define an AWS Bedrock route with the required f
 | **aws_session_token**    | No       | None                         | Optional session token, if required                   |
 +--------------------------+----------+------------------------------+-------------------------------------------------------+
 
-Alternatively, for role-based authentication, an AWS Bedrock route can be defined and initialized with an a IAM Role  ARN that is authorized to access Bedrock.  The MLflow AI Gateway will attempt to assume this role with using the standard credential provider chain and will renew the role credentials if they have expired.
+Alternatively, for role-based authentication, an Amazon Bedrock route can be defined and initialized with an a IAM Role  ARN that is authorized to access Bedrock.  The MLflow AI Gateway will attempt to assume this role with using the standard credential provider chain and will renew the role credentials if they have expired.
 
 +--------------------------+----------+------------------------------+-------------------------------------------------------+
 | Configuration Parameter  | Required | Default                      | Description                                           |

--- a/docs/source/new-features/index.rst
+++ b/docs/source/new-features/index.rst
@@ -159,7 +159,7 @@ Find out about the details of major features, changes, and deprecations below.
             <div class="grid-card">
                 <div class="content-container">
                     <div class="header">
-                        AWS Bedrock added as an MLflow Gateway provider 
+                        Amazon Bedrock added as an MLflow Gateway provider 
                     </div>
                     <img class="card-image" src="../_static/images/logos/aws-logo.svg" alt="MLflow"></img>
                     <div class="body">

--- a/examples/deployments/deployments_server/bedrock/README.md
+++ b/examples/deployments/deployments_server/bedrock/README.md
@@ -1,4 +1,4 @@
-## Example endpoint configuration for AWS Bedrock
+## Example endpoint configuration for Amazon Bedrock
 
 To view an example of a Bedrock endpoint configuration, see [the configuration example](config.yaml) YAML file.
 

--- a/examples/deployments/deployments_server/bedrock/config.yaml
+++ b/examples/deployments/deployments_server/bedrock/config.yaml
@@ -2,7 +2,7 @@ endpoints:
   - name: completions
     endpoint_type: llm/v1/completions
     model:
-      provider: bedrock
+      provider: amazon-bedrock
       name: amazon.titan-tg1-large
       config:
         aws_config:

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -43,6 +43,7 @@ class Provider(str, Enum):
     HUGGINGFACE_TEXT_GENERATION_INFERENCE = "huggingface-text-generation-inference"
     PALM = "palm"
     BEDROCK = "bedrock"
+    AMAZON_BEDROCK = "amazon-bedrock"  # an alias for bedrock
     # Note: The following providers are only supported on Databricks
     DATABRICKS_MODEL_SERVING = "databricks-model-serving"
     DATABRICKS = "databricks"
@@ -212,7 +213,7 @@ class AWSIdAndKey(AWSBaseConfig):
     aws_session_token: Optional[str] = None
 
 
-class AWSBedrockConfig(ConfigModel):
+class AmazonBedrockConfig(ConfigModel):
     # order here is important, at least for pydantic<2
     aws_config: Union[AWSRole, AWSIdAndKey, AWSBaseConfig]
 
@@ -232,7 +233,8 @@ config_types = {
     Provider.ANTHROPIC: AnthropicConfig,
     Provider.AI21LABS: AI21LabsConfig,
     Provider.MOSAICML: MosaicMLConfig,
-    Provider.BEDROCK: AWSBedrockConfig,
+    Provider.BEDROCK: AmazonBedrockConfig,
+    Provider.AMAZON_BEDROCK: AmazonBedrockConfig,
     Provider.MLFLOW_MODEL_SERVING: MlflowModelServingConfig,
     Provider.PALM: PaLMConfig,
     Provider.HUGGINGFACE_TEXT_GENERATION_INFERENCE: HuggingFaceTextGenerationInferenceConfig,
@@ -291,7 +293,7 @@ class Model(ConfigModel):
             OpenAIConfig,
             AI21LabsConfig,
             AnthropicConfig,
-            AWSBedrockConfig,
+            AmazonBedrockConfig,
             MosaicMLConfig,
             MlflowModelServingConfig,
             HuggingFaceTextGenerationInferenceConfig,

--- a/mlflow/gateway/providers/__init__.py
+++ b/mlflow/gateway/providers/__init__.py
@@ -8,7 +8,7 @@ from mlflow.gateway.providers.base import BaseProvider
 def get_provider(provider: Provider) -> Type[BaseProvider]:
     from mlflow.gateway.providers.ai21labs import AI21LabsProvider
     from mlflow.gateway.providers.anthropic import AnthropicProvider
-    from mlflow.gateway.providers.bedrock import AWSBedrockProvider
+    from mlflow.gateway.providers.bedrock import AmazonBedrockProvider
     from mlflow.gateway.providers.cohere import CohereProvider
     from mlflow.gateway.providers.huggingface import HFTextGenerationInferenceServerProvider
     from mlflow.gateway.providers.mistral import MistralProvider
@@ -26,7 +26,7 @@ def get_provider(provider: Provider) -> Type[BaseProvider]:
         Provider.PALM: PaLMProvider,
         Provider.MLFLOW_MODEL_SERVING: MlflowModelServingProvider,
         Provider.HUGGINGFACE_TEXT_GENERATION_INFERENCE: HFTextGenerationInferenceServerProvider,
-        Provider.BEDROCK: AWSBedrockProvider,
+        Provider.BEDROCK: AmazonBedrockProvider,
         Provider.MISTRAL: MistralProvider,
     }
     if prov := provider_to_class.get(provider):

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -22,7 +22,7 @@ from mlflow.gateway.schemas import completions
 AWS_BEDROCK_ANTHROPIC_MAXIMUM_MAX_TOKENS = 8191
 
 
-class AWSBedrockAnthropicAdapter(AnthropicAdapter):
+class AmazonBedrockAnthropicAdapter(AnthropicAdapter):
     @classmethod
     def completions_to_model(cls, payload, config):
         payload = super().completions_to_model(payload, config)
@@ -136,7 +136,7 @@ class AI21Adapter(ProviderAdapter):
         raise NotImplementedError
 
 
-class AWSBedrockModelProvider(Enum):
+class AmazonBedrockModelProvider(Enum):
     AMAZON = "amazon"
     COHERE = "cohere"
     AI21 = "ai21"
@@ -156,10 +156,10 @@ class AWSBedrockModelProvider(Enum):
 
 
 AWS_MODEL_PROVIDER_TO_ADAPTER = {
-    AWSBedrockModelProvider.COHERE: CohereAdapter,
-    AWSBedrockModelProvider.ANTHROPIC: AWSBedrockAnthropicAdapter,
-    AWSBedrockModelProvider.AMAZON: AWSTitanAdapter,
-    AWSBedrockModelProvider.AI21: AI21Adapter,
+    AmazonBedrockModelProvider.COHERE: CohereAdapter,
+    AmazonBedrockModelProvider.ANTHROPIC: AmazonBedrockAnthropicAdapter,
+    AmazonBedrockModelProvider.AMAZON: AWSTitanAdapter,
+    AmazonBedrockModelProvider.AI21: AI21Adapter,
 }
 
 
@@ -242,7 +242,7 @@ class AmazonBedrockProvider(BaseProvider):
         if (not self.config.model.name) or "." not in self.config.model.name:
             return None
         provider = self.config.model.name.split(".")[0]
-        return AWSBedrockModelProvider.of_str(provider)
+        return AmazonBedrockModelProvider.of_str(provider)
 
     @property
     def underlying_provider_adapter(self) -> ProviderAdapter:

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -8,7 +8,7 @@ import botocore.exceptions
 from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 
-from mlflow.gateway.config import AWSBedrockConfig, AWSIdAndKey, AWSRole, RouteConfig
+from mlflow.gateway.config import AmazonBedrockConfig, AWSIdAndKey, AWSRole, RouteConfig
 from mlflow.gateway.constants import (
     MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS,
 )
@@ -163,15 +163,15 @@ AWS_MODEL_PROVIDER_TO_ADAPTER = {
 }
 
 
-class AWSBedrockProvider(BaseProvider):
-    NAME = "AWS Bedrock"
+class AmazonBedrockProvider(BaseProvider):
+    NAME = "Amazon Bedrock"
 
     def __init__(self, config: RouteConfig):
         super().__init__(config)
 
-        if config.model.config is None or not isinstance(config.model.config, AWSBedrockConfig):
+        if config.model.config is None or not isinstance(config.model.config, AmazonBedrockConfig):
             raise TypeError(f"Invalid config type {config.model.config}")
-        self.bedrock_config: AWSBedrockConfig = config.model.config
+        self.bedrock_config: AmazonBedrockConfig = config.model.config
         self._client = None
         self._client_created = 0
 
@@ -201,10 +201,10 @@ class AWSBedrockProvider(BaseProvider):
             return self._client
         except botocore.exceptions.UnknownServiceError as e:
             raise AIGatewayConfigException(
-                "Cannot create AWS Bedrock client; ensure boto3/botocore "
-                "linked from the AWS Bedrock user guide are installed. "
+                "Cannot create Amazon Bedrock client; ensure boto3/botocore "
+                "linked from the Amazon Bedrock user guide are installed. "
                 "Otherwise likely missing credentials or accessing account without to "
-                "AWS Bedrock Private Preview"
+                "Amazon Bedrock Private Preview"
             ) from e
 
     def _construct_session_args(self):
@@ -250,13 +250,13 @@ class AWSBedrockProvider(BaseProvider):
         if not provider:
             raise HTTPException(
                 status_code=422,
-                detail=f"Unknown AWS Bedrock model type {self._underlying_provider}",
+                detail=f"Unknown Amazon Bedrock model type {self._underlying_provider}",
             )
         adapter = provider.adapter
         if not adapter:
             raise HTTPException(
                 status_code=422,
-                detail=f"Don't know how to handle {self._underlying_provider} for AWS Bedrock",
+                detail=f"Don't know how to handle {self._underlying_provider} for Amazon Bedrock",
             )
         return adapter
 

--- a/tests/gateway/providers/test_bedrock.py
+++ b/tests/gateway/providers/test_bedrock.py
@@ -10,7 +10,7 @@ from mlflow.gateway.config import (
     AWSRole,
     RouteConfig,
 )
-from mlflow.gateway.providers.bedrock import AmazonBedrockProvider, AWSBedrockModelProvider
+from mlflow.gateway.providers.bedrock import AmazonBedrockModelProvider, AmazonBedrockProvider
 from mlflow.gateway.schemas import completions
 
 from tests.gateway.providers.test_anthropic import (
@@ -107,7 +107,7 @@ def ai21_parsed_completion_response(mdl):
 
 bedrock_model_provider_fixtures = [
     {
-        "provider": AWSBedrockModelProvider.ANTHROPIC,
+        "provider": AmazonBedrockModelProvider.ANTHROPIC,
         "config": {
             "name": "completions",
             "route_type": "llm/v1/completions",
@@ -126,7 +126,7 @@ bedrock_model_provider_fixtures = [
         },
     },
     {
-        "provider": AWSBedrockModelProvider.ANTHROPIC,
+        "provider": AmazonBedrockModelProvider.ANTHROPIC,
         "config": {
             "name": "completions",
             "route_type": "llm/v1/completions",
@@ -145,7 +145,7 @@ bedrock_model_provider_fixtures = [
         },
     },
     {
-        "provider": AWSBedrockModelProvider.ANTHROPIC,
+        "provider": AmazonBedrockModelProvider.ANTHROPIC,
         "config": {
             "name": "completions",
             "route_type": "llm/v1/completions",
@@ -164,7 +164,7 @@ bedrock_model_provider_fixtures = [
         },
     },
     {
-        "provider": AWSBedrockModelProvider.AMAZON,
+        "provider": AmazonBedrockModelProvider.AMAZON,
         "config": {
             "name": "completions",
             "route_type": "llm/v1/completions",
@@ -214,7 +214,7 @@ bedrock_model_provider_fixtures = [
         },
     },
     {
-        "provider": AWSBedrockModelProvider.AI21,
+        "provider": AmazonBedrockModelProvider.AI21,
         "config": {
             "name": "completions",
             "route_type": "llm/v1/completions",
@@ -231,7 +231,7 @@ bedrock_model_provider_fixtures = [
         "model_request": {"prompt": "This is a test"},
     },
     {
-        "provider": AWSBedrockModelProvider.AI21,
+        "provider": AmazonBedrockModelProvider.AI21,
         "config": {
             "name": "completions",
             "route_type": "llm/v1/completions",
@@ -251,7 +251,7 @@ bedrock_model_provider_fixtures = [
         },
     },
     {
-        "provider": AWSBedrockModelProvider.COHERE,
+        "provider": AmazonBedrockModelProvider.COHERE,
         "config": {
             "name": "completions",
             "route_type": "llm/v1/completions",
@@ -373,7 +373,7 @@ def test_bedrock_aws_client(provider, config, aws_config):
             fix["expected"],
             fix["model_request"],
             marks=[]
-            if fix["provider"] is not AWSBedrockModelProvider.COHERE
+            if fix["provider"] is not AmazonBedrockModelProvider.COHERE
             else pytest.mark.skip("Cohere isn't available on Amazon Bedrock yet"),
         )
         for fix in bedrock_model_provider_fixtures

--- a/tests/gateway/test_integration.py
+++ b/tests/gateway/test_integration.py
@@ -11,7 +11,7 @@ from mlflow.gateway import MlflowGatewayClient, get_route, query, set_gateway_ur
 from mlflow.gateway.config import Route
 from mlflow.gateway.providers.ai21labs import AI21LabsProvider
 from mlflow.gateway.providers.anthropic import AnthropicProvider
-from mlflow.gateway.providers.bedrock import AWSBedrockProvider
+from mlflow.gateway.providers.bedrock import AmazonBedrockProvider
 from mlflow.gateway.providers.cohere import CohereProvider
 from mlflow.gateway.providers.huggingface import HFTextGenerationInferenceServerProvider
 from mlflow.gateway.providers.mistral import MistralProvider
@@ -980,7 +980,7 @@ def test_bedrock_completions(gateway):
     async def mock_completions(self, payload):
         return expected_output
 
-    with patch.object(AWSBedrockProvider, "completions", mock_completions):
+    with patch.object(AmazonBedrockProvider, "completions", mock_completions):
         response = query(route=route.name, data=data)
 
     assert response == expected_output


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11162?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11162/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11162
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Rename AWS Bedrock to Amazon Bedrock.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
