### PR TITLE
Resolve model metadata for saved models that do not define an artifact_path

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -285,10 +285,8 @@ class Model:
         **kwargs,
     ):
         # store model id instead of run_id and path to avoid confusion when model gets exported
-        if run_id:
-            self.run_id = run_id
-            self.artifact_path = artifact_path
-
+        self.run_id = run_id
+        self.artifact_path = artifact_path
         self.utc_time_created = str(utc_time_created or datetime.utcnow())
         self.flavors = flavors if flavors is not None else {}
         self.signature = signature

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -483,4 +483,6 @@ def test_save_load_input_example_without_conversion(tmp_path):
 
 def test_model_saved_by_save_model_can_be_loaded(tmp_path, sklearn_knn_model):
     mlflow.sklearn.save_model(sklearn_knn_model, tmp_path)
-    Model.load(tmp_path).get_model_info()
+    info = Model.load(tmp_path).get_model_info()
+    assert info.run_id is None
+    assert info.artifact_path is None

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -479,3 +479,8 @@ def test_save_load_input_example_without_conversion(tmp_path):
     assert loaded_model.saved_input_example_info["type"] == "json_object"
     loaded_example = loaded_model.load_input_example(local_path)
     assert loaded_example == input_example
+
+
+def test_model_saved_by_save_model_can_be_loaded(tmp_path):
+    mlflow.sklearn.save_model("model", tmp_path)
+    Model.load(tmp_path).get_model_info()

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -481,6 +481,6 @@ def test_save_load_input_example_without_conversion(tmp_path):
     assert loaded_example == input_example
 
 
-def test_model_saved_by_save_model_can_be_loaded(tmp_path):
-    mlflow.sklearn.save_model("model", tmp_path)
+def test_model_saved_by_save_model_can_be_loaded(tmp_path, sklearn_knn_model):
+    mlflow.sklearn.save_model(sklearn_knn_model, tmp_path)
     Model.load(tmp_path).get_model_info()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11166?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11166/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11166
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The following code fails with `'Model' object has no attribute 'artifact_path'` because the `artifact` attribute is conditionally defined in the constructor. This PR fixes it.

```python
mlflow.sklearn.save_model(sklearn_model, tmp_path)
Model.load(tmp_path).get_model_info()
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
