### PR TITLE
Make it possible to log a dataset without loading anything

### DIFF
--- a/mlflow/data/__init__.py
+++ b/mlflow/data/__init__.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Union
 
-from mlflow.data import dataset_registry
+from mlflow.data import dataset_registry, meta_dataset
 from mlflow.data import sources as mlflow_data_sources
 from mlflow.data.dataset import Dataset
 from mlflow.data.dataset_source import DatasetSource
@@ -47,7 +47,7 @@ def get_source(dataset: Union[DatasetEntity, DatasetInput, Dataset]) -> DatasetS
     return dataset_source
 
 
-__all__ = ["get_source"]
+__all__ = ["get_source", "meta_dataset"]
 
 
 def _define_dataset_constructors_in_current_module():

--- a/mlflow/data/__init__.py
+++ b/mlflow/data/__init__.py
@@ -1,7 +1,8 @@
 import sys
+from contextlib import suppress
 from typing import Union
 
-from mlflow.data import dataset_registry, meta_dataset
+from mlflow.data import dataset_registry
 from mlflow.data import sources as mlflow_data_sources
 from mlflow.data.dataset import Dataset
 from mlflow.data.dataset_source import DatasetSource
@@ -11,6 +12,10 @@ from mlflow.entities import DatasetInput
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.utils.annotations import experimental
+
+with suppress(ImportError):
+    # Suppressing ImportError to pass mlflow-skinny testing.
+    from mlflow.data import meta_dataset  # noqa: F401
 
 
 @experimental
@@ -47,7 +52,7 @@ def get_source(dataset: Union[DatasetEntity, DatasetInput, Dataset]) -> DatasetS
     return dataset_source
 
 
-__all__ = ["get_source", "meta_dataset"]
+__all__ = ["get_source"]
 
 
 def _define_dataset_constructors_in_current_module():

--- a/mlflow/data/dataset.py
+++ b/mlflow/data/dataset.py
@@ -45,6 +45,9 @@ class Dataset:
 
         Subclasses should override this method to provide additional fields in the config dict,
         e.g., schema, profile, etc.
+
+        Returns a string dictionary containing the following fields: name, digest, source, source
+        type.
         """
         return {
             "name": self.name,

--- a/mlflow/data/dataset.py
+++ b/mlflow/data/dataset.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 from abc import abstractmethod
 from typing import Any, Dict, Optional
@@ -31,28 +30,20 @@ class Dataset:
 
     @abstractmethod
     def _compute_digest(self) -> str:
-        """Computes a digest for the dataset.
-
-        Called if the user doesn't supply a digest when constructing the dataset. Users can override
-        this method in subclasses to provide custom digest computation logic.
+        """Computes a digest for the dataset. Called if the user doesn't supply
+        a digest when constructing the dataset.
 
         Returns:
             A string digest for the dataset. We recommend a maximum digest length
             of 10 characters with an ideal length of 8 characters.
 
         """
-        config = {
-            "name": self.name,
-            "source": self.source.to_json(),
-            "source_type": self.source._get_source_type(),
-        }
-        return hashlib.md5(json.dumps(config).encode("utf-8")).hexdigest()[:8]
 
     @abstractmethod
     def to_dict(self) -> Dict[str, str]:
         """Create config dictionary for the dataset.
 
-        Subclasses should override this method to provide a additional fields in the config dict,
+        Subclasses should override this method to provide additional fields in the config dict,
         e.g., schema, profile, etc.
         """
         return {

--- a/mlflow/data/huggingface_dataset.py
+++ b/mlflow/data/huggingface_dataset.py
@@ -70,7 +70,11 @@ class HuggingFaceDataset(Dataset, PyFuncConvertibleDatasetMixin):
         return compute_pandas_digest(df)
 
     def to_dict(self) -> Dict[str, str]:
-        """Create config dictionary for the dataset."""
+        """Create config dictionary for the dataset.
+
+        Returns a string dictionary containing the following fields: name, digest, source, source
+        type, schema, and profile.
+        """
         schema = json.dumps({"mlflow_colspec": self.schema.to_dict()}) if self.schema else None
         config = super().to_dict()
         config.update(

--- a/mlflow/data/huggingface_dataset.py
+++ b/mlflow/data/huggingface_dataset.py
@@ -69,25 +69,17 @@ class HuggingFaceDataset(Dataset, PyFuncConvertibleDatasetMixin):
         )
         return compute_pandas_digest(df)
 
-    def _to_dict(self, base_dict: Dict[str, str]) -> Dict[str, str]:
-        """
-        Args:
-            base_dict: A string dictionary of base information about the
-                dataset, including: name, digest, source, and source
-                type.
-
-        Returns:
-            A string dictionary containing the following fields: name,
-            digest, source, source type, schema (optional), profile
-            (optional).
-        """
-        return {
-            **base_dict,
-            "schema": json.dumps({"mlflow_colspec": self.schema.to_dict()})
-            if self.schema
-            else None,
-            "profile": json.dumps(self.profile),
-        }
+    def to_dict(self) -> Dict[str, str]:
+        """Create config dictionary for the dataset."""
+        schema = json.dumps({"mlflow_colspec": self.schema.to_dict()}) if self.schema else None
+        config = super().to_dict()
+        config.update(
+            {
+                "schema": schema,
+                "profile": json.dumps(self.profile),
+            }
+        )
+        return config
 
     @property
     def ds(self) -> "datasets.Dataset":

--- a/mlflow/data/meta_dataset.py
+++ b/mlflow/data/meta_dataset.py
@@ -1,5 +1,5 @@
-import json
 import hashlib
+import json
 from typing import Any, Dict, Optional
 
 from mlflow.data.dataset import Dataset
@@ -74,7 +74,12 @@ class MetaDataset(Dataset):
         super().__init__(source=source, name=name, digest=digest)
 
     def _compute_digest(self) -> str:
-        """Computes a digest for the dataset."""
+        """Computes a digest for the dataset.
+
+        The digest computation of `MetaDataset` is based on the dataset's name, source, source type,
+        and schema instead of the actual data. Basically we compute the sha256 hash of the config
+        dict.
+        """
         config = {
             "name": self.name,
             "source": self.source.to_json(),
@@ -89,6 +94,11 @@ class MetaDataset(Dataset):
         return self._schema
 
     def to_dict(self) -> Dict[str, str]:
+        """Create config dictionary for the MetaDataset.
+
+        Returns a string dictionary containing the following fields: name, digest, source, source
+        type, schema, and profile.
+        """
         config = super().to_dict()
         if self.schema:
             schema = json.dumps({"mlflow_colspec": self.schema.to_dict()}) if self.schema else None

--- a/mlflow/data/meta_dataset.py
+++ b/mlflow/data/meta_dataset.py
@@ -1,0 +1,96 @@
+import json
+import hashlib
+from typing import Any, Dict, Optional
+
+from mlflow.data.dataset import Dataset
+from mlflow.data.dataset_source import DatasetSource
+from mlflow.types import Schema
+from mlflow.utils.annotations import experimental
+
+
+@experimental
+class MetaDataset(Dataset):
+    """Dataset that only contains metadata.
+
+    This class is used to represent a dataset that only contains metadata, which is useful when
+    users only want to log metadata to MLflow without logging the actual data. For example, users
+    build a custom dataset from a text file publicly hosted in the Internet, and they want to log
+    the text file's URL to MLflow for future tracking instead of the dataset itself.
+
+    Args:
+        source: dataset source of type `DatasetSource`, indicates where the data is from.
+        name: name of the dataset. If not specified, a name is automatically generated.
+        digest: digest (hash, fingerprint) of the dataset. If not specified, a digest is
+            automatically computed.
+        schame: schema of the dataset.
+
+    .. code-block:: python
+        :caption: Create a MetaDataset
+
+        import mlflow
+
+        mlflow.set_experiment("/test-mlflow-meta-dataset")
+
+        source = mlflow.data.http_dataset_source.HTTPDatasetSource(
+            url="https://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz"
+        )
+        ds = mlflow.data.meta_dataset.MetaDataset(source)
+
+        with mlflow.start_run() as run:
+            mlflow.log_input(ds)
+
+    .. code-block:: python
+        :caption: Create a MetaDataset with schema
+
+        import mlflow
+
+        mlflow.set_experiment("/test-mlflow-meta-dataset")
+
+        source = mlflow.data.http_dataset_source.HTTPDatasetSource(
+            url="https://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz"
+        )
+        schema = Schema(
+            [
+                ColSpec(type=mlflow.types.DataType.string, name="text"),
+                ColSpec(type=mlflow.types.DataType.integer, name="label"),
+            ]
+        )
+        ds = mlflow.data.meta_dataset.MetaDataset(source, schema=schema)
+
+        with mlflow.start_run() as run:
+            mlflow.log_input(ds)
+    """
+
+    def __init__(
+        self,
+        source: DatasetSource,
+        name: Optional[str] = None,
+        digest: Optional[str] = None,
+        schema: Optional[Schema] = None,
+    ):
+        # Set `self._schema` before calling the superclass constructor because
+        # `self._compute_digest` depends on `self._schema`.
+        self._schema = schema
+        super().__init__(source=source, name=name, digest=digest)
+
+    def _compute_digest(self) -> str:
+        """Computes a digest for the dataset."""
+        config = {
+            "name": self.name,
+            "source": self.source.to_json(),
+            "source_type": self.source._get_source_type(),
+            "schema": self.schema.to_dict() if self.schema else "",
+        }
+        return hashlib.sha256(json.dumps(config).encode("utf-8")).hexdigest()[:8]
+
+    @property
+    def schema(self) -> Optional[Any]:
+        """Returns the schema of the dataset."""
+        return self._schema
+
+    def to_dict(self) -> Dict[str, str]:
+        config = super().to_dict()
+        if self.schema:
+            schema = json.dumps({"mlflow_colspec": self.schema.to_dict()}) if self.schema else None
+            config["schema"] = schema
+        return config

--- a/mlflow/data/numpy_dataset.py
+++ b/mlflow/data/numpy_dataset.py
@@ -55,7 +55,7 @@ class NumpyDataset(Dataset, PyFuncConvertibleDatasetMixin):
 
     def to_dict(self) -> Dict[str, str]:
         """Create config dictionary for the dataset."""
-        schema = json.dumps({"mlflow_colspec": self.schema.to_dict()}) if self.schema else None
+        schema = json.dumps(self.schema.to_dict()) if self.schema else None
         config = super().to_dict()
         config.update(
             {

--- a/mlflow/data/numpy_dataset.py
+++ b/mlflow/data/numpy_dataset.py
@@ -53,22 +53,17 @@ class NumpyDataset(Dataset, PyFuncConvertibleDatasetMixin):
         """
         return compute_numpy_digest(self._features, self._targets)
 
-    def _to_dict(self, base_dict: Dict[str, str]) -> Dict[str, str]:
-        """
-        Args:
-            base_dict: A string dictionary of base information about the
-                dataset, including: name, digest, source, and source type.
-
-        Returns:
-            A string dictionary containing the following fields: name,
-            digest, source, source type, schema (optional), profile
-            (optional).
-        """
-        return {
-            **base_dict,
-            "schema": json.dumps(self.schema.to_dict()) if self.schema else None,
-            "profile": json.dumps(self.profile),
-        }
+    def to_dict(self) -> Dict[str, str]:
+        """Create config dictionary for the dataset."""
+        schema = json.dumps({"mlflow_colspec": self.schema.to_dict()}) if self.schema else None
+        config = super().to_dict()
+        config.update(
+            {
+                "schema": schema,
+                "profile": json.dumps(self.profile),
+            }
+        )
+        return config
 
     @property
     def source(self) -> DatasetSource:

--- a/mlflow/data/numpy_dataset.py
+++ b/mlflow/data/numpy_dataset.py
@@ -54,7 +54,11 @@ class NumpyDataset(Dataset, PyFuncConvertibleDatasetMixin):
         return compute_numpy_digest(self._features, self._targets)
 
     def to_dict(self) -> Dict[str, str]:
-        """Create config dictionary for the dataset."""
+        """Create config dictionary for the dataset.
+
+        Returns a string dictionary containing the following fields: name, digest, source, source
+        type, schema, and profile.
+        """
         schema = json.dumps(self.schema.to_dict()) if self.schema else None
         config = super().to_dict()
         config.update(

--- a/mlflow/data/pandas_dataset.py
+++ b/mlflow/data/pandas_dataset.py
@@ -70,7 +70,7 @@ class PandasDataset(Dataset, PyFuncConvertibleDatasetMixin):
         """
         return compute_pandas_digest(self._df)
 
-    def to_dict(self) -> Dict[str, str]:
+    def _to_dict(self) -> Dict[str, str]:
         """Create config dictionary for the dataset."""
         schema = json.dumps({"mlflow_colspec": self.schema.to_dict()}) if self.schema else None
         config = super().to_dict()

--- a/mlflow/data/pandas_dataset.py
+++ b/mlflow/data/pandas_dataset.py
@@ -70,24 +70,17 @@ class PandasDataset(Dataset, PyFuncConvertibleDatasetMixin):
         """
         return compute_pandas_digest(self._df)
 
-    def _to_dict(self, base_dict: Dict[str, str]) -> Dict[str, str]:
-        """
-        Args:
-            base_dict: A string dictionary of base information about the
-                dataset, including: name, digest, source, and source type.
-
-        Returns:
-            A string dictionary containing the following fields: name,
-            digest, source, source type, schema (optional), profile
-            (optional).
-        """
-        return {
-            **base_dict,
-            "schema": json.dumps({"mlflow_colspec": self.schema.to_dict()})
-            if self.schema
-            else None,
-            "profile": json.dumps(self.profile),
-        }
+    def to_dict(self) -> Dict[str, str]:
+        """Create config dictionary for the dataset."""
+        schema = json.dumps({"mlflow_colspec": self.schema.to_dict()}) if self.schema else None
+        config = super().to_dict()
+        config.update(
+            {
+                "schema": schema,
+                "profile": json.dumps(self.profile),
+            }
+        )
+        return config
 
     @property
     def df(self) -> pd.DataFrame:

--- a/mlflow/data/pandas_dataset.py
+++ b/mlflow/data/pandas_dataset.py
@@ -70,8 +70,12 @@ class PandasDataset(Dataset, PyFuncConvertibleDatasetMixin):
         """
         return compute_pandas_digest(self._df)
 
-    def _to_dict(self) -> Dict[str, str]:
-        """Create config dictionary for the dataset."""
+    def to_dict(self) -> Dict[str, str]:
+        """Create config dictionary for the dataset.
+
+        Returns a string dictionary containing the following fields: name, digest, source, source
+        type, schema, and profile.
+        """
         schema = json.dumps({"mlflow_colspec": self.schema.to_dict()}) if self.schema else None
         config = super().to_dict()
         config.update(

--- a/mlflow/data/spark_dataset.py
+++ b/mlflow/data/spark_dataset.py
@@ -57,24 +57,17 @@ class SparkDataset(Dataset, PyFuncConvertibleDatasetMixin):
         # and deterministic than hashing DataFrame records
         return compute_spark_df_digest(self._df)
 
-    def _to_dict(self, base_dict: Dict[str, str]) -> Dict[str, str]:
-        """
-        Args:
-            base_dict: A string dictionary of base information about the
-                dataset, including: name, digest, source, and source type.
-
-        Returns:
-            A string dictionary containing the following fields: name,
-            digest, source, source type, schema (optional), profile
-            (optional).
-        """
-        return {
-            **base_dict,
-            "schema": json.dumps({"mlflow_colspec": self.schema.to_dict()})
-            if self.schema
-            else None,
-            "profile": json.dumps(self.profile),
-        }
+    def to_dict(self) -> Dict[str, str]:
+        """Create config dictionary for the dataset."""
+        schema = json.dumps({"mlflow_colspec": self.schema.to_dict()}) if self.schema else None
+        config = super().to_dict()
+        config.update(
+            {
+                "schema": schema,
+                "profile": json.dumps(self.profile),
+            }
+        )
+        return config
 
     @property
     def df(self):

--- a/mlflow/data/spark_dataset.py
+++ b/mlflow/data/spark_dataset.py
@@ -58,7 +58,11 @@ class SparkDataset(Dataset, PyFuncConvertibleDatasetMixin):
         return compute_spark_df_digest(self._df)
 
     def to_dict(self) -> Dict[str, str]:
-        """Create config dictionary for the dataset."""
+        """Create config dictionary for the dataset.
+
+        Returns a string dictionary containing the following fields: name, digest, source, source
+        type, schema, and profile.
+        """
         schema = json.dumps({"mlflow_colspec": self.schema.to_dict()}) if self.schema else None
         config = super().to_dict()
         config.update(

--- a/mlflow/data/tensorflow_dataset.py
+++ b/mlflow/data/tensorflow_dataset.py
@@ -88,22 +88,17 @@ class TensorFlowDataset(Dataset, PyFuncConvertibleDatasetMixin):
             else compute_tensor_digest(self._features, self._targets)
         )
 
-    def _to_dict(self, base_dict: Dict[str, str]) -> Dict[str, str]:
-        """
-        Args:
-            base_dict: A string dictionary of base information about the
-                dataset, including: name, digest, source, and source type.
-
-        Returns:
-            A string dictionary containing the following fields: name,
-            digest, source, source type, schema (optional), profile
-            (optional).
-        """
-        return {
-            **base_dict,
-            "schema": json.dumps(self.schema.to_dict()) if self.schema else None,
-            "profile": json.dumps(self.profile),
-        }
+    def to_dict(self) -> Dict[str, str]:
+        """Create config dictionary for the dataset."""
+        schema = json.dumps(self.schema.to_dict()) if self.schema else None
+        config = super().to_dict()
+        config.update(
+            {
+                "schema": schema,
+                "profile": json.dumps(self.profile),
+            }
+        )
+        return config
 
     @property
     def data(self):

--- a/mlflow/data/tensorflow_dataset.py
+++ b/mlflow/data/tensorflow_dataset.py
@@ -89,7 +89,11 @@ class TensorFlowDataset(Dataset, PyFuncConvertibleDatasetMixin):
         )
 
     def to_dict(self) -> Dict[str, str]:
-        """Create config dictionary for the dataset."""
+        """Create config dictionary for the dataset.
+
+        Returns a string dictionary containing the following fields: name, digest, source, source
+        type, schema, and profile.
+        """
         schema = json.dumps(self.schema.to_dict()) if self.schema else None
         config = super().to_dict()
         config.update(

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -1,7 +1,5 @@
 import json
 
-from mlflow.data.dataset import Dataset
-from mlflow.data.http_dataset_source import HTTPDatasetSource
 from mlflow.types.schema import Schema
 
 from tests.resources.data.dataset import SampleDataset
@@ -42,16 +40,3 @@ def test_expected_name_is_used():
 
     dataset_with_name = SampleDataset(data_list=[1, 2, 3], source=source, name="testname")
     assert dataset_with_name.name == "testname"
-
-
-def test_create_dataset_from_only_source():
-    source_uri = "test:/my/test/uri"
-    source = HTTPDatasetSource(url=source_uri)
-    dataset = Dataset(source=source)
-
-    json_str = dataset.to_json()
-    parsed_json = json.loads(json_str)
-
-    assert parsed_json["digest"] != None
-    assert parsed_json["source"] == '{"url": "test:/my/test/uri"}'
-    assert parsed_json["source_type"] == "http"

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -1,5 +1,7 @@
 import json
 
+from mlflow.data.dataset import Dataset
+from mlflow.data.http_dataset_source import HTTPDatasetSource
 from mlflow.types.schema import Schema
 
 from tests.resources.data.dataset import SampleDataset
@@ -40,3 +42,16 @@ def test_expected_name_is_used():
 
     dataset_with_name = SampleDataset(data_list=[1, 2, 3], source=source, name="testname")
     assert dataset_with_name.name == "testname"
+
+
+def test_create_dataset_from_only_source():
+    source_uri = "test:/my/test/uri"
+    source = HTTPDatasetSource(url=source_uri)
+    dataset = Dataset(source=source)
+
+    json_str = dataset.to_json()
+    parsed_json = json.loads(json_str)
+
+    assert parsed_json["digest"] != None
+    assert parsed_json["source"] == '{"url": "test:/my/test/uri"}'
+    assert parsed_json["source_type"] == "http"

--- a/tests/data/test_meta_dataset.py
+++ b/tests/data/test_meta_dataset.py
@@ -58,18 +58,18 @@ def test_create_meta_dataset_from_source_with_schema(dataset_source_class, path)
 
 
 def test_meta_dataset_digest():
-    source = HTTPDatasetSource("test:/my/test/uri")
-    dataset1 = MetaDataset(source=source)
+    http_source = HTTPDatasetSource("test:/my/test/uri")
+    dataset1 = MetaDataset(source=http_source)
     schema = Schema(
         [
             ColSpec(type=DataType.long, name="foo"),
             ColSpec(type=DataType.integer, name="bar"),
         ]
     )
-    dataset2 = MetaDataset(source=source, schema=schema)
+    dataset2 = MetaDataset(source=http_source, schema=schema)
 
     assert dataset1.digest != dataset2.digest
 
-    source = DeltaDatasetSource("fake/path/to/delta")
-    dataset3 = MetaDataset(source=source)
+    delta_source = DeltaDatasetSource("fake/path/to/delta")
+    dataset3 = MetaDataset(source=delta_source)
     assert dataset1.digest != dataset3.digest

--- a/tests/data/test_meta_dataset.py
+++ b/tests/data/test_meta_dataset.py
@@ -1,12 +1,13 @@
 import json
+
 import pytest
 
-from mlflow.data.http_dataset_source import HTTPDatasetSource
 from mlflow.data.delta_dataset_source import DeltaDatasetSource
+from mlflow.data.http_dataset_source import HTTPDatasetSource
 from mlflow.data.huggingface_dataset_source import HuggingFaceDatasetSource
 from mlflow.data.meta_dataset import MetaDataset
-from mlflow.types.schema import Schema, ColSpec
 from mlflow.types import DataType
+from mlflow.types.schema import ColSpec, Schema
 
 
 @pytest.mark.parametrize(
@@ -24,7 +25,7 @@ def test_create_meta_dataset_from_source(dataset_source_class, path):
     json_str = dataset.to_json()
     parsed_json = json.loads(json_str)
 
-    assert parsed_json["digest"] != None
+    assert parsed_json["digest"] is not None
     assert path in parsed_json["source"]
     assert parsed_json["source_type"] == dataset_source_class._get_source_type()
 
@@ -50,7 +51,25 @@ def test_create_meta_dataset_from_source_with_schema(dataset_source_class, path)
     json_str = dataset.to_json()
     parsed_json = json.loads(json_str)
 
-    assert parsed_json["digest"] != None
+    assert parsed_json["digest"] is not None
     assert path in parsed_json["source"]
     assert parsed_json["source_type"] == dataset_source_class._get_source_type()
     assert json.loads(parsed_json["schema"])["mlflow_colspec"] == schema.to_dict()
+
+
+def test_meta_dataset_digest():
+    source = HTTPDatasetSource("test:/my/test/uri")
+    dataset1 = MetaDataset(source=source)
+    schema = Schema(
+        [
+            ColSpec(type=DataType.long, name="foo"),
+            ColSpec(type=DataType.integer, name="bar"),
+        ]
+    )
+    dataset2 = MetaDataset(source=source, schema=schema)
+
+    assert dataset1.digest != dataset2.digest
+
+    source = DeltaDatasetSource("fake/path/to/delta")
+    dataset3 = MetaDataset(source=source)
+    assert dataset1.digest != dataset3.digest

--- a/tests/data/test_meta_dataset.py
+++ b/tests/data/test_meta_dataset.py
@@ -1,0 +1,56 @@
+import json
+import pytest
+
+from mlflow.data.http_dataset_source import HTTPDatasetSource
+from mlflow.data.delta_dataset_source import DeltaDatasetSource
+from mlflow.data.huggingface_dataset_source import HuggingFaceDatasetSource
+from mlflow.data.meta_dataset import MetaDataset
+from mlflow.types.schema import Schema, ColSpec
+from mlflow.types import DataType
+
+
+@pytest.mark.parametrize(
+    ("dataset_source_class", "path"),
+    [
+        (HTTPDatasetSource, "test:/my/test/uri"),
+        (DeltaDatasetSource, "fake/path/to/delta"),
+        (HuggingFaceDatasetSource, "databricks/databricks-dolly-15k"),
+    ],
+)
+def test_create_meta_dataset_from_source(dataset_source_class, path):
+    source = dataset_source_class(path)
+    dataset = MetaDataset(source=source)
+
+    json_str = dataset.to_json()
+    parsed_json = json.loads(json_str)
+
+    assert parsed_json["digest"] != None
+    assert path in parsed_json["source"]
+    assert parsed_json["source_type"] == dataset_source_class._get_source_type()
+
+
+@pytest.mark.parametrize(
+    ("dataset_source_class", "path"),
+    [
+        (HTTPDatasetSource, "test:/my/test/uri"),
+        (DeltaDatasetSource, "fake/path/to/delta"),
+        (HuggingFaceDatasetSource, "databricks/databricks-dolly-15k"),
+    ],
+)
+def test_create_meta_dataset_from_source_with_schema(dataset_source_class, path):
+    source = dataset_source_class(path)
+    schema = Schema(
+        [
+            ColSpec(type=DataType.long, name="foo"),
+            ColSpec(type=DataType.integer, name="bar"),
+        ]
+    )
+    dataset = MetaDataset(source=source, schema=schema)
+
+    json_str = dataset.to_json()
+    parsed_json = json.loads(json_str)
+
+    assert parsed_json["digest"] != None
+    assert path in parsed_json["source"]
+    assert parsed_json["source_type"] == dataset_source_class._get_source_type()
+    assert json.loads(parsed_json["schema"])["mlflow_colspec"] == schema.to_dict()

--- a/tests/resources/data/dataset.py
+++ b/tests/resources/data/dataset.py
@@ -34,7 +34,7 @@ class SampleDataset(Dataset):
             hash_md5.update(hash_part)
         return base64.b64encode(hash_md5.digest()).decode("ascii")
 
-    def _to_dict(self, base_dict: Dict[str, str]) -> Dict[str, str]:
+    def to_dict(self) -> Dict[str, str]:
         """
         Args:
             base_dict: A string dictionary of base information about the
@@ -46,11 +46,14 @@ class SampleDataset(Dataset):
             digest, source, source type, schema (optional), profile
             (optional).
         """
-        return {
-            **base_dict,
-            "schema": json.dumps({"mlflow_colspec": self.schema.to_dict()}),
-            "profile": json.dumps(self.profile),
-        }
+        config = super().to_dict()
+        config.update(
+            {
+                "schema": json.dumps({"mlflow_colspec": self.schema.to_dict()}),
+                "profile": json.dumps(self.profile),
+            }
+        )
+        return config
 
     @property
     def data_list(self) -> List[int]:

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1277,14 +1277,14 @@ def test_log_input(tmp_path):
 def test_log_input_metadata_only():
     source_uri = "test:/my/test/uri"
     source = HTTPDatasetSource(url=source_uri)
-    dataset = mlflow.data.Dataset(source=source)
+    dataset = mlflow.data.meta_dataset.MetaDataset(source=source)
 
     with start_run() as run:
         mlflow.log_input(dataset, "train")
     dataset_inputs = MlflowClient().get_run(run.info.run_id).inputs.dataset_inputs
     assert len(dataset_inputs) == 1
     assert dataset_inputs[0].dataset.name == "dataset"
-    assert dataset_inputs[0].dataset.digest != None
+    assert dataset_inputs[0].dataset.digest is not None
     assert dataset_inputs[0].dataset.source_type == "http"
     assert json.loads(dataset_inputs[0].dataset.source) == {"url": source_uri}
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -15,6 +15,7 @@ import mlflow
 import mlflow.tracking.context.registry
 import mlflow.tracking.fluent
 from mlflow import MlflowClient
+from mlflow.data.http_dataset_source import HTTPDatasetSource
 from mlflow.data.pandas_dataset import from_pandas
 from mlflow.entities import (
     LifecycleStage,
@@ -1271,6 +1272,21 @@ def test_log_input(tmp_path):
     assert len(dataset_inputs[0].tags) == 1
     assert dataset_inputs[0].tags[0].key == mlflow_tags.MLFLOW_DATASET_CONTEXT
     assert dataset_inputs[0].tags[0].value == "train"
+
+
+def test_log_input_metadata_only():
+    source_uri = "test:/my/test/uri"
+    source = HTTPDatasetSource(url=source_uri)
+    dataset = mlflow.data.Dataset(source=source)
+
+    with start_run() as run:
+        mlflow.log_input(dataset, "train")
+    dataset_inputs = MlflowClient().get_run(run.info.run_id).inputs.dataset_inputs
+    assert len(dataset_inputs) == 1
+    assert dataset_inputs[0].dataset.name == "dataset"
+    assert dataset_inputs[0].dataset.digest != None
+    assert dataset_inputs[0].dataset.source_type == "http"
+    assert json.loads(dataset_inputs[0].dataset.source) == {"url": source_uri}
 
 
 def test_get_parent_run():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/11172?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11172/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11172
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Make it possible to log a dataset without loading anything. In more details, this is what happens under the hood:
- Allow constructing a dataset from only dataset source.
- Log all the metadata when calling `log_input`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
