### PR TITLE
Fix fixable `line-too-long`

### DIFF
--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -79,7 +79,8 @@ Failed to find a documentation preview for {args.commit_sha}.
 <details>
 <summary>More info</summary>
 
-- If the `ci/circleci: {build_doc_job_name}` job status is successful, you can see the preview with the following steps:
+- If the `ci/circleci: {build_doc_job_name}` job status is successful, you can see the preview with
+  the following steps:
   1. Click `Details`.
   2. Click `Artifacts`.
   3. Click `docs/build/html/index.html`.
@@ -102,7 +103,8 @@ Failed to find a documentation preview for {args.commit_sha}.
 
     # Post the artifact URL as a comment
     comment_body = f"""
-Documentation preview for {args.commit_sha} will be available when [this CircleCI job]({job_url}) completes successfully.
+Documentation preview for {args.commit_sha} will be available when [this CircleCI job]({job_url})
+completes successfully.
 
 - [Top page]({top_page})
 - [Changed pages]({changed_pages})

--- a/dev/ruff.py
+++ b/dev/ruff.py
@@ -19,7 +19,10 @@ def transform(stdout: str, is_maintainer: bool) -> str:
                 )
                 line = f"{line}. Run {command} to fix this error."
             else:
-                line = f"{line}. See https://docs.astral.sh/ruff/rules/{m.group(1)} for how to fix this error."
+                line = (
+                    f"{line}. See https://docs.astral.sh/ruff/rules/{m.group(1)} for how to fix "
+                    f"this error."
+                )
         transformed.append(line)
     return "\n".join(transformed)
 

--- a/mlflow/deployments/openai/__init__.py
+++ b/mlflow/deployments/openai/__init__.py
@@ -30,7 +30,8 @@ class OpenAIDeploymentClient(BaseDeploymentClient):
 
     .. seealso::
 
-        See https://mlflow.org/docs/latest/python_api/openai/index.html for other authentication methods.
+        See https://mlflow.org/docs/latest/python_api/openai/index.html for other authentication
+        methods.
 
     Then, create a deployment client and use it to interact with OpenAI endpoints:
 

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -387,13 +387,14 @@ class MlflowGatewayClient:
             limits: Limits (Array of dictionary) to set on the route. Each limit is defined by a
                 dictionary representing the limit details to be associated with the route. This
                 dictionary should define:
-                - renewal_period: a string representing the length of the window to enforce limit on
-                    (only supports "minute" for now).
+
+                - renewal_period: a string representing the length of the window to enforce limit
+                  on (only supports "minute" for now).
                 - calls: a non-negative integer representing the number of calls allowed per
-                    renewal_period (e.g., 10, 0, 55).
+                  renewal_period (e.g., 10, 0, 55).
                 - key: an optional string represents per route limit or per user limit ("user" for
-                    per user limit, "route" for per route limit, if not supplied, default to per
-                    route limit).
+                  per user limit, "route" for per route limit, if not supplied, default to per
+                  route limit).
 
         Returns:
             The returned data structure is a serialized representation of the `Limit`

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -388,12 +388,12 @@ class MlflowGatewayClient:
                 dictionary representing the limit details to be associated with the route. This
                 dictionary should define:
                 - renewal_period: a string representing the length of the window to enforce limit on
-                  (only supports "minute" for now). # pylint: disable=line-too-long
+                    (only supports "minute" for now).
                 - calls: a non-negative integer representing the number of calls allowed per
-                  renewal_period (e.g., 10, 0, 55). # pylint: disable=line-too-long
+                    renewal_period (e.g., 10, 0, 55).
                 - key: an optional string represents per route limit or per user limit ("user" for
-                  per user limit, "route" for per route limit, if not supplied, default to per
-                  route limit).
+                    per user limit, "route" for per route limit, if not supplied, default to per
+                    route limit).
 
         Returns:
             The returned data structure is a serialized representation of the `Limit`

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -387,9 +387,13 @@ class MlflowGatewayClient:
             limits: Limits (Array of dictionary) to set on the route. Each limit is defined by a
                 dictionary representing the limit details to be associated with the route. This
                 dictionary should define:
-                - renewal_period: a string representing the length of the window to enforce limit on (only supports "minute" for now). # pylint: disable=line-too-long
-                - calls: a non-negative integer representing the number of calls allowed per  renewal_period (e.g., 10, 0, 55). # pylint: disable=line-too-long
-                - key: an optional string represents per route limit or per user limit ("user" for per user limit, "route" for per route limit, if not supplied, default to per route limit). # pylint: disable=line-too-long
+                - renewal_period: a string representing the length of the window to enforce limit on
+                  (only supports "minute" for now). # pylint: disable=line-too-long
+                - calls: a non-negative integer representing the number of calls allowed per
+                  renewal_period (e.g., 10, 0, 55). # pylint: disable=line-too-long
+                - key: an optional string represents per route limit or per user limit ("user" for
+                  per user limit, "route" for per route limit, if not supplied, default to per
+                  route limit).
 
         Returns:
             The returned data structure is a serialized representation of the `Limit`

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -298,8 +298,8 @@ class DatabricksJobRunner:
             databricks_run_id: Integer Databricks job run ID.
 
         Returns:
-            `RunResultState <https://docs.databricks.com/api/latest/jobs.html#runresultstate>`_ or None if
-            the run is still active.
+            `RunResultState <https://docs.databricks.com/api/latest/jobs.html#runresultstate>`_ or
+            None if the run is still active.
         """
         res = self.jobs_runs_get(databricks_run_id)
         return res["state"].get("result_state", None)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2198,7 +2198,10 @@ def log_model(
 
 
                 with mlflow.start_run():
-                    model_info = mlflow.pyfunc.log_model(artifact_path="model", python_model=MyModel())  # noqa # pylint: disable=line-too-long
+                    model_info = mlflow.pyfunc.log_model(
+                        artifact_path="model",
+                        python_model=MyModel(),
+                    )
 
 
                 loaded_model = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)

--- a/mlflow/recipes/__init__.py
+++ b/mlflow/recipes/__init__.py
@@ -1,5 +1,3 @@
-# pylint: disable=line-too-long
-
 """
 MLflow Recipes is a framework that enables you to quickly develop high-quality models and deploy
 them to production. Compared to ad-hoc ML workflows, MLflow Recipes offers several major benefits:
@@ -21,8 +19,6 @@ them to production. Compared to ad-hoc ML workflows, MLflow Recipes offers sever
 
 For more information, see the :ref:`MLflow Recipes overview <recipes>`.
 """
-
-# pylint: enable=line-too-long
 
 from mlflow.recipes.recipe import Recipe
 

--- a/mlflow/recipes/cards/pandas_renderer.py
+++ b/mlflow/recipes/cards/pandas_renderer.py
@@ -259,7 +259,18 @@ def get_facets_polyfills() -> str:
         };
     })();
     """
-    return '!function(){let t=window.URL;window.URL=function(n,e){return"string"==typeof e&&e.startsWith("blob:")?new URL(e):new t(n,e)}}();'  # pylint: disable=line-too-long
+    return """
+!function() {
+  let t = window.URL;
+  window.URL = function(n, e) {
+    if (typeof e === "string" && e.startsWith("blob:")) {
+      return new URL(e);
+    } else {
+      return new t(n, e);
+    }
+  }
+}();
+"""
 
 
 def construct_facets_html(

--- a/mlflow/recipes/regression/v1/recipe.py
+++ b/mlflow/recipes/regression/v1/recipe.py
@@ -115,13 +115,20 @@ The recipe steps are defined as follows:
                 In Databricks, the **predict** step writes the output parquet/delta files to
                 DBFS.
 
-.. |'ingest' step definition in recipe.yaml| replace:: `'ingest' step definition in recipe.yaml <https://github.com/mlflow/recipes-regression-template/blob/main/recipe.yaml#L30>`__
-.. |'split' step definition in recipe.yaml| replace:: `'split' step definition in recipe.yaml <https://github.com/mlflow/recipes-regression-template/blob/main/recipe.yaml#L31-L39>`__
-.. |'register' step definition of recipe.yaml| replace:: `'register' step definition of recipe.yaml <https://github.com/mlflow/recipes-regression-template/blob/main/recipe.yaml#L57-L62>`__
-.. |'ingest_scoring' section in recipe.yaml| replace:: `'ingest_scoring' step definition in recipe.yaml <https://github.com/mlflow/recipes-regression-template/blob/main/recipe.yaml#L63>`__
-.. |'custom_metrics' section of recipe.yaml| replace:: `'custom_metrics' section of recipe.yaml <https://github.com/mlflow/recipes-regression-template/blob/main/recipe.yaml#L69-L73>`__
-.. |'validation_criteria' section of the 'evaluate' step definition in recipe.yaml| replace:: `'validation_criteria' section of the 'evaluate' step definition in recipe.yaml <https://github.com/mlflow/recipes-regression-template/blob/main/recipe.yaml#L54-L56>`__
-.. |'tuning' section of the 'train' step definition in recipe.yaml| replace:: `'tuning' section of the 'train' step definition in recipe.yaml <https://github.com/mlflow/recipes-regression-template/blob/main/recipe.yaml#L45>`__
+.. |'ingest' step definition in recipe.yaml|
+    replace:: `'ingest' step definition in recipe.yaml <https://github.com/mlflow/recipes-regression-template/blob/main/recipe.yaml#L30>`__
+.. |'split' step definition in recipe.yaml|
+    replace:: `'split' step definition in recipe.yaml <https://github.com/mlflow/recipes-regression-template/blob/main/recipe.yaml#L31-L39>`__
+.. |'register' step definition of recipe.yaml|
+    replace:: `'register' step definition of recipe.yaml <https://github.com/mlflow/recipes-regression-template/blob/main/recipe.yaml#L57-L62>`__
+.. |'ingest_scoring' section in recipe.yaml|
+    replace:: `'ingest_scoring' step definition in recipe.yaml <https://github.com/mlflow/recipes-regression-template/blob/main/recipe.yaml#L63>`__
+.. |'custom_metrics' section of recipe.yaml|
+    replace:: `'custom_metrics' section of recipe.yaml <https://github.com/mlflow/recipes-regression-template/blob/main/recipe.yaml#L69-L73>`__
+.. |'validation_criteria' section of the 'evaluate' step definition in recipe.yaml|
+    replace:: `'validation_criteria' section of the 'evaluate' step definition in recipe.yaml <https://github.com/mlflow/recipes-regression-template/blob/main/recipe.yaml#L54-L56>`__
+.. |'tuning' section of the 'train' step definition in recipe.yaml|
+    replace:: `'tuning' section of the 'train' step definition in recipe.yaml <https://github.com/mlflow/recipes-regression-template/blob/main/recipe.yaml#L45>`__
 .. |steps/ingest.py| replace:: `steps/ingest.py <https://github.com/mlflow/recipes-regression-template/blob/main/steps/ingest.py>`__
 .. |steps/split.py| replace:: `steps/split.py <https://github.com/mlflow/recipes-regression-template/blob/main/steps/split.py>`__
 .. |steps/train.py| replace:: `steps/train.py <https://github.com/mlflow/recipes-regression-template/blob/main/steps/train.py>`__

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -332,11 +332,11 @@ def _deploy(
                 :caption: Example
                     "AsyncInferenceConfig": {
                         "ClientConfig": {
-                            "MaxConcurrentInvocationsPerInstance": 4  # pylint: disable=line-too-long
+                            "MaxConcurrentInvocationsPerInstance": 4
                         },
                         "OutputConfig": {
-                            "S3OutputPath": "s3://<path-to-output-bucket>",  # pylint: disable=line-too-long
-                            "NotificationConfig": {},  # pylint: disable=line-too-long
+                            "S3OutputPath": "s3://<path-to-output-bucket>",
+                            "NotificationConfig": {},
                         },
                     }
         serverless_config: An optional dictionary specifying the serverless configuration
@@ -1694,7 +1694,7 @@ def _update_sagemaker_endpoint(
         role: SageMaker execution ARN role.
         sage_client: A boto3 client for SageMaker.
         s3_client: A boto3 client for S3.
-        variant_name: The name to assign to the new production variant if it doesn't already exist. # pylint: disable=line-too-long
+        variant_name: The name to assign to the new production variant if it doesn't already exist.
         async_inference_config: A dictionary specifying the async inference configuration to use.
             For more information, see https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_AsyncInferenceConfig.html.
             Defaults to ``None``.

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -196,7 +196,7 @@ class UcModelRegistryStore(BaseRestStore):
             GetModelVersionRequest: GetModelVersionResponse,
             SearchRegisteredModelsRequest: SearchRegisteredModelsResponse,
             GenerateTemporaryModelVersionCredentialsRequest: (
-                GenerateTemporaryModelVersionCredentialsResponse,
+                GenerateTemporaryModelVersionCredentialsResponse
             ),
             GetRun: GetRun.Response,
             SetRegisteredModelAliasRequest: SetRegisteredModelAliasResponse,

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -195,8 +195,9 @@ class UcModelRegistryStore(BaseRestStore):
             GetRegisteredModelRequest: GetRegisteredModelResponse,
             GetModelVersionRequest: GetModelVersionResponse,
             SearchRegisteredModelsRequest: SearchRegisteredModelsResponse,
-            # pylint: disable=line-too-long
-            GenerateTemporaryModelVersionCredentialsRequest: GenerateTemporaryModelVersionCredentialsResponse,
+            GenerateTemporaryModelVersionCredentialsRequest: (
+                GenerateTemporaryModelVersionCredentialsResponse,
+            ),
             GetRun: GetRun.Response,
             SetRegisteredModelAliasRequest: SetRegisteredModelAliasResponse,
             DeleteRegisteredModelAliasRequest: DeleteRegisteredModelAliasResponse,

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -388,7 +388,7 @@ def save_model(
                 sentence_pipeline = pipeline(
                     task=task,
                     tokenizer=AutoTokenizer.from_pretrained(architecture),
-                    model=architecture,  # pylint: disable=line-too-long
+                    model=architecture,
                 )
 
                 # Validate that the overrides function
@@ -794,7 +794,7 @@ def log_model(
                 sentence_pipeline = pipeline(
                     task=task,
                     tokenizer=AutoTokenizer.from_pretrained(architecture),
-                    model=architecture,  # pylint: disable=line-too-long
+                    model=architecture,
                 )
 
                 # Validate that the overrides function

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -634,7 +634,7 @@ def test_safe_patch_makes_expected_event_logging_calls_for_successful_patch_invo
     assert patch_success.exception is original_success.exception is None
 
 
-def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation_throws_and_original_succeeds(  # pylint: disable=line-too-long
+def test_safe_patch_makes_expected_event_logging_calls_when_patch_impl_throws_and_original_succeeds(
     patch_destination,
     test_autologging_integration,
     mock_event_logger,
@@ -674,7 +674,7 @@ def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation
         assert patch_error.exception == exc_to_raise
 
 
-def test_safe_patch_makes_expected_event_logging_calls_when_patch_implementation_throws_and_original_throws(  # pylint: disable=line-too-long
+def test_safe_patch_makes_expected_event_logging_calls_when_patch_impl_throws_and_original_throws(
     patch_destination,
     test_autologging_integration,
     mock_event_logger,

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -1016,7 +1016,7 @@ def test_make_genai_metric_metric_details():
 
     assert custom_metric.__str__() == (
         f"EvaluationMetric(name=correctness, greater_is_better=True, long_name=correctness, "
-        f"version=1, metric_details={expected_metric_details})"
+        f"version=v1, metric_details={expected_metric_details})"
     )
 
 

--- a/tests/metrics/genai/test_genai_metrics.py
+++ b/tests/metrics/genai/test_genai_metrics.py
@@ -1014,11 +1014,10 @@ def test_make_genai_metric_metric_details():
 
     assert custom_metric.metric_details == expected_metric_details
 
-    assert (
-        custom_metric.__str__()
-        == f"EvaluationMetric(name=correctness, greater_is_better=True, long_name=correctness, version=v1, metric_details={expected_metric_details})"
+    assert custom_metric.__str__() == (
+        f"EvaluationMetric(name=correctness, greater_is_better=True, long_name=correctness, "
+        f"version=1, metric_details={expected_metric_details})"
     )
-    # pylint: enable=line-too-long
 
 
 def test_make_genai_metric_without_example():

--- a/tests/resources/mlflow-test-plugin/setup.py
+++ b/tests/resources/mlflow-test-plugin/setup.py
@@ -12,31 +12,49 @@ setup(
         # Define a Tracking Store plugin for tracking URIs with scheme 'file-plugin'
         "mlflow.tracking_store": "file-plugin=mlflow_test_plugin.file_store:PluginFileStore",
         # Define a ArtifactRepository plugin for artifact URIs with scheme 'file-plugin'
-        "mlflow.artifact_repository": "file-plugin=mlflow_test_plugin.local_artifact:PluginLocalArtifactRepository",  # pylint: disable=line-too-long
+        "mlflow.artifact_repository": (
+            "file-plugin=mlflow_test_plugin.local_artifact:PluginLocalArtifactRepository"
+        ),
         # Define a RunContextProvider plugin. The entry point name for run context providers
         # is not used, and so is set to the string "unused" here
-        "mlflow.run_context_provider": "unused=mlflow_test_plugin.run_context_provider:PluginRunContextProvider",  # pylint: disable=line-too-long
+        "mlflow.run_context_provider": (
+            "unused=mlflow_test_plugin.run_context_provider:PluginRunContextProvider"
+        ),
         # Define a DefaultExperimentProvider plugin. The entry point name for
         # default experiment providers is not used, and so is set to the string "unused" here
-        "mlflow.default_experiment_provider": "unused=mlflow_test_plugin.default_experiment_provider:PluginDefaultExperimentProvider",  # pylint: disable=line-too-long
+        "mlflow.default_experiment_provider": (
+            "unused=mlflow_test_plugin.default_experiment_provider:PluginDefaultExperimentProvider"
+        ),
         # Define a RequestHeaderProvider plugin. The entry point name for request header providers
         # is not used, and so is set to the string "unused" here
-        "mlflow.request_header_provider": "unused=mlflow_test_plugin.request_header_provider:PluginRequestHeaderProvider",  # pylint: disable=line-too-long
+        "mlflow.request_header_provider": (
+            "unused=mlflow_test_plugin.request_header_provider:PluginRequestHeaderProvider"
+        ),
         # Define a RequestAuthProvider plugin. The entry point name for request auth providers
         # is not used, and so is set to the string "unused" here
-        "mlflow.request_auth_provider": "unused=mlflow_test_plugin.request_auth_provider:PluginRequestAuthProvider",  # pylint: disable=line-too-long
+        "mlflow.request_auth_provider": (
+            "unused=mlflow_test_plugin.request_auth_provider:PluginRequestAuthProvider"
+        ),
         # Define a Model Registry Store plugin for tracking URIs with scheme 'file-plugin'
-        "mlflow.model_registry_store": "file-plugin=mlflow_test_plugin.sqlalchemy_store:PluginRegistrySqlAlchemyStore",  # pylint: disable=line-too-long
+        "mlflow.model_registry_store": (
+            "file-plugin=mlflow_test_plugin.sqlalchemy_store:PluginRegistrySqlAlchemyStore"
+        ),
         # Define a MLflow Project Backend plugin called 'dummy-backend'
-        "mlflow.project_backend": "dummy-backend=mlflow_test_plugin.dummy_backend:PluginDummyProjectBackend",  # pylint: disable=line-too-long
+        "mlflow.project_backend": (
+            "dummy-backend=mlflow_test_plugin.dummy_backend:PluginDummyProjectBackend"
+        ),
         # Define a MLflow model deployment plugin for target 'faketarget'
         "mlflow.deployments": "faketarget=mlflow_test_plugin.fake_deployment_plugin",
         # Define a MLflow model evaluator with name "dummy_evaluator"
-        "mlflow.model_evaluator": "dummy_evaluator=mlflow_test_plugin.dummy_evaluator:DummyEvaluator",  # pylint: disable=line-too-long
+        "mlflow.model_evaluator": (
+            "dummy_evaluator=mlflow_test_plugin.dummy_evaluator:DummyEvaluator"
+        ),
         # Define a custom MLflow application with name custom_app
         "mlflow.app": "custom_app=mlflow_test_plugin.app:custom_app",
         # Define an MLflow dataset source called "dummy_source"
-        "mlflow.dataset_source": "dummy_source=mlflow_test_plugin.dummy_dataset_source:DummyDatasetSource",  # pylint: disable=line-too-long
+        "mlflow.dataset_source": (
+            "dummy_source=mlflow_test_plugin.dummy_dataset_source:DummyDatasetSource"
+        ),
         # Define an MLflow dataset constructor called "from_dummy"
         "mlflow.dataset_constructor": "from_dummy=mlflow_test_plugin.dummy_dataset:from_dummy",
     },

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -160,7 +160,7 @@ def test_init_artifact_uri(artifact_uri, expected_uri, expected_db_uri):
         ("dbfs:/databricks/mlflow-tracking/MOCK-EXP/MOCK-RUN-ID/artifacts", ""),
         ("dbfs:/databricks/mlflow-tracking/MOCK-EXP/MOCK-RUN-ID/artifacts/arty", "arty"),
         (
-            "dbfs://prof@databricks/databricks/mlflow-tracking/MOCK-EXP/MOCK-RUN-ID/artifacts/arty",  # pylint: disable=line-too-long
+            "dbfs://prof@databricks/databricks/mlflow-tracking/MOCK-EXP/MOCK-RUN-ID/artifacts/arty",
             "arty",
         ),
         (

--- a/tests/store/tracking/test_sqlalchemy_store_schema.py
+++ b/tests/store/tracking/test_sqlalchemy_store_schema.py
@@ -139,7 +139,8 @@ def test_create_index_on_run_uuid(tmp_path, db_url):
 
 
 def test_index_for_dataset_tables(tmp_path, db_url):
-    # Test for mlflow/store/db_migrations/versions/7f2a7d5fae7d_add_datasets_inputs_input_tags_tables.py # pylint: disable=line-too-long
+    # Test for
+    # mlflow/store/db_migrations/versions/7f2a7d5fae7d_add_datasets_inputs_input_tags_tables.py
     SqlAlchemyStore(db_url, tmp_path.joinpath("ARTIFACTS").as_uri())
     with sqlite3.connect(db_url[len("sqlite:///") :]) as conn:
         cursor = conn.cursor()

--- a/tests/tracking/default_experiment/test_registry.py
+++ b/tests/tracking/default_experiment/test_registry.py
@@ -62,7 +62,9 @@ def test_default_experiment_provider_registry_register_entrypoints_handles_excep
 def _currently_registered_default_experiment_provider_classes():
     return {
         provider.__class__
-        for provider in mlflow.tracking.default_experiment.registry._default_experiment_provider_registry  # pylint: disable=line-too-long
+        for provider in (
+            mlflow.tracking.default_experiment.registry._default_experiment_provider_registry
+        )
     }
 
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -737,8 +737,8 @@ def _assert_get_artifact_uri_appends_to_uri_path_component_correctly(
             "mysql://user:password@host:port/dbname/{run_id}/artifacts/{path}?driver=mydriver",
         ),
         (
-            "mysql+driver://user:password@host:port/dbname/subpath/#fragment",
-            "mysql+driver://user:password@host:port/dbname/subpath/{run_id}/artifacts/{path}#fragment",  # pylint: disable=line-too-long
+            "mysql+driver://user:pass@host:port/dbname/subpath/#fragment",
+            "mysql+driver://user:pass@host:port/dbname/subpath/{run_id}/artifacts/{path}#fragment",
         ),
         ("s3://bucketname/rootpath", "s3://bucketname/rootpath/{run_id}/artifacts/{path}"),
     ],


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

I want to remove pylint because it's slow. To remove pylint, we need fix lines violating ruff's line-too-long (E501). This PR fixes lines that can be fixed easily.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
