### PR TITLE
Remove `warnings.filterwarnings` for numpy

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -29,18 +29,6 @@ For a lower level API, see the :py:mod:`mlflow.client` module.
 """
 import contextlib
 
-# Filter annoying Cython warnings that serve no good purpose, and so before
-# importing other modules.
-# See: https://github.com/numpy/numpy/pull/432/commits/170ed4e33d6196d7
-import warnings
-
-from mlflow.utils.lazy_load import LazyLoader
-from mlflow.utils.logging_utils import _configure_mlflow_loggers
-from mlflow.version import VERSION as __version__  # noqa: F401
-
-warnings.filterwarnings("ignore", message="numpy.dtype size changed")
-warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
-
 from mlflow import (
     artifacts,  # noqa: F401
     client,  # noqa: F401
@@ -50,6 +38,9 @@ from mlflow import (
     projects,  # noqa: F401
     tracking,  # noqa: F401
 )
+from mlflow.utils.lazy_load import LazyLoader
+from mlflow.utils.logging_utils import _configure_mlflow_loggers
+from mlflow.version import VERSION as __version__  # noqa: F401
 
 # Lazily load mlflow flavors to avoid excessive dependencies.
 catboost = LazyLoader("mlflow.catboost", globals(), "mlflow.catboost")

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -29,6 +29,10 @@ For a lower level API, see the :py:mod:`mlflow.client` module.
 """
 import contextlib
 
+from mlflow.version import VERSION
+
+__version__ = VERSION
+
 from mlflow import (
     artifacts,  # noqa: F401
     client,  # noqa: F401
@@ -40,7 +44,6 @@ from mlflow import (
 )
 from mlflow.utils.lazy_load import LazyLoader
 from mlflow.utils.logging_utils import _configure_mlflow_loggers
-from mlflow.version import VERSION as __version__  # noqa: F401
 
 # Lazily load mlflow flavors to avoid excessive dependencies.
 catboost = LazyLoader("mlflow.catboost", globals(), "mlflow.catboost")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11179?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11179/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11179
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

https://github.com/mlflow/mlflow/pull/317 added the following lines for #432:

```python
warnings.filterwarnings("ignore", message="numpy.dtype size changed")
warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
```

MLflow doesn't have to suppress warnings Cython/numpy emits. That's not mlflow's business.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
