### PR TITLE
Fix false warning for missing signature in Databricks

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -21,6 +21,7 @@ from mlflow.tracking._tracking_service.utils import _resolve_tracking_uri
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri, _upload_artifact_to_uri
 from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import get_databricks_runtime
+from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
     _REQUIREMENTS_FILE_NAME,
@@ -566,6 +567,7 @@ class Model:
 
         return cls(**model_dict)
 
+    @format_docstring(LOG_MODEL_PARAM_DOCS)
     @classmethod
     def log(
         cls,
@@ -589,32 +591,8 @@ class Model:
             registered_model_name: If given, create a model version under
                 ``registered_model_name``, also creating a registered model if
                 one with the given name does not exist.
-            signature: :py:class:`ModelSignature` describes model input
-                and output :py:class:`Schema <mlflow.types.Schema>`. The model signature
-                can be :py:func:`inferred <infer_signature>` from datasets representing
-                valid model input (e.g. the training dataset) and valid model output
-                (e.g. model predictions generated on the training dataset), for example:
-
-                .. code-block:: python
-
-                    from mlflow.models import infer_signature
-
-                    train = df.drop_column("target_label")
-                    signature = infer_signature(train, model.predict(train))
-
-            input_example: one or several instances of valid model input. The input example is
-                used as a hint of what data to feed the model. It will be converted to
-                a Pandas DataFrame and then serialized to json using the Pandas
-                split-oriented format, or a numpy array where the example will be
-                serialized to json by converting it to a list. If input example is a
-                tuple, then the first element must be a valid model input, and the
-                second element must be a valid params dictionary that can optionally
-                be used during model inference. Bytes are base64-encoded. When the
-                ``signature`` parameter is ``None``, the input example is used to infer
-                a model's signature. If an input example containing params is provided,
-                and signature is inferred from the input example, then params will be
-                used as default params during model inference if no extra params are
-                passed at inference time.
+            signature: {{ signature }}
+            input_example: {{ input_example }}
             await_registration_for: Number of seconds to wait for the model version to finish
                 being created and is in ``READY`` status. By default, the
                 function waits for five minutes. Specify 0 or None to skip
@@ -634,14 +612,14 @@ class Model:
             if run_id is None:
                 run_id = mlflow.tracking.fluent._get_or_start_run().info.run_id
             mlflow_model = cls(artifact_path=artifact_path, run_id=run_id, metadata=metadata)
+            flavor.save_model(path=local_path, mlflow_model=mlflow_model, **kwargs)
             tracking_uri = _resolve_tracking_uri()
-            if (
-                (tracking_uri == "databricks" or get_uri_scheme(tracking_uri) == "databricks")
-                and kwargs.get("signature") is None
-                and kwargs.get("input_example") is None
+            # We check signature presence here as some flavors have a default signature as a
+            # fallback when not provided by user, which is set during flavor's save_model() call.
+            if getattr(mlflow_model, "signature") is None and (
+                tracking_uri == "databricks" or get_uri_scheme(tracking_uri) == "databricks"
             ):
                 _logger.warning(_LOG_MODEL_MISSING_SIGNATURE_WARNING)
-            flavor.save_model(path=local_path, mlflow_model=mlflow_model, **kwargs)
             mlflow.tracking.fluent.log_artifacts(local_path, mlflow_model.artifact_path, run_id)
             try:
                 mlflow.tracking.fluent._record_logged_model(mlflow_model, run_id)

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -616,7 +616,7 @@ class Model:
             tracking_uri = _resolve_tracking_uri()
             # We check signature presence here as some flavors have a default signature as a
             # fallback when not provided by user, which is set during flavor's save_model() call.
-            if getattr(mlflow_model, "signature") is None and (
+            if mlflow_model.signature is None and (
                 tracking_uri == "databricks" or get_uri_scheme(tracking_uri) == "databricks"
             ):
                 _logger.warning(_LOG_MODEL_MISSING_SIGNATURE_WARNING)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11181?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11181/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11181
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

During testing PEFT support on Databricks notebook, realize that the missing signature warning is raised even though it was logged to the model.
```
2024/02/19 08:56:52 WARNING mlflow.models.model: Model logged without a signature. Signatures will be required for upcoming model registry features as they validate model inputs and denote the expected schema of model outputs. Please visit https://www.mlflow.org/docs/2.10.3/models.html#set-signature-on-logged-model for instructions on setting a model signature on your logged model.
```

Turns out that MLflow only checks if user specifies signature or not, meaning that it warns even when we have default fallback signature. Fixing the validation logic to check the final signature after flavor's `save_model` is called.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested in DB notebook and confirm the warning is not raised for Transformer model with default signature fallback.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
