### PR TITLE
Skip requirement inference for PEFT model

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -7,6 +7,7 @@ import binascii
 import contextlib
 import copy
 import functools
+import importlib
 import json
 import logging
 import os
@@ -161,31 +162,6 @@ _PROMPT_TEMPLATE_RETURN_FULL_TEXT_INFO = (
 _logger = logging.getLogger(__name__)
 
 
-def _model_packages(model) -> List[str]:
-    """
-    Determines which pip libraries should be included based on the base model engine type.
-
-    Args:
-        model: The model instance to be saved in order to provide the required underlying
-            deep learning execution framework dependency requirements.
-
-    Returns:
-        A list of strings representing the underlying engine-specific dependencies
-    """
-    engine = _get_engine_type(model)
-    if engine == "torch":
-        packages = ["torch", "torchvision"]
-        try:
-            import accelerate  # noqa: F401
-
-            packages.append("accelerate")
-        except ImportError:
-            pass
-        return packages
-    else:
-        return [engine]
-
-
 @experimental
 def get_default_pip_requirements(model) -> List[str]:
     """
@@ -199,20 +175,28 @@ def get_default_pip_requirements(model) -> List[str]:
         ``transformers`` flavor. Calls to :py:func:`save_model()` and :py:func:`log_model()`
         produce a pip environment that contain these requirements at a minimum.
     """
+    packages = ["transformers"]
+
     try:
-        base_reqs = ["transformers", *_model_packages(model)]
-        return [_get_pinned_requirement(module) for module in base_reqs]
+        engine = _get_engine_type(model)
+        packages.append(engine)
     except Exception as e:
-        dependencies = [
-            _get_pinned_requirement(module)
-            for module in ["transformers", "torch", "torchvision", "tensorflow"]
-        ]
+        packages += ["torch", "tensorflow"]
         _logger.warning(
             "Could not infer model execution engine type due to huggingface_hub not "
-            "being installed or unable to connect in online mode. Adding full "
-            f"dependency chain: {dependencies}. \nFailure cause: {e}"
+            "being installed or unable to connect in online mode. Adding both Pytorch"
+            f"and Tensorflow to requirements.\nFailure cause: {e}"
         )
-        return dependencies
+
+    if "torch" in packages:
+        packages.append("torchvision")
+        if importlib.util.find_spec("accelerate"):
+            packages.append("accelerate")
+
+    if is_peft_model(model):
+        packages.append("peft")
+
+    return [_get_pinned_requirement(module) for module in packages]
 
 
 def _validate_transformers_model_dict(transformers_model):
@@ -654,11 +638,17 @@ def save_model(
     if conda_env is None:
         if pip_requirements is None:
             default_reqs = get_default_pip_requirements(built_pipeline.model)
-            # Infer the pip requirements with a timeout to avoid hanging indefinitely at prediction
-            inferred_reqs = infer_pip_requirements_with_timeout(
-                str(path), FLAVOR_NAME, fallback=default_reqs
-            )
-            default_reqs = sorted(set(inferred_reqs).union(default_reqs))
+            # NB: Skip inferring requirements for PEFT models to avoid loading the full pretrained
+            # model into memory. PEFT is mainly designed for fine-tuning large models under limited
+            # computational resources, so loading the full model is not preferred and can even crash
+            # the process due to OOM.
+            if not is_peft_model(built_pipeline.model):
+                # Infer the pip requirements with a timeout to avoid hanging at prediction
+                inferred_reqs = infer_pip_requirements_with_timeout(
+                    str(path), FLAVOR_NAME, fallback=default_reqs
+                )
+                default_reqs = set(inferred_reqs).union(default_reqs)
+            default_reqs = sorted(default_reqs)
         else:
             default_reqs = None
         conda_env, pip_requirements, pip_constraints = _process_pip_requirements(

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -55,10 +55,8 @@ from tests.helper_functions import (
     assert_register_model_called_with_local_model_path,
     pyfunc_serve_and_score_model,
 )
-from tests.transformers.helper import (
-    IS_NEW_FEATURE_EXTRACTION_API,
-    flaky,
-)
+from tests.transformers.helper import IS_NEW_FEATURE_EXTRACTION_API, flaky
+from tests.transformers.test_transformers_peft_model import SKIP_IF_PEFT_NOT_AVAILABLE
 
 _IS_PIPELINE_DTYPE_SUPPORTED_VERSION = Version(transformers.__version__) >= Version("4.26.1")
 
@@ -130,34 +128,31 @@ def read_raw_audio_file():
     return datasets_path.joinpath("apollo11_launch.wav").read_bytes()
 
 
-def test_dependencies_pytorch(small_qa_pipeline):
-    pip_requirements = get_default_pip_requirements(small_qa_pipeline.model)
-    expected_requirments = {"transformers", "torch", "torchvision"}
-    assert {package.split("=")[0] for package in pip_requirements}.intersection(
-        expected_requirments
-    ) == expected_requirments
-    conda_requirements = get_default_conda_env(small_qa_pipeline.model)
-    pip_in_conda = {
-        package.split("=")[0] for package in conda_requirements["dependencies"][2]["pip"]
-    }
-    expected_conda = {"mlflow"}
-    expected_conda.update(expected_requirments)
-    assert pip_in_conda.intersection(expected_conda) == expected_conda
+@pytest.mark.parametrize(
+    ("pipeline", "expected_requirements"),
+    [
+        ("small_qa_pipeline", {"transformers", "torch", "torchvision"}),
+        ("small_seq2seq_pipeline", {"transformers", "tensorflow"}),
+        pytest.param(
+            "peft_pipeline",
+            {"peft", "transformers", "torch", "torchvision"},
+            marks=SKIP_IF_PEFT_NOT_AVAILABLE,
+        ),
+    ],
+)
+def test_default_requirements(pipeline, expected_requirements, request):
+    if "torch" in expected_requirements and importlib.util.find_spec("accelerate"):
+        expected_requirements.add("accelerate")
 
+    model = request.getfixturevalue(pipeline).model
+    pip_requirements = get_default_pip_requirements(model)
+    conda_requirements = get_default_conda_env(model)["dependencies"][2]["pip"]
 
-def test_dependencies_tensorflow(small_seq2seq_pipeline):
-    pip_requirements = get_default_pip_requirements(small_seq2seq_pipeline.model)
-    expected_requirments = {"transformers", "tensorflow"}
-    assert {package.split("=")[0] for package in pip_requirements}.intersection(
-        expected_requirments
-    ) == expected_requirments
-    conda_requirements = get_default_conda_env(small_seq2seq_pipeline.model)
-    pip_in_conda = {
-        package.split("=")[0] for package in conda_requirements["dependencies"][2]["pip"]
-    }
-    expected_conda = {"mlflow"}
-    expected_conda.update(expected_requirments)
-    assert pip_in_conda.intersection(expected_conda) == expected_conda
+    def _strip_requirements(requirements):
+        return {req.split("==")[0] for req in requirements}
+
+    assert _strip_requirements(pip_requirements) == expected_requirements
+    assert _strip_requirements(conda_requirements) == (expected_requirements | {"mlflow"})
 
 
 def test_inference_task_validation(small_seq2seq_pipeline, text_generation_pipeline):

--- a/tests/transformers/test_transformers_peft_model.py
+++ b/tests/transformers/test_transformers_peft_model.py
@@ -8,15 +8,14 @@ import mlflow
 from mlflow.models import Model
 from mlflow.transformers.peft import get_peft_base_model, is_peft_model
 
-from tests.transformers.test_transformers_model_export import HF_COMMIT_HASH_PATTERN
-
-pytestmark = pytest.mark.skipif(
+SKIP_IF_PEFT_NOT_AVAILABLE = pytest.mark.skipif(
     (
         importlib.util.find_spec("peft") is None
         or Version(transformers.__version__) <= Version("4.25.1")
     ),
     reason="PEFT is not installed or Transformer version is too old",
 )
+pytestmark = SKIP_IF_PEFT_NOT_AVAILABLE
 
 
 def test_is_peft_model(peft_pipeline, small_qa_pipeline):
@@ -47,6 +46,8 @@ def test_get_peft_base_model_prompt_learning(small_qa_pipeline):
 
 def test_save_and_load_peft_pipeline(peft_pipeline, tmp_path):
     import peft
+
+    from tests.transformers.test_transformers_model_export import HF_COMMIT_HASH_PATTERN
 
     mlflow.transformers.save_model(
         transformers_model=peft_pipeline,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11184?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11184/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11184
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Pip requirement inference calls `mlflow.pyfunc.load_model()` for the model to be logged, which loads a full copy of the model weight onto the memory in a subprocess. This is not preferable for PEFT use case as it is designed for fine-tuning large model under limited GPU memory. At worst case, it crashes the training process due to OOM. Also it is common technique to use lower precision for the base model during fine-tuning ([QLoRA](https://github.com/artidoro/qlora)), but the requirement inference always use the default precision, leading to much larger GPU memory than required for fine-tuning itself.

Ideally, we can implement more light-weight inference logic, for example, patch model loading method, but it needs to be designed more carefully not to cause regression. The default requirements should work for most of the PEFT use cases, because there is very little space for users to write custom inference logic over PEFT's abstraction.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

This behavior will be added to documentation in follow-up.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
