### PR TITLE
Suppress pipeline construction error message for PEFT model

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -107,6 +107,7 @@ from mlflow.utils.environment import (
     infer_pip_requirements_with_timeout,
 )
 from mlflow.utils.file_utils import TempDir, get_total_file_size, write_to
+from mlflow.utils.logging_utils import suppress_logs
 from mlflow.utils.model_utils import (
     _add_code_from_conf_to_system_path,
     _download_artifact_from_uri,
@@ -121,6 +122,10 @@ from mlflow.utils.requirements_utils import _get_pinned_requirement
 if TYPE_CHECKING:
     from transformers import Pipeline
 
+# Transformers pipeline complains that PeftModel is not supported for any task type, even
+# when the wrapped model is supported. As MLflow require users to use pipeline for logging,
+# we should suppress that confusing error message.
+_PEFT_PIPELINE_ERROR_MSG = r"The model '(PeftModel[^']*)' is not supported for ([^.]+)\."
 
 FLAVOR_NAME = "transformers"
 
@@ -1318,7 +1323,8 @@ def _build_pipeline_from_model_input(model_dict: Dict[str, Any], task: Optional[
         task = get_task(model_dict[FlavorKey.MODEL].name_or_path)
 
     try:
-        return pipeline(task=task, **model_dict)
+        with suppress_logs("transformers.pipelines.base", filter_regex=_PEFT_PIPELINE_ERROR_MSG):
+            return pipeline(task=task, **model_dict)
     except Exception as e:
         raise MlflowException(
             "The provided model configuration cannot be created as a Pipeline. "

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1191,7 +1191,8 @@ def _load_model(path: str, flavor_config, return_type: str, device=None, **kwarg
 
     if return_type == "pipeline":
         conf.update(**kwargs)
-        return transformers.pipeline(**conf)
+        with suppress_logs("transformers.pipelines.base", filter_regex=_PEFT_PIPELINE_ERROR_MSG):
+            return transformers.pipeline(**conf)
     elif return_type == "components":
         return conf
 

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -125,7 +125,7 @@ if TYPE_CHECKING:
 # Transformers pipeline complains that PeftModel is not supported for any task type, even
 # when the wrapped model is supported. As MLflow require users to use pipeline for logging,
 # we should suppress that confusing error message.
-_PEFT_PIPELINE_ERROR_MSG = r"The model '(PeftModel[^']*)' is not supported for ([^.]+)\."
+_PEFT_PIPELINE_ERROR_MSG = re.compile(r"The model 'PeftModel[^']*' is not supported for")
 
 FLAVOR_NAME = "transformers"
 

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -92,9 +92,9 @@ def eprint(*args, **kwargs):
 
 
 class LoggerMessageFilter(logging.Filter):
-    def __init__(self, module: str, filter_regex: str):
+    def __init__(self, module: str, filter_regex: re.Pattern):
         super().__init__()
-        self._pattern = re.compile(filter_regex)
+        self._pattern = filter_regex
         self._module = module
 
     def filter(self, record):
@@ -104,7 +104,7 @@ class LoggerMessageFilter(logging.Filter):
 
 
 @contextlib.contextmanager
-def suppress_logs(module: str, filter_regex: str):
+def suppress_logs(module: str, filter_regex: re.Pattern):
     """
     Context manager that suppresses log messages from the specified module that match the specified
     regular expression. This is useful for suppressing expected log messages from third-party

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -1,5 +1,7 @@
+import contextlib
 import logging
 import logging.config
+import re
 import sys
 
 # Logging format example:
@@ -87,3 +89,31 @@ def _configure_mlflow_loggers(root_module_name):
 
 def eprint(*args, **kwargs):
     print(*args, file=MLFLOW_LOGGING_STREAM, **kwargs)  # pylint: disable=print-function
+
+
+class LoggerMessageFilter(logging.Filter):
+    def __init__(self, module: str, filter_regex: str):
+        super().__init__()
+        self._pattern = re.compile(filter_regex)
+        self._module = module
+
+    def filter(self, record):
+        if record.name == self._module and self._pattern.search(record.msg):
+            return False
+        return True
+
+
+@contextlib.contextmanager
+def suppress_logs(module: str, filter_regex: str):
+    """
+    Context manager that suppresses log messages from the specified module that match the specified
+    regular expression. This is useful for suppressing expected log messages from third-party
+    libraries that are not relevant to the current test.
+    """
+    logger = logging.getLogger(module)
+    filter = LoggerMessageFilter(module=module, filter_regex=filter_regex)
+    logger.addFilter(filter)
+    try:
+        yield
+    finally:
+        logger.removeFilter(filter)

--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -7,6 +7,9 @@ from functools import wraps
 import transformers
 from packaging.version import Version
 
+from mlflow.transformers import _PEFT_PIPELINE_ERROR_MSG
+from mlflow.utils.logging_utils import suppress_logs
+
 _logger = logging.getLogger(__name__)
 
 transformers_version = Version(transformers.__version__)
@@ -278,7 +281,10 @@ def load_peft_pipeline():
         task_type=TaskType.SEQ_CLS, inference_mode=False, r=8, lora_alpha=32, lora_dropout=0.1
     )
     peft_model = get_peft_model(base_model, peft_config)
-    return transformers.pipeline(task="text-classification", model=peft_model, tokenizer=tokenizer)
+    with suppress_logs("transformers.pipelines.base", filter_regex=_PEFT_PIPELINE_ERROR_MSG):
+        return transformers.pipeline(
+            task="text-classification", model=peft_model, tokenizer=tokenizer
+        )
 
 
 def prefetch_models():

--- a/tests/transformers/test_transformers_peft_model.py
+++ b/tests/transformers/test_transformers_peft_model.py
@@ -73,7 +73,7 @@ def test_save_and_load_peft_pipeline(peft_pipeline, tmp_path):
     loaded_pipeline.predict("Hi")
 
 
-def test_save_and_load_peft_components(peft_pipeline, tmp_path):
+def test_save_and_load_peft_components(peft_pipeline, tmp_path, capsys):
     from peft import PeftModel
 
     mlflow.transformers.save_model(
@@ -83,6 +83,12 @@ def test_save_and_load_peft_components(peft_pipeline, tmp_path):
         },
         path=tmp_path,
     )
+
+    # PEFT pipeline construction error should not be raised
+    peft_err_msg = (
+        "The model 'PeftModelForSequenceClassification' is not supported for text-classification"
+    )
+    assert peft_err_msg not in capsys.readouterr().err
 
     loaded_pipeline = mlflow.transformers.load_model(tmp_path)
     assert isinstance(loaded_pipeline.model, PeftModel)

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import sys
 from io import StringIO
 
@@ -123,6 +124,6 @@ def test_suppress_logs():
     assert message in capture_stream.getvalue()
 
     capture_stream.truncate(0)
-    with suppress_logs(module, "This .* be suppressed."):
+    with suppress_logs(module, re.compile("This .* be suppressed.")):
         logger.error(message)
     assert len(capture_stream.getvalue()) == 0

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -1,11 +1,12 @@
 import logging
 import sys
+from io import StringIO
 
 import pytest
 
 import mlflow
 from mlflow.utils import logging_utils
-from mlflow.utils.logging_utils import eprint
+from mlflow.utils.logging_utils import eprint, suppress_logs
 
 logger = logging.getLogger(mlflow.__name__)
 
@@ -106,3 +107,22 @@ def test_debug_logs_emitted_correctly_when_configured():
     logger.setLevel(logging.DEBUG)
     logger.debug("test debug")
     assert "test debug" in stream.content
+
+
+def test_suppress_logs():
+    module = "test_logger"
+    logger = logging.getLogger(module)
+
+    message = "This message should be suppressed."
+
+    capture_stream = StringIO()
+    stream_handler = logging.StreamHandler(capture_stream)
+    logger.addHandler(stream_handler)
+
+    logger.error(message)
+    assert message in capture_stream.getvalue()
+
+    capture_stream.truncate(0)
+    with suppress_logs(module, "This .* be suppressed."):
+        logger.error(message)
+    assert len(capture_stream.getvalue()) == 0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11187?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11187/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11187
```

</p>
</details>

### What changes are proposed in this pull request?

Transformers pipeline emits the following error message when a pipeline is constructed with a PEFT model.

> The model 'PeftModelForCausalLM' is not supported for text-generation. Supported models are ['BartForCausalLM', 'BertLMHeadModel', ...

This is (mostly) false alert because PEFT model works equally as the wrapped model that is supported by the pipeline. This message is emitted as error log ([source](https://github.com/huggingface/transformers/blob/main/src/transformers/pipelines/base.py#L1042-L1045)) but it doesn't block us to create pipeline. We can simply suppress that error to avoid confusion. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
