### PR TITLE
Update serving docs for LLM flat dict input

### DIFF
--- a/docs/source/deployment/deploy-model-locally.rst
+++ b/docs/source/deployment/deploy-model-locally.rst
@@ -166,20 +166,20 @@ the required payload format, you can leverage the dict payload structures below.
       - 
         .. code-block:: python
 
-          {"inputs": {"messages": [{"role": "user", "content": "Tell a joke!"}]}}
+          {"inputs": [["Cheese"], ["and", "Crackers"]]}
 
 .. code-block:: python
   :caption: Example
 
-  # Prerequisite: serve an OpenAI model on localhost:5678 that defines
-  #   inputs in the below format and params of `temperature` and `max_tokens`
+  # Prerequisite: serve a custom pyfunc OpenAI model (not mlflow.openai) on localhost:5678 
+  #   that defines inputs in the below format and params of `temperature` and `max_tokens`
 
   import json
   import requests
 
   payload = json.dumps(
       {
-          "inputs": [{"role": "user", "content": "Tell a joke!"}],
+          "inputs": {"messages": [{"role": "user", "content": "Tell a joke!"}]},
           "params": {
               "temperature": 0.5,
               "max_tokens": 20,

--- a/docs/source/deployment/deploy-model-locally.rst
+++ b/docs/source/deployment/deploy-model-locally.rst
@@ -166,7 +166,7 @@ the required payload format, you can leverage the dict payload structures below.
       - 
         .. code-block:: python
 
-          {"inputs": [["Hello!"], ["Cheese", "and", "crackers"]]}
+          {"inputs": {"messages": [{"role": "user", "content": "Tell a joke!"}]}}
 
 .. code-block:: python
   :caption: Example

--- a/docs/source/deployment/deploy-model-locally.rst
+++ b/docs/source/deployment/deploy-model-locally.rst
@@ -99,7 +99,15 @@ models below, you can pass a raw payload dict.
       - 
         .. code-block:: python
 
-          {"messages": [{"role": "user", "content": "Tell a joke!"}], "temperature": 0.0}
+          {
+            "messages": [
+              {
+                "role": "user", 
+                "content": "Tell a joke!"
+              }
+            ], 
+            "temperature": 0.0
+          }
 
 † Note that the ``model`` argument **should not** be included when using the OpenAI APIs, due to its configuration being set by the MLflow model instance. All other parameters can be freely used, provided that they are defined within the ``params`` argument within the logged model signature.
 

--- a/docs/source/deployment/deploy-model-locally.rst
+++ b/docs/source/deployment/deploy-model-locally.rst
@@ -80,60 +80,6 @@ JSON Input
 You can either pass a flat dictionary corresponding to the desired model payload or wrap the
 payload in a dict with a dict key that specifies your payload format. 
 
-Raw Payload Dict
-^^^^^^^^^^^^^^^^
-
-If your payload is in a format that your mlflow served model will accept and it's in the supported
-models below, you can pass a raw payload dict.
-
-.. list-table::
-    :widths: 20 40 40
-    :header-rows: 1
-    :class: wrap-table
-
-    * - Supported Request Format
-      - Description
-      - Example
-    * - OpenAI Chat
-      - `OpenAI chat request payload <https://platform.openai.com/docs/api-reference/chat/create>`_.†
-      - 
-        .. code-block:: python
-
-          {
-            "messages": [
-              {
-                "role": "user", 
-                "content": "Tell a joke!"
-              }
-            ], 
-            "temperature": 0.0
-          }
-
-† Note that the ``model`` argument **should not** be included when using the OpenAI APIs, due to its configuration being set by the MLflow model instance. All other parameters can be freely used, provided that they are defined within the ``params`` argument within the logged model signature.
-
-.. code-block:: python
-  :caption: Example
-
-  # Prerequisite: serve a Pyfunc model accepts OpenAI-compatible chat requests on localhost:5678 that defines
-  #   `temperature` and `max_tokens` as parameters within the logged model signature
-
-  import json
-  import requests
-
-  payload = json.dumps(
-      {
-          "messages": [{"role": "user", "content": "Tell a joke!"}],
-          "temperature": 0.5,
-          "max_tokens": 20,
-      }
-  )
-  requests.post(
-      url=f"http://localhost:5678/invocations",
-      data=payload,
-      headers={"Content-Type": "application/json"},
-  )
-  print(requests.json())
-
 Wrapped Payload Dict
 ^^^^^^^^^^^^^^^^^^^^
 If your model format is not supported above or you want to avoid transforming your input data to 
@@ -219,6 +165,60 @@ a valid :ref:`Model Signature <model-signature>` with ``params`` must be defined
     In particular, Deep Learning models are typically strict about input types and will need a model schema in order
     for the model to score correctly. For complex data types, see :ref:`encoding-complex-data` below.
 
+Raw Payload Dict
+^^^^^^^^^^^^^^^^
+
+If your payload is in a format that your mlflow served model will accept and it's in the supported
+models below, you can pass a raw payload dict.
+
+.. list-table::
+    :widths: 20 40 40
+    :header-rows: 1
+    :class: wrap-table
+
+    * - Supported Request Format
+      - Description
+      - Example
+    * - OpenAI Chat
+      - `OpenAI chat request payload <https://platform.openai.com/docs/api-reference/chat/create>`_.†
+      - 
+        .. code-block:: python
+
+          {
+            "messages": [
+              {
+                "role": "user", 
+                "content": "Tell a joke!"
+              }
+            ], 
+            "temperature": 0.0
+          }
+
+† Note that the ``model`` argument **should not** be included when using the OpenAI APIs, due to its configuration being set by the MLflow model instance. All other parameters can be freely used, provided that they are defined within the ``params`` argument within the logged model signature.
+
+.. code-block:: python
+  :caption: Example
+
+  # Prerequisite: serve a Pyfunc model accepts OpenAI-compatible chat requests on localhost:5678 that defines
+  #   `temperature` and `max_tokens` as parameters within the logged model signature
+
+  import json
+  import requests
+
+  payload = json.dumps(
+      {
+          "messages": [{"role": "user", "content": "Tell a joke!"}],
+          "temperature": 0.5,
+          "max_tokens": 20,
+      }
+  )
+  requests.post(
+      url=f"http://localhost:5678/invocations",
+      data=payload,
+      headers={"Content-Type": "application/json"},
+  )
+  print(requests.json())
+
 .. _encoding-complex-data:
 
 Encoding complex data
@@ -251,7 +251,6 @@ Example requests:
         {"a": 1, "b": "2020-02-01T12:34:56Z"},
         {"a": 2, "b": "2021-03-01T00:00:00Z"}
     ]'
-
 
 .. _serving_frameworks:
 

--- a/docs/source/deployment/deploy-model-locally.rst
+++ b/docs/source/deployment/deploy-model-locally.rst
@@ -1,5 +1,5 @@
 .. _local_model_deployment:
-
+ 
 Deploy MLflow Model as a Local Inference Server
 ===============================================
 
@@ -184,15 +184,7 @@ models below, you can pass a raw payload dict.
       - 
         .. code-block:: python
 
-          {
-            "messages": [
-              {
-                "role": "user", 
-                "content": "Tell a joke!"
-              }
-            ], 
-            "temperature": 0.0
-          }
+          {"messages": [{"role": "user", "content": "Tell a joke!"}], "temperature": 0.0}
 
 † Note that the ``model`` argument **should not** be included when using the OpenAI APIs, due to its configuration being set by the MLflow model instance. All other parameters can be freely used, provided that they are defined within the ``params`` argument within the logged model signature.
 

--- a/docs/source/deployment/deploy-model-locally.rst
+++ b/docs/source/deployment/deploy-model-locally.rst
@@ -95,14 +95,13 @@ models below, you can pass a raw payload dict.
       - Description
       - Example
     * - OpenAI Chat
-      - `OpenAI chat request payload <https://platform.openai.com/docs/api-reference/chat/create>`_.
-        Note that openai's ``model`` kwarg should not be included because we are querying the
-        mlflow served model. However, any other openai.chat parameter defined in our served model's 
-        signature will be applied.
+      - `OpenAI chat request payload <https://platform.openai.com/docs/api-reference/chat/create>`_.†
       - 
         .. code-block:: python
 
           {"messages": [{"role": "user", "content": "Tell a joke!"}], "temperature": 0.0}
+
+† Note that the ``model`` argument **should not** be included when using the OpenAI APIs, due to its configuration being set by the MLflow model instance. All other parameters can be freely used, provided that they are defined within the ``params`` argument within the logged model signature.
 
 .. code-block:: python
   :caption: Example

--- a/docs/source/deployment/deploy-model-locally.rst
+++ b/docs/source/deployment/deploy-model-locally.rst
@@ -6,7 +6,7 @@ Deploy MLflow Model as a Local Inference Server
 MLflow allows you to deploy your model as a locally using just a single command.
 This approach is ideal for lightweight applications or for testing your model locally before moving it to a staging or production environment.
 
-If you are new to MLflow model deployment, please read the guide on `MLflow Deployment <index.html>`_ first to understand the basic concepts of MLflow models and deployments.
+If you are new to MLflow model deployment, please read the guide on `MLflow Deployment <index.html>`_ first to understand the basic concepts of MLflow models and deployments. 
 
 
 Deploying Inference Server
@@ -171,7 +171,7 @@ the required payload format, you can leverage the dict payload structures below.
 .. code-block:: python
   :caption: Example
 
-  # Prerequisite: serve a custom pyfunc OpenAI model (not mlflow.openai) on localhost:5678 
+  # Prerequisite: serve a custom pyfunc OpenAI model (not mlflow.openai) on localhost:5678
   #   that defines inputs in the below format and params of `temperature` and `max_tokens`
 
   import json

--- a/docs/source/deployment/deploy-model-locally.rst
+++ b/docs/source/deployment/deploy-model-locally.rst
@@ -184,7 +184,10 @@ models below, you can pass a raw payload dict.
       - 
         .. code-block:: python
 
-          {"messages": [{"role": "user", "content": "Tell a joke!"}], "temperature": 0.0}
+          {
+              "messages": [{"role": "user", "content": "Tell a joke!"}],  # noqa
+              "temperature": 0.0,
+          }
 
 † Note that the ``model`` argument **should not** be included when using the OpenAI APIs, due to its configuration being set by the MLflow model instance. All other parameters can be freely used, provided that they are defined within the ``params`` argument within the logged model signature.
 

--- a/docs/source/deployment/deploy-model-locally.rst
+++ b/docs/source/deployment/deploy-model-locally.rst
@@ -108,7 +108,7 @@ models below, you can pass a raw payload dict.
   :caption: Example
 
   # Prerequisite: serve an OpenAI model on localhost:5678 that defines
-  #   `temperature` and `max_tokens` as parameters in our model signature
+  #   `temperature` and `max_tokens` as parameters within the logged model signature
 
   import json
   import requests

--- a/docs/source/deployment/deploy-model-locally.rst
+++ b/docs/source/deployment/deploy-model-locally.rst
@@ -91,7 +91,7 @@ models below, you can pass a raw payload dict.
     :header-rows: 1
     :class: wrap-table
 
-    * - Supported Model Type
+    * - Supported Request Format
       - Description
       - Example
     * - OpenAI Chat

--- a/docs/source/deployment/deploy-model-locally.rst
+++ b/docs/source/deployment/deploy-model-locally.rst
@@ -106,7 +106,7 @@ models below, you can pass a raw payload dict.
 .. code-block:: python
   :caption: Example
 
-  # Prerequisite: serve an OpenAI model on localhost:5678 that defines
+  # Prerequisite: serve a Pyfunc model accepts OpenAI-compatible chat requests on localhost:5678 that defines
   #   `temperature` and `max_tokens` as parameters within the logged model signature
 
   import json


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/michael-berk/mlflow/pull/11189?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11189/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11189
```

</p>
</details>

### Related Issues/PRs

https://databricks.atlassian.net/browse/ML-38108

### What changes are proposed in this pull request?
* Add flat dictionary examples
* Fix some formatting in existing docs by using `code-block` instead of double backtick (it's smaller so renders better)

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
