### PR TITLE
Implement chat & chat streaming for Anthropic in Deployments

### DIFF
--- a/docs/source/llms/deployments/index.rst
+++ b/docs/source/llms/deployments/index.rst
@@ -236,9 +236,9 @@ below can be used as a helpful guide when configuring a given endpoint for any n
 |                          | - mpt-30b-instruct       |                          | - instructor-xl          |
 |                          | - llama2-70b-chat†       |                          |                          |
 +--------------------------+--------------------------+--------------------------+--------------------------+
-| Anthropic                | - claude-1               | N/A                      | N/A                      |
-|                          | - claude-1.3-100k        |                          |                          |
-|                          | - claude-2               |                          |                          |
+| Anthropic                | - claude-instant-1.2     | - claude-instant-1.2     | N/A                      |
+|                          | - claude-2.1             | - claude-2.1             |                          |
+|                          | - claude-2.0             | - claude-2.0             |                          |
 +--------------------------+--------------------------+--------------------------+--------------------------+
 | Cohere                   | - command                | - command                | - embed-english-v2.0     |
 |                          | - command-light          | - command-light          | - embed-multilingual-v2.0|
@@ -902,6 +902,8 @@ generated before receiving it. Streaming responses are supported by the followin
 | OpenAI     | ✓                   | ✓            |
 +------------+---------------------+--------------+
 | Cohere     | ✓                   | ✓            |
++------------+---------------------+--------------+
+| Anthropic  | ✘                   | ✓            |
 +------------+---------------------+--------------+
 
 To enable streaming responses, set the ``stream`` parameter to ``true`` in your request. For example:

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -35,8 +35,7 @@ class AnthropicAdapter(ProviderAdapter):
             )
         payload["max_tokens"] = max_tokens
 
-        n = payload.pop("n", 1)
-        if n != 1:
+        if payload.pop("n", 1) != 1:
             raise HTTPException(
                 status_code=422,
                 detail="'n' must be '1' for the Anthropic provider. Received value: '{n}'.",

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -41,6 +41,16 @@ class AnthropicAdapter(ProviderAdapter):
                 detail="'n' must be '1' for the Anthropic provider. Received value: '{n}'.",
             )
 
+        # Cohere uses `system` to set the system message
+        # we concatenate all system messages from the user with a newline
+        system_messages = [m for m in payload["messages"] if m["role"] == "system"]
+        if len(system_messages) > 0:
+            payload["system"] = "\n".join(m["content"] for m in system_messages)
+
+        # remaining messages are chat history
+        # we want to include only user and assistant messages
+        payload["messages"] = [m for m in payload["messages"] if m["role"] in ("user", "assistant")]
+
         # The range of Anthropic's temperature is 0-1, but ours is 0-2, so we halve it
         if "temperature" in payload:
             payload["temperature"] = 0.5 * payload["temperature"]

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -202,6 +202,7 @@ def chat_response():
 def chat_payload(stream: bool = False):
     payload = {
         "messages": [
+            {"role": "system", "content": "System message"},
             {"role": "user", "content": "Message 1"},
             {"role": "assistant", "content": "Message 2"},
             {"role": "user", "content": "Message 3"},
@@ -287,6 +288,7 @@ async def test_chat():
                     {"role": "assistant", "content": "Message 2"},
                     {"role": "user", "content": "Message 3"},
                 ],
+                "system": "System message",
                 "max_tokens": MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS,
                 "temperature": 0.25,
             },
@@ -357,6 +359,7 @@ async def test_chat_stream():
                     {"role": "assistant", "content": "Message 2"},
                     {"role": "user", "content": "Message 3"},
                 ],
+                "system": "System message",
                 "max_tokens": MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS,
                 "temperature": 0.25,
                 "stream": True,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/gabrielfu/mlflow/pull/11195?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11195/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11195
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Implement chat & chat streaming endpoints for Anthropic provider in MLflow Deployments Server

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Implement chat & chat streaming endpoints for Anthropic provider in MLflow Deployments Server

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
