### PR TITLE
Remove `pylint: disable` comments

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -215,7 +215,7 @@ def pytest_ignore_collect(path, config):
 
 
 @pytest.hookimpl(trylast=True)
-def pytest_collection_modifyitems(session, config, items):  # pylint: disable=unused-argument
+def pytest_collection_modifyitems(session, config, items):
     # Executing `tests.server.test_prometheus_exporter` after `tests.server.test_handlers`
     # results in an error because Flask >= 2.2.0 doesn't allow calling setup method such as
     # `before_request` on the application after the first request. To avoid this issue,
@@ -228,7 +228,7 @@ def pytest_collection_modifyitems(session, config, items):  # pylint: disable=un
 
 
 @pytest.hookimpl(hookwrapper=True)
-def pytest_terminal_summary(terminalreporter, exitstatus, config):  # pylint: disable=unused-argument
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
     yield
     failed_test_reports = terminalreporter.stats.get("failed", [])
     if failed_test_reports:

--- a/dev/create_release_branch.py
+++ b/dev/create_release_branch.py
@@ -44,4 +44,4 @@ def main(new_version: str, remote: str, dry_run=False):
 
 
 if __name__ == "__main__":
-    main()  # pylint: disable=no-value-for-parameter
+    main()

--- a/dev/create_release_tag.py
+++ b/dev/create_release_tag.py
@@ -46,4 +46,4 @@ def main(new_version: str, remote: str, dry_run: bool = False):
 
 
 if __name__ == "__main__":
-    main()  # pylint: disable=no-value-for-parameter
+    main()

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -77,15 +77,15 @@ class TestConfig(BaseModel):
         arbitrary_types_allowed = True
 
     @validator("minimum", pre=True)
-    def validate_minimum(cls, v):  # pylint: disable=no-self-argument
+    def validate_minimum(cls, v):
         return Version(v)
 
     @validator("maximum", pre=True)
-    def validate_maximum(cls, v):  # pylint: disable=no-self-argument
+    def validate_maximum(cls, v):
         return Version(v)
 
     @validator("unsupported", pre=True)
-    def validate_unsupported(cls, v):  # pylint: disable=no-self-argument
+    def validate_unsupported(cls, v):
         return [Version(v) for v in v] if v else None
 
 

--- a/dev/tests/test_set_matrix.py
+++ b/dev/tests/test_set_matrix.py
@@ -28,7 +28,7 @@ class MockResponse:
 
 
 def mock_pypi_api(mock_responses):
-    def requests_get_patch(url, *args, **kwargs):  # pylint: disable=unused-argument
+    def requests_get_patch(url, *args, **kwargs):
         package_name = re.search(r"https://pypi\.org/pypi/(.+)/json", url).group(1)
         return mock_responses[package_name]
 

--- a/dev/update_changelog.py
+++ b/dev/update_changelog.py
@@ -207,4 +207,4 @@ def main(prev_version, release_version, remote):
 
 
 if __name__ == "__main__":
-    main()  # pylint: disable=no-value-for-parameter
+    main()

--- a/dev/update_mlflow_versions.py
+++ b/dev/update_mlflow_versions.py
@@ -74,7 +74,7 @@ def update_versions(new_py_version: str) -> None:
 def validate_new_version(
     ctx: click.Context,
     param: click.Parameter,
-    value: str,  # pylint: disable=unused-argument
+    value: str,
 ) -> str:
     new = Version(value)
     current = Version(get_current_py_version())

--- a/dev/update_pypi_package_index.py
+++ b/dev/update_pypi_package_index.py
@@ -33,7 +33,7 @@ def main(args):
     args = parse_args(args)
     package_names = set()
 
-    class PyPIHTMLParser(HTMLParser):  # pylint: disable=abstract-method
+    class PyPIHTMLParser(HTMLParser):
         def handle_starttag(self, tag, attrs):
             if tag == "a":
                 for name, value in attrs:

--- a/examples/flower_classifier/image_pyfunc.py
+++ b/examples/flower_classifier/image_pyfunc.py
@@ -61,7 +61,7 @@ class KerasImageClassifierPyfunc:
     def predict(
         self,
         input,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ):
         """
         Generate predictions for the data.

--- a/examples/pyfunc/train.py
+++ b/examples/pyfunc/train.py
@@ -15,7 +15,7 @@ class CustomPredict(mlflow.pyfunc.PythonModel):
     def load_context(self, context):
         self.model = mlflow.sklearn.load_model(context.artifacts["custom_model"])
 
-    def predict(self, context, model_input, params: Optional[Dict[str, Any]] = None):  # pylint: disable=unused-argument
+    def predict(self, context, model_input, params: Optional[Dict[str, Any]] = None):
         prediction = self.model.predict(model_input)
         return iris_classes(prediction)
 

--- a/examples/pytorch/AxHyperOptimizationPTL/iris.py
+++ b/examples/pytorch/AxHyperOptimizationPTL/iris.py
@@ -1,7 +1,3 @@
-# pylint: disable=arguments-differ
-# pylint: disable=unused-argument
-# pylint: disable=abstract-method
-
 import pytorch_lightning as pl
 import torch
 import torch.nn.functional as F

--- a/examples/pytorch/AxHyperOptimizationPTL/iris_data_module.py
+++ b/examples/pytorch/AxHyperOptimizationPTL/iris_data_module.py
@@ -1,8 +1,3 @@
-# pylint: disable=arguments-differ
-# pylint: disable=abstract-method
-# pylint: disable=attribute-defined-outside-init
-
-
 import pytorch_lightning as pl
 import torch
 from sklearn.datasets import load_iris

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -1,7 +1,3 @@
-# pylint: disable=arguments-differ
-# pylint: disable=unused-argument
-# pylint: disable=abstract-method
-
 import math
 import os
 

--- a/examples/pytorch/IterativePruning/mnist.py
+++ b/examples/pytorch/IterativePruning/mnist.py
@@ -5,9 +5,8 @@
 # pytorch-lightning (using pip install pytorch-lightning)
 #       and mlflow (using pip install mlflow).
 #
-# pylint: disable=arguments-differ
-# pylint: disable=unused-argument
-# pylint: disable=abstract-method
+
+
 import lightning as L
 import torch
 from torch.nn import functional as F

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -5,9 +5,8 @@
 # pytorch-lightning (using pip install pytorch-lightning)
 #       and mlflow (using pip install mlflow).
 #
-# pylint: disable=arguments-differ
-# pylint: disable=unused-argument
-# pylint: disable=abstract-method
+
+
 import os
 
 import lightning as L

--- a/examples/pytorch/torchscript/IrisClassification/iris_classification.py
+++ b/examples/pytorch/torchscript/IrisClassification/iris_classification.py
@@ -1,4 +1,3 @@
-# pylint: disable=abstract-method
 import argparse
 
 import torch

--- a/examples/pytorch/torchscript/MNIST/mnist_torchscript.py
+++ b/examples/pytorch/torchscript/MNIST/mnist_torchscript.py
@@ -1,5 +1,3 @@
-# pylint: disable=abstract-method
-
 import argparse
 
 import torch

--- a/examples/sktime/flavor.py
+++ b/examples/sktime/flavor.py
@@ -470,7 +470,7 @@ class _SktimeModelWrapper:
     def __init__(self, sktime_model):
         self.sktime_model = sktime_model
 
-    def predict(self, dataframe, params: Optional[Dict[str, Any]] = None) -> pd.DataFrame:  # pylint: disable=unused-argument
+    def predict(self, dataframe, params: Optional[Dict[str, Any]] = None) -> pd.DataFrame:
         df_schema = dataframe.columns.values.tolist()
 
         if len(dataframe) > 1:

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -1,4 +1,3 @@
-# pylint: disable=wrong-import-position
 """
 The ``mlflow`` module provides a high-level "fluent" API for starting and managing MLflow runs.
 For example:

--- a/mlflow/catboost/__init__.py
+++ b/mlflow/catboost/__init__.py
@@ -341,7 +341,7 @@ class _CatboostModelWrapper:
     def __init__(self, cb_model):
         self.cb_model = cb_model
 
-    def predict(self, dataframe, params: Optional[Dict[str, Any]] = None):  # pylint: disable=unused-argument
+    def predict(self, dataframe, params: Optional[Dict[str, Any]] = None):
         """
         Args:
             dataframe: Model input data.

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -261,7 +261,7 @@ def _validate_server_args(gunicorn_opts=None, workers=None, waitress_opts=None):
             )
 
 
-def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argument
+def _validate_static_prefix(ctx, param, value):
     """
     Validate that the static_prefix option starts with a "/" and does not end in a "/".
     Conforms to the callback interface of click documented at

--- a/mlflow/data/delta_dataset_source.py
+++ b/mlflow/data/delta_dataset_source.py
@@ -62,7 +62,7 @@ class DeltaDatasetSource(DatasetSource):
     def _get_source_type() -> str:
         return "delta_table"
 
-    def load(self, **kwargs):  # pylint: disable=unused-argument
+    def load(self, **kwargs):
         """
         Loads the dataset source as a Delta Dataset Source.
 

--- a/mlflow/data/spark_dataset_source.py
+++ b/mlflow/data/spark_dataset_source.py
@@ -31,7 +31,7 @@ class SparkDatasetSource(DatasetSource):
     def _get_source_type() -> str:
         return "spark"
 
-    def load(self, **kwargs):  # pylint: disable=unused-argument
+    def load(self, **kwargs):
         """Loads the dataset source as a Spark Dataset Source.
 
         Returns:

--- a/mlflow/deployments/base.py
+++ b/mlflow/deployments/base.py
@@ -15,7 +15,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import developer_stable
 
 
-def run_local(target, name, model_uri, flavor=None, config=None):  # pylint: disable=unused-argument
+def run_local(target, name, model_uri, flavor=None, config=None):
     """Deploys the specified model locally, for testing. This function should be defined
     within the plugin module. Also note that this function has a signature which is very
     similar to :py:meth:`BaseDeploymentClient.create_deployment` since both does logically
@@ -225,7 +225,7 @@ class BaseDeploymentClient(abc.ABC):
         """
         pass
 
-    def explain(self, deployment_name=None, df=None, endpoint=None):  # pylint: disable=unused-argument
+    def explain(self, deployment_name=None, df=None, endpoint=None):
         """
         Generate explanations of model predictions on the specified input pandas Dataframe
         ``df`` for the deployed model. Explanation output formats vary by deployment target,

--- a/mlflow/diviner/__init__.py
+++ b/mlflow/diviner/__init__.py
@@ -452,7 +452,7 @@ class _DivinerModelWrapper:
     def __init__(self, diviner_model):
         self.diviner_model = diviner_model
 
-    def predict(self, dataframe, params: Optional[Dict[str, Any]] = None) -> pd.DataFrame:  # pylint: disable=unused-argument
+    def predict(self, dataframe, params: Optional[Dict[str, Any]] = None) -> pd.DataFrame:
         """A method that allows a pyfunc implementation of this flavor to generate forecasted values
         from the end of a trained Diviner model's training series per group.
 

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -75,7 +75,7 @@ def get_default_pip_requirements(include_cloudpickle=False):
     return pip_deps
 
 
-def get_default_conda_env(include_cloudpickle=False):  # pylint: disable=unused-argument
+def get_default_conda_env(include_cloudpickle=False):
     """
     Returns:
         The default Conda environment for MLflow Models produced by calls to
@@ -353,7 +353,7 @@ class _FastaiModelWrapper:
     def predict(
         self,
         dataframe,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ):
         """
         Args:
@@ -438,7 +438,7 @@ def autolog(
     silent=False,
     registered_model_name=None,
     extra_tags=None,
-):  # pylint: disable=unused-argument
+):
     """
     Enable automatic logging from Fastai to MLflow.
 

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -63,7 +63,6 @@ class RouteType(str, Enum):
 class CohereConfig(ConfigModel):
     cohere_api_key: str
 
-    # pylint: disable=no-self-argument
     @validator("cohere_api_key", pre=True)
     def validate_cohere_api_key(cls, value):
         return _resolve_api_key_from_input(value)
@@ -72,7 +71,6 @@ class CohereConfig(ConfigModel):
 class AI21LabsConfig(ConfigModel):
     ai21labs_api_key: str
 
-    # pylint: disable=no-self-argument
     @validator("ai21labs_api_key", pre=True)
     def validate_ai21labs_api_key(cls, value):
         return _resolve_api_key_from_input(value)
@@ -82,7 +80,6 @@ class MosaicMLConfig(ConfigModel):
     mosaicml_api_key: str
     mosaicml_api_base: Optional[str] = None
 
-    # pylint: disable=no-self-argument
     @validator("mosaicml_api_key", pre=True)
     def validate_mosaicml_api_key(cls, value):
         return _resolve_api_key_from_input(value)
@@ -113,7 +110,6 @@ class OpenAIConfig(ConfigModel):
     openai_deployment_name: Optional[str] = None
     openai_organization: Optional[str] = None
 
-    # pylint: disable=no-self-argument
     @validator("openai_api_key", pre=True)
     def validate_openai_api_key(cls, value):
         return _resolve_api_key_from_input(value)
@@ -171,7 +167,6 @@ class AnthropicConfig(ConfigModel):
     anthropic_api_key: str
     anthropic_version: str = "2023-06-01"
 
-    # pylint: disable=no-self-argument
     @validator("anthropic_api_key", pre=True)
     def validate_anthropic_api_key(cls, value):
         return _resolve_api_key_from_input(value)
@@ -180,7 +175,6 @@ class AnthropicConfig(ConfigModel):
 class PaLMConfig(ConfigModel):
     palm_api_key: str
 
-    # pylint: disable=no-self-argument
     @validator("palm_api_key", pre=True)
     def validate_palm_api_key(cls, value):
         return _resolve_api_key_from_input(value)
@@ -221,7 +215,6 @@ class AmazonBedrockConfig(ConfigModel):
 class MistralConfig(ConfigModel):
     mistral_api_key: str
 
-    # pylint: disable=no-self-argument
     @validator("mistral_api_key", pre=True)
     def validate_mistral_api_key(cls, value):
         return _resolve_api_key_from_input(value)
@@ -283,7 +276,6 @@ def _resolve_api_key_from_input(api_key_input):
     return api_key_input
 
 
-# pylint: disable=no-self-argument
 class Model(ConfigModel):
     name: Optional[str] = None
     provider: Union[str, Provider]
@@ -357,7 +349,6 @@ class LimitsConfig(ConfigModel):
     limits: Optional[List[Limit]] = []
 
 
-# pylint: disable=no-self-argument
 class RouteConfig(AliasedConfigModel):
     name: str
     route_type: RouteType = Field(alias="endpoint_type")

--- a/mlflow/gluon/__init__.py
+++ b/mlflow/gluon/__init__.py
@@ -106,7 +106,7 @@ class _GluonModelWrapper:
     def predict(
         self,
         data,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ):
         """This is a docstring. Here is more info.
 
@@ -400,7 +400,7 @@ def autolog(
     disable_for_unsupported_versions=False,
     silent=False,
     registered_model_name=None,
-):  # pylint: disable=unused-argument
+):
     """
     Enables (or disables) and configures autologging from Gluon to MLflow.
     Logs loss and any other metrics specified in the fit

--- a/mlflow/h2o/__init__.py
+++ b/mlflow/h2o/__init__.py
@@ -281,7 +281,7 @@ class _H2OModelWrapper:
     def __init__(self, h2o_model):
         self.h2o_model = h2o_model
 
-    def predict(self, dataframe, params: Optional[Dict[str, Any]] = None):  # pylint: disable=unused-argument
+    def predict(self, dataframe, params: Optional[Dict[str, Any]] = None):
         """
         Args:
             dataframe: Model input data.

--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -390,8 +390,8 @@ def _save_model_metadata(
     input_example=None,
     pip_requirements=None,
     extra_pip_requirements=None,
-    remote_model_path=None,  # pylint: disable=unused-argument
-    store_license=False,  # pylint: disable=unused-argument
+    remote_model_path=None,
+    store_license=False,
 ):
     """
     Saves model metadata into the passed-in directory.
@@ -668,7 +668,7 @@ def _load_model(model_uri, dfs_tmpdir_base=None, local_model_path=None):
     return nlp.load(path=local_model_path)
 
 
-def load_model(model_uri, dfs_tmpdir=None, dst_path=None, **kwargs):  # pylint: disable=unused-argument
+def load_model(model_uri, dfs_tmpdir=None, dst_path=None, **kwargs):
     """
     Load the Johnsnowlabs MLflow model from the path.
 

--- a/mlflow/keras/autologging.py
+++ b/mlflow/keras/autologging.py
@@ -138,8 +138,6 @@ def autolog(
     save_model_kwargs=None,
     extra_tags=None,
 ):
-    # pylint: disable=unused-argument
-    # pylint: disable=no-name-in-module
     """
     Enable autologging for Keras.
 

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -494,10 +494,10 @@ class _LangChainModelWrapper:
     def __init__(self, lc_model):
         self.lc_model = lc_model
 
-    def predict(  # pylint: disable=unused-argument
+    def predict(
         self,
         data: Union[pd.DataFrame, List[Union[str, Dict[str, Any]]], Any],
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ) -> List[str]:
         """
         Args:
@@ -520,10 +520,10 @@ class _LangChainModelWrapper:
         return results[0] if return_first_element else results
 
     @experimental
-    def _predict_with_callbacks(  # pylint: disable=unused-argument
+    def _predict_with_callbacks(
         self,
         data: Union[pd.DataFrame, List[Union[str, Dict[str, Any]]], Any],
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
         callback_handlers=None,
         convert_chat_responses=False,
     ) -> List[str]:
@@ -592,7 +592,7 @@ class _TestLangChainWrapper(_LangChainModelWrapper):
     def predict(
         self,
         data,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ):
         """
         Model input data and additional parameters.
@@ -707,7 +707,7 @@ def autolog(
     silent=False,
     registered_model_name=None,
     extra_tags=None,
-):  # pylint: disable=unused-argument
+):
     """
     Enables (or disables) and configures autologging from Langchain to MLflow.
 

--- a/mlflow/legacy_databricks_cli/configure/provider.py
+++ b/mlflow/legacy_databricks_cli/configure/provider.py
@@ -220,7 +220,7 @@ class SparkTaskContextConfigProvider(DatabricksConfigProvider):
     @staticmethod
     def _get_spark_task_context_or_none():
         try:
-            from pyspark import TaskContext  # pylint: disable=import-error
+            from pyspark import TaskContext
 
             return TaskContext.get()
         except ImportError:
@@ -228,7 +228,7 @@ class SparkTaskContextConfigProvider(DatabricksConfigProvider):
 
     @staticmethod
     def set_insecure(x):
-        from pyspark import SparkContext  # pylint: disable=import-error
+        from pyspark import SparkContext
 
         new_val = "True" if x else None
         SparkContext._active_spark_context.setLocalProperty("spark.databricks.ignoreTls", new_val)

--- a/mlflow/lightgbm/__init__.py
+++ b/mlflow/lightgbm/__init__.py
@@ -481,7 +481,7 @@ class _LGBModelWrapper:
     def __init__(self, lgb_model):
         self.lgb_model = lgb_model
 
-    def predict(self, dataframe, params: Optional[Dict[str, Any]] = None):  # pylint: disable=unused-argument
+    def predict(self, dataframe, params: Optional[Dict[str, Any]] = None):
         """
         Args:
             dataframe: Model input data.
@@ -534,7 +534,7 @@ def autolog(
     silent=False,
     registered_model_name=None,
     extra_tags=None,
-):  # pylint: disable=unused-argument
+):
     """
     Enables (or disables) and configures autologging from LightGBM to MLflow. Logs the following:
 
@@ -712,7 +712,6 @@ def autolog(
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 try:
-                    # pylint: disable=undefined-loop-variable
                     filepath = os.path.join(tmpdir, f"feature_importance_{imp_type}.png")
                     fig.savefig(filepath)
                     mlflow.log_artifact(filepath)

--- a/mlflow/models/evaluation/_shap_patch.py
+++ b/mlflow/models/evaluation/_shap_patch.py
@@ -18,7 +18,7 @@ class _PatchedKernelExplainer(shap.KernelExplainer):
         else:
             return 0 if i == j else 1
 
-    def save(self, out_file, model_saver=None, masker_saver=None):  # pylint: disable=unused-argument
+    def save(self, out_file, model_saver=None, masker_saver=None):
         """
         This patched `save` method fix `KernelExplainer.save`.
         Issues in original `KernelExplainer.save`:
@@ -39,7 +39,7 @@ class _PatchedKernelExplainer(shap.KernelExplainer):
             s.save("data", self.data)
 
     @classmethod
-    def load(cls, in_file, model_loader=None, masker_loader=None, instantiate=True):  # pylint: disable=unused-argument
+    def load(cls, in_file, model_loader=None, masker_loader=None, instantiate=True):
         """
         This patched `load` method fix `KernelExplainer.load`.
         Issues in original KernelExplainer.load:

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -719,12 +719,10 @@ def _shap_predict_fn(x, predict_fn, feature_names):
     return predict_fn(_get_dataframe_with_renamed_columns(x, feature_names))
 
 
-# pylint: disable=attribute-defined-outside-init
 class DefaultEvaluator(ModelEvaluator):
     def __init__(self):
         self.client = MlflowClient()
 
-    # pylint: disable=unused-argument
     def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
         return model_type in _ModelType.values() or model_type is None
 

--- a/mlflow/models/flavor_backend.py
+++ b/mlflow/models/flavor_backend.py
@@ -12,7 +12,7 @@ class FlavorBackend:
 
     __metaclass__ = ABCMeta
 
-    def __init__(self, config, **kwargs):  # pylint: disable=unused-argument
+    def __init__(self, config, **kwargs):
         self._config = config
 
     @abstractmethod

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -410,7 +410,6 @@ class Model:
     @experimental
     @metadata.setter
     def metadata(self, value: Optional[Dict[str, Any]]):
-        # pylint: disable=attribute-defined-outside-init
         self._metadata = value
 
     @property
@@ -432,7 +431,6 @@ class Model:
         # signature cannot be set to `False`, which is used in `log_model` and `save_model` calls
         # to disable automatic signature inference
         if value is not False:
-            # pylint: disable=attribute-defined-outside-init
             self._signature = value
 
     @property
@@ -445,7 +443,6 @@ class Model:
 
     @saved_input_example_info.setter
     def saved_input_example_info(self, value: Dict[str, Any]):
-        # pylint: disable=attribute-defined-outside-init
         self._saved_input_example_info = value
 
     @property
@@ -461,7 +458,6 @@ class Model:
 
     @model_size_bytes.setter
     def model_size_bytes(self, value: Optional[int]):
-        # pylint: disable=attribute-defined-outside-init
         self._model_size_bytes = value
 
     def get_model_info(self):

--- a/mlflow/onnx/__init__.py
+++ b/mlflow/onnx/__init__.py
@@ -320,7 +320,7 @@ class _OnnxModelWrapper:
                     feeds[input_name] = feed.astype(np.float32)
         return feeds
 
-    def predict(self, data, params: Optional[Dict[str, Any]] = None):  # pylint: disable=unused-argument
+    def predict(self, data, params: Optional[Dict[str, Any]] = None):
         """
         Args:
             data: Either a pandas DataFrame, numpy.ndarray or a dictionary.

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -444,7 +444,7 @@ class _PaddleWrapper:
     def predict(
         self,
         data,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ):
         """
         Args:
@@ -494,7 +494,7 @@ def autolog(
     silent=False,
     registered_model_name=None,
     extra_tags=None,
-):  # pylint: disable=unused-argument
+):
     """
     Enables (or disables) and configures autologging from PaddlePaddle to MLflow.
 

--- a/mlflow/paddle/_paddle_autolog.py
+++ b/mlflow/paddle/_paddle_autolog.py
@@ -33,7 +33,7 @@ class __MLflowPaddleCallback(paddle.callbacks.Callback, metaclass=ExceptionSafeA
             self._log_metrics(logs, epoch)
             self.epoch = epoch
 
-    def on_train_begin(self, logs=None):  # pylint: disable=unused-argument
+    def on_train_begin(self, logs=None):
         params = {
             "optimizer_name": self.model._optimizer.__class__.__name__,
             "learning_rate": self.model._optimizer._learning_rate,
@@ -41,7 +41,7 @@ class __MLflowPaddleCallback(paddle.callbacks.Callback, metaclass=ExceptionSafeA
         self.client.log_params(self.run_id, params)
         self.client.flush(synchronous=True)
 
-    def on_train_end(self, logs=None):  # pylint: disable=unused-argument
+    def on_train_end(self, logs=None):
         self.metrics_logger.flush()
         self.client.flush(synchronous=True)
 

--- a/mlflow/pmdarima/__init__.py
+++ b/mlflow/pmdarima/__init__.py
@@ -522,7 +522,7 @@ class _PmdarimaModelWrapper:
         self.pmdarima_model = pmdarima_model
         self._pmdarima_version = pmdarima.__version__
 
-    def predict(self, dataframe, params: Optional[Dict[str, Any]] = None) -> pd.DataFrame:  # pylint: disable=unused-argument
+    def predict(self, dataframe, params: Optional[Dict[str, Any]] = None) -> pd.DataFrame:
         """
         Args:
             dataframe: Model input data.

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -351,7 +351,6 @@ def _get_local_artifact_cmd_and_envs(artifact_repo):
 
 
 def _get_s3_artifact_cmd_and_envs(artifact_repo):
-    # pylint: disable=unused-argument
     if platform.system() == "Windows":
         win_user_dir = os.environ["USERPROFILE"]
         aws_path = os.path.join(win_user_dir, ".aws")
@@ -372,7 +371,6 @@ def _get_s3_artifact_cmd_and_envs(artifact_repo):
 
 
 def _get_azure_blob_artifact_cmd_and_envs(artifact_repo):
-    # pylint: disable=unused-argument
     envs = {
         "AZURE_STORAGE_CONNECTION_STRING": os.environ.get("AZURE_STORAGE_CONNECTION_STRING"),
         "AZURE_STORAGE_ACCESS_KEY": os.environ.get("AZURE_STORAGE_ACCESS_KEY"),
@@ -382,7 +380,6 @@ def _get_azure_blob_artifact_cmd_and_envs(artifact_repo):
 
 
 def _get_gcs_artifact_cmd_and_envs(artifact_repo):
-    # pylint: disable=unused-argument
     cmds = []
     envs = {}
 
@@ -394,7 +391,6 @@ def _get_gcs_artifact_cmd_and_envs(artifact_repo):
 
 
 def _get_hdfs_artifact_cmd_and_envs(artifact_repo):
-    # pylint: disable=unused-argument
     cmds = []
     envs = {
         "MLFLOW_KERBEROS_TICKET_CACHE": MLFLOW_KERBEROS_TICKET_CACHE.get(),

--- a/mlflow/prophet/__init__.py
+++ b/mlflow/prophet/__init__.py
@@ -351,7 +351,7 @@ class _ProphetModelWrapper:
     def __init__(self, pr_model):
         self.pr_model = pr_model
 
-    def predict(self, dataframe, params: Optional[Dict[str, Any]] = None):  # pylint: disable=unused-argument
+    def predict(self, dataframe, params: Optional[Dict[str, Any]] = None):
         """
         Args:
             dataframe: Model input data.

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -804,7 +804,7 @@ def _load_model_or_server(
     )
 
 
-def _get_model_dependencies(model_uri, format="pip"):  # pylint: disable=redefined-builtin
+def _get_model_dependencies(model_uri, format="pip"):
     model_dir = _download_artifact_from_uri(model_uri)
 
     def get_conda_yaml_path():
@@ -860,7 +860,7 @@ def _get_model_dependencies(model_uri, format="pip"):  # pylint: disable=redefin
         )
 
 
-def get_model_dependencies(model_uri, format="pip"):  # pylint: disable=redefined-builtin
+def get_model_dependencies(model_uri, format="pip"):
     """
     Downloads the model dependencies and returns the path to requirements.txt or conda.yaml file.
 

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -138,7 +138,7 @@ class _FunctionPythonModel(PythonModel):
 
     def predict(
         self,
-        context,  # pylint: disable=unused-argument
+        context,
         model_input,
         params: Optional[Dict[str, Any]] = None,
     ):

--- a/mlflow/pyfunc/spark_model_cache.py
+++ b/mlflow/pyfunc/spark_model_cache.py
@@ -42,7 +42,7 @@ class SparkModelCache:
 
         # We must rely on a supposed cyclic import here because we want this behavior
         # on the Spark Executors (i.e., don't try to pickle the load_model function).
-        from mlflow.pyfunc import load_model  # pylint: disable=cyclic-import
+        from mlflow.pyfunc import load_model
 
         SparkModelCache._models[archive_path] = (load_model(local_model_dir), local_model_dir)
         return SparkModelCache._models[archive_path]

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -590,12 +590,10 @@ class _AutologgingMetricsManager:
 
     def disable_log_post_training_metrics(self):
         class LogPostTrainingMetricsDisabledScope:
-            def __enter__(inner_self):  # pylint: disable=no-self-argument
-                # pylint: disable=attribute-defined-outside-init
+            def __enter__(inner_self):
                 inner_self.old_status = self._log_post_training_metrics_enabled
                 self._log_post_training_metrics_enabled = False
 
-            # pylint: disable=no-self-argument
             def __exit__(inner_self, exc_type, exc_val, exc_tb):
                 self._log_post_training_metrics_enabled = inner_self.old_status
 
@@ -778,7 +776,7 @@ def autolog(
     log_model_signatures=True,
     log_model_allowlist=None,
     extra_tags=None,
-):  # pylint: disable=unused-argument
+):
     """
     Enables (or disables) and configures autologging for pyspark ml estimators.
     This method is not threadsafe.

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -909,7 +909,7 @@ def autolog(
     checkpoint_save_best_only=True,
     checkpoint_save_weights_only=False,
     checkpoint_save_freq="epoch",
-):  # pylint: disable=unused-argument
+):
     """
     Enables (or disables) and configures autologging from `PyTorch Lightning
     <https://pytorch-lightning.readthedocs.io/en/latest>`_ to MLflow.

--- a/mlflow/pytorch/_lightning_autolog.py
+++ b/mlflow/pytorch/_lightning_autolog.py
@@ -42,10 +42,8 @@ _logger = logging.getLogger(__name__)
 
 _pl_version = Version(pl.__version__)
 if _pl_version < Version("1.5.0"):
-    # pylint: disable-next=ungrouped-imports
     from pytorch_lightning.core.memory import ModelSummary
 else:
-    # pylint: disable-next=ungrouped-imports
     from pytorch_lightning.utilities.model_summary import ModelSummary
 
 
@@ -62,7 +60,6 @@ def _get_optimizer_name(optimizer):
     if Version(pl.__version__) < Version("1.1.0"):
         return optimizer.__class__.__name__
     else:
-        # pylint: disable-next=ungrouped-imports
         from pytorch_lightning.core.optimizer import LightningOptimizer
 
         return (
@@ -139,7 +136,7 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
     if _pl_version >= Version("1.4.0dev"):
 
         @rank_zero_only
-        def on_train_epoch_end(self, trainer, pl_module, *args):  # pylint: disable=signature-differs,arguments-differ,unused-argument
+        def on_train_epoch_end(self, trainer, pl_module, *args):
             self._log_epoch_metrics(trainer, pl_module)
 
     # In pytorch-lightning >= 1.2.0, logging metrics in `on_epoch_end` results in duplicate
@@ -154,7 +151,7 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
         # pytorch-lightning >= 1.3.0
 
         @rank_zero_only
-        def on_train_epoch_end(self, trainer, pl_module, *args):  # pylint: disable=signature-differs,arguments-differ,unused-argument
+        def on_train_epoch_end(self, trainer, pl_module, *args):
             """
             Log loss and other metrics values after each train epoch
 
@@ -193,7 +190,7 @@ class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
             self._log_epoch_metrics(trainer, pl_module)
 
     @rank_zero_only
-    def on_train_batch_end(self, trainer, pl_module, *args):  # pylint: disable=signature-differs,arguments-differ,unused-argument
+    def on_train_batch_end(self, trainer, pl_module, *args):
         """
         Log metric values after each step
 
@@ -607,7 +604,6 @@ def patched_fit(original, self, *args, **kwargs):
             _log_early_stop_metrics(early_stop_callback, client, run_id)
 
         if Version(pl.__version__) < Version("1.4.0"):
-            # pylint: disable-next=unexpected-keyword-arg
             summary = str(ModelSummary(self.model, mode="full"))
         else:
             summary = str(ModelSummary(self.model, max_depth=-1))

--- a/mlflow/pytorch/pickle_module.py
+++ b/mlflow/pytorch/pickle_module.py
@@ -15,8 +15,8 @@ compatible pickling APIs.
 
 # Import all contents of the CloudPickle module in an attempt to include all functions required
 # by ``torch.save``.
-# pylint: disable=wildcard-import
-# pylint: disable=unused-wildcard-import
+
+
 # CloudPickle does not include `Unpickler` in its namespace, which is required by PyTorch for
 # deserialization. Noting that CloudPickle's `load()` and `loads()` routines are aliases for
 # `pickle.load()` and `pickle.loads()`, we therefore import Unpickler from the native

--- a/mlflow/recipes/steps/automl/flaml.py
+++ b/mlflow/recipes/steps/automl/flaml.py
@@ -69,8 +69,6 @@ def _create_custom_metric_flaml(
         res_df["target"] = y if task == "classification" else y.values
         return eval_metric.eval_fn(res_df, builtin_metrics)
 
-    # pylint: disable=keyword-arg-before-vararg
-    # pylint: disable=unused-argument
     def custom_metric(
         X_val,
         y_val,
@@ -94,8 +92,6 @@ def _create_custom_metric_flaml(
 
 
 def _create_sklearn_metric_flaml(metric_name: str, coeff: int, avg: str = "binary") -> callable:
-    # pylint: disable=keyword-arg-before-vararg
-    # pylint: disable=unused-argument
     def sklearn_metric(
         X_val,
         y_val,

--- a/mlflow/recipes/steps/train.py
+++ b/mlflow/recipes/steps/train.py
@@ -787,9 +787,7 @@ class TrainStep(BaseStep):
                 columns=["Model Rank", *metric_columns, "Run Time", "Run ID"],
             )
             .apply(
-                lambda s: s.map(lambda x: f"{x:.6g}")  # pylint: disable=unnecessary-lambda
-                if s.name in metric_names
-                else s,  # pylint: disable=unnecessary-lambda
+                lambda s: s.map(lambda x: f"{x:.6g}") if s.name in metric_names else s,
                 axis=0,
             )
             .set_axis(["Latest"] + top_leaderboard_item_index_values, axis="index")

--- a/mlflow/recipes/steps/transform.py
+++ b/mlflow/recipes/steps/transform.py
@@ -65,7 +65,7 @@ def _validate_user_code_output(transformer_fn):
 
 
 class TransformStep(BaseStep):
-    def __init__(self, step_config, recipe_root):  # pylint: disable=useless-super-delegation
+    def __init__(self, step_config, recipe_root):
         super().__init__(step_config, recipe_root)
         self.tracking_config = TrackingConfig.from_dict(self.step_config)
 

--- a/mlflow/recipes/utils/wrapped_recipe_model.py
+++ b/mlflow/recipes/utils/wrapped_recipe_model.py
@@ -23,7 +23,7 @@ class WrappedRecipeModel(PythonModel):
         self,
         context,
         model_input,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ):
         """
         Args:

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -1069,7 +1069,7 @@ def push_model_to_sagemaker(
     _logger.info("Created Sagemaker model with arn: %s", model_response["ModelArn"])
 
 
-def run_local(name, model_uri, flavor=None, config=None):  # pylint: disable=unused-argument
+def run_local(name, model_uri, flavor=None, config=None):
     """
     Serve the model locally in a SageMaker compatible Docker container.
 
@@ -2328,7 +2328,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
 
         return {"name": app_name, "flavor": flavor}
 
-    def update_deployment(self, name, model_uri, flavor=None, config=None, endpoint=None):  # pylint: disable=signature-differs
+    def update_deployment(self, name, model_uri, flavor=None, config=None, endpoint=None):
         """
         Update a deployment on AWS SageMaker. This function can replace or add a new model to
         an existing SageMaker endpoint. By default, this function replaces the existing model
@@ -2764,7 +2764,7 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
         self,
         deployment_name=None,
         inputs=None,
-        endpoint=None,  # pylint: disable=unused-argument
+        endpoint=None,
         params: Optional[Dict[str, Any]] = None,
     ):
         """

--- a/mlflow/shap/__init__.py
+++ b/mlflow/shap/__init__.py
@@ -665,7 +665,7 @@ class _SHAPWrapper:
     def predict(
         self,
         dataframe,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ):
         """
         Args:

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -512,7 +512,7 @@ class _SklearnModelWrapper:
     def predict(
         self,
         data,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ):
         """
         Args:
@@ -705,12 +705,10 @@ class _AutologgingMetricsManager:
 
     def disable_log_post_training_metrics(self):
         class LogPostTrainingMetricsDisabledScope:
-            def __enter__(inner_self):  # pylint: disable=no-self-argument
-                # pylint: disable=attribute-defined-outside-init
+            def __enter__(inner_self):
                 inner_self.old_status = self._log_post_training_metrics_enabled
                 self._log_post_training_metrics_enabled = False
 
-            # pylint: disable=no-self-argument
             def __exit__(inner_self, exc_type, exc_val, exc_tb):
                 self._log_post_training_metrics_enabled = inner_self.old_status
 
@@ -1005,7 +1003,7 @@ def autolog(
     registered_model_name=None,
     pos_label=None,
     extra_tags=None,
-):  # pylint: disable=unused-argument
+):
     """
     Enables (or disables) and configures autologging for scikit-learn estimators.
 
@@ -1308,7 +1306,7 @@ def _autolog(
     serialization_format=SERIALIZATION_FORMAT_CLOUDPICKLE,
     pos_label=None,
     extra_tags=None,
-):  # pylint: disable=unused-argument
+):
     """
     Internal autologging function for scikit-learn models.
 
@@ -1429,7 +1427,7 @@ def _autolog(
         params_logging_future.await_completion()
         return fit_output
 
-    def _log_pretraining_metadata(autologging_client, estimator, X, y):  # pylint: disable=unused-argument
+    def _log_pretraining_metadata(autologging_client, estimator, X, y):
         """
         Records metadata (e.g., params and tags) for a scikit-learn estimator prior to training.
         This is intended to be invoked within a patched scikit-learn training routine
@@ -1781,7 +1779,6 @@ def _autolog(
             if not hasattr(sklearn.utils.metaestimators, "_IffHasAttrDescriptor"):
                 return
 
-            # pylint: disable=redefined-builtin,unused-argument
             def patched_IffHasAttrDescriptor__get__(self, obj, type=None):
                 """
                 For sklearn version <= 0.24.2, `_IffHasAttrDescriptor.__get__` method does not

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -918,8 +918,6 @@ def _backported_all_estimators(type_filter=None):
         RegressorMixin,
         TransformerMixin,
     )
-
-    # pylint: disable=no-name-in-module, import-error
     from sklearn.utils.testing import ignore_warnings
 
     IS_PYPY = platform.python_implementation() == "PyPy"

--- a/mlflow/spacy/__init__.py
+++ b/mlflow/spacy/__init__.py
@@ -284,7 +284,7 @@ class _SpacyModelWrapper:
     def predict(
         self,
         dataframe,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ):
         """Only works for predicting using text categorizer.
         Not suitable for other pipeline components (e.g: parser)

--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -970,7 +970,7 @@ class _PyFuncModelWrapper:
     def predict(
         self,
         pandas_df,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ):
         """
         Generate predictions given input data in a pandas DataFrame.
@@ -1022,7 +1022,7 @@ class _PyFuncModelWrapper:
 
 
 @autologging_integration(FLAVOR_NAME)
-def autolog(disable=False, silent=False):  # pylint: disable=unused-argument
+def autolog(disable=False, silent=False):
     """
     Enables (or disables) and configures logging of Spark datasource paths, versions
     (if applicable), and formats when they are read. This method is not threadsafe and assumes a

--- a/mlflow/statsmodels/__init__.py
+++ b/mlflow/statsmodels/__init__.py
@@ -339,7 +339,7 @@ class _StatsmodelsModelWrapper:
     def predict(
         self,
         dataframe,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ):
         """
         Args:
@@ -433,7 +433,7 @@ def autolog(
     silent=False,
     registered_model_name=None,
     extra_tags=None,
-):  # pylint: disable=unused-argument
+):
     """
     Enables (or disables) and configures automatic logging from statsmodels to MLflow.
     Logs the following:

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -41,7 +41,7 @@ def _cached_get_s3_client(
     secret_access_key=None,
     session_token=None,
     region_name=None,
-):  # pylint: disable=unused-argument
+):
     """Returns a boto3 client, caching to avoid extra boto3 verify calls.
 
     This method is outside of the S3ArtifactRepository as it is

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -4,7 +4,7 @@ import time
 from contextlib import contextmanager
 
 import sqlalchemy
-from alembic.migration import MigrationContext  # pylint: disable=import-error
+from alembic.migration import MigrationContext
 from alembic.script import ScriptDirectory
 from sqlalchemy import sql
 

--- a/mlflow/store/model_registry/base_rest_store.py
+++ b/mlflow/store/model_registry/base_rest_store.py
@@ -9,7 +9,7 @@ from mlflow.utils.rest_utils import (
 
 
 @experimental
-class BaseRestStore(AbstractStore):  # pylint: disable=abstract-method
+class BaseRestStore(AbstractStore):
     """
     Base class client for a remote model registry server accessed via REST API calls
     """

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -400,7 +400,6 @@ class SqlAlchemyStore(AbstractStore):
                 select(SqlRegisteredModelTag.name)
                 .filter(sqlalchemy.or_(*sql_tag_filters))
                 .group_by(SqlRegisteredModelTag.name)
-                # pylint: disable-next=not-callable
                 .having(sqlalchemy.func.count(sqlalchemy.literal(1)) == len(tag_filters))
                 .subquery()
             )
@@ -487,7 +486,6 @@ class SqlAlchemyStore(AbstractStore):
                 select(SqlModelVersionTag.name, SqlModelVersionTag.version)
                 .filter(sqlalchemy.or_(*sql_tag_filters))
                 .group_by(SqlModelVersionTag.name, SqlModelVersionTag.version)
-                # pylint: disable-next=not-callable
                 .having(sqlalchemy.func.count(sqlalchemy.literal(1)) == len(tag_filters))
                 .subquery()
             )

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -670,9 +670,7 @@ def _load_tf1_estimator_saved_model(tf_saved_model_dir, tf_meta_graph_tags, tf_s
     """
     import tensorflow as tf
 
-    loaded = tf.saved_model.load(  # pylint: disable=no-value-for-parameter
-        tags=tf_meta_graph_tags, export_dir=tf_saved_model_dir
-    )
+    loaded = tf.saved_model.load(tags=tf_meta_graph_tags, export_dir=tf_saved_model_dir)
     loaded_sig = loaded.signatures
     if tf_signature_def_key not in loaded_sig:
         raise MlflowException(
@@ -733,9 +731,7 @@ def _load_pyfunc(path):
         tf_meta_graph_tags = flavor_conf["meta_graph_tags"]
         tf_signature_def_key = flavor_conf["signature_def_key"]
 
-        loaded_model = tf.saved_model.load(  # pylint: disable=no-value-for-parameter
-            export_dir=tf_saved_model_dir, tags=tf_meta_graph_tags
-        )
+        loaded_model = tf.saved_model.load(export_dir=tf_saved_model_dir, tags=tf_meta_graph_tags)
         return _TF2Wrapper(model=loaded_model, infer=loaded_model.signatures[tf_signature_def_key])
     if model_type == _MODEL_TYPE_TF2_MODULE:
         flavor_conf = _get_flavor_configuration(path, FLAVOR_NAME)
@@ -768,7 +764,7 @@ class _TF2Wrapper:
     def predict(
         self,
         data,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ):
         """
         Args:
@@ -824,7 +820,7 @@ class _TF2ModuleWrapper:
     def predict(
         self,
         data,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ):
         """
         Args:
@@ -860,7 +856,7 @@ class _KerasModelWrapper:
     def predict(
         self,
         data,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ):
         """
         Args:
@@ -928,7 +924,6 @@ def _setup_callbacks(callbacks, log_every_epoch, log_every_n_steps):
     Adds TensorBoard and MlfLowTfKeras callbacks to the
     input list, and returns the new list and appropriate log directory.
     """
-    # pylint: disable=no-name-in-module
     from mlflow.tensorflow.autologging import _TensorBoard
     from mlflow.tensorflow.callback import MLflowCallback
 
@@ -972,8 +967,7 @@ def autolog(
     extra_tags=None,
     log_every_epoch=True,
     log_every_n_steps=None,
-):  # pylint: disable=unused-argument
-    # pylint: disable=no-name-in-module
+):
     """
     Enables autologging for ``tf.keras``.
     Note that only ``tensorflow>=2.3`` are supported.
@@ -1185,7 +1179,7 @@ def autolog(
         def __init__(self):
             self.log_dir = None
 
-        def _patch_implementation(self, original, inst, *args, **kwargs):  # pylint: disable=arguments-differ
+        def _patch_implementation(self, original, inst, *args, **kwargs):
             unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
 
             batch_size = None

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -34,7 +34,7 @@ class ModelRegistryClient:
         # NB: Fetch the tracking store (`self.store`) upon client initialization to ensure that
         # the tracking URI is valid and the store can be properly resolved. We define `store` as a
         # property method to ensure that the client is serializable, even if the store is not
-        self.store  # pylint: disable=pointless-statement
+        self.store
 
     @property
     def store(self):

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -49,7 +49,7 @@ class TrackingServiceClient:
         # NB: Fetch the tracking store (`self.store`) upon client initialization to ensure that
         # the tracking URI is valid and the store can be properly resolved. We define `store` as a
         # property method to ensure that the client is serializable, even if the store is not
-        # self.store  # pylint: disable=pointless-statement
+        # self.store
         self.store
 
     @property

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -3331,7 +3331,7 @@ class MlflowClient:
         )
 
     @deprecated(since="2.9.0", impact=_STAGES_DEPRECATION_WARNING)
-    def get_model_version_stages(self, name: str, version: str) -> List[str]:  # pylint: disable=unused-argument
+    def get_model_version_stages(self, name: str, version: str) -> List[str]:
         """
         This is a docstring. Here is info.
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -182,7 +182,7 @@ def _set_experiment_primary_metric(
     )
 
 
-class ActiveRun(Run):  # pylint: disable=abstract-method
+class ActiveRun(Run):
     """Wrapper around :py:class:`mlflow.entities.Run` to enable using Python ``with`` syntax."""
 
     def __init__(self, run):
@@ -2021,7 +2021,6 @@ def autolog(
     disable_for_unsupported_versions: bool = False,
     silent: bool = False,
     extra_tags: Optional[Dict[str, str]] = None,
-    # pylint: disable=unused-argument
 ) -> None:
     """
     Enables (or disables) and configures autologging for all supported integrations.

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -285,7 +285,7 @@ def save_model(
     model_config: Optional[Dict[str, Any]] = None,
     example_no_conversion: bool = False,
     prompt_template: Optional[str] = None,
-    **kwargs,  # pylint: disable=unused-argument
+    **kwargs,
 ) -> None:
     """
     Save a trained transformers model to a path on the local file system.
@@ -2784,7 +2784,7 @@ def autolog(
     disable_for_unsupported_versions=False,
     silent=False,
     extra_tags=None,
-):  # pylint: disable=unused-argument
+):
     """
     This autologging integration is solely used for disabling spurious autologging of irrelevant
     sub-models that are created during the training and evaluation of transformers-based models.

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -523,7 +523,7 @@ class ColSpec:
 
     def __init__(
         self,
-        type: Union[DataType, Array, Object, str],  # pylint: disable=redefined-builtin
+        type: Union[DataType, Array, Object, str],
         name: Optional[str] = None,
         optional: Optional[bool] = None,
         required: Optional[bool] = None,  # TODO: update to required=True after deprecating optional
@@ -698,7 +698,7 @@ class TensorSpec:
 
     def __init__(
         self,
-        type: np.dtype,  # pylint: disable=redefined-builtin
+        type: np.dtype,
         shape: Union[tuple, list],
         name: Optional[str] = None,
     ):

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -164,7 +164,7 @@ def _inspect_original_var_name(var, fallback_name):
 
         frame = inspect.currentframe().f_back
         while frame is not None:
-            arg_info = inspect.getargvalues(frame)  # pylint: disable=deprecated-method
+            arg_info = inspect.getargvalues(frame)
 
             fixed_args = [arg_info.locals[arg_name] for arg_name in arg_info.args]
             varlen_args = list(arg_info.locals[arg_info.varargs]) if arg_info.varargs else []

--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -40,7 +40,6 @@ class _CaptureImportedModules:
         self.original_import_module = None
 
     def _wrap_import(self, original):
-        # pylint: disable=redefined-builtin
         @functools.wraps(original)
         def wrapper(name, globals=None, locals=None, fromlist=(), level=0):
             is_absolute_import = level == 0

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -1,5 +1,3 @@
-# pylint: disable=unused-wildcard-import,wildcard-import
-
 import contextlib
 import inspect
 import logging

--- a/mlflow/utils/autologging_utils/client.py
+++ b/mlflow/utils/autologging_utils/client.py
@@ -113,7 +113,7 @@ class MlflowAutologgingQueueingClient:
         """
         return self
 
-    def __exit__(self, exc_type, exc, traceback):  # pylint: disable=unused-argument
+    def __exit__(self, exc_type, exc, traceback):
         """
         Enables `MlflowAutologgingQueueingClient` to be used as a context manager with
         synchronous flushing upon exit, removing the need to call `flush()` for use cases

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -131,7 +131,7 @@ def acl_path_of_acl_root():
 
 def _get_property_from_spark_context(key):
     try:
-        from pyspark import TaskContext  # pylint: disable=import-error
+        from pyspark import TaskContext
 
         task_context = TaskContext.get()
         if task_context:

--- a/mlflow/utils/gorilla.py
+++ b/mlflow/utils/gorilla.py
@@ -231,7 +231,7 @@ class Patch:
         is_equal = self.__eq__(other)
         return is_equal if is_equal is NotImplemented else not is_equal
 
-    def __hash__(self):  # pylint: disable=useless-super-delegation
+    def __hash__(self):
         return super().__hash__()
 
     def _update(self, **kwargs):
@@ -492,7 +492,7 @@ def settings(**kwargs):
     return decorator
 
 
-def filter(value):  # pylint: disable=redefined-builtin
+def filter(value):
     """Modifier decorator to force the inclusion or exclusion of an attribute.
 
     This only modifies the behaviour of the :func:`create_patches` function
@@ -795,6 +795,6 @@ def _module_iterator(root, recursive=True):
                     yield module
 
 
-def _true(*args, **kwargs):  # pylint: disable=unused-argument
+def _true(*args, **kwargs):
     """Return ``True``."""
     return True

--- a/mlflow/utils/import_hooks/__init__.py
+++ b/mlflow/utils/import_hooks/__init__.py
@@ -293,7 +293,7 @@ class ImportHookFinder:
             # notify the hooks for import errors
             except (ImportError, AttributeError):
                 notify_module_import_error(fullname)
-                loader = importlib.find_loader(fullname, path)  # pylint: disable=deprecated-method
+                loader = importlib.find_loader(fullname, path)
             if loader:
                 return _ImportHookChainedLoader(loader)
         finally:
@@ -301,7 +301,7 @@ class ImportHookFinder:
 
     @synchronized(_post_import_hooks_lock)
     @synchronized(_import_error_hooks_lock)
-    def find_spec(self, fullname, path, target=None):  # pylint: disable=unused-argument
+    def find_spec(self, fullname, path, target=None):
         # If the module being imported is not one we have registered
         # import hooks for, we can return immediately. We will
         # take no further part in the importing of this module.

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -86,4 +86,4 @@ def _configure_mlflow_loggers(root_module_name):
 
 
 def eprint(*args, **kwargs):
-    print(*args, file=MLFLOW_LOGGING_STREAM, **kwargs)  # pylint: disable=print-function
+    print(*args, file=MLFLOW_LOGGING_STREAM, **kwargs)

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -517,7 +517,6 @@ def parse_tf_serving_input(inp_dict, schema=None):
         schema: MLflow schema used when parsing the data.
     """
 
-    # pylint: disable=broad-except
     if "signature_name" in inp_dict:
         raise MlflowInvalidInputException('"signature_name" parameter is currently not supported')
 

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -729,7 +729,7 @@ class SearchUtils:
         # the ordering conditions in reverse order.
         for order_by_clause in reversed(order_by_list):
             (key_type, key, ascending) = cls.parse_order_by_for_search_runs(order_by_clause)
-            # pylint: disable=cell-var-from-loop
+
             runs = sorted(
                 runs,
                 key=lambda run: cls._get_value_for_sort(run, key_type, key, ascending),
@@ -939,7 +939,7 @@ class SearchExperimentsUtils(SearchUtils):
         return False
 
     @classmethod
-    def _does_experiment_match_clause(cls, experiment, sed):  # pylint: disable=arguments-renamed
+    def _does_experiment_match_clause(cls, experiment, sed):
         key_type = sed.get("type")
         key = sed.get("key")
         value = sed.get("value")
@@ -964,7 +964,7 @@ class SearchExperimentsUtils(SearchUtils):
         return SearchUtils.get_comparison_func(comparator)(lhs, value)
 
     @classmethod
-    def filter(cls, experiments, filter_string):  # pylint: disable=arguments-renamed
+    def filter(cls, experiments, filter_string):
         if not filter_string:
             return experiments
         parsed = cls.parse_search_filter(filter_string)
@@ -1015,7 +1015,7 @@ class SearchExperimentsUtils(SearchUtils):
         return lambda experiment: tuple(_apply_sorter(experiment, k, asc) for (k, asc) in order_by)
 
     @classmethod
-    def sort(cls, experiments, order_by_list):  # pylint: disable=arguments-renamed
+    def sort(cls, experiments, order_by_list):
         return sorted(experiments, key=cls._get_sort_key(order_by_list))
 
 
@@ -1043,7 +1043,7 @@ class SearchModelUtils(SearchUtils):
     VALID_ORDER_BY_KEYS_REGISTERED_MODELS = {"name", "creation_timestamp", "last_updated_timestamp"}
 
     @classmethod
-    def _does_registered_model_match_clauses(cls, model, sed):  # pylint: disable=arguments-renamed
+    def _does_registered_model_match_clauses(cls, model, sed):
         key_type = sed.get("type")
         key = sed.get("key")
         value = sed.get("value")
@@ -1068,7 +1068,7 @@ class SearchModelUtils(SearchUtils):
         return SearchUtils.get_comparison_func(comparator)(lhs, value)
 
     @classmethod
-    def filter(cls, registered_models, filter_string):  # pylint: disable=arguments-renamed
+    def filter(cls, registered_models, filter_string):
         """Filters a set of registered models based on a search filter string."""
         if not filter_string:
             return registered_models
@@ -1108,7 +1108,7 @@ class SearchModelUtils(SearchUtils):
         return lambda model: tuple(_apply_reversor(model, k, asc) for (k, asc) in order_by)
 
     @classmethod
-    def sort(cls, models, order_by_list):  # pylint: disable=arguments-renamed
+    def sort(cls, models, order_by_list):
         return sorted(models, key=cls._get_sort_key(order_by_list))
 
     @classmethod
@@ -1222,7 +1222,7 @@ class SearchModelVersionUtils(SearchUtils):
     VALID_STRING_ATTRIBUTE_COMPARATORS = {"!=", "=", "LIKE", "ILIKE", "IN"}
 
     @classmethod
-    def _does_model_version_match_clauses(cls, mv, sed):  # pylint: disable=arguments-renamed
+    def _does_model_version_match_clauses(cls, mv, sed):
         key_type = sed.get("type")
         key = sed.get("key")
         value = sed.get("value")
@@ -1250,7 +1250,7 @@ class SearchModelVersionUtils(SearchUtils):
         return SearchUtils.get_comparison_func(comparator)(lhs, value)
 
     @classmethod
-    def filter(cls, model_versions, filter_string):  # pylint: disable=arguments-renamed
+    def filter(cls, model_versions, filter_string):
         """Filters a set of model versions based on a search filter string."""
         model_versions = [mv for mv in model_versions if mv.current_stage != STAGE_DELETED_INTERNAL]
         if not filter_string:
@@ -1294,7 +1294,7 @@ class SearchModelVersionUtils(SearchUtils):
         )
 
     @classmethod
-    def sort(cls, model_versions, order_by_list):  # pylint: disable=arguments-renamed
+    def sort(cls, model_versions, order_by_list):
         return sorted(model_versions, key=cls._get_sort_key(order_by_list))
 
     @classmethod

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -355,7 +355,7 @@ class _XGBModelWrapper:
     def predict(
         self,
         dataframe,
-        params: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        params: Optional[Dict[str, Any]] = None,
     ):
         """
         Args:
@@ -390,7 +390,7 @@ def autolog(
     registered_model_name=None,
     model_format="xgb",
     extra_tags=None,
-):  # pylint: disable=unused-argument
+):
     """
     Enables (or disables) and configures autologging from XGBoost to MLflow. Logs the following:
 
@@ -582,7 +582,6 @@ def autolog(
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 try:
-                    # pylint: disable=undefined-loop-variable
                     filepath = os.path.join(tmpdir, f"feature_importance_{imp_type}.png")
                     fig.savefig(filepath)
                     mlflow.log_artifact(filepath)

--- a/mlflow/xgboost/_autolog.py
+++ b/mlflow/xgboost/_autolog.py
@@ -42,11 +42,10 @@ if IS_TRAINING_CALLBACK_SUPPORTED:
         metaclass=ExceptionSafeAbstractClass,
     ):
         def __init__(self, metrics_logger, eval_results):
-            # pylint: disable=super-init-not-called
             self.metrics_logger = metrics_logger
             self.eval_results = eval_results
 
-        def after_iteration(self, model, epoch, evals_log):  # pylint: disable=unused-argument
+        def after_iteration(self, model, epoch, evals_log):
             """
             Run after each iteration. Return True when training should stop.
             """

--- a/tests/autologging/fixtures.py
+++ b/tests/autologging/fixtures.py
@@ -17,7 +17,7 @@ def patch_destination():
             self.fn_call_count = 0
             self.recurse_fn_call_count = 0
 
-        def fn(self, *args, **kwargs):  # pylint: disable=unused-argument
+        def fn(self, *args, **kwargs):
             self.fn_call_count += 1
             return PATCH_DESTINATION_FN_DEFAULT_RESULT
 

--- a/tests/autologging/test_autologging_behaviors_integration.py
+++ b/tests/autologging/test_autologging_behaviors_integration.py
@@ -1,5 +1,3 @@
-# pylint: disable=unused-argument
-
 import importlib
 import logging
 import sys

--- a/tests/autologging/test_autologging_behaviors_unit.py
+++ b/tests/autologging/test_autologging_behaviors_unit.py
@@ -1,5 +1,3 @@
-# pylint: disable=unused-argument
-
 import logging
 import sys
 import time

--- a/tests/autologging/test_autologging_client.py
+++ b/tests/autologging/test_autologging_client.py
@@ -137,7 +137,7 @@ def test_client_run_creation_and_termination_are_successful():
 def test_client_asynchronous_flush_operates_correctly():
     original_log_batch = MlflowClient().log_batch
 
-    def mock_log_batch(run_id, metrics=(), params=(), tags=()):  # pylint: disable=unused-argument
+    def mock_log_batch(run_id, metrics=(), params=(), tags=()):
         # Sleep to simulate a long-running logging operation
         time.sleep(3)
         return original_log_batch(run_id, metrics, params, tags)
@@ -168,7 +168,7 @@ def test_client_asynchronous_flush_operates_correctly():
 def test_client_synchronous_flush_operates_correctly():
     original_log_batch = MlflowClient().log_batch
 
-    def mock_log_batch(run_id, metrics=(), params=(), tags=()):  # pylint: disable=unused-argument
+    def mock_log_batch(run_id, metrics=(), params=(), tags=()):
         # Sleep to simulate a long-running logging operation
         time.sleep(3)
         return original_log_batch(run_id, metrics, params, tags)

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -1,5 +1,3 @@
-# pylint: disable=unused-argument
-
 import abc
 import copy
 import inspect
@@ -199,7 +197,7 @@ def test_safe_patch_forwards_expected_arguments_to_class_based_patch(
     bar_val = None
 
     class TestPatch(PatchFunction):
-        def _patch_implementation(self, original, foo, bar=10):  # pylint: disable=arguments-differ
+        def _patch_implementation(self, original, foo, bar=10):
             nonlocal foo_val
             nonlocal bar_val
             foo_val = foo
@@ -248,7 +246,7 @@ def test_safe_patch_provides_expected_original_function_to_class_based_patch(
     patch_destination.fn = original_fn
 
     class TestPatch(PatchFunction):
-        def _patch_implementation(self, original, foo, bar=10):  # pylint: disable=arguments-differ
+        def _patch_implementation(self, original, foo, bar=10):
             return original(foo + 1, bar + 2)
 
         def _on_exception(self, exception):
@@ -1781,7 +1779,7 @@ def test_safe_patch_support_property_decorated_method():
     flavor_name = "test_if_delegate_has_method_decorated_method_patch"
 
     @autologging_integration(flavor_name)
-    def autolog(disable=False, exclusive=False, silent=False):  # pylint: disable=unused-argument
+    def autolog(disable=False, exclusive=False, silent=False):
         mlflow.sklearn._patch_estimator_method_if_available(
             flavor_name,
             BaseEstimator,
@@ -1835,7 +1833,7 @@ def test_safe_patch_preserves_original_function_attributes():
     flavor_name = "test_safe_patch_preserves_original_function_attributes"
 
     @autologging_integration(flavor_name)
-    def autolog(disable=False, exclusive=False, silent=False):  # pylint: disable=unused-argument
+    def autolog(disable=False, exclusive=False, silent=False):
         safe_patch(flavor_name, Test1, "predict", patched_predict, manage_run=False)
 
     original_predict = Test1.predict

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -1,5 +1,3 @@
-# pylint: disable=unused-argument
-
 import inspect
 import sys
 import time
@@ -91,7 +89,7 @@ def start_run():
     mlflow.end_run()
 
 
-def dummy_fn(arg1, arg2="value2", arg3="value3"):  # pylint: disable=unused-argument
+def dummy_fn(arg1, arg2="value2", arg3="value3"):
     pass
 
 
@@ -110,7 +108,7 @@ log_test_args = [
 
 
 @pytest.mark.parametrize(("args", "kwargs", "expected"), log_test_args)
-def test_log_fn_args_as_params(args, kwargs, expected, start_run):  # pylint: disable=unused-argument
+def test_log_fn_args_as_params(args, kwargs, expected, start_run):
     log_fn_args_as_params(dummy_fn, args, kwargs)
     client = MlflowClient()
     params = client.get_run(mlflow.active_run().info.run_id).data.params
@@ -121,7 +119,7 @@ def test_log_fn_args_as_params(args, kwargs, expected, start_run):  # pylint: di
 
 def test_log_fn_args_as_params_ignores_unwanted_parameters(
     start_run,
-):  # pylint: disable=unused-argument
+):
     args, kwargs, unlogged = ("arg1", {"arg2": "value"}, ["arg1", "arg2", "arg3"])
     log_fn_args_as_params(dummy_fn, args, kwargs, unlogged)
     client = MlflowClient()

--- a/tests/data/test_dataset_registry.py
+++ b/tests/data/test_dataset_registry.py
@@ -31,7 +31,6 @@ def test_register_constructor_function_performs_validation():
     registry = DatasetRegistry()
 
     def from_good_function(
-        # pylint: disable=unused-argument
         path: str,
         name: Optional[str] = None,
         digest: Optional[str] = None,
@@ -41,7 +40,6 @@ def test_register_constructor_function_performs_validation():
     registry.register_constructor(from_good_function)
 
     def bad_name_fn(
-        # pylint: disable=unused-argument
         name: Optional[str] = None,
         digest: Optional[str] = None,
     ) -> Dataset:
@@ -56,7 +54,7 @@ def test_register_constructor_function_performs_validation():
         )
 
     def from_no_name_fn(
-        digest: Optional[str] = None,  # pylint: disable=unused-argument
+        digest: Optional[str] = None,
     ) -> Dataset:
         pass
 
@@ -64,7 +62,7 @@ def test_register_constructor_function_performs_validation():
         registry.register_constructor(from_no_name_fn)
 
     def from_no_digest_fn(
-        name: Optional[str] = None,  # pylint: disable=unused-argument
+        name: Optional[str] = None,
     ) -> Dataset:
         pass
 
@@ -72,7 +70,6 @@ def test_register_constructor_function_performs_validation():
         registry.register_constructor(from_no_digest_fn)
 
     def from_bad_return_type_fn(
-        # pylint: disable=unused-argument
         path: str,
         name: Optional[str] = None,
         digest: Optional[str] = None,
@@ -83,7 +80,6 @@ def test_register_constructor_function_performs_validation():
         registry.register_constructor(from_bad_return_type_fn)
 
     def from_no_return_type_fn(
-        # pylint: disable=unused-argument
         path: str,
         name: Optional[str] = None,
         digest: Optional[str] = None,
@@ -94,7 +90,7 @@ def test_register_constructor_function_performs_validation():
         registry.register_constructor(from_no_return_type_fn)
 
 
-def test_register_constructor_from_entrypoints_and_call(dataset_registry, tmp_path):  # pylint: disable=unused-argument
+def test_register_constructor_from_entrypoints_and_call(dataset_registry, tmp_path):
     """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
 
     from mlflow_test_plugin.dummy_dataset import DummyDataset
@@ -115,7 +111,7 @@ def test_register_constructor_from_entrypoints_and_call(dataset_registry, tmp_pa
     assert dataset.digest == "foo"
 
 
-def test_register_constructor_and_call(dataset_registry, dataset_source_registry, tmp_path):  # pylint: disable=unused-argument
+def test_register_constructor_and_call(dataset_registry, dataset_source_registry, tmp_path):
     dataset_source_registry.register(SampleDatasetSource)
 
     def from_test(data_list, source, name=None, digest=None) -> SampleDataset:

--- a/tests/db/test_tracking_operations.py
+++ b/tests/db/test_tracking_operations.py
@@ -121,7 +121,7 @@ def test_database_operational_error(exception, monkeypatch):
     def connect(*args, **kwargs):
         """Wraps sqlite3.dbapi.connect(), returning a wrapped connection."""
         global connect_counter
-        conn = old_connect(*args, **kwargs)  # pylint: disable=not-callable
+        conn = old_connect(*args, **kwargs)
         return ConnectionWrapper(conn)
 
     def dbapi(*args, **kwargs):

--- a/tests/deployments/test_deployments.py
+++ b/tests/deployments/test_deployments.py
@@ -86,7 +86,7 @@ def test_wrong_target_name():
 
 def test_plugin_doesnot_have_required_attrib():
     class DummyPlugin:
-        ...
+        pass
 
     dummy_plugin = DummyPlugin()
     plugin_manager = DeploymentPlugins()

--- a/tests/deployments/test_deployments.py
+++ b/tests/deployments/test_deployments.py
@@ -86,13 +86,13 @@ def test_wrong_target_name():
 
 def test_plugin_doesnot_have_required_attrib():
     class DummyPlugin:
-        ...  # pylint: disable=pointless-statement
+        ...
 
     dummy_plugin = DummyPlugin()
     plugin_manager = DeploymentPlugins()
     plugin_manager.registry["dummy"] = dummy_plugin
     with pytest.raises(MlflowException, match="Plugin registered for the target dummy"):
-        plugin_manager["dummy"]  # pylint: disable=pointless-statement
+        plugin_manager["dummy"]
 
 
 def test_plugin_raising_error():

--- a/tests/fastai/test_fastai_autolog.py
+++ b/tests/fastai/test_fastai_autolog.py
@@ -114,7 +114,6 @@ def test_fastai_autolog_persists_manually_created_run(iris_data, fit_variant):
 
 @pytest.fixture
 def fastai_random_tabular_data_run(iris_data, fit_variant):
-    # pylint: disable=unused-argument
     mlflow.fastai.autolog()
 
     model = fastai_tabular_model(iris_data)
@@ -132,7 +131,6 @@ def fastai_random_tabular_data_run(iris_data, fit_variant):
 
 @pytest.mark.parametrize("fit_variant", ["fit", "fit_one_cycle", "fine_tune"])
 def test_fastai_autolog_logs_expected_data(fastai_random_tabular_data_run, fit_variant):
-    # pylint: disable=unused-argument
     model, run = fastai_random_tabular_data_run
     data = run.data
 
@@ -188,7 +186,6 @@ def test_fastai_autolog_logs_expected_data(fastai_random_tabular_data_run, fit_v
 
 @pytest.mark.parametrize("fit_variant", ["fit", "fit_one_cycle", "fine_tune"])
 def test_fastai_autolog_opt_func_expected_data(iris_data, fit_variant):
-    # pylint: disable=unused-argument
     mlflow.fastai.autolog()
     model = fastai_tabular_model(iris_data, opt_func=partial(OptimWrapper, opt=optim.Adam))
 
@@ -226,7 +223,6 @@ def test_fastai_autolog_log_models_configuration(log_models, iris_data):
 
 @pytest.mark.parametrize("fit_variant", ["fit_one_cycle", "fine_tune"])
 def test_fastai_autolog_logs_default_params(fastai_random_tabular_data_run, fit_variant):
-    # pylint: disable=unused-argument
     client = MlflowClient()
     run_id = client.search_runs(["0"])[0].info.run_id
     artifacts = client.list_artifacts(run_id)
@@ -254,7 +250,6 @@ def test_fastai_autolog_model_can_load_from_artifact(fastai_random_tabular_data_
 
 
 def get_fastai_random_data_run_with_callback(iris_data, fit_variant, callback, patience, tmp_path):
-    # pylint: disable=unused-argument
     mlflow.fastai.autolog()
 
     model = fastai_tabular_model(iris_data, model_dir=tmp_path)

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -48,7 +48,7 @@ def h2o_iris_model():
             "target": ([f"Flower {i}" for i in iris.target]),
         }
     )
-    train, test = data.split_frame(ratios=[0.7])  # pylint: disable=unbalanced-tuple-unpacking
+    train, test = data.split_frame(ratios=[0.7])
 
     h2o_gbm = H2OGradientBoostingEstimator(ntrees=10, max_depth=6)
     h2o_gbm.train(["feature1", "feature2"], "target", training_frame=train)

--- a/tests/johnsnowlabs/test_johnsnowlabs_model_export.py
+++ b/tests/johnsnowlabs/test_johnsnowlabs_model_export.py
@@ -644,7 +644,7 @@ def test_log_model_calls_register_model(tmp_path, jsl_model):
 # def test_model_logging_uses_mlflowdbfs_if_appropriate_when_hdfs_check_fails(
 #     monkeypatch, jsl_model, dummy_read_shows_mlflowdbfs_available
 # ):
-#     def mock_spark_session_load(path):  # pylint: disable=unused-argument
+#     def mock_spark_session_load(path):
 #         if dummy_read_shows_mlflowdbfs_available:
 #             raise Exception("MlflowdbfsClient operation failed!")
 #         else:

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -160,7 +160,6 @@ class FakeLLM(LLM):
         """Return type of llm."""
         return "fake"
 
-    # pylint: disable=arguments-differ
     def _call(self, prompt: str, stop: Optional[List[str]] = None, run_manager=None) -> str:
         """First try to lookup in queries, else return 'foo' or 'bar'."""
         if self.queries is not None:
@@ -192,7 +191,6 @@ class FakeChain(Chain):
         """Output key of bar."""
         return self.the_output_keys
 
-    # pylint: disable=arguments-differ
     def _call(self, inputs: Dict[str, str], run_manager=None) -> Dict[str, str]:
         if self.be_correct:
             return {"bar": "baz"}
@@ -1674,7 +1672,7 @@ def test_predict_with_builtin_pyfunc_chat_conversion(spark):
     from langchain.schema.output_parser import StrOutputParser
 
     class ChatModel(SimpleChatModel):
-        def _call(self, messages, stop, run_manager, **kwargs):  # pylint: disable=signature-differs
+        def _call(self, messages, stop, run_manager, **kwargs):
             return "\n".join([f"{message.type}: {message.content}" for message in messages])
 
         @property
@@ -1792,7 +1790,7 @@ def test_predict_with_builtin_pyfunc_chat_conversion_for_aimessage_response():
     from langchain.chat_models.base import SimpleChatModel
 
     class ChatModel(SimpleChatModel):
-        def _call(self, messages, stop, run_manager, **kwargs):  # pylint: disable=signature-differs
+        def _call(self, messages, stop, run_manager, **kwargs):
             return "You own MLflow"
 
         @property

--- a/tests/models/test_model_input_examples.py
+++ b/tests/models/test_model_input_examples.py
@@ -287,7 +287,7 @@ class DummySklearnModel(BaseEstimator, ClassifierMixin):
     def __init__(self, output_shape=(1,)):
         self.output_shape = output_shape
 
-    def fit(self, X, y=None):  # pylint: disable=unused-argument
+    def fit(self, X, y=None):
         return self
 
     def predict(self, X):
@@ -361,7 +361,7 @@ def test_infer_signature_silently_fails(monkeypatch):
     monkeypatch.setenv("MLFLOW_TESTING", "false")
 
     class ErrorModel(BaseEstimator, ClassifierMixin):
-        def fit(self, X, y=None):  # pylint: disable=unused-argument
+        def fit(self, X, y=None):
             return self
 
         def predict(self, X):
@@ -424,7 +424,7 @@ def test_infer_signature_on_multi_column_input_examples(input_example, iris_mode
 )
 def test_infer_signature_on_scalar_input_examples(input_example):
     class IdentitySklearnModel(BaseEstimator, ClassifierMixin):
-        def fit(self, X, y=None):  # pylint: disable=unused-argument
+        def fit(self, X, y=None):
             return self
 
         def predict(self, X):

--- a/tests/paddle/test_paddle_autolog.py
+++ b/tests/paddle/test_paddle_autolog.py
@@ -12,7 +12,7 @@ class LinearRegression(paddle.nn.Layer):
         super().__init__()
         self.fc = paddle.nn.Linear(13, 1)
 
-    def forward(self, feature):  # pylint: disable=arguments-differ
+    def forward(self, feature):
         return self.fc(feature)
 
 

--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -64,7 +64,7 @@ def pd_model():
             self.fc_ = Linear(in_features=in_features, out_features=1)
 
         @paddle.jit.to_static
-        def forward(self, inputs):  # pylint: disable=arguments-differ
+        def forward(self, inputs):
             return self.fc_(inputs)
 
     training_data, test_data = get_dataset()
@@ -311,7 +311,7 @@ class UCIHousing(paddle.nn.Layer):
         super().__init__()
         self.fc_ = paddle.nn.Linear(13, 1, None)
 
-    def forward(self, inputs):  # pylint: disable=arguments-differ
+    def forward(self, inputs):
         return self.fc_(inputs)
 
 

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -96,7 +96,7 @@ def upload_to_dbfs_mock(dbfs_root_mock):
 
 
 @pytest.fixture
-def dbfs_path_exists_mock(dbfs_root_mock):  # pylint: disable=unused-argument
+def dbfs_path_exists_mock(dbfs_root_mock):
     with mock.patch(
         "mlflow.projects.databricks.DatabricksJobRunner._dbfs_path_exists"
     ) as path_exists_mock:
@@ -104,7 +104,7 @@ def dbfs_path_exists_mock(dbfs_root_mock):  # pylint: disable=unused-argument
 
 
 @pytest.fixture
-def dbfs_mocks(dbfs_path_exists_mock, upload_to_dbfs_mock):  # pylint: disable=unused-argument
+def dbfs_mocks(dbfs_path_exists_mock, upload_to_dbfs_mock):
     return
 
 
@@ -146,7 +146,7 @@ def run_databricks_project(cluster_spec, **kwargs):
 
 def test_upload_project_to_dbfs(
     dbfs_root_mock, tmp_path, dbfs_path_exists_mock, upload_to_dbfs_mock
-):  # pylint: disable=unused-argument
+):
     # Upload project to a mock directory
     dbfs_path_exists_mock.return_value = False
     runner = DatabricksJobRunner(databricks_profile_uri=construct_db_uri_from_profile("DEFAULT"))
@@ -165,7 +165,7 @@ def test_upload_project_to_dbfs(
     assert filecmp.cmp(local_tar_path, expected_tar_path, shallow=False)
 
 
-def test_upload_existing_project_to_dbfs(dbfs_path_exists_mock):  # pylint: disable=unused-argument
+def test_upload_existing_project_to_dbfs(dbfs_path_exists_mock):
     # Check that we don't upload the project if it already exists on DBFS
     with mock.patch(
         "mlflow.projects.databricks.DatabricksJobRunner._upload_to_dbfs"
@@ -214,7 +214,7 @@ def test_run_databricks_validations(
     cluster_spec_mock,
     dbfs_mocks,
     set_tag_mock,
-):  # pylint: disable=unused-argument
+):
     """
     Tests that running on Databricks fails before making any API requests if validations fail.
     """
@@ -400,7 +400,6 @@ def test_run_databricks_cancel(
     cluster_spec_mock,
     monkeypatch,
 ):
-    # pylint: disable=unused-argument
     # Test that MLflow properly handles Databricks run cancellation. We mock the result of
     # the runs-get API to indicate run failure so that cancel() exits instead of blocking while
     # waiting for run status.

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -34,7 +34,7 @@ def _build_uri(base_uri, subdirectory):
 
 
 @pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
-def test_docker_project_execution(use_start_run, docker_example_base_image):  # pylint: disable=unused-argument
+def test_docker_project_execution(use_start_run, docker_example_base_image):
     expected_params = {"use_start_run": use_start_run}
     submitted_run = mlflow.projects.run(
         TEST_DOCKER_PROJECT_DIR,
@@ -78,7 +78,7 @@ def test_docker_project_execution(use_start_run, docker_example_base_image):  # 
 
 def test_docker_project_execution_async_docker_args(
     docker_example_base_image,
-):  # pylint: disable=unused-argument
+):
     submitted_run = mlflow.projects.run(
         TEST_DOCKER_PROJECT_DIR,
         experiment_id=file_store.FileStore.DEFAULT_EXPERIMENT_ID,
@@ -112,7 +112,7 @@ def test_docker_project_tracking_uri_propagation(
     tracking_uri,
     expected_command_segment,
     docker_example_base_image,
-):  # pylint: disable=unused-argument
+):
     mock_provider = mock.MagicMock()
     mock_provider.get_config.return_value = DatabricksConfig.from_password(
         "host", "user", "pass", insecure=True
@@ -136,7 +136,7 @@ def test_docker_project_tracking_uri_propagation(
         mlflow.set_tracking_uri(old_uri)
 
 
-def test_docker_uri_mode_validation(docker_example_base_image):  # pylint: disable=unused-argument
+def test_docker_uri_mode_validation(docker_example_base_image):
     with pytest.raises(ExecutionException, match="When running on Databricks"):
         mlflow.projects.run(TEST_DOCKER_PROJECT_DIR, backend="databricks", backend_config={})
 

--- a/tests/projects/test_kubernetes.py
+++ b/tests/projects/test_kubernetes.py
@@ -10,7 +10,7 @@ from mlflow.exceptions import ExecutionException
 from mlflow.projects import kubernetes as kb
 
 
-def test_run_command_creation():  # pylint: disable=unused-argument
+def test_run_command_creation():
     """
     Tests command creation.
     """
@@ -34,7 +34,7 @@ def test_run_command_creation():  # pylint: disable=unused-argument
     ]
 
 
-def test_valid_kubernetes_job_spec():  # pylint: disable=unused-argument
+def test_valid_kubernetes_job_spec():
     """
     Tests job specification for Kubernetes.
     """

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -336,7 +336,7 @@ def test_create_env_with_mamba(monkeypatch):
     installed in the test environment anyway)
     """
 
-    def exec_cmd_mock(cmd, *args, **kwargs):  # pylint: disable=unused-argument
+    def exec_cmd_mock(cmd, *args, **kwargs):
         if cmd[-1] == "--json":
             # We are supposed to list environments in JSON format
             return subprocess.CompletedProcess(
@@ -347,7 +347,7 @@ def test_create_env_with_mamba(monkeypatch):
             # anything
             return subprocess.CompletedProcess(cmd, 0)
 
-    def exec_cmd_mock_raise(cmd, *args, **kwargs):  # pylint: disable=unused-argument
+    def exec_cmd_mock_raise(cmd, *args, **kwargs):
         if os.path.basename(cmd[0]) == "mamba":
             raise OSError()
 

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -47,7 +47,7 @@ def test_run_local_params(name):
 
 
 @skip_if_skinny
-def test_run_local_with_docker_args(docker_example_base_image):  # pylint: disable=unused-argument
+def test_run_local_with_docker_args(docker_example_base_image):
     # Verify that Docker project execution is successful when Docker flag and string
     # commandline arguments are supplied (`tty` and `name`, respectively)
     invoke_cli_runner(cli.run, [TEST_DOCKER_PROJECT_DIR, "-A", "tty", "-A", "name=mycontainer"])

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -63,7 +63,7 @@ def get_model_class():
 
         def load_context(self, context):
             super().load_context(context)
-            # pylint: disable=attribute-defined-outside-init
+
             self.model = mlflow.sklearn.load_model(model_uri=context.artifacts["sk_model"])
 
         def predict(self, context, model_input, params=None):
@@ -221,7 +221,7 @@ def test_python_model_predict_compatible_without_params(sklearn_knn_model, iris_
 
         def load_context(self, context):
             super().load_context(context)
-            # pylint: disable=attribute-defined-outside-init
+
             self.model = mlflow.sklearn.load_model(model_uri=context.artifacts["sk_model"])
 
         def predict(self, context, model_input):
@@ -1367,7 +1367,7 @@ def test_functional_python_model_unsupported_types(tmp_path):
 
 
 def requires_sklearn(x: List[str]) -> List[str]:
-    import sklearn  # pylint: disable=reimported  # noqa: F401
+    import sklearn  # noqa: F401
 
     return x
 

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -25,7 +25,7 @@ from tests.helper_functions import _assert_pip_requirements
 
 def _load_pyfunc(path):
     with open(path, "rb") as f:
-        return pickle.load(f, encoding="latin1")  # pylint: disable=unexpected-keyword-arg
+        return pickle.load(f, encoding="latin1")
 
 
 @pytest.fixture

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -34,7 +34,6 @@ from tests.helper_functions import (
     random_str,
 )
 
-# pylint: disable=no-name-in-module,reimported
 if Version(keras.__version__) >= Version("2.6.0"):
     from tensorflow.keras.layers import Concatenate, Dense, Input
     from tensorflow.keras.models import Model

--- a/tests/pytorch/iris.py
+++ b/tests/pytorch/iris.py
@@ -1,7 +1,3 @@
-# pylint: disable=arguments-differ
-# pylint: disable=unused-argument
-# pylint: disable=abstract-method
-
 import tempfile
 
 import pytorch_lightning as pl
@@ -26,7 +22,7 @@ def create_multiclass_accuracy():
         if Version(torchmetrics.__version__) >= Version("0.11"):
             return Accuracy(task="multiclass", num_classes=3)
         else:
-            return Accuracy()  # pylint: disable=no-value-for-parameter
+            return Accuracy()
     except ImportError:
         from pytorch_lightning.metrics import Accuracy
 

--- a/tests/pytorch/iris_data_module.py
+++ b/tests/pytorch/iris_data_module.py
@@ -1,8 +1,3 @@
-# pylint: disable=arguments-differ
-# pylint: disable=abstract-method
-# pylint: disable=attribute-defined-outside-init
-
-
 import pytorch_lightning as pl
 import torch
 from sklearn.datasets import load_iris

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -225,7 +225,6 @@ def test_pytorch_autolog_raises_error_when_step_logging_unsupported():
         trainer.fit(model, dm)
 
 
-# pylint: disable=unused-argument
 def test_pytorch_autolog_persists_manually_created_run():
     with mlflow.start_run() as manual_run:
         mlflow.pytorch.autolog()

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -125,14 +125,12 @@ def get_subclassed_model_definition():
     can be invoked within a module to define the class in the module's scope.
     """
 
-    # pylint: disable=abstract-method
     class SubclassedModel(torch.nn.Module):
         def __init__(self):
             super().__init__()
             self.linear = torch.nn.Linear(4, 1)
 
         def forward(self, x):
-            # pylint: disable=arguments-differ
             return self.linear(x)
 
     return SubclassedModel
@@ -150,7 +148,6 @@ def main_scoped_subclassed_model(data):
     return model
 
 
-# pylint: disable=abstract-method
 class ModuleScopedSubclassedModel(get_subclassed_model_definition()):
     """
     A custom PyTorch model class defined in the test module scope. This is a subclass of
@@ -582,7 +579,6 @@ def test_pyfunc_model_serving_with_module_scoped_subclassed_model_and_default_co
 def test_save_model_with_wrong_codepaths_fails_correctly(
     module_scoped_subclassed_model, model_path, data
 ):
-    # pylint: disable=unused-argument
     with pytest.raises(TypeError, match="Argument code_paths should be a list, not <class 'str'>"):
         mlflow.pytorch.save_model(
             path=model_path, pytorch_model=module_scoped_subclassed_model, code_paths="some string"
@@ -630,7 +626,6 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
     # `mlflow.pytorch.load_model`
     class TorchValidatorModel(pyfunc.PythonModel):
         def load_context(self, context):
-            # pylint: disable=attribute-defined-outside-init
             self.pytorch_model = mlflow.pytorch.load_model(context.artifacts["pytorch_model"])
 
         def predict(self, _, model_input, params=None):
@@ -858,12 +853,12 @@ def test_pyfunc_serve_and_score(data):
 
 @pytest.mark.skipif(not _is_importable("transformers"), reason="This test requires transformers")
 def test_pyfunc_serve_and_score_transformers():
-    from transformers import BertConfig, BertModel  # pylint: disable=import-error
+    from transformers import BertConfig, BertModel
 
     from mlflow.deployments import PredictionsResponse
 
     class MyBertModel(BertModel):
-        def forward(self, *args, **kwargs):  # pylint: disable=arguments-differ
+        def forward(self, *args, **kwargs):
             return super().forward(*args, **kwargs).last_hidden_state
 
     model = MyBertModel(

--- a/tests/recipes/test_execution_utils.py
+++ b/tests/recipes/test_execution_utils.py
@@ -39,7 +39,7 @@ def pandas_df():
 
 
 @pytest.fixture
-def test_recipe(enter_test_recipe_directory, pandas_df, tmp_path):  # pylint: disable=unused-argument
+def test_recipe(enter_test_recipe_directory, pandas_df, tmp_path):
     dataset_path = tmp_path / "df.parquet"
     pandas_df.to_parquet(dataset_path)
     ingest_step = IngestStep.from_recipe_config(
@@ -97,7 +97,7 @@ def test_recipe(enter_test_recipe_directory, pandas_df, tmp_path):  # pylint: di
 
 
 @pytest.fixture(autouse=True)
-def clean_test_recipe(enter_test_recipe_directory):  # pylint: disable=unused-argument
+def clean_test_recipe(enter_test_recipe_directory):
     Recipe(profile="local").clean()
     try:
         yield
@@ -107,7 +107,7 @@ def clean_test_recipe(enter_test_recipe_directory):  # pylint: disable=unused-ar
 
 def test_create_required_step_files(tmp_path):
     class TestStep(BaseStepImplemented):
-        def __init__(self):  # pylint: disable=super-init-not-called
+        def __init__(self):
             pass
 
         @property
@@ -135,7 +135,7 @@ def test_create_required_step_files(tmp_path):
 
 def test_get_or_create_execution_directory_is_idempotent(tmp_path):
     class TestStep(BaseStepImplemented):
-        def __init__(self):  # pylint: disable=super-init-not-called
+        def __init__(self):
             pass
 
         @property
@@ -215,7 +215,7 @@ def test_get_or_create_execution_directory_is_idempotent(tmp_path):
 
 def test_run_recipe_step_sets_environment_as_expected(tmp_path):
     class TestStep1(BaseStepImplemented):
-        def __init__(self):  # pylint: disable=super-init-not-called
+        def __init__(self):
             self.step_config = {}
 
         @property
@@ -227,7 +227,7 @@ def test_run_recipe_step_sets_environment_as_expected(tmp_path):
             return {"A": "B"}
 
     class TestStep2(BaseStepImplemented):
-        def __init__(self):  # pylint: disable=super-init-not-called
+        def __init__(self):
             self.step_config = {}
 
         @property
@@ -264,7 +264,7 @@ def test_run_recipe_step_sets_environment_as_expected(tmp_path):
 
 def test_run_recipe_step_calls_execution_plan(tmp_path):
     class TestStep(BaseStepImplemented):
-        def __init__(self):  # pylint: disable=super-init-not-called
+        def __init__(self):
             self.step_config = {}
 
         @property

--- a/tests/recipes/test_ingest_step.py
+++ b/tests/recipes/test_ingest_step.py
@@ -94,7 +94,7 @@ def test_ingests_parquet_successfully(use_relative_path, multiple_files, pandas_
     pd.testing.assert_frame_equal(reloaded_df, pandas_df)
 
 
-def custom_load_csv(file_path, file_format):  # pylint: disable=unused-argument
+def custom_load_csv(file_path, file_format):
     return pd.read_csv(file_path, index_col=0)
 
 
@@ -182,7 +182,7 @@ def test_ingests_csv_successfully(
     pd.testing.assert_frame_equal(reloaded_df, pandas_df)
 
 
-def custom_load_wine_csv(file_path, file_format):  # pylint: disable=unused-argument
+def custom_load_wine_csv(file_path, file_format):
     return pd.read_csv(file_path, sep=";")
 
 
@@ -213,7 +213,7 @@ def test_ingests_remote_http_datasets_with_multiple_files_successfully(tmp_path)
         assert reloaded_df.count()[0] == 6497
 
 
-def custom_load_file_as_dataframe(file_path, file_format):  # pylint: disable=unused-argument
+def custom_load_file_as_dataframe(file_path, file_format):
     return pd.read_csv(file_path, sep="#", index_col=0)
 
 

--- a/tests/recipes/test_train_step.py
+++ b/tests/recipes/test_train_step.py
@@ -361,7 +361,7 @@ def xgb_classifier():
     return xgb.XGBClassifier()
 
 
-def early_stop_fn(trial, count=0):  # pylint: disable=unused-argument
+def early_stop_fn(trial, count=0):
     return count + 1 <= 2, [count + 1]
 
 

--- a/tests/resources/example_project/check_conda_env.py
+++ b/tests/resources/example_project/check_conda_env.py
@@ -4,7 +4,7 @@
 import os
 import sys
 
-import psutil  # pylint: disable=import-error
+import psutil
 
 import mlflow
 

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/dummy_evaluator.py
@@ -27,9 +27,7 @@ class Array2DEvaluationArtifact(EvaluationArtifact):
         return pdf.to_numpy()
 
 
-# pylint: disable=attribute-defined-outside-init
 class DummyEvaluator(ModelEvaluator):
-    # pylint: disable=unused-argument
     def can_evaluate(self, *, model_type, evaluator_config, **kwargs):
         return model_type in ["classifier", "regressor"]
 
@@ -113,7 +111,6 @@ class DummyEvaluator(ModelEvaluator):
 
         return EvaluationResult(metrics=metrics, artifacts=artifacts)
 
-    # pylint: disable=unused-argument
     def evaluate(
         self, *, model, model_type, dataset, run_id, evaluator_config, baseline_model=None, **kwargs
     ):

--- a/tests/resources/onnx/generate_onnx_models.py
+++ b/tests/resources/onnx/generate_onnx_models.py
@@ -1,5 +1,3 @@
-# pylint: disable=import-error
-
 """
 Generates the following test resources:
 

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -513,7 +513,7 @@ class SageMakerBackend(BaseBackend):
             summaries.append(summary)
         return summaries
 
-    def list_tags(self, resource_arn, region_name, resource_type):  # pylint: disable=unused-argument
+    def list_tags(self, resource_arn, region_name, resource_type):
         """
         Modifies backend state during calls to the SageMaker "ListTags" API
         https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ListTags.html

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -257,7 +257,6 @@ def test_catch_mlflow_exception():
     def test_handler():
         raise MlflowException("test error", error_code=INTERNAL_ERROR)
 
-    # pylint: disable=assignment-from-no-return
     response = test_handler()
     json_response = json.loads(response.get_data())
     assert response.status_code == 500

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -491,7 +491,7 @@ def test_call_fit_with_arguments_score_does_not_accept():
 
     mock_obj = mock.Mock()
 
-    def mock_score(self, X, y, sample_weight=None):  # pylint: disable=unused-argument
+    def mock_score(self, X, y, sample_weight=None):
         mock_obj(X, y, sample_weight)
         return 0
 
@@ -532,7 +532,7 @@ def test_both_fit_and_score_contain_sample_weight(sample_weight_passed_as):
 
     mock_obj = mock.Mock()
 
-    def mock_score(self, X, y, sample_weight=None):  # pylint: disable=unused-argument
+    def mock_score(self, X, y, sample_weight=None):
         mock_obj(X, y, sample_weight)
         return 0
 
@@ -575,7 +575,7 @@ def test_only_fit_contains_sample_weight():
 
     mock_obj = mock.Mock()
 
-    def mock_score(self, X, y):  # pylint: disable=unused-argument
+    def mock_score(self, X, y):
         mock_obj(X, y)
         return 0
 
@@ -613,7 +613,7 @@ def test_only_score_contains_sample_weight():
 
     mock_obj = mock.Mock()
 
-    def mock_score(self, X, y, sample_weight=None):  # pylint: disable=unused-argument
+    def mock_score(self, X, y, sample_weight=None):
         mock_obj(X, y, sample_weight)
         return 0
 
@@ -677,7 +677,7 @@ def test_autolog_emits_warning_message_when_score_fails():
     model = sklearn.cluster.KMeans()
 
     @functools.wraps(model.score)
-    def throwing_score(X, y=None, sample_weight=None):  # pylint: disable=unused-argument
+    def throwing_score(X, y=None, sample_weight=None):
         raise Exception("EXCEPTION")
 
     model.score = throwing_score
@@ -700,7 +700,7 @@ def test_autolog_emits_warning_message_when_metric_fails():
     model = sklearn.svm.SVC()
 
     @functools.wraps(sklearn.metrics.precision_score)
-    def throwing_metrics(y_true, y_pred):  # pylint: disable=unused-argument
+    def throwing_metrics(y_true, y_pred):
         raise Exception("EXCEPTION")
 
     with mlflow.start_run(), mock.patch(
@@ -955,10 +955,10 @@ def test_autolog_metrics_input_example_and_signature_do_not_reflect_training_mut
     y_train = pd.Series([1.33, 1.35, 0.93])
 
     class CustomTransformer(BaseEstimator, TransformerMixin):
-        def fit(self, X, y=None):  # pylint: disable=unused-argument
+        def fit(self, X, y=None):
             return self
 
-        def transform(self, X, y=None):  # pylint: disable=unused-argument
+        def transform(self, X, y=None):
             # Perform arbitary transformation
             if "XXLarge Bags" in X.columns:
                 raise Exception("Found unexpected 'XXLarge Bags' column!")
@@ -1276,10 +1276,10 @@ def test_autolog_produces_expected_results_for_estimator_when_parent_also_define
         def get_params(self, deep=False):
             return {}
 
-        def fit(self, X, y):  # pylint: disable=unused-argument
+        def fit(self, X, y):
             self.prediction = np.array([7])
 
-        def predict(self, X):  # pylint: disable=unused-argument
+        def predict(self, X):
             return self.prediction
 
     class ChildMod(ParentMod):
@@ -1567,9 +1567,9 @@ def test_meta_estimator_disable_nested_post_training_autologging(scoring):
             cv_model = sklearn.model_selection.GridSearchCV(
                 svc, {"C": [1, 0.5]}, n_jobs=1, scoring=scoring
             )
-            cv_model.fit(X, y)  # pylint: disable=pointless-statement
-            cv_model.predict(X)  # pylint: disable=pointless-statement
-            cv_model.score(X, y)  # pylint: disable=pointless-statement
+            cv_model.fit(X, y)
+            cv_model.predict(X)
+            cv_model.score(X, y)
             mock_register_model.assert_called_once()
             assert mock_is_metric_value_loggable.call_count <= 1
             assert mock_log_post_training_metric.call_count <= 1
@@ -1602,7 +1602,6 @@ def test_meta_estimator_post_training_autologging(scoring):
 
 
 def test_gen_metric_call_commands():
-    # pylint: disable=unused-argument
     def metric_fn1(a1, b1, *, c2=3, d1=None, d2=True, d3="abc", **kwargs):
         pass
 

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -146,7 +146,7 @@ def test_predict_df_with_wrong_shape(spacy_model_with_data, model_path):
         )
 
 
-def test_model_log(spacy_model_with_data, tracking_uri_mock):  # pylint: disable=unused-argument
+def test_model_log(spacy_model_with_data, tracking_uri_mock):
     spacy_model = spacy_model_with_data.model
     old_uri = mlflow.get_tracking_uri()
     # should_start_run tests whether or not calling log_model() automatically starts a run.

--- a/tests/spark/autologging/datasource/test_spark_datasource_autologging_unit.py
+++ b/tests/spark/autologging/datasource/test_spark_datasource_autologging_unit.py
@@ -45,7 +45,6 @@ def test_subscriber_methods():
 def test_enabling_autologging_throws_for_wrong_spark_version(
     spark_session, mock_get_current_listener
 ):
-    # pylint: disable=unused-argument
     with mock.patch("mlflow.spark.autologging._get_spark_major_version", return_value=2):
         with pytest.raises(
             MlflowException, match="Spark autologging unsupported for Spark versions < 3"

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -200,7 +200,7 @@ def test_basic_estimator(dataset_binomial):
     Version(pyspark.__version__) < Version("3.1"),
     reason="This test require spark version >= 3.1",
 )
-def test_models_in_allowlist_exist(spark_session):  # pylint: disable=unused-argument
+def test_models_in_allowlist_exist(spark_session):
     mlflow.pyspark.ml.autolog()  # initialize the variable `mlflow.pyspark.ml._log_model_allowlist`
 
     def model_does_not_exist(model_class):
@@ -508,7 +508,7 @@ def test_pipeline(dataset_text):
 # Test on metric of rmse (smaller is better) and r2 (larger is better)
 @pytest.mark.parametrize("metric_name", ["rmse", "r2"])
 @pytest.mark.parametrize("param_search_estimator", [CrossValidator, TrainValidationSplit])
-def test_param_search_estimator(  # pylint: disable=unused-argument
+def test_param_search_estimator(
     metric_name, param_search_estimator, spark_session, dataset_regression
 ):
     mlflow.pyspark.ml.autolog(log_input_examples=True)
@@ -621,7 +621,7 @@ def test_param_search_estimator(  # pylint: disable=unused-argument
             assert math.isclose(std_metric_value, float(row.get(std_metric_name)), rel_tol=1e-6)
 
 
-def test_get_params_to_log(spark_session):  # pylint: disable=unused-argument
+def test_get_params_to_log(spark_session):
     lor = LogisticRegression(maxIter=3, standardization=False)
     lor_params = get_params_to_log(lor)
     assert lor_params["maxIter"] == 3
@@ -657,7 +657,7 @@ def test_get_params_to_log(spark_session):  # pylint: disable=unused-argument
         assert params_to_test["LogisticRegression.maxIter"] == 3
 
 
-def test_gen_estimator_metadata(spark_session):  # pylint: disable=unused-argument
+def test_gen_estimator_metadata(spark_session):
     tokenizer1 = Tokenizer(inputCol="text1", outputCol="words1")
     hashing_tf1 = HashingTF(inputCol=tokenizer1.getOutputCol(), outputCol="features1")
 
@@ -980,9 +980,6 @@ def test_autologging_handle_wrong_tuning_params(dataset_regression):
         ValueError, match="Tuning params should not include params not owned by the tuned estimator"
     ):
         pipeline.fit(dataset_regression)
-
-
-# pylint: disable=unused-argument
 
 
 def test_autolog_registering_model(spark_session, dataset_binomial):

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -848,7 +848,7 @@ def test_model_logged_via_mlflowdbfs_when_appropriate(
 def test_model_logging_uses_mlflowdbfs_if_appropriate_when_hdfs_check_fails(
     monkeypatch, spark_model_iris, dummy_read_shows_mlflowdbfs_available
 ):
-    def mock_spark_session_load(path):  # pylint: disable=unused-argument
+    def mock_spark_session_load(path):
         if dummy_read_shows_mlflowdbfs_available:
             raise Exception("MlflowdbfsClient operation failed!")
         else:

--- a/tests/statsmodels/model_fixtures.py
+++ b/tests/statsmodels/model_fixtures.py
@@ -111,9 +111,7 @@ def recursivels_model():
     endog = dta.WORLDCONSUMPTION
 
     # To the regressors in the dataset, we add a column of ones for an intercept
-    exog = sm.add_constant(
-        dta[["COPPERPRICE", "INCOMEINDEX", "ALUMPRICE", "INVENTORYINDEX"]]  # pylint: disable=unsubscriptable-object
-    )
+    exog = sm.add_constant(dta[["COPPERPRICE", "INCOMEINDEX", "ALUMPRICE", "INVENTORYINDEX"]])
     rls = sm.RecursiveLS(endog, exog)
     model = rls.fit()
 

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -289,7 +289,7 @@ def test_create_model_version_missing_output_signature(store, tmp_path):
 
 
 @mock_http_200
-def test_update_registered_model_name(mock_http, store):  # pylint: disable=unused-argument
+def test_update_registered_model_name(mock_http, store):
     name = "model_1"
     new_name = "model_2"
     with pytest.raises(
@@ -530,10 +530,10 @@ def get_request_mock(
         host_creds,
         endpoint,
         method,
-        max_retries=None,  # pylint: disable=unused-argument
-        backoff_factor=None,  # pylint: disable=unused-argument
-        retry_codes=None,  # pylint: disable=unused-argument
-        timeout=None,  # pylint: disable=unused-argument
+        max_retries=None,
+        backoff_factor=None,
+        retry_codes=None,
+        timeout=None,
         **kwargs,
     ):
         run_workspace_id = _get_workspace_id_for_run(run_id)

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -44,7 +44,6 @@ def mock_client():
 
 
 def test_artifact_uri_factory(mock_client):
-    # pylint: disable=unused-argument
     # We pass in the mock_client here to clear Azure environment variables, but we don't use it;
     # We do need to set up a fake access key for the code to run though
     os.environ["AZURE_STORAGE_ACCESS_KEY"] = ""
@@ -55,7 +54,6 @@ def test_artifact_uri_factory(mock_client):
 
 @mock.patch("azure.identity.DefaultAzureCredential")
 def test_default_az_cred_if_no_env_vars(mock_default_azure_credential, mock_client):
-    # pylint: disable=unused-argument
     # We pass in the mock_client here to clear Azure environment variables, but we don't use it
     AzureBlobArtifactRepository(TEST_URI)
     assert mock_default_azure_credential.call_count == 1
@@ -264,7 +262,7 @@ def test_download_directory_artifact_succeeds_when_artifact_root_is_not_blob_con
         without recursively listing the same artifacts at every level of the
         directory traversal.
         """
-        # pylint: disable=unused-argument
+
         if posixpath.abspath(kwargs["name_starts_with"]) == posixpath.abspath(TEST_ROOT_PATH):
             return MockBlobList([blob_props_1, blob_props_2])
         else:
@@ -313,7 +311,7 @@ def test_download_directory_artifact_succeeds_when_artifact_root_is_blob_contain
         `_download_artifacts_into` subroutine without recursively listing the same artifacts at
         every level of the directory traversal.
         """
-        # pylint: disable=unused-argument
+
         if posixpath.abspath(kwargs["name_starts_with"]) == "/":
             return MockBlobList([dir_prefix])
         if posixpath.abspath(kwargs["name_starts_with"]) == posixpath.abspath(subdir_path):
@@ -355,7 +353,7 @@ def test_download_artifact_throws_value_error_when_listed_blobs_do_not_contain_a
         without recursively listing the same artifacts at every level of the
         directory traversal.
         """
-        # pylint: disable=unused-argument
+
         if posixpath.abspath(kwargs["name_starts_with"]) == posixpath.abspath(TEST_ROOT_PATH):
             # Return a blob that is not prefixed by the root path of the artifact store. This
             # should result in an exception being raised

--- a/tests/store/artifact/test_azure_data_lake_artifact_repo.py
+++ b/tests/store/artifact/test_azure_data_lake_artifact_repo.py
@@ -335,7 +335,7 @@ def test_download_directory_artifact(mock_filesystem_client, mock_file_client, t
         without recursively listing the same artifacts at every level of the
         directory traversal.
         """
-        # pylint: disable=unused-argument
+
         path_arg = posixpath.abspath(kwargs["path"])
         if path_arg == posixpath.abspath(TEST_ROOT_PATH):
             return MockPathList([path_props_1, path_props_2, dir_props])

--- a/tests/store/artifact/test_cli.py
+++ b/tests/store/artifact/test_cli.py
@@ -41,7 +41,7 @@ def test_download_from_uri():
         def __init__(self, scheme):
             self.scheme = scheme
 
-        def download_artifacts(self, artifact_path, **kwargs):  # pylint: disable=unused-argument
+        def download_artifacts(self, artifact_path, **kwargs):
             return (self.scheme, artifact_path)
 
     def test_get_artifact_repository(artifact_uri):

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -1036,7 +1036,7 @@ def test_download_artifacts_awaits_download_completion(databricks_artifact_repo,
     """
 
     def mock_download_from_cloud(
-        cloud_credential_info,  # pylint: disable=unused-argument
+        cloud_credential_info,
         dst_local_file_path,
     ):
         # Sleep in order to simulate a longer-running asynchronous download
@@ -1086,7 +1086,7 @@ def test_artifact_logging(databricks_artifact_repo, tmp_path):
     dst_dir.mkdir()
 
     def mock_upload_to_cloud(
-        cloud_credential_info,  # pylint: disable=unused-argument
+        cloud_credential_info,
         src_file_path,
         artifact_file_path,
     ):

--- a/tests/store/artifact/test_dbfs_artifact_repo_delegation.py
+++ b/tests/store/artifact/test_dbfs_artifact_repo_delegation.py
@@ -24,7 +24,7 @@ def host_creds_mock():
 @mock.patch("mlflow.utils.databricks_utils.is_dbfs_fuse_available")
 def test_dbfs_artifact_repo_delegates_to_correct_repo(
     is_dbfs_fuse_available, host_creds_mock, monkeypatch
-):  # pylint: disable=unused-argument
+):
     # fuse available
     is_dbfs_fuse_available.return_value = True
     artifact_uri = "dbfs:/databricks/my/absolute/dbfs/path"

--- a/tests/store/artifact/test_dbfs_fuse_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_fuse_artifact_repo.py
@@ -28,7 +28,7 @@ def force_dbfs_fuse_repo(artifact_dir):
 
 
 @pytest.fixture
-def dbfs_fuse_artifact_repo(force_dbfs_fuse_repo):  # pylint: disable=unused-argument
+def dbfs_fuse_artifact_repo(force_dbfs_fuse_repo):
     return get_artifact_repository("dbfs:/unused/path/replaced/by/mock")
 
 

--- a/tests/store/artifact/test_dbfs_rest_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_rest_artifact_repo.py
@@ -116,7 +116,7 @@ def test_log_artifact(dbfs_artifact_repo, test_file, artifact_path, expected_end
         endpoints = []
         data = []
 
-        def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
+        def my_http_request(host_creds, **kwargs):
             endpoints.append(kwargs["endpoint"])
             data.append(kwargs["data"].read())
             return http_request(host_creds, **kwargs)
@@ -135,7 +135,7 @@ def test_log_artifact_empty_file(dbfs_artifact_repo, test_dir):
         "requests.Session.request", return_value=MOCK_SUCCESS_RESPONSE
     ) as mock_base_request:
 
-        def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
+        def my_http_request(host_creds, **kwargs):
             assert kwargs["endpoint"] == "/dbfs/test/empty-file"
             assert kwargs["data"] == ""
             return http_request(host_creds, **kwargs)
@@ -152,7 +152,7 @@ def test_log_artifact_empty_artifact_path(dbfs_artifact_repo, test_file):
         "requests.Session.request", return_value=MOCK_SUCCESS_RESPONSE
     ) as mock_base_request:
 
-        def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
+        def my_http_request(host_creds, **kwargs):
             assert kwargs["endpoint"] == "/dbfs/test/test.txt"
             assert kwargs["data"].read() == TEST_FILE_1_CONTENT
             return http_request(host_creds, **kwargs)
@@ -187,7 +187,7 @@ def test_log_artifacts(dbfs_artifact_repo, test_dir, artifact_path):
         endpoints = []
         data = []
 
-        def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
+        def my_http_request(host_creds, **kwargs):
             endpoints.append(kwargs["endpoint"])
             if kwargs["endpoint"] == "/dbfs/test/empty-file":
                 data.append(kwargs["data"])
@@ -254,7 +254,7 @@ def test_log_artifacts_with_artifact_path(
     ) as mock_base_request:
         endpoints = []
 
-        def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
+        def my_http_request(host_creds, **kwargs):
             endpoints.append(kwargs["endpoint"])
             return http_request(host_creds, **kwargs)
 

--- a/tests/store/artifact/test_ftp_artifact_repo.py
+++ b/tests/store/artifact/test_ftp_artifact_repo.py
@@ -1,4 +1,3 @@
-# pylint: disable=redefined-outer-name
 import ftplib
 import posixpath
 from ftplib import FTP

--- a/tests/store/artifact/test_gcs_artifact_repo.py
+++ b/tests/store/artifact/test_gcs_artifact_repo.py
@@ -1,4 +1,3 @@
-# pylint: disable=redefined-outer-name
 import os
 import posixpath
 from unittest import mock
@@ -196,7 +195,6 @@ def test_download_artifacts_calls_expected_gcs_client_methods(mock_client, tmp_p
     repo = GCSArtifactRepository("gs://test_bucket/some/path", mock_client)
 
     def mkfile(fname, **kwargs):
-        # pylint: disable=unused-argument
         fname = os.path.basename(fname)
         f = tmp_path.joinpath(fname)
         f.write_text("hello world!")
@@ -258,7 +256,7 @@ def test_download_artifacts_downloads_expected_content(mock_client, tmp_path):
         without recursively listing the same artifacts at every level of the
         directory traversal.
         """
-        # pylint: disable=unused-argument
+
         prefix = os.path.join("/", prefix)
         if os.path.abspath(prefix) == os.path.abspath(artifact_root_path):
             return mock_populated_results
@@ -266,7 +264,6 @@ def test_download_artifacts_downloads_expected_content(mock_client, tmp_path):
             return mock_empty_results
 
     def mkfile(fname, **kwargs):
-        # pylint: disable=unused-argument
         fname = os.path.basename(fname)
         f = tmp_path.joinpath(fname)
         f.write_text("hello world!")
@@ -321,7 +318,6 @@ def test_delete_artifacts(mock_client):
         directory traversal.
         """
 
-        # pylint: disable=unused-argument
         if hasattr(obj_mock, "name") and hasattr(obj_mock, "size"):
             mock_results = mock.MagicMock()
             mock_results.__iter__.return_value = [obj_mock]

--- a/tests/store/artifact/test_http_artifact_repo.py
+++ b/tests/store/artifact/test_http_artifact_repo.py
@@ -46,7 +46,7 @@ class MockResponse:
 
 
 class MockStreamResponse(MockResponse):
-    def iter_content(self, chunk_size):  # pylint: disable=unused-argument
+    def iter_content(self, chunk_size):
         yield self.data.encode("utf-8")
 
     def __enter__(self):

--- a/tests/store/artifact/test_mlflow_artifact_repo.py
+++ b/tests/store/artifact/test_mlflow_artifact_repo.py
@@ -79,7 +79,7 @@ class MockResponse:
 
 
 class MockStreamResponse(MockResponse):
-    def iter_content(self, chunk_size):  # pylint: disable=unused-argument
+    def iter_content(self, chunk_size):
         yield self.data.encode("utf-8")
 
     def __enter__(self):

--- a/tests/store/artifact/test_optimized_s3_artifact_repo.py
+++ b/tests/store/artifact/test_optimized_s3_artifact_repo.py
@@ -36,7 +36,6 @@ def test_get_s3_client_hits_cache(s3_artifact_root, monkeypatch):
         mock_get_s3_client.return_value = s3_client_mock
         s3_client_mock.head_bucket.return_value = {"BucketRegion": "us-west-2"}
 
-        # pylint: disable=no-value-for-parameter
         repo = OptimizedS3ArtifactRepository(posixpath.join(s3_artifact_root, "some/path"))
 
         # We get the s3 client once during initialization to get the bucket region name

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -77,7 +77,6 @@ def test_file_artifact_is_logged_with_content_metadata(
 
 
 def test_get_s3_client_hits_cache(s3_artifact_root, monkeypatch):
-    # pylint: disable=no-value-for-parameter
     repo = get_artifact_repository(posixpath.join(s3_artifact_root, "some/path"))
     repo._get_s3_client()
     cache_info = _cached_get_s3_client.cache_info()

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1829,7 +1829,7 @@ def test_log_batch_internal_error(store):
         run_name="name",
     )
 
-    def _raise_exception_fn(*args, **kwargs):  # pylint: disable=unused-argument
+    def _raise_exception_fn(*args, **kwargs):
         raise Exception("Some internal error")
 
     with mock.patch(

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -2704,7 +2704,7 @@ class TestSqlAlchemyStore(unittest.TestCase, AbstractStoreTest):
         # MlflowExceptions
         run = self._run_factory()
 
-        def _raise_exception_fn(*args, **kwargs):  # pylint: disable=unused-argument
+        def _raise_exception_fn(*args, **kwargs):
             raise Exception("Some internal error")
 
         package = "mlflow.store.tracking.sqlalchemy_store.SqlAlchemyStore"

--- a/tests/store/tracking/test_sqlalchemy_store_schema.py
+++ b/tests/store/tracking/test_sqlalchemy_store_schema.py
@@ -6,7 +6,7 @@ import pytest
 import sqlalchemy
 from alembic import command
 from alembic.autogenerate import compare_metadata
-from alembic.migration import MigrationContext  # pylint: disable=import-error
+from alembic.migration import MigrationContext
 from alembic.script import ScriptDirectory
 
 import mlflow.db

--- a/tests/tensorflow/save_keras_model.py
+++ b/tests/tensorflow/save_keras_model.py
@@ -33,7 +33,7 @@ if save_as_type == "tf1-estimator":
         tf.saved_model.save(model, tmp.path())
         if task_type == "save_model":
             save_path = args.save_path
-            # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+
             mlflow.tensorflow.save_model(
                 tf_saved_model_dir=tmp.path(),
                 tf_meta_graph_tags=["serve"],
@@ -43,7 +43,6 @@ if save_as_type == "tf1-estimator":
             )
         elif task_type == "log_model":
             with mlflow.start_run() as run:
-                # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
                 mlflow.tensorflow.log_model(
                     tf_saved_model_dir=tmp.path(),
                     tf_meta_graph_tags=["serve"],

--- a/tests/tensorflow/save_tf_estimator_model.py
+++ b/tests/tensorflow/save_tf_estimator_model.py
@@ -214,7 +214,6 @@ with TempDir() as tmp:
 
     if args.task_type == "log_model":
         with mlflow.start_run() as run:
-            # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
             mlflow.tensorflow.log_model(
                 tf_saved_model_dir=saved_model.path,
                 tf_meta_graph_tags=saved_model.meta_graph_tags,
@@ -224,7 +223,6 @@ with TempDir() as tmp:
             )
             run_id = run.info.run_id
     elif args.task_type == "save_model":
-        # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
         mlflow.tensorflow.save_model(
             tf_saved_model_dir=saved_model.path,
             tf_meta_graph_tags=saved_model.meta_graph_tags,

--- a/tests/tensorflow/test_keras_model_export.py
+++ b/tests/tensorflow/test_keras_model_export.py
@@ -12,8 +12,6 @@ import pytest
 import tensorflow as tf
 import yaml
 from packaging.version import Version
-
-# pylint: disable=no-name-in-module
 from sklearn import datasets
 from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Dense, Layer
@@ -135,7 +133,6 @@ def custom_layer():
             super().__init__(**kwargs)
 
         def build(self, input_shape):
-            # pylint: disable=attribute-defined-outside-init
             self.kernel = self.add_weight(
                 name="kernel",
                 shape=(input_shape[1], self.output_dim),
@@ -144,7 +141,7 @@ def custom_layer():
             )
             super().build(input_shape)
 
-        def call(self, inputs):  # pylint: disable=arguments-differ
+        def call(self, inputs):
             return K.dot(inputs, self.kernel)
 
         def compute_output_shape(self, input_shape):
@@ -640,7 +637,7 @@ def test_load_without_save_format(tf_keras_model, model_path, data):
     "https://github.com/huggingface/transformers/issues/22421",
 )
 def test_pyfunc_serve_and_score_transformers():
-    from transformers import BertConfig, TFBertModel  # pylint: disable=import-error
+    from transformers import BertConfig, TFBertModel
 
     bert_model = TFBertModel(
         BertConfig(

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -195,7 +195,6 @@ def test_extra_tags_tensorflow_autolog(random_train_data, random_one_hot_labels)
 def test_tf_keras_autolog_log_models_configuration(
     random_train_data, random_one_hot_labels, log_models
 ):
-    # pylint: disable=unused-argument
     mlflow.tensorflow.autolog(log_models=log_models)
 
     data = random_train_data
@@ -366,7 +365,6 @@ def test_tf_keras_autolog_persists_manually_created_run(random_train_data, rando
 
 @pytest.fixture
 def tf_keras_random_data_run(random_train_data, random_one_hot_labels, initial_epoch):
-    # pylint: disable=unused-argument
     mlflow.tensorflow.autolog()
 
     data = random_train_data
@@ -727,7 +725,6 @@ def get_tf_keras_random_data_run_with_callback(
     initial_epoch,
     log_models,
 ):
-    # pylint: disable=unused-argument
     mlflow.tensorflow.autolog(every_n_iter=1, log_models=log_models)
 
     data = random_train_data
@@ -965,7 +962,6 @@ def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboa
 def get_text_vec_model(train_samples):
     # Taken from: https://github.com/mlflow/mlflow/issues/3910
 
-    # pylint: disable=no-name-in-module
     try:
         from tensorflow.keras.layers.experimental.preprocessing import TextVectorization
     except ModuleNotFoundError:
@@ -1087,7 +1083,7 @@ def test_tf_keras_autolog_distributed_training(random_train_data, random_one_hot
 def test_import_tensorflow_with_fluent_autolog_enables_tensorflow_autologging():
     mlflow.autolog()
 
-    import tensorflow  # pylint: disable=reimported  # noqa: F401
+    import tensorflow  # noqa: F401
 
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 

--- a/tests/tensorflow/test_tensorflow2_core_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_core_model_export.py
@@ -10,7 +10,6 @@ import mlflow.tensorflow
 from mlflow.models import Model, infer_signature
 
 
-# pylint: disable=abstract-method
 class ToyModel(tf.Module):
     def __init__(self, w, b):
         super().__init__()

--- a/tests/tracking/_model_registry/test_model_registry_client.py
+++ b/tests/tracking/_model_registry/test_model_registry_client.py
@@ -109,7 +109,6 @@ def test_rename_registered_model(mock_store):
 
 
 def test_update_registered_model_validation_errors_on_empty_new_name(mock_store):
-    # pylint: disable=unused-argument
     with pytest.raises(MlflowException, match="The name must not be an empty string"):
         newModelRegistryClient().rename_registered_model("Model 1", " ")
 
@@ -324,7 +323,6 @@ def test_transition_model_version_stage(mock_store):
 
 
 def test_transition_model_version_stage_validation_errors(mock_store):
-    # pylint: disable=unused-argument
     with pytest.raises(MlflowException, match="The stage must not be an empty string"):
         newModelRegistryClient().transition_model_version_stage("Model 1", "12", stage=" ")
 

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -32,8 +32,6 @@ from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.os import is_windows
 
-# pylint: disable=unused-argument
-
 # Disable mocking tracking URI here, as we want to test setting the tracking URI via
 # environment variable. See
 # http://doc.pytest.org/en/latest/skipping.html#skip-all-test-functions-of-a-class-or-module

--- a/tests/tracking/context/test_default_context.py
+++ b/tests/tracking/context/test_default_context.py
@@ -6,9 +6,6 @@ from mlflow.entities import SourceType
 from mlflow.tracking.context.default_context import DefaultRunContext
 from mlflow.utils.mlflow_tags import MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE, MLFLOW_USER
 
-# pylint: disable=unused-argument
-
-
 MOCK_SCRIPT_NAME = "/path/to/script.py"
 
 

--- a/tests/tracking/context/test_git_context.py
+++ b/tests/tracking/context/test_git_context.py
@@ -6,9 +6,6 @@ import pytest
 from mlflow.tracking.context.git_context import GitRunContext
 from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT
 
-# pylint: disable=unused-argument
-
-
 MOCK_SCRIPT_NAME = "/path/to/script.py"
 MOCK_COMMIT_HASH = "commit-hash"
 

--- a/tests/tracking/context/test_registry.py
+++ b/tests/tracking/context/test_registry.py
@@ -11,8 +11,6 @@ from mlflow.tracking.context.default_context import DefaultRunContext
 from mlflow.tracking.context.git_context import GitRunContext
 from mlflow.tracking.context.registry import RunContextProviderRegistry, resolve_tags
 
-# pylint: disable=unused-argument
-
 
 def test_run_context_provider_registry_register():
     provider_class = mock.Mock()

--- a/tests/tracking/default_experiment/test_registry.py
+++ b/tests/tracking/default_experiment/test_registry.py
@@ -12,8 +12,6 @@ from mlflow.tracking.default_experiment.registry import (
     get_experiment_id,
 )
 
-# pylint: disable=unused-argument
-
 
 def test_default_experiment_provider_registry_register():
     provider_class = mock.Mock()

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -513,7 +513,7 @@ def is_from_run(active_run, run):
     return active_run.info == run.info and active_run.data == run.data
 
 
-def test_start_run_defaults(empty_active_run_stack):  # pylint: disable=unused-argument
+def test_start_run_defaults(empty_active_run_stack):
     mlflow.disable_system_metrics_logging()
     mock_experiment_id = mock.Mock()
     experiment_id_patch = mock.patch(
@@ -563,7 +563,7 @@ def test_start_run_defaults(empty_active_run_stack):  # pylint: disable=unused-a
 
 def test_start_run_defaults_databricks_notebook(
     empty_active_run_stack,
-):  # pylint: disable=unused-argument
+):
     mock_experiment_id = mock.Mock()
     experiment_id_patch = mock.patch(
         "mlflow.tracking.fluent._get_experiment_id", return_value=mock_experiment_id
@@ -749,7 +749,7 @@ def test_start_run_with_parent_non_nested():
             start_run()
 
 
-def test_start_run_existing_run(empty_active_run_stack):  # pylint: disable=unused-argument
+def test_start_run_existing_run(empty_active_run_stack):
     mock_run = mock.Mock()
     mock_run.info.lifecycle_stage = LifecycleStage.ACTIVE
 
@@ -763,7 +763,7 @@ def test_start_run_existing_run(empty_active_run_stack):  # pylint: disable=unus
         MlflowClient.get_run.assert_called_with(run_id)
 
 
-def test_start_run_existing_run_from_environment(empty_active_run_stack, monkeypatch):  # pylint: disable=unused-argument
+def test_start_run_existing_run_from_environment(empty_active_run_stack, monkeypatch):
     mock_run = mock.Mock()
     mock_run.info.lifecycle_stage = LifecycleStage.ACTIVE
 
@@ -780,7 +780,7 @@ def test_start_run_existing_run_from_environment(empty_active_run_stack, monkeyp
 
 def test_start_run_existing_run_from_environment_with_set_environment(
     empty_active_run_stack, monkeypatch
-):  # pylint: disable=unused-argument
+):
     mock_run = mock.Mock()
     mock_run.info.lifecycle_stage = LifecycleStage.ACTIVE
 
@@ -794,7 +794,7 @@ def test_start_run_existing_run_from_environment_with_set_environment(
             start_run()
 
 
-def test_start_run_existing_run_deleted(empty_active_run_stack):  # pylint: disable=unused-argument
+def test_start_run_existing_run_deleted(empty_active_run_stack):
     mock_run = mock.Mock()
     mock_run.info.lifecycle_stage = LifecycleStage.DELETED
 
@@ -806,7 +806,7 @@ def test_start_run_existing_run_deleted(empty_active_run_stack):  # pylint: disa
             start_run(run_id)
 
 
-def test_start_existing_run_status(empty_active_run_stack):  # pylint: disable=unused-argument
+def test_start_existing_run_status(empty_active_run_stack):
     run_id = mlflow.start_run().info.run_id
     mlflow.end_run()
     assert MlflowClient().get_run(run_id).info.status == RunStatus.to_string(RunStatus.FINISHED)
@@ -814,7 +814,7 @@ def test_start_existing_run_status(empty_active_run_stack):  # pylint: disable=u
     assert restarted_run.info.status == RunStatus.to_string(RunStatus.RUNNING)
 
 
-def test_start_existing_run_end_time(empty_active_run_stack):  # pylint: disable=unused-argument
+def test_start_existing_run_end_time(empty_active_run_stack):
     run_id = mlflow.start_run().info.run_id
     mlflow.end_run()
     run_obj_info = MlflowClient().get_run(run_id).info
@@ -826,7 +826,7 @@ def test_start_existing_run_end_time(empty_active_run_stack):  # pylint: disable
     assert run_obj_info.end_time > old_end
 
 
-def test_start_run_with_description(empty_active_run_stack):  # pylint: disable=unused-argument
+def test_start_run_with_description(empty_active_run_stack):
     mock_experiment_id = mock.Mock()
     experiment_id_patch = mock.patch(
         "mlflow.tracking.fluent._get_experiment_id", return_value=mock_experiment_id

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -88,7 +88,7 @@ def reset_global_states():
 #   and is only imported when we call wrapt.notify_module_loaded in the tests below. Normally,
 #   notify_module_loaded would be called by register_post_import_hook if it sees that the module
 #   is already loaded.
-def only_register(callback_fn, module, overwrite):  # pylint: disable=unused-argument
+def only_register(callback_fn, module, overwrite):
     mlflow.utils.import_hooks._post_import_hooks[module] = [callback_fn]
 
 

--- a/tests/tracking/request_header/test_registry.py
+++ b/tests/tracking/request_header/test_registry.py
@@ -12,8 +12,6 @@ from mlflow.tracking.request_header.registry import (
     resolve_request_headers,
 )
 
-# pylint: disable=unused-argument
-
 
 @pytest.fixture(autouse=True)
 def reload_registry():

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -64,7 +64,7 @@ def mock_databricks_tracking_store():
             self.run_id = run_id
             self.experiment_id = experiment_id
 
-        def get_run(self, *args, **kwargs):  # pylint: disable=unused-argument
+        def get_run(self, *args, **kwargs):
             return Run(
                 RunInfo(self.run_id, self.experiment_id, "userid", "status", 0, 1, None), None
             )

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -1018,7 +1018,7 @@ def test_get_metric_history_bulk_calls_optimized_impl_when_expected(tmp_path):
 
         def to_dict(
             self,
-            flat,  # pylint: disable=unused-argument
+            flat,
         ):
             return self.args_dict
 

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -259,9 +259,7 @@ def test_use_repl_context_if_available(tmp_path, monkeypatch):
 
     command_context_mock = mock.MagicMock()
     command_context_mock.jobId().get.return_value = "job_id"
-    command_context_mock.tags().get(  # pylint: disable=not-callable
-        "jobType"
-    ).get.return_value = "NORMAL"
+    command_context_mock.tags().get("jobType").get.return_value = "NORMAL"
     with mock.patch(
         "mlflow.utils.databricks_utils._get_command_context", return_value=command_context_mock
     ) as mock_get_command_context:

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -41,7 +41,7 @@ def spark_session():
 def test_yaml_read_and_write(tmp_path):
     temp_dir = str(tmp_path)
     yaml_file = random_file("yaml")
-    long_value = 1  # pylint: disable=undefined-variable
+    long_value = 1
     data = {
         "a": random_int(),
         "B": random_int(),

--- a/tests/utils/test_gorilla.py
+++ b/tests/utils/test_gorilla.py
@@ -49,13 +49,13 @@ def test_basic_patch_for_class(gorilla_setting):
     original_A_f2 = A.f2
     original_B_f1 = B.f1
 
-    def patched_A_f1(self):  # pylint: disable=unused-argument
+    def patched_A_f1(self):
         pass
 
-    def patched_A_f2(self):  # pylint: disable=unused-argument
+    def patched_A_f2(self):
         pass
 
-    def patched_B_f1(self):  # pylint: disable=unused-argument
+    def patched_B_f1(self):
         pass
 
     patch_A_f1 = gorilla.Patch(A, "f1", patched_A_f1, gorilla_setting)
@@ -107,7 +107,7 @@ def test_patch_for_descriptor(gorilla_setting):
 
     original_A_f3_raw = object.__getattribute__(A, "f3")
 
-    def patched_A_f3(self):  # pylint: disable=unused-argument
+    def patched_A_f3(self):
         pass
 
     patch_A_f3 = gorilla.Patch(A, "f3", patched_A_f3, gorilla_setting)
@@ -136,7 +136,7 @@ def test_patch_for_descriptor(gorilla_setting):
 
     # test patch a descriptor
     @delegate(patched_A_f3)
-    def new_patched_A_f3(self):  # pylint: disable=unused-argument
+    def new_patched_A_f3(self):
         pass
 
     new_patch_A_f3 = gorilla.Patch(A, "f3", new_patched_A_f3, gorilla_setting)
@@ -156,7 +156,7 @@ def test_patch_on_inherit_method(store_hit):
 
     original_A_f2 = A.f2
 
-    def patched_B_f2(self):  # pylint: disable=unused-argument
+    def patched_B_f2(self):
         pass
 
     gorilla_setting = gorilla.Settings(allow_hit=True, store_hit=store_hit)
@@ -177,7 +177,7 @@ def test_patch_on_inherit_method(store_hit):
 def test_patch_on_attribute_not_exist(store_hit):
     A, _ = gen_class_A_B()
 
-    def patched_fx(self):  # pylint: disable=unused-argument
+    def patched_fx(self):
         return 101
 
     gorilla_setting = gorilla.Settings(allow_hit=True, store_hit=store_hit)


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

#11183 removed pylint. We can remove `pylint: disable` comments.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
