### PR TITLE
Make _init_databricks_cli_config_provider supporting Databricks Runtime 9 ~ 13

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -738,54 +738,78 @@ def _init_databricks_cli_config_provider(entry_point):
     """
     notebook_utils = entry_point.getDbutils().notebook()
 
-    class DynamicConfigProvider(DatabricksConfigProvider):
-        def get_config(self):
-            logger = entry_point.getLogger()
-            try:
-                from dbruntime.databricks_repl_context import get_context
+    dbr_version = os.environ["DATABRICKS_RUNTIME_VERSION"]
+    dbr_major_version = int(dbr_version.split(".", maxsplit=1)[0])
 
-                ctx = get_context()
-                if ctx and ctx.apiUrl and ctx.apiToken:
-                    return DatabricksConfig.from_token(
-                        host=ctx.apiUrl, token=ctx.apiToken, insecure=ctx.sslTrustAll
+    if dbr_major_version > 9:
+        class DynamicConfigProvider(DatabricksConfigProvider):
+            def get_config(self):
+                logger = entry_point.getLogger()
+                try:
+                    from dbruntime.databricks_repl_context import get_context
+
+                    ctx = get_context()
+                    if ctx and ctx.apiUrl and ctx.apiToken:
+                        return DatabricksConfig.from_token(
+                            host=ctx.apiUrl, token=ctx.apiToken, insecure=ctx.sslTrustAll
+                        )
+                except Exception as e:
+                    print(  # noqa
+                        "Unexpected internal error while constructing `DatabricksConfig` "
+                        f"from REPL context: {e}",
+                        file=stderr,
                     )
-            except Exception as e:
-                print(  # noqa
-                    "Unexpected internal error while constructing `DatabricksConfig` "
-                    f"from REPL context: {e}",
-                    file=stderr,
+                # Invoking getContext() will attempt to find the credentials related to the
+                # current command execution, so it's critical that we execute it on every
+                # get_config().
+                api_url_option = notebook_utils.getContext().apiUrl()
+                api_url = api_url_option.get() if api_url_option.isDefined() else None
+                # Invoking getNonUcApiToken() will attempt to find the current credentials related
+                # to the current command execution and refresh it if its expired automatically,
+                # so it's critical that we execute it on every get_config().
+                api_token = None
+                try:
+                    api_token = entry_point.getNonUcApiToken()
+                except Exception:
+                    # Using apiToken from command context would return back the token which is not
+                    # refreshed.
+                    fallback_api_token_option = notebook_utils.getContext().apiToken()
+                    logger.logUsage(
+                        "refreshableTokenNotFound",
+                        {"api_url": api_url},
+                        None,
+                    )
+                    if fallback_api_token_option.isDefined():
+                        api_token = fallback_api_token_option.get()
+
+                ssl_trust_all = entry_point.getDriverConf().workflowSslTrustAll()
+
+                # Fallback to the default behavior if we were unable to find a token.
+                if api_token is None or api_url is None:
+                    return DefaultConfigProvider().get_config()
+
+                return DatabricksConfig.from_token(
+                    host=api_url, token=api_token, insecure=ssl_trust_all
                 )
-            # Invoking getContext() will attempt to find the credentials related to the
-            # current command execution, so it's critical that we execute it on every get_config().
-            api_url_option = notebook_utils.getContext().apiUrl()
-            api_url = api_url_option.get() if api_url_option.isDefined() else None
-            # Invoking getNonUcApiToken() will attempt to find the current credentials related to
-            # the current command execution and refresh it if its expired automatically,
-            # so it's critical that we execute it on every get_config().
-            api_token = None
-            try:
-                api_token = entry_point.getNonUcApiToken()
-            except Exception:
-                # Using apiToken from command context would return back the token which is not
-                # refreshed.
-                fallback_api_token_option = notebook_utils.getContext().apiToken()
-                logger.logUsage(
-                    "refreshableTokenNotFound",
-                    {"api_url": api_url},
-                    None,
+    else:
+        notebook_utils = entry_point.getDbutils().notebook()
+
+        class DynamicConfigProvider(DatabricksConfigProvider):
+            def get_config(self):
+                # Invoking getContext() will attempt to find the credentials related to the
+                # current command execution, so it's critical that we execute it on every
+                # get_config().
+                api_token_option = notebook_utils.getContext().apiToken()
+                api_url_option = notebook_utils.getContext().apiUrl()
+                ssl_trust_all = entry_point.getDriverConf().workflowSslTrustAll()
+
+                # Fallback to the default behavior if we were unable to find a token.
+                if not api_token_option.isDefined() or not api_url_option.isDefined():
+                    return DefaultConfigProvider().get_config()
+
+                return DatabricksConfig.from_token(
+                    host=api_url_option.get(), token=api_token_option.get(), insecure=ssl_trust_all
                 )
-                if fallback_api_token_option.isDefined():
-                    api_token = fallback_api_token_option.get()
-
-            ssl_trust_all = entry_point.getDriverConf().workflowSslTrustAll()
-
-            # Fallback to the default behavior if we were unable to find a token.
-            if api_token is None or api_url is None:
-                return DefaultConfigProvider().get_config()
-
-            return DatabricksConfig.from_token(
-                host=api_url, token=api_token, insecure=ssl_trust_all
-            )
 
     set_config_provider(DynamicConfigProvider())
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -792,7 +792,7 @@ def _init_databricks_cli_config_provider(entry_point):
                 return DatabricksConfig.from_token(
                     host=api_url, token=api_token, insecure=ssl_trust_all
                 )
-    elif dbr_major_minor_version >= (9, 0):
+    elif dbr_major_minor_version >= (10, 3):
         class DynamicConfigProvider(DatabricksConfigProvider):
             def get_config(self):
                 try:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -735,9 +735,7 @@ def get_databricks_runtime_major_minor_version():
         dbr_version_splits = dbr_version.split(".", maxsplit=2)
         return int(dbr_version_splits[0]), int(dbr_version_splits[1])
     except Exception:
-        raise MlflowException(
-            f"Failed to parse databricks runtime version '{dbr_version}'."
-        )
+        raise MlflowException(f"Failed to parse databricks runtime version '{dbr_version}'.")
 
 
 def _init_databricks_cli_config_provider(entry_point):

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -803,9 +803,9 @@ def _init_databricks_cli_config_provider(entry_point):
                         return DatabricksConfig.from_token(
                             host=ctx.apiUrl, token=ctx.apiToken, insecure=ctx.sslTrustAll)
                 except Exception as e:
-                    print(
+                    print(  # noqa
                         "Unexpected internal error while constructing `DatabricksConfig` "
-                        "from REPL context: {e}".format(e=e),
+                        f"from REPL context: {e}",
                         file=stderr,
                     )
                 # Invoking getContext() will attempt to find the credentials related to the

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -743,6 +743,7 @@ def _init_databricks_cli_config_provider(entry_point):
     dbr_major_minor_version = (int(dbr_version_splits[0]), int(dbr_version_splits[1]))
 
     if dbr_major_minor_version >= (13, 2):
+
         class DynamicConfigProvider(DatabricksConfigProvider):
             def get_config(self):
                 logger = entry_point.getLogger()
@@ -793,6 +794,7 @@ def _init_databricks_cli_config_provider(entry_point):
                     host=api_url, token=api_token, insecure=ssl_trust_all
                 )
     elif dbr_major_minor_version >= (10, 3):
+
         class DynamicConfigProvider(DatabricksConfigProvider):
             def get_config(self):
                 try:
@@ -801,7 +803,8 @@ def _init_databricks_cli_config_provider(entry_point):
                     ctx = get_context()
                     if ctx and ctx.apiUrl and ctx.apiToken:
                         return DatabricksConfig.from_token(
-                            host=ctx.apiUrl, token=ctx.apiToken, insecure=ctx.sslTrustAll)
+                            host=ctx.apiUrl, token=ctx.apiToken, insecure=ctx.sslTrustAll
+                        )
                 except Exception as e:
                     print(  # noqa
                         "Unexpected internal error while constructing `DatabricksConfig` "
@@ -823,6 +826,7 @@ def _init_databricks_cli_config_provider(entry_point):
                     host=api_url_option.get(), token=api_token_option.get(), insecure=ssl_trust_all
                 )
     else:
+
         class DynamicConfigProvider(DatabricksConfigProvider):
             def get_config(self):
                 # Invoking getContext() will attempt to find the credentials related to the

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -729,6 +729,17 @@ def get_databricks_env_vars(tracking_uri):
     return env_vars
 
 
+def get_databricks_runtime_major_minor_version():
+    dbr_version = os.environ["DATABRICKS_RUNTIME_VERSION"]
+    try:
+        dbr_version_splits = dbr_version.split(".", maxsplit=2)
+        return int(dbr_version_splits[0]), int(dbr_version_splits[1])
+    except Exception:
+        raise MlflowException(
+            f"Failed to parse databricks runtime version '{dbr_version}'."
+        )
+
+
 def _init_databricks_cli_config_provider(entry_point):
     """
     set a custom DatabricksConfigProvider with the hostname and token of the
@@ -738,9 +749,7 @@ def _init_databricks_cli_config_provider(entry_point):
     """
     notebook_utils = entry_point.getDbutils().notebook()
 
-    dbr_version = os.environ["DATABRICKS_RUNTIME_VERSION"]
-    dbr_version_splits = dbr_version.split(".", maxsplit=2)
-    dbr_major_minor_version = (int(dbr_version_splits[0]), int(dbr_version_splits[1]))
+    dbr_major_minor_version = get_databricks_runtime_major_minor_version()
 
     if dbr_major_minor_version >= (13, 2):
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/11198?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11198/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11198
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Make _init_databricks_cli_config_provider supporting Databricks Runtime 9

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
