### PR TITLE
Add h2o mojo model export format

### DIFF
--- a/mlflow/h2o/__init__.py
+++ b/mlflow/h2o/__init__.py
@@ -316,9 +316,9 @@ def _load_model(path, init=False):
             "Please upgrade H2O version to a newer version"
         )
         if "model_format" in params and params["model_format"] == MODEL_FORMAT_MOJO:
-            model = h2o.import_mojo(path=model_path)
+            model = h2o.import_mojo(model_path)
         else:
-            model = h2o.load_model(path=model_path)
+            model = h2o.load_model(model_path)
 
     return model
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sateeshmannar/mlflow/pull/11199?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11199/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11199
```

</p>
</details>

### Related Issues/PRs

Resolve #11041 

### What changes are proposed in this pull request?
H2O binary models are not compatible across H2O versions.  Ability to save and load h2o models in MOJO format will facilitate deployment of h2o models in environment with newer h2o version and also enable orgs to adopt multi-model deployment pattern.
The current mlflow h2o flavor saves model in binary format. This change will continue to use binary format as the default format to make this enhancement backward compatible.

<!-- Please fill in changes proposed in this PR. -->
mlflow/h2o/__init__.py:
- Added new parameter model_format to func log_model and save_model
- Support export of h2o model in binary(default) and mojo format 
  + added validation to verify the supplied model_format is either binary/mojo
- Add model_format, model type and model class values to h2o_model parameter (h2o.yaml)
- During model load use model_format from h2o.yaml and determine the right func to use to load the saved model
  + for h2o models  saved/logged prior to this change, binary format will be used to load the model as the "model_format" would not be present in h2o.yaml

tests/h2o/test_h2o_model_export.py
- Parameterize test_model_save_load to test with model_format of binary/mojo or no parameter(to test default binary format)
- Added new test cases for func validate_export_format

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes
add support to save and load h2o models in "mojo" format 

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations



#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
