### PR TITLE
Fix small errata in mlflow.models.predict docs

### DIFF
--- a/docs/source/model/dependencies.rst
+++ b/docs/source/model/dependencies.rst
@@ -437,10 +437,10 @@ To do so, use the **pip-requirements-override** option to specify pip dependenci
 
         import mlflow
 
-        mlflow.model.predict(
+        mlflow.models.predict(
             model_uri="runs:/<run_id>/model",
             input_data=<input_data>,
-            pip_requirements="opencv-python==4.8.0",
+            pip_requirements_override="opencv-python==4.8.0",
         )
 
     .. code-tab:: bash

--- a/docs/source/model/dependencies.rst
+++ b/docs/source/model/dependencies.rst
@@ -132,7 +132,7 @@ In this case, MLflow will install Pandas 2.0.3 in addition to the inferred depen
 .. note::
 
     Once you log the model with dependencies, it is advisable to test it in a sandbox environment to avoid any dependency
-    issues when deploying the model to production. Since MLflow 2.10.0, you can use the ``mlflow.models.predict`` API to quickly test
+    issues when deploying the model to production. Since MLflow 2.10.0, you can use the :py:func:`mlflow.models.predict()` API to quickly test
     your model in a virtual environment. Please refer to :ref:`Validating Environment for Prediction <validating-environment-for-prediction>` for more details.
 
 Defining All Dependencies by Yourself
@@ -173,7 +173,7 @@ The manually defined dependencies will override the default ones MLflow detects 
 .. note::
 
     Once you log the model with dependencies, it is advisable to test it in a sandbox environment to avoid any dependency
-    issues when deploying the model to production. Since MLflow 2.10.0, you can use the ``mlflow.models.predict`` API to quickly
+    issues when deploying the model to production. Since MLflow 2.10.0, you can use the :py:func:`mlflow.models.predict()` API to quickly
     test your model in a virtual environment. Please refer to :ref:`Validating Environment for Prediction <validating-environment-for-prediction>` for more details.
 
 
@@ -329,7 +329,7 @@ Testing offline prediction with a virtual environment
 You can use MLflow Models **predict** API via Python or CLI to make test predictions with your model.
 This will load your model from the model URI, create a virtual environment with the model dependencies (defined in MLflow Model),
 and run offline predictions with the model.
-Please refer to :py:func:`mlflow.models.predict` or the `CLI reference <../cli.html#mlflow-models>`_ for more detailed usage for the predict API.
+Please refer to :py:func:`mlflow.models.predict()` or the `CLI reference <../cli.html#mlflow-models>`_ for more detailed usage for the predict API.
 
 .. note::
 
@@ -350,7 +350,7 @@ Please refer to :py:func:`mlflow.models.predict` or the `CLI reference <../cli.h
 
         mlflow models predict -m runs:/<run_id>/model-i <input_path>
 
-Using the ``mlflow.models.predict`` API is convenient for testing your model and inference environment quickly.
+Using the :py:func:`mlflow.models.predict()` API is convenient for testing your model and inference environment quickly.
 However, it may not be a perfect simulation of the serving because it does not start the online inference server.
 
 Testing online inference endpoint with a virtual environment
@@ -426,7 +426,7 @@ The missing dependencies are listed in the error message. For example, if you se
 ********************************************************
 Now that you know the missing dependencies, you can create a new model version with the correct dependencies.
 However, creating a new model for trying new dependencies might be a bit tedious, particularly because you may need to
-iterate multiple times to find the correct solution. Instead, you can use the ``mlflow.models.predict`` API to test your change without
+iterate multiple times to find the correct solution. Instead, you can use the :py:func:`mlflow.models.predict()` API to test your change without
 actually needing to re-log the model repeatedly while troubleshooting the installation errors.
 
 To do so, use the **pip-requirements-override** option to specify pip dependencies like ``opencv-python==4.8.0``.
@@ -440,7 +440,7 @@ To do so, use the **pip-requirements-override** option to specify pip dependenci
         mlflow.models.predict(
             model_uri="runs:/<run_id>/model",
             input_data=<input_data>,
-            pip_requirements_override="opencv-python==4.8.0",
+            pip_requirements_override=["opencv-python==4.8.0"],
         )
 
     .. code-tab:: bash

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -3,7 +3,7 @@ import logging
 import os
 from datetime import datetime
 from io import StringIO
-from typing import ForwardRef, List, Literal, Optional, get_args, get_origin
+from typing import ForwardRef, get_args, get_origin
 
 from mlflow.exceptions import MlflowException
 from mlflow.models.flavor_backend_registry import get_flavor_backend
@@ -91,14 +91,14 @@ _CONTENT_TYPE_JSON = "json"
 
 
 def predict(
-    model_uri: str,
-    input_data: Optional["PyFuncInput"] = None,  # noqa: F821
-    input_path: Optional[str] = None,
-    content_type: str = _CONTENT_TYPE_JSON,
-    output_path: Optional[str] = None,
-    env_manager: Literal["virtualenv", "local", "conda"] = _EnvManager.VIRTUALENV,
-    install_mlflow: bool = False,
-    pip_requirements_override: Optional[List[str]] = None,
+    model_uri,
+    input_data=None,
+    input_path=None,
+    content_type=_CONTENT_TYPE_JSON,
+    output_path=None,
+    env_manager=_EnvManager.VIRTUALENV,
+    install_mlflow=False,
+    pip_requirements_override=None,
 ):
     """
     Generate predictions in json format using a saved MLflow model. For information about the input

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -107,7 +107,8 @@ def predict(
 
     Args:
         model_uri: URI to the model. A local path, a local or remote URI e.g. runs:/, s3://.
-        input_data: Input data for prediction. Must be valid input for the PyFunc model.
+        input_data: Input data for prediction. Must be valid input for the PyFunc model. Please refer
+            to the :py:func:`mlflow.pyfunc.PyFuncModel.predict()` for the supported input types.
         input_path: Path to a file containing input data. If provided, 'input_data' must be None.
         content_type: Content type of the input data. Can be one of {‘json’, ‘csv’}.
         output_path: File to output results to as json. If not provided, output to stdout.

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -3,7 +3,7 @@ import logging
 import os
 from datetime import datetime
 from io import StringIO
-from typing import ForwardRef, List, Optional, get_args, get_origin
+from typing import ForwardRef, List, Literal, Optional, get_args, get_origin
 
 from mlflow.exceptions import MlflowException
 from mlflow.models.flavor_backend_registry import get_flavor_backend
@@ -96,7 +96,7 @@ def predict(
     input_path: Optional[str] = None,
     content_type: str = _CONTENT_TYPE_JSON,
     output_path: Optional[str] = None,
-    env_manager: _EnvManager = _EnvManager.VIRTUALENV,
+    env_manager: Literal["virtualenv", "local", "conda"] = _EnvManager.VIRTUALENV,
     install_mlflow: bool = False,
     pip_requirements_override: Optional[List[str]] = None,
 ):
@@ -113,9 +113,9 @@ def predict(
         output_path: File to output results to as json. If not provided, output to stdout.
         env_manager: Specify a way to create an environment for MLmodel inference:
 
-            - virtualenv (default): use virtualenv (and pyenv for Python version management)
-            - local: use the local environment
-            - conda: use conda
+            - "virtualenv" (default): use virtualenv (and pyenv for Python version management)
+            - "local": use the local environment
+            - "conda": use conda
 
         install_mlflow: If specified and there is a conda or virtualenv environment to be activated
             mlflow will be installed into the environment after it has been activated. The version
@@ -132,14 +132,14 @@ def predict(
 
         run_id = "..."
 
-        mlflow.pyfunc.predict(
+        mlflow.models.predict(
             model_uri=f"runs:/{run_id}/model",
             input_data={"x": 1, "y": 2},
             content_type="json",
         )
 
         # Run prediction with additional pip dependencies
-        mlflow.pyfunc.predict(
+        mlflow.models.predict(
             model_uri=f"runs:/{run_id}/model",
             input_data='{"x": 1, "y": 2}',
             content_type="json",

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -107,7 +107,7 @@ def predict(
 
     Args:
         model_uri: URI to the model. A local path, a local or remote URI e.g. runs:/, s3://.
-        input_data: Input data for prediction. Must be valid input for the PyFunc model. Please refer
+        input_data: Input data for prediction. Must be valid input for the PyFunc model. Refer
             to the :py:func:`mlflow.pyfunc.PyFuncModel.predict()` for the supported input types.
         input_path: Path to a file containing input data. If provided, 'input_data' must be None.
         content_type: Content type of the input data. Can be one of {‘json’, ‘csv’}.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11204?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11204/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11204
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix some small but critical errors in docs about `mlflow.models.predict` API.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
