### PR TITLE
Skip `test_xgb_autolog_does_not_break_dmatrix_instantiation_with_data_none` for xgboost > 2.0.3

### DIFF
--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -668,6 +668,20 @@ def test_xgb_autolog_log_models_configuration(bst_params, log_models):
     assert ("model" in artifacts) == log_models
 
 
+@pytest.mark.skipif(
+    Version(xgb.__version__) > Version("2.0.3"),
+    reason="XGBoost > 2.0.3 does not support `None` data",
+)
+def test_xgb_autolog_does_not_break_dmatrix_instantiation_with_data_none():
+    """
+    This test verifies that `xgboost.DMatrix(None)` doesn't fail after patching.
+    XGBoost internally calls `xgboost.DMatrix(None)` to create a blank `DMatrix` object.
+    Example: https://github.com/dmlc/xgboost/blob/v1.2.1/python-package/xgboost/core.py#L701
+    """
+    mlflow.xgboost.autolog()
+    xgb.DMatrix(None)
+
+
 def test_callback_func_is_pickable():
     cb = picklable_exception_safe_function(
         functools.partial(autolog_callback, BatchMetricsLogger(run_id="1234"), eval_results={})

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -668,16 +668,6 @@ def test_xgb_autolog_log_models_configuration(bst_params, log_models):
     assert ("model" in artifacts) == log_models
 
 
-def test_xgb_autolog_does_not_break_dmatrix_instantiation_with_data_none():
-    """
-    This test verifies that `xgboost.DMatrix(None)` doesn't fail after patching.
-    XGBoost internally calls `xgboost.DMatrix(None)` to create a blank `DMatrix` object.
-    Example: https://github.com/dmlc/xgboost/blob/v1.2.1/python-package/xgboost/core.py#L701
-    """
-    mlflow.xgboost.autolog()
-    xgb.DMatrix(None)
-
-
 def test_callback_func_is_pickable():
     cb = picklable_exception_safe_function(
         functools.partial(autolog_callback, BatchMetricsLogger(run_id="1234"), eval_results={})


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11205?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11205/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11205
```

</p>
</details>

…a_none

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fixes https://github.com/mlflow-automation/mlflow/actions/runs/7974102001/job/21780084632#step:15:336:

```
>       raise TypeError("Not supported type for data." + str(type(data)))
E       TypeError: Not supported type for data.<class 'NoneType'>
```

XGBoost no longer accepts None as DMatrix: https://github.com/dmlc/xgboost/pull/10052 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
