### PR TITLE
Truncate long tag and param values to maximum length

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -517,3 +517,11 @@ MLFLOW_GATEWAY_RATE_LIMITS_STORAGE_URI = _EnvironmentVariable(
 #: logging handlers and formatters.
 #: (default: ``True``)
 MLFLOW_CONFIGURE_LOGGING = _BooleanEnvironmentVariable("MLFLOW_LOGGING_CONFIGURE_LOGGING", True)
+
+#: If set to True, the following entities will be truncated to their maximum length:
+#: - Param value
+#: - Tag value
+#: If set to False, an exception will be raised if the length of the entity exceeds the maximum
+#: length.
+#: (default: ``True``)
+MLFLOW_TRUNCATE_LONG_VALUES = _BooleanEnvironmentVariable("MLFLOW_TRUNCATE_LONG_VALUES", True)

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -946,7 +946,7 @@ class FileStore(AbstractStore):
 
     def log_param(self, run_id, param):
         _validate_run_id(run_id)
-        _validate_param(param.key, param.value)
+        param = _validate_param(param.key, param.value)
         run_info = self._get_run_info(run_id)
         check_run_is_active(run_info)
         self._log_run_param(run_info, param)
@@ -1046,7 +1046,7 @@ class FileStore(AbstractStore):
 
     def log_batch(self, run_id, metrics, params, tags):
         _validate_run_id(run_id)
-        _validate_batch_log_data(metrics, params, tags)
+        metrics, params, tags = _validate_batch_log_data(metrics, params, tags)
         _validate_batch_log_limits(metrics, params, tags)
         _validate_param_keys_unique(params)
         run_info = self._get_run_info(run_id)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1030,7 +1030,7 @@ class SqlAlchemyStore(AbstractStore):
             ]
 
     def log_param(self, run_id, param):
-        _validate_param(param.key, param.value)
+        param = _validate_param(param.key, param.value)
         with self.ManagedSessionMaker() as session:
             run = self._get_run(run_uuid=run_id, session=session)
             self._check_run_is_active(run)
@@ -1139,7 +1139,7 @@ class SqlAlchemyStore(AbstractStore):
             tag: RunTag instance to log.
         """
         with self.ManagedSessionMaker() as session:
-            _validate_tag(tag.key, tag.value)
+            tag = _validate_tag(tag.key, tag.value)
             run = self._get_run(run_uuid=run_id, session=session)
             self._check_run_is_active(run)
             if tag.key == MLFLOW_RUN_NAME:
@@ -1160,8 +1160,7 @@ class SqlAlchemyStore(AbstractStore):
         if not tags:
             return
 
-        for tag in tags:
-            _validate_tag(tag.key, tag.value)
+        tags = [_validate_tag(t.key, t.value) for t in tags]
 
         with self.ManagedSessionMaker() as session:
             run = self._get_run(run_uuid=run_id, session=session)
@@ -1331,7 +1330,7 @@ class SqlAlchemyStore(AbstractStore):
 
     def log_batch(self, run_id, metrics, params, tags):
         _validate_run_id(run_id)
-        _validate_batch_log_data(metrics, params, tags)
+        metrics, params, tags = _validate_batch_log_data(metrics, params, tags)
         _validate_batch_log_limits(metrics, params, tags)
         _validate_param_keys_unique(params)
 

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -1,16 +1,20 @@
 """
 Utilities for validating user inputs such as metric names and parameter names.
 """
+import logging
 import numbers
 import posixpath
 import re
 from typing import List
 
-from mlflow.entities import Dataset, DatasetInput, InputTag
+from mlflow.entities import Dataset, DatasetInput, InputTag, Param, RunTag
+from mlflow.environment_variables import MLFLOW_TRUNCATE_LONG_VALUES
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.utils.string_utils import is_string_type
+
+_logger = logging.getLogger(__name__)
 
 # Regex for valid param and metric names: may only contain slashes, alphanumerics,
 # underscores, periods, dashes, and spaces.
@@ -172,8 +176,10 @@ def _validate_param(key, value):
     isn't.
     """
     _validate_param_name(key)
-    _validate_length_limit("Param key", MAX_ENTITY_KEY_LENGTH, key)
-    _validate_length_limit("Param value", MAX_PARAM_VAL_LENGTH, value)
+    return Param(
+        _validate_length_limit("Param key", MAX_ENTITY_KEY_LENGTH, key),
+        _validate_length_limit("Param value", MAX_PARAM_VAL_LENGTH, value, truncate=True),
+    )
 
 
 def _validate_tag(key, value):
@@ -181,8 +187,10 @@ def _validate_tag(key, value):
     Check that a tag with the specified key & value is valid and raise an exception if it isn't.
     """
     _validate_tag_name(key)
-    _validate_length_limit("Tag key", MAX_ENTITY_KEY_LENGTH, key)
-    _validate_length_limit("Tag value", MAX_TAG_VAL_LENGTH, value)
+    return RunTag(
+        _validate_length_limit("Tag key", MAX_ENTITY_KEY_LENGTH, key),
+        _validate_length_limit("Tag value", MAX_TAG_VAL_LENGTH, value, truncate=True),
+    )
 
 
 def _validate_experiment_tag(key, value):
@@ -270,13 +278,25 @@ def _validate_tag_name(name):
         )
 
 
-def _validate_length_limit(entity_name, limit, value):
-    if value is not None and len(value) > limit:
-        raise MlflowException(
-            f"{entity_name} '{value[:250]}' had length {len(value)}, "
-            f"which exceeded length limit of {limit}",
-            error_code=INVALID_PARAMETER_VALUE,
+def _validate_length_limit(entity_name, limit, value, *, truncate=False):
+    if value is None:
+        return None
+
+    if len(value) <= limit:
+        return value
+
+    if truncate and MLFLOW_TRUNCATE_LONG_VALUES.get():
+        _logger.warning(
+            f"{entity_name} {value[:100]}...' ({len(value)} characters) is truncated to "
+            f"{limit} characters to meet the length limit."
         )
+        return value[:limit]
+
+    raise MlflowException(
+        f"{entity_name} '{value[:250]}' had length {len(value)}, "
+        f"which exceeded length limit of {limit}",
+        error_code=INVALID_PARAMETER_VALUE,
+    )
 
 
 def _validate_run_id(run_id):
@@ -317,10 +337,11 @@ def _validate_batch_log_limits(metrics, params, tags):
 def _validate_batch_log_data(metrics, params, tags):
     for metric in metrics:
         _validate_metric(metric.key, metric.value, metric.timestamp, metric.step)
-    for param in params:
-        _validate_param(param.key, param.value)
-    for tag in tags:
-        _validate_tag(tag.key, tag.value)
+    return (
+        metrics,
+        [_validate_param(p.key, p.value) for p in params],
+        [_validate_tag(t.key, t.value) for t in tags],
+    )
 
 
 def _validate_batch_log_api_req(json_req):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -287,7 +287,7 @@ def _validate_length_limit(entity_name, limit, value, *, truncate=False):
 
     if truncate and MLFLOW_TRUNCATE_LONG_VALUES.get():
         _logger.warning(
-            f"{entity_name} {value[:100]}...' ({len(value)} characters) is truncated to "
+            f"{entity_name} '{value[:100]}...' ({len(value)} characters) is truncated to "
             f"{limit} characters to meet the length limit."
         )
         return value[:limit]

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1154,7 +1154,7 @@ def test_log_null_param(store: SqlAlchemyStore):
     reason="large string parameters are sent as TEXT/NTEXT; "
     "see tests/db/compose.yml for details",
 )
-def test_log_param_max_length_value(store: SqlAlchemyStore):
+def test_log_param_max_length_value(store: SqlAlchemyStore, monkeypatch):
     run = _run_factory(store)
     tkey = "blahmetric"
     tval = "x" * 6000
@@ -1162,8 +1162,12 @@ def test_log_param_max_length_value(store: SqlAlchemyStore):
     store.log_param(run.info.run_id, param)
     run = store.get_run(run.info.run_id)
     assert run.data.params[tkey] == str(tval)
+    monkeypatch.setenv("MLFLOW_TRUNCATE_LONG_VALUES", "false")
     with pytest.raises(MlflowException, match="exceeded length"):
         store.log_param(run.info.run_id, entities.Param(tkey, "x" * 6001))
+
+    monkeypatch.setenv("MLFLOW_TRUNCATE_LONG_VALUES", "true")
+    store.log_param(run.info.run_id, entities.Param(tkey, "x" * 6001))
 
 
 def test_set_experiment_tag(store: SqlAlchemyStore):
@@ -1206,7 +1210,7 @@ def test_set_experiment_tag(store: SqlAlchemyStore):
         store.set_experiment_tag(exp_id, entities.ExperimentTag("should", "notset"))
 
 
-def test_set_tag(store: SqlAlchemyStore):
+def test_set_tag(store: SqlAlchemyStore, monkeypatch):
     run = _run_factory(store)
 
     tkey = "test tag"
@@ -1218,8 +1222,13 @@ def test_set_tag(store: SqlAlchemyStore):
     # Overwriting tags is allowed
     store.set_tag(run.info.run_id, new_tag)
     # test setting tags that are too long fails.
+    monkeypatch.setenv("MLFLOW_TRUNCATE_LONG_VALUES", "false")
     with pytest.raises(MlflowException, match="exceeded length limit of 5000"):
         store.set_tag(run.info.run_id, entities.RunTag("longTagKey", "a" * 5001))
+
+    monkeypatch.setenv("MLFLOW_TRUNCATE_LONG_VALUES", "true")
+    store.set_tag(run.info.run_id, entities.RunTag("longTagKey", "a" * 5001))
+
     # test can set tags that are somewhat long
     store.set_tag(run.info.run_id, entities.RunTag("longTagKey", "a" * 4999))
     run = store.get_run(run.info.run_id)
@@ -2747,15 +2756,19 @@ def test_log_batch_null_metrics(store: SqlAlchemyStore):
     assert exception_context.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
-def test_log_batch_params_max_length_value(store: SqlAlchemyStore):
+def test_log_batch_params_max_length_value(store: SqlAlchemyStore, monkeypatch):
     run = _run_factory(store)
     param_entities = [Param("long param", "x" * 6000), Param("short param", "xyz")]
     expected_param_entities = [Param("long param", "x" * 6000), Param("short param", "xyz")]
     store.log_batch(run.info.run_id, [], param_entities, [])
     _verify_logged(store, run.info.run_id, [], expected_param_entities, [])
     param_entities = [Param("long param", "x" * 6001)]
+    monkeypatch.setenv("MLFLOW_TRUNCATE_LONG_VALUES", "false")
     with pytest.raises(MlflowException, match="exceeded length"):
         store.log_batch(run.info.run_id, [], param_entities, [])
+
+    monkeypatch.setenv("MLFLOW_TRUNCATE_LONG_VALUES", "true")
+    store.log_batch(run.info.run_id, [], param_entities, [])
 
 
 def test_upgrade_cli_idempotence(store: SqlAlchemyStore):

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -219,7 +219,7 @@ def test_validate_batch_log_limits():
     _validate_batch_log_limits([], [], too_many_tags[:100])
 
 
-def test_validate_batch_log_data():
+def test_validate_batch_log_data(monkeypatch):
     metrics_with_bad_key = [
         Metric("good-metric-key", 1.0, 0, 0),
         Metric("super-long-bad-key" * 1000, 4.0, 0, 0),
@@ -258,6 +258,7 @@ def test_validate_batch_log_data():
         "tags": [tags_with_bad_key, tags_with_bad_val],
     }
     good_kwargs = {"metrics": [], "params": [], "tags": []}
+    monkeypatch.setenv("MLFLOW_TRUNCATE_LONG_VALUES", "false")
     for arg_name, arg_values in bad_kwargs.items():
         for arg_value in arg_values:
             final_kwargs = copy.deepcopy(good_kwargs)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11208?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11208/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11208
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Truncate long tag and param values to maximum length.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
