### PR TITLE
Fix langchain autologging missing source on created run

### DIFF
--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -215,13 +215,14 @@ def patched_inference(func_name, original, self, *args, **kwargs):
         )
 
     run_id = getattr(self, "run_id", None)
+    active_run = mlflow.active_run()
     if run_id is None:
         # only log the tags once
         extra_tags = get_autologging_config(mlflow.langchain.FLAVOR_NAME, "extra_tags", None)
         # include run context tags
         resolved_tags = context_registry.resolve_tags(extra_tags)
         tags = _resolve_extra_tags(mlflow.langchain.FLAVOR_NAME, resolved_tags)
-        if active_run := mlflow.active_run():
+        if active_run:
             run_id = active_run.info.run_id
             mlflow.MlflowClient().log_batch(
                 run_id=run_id,

--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -8,8 +8,10 @@ from copy import deepcopy
 from packaging.version import Version
 
 import mlflow
+from mlflow.entities import RunTag
 from mlflow.exceptions import MlflowException
 from mlflow.ml_package_versions import _ML_PACKAGE_VERSIONS
+from mlflow.tracking.context import registry as context_registry
 from mlflow.utils.autologging_utils import (
     ExceptionSafeAbstractClass,
     disable_autologging,
@@ -213,8 +215,20 @@ def patched_inference(func_name, original, self, *args, **kwargs):
         )
 
     run_id = getattr(self, "run_id", None)
-    if (active_run := mlflow.active_run()) and run_id is None:
-        run_id = active_run.info.run_id
+    if run_id is None:
+        # only log the tags once
+        extra_tags = get_autologging_config(mlflow.langchain.FLAVOR_NAME, "extra_tags", None)
+        # include run context tags
+        resolved_tags = context_registry.resolve_tags(extra_tags)
+        tags = _resolve_extra_tags(mlflow.langchain.FLAVOR_NAME, resolved_tags)
+        if active_run := mlflow.active_run():
+            run_id = active_run.info.run_id
+            mlflow.MlflowClient().log_batch(
+                run_id=run_id,
+                tags=[RunTag(key, str(value)) for key, value in tags.items()],
+            )
+    else:
+        tags = None
     # TODO: test adding callbacks works
     # Use session_id-inference_id as artifact directory where mlflow
     # callback logs artifacts into, to avoid overriding artifacts
@@ -224,6 +238,7 @@ def patched_inference(func_name, original, self, *args, **kwargs):
         tracking_uri=mlflow.get_tracking_uri(),
         run_id=run_id,
         artifacts_dir=f"artifacts-{session_id}-{inference_id}",
+        tags=tags,
     )
     args, kwargs = _inject_mlflow_callback(func_name, mlflow_callback, args, kwargs)
     with disable_autologging():
@@ -263,12 +278,6 @@ def patched_inference(func_name, original, self, *args, **kwargs):
             registered_model_name = get_autologging_config(
                 mlflow.langchain.FLAVOR_NAME, "registered_model_name", None
             )
-            extra_tags = get_autologging_config(mlflow.langchain.FLAVOR_NAME, "extra_tags", None)
-            tags = _resolve_extra_tags(mlflow.langchain.FLAVOR_NAME, extra_tags)
-            # self manage the run as we need to get the run_id from mlflow_callback
-            # only log the tags once the first time we log the model
-            for key, value in tags.items():
-                mlflow.MlflowClient().set_tag(mlflow_callback.mlflg.run_id, key, value)
             try:
                 with disable_autologging():
                     mlflow.langchain.log_model(

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -232,6 +232,19 @@ def test_autolog_manage_run():
     mlflow.end_run()
 
 
+def test_autolog_manage_run_no_active_run():
+    mlflow.langchain.autolog(log_models=True, extra_tags={"test_tag": "test"})
+    assert mlflow.active_run() is None
+    with _mock_request(return_value=_mock_chat_completion_response()):
+        model = create_openai_llmchain()
+        model.invoke("MLflow")
+    assert mlflow.active_run() is None
+    run = MlflowClient().get_run(model.run_id)
+    assert run.data.metrics != {}
+    assert run.data.tags["test_tag"] == "test"
+    assert run.data.tags["mlflow.autologging"] == "langchain"
+
+
 def test_llmchain_autolog():
     mlflow.langchain.autolog(log_models=True)
     question = "MLflow"

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -220,13 +220,15 @@ def create_runnable_sequence():
 
 
 def test_autolog_manage_run():
-    mlflow.langchain.autolog(log_models=True)
+    mlflow.langchain.autolog(log_models=True, extra_tags={"test_tag": "test"})
     run = mlflow.start_run()
     with _mock_request(return_value=_mock_chat_completion_response()):
         model = create_openai_llmchain()
         model.invoke("MLflow")
     assert mlflow.active_run() is not None
     assert MlflowClient().get_run(run.info.run_id).data.metrics != {}
+    assert MlflowClient().get_run(run.info.run_id).data.tags["test_tag"] == "test"
+    assert MlflowClient().get_run(run.info.run_id).data.tags["mlflow.autologging"] == "langchain"
     mlflow.end_run()
 
 


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> ML-38293

### What changes are proposed in this pull request?
Fix missing tags in langchain autologging created run.
Tested langchain_community < 0.0.20 works. (langchain_community >=0.0.20 contains problems, only happens on databricks) --> found root commit: https://github.com/langchain-ai/langchain/commit/780e84ae79b4c9d958110c3a5e89d5e31e457361#diff-a2ae437cfd1af52a7d41f03ddfba8baeb221360a2873e7c4ff676558a2f363b3
--> Because sqlalchemy 1.x has ImportError when `from sqlalchemy import Result` is called inside file https://github.com/langchain-ai/langchain/blob/780e84ae79b4c9d958110c3a5e89d5e31e457361/libs/community/langchain_community/tools/sql_database/tool.py#L5


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
