### PR TITLE
Add unit tests with mocks to Databricks dependencies

### DIFF
--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -2,7 +2,9 @@ import sys
 from collections import defaultdict
 from unittest.mock import MagicMock
 
+import langchain
 import pytest
+from packaging.version import Version
 
 from mlflow.langchain.databricks_dependencies import (
     _DATABRICKS_CHAT_ENDPOINT_NAME_KEY,
@@ -32,6 +34,9 @@ class MockDatabricksServingEndpointClient:
         self.task = task
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
+)
 def test_parsing_dependency_from_databricks_llm(monkeypatch: pytest.MonkeyPatch):
     from langchain.llms import Databricks
 
@@ -64,6 +69,9 @@ class MockVectorSearchClient:
         return MockVectorSearchIndex(endpoint_name, index_name)
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
+)
 def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.MonkeyPatch):
     from langchain.embeddings import DatabricksEmbeddings
     from langchain.vectorstores import DatabricksVectorSearch
@@ -89,6 +97,9 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
     assert d.get(_DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY) == ["dbdemos_vs_endpoint"]
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
+)
 def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch):
     from langchain.chat_models import ChatDatabricks
 

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -1,0 +1,102 @@
+import sys
+from collections import defaultdict
+from unittest.mock import MagicMock
+
+import pytest
+
+from mlflow.langchain.databricks_dependencies import (
+    _DATABRICKS_CHAT_ENDPOINT_NAME_KEY,
+    _DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY,
+    _DATABRICKS_LLM_ENDPOINT_NAME_KEY,
+    _DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY,
+    _DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY,
+    _extract_databricks_dependencies_from_chat_model,
+    _extract_databricks_dependencies_from_llm,
+    _extract_databricks_dependencies_from_retriever,
+)
+
+
+class MockDatabricksServingEndpointClient:
+    def __init__(
+        self,
+        host: str,
+        api_token: str,
+        endpoint_name: str,
+        databricks_uri: str,
+        task: str,
+    ):
+        self.host = host
+        self.api_token = api_token
+        self.endpoint_name = endpoint_name
+        self.databricks_uri = databricks_uri
+        self.task = task
+
+
+def test_parsing_dependency_from_databricks_llm(monkeypatch: pytest.MonkeyPatch):
+    from langchain.llms import Databricks
+
+    monkeypatch.setattr(
+        "langchain_community.llms.databricks._DatabricksServingEndpointClient",
+        MockDatabricksServingEndpointClient,
+    )
+    monkeypatch.setenv("DATABRICKS_HOST", "my-default-host")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "my-default-token")
+
+    llm = Databricks(endpoint_name="databricks-mixtral-8x7b-instruct")
+    d = defaultdict(list)
+    _extract_databricks_dependencies_from_llm(llm, d)
+    assert d.get(_DATABRICKS_LLM_ENDPOINT_NAME_KEY) == ["databricks-mixtral-8x7b-instruct"]
+
+
+class MockVectorSearchIndex:
+    def __init__(self, endpoint_name, index_name) -> None:
+        self.endpoint_name = endpoint_name
+        self.name = index_name
+
+    def describe(self):
+        return {
+            "primary_key": "id",
+        }
+
+
+class MockVectorSearchClient:
+    def get_index(self, endpoint_name, index_name):
+        return MockVectorSearchIndex(endpoint_name, index_name)
+
+
+def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.MonkeyPatch):
+    from langchain.embeddings import DatabricksEmbeddings
+    from langchain.vectorstores import DatabricksVectorSearch
+
+    vsc = MockVectorSearchClient()
+    vs_index = vsc.get_index(endpoint_name="dbdemos_vs_endpoint", index_name="mlflow.rag.vs_index")
+    mock_get_deploy_client = MagicMock()
+
+    monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
+    embedding_model = DatabricksEmbeddings(endpoint="databricks-bge-large-en")
+
+    mock_module = MagicMock()
+    mock_module.VectorSearchIndex = MockVectorSearchIndex
+
+    monkeypatch.setitem(sys.modules, "databricks.vector_search.client", mock_module)
+
+    vectorstore = DatabricksVectorSearch(vs_index, text_column="content", embedding=embedding_model)
+    retriever = vectorstore.as_retriever()
+    d = defaultdict(list)
+    _extract_databricks_dependencies_from_retriever(retriever, d)
+    assert d.get(_DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY) == ["databricks-bge-large-en"]
+    assert d.get(_DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY) == ["mlflow.rag.vs_index"]
+    assert d.get(_DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY) == ["dbdemos_vs_endpoint"]
+
+
+def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch):
+    from langchain.chat_models import ChatDatabricks
+
+    mock_get_deploy_client = MagicMock()
+
+    monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
+
+    chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
+    d = defaultdict(list)
+    _extract_databricks_dependencies_from_chat_model(chat_model, d)
+    assert d.get(_DATABRICKS_CHAT_ENDPOINT_NAME_KEY) == ["databricks-llama-2-70b-chat"]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/liangz1/mlflow/pull/11217?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11217/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11217
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Follow up: https://github.com/mlflow/mlflow/pull/10969#discussion_r1479142517

The current test cannot detect if the LangChain Databricks LLM updates its structure, and the dependency extraction could fail.

This PR mocks the dependencies of Databricks llm, DatabricksEmbeddings, DatabricksVectorSearch and ChatDatabricks model, and test the extractor logic with these models instantiated.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
