### PR TITLE
Replace `!pip` with `%pip`

### DIFF
--- a/docs/source/deep-learning/tensorflow/quickstart/quickstart_tensorflow.ipynb
+++ b/docs/source/deep-learning/tensorflow/quickstart/quickstart_tensorflow.ipynb
@@ -26,7 +26,7 @@
     "Let's install the `mlflow` package.\n",
     "\n",
     "```\n",
-    "!pip install -q mlflow\n",
+    "%pip install -q mlflow\n",
     "```"
    ]
   },

--- a/docs/source/getting-started/tracking-server-overview/index.rst
+++ b/docs/source/getting-started/tracking-server-overview/index.rst
@@ -189,7 +189,7 @@ Install Dependencies
 
 .. code-block:: bash
 
-  pip install -q mlflow databricks-sdk
+  %pip install -q mlflow databricks-sdk
 
 Set Up Authentication of Databricks CE
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/getting-started/tracking-server-overview/index.rst
+++ b/docs/source/getting-started/tracking-server-overview/index.rst
@@ -189,7 +189,7 @@ Install Dependencies
 
 .. code-block:: bash
 
-  !pip install -q mlflow databricks-sdk
+  pip install -q mlflow databricks-sdk
 
 Set Up Authentication of Databricks CE
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/traditional-ml/serving-multiple-models-with-pyfunc/notebooks/MME_Tutorial.ipynb
+++ b/docs/source/traditional-ml/serving-multiple-models-with-pyfunc/notebooks/MME_Tutorial.ipynb
@@ -52,7 +52,7 @@
     }
    ],
    "source": [
-    "!pip install --upgrade mlflow scikit-learn -q"
+    "%pip install --upgrade mlflow scikit-learn -q"
    ]
   },
   {

--- a/examples/transformers/MLFlow_X_HuggingFace_Finetune_a_text_classification_model.ipynb
+++ b/examples/transformers/MLFlow_X_HuggingFace_Finetune_a_text_classification_model.ipynb
@@ -62,7 +62,7 @@
     }
    ],
    "source": [
-    "!pip install -q mlflow datasets evaluate transformers"
+    "%pip install -q mlflow datasets evaluate transformers"
    ]
   },
   {
@@ -95,7 +95,7 @@
     }
    ],
    "source": [
-    "!pip install -U -q accelerate"
+    "%pip install -U -q accelerate"
    ]
   },
   {
@@ -128,7 +128,7 @@
    ],
    "source": [
     "# There is a strange pydantic issue, we can delete this in the future.\n",
-    "!pip install pydantic==1.10.12"
+    "%pip install pydantic==1.10.12"
    ]
   },
   {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11218?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11218/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11218
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Replace `!pip` with `%pip`.

<img width="506" alt="Screenshot 2024-02-22 at 9 26 00" src="https://github.com/mlflow/mlflow/assets/17039389/41562a75-c611-46aa-936d-922cdbef420d">


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
