### PR TITLE
Enable `RUF100` to disallow unused `noqa` comments

### DIFF
--- a/mlflow/legacy_databricks_cli/configure/provider.py
+++ b/mlflow/legacy_databricks_cli/configure/provider.py
@@ -14,7 +14,7 @@ _home = expanduser("~")
 CONFIG_FILE_ENV_VAR = "DATABRICKS_CONFIG_FILE"
 HOST = "host"
 USERNAME = "username"
-PASSWORD = "password"  # NOQA
+PASSWORD = "password"
 TOKEN = "token"
 REFRESH_TOKEN = "refresh_token"
 INSECURE = "insecure"
@@ -299,7 +299,7 @@ class DatabricksConfig:
         refresh_token=None,
         insecure=None,
         jobs_api_version=None,
-    ):  # noqa
+    ):
         self.host = host
         self.username = username
         self.password = password

--- a/mlflow/promptlab/__init__.py
+++ b/mlflow/promptlab/__init__.py
@@ -5,7 +5,7 @@ from typing import List
 import yaml
 
 from mlflow.exceptions import MlflowException
-from mlflow.version import VERSION as __version__  # noqa: F401
+from mlflow.version import VERSION as __version__
 
 
 class _PromptlabModel:

--- a/mlflow/utils/promptlab_utils.py
+++ b/mlflow/utils/promptlab_utils.py
@@ -10,7 +10,7 @@ from mlflow.entities.run_status import RunStatus
 from mlflow.entities.run_tag import RunTag
 from mlflow.utils.file_utils import make_containing_dirs, write_to
 from mlflow.utils.mlflow_tags import MLFLOW_LOGGED_ARTIFACTS, MLFLOW_RUN_SOURCE_TYPE
-from mlflow.version import VERSION as __version__  # noqa: F401
+from mlflow.version import VERSION as __version__
 
 
 def create_eval_results_json(prompt_parameters, model_input, model_output_parameters, model_output):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ select = [
   "RET504",  # unnecessary-assign
   "RUF010",  # explicit-f-string-type-conversion
   "RUF013",  # implicit-optional
+  "RUF100",  # unused-noqa
   "S307",    # suspicious-eval-usage
   "S324",    # hashlib-insecure-hash-function
   "SIM101",  # duplicate-isinstance-call

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -39,7 +39,7 @@ from tests.pmdarima.test_pmdarima_model_export import (  # noqa: F401
     test_data,
 )
 from tests.prophet.test_prophet_model_export import prophet_model as prophet_raw_model  # noqa: F401
-from tests.pyfunc.docker.conftest import (  # noqa: F401
+from tests.pyfunc.docker.conftest import (
     MLFLOW_ROOT,
     TEST_IMAGE_NAME,
     docker_client,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11219?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11219/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11219
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Enable `RUF100` to disallow unused `noqa` comments.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
