### PR TITLE
Fix f-strings missing f prefix

### DIFF
--- a/examples/sktime/flavor.py
+++ b/examples/sktime/flavor.py
@@ -218,7 +218,7 @@ def save_model(
             message=(
                 f"Unrecognized serialization format: {serialization_format}. "
                 "Please specify one of the following supported formats: "
-                "{SUPPORTED_SERIALIZATION_FORMATS}."
+                f"{SUPPORTED_SERIALIZATION_FORMATS}."
             ),
             error_code=INVALID_PARAMETER_VALUE,
         )

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -67,7 +67,7 @@ class AnthropicAdapter(ProviderAdapter):
         if n != 1:
             raise HTTPException(
                 status_code=422,
-                detail="'n' must be '1' for the Anthropic provider. Received value: '{n}'.",
+                detail=f"'n' must be '1' for the Anthropic provider. Received value: '{n}'.",
             )
 
         payload = rename_payload_keys(payload, key_mapping)

--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -50,7 +50,7 @@ class AWSTitanAdapter(ProviderAdapter):
         if n != 1:
             raise HTTPException(
                 status_code=422,
-                detail="'n' must be '1' for AWS Titan models. Received value: '{n}'.",
+                detail=f"'n' must be '1' for AWS Titan models. Received value: '{n}'.",
             )
 
         # The range of Titan's temperature is 0-1, but ours is 0-2, so we halve it

--- a/mlflow/recipes/cards/pandas_renderer.py
+++ b/mlflow/recipes/cards/pandas_renderer.py
@@ -291,7 +291,7 @@ def construct_facets_html(
     protostr = base64.b64encode(proto.SerializeToString()).decode("utf-8")
     polyfills_code = get_facets_polyfills()
 
-    html_template = """
+    return f"""
         <div style="background-color: white">
         <script>{polyfills_code}</script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js"></script>
@@ -299,7 +299,6 @@ def construct_facets_html(
         <facets-overview id="facets" proto-input="{protostr}" compare-mode="{compare}"></facets-overview>
         </div>
     """  # noqa: E501
-    return html_template.format(protostr=protostr, compare=compare, polyfills_code=polyfills_code)
 
 
 def get_html(inputs: Union[pd.DataFrame, Iterable[Tuple[str, pd.DataFrame]]]) -> str:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -3555,7 +3555,7 @@ class MlflowClient:
             )
             latest_versions = self.get_latest_versions(name, stages=[stage])
             if not latest_versions:
-                raise MlflowException("Could not find any model version for {stage} stage")
+                raise MlflowException(f"Could not find any model version for {stage} stage")
             version = latest_versions[0].version
         self._get_registry_client().delete_model_version_tag(name, version, key)
 

--- a/mlflow/transformers/signature.py
+++ b/mlflow/transformers/signature.py
@@ -105,14 +105,14 @@ def infer_or_get_default_signature(
             if isinstance(e, MlflowTimeoutError):
                 msg = (
                     "Attempted to generate a signature for the saved pipeline but prediction timed "
-                    "out after {timeout} seconds. Falling back to the default signature for the "
+                    f"out after {timeout} seconds. Falling back to the default signature for the "
                     "pipeline. You can specify a signature manually or increase the timeout "
                     f"by setting the environment variable {MLFLOW_INPUT_EXAMPLE_INFERENCE_TIMEOUT}"
                 )
             else:
                 msg = (
                     "Attempted to generate a signature for the saved pipeline but encountered an "
-                    "error. Fall back to the default signature for the pipeline type. Error: {e}"
+                    f"error. Fall back to the default signature for the pipeline type. Error: {e}"
                 )
             _logger.warning(msg)
 

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -220,12 +220,12 @@ def _validate_onnx_session_options(onnx_session_options):
             elif key == "execution_mode" and value.upper() not in ["PARALLEL", "SEQUENTIAL"]:
                 raise ValueError(
                     f"Value for key {key} in onnx_session_options should be "
-                    "'parallel' or 'sequential', not {value}"
+                    f"'parallel' or 'sequential', not {value}"
                 )
             elif key == "graph_optimization_level" and value not in [0, 1, 2, 99]:
                 raise ValueError(
                     f"Value for key {key} in onnx_session_options should be 0, 1, 2, or 99, "
-                    "not {value}"
+                    f"not {value}"
                 )
             elif key in ["intra_op_num_threads", "intra_op_num_threads"] and value < 0:
                 raise ValueError(

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -519,7 +519,7 @@ class SearchUtils:
         if key_type == cls._ATTRIBUTE_IDENTIFIER and key_name not in cls.NUMERIC_ATTRIBUTES:
             if comparator not in cls.VALID_STRING_ATTRIBUTE_COMPARATORS:
                 raise MlflowException(
-                    "Invalid comparator '{comparator}' not one of "
+                    f"Invalid comparator '{comparator}' not one of "
                     f"'{cls.VALID_STRING_ATTRIBUTE_COMPARATORS}'"
                 )
             return True
@@ -932,7 +932,7 @@ class SearchExperimentsUtils(SearchUtils):
         if key_type == cls._ATTRIBUTE_IDENTIFIER:
             if comparator not in cls.VALID_STRING_ATTRIBUTE_COMPARATORS:
                 raise MlflowException(
-                    "Invalid comparator '{comparator}' not one of "
+                    f"Invalid comparator '{comparator}' not one of "
                     f"'{cls.VALID_STRING_ATTRIBUTE_COMPARATORS}'"
                 )
             return True

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -2382,7 +2382,7 @@ def test_log_input_multiple_times_does_not_overwrite_tags_or_dataset(store):
         overwrite_dataset = Dataset(
             name="name",
             digest="digest",
-            source_type="st{i}",
+            source_type=f"st{i}",
             source=f"source{i}",
             schema=f"schema{i}",
             profile=f"profile{i}",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11220?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11220/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11220
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix f-strings missing an `f` prefix.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
