### PR TITLE
Fix issue with aliases not appearing in table of model versions within registered model detail page

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/types.ts
@@ -21,7 +21,7 @@ export interface KeyValueEntity {
   getValue(): string;
 }
 
-type ModelAliasMap = { alias: string; version: string }[];
+export type ModelAliasMap = { alias: string; version: string }[];
 type ModelVersionAliasList = string[];
 
 /**

--- a/mlflow/server/js/src/model-registry/components/ModelVersionTable.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionTable.test.tsx
@@ -76,7 +76,7 @@ describe('ModelVersionTable', () => {
       modelName: modelName,
       usingNextModelsUI: true,
       modelVersions: [mockModelVersionDetailed(modelName, 1, Stages.NONE, ModelVersionStatus.READY)],
-      aliases: [{alias: 'Champion', version: '1'}]
+      aliases: [{alias: 'champion', version: '1'}]
     };
     renderWithProviders(<ModelVersionTable {...props} />);
     expect(screen.queryByRole('columnheader', { name: 'Stage' })).not.toBeInTheDocument();

--- a/mlflow/server/js/src/model-registry/components/ModelVersionTable.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionTable.test.tsx
@@ -82,6 +82,6 @@ describe('ModelVersionTable', () => {
     expect(screen.queryByRole('columnheader', { name: 'Stage' })).not.toBeInTheDocument();
     expect(screen.queryByRole('columnheader', { name: 'Aliases' })).toBeInTheDocument();
     expect(screen.queryByRole('columnheader', { name: 'Tags' })).toBeInTheDocument();
-    expect(screen.queryByRole('status', { name: 'champion' })).toBeInTheDocument();
+    expect(screen.queryByText(/champion/)).toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/model-registry/components/ModelVersionTable.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionTable.test.tsx
@@ -22,6 +22,7 @@ describe('ModelVersionTable', () => {
     onChange: jest.fn(),
     onMetadataUpdated: jest.fn(),
     usingNextModelsUI: false,
+    aliases: [],
   };
 
   const mockStoreFactory = configureStore([thunk, promiseMiddleware()]);
@@ -67,14 +68,20 @@ describe('ModelVersionTable', () => {
     expect(screen.queryByRole('columnheader', { name: 'Aliases' })).not.toBeInTheDocument();
     expect(screen.queryByRole('columnheader', { name: 'Tags' })).not.toBeInTheDocument();
   });
+
   test('should display aliases and tags column instead of stage when new models UI is used', () => {
+    const modelName = 'Random Forest Model';
     const props = {
       ...minimalProps,
+      modelName: modelName,
       usingNextModelsUI: true,
+      modelVersions: [mockModelVersionDetailed(modelName, 1, Stages.NONE, ModelVersionStatus.READY)],
+      aliases: [{alias: 'Champion', version: '1'}]
     };
     renderWithProviders(<ModelVersionTable {...props} />);
     expect(screen.queryByRole('columnheader', { name: 'Stage' })).not.toBeInTheDocument();
     expect(screen.queryByRole('columnheader', { name: 'Aliases' })).toBeInTheDocument();
     expect(screen.queryByRole('columnheader', { name: 'Tags' })).toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: 'champion' })).toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/model-registry/components/ModelVersionTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionTable.tsx
@@ -23,7 +23,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { KeyValueEntity, ModelEntity, ModelVersionInfoEntity } from '../../experiment-tracking/types';
+import { KeyValueEntity, ModelEntity, ModelVersionInfoEntity, ModelAliasMap } from '../../experiment-tracking/types';
 import { useEffect, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { RegisteringModelDocUrl } from '../../common/constants';
@@ -57,6 +57,7 @@ type ModelVersionTableProps = {
   modelEntity?: ModelEntity;
   onMetadataUpdated: () => void;
   usingNextModelsUI: boolean;
+  aliases: ModelAliasMap
 };
 
 type ModelVersionColumnDef = ColumnDef<ModelVersionInfoEntity> & {
@@ -82,7 +83,18 @@ export const ModelVersionTable = ({
   modelEntity,
   onMetadataUpdated,
   usingNextModelsUI,
+  aliases
 }: ModelVersionTableProps) => {
+  const aliasesByVersion = useMemo(() => {
+    const result: Record<string, string[]> = {};
+    aliases.forEach(({ alias, version }) => {
+      if (!result[version]) {
+        result[version] = [];
+      }
+      result[version].push(alias);
+    })
+    return result;
+  }, [aliases]);
   const versions = useMemo(
     () =>
       activeStageOnly
@@ -226,11 +238,12 @@ export const ModelVersionTable = ({
           }),
           meta: { styles: { flex: 2 }, multiline: true },
           cell: ({ getValue, row: { original } }) => {
+            const mvAliases = aliasesByVersion[original.version] || [];
             return (
               <ModelVersionTableAliasesCell
                 modelName={modelName}
                 version={original.version}
-                aliases={getValue() as string[]}
+                aliases={mvAliases}
                 onAddEdit={() => {
                   showEditAliasesModal?.(original.version);
                 }}

--- a/mlflow/server/js/src/model-registry/components/ModelVersionTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionTable.tsx
@@ -57,7 +57,7 @@ type ModelVersionTableProps = {
   modelEntity?: ModelEntity;
   onMetadataUpdated: () => void;
   usingNextModelsUI: boolean;
-  aliases: ModelAliasMap
+  aliases?: ModelAliasMap
 };
 
 type ModelVersionColumnDef = ColumnDef<ModelVersionInfoEntity> & {
@@ -87,7 +87,7 @@ export const ModelVersionTable = ({
 }: ModelVersionTableProps) => {
   const aliasesByVersion = useMemo(() => {
     const result: Record<string, string[]> = {};
-    aliases.forEach(({ alias, version }) => {
+    aliases?.forEach(({ alias, version }) => {
       if (!result[version]) {
         result[version] = [];
       }

--- a/mlflow/server/js/src/model-registry/components/ModelVersionTable.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionTable.tsx
@@ -279,7 +279,7 @@ export const ModelVersionTable = ({
       cell: ({ getValue }) => truncateToFirstLineWithMaxLength(getValue(), 32),
     });
     return columns;
-  }, [theme, intl, modelName, showEditTagsModal, showEditAliasesModal, usingNextModelsUI]);
+  }, [theme, intl, modelName, showEditTagsModal, showEditAliasesModal, usingNextModelsUI, aliasesByVersion]);
 
   const [sorting, setSorting] = useState<SortingState>([{ id: COLUMN_IDS.CREATION_TIMESTAMP, desc: true }]);
 

--- a/mlflow/server/js/src/model-registry/components/ModelView.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelView.tsx
@@ -393,7 +393,7 @@ export class ModelViewImpl extends React.Component<ModelViewImplProps, ModelView
             onChange={this.onChange}
             onMetadataUpdated={this.props.onMetadataUpdated}
             usingNextModelsUI={this.props.usingNextModelsUI}
-            aliases={model?.aliases || {}}
+            aliases={model?.aliases}
           />
         </CollapsibleSection>
 

--- a/mlflow/server/js/src/model-registry/components/ModelView.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelView.tsx
@@ -393,6 +393,7 @@ export class ModelViewImpl extends React.Component<ModelViewImplProps, ModelView
             onChange={this.onChange}
             onMetadataUpdated={this.props.onMetadataUpdated}
             usingNextModelsUI={this.props.usingNextModelsUI}
+            aliases={model?.aliases || {}}
           />
         </CollapsibleSection>
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smurching/mlflow/pull/11223?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11223/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11223
```

</p>
</details>

### Related Issues/PRs

See title; fixes https://github.com/mlflow/mlflow/issues/10961

With the fix, I'm able to set/delete aliases in the UI after:
* Running the MLflow server against a SQL backend via `mlflow server --backend-store-uri sqlite:////tmp/mlflow.sqlite`
* Running the local development UI via `cd mlflow/server/js && yarn start`

![image](https://github.com/mlflow/mlflow/assets/2358483/2d554152-7f0d-4ad6-9840-2832db4b313b)

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
