### PR TITLE
Temporarily use `https://cloud.r-project.org` instead of `https://packagemanager.rstudio.com`

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -68,6 +68,8 @@ jobs:
           key: ${{ steps.os-name.outputs.os-name }}-${{ hashFiles('mlflow/R/mlflow/R-version') }}-0-${{ hashFiles('mlflow/R/mlflow/depends.Rds') }}
       - name: Install dependencies
         run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libcurl4-openssl-dev
           Rscript -e 'source(".install-deps.R", echo=TRUE)'
       - name: Set USE_R_DEVEL
         run: |

--- a/mlflow/R/mlflow/.Rprofile
+++ b/mlflow/R/mlflow/.Rprofile
@@ -1,7 +1,7 @@
 # https://packagemanager.rstudio.com provides pre-compiled package binaries for Linux
 # that can be installed significantly faster than uncompiled package sources.
 if (Sys.which("lsb_release") != "") {
-    ubuntu_codename <- tolower(system("lsb_release -cs", intern = TRUE))
-    repo_name <- sprintf("https://packagemanager.rstudio.com/cran/__linux__/%s/latest", ubuntu_codename)
-    options(repos = c(REPO_NAME = repo_name))
+    # ubuntu_codename <- tolower(system("lsb_release -cs", intern = TRUE))
+    # repo_name <- sprintf("https://packagemanager.rstudio.com/cran/__linux__/%s/latest", ubuntu_codename)
+    # options(repos = c(REPO_NAME = repo_name))
 }

--- a/mlflow/R/mlflow/.Rprofile
+++ b/mlflow/R/mlflow/.Rprofile
@@ -1,6 +1,7 @@
 # https://packagemanager.rstudio.com provides pre-compiled package binaries for Linux
 # that can be installed significantly faster than uncompiled package sources.
 if (Sys.which("lsb_release") != "") {
+    # TODO: https://packagemanager.rstudio.com is down. Uncomment the following lines when it's back up.
     # ubuntu_codename <- tolower(system("lsb_release -cs", intern = TRUE))
     # repo_name <- sprintf("https://packagemanager.rstudio.com/cran/__linux__/%s/latest", ubuntu_codename)
     # options(repos = c(REPO_NAME = repo_name))

--- a/mlflow/R/mlflow/.Rprofile
+++ b/mlflow/R/mlflow/.Rprofile
@@ -4,5 +4,6 @@ if (Sys.which("lsb_release") != "") {
     # TODO: https://packagemanager.rstudio.com is down. Uncomment the following lines when it's back up.
     # ubuntu_codename <- tolower(system("lsb_release -cs", intern = TRUE))
     # repo_name <- sprintf("https://packagemanager.rstudio.com/cran/__linux__/%s/latest", ubuntu_codename)
-    # options(repos = c(REPO_NAME = repo_name))
+    repo_name <- "https://cloud.r-project.org"
+    options(repos = c(REPO_NAME = repo_name))
 }


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

We use https://packagemanager.rstudio.com for faster R package installation. It's down. https://cloud.r-project.org is not.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
