### PR TITLE
Fix spark model loading failure

### DIFF
--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -116,8 +116,11 @@ def _create_local_spark_session_for_loading_spark_model():
         # In Spark 3.1 and above, we need to set this conf explicitly to enable creating
         # a SparkSession on the workers
         .config("spark.executor.allowSparkContext", "true")
-        # Binding "spark.driver.bindAddress" to 127.0.0.1 helps avoiding some local hostname
+        # Binding "spark.driver.host" to 127.0.0.1 helps avoiding some local hostname
         # related issues (e.g. https://github.com/mlflow/mlflow/issues/5733).
+        # Note that we should set "spark.driver.host" instead of "spark.driver.bindAddress",
+        # the latter one only set server binding host, but it doesn't set client side request
+        # destination host.
         .config("spark.driver.host", "127.0.0.1")
         .config("spark.executor.allowSparkContext", "true")
         .config(

--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -118,7 +118,7 @@ def _create_local_spark_session_for_loading_spark_model():
         .config("spark.executor.allowSparkContext", "true")
         # Binding "spark.driver.bindAddress" to 127.0.0.1 helps avoiding some local hostname
         # related issues (e.g. https://github.com/mlflow/mlflow/issues/5733).
-        .config("spark.driver.bindAddress", "127.0.0.1")
+        .config("spark.driver.host", "127.0.0.1")
         .config("spark.executor.allowSparkContext", "true")
         .config(
             "spark.driver.extraJavaOptions",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/11227?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11227/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11227
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fix spark model loading failure
Context:
https://databricks.slack.com/archives/C022KUWGVQS/p1708462567389479

Root cause:
We bind spark local cluster "spark.driver.bindAddress" to 127.0.0.1, but this is not sufficient, we should also set "spark.driver.host" to 127.0.0.1, otherwise spark driver service binds to 127.0.0.1 but remote connection client sends requests to driver host address which is not 127.0.0.1 , this causes errors in databricks runtime like the following:
```
java.io.IOException: Failed to connect to ip-10-0-9-111.us-west-2.compute.internal/10.0.9.111:46339
```

Test:
https://e2-demo-field-eng.cloud.databricks.com/?o=1444828305810485#notebook/1450182024683572/command/1450182024683578

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
