### PR TITLE
Fix keras output dtype in signature

### DIFF
--- a/mlflow/keras/utils.py
+++ b/mlflow/keras/utils.py
@@ -11,6 +11,7 @@ def get_model_signature(model):
     input_shape = model.input_shape
     input_dtype = model.input_dtype
     output_shape = model.output_shape
+    output_dtype = model.compute_dtype
 
     if isinstance(input_shape, list):
         input_schema = Schema(
@@ -26,12 +27,12 @@ def get_model_signature(model):
     if isinstance(output_shape, list):
         output_schema = Schema(
             [
-                TensorSpec(np.dtype(input_dtype), replace_none_in_shape(shape))
+                TensorSpec(np.dtype(output_dtype), replace_none_in_shape(shape))
                 for shape in output_shape
             ]
         )
     else:
         output_schema = Schema(
-            [TensorSpec(np.dtype(input_dtype), replace_none_in_shape(output_shape))]
+            [TensorSpec(np.dtype(output_dtype), replace_none_in_shape(output_shape))]
         )
     return ModelSignature(inputs=input_schema, outputs=output_schema)

--- a/tests/keras/test_save.py
+++ b/tests/keras/test_save.py
@@ -96,9 +96,11 @@ def test_keras_save_model_non_export():
 
 
 def test_save_model_with_signature():
+    keras.mixed_precision.set_dtype_policy("mixed_float16")
+
     model = _get_keras_model()
     signature = get_model_signature(model)
-
+    assert signature.outputs.input_types()[0] == np.dtype("float16")
     model_path = "model"
     with mlflow.start_run() as run:
         mlflow.keras.log_model(model, model_path, signature=signature)
@@ -114,3 +116,6 @@ def test_save_model_with_signature():
         keras.ops.convert_to_numpy(model(test_input)),
         loaded_pyfunc_model.predict(test_input),
     )
+
+    # Clean up the global policy.
+    keras.mixed_precision.set_dtype_policy("float32")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/11230?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11230/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11230
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix keras output dtype in signature

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
