### PR TITLE
Log image with time dimension

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1544,9 +1544,7 @@ class MlflowClient:
 
             step = step or 0
             timestamp = timestamp or get_current_time_millis()
-            # timestamp ensures that the image is logged with a unique name
-
-            filename = f"images/{key}/{key}_step_{step}_{uuid.uuid4()!s}"
+            filename = f"images/{key}/{key}_step_{step}_{uuid.uuid4()}"
             image_filepath = f"{filename}.png"
             metadata_filepath = f"{filename}.json"
             self._log_image_as_artifact(run_id, image, image_filepath)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1540,23 +1540,27 @@ class MlflowClient:
             self._log_image_as_artifact(run_id, image, artifact_file)
 
         elif key is not None:
+            import uuid
+
             step = step or 0
             timestamp = timestamp or get_current_time_millis()
             # timestamp ensures that the image is logged with a unique name
-            filename = f"images/{key}/{key}_step_{step}_timestamp_{timestamp}"
+
+            filename = f"images/{key}/{key}_step_{step}_{uuid.uuid4()!s}"
             image_filepath = f"{filename}.png"
             metadata_filepath = f"{filename}.json"
             self._log_image_as_artifact(run_id, image, image_filepath)
             with self._log_artifact_helper(run_id, metadata_filepath) as tmp_path:
-                json.dump(
-                    {
-                        "filepath": image_filepath,
-                        "key": key,
-                        "step": step,
-                        "timestamp": timestamp,
-                    },
-                    tmp_path,
-                )
+                with open(tmp_path, "w+") as f:
+                    json.dump(
+                        {
+                            "filepath": image_filepath,
+                            "key": key,
+                            "step": step,
+                            "timestamp": timestamp,
+                        },
+                        f,
+                    )
 
     def _log_image_as_artifact(
         self,
@@ -1583,7 +1587,7 @@ class MlflowClient:
             if x.min() < low or x.max() > high:
                 if is_int:
                     raise ValueError(
-                        "Integer pixel value out of acceptable range [0, 255]. "
+                        "Integer pixel values out of acceptable range [0, 255]. "
                         "Ensure all pixel values are within the specified range."
                     )
                 else:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1531,9 +1531,9 @@ class MlflowClient:
                     )
 
             _log_image(*args, **kwargs)
-        elif _check_types(
-            image_as_artifact_params, *args, **kwargs
-        ) and _check_required(image_as_artifact_required, *args, **kwargs):
+        elif _check_types(image_as_artifact_params, *args, **kwargs) and _check_required(
+            image_as_artifact_required, *args, **kwargs
+        ):
             # log image as artifact file
             self._log_image_as_artifact(run_id, *args, **kwargs)
         else:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1573,7 +1573,7 @@ class MlflowClient:
                 self,
                 key: str,
                 image: Union["numpy.ndarray", "PIL.Image.Image"],
-                step: Optional[int] = None,
+                step: Optional[int] = 0,
                 timestamp: Optional[int] = None,
             ) -> None:
                 timestamp = timestamp or get_current_time_millis()
@@ -1603,7 +1603,7 @@ class MlflowClient:
         else:
             raise TypeError(
                 "Unexpected parameter(s) provided. "
-                "The `log_image` function can be used in two ways: either as "
+                "The `log_image` function can be used in one of two ways: either as "
                 "`log_image(image, artifact_path)` or as `log_image(key, image, step)`. "
                 "Please refer to the function documentation for additional details."
             )

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1431,10 +1431,10 @@ class MlflowClient:
         """
         Logs an image in MLflow, supporting two use cases:
 
-        1. Time-Stepped Image Logging: Ideal for tracking changes or progressions through iterative
+        1. Time-stepped image logging: ideal for tracking changes or progressions through iterative
             processes (e.g., during model training phases).
             - Usage: `log_image(image, key=key, step=step, timestamp=timestamp)`
-        2. Artifact File Image Logging: Best suited for static image logging where the image
+        2. Artifact file image logging: best suited for static image logging where the image
             is saved directly as a file artifact.
             - Usage: `log_image(image, artifact_file)`
 
@@ -1451,7 +1451,7 @@ class MlflowClient:
         Numpy array support
             - data types:
 
-                - bool
+                - bool (useful for logging image masks)
                 - integer [0, 255]
                 - unsigned integer [0, 255]
                 - float [0.0, 1.0]

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -11,6 +11,7 @@ import posixpath
 import sys
 import tempfile
 import urllib
+import uuid
 import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 
@@ -1540,8 +1541,6 @@ class MlflowClient:
             self._log_image_as_artifact(run_id, image, artifact_file)
 
         elif key is not None:
-            import uuid
-
             step = step or 0
             timestamp = timestamp or get_current_time_millis()
             filename = f"images/{key}/{key}_step_{step}_{uuid.uuid4()}"

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1472,6 +1472,8 @@ class MlflowClient:
                 will be stored as an artifact relative to the run's root directory (for
                 example, "dir/image.png"). This parameter is kept for backward compatibility
                 and should not be used together with `key`, `step`, or `timestamp`.
+            *args: Positional arguments placeholder. Please refer to the documentation above.
+            **kwargs: Keyword arguments placeholder. Please refer to the documentation above.
 
         .. code-block:: python
             :caption: Time-stepped image logging numpy example

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1550,8 +1550,7 @@ class MlflowClient:
         image: Union["numpy.ndarray", "PIL.Image.Image"],
         artifact_file: str,
     ) -> None:
-        """
-        Log an image as an artifact. The following image objects are supported:
+        """Log an image as an artifact. The following image objects are supported:
 
         - `numpy.ndarray`_
         - `PIL.Image.Image`_
@@ -1582,10 +1581,11 @@ class MlflowClient:
                 - H x W x 3 (an RGB channel order is assumed)
                 - H x W x 4 (an RGBA channel order is assumed)
 
-        :param run_id: String ID of the run.
-        :param image: Image to log.
-        :param artifact_file: The run-relative artifact file path in posixpath format to which
-                              the image is saved (e.g. "dir/image.png").
+        Args:
+            run_id: String ID of the run.
+            image: Image to log.
+            artifact_file: The run-relative artifact file path in posixpath format to which
+                the image is saved (e.g. "dir/image.png").
 
         .. code-block:: python
             :caption: Numpy Example

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1460,8 +1460,10 @@ class MlflowClient:
         ```
 
         Supported image objects:
-        - `numpy.ndarray`: Refer to the NumPy documentation for more details: https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html
-        - `PIL.Image.Image`: Refer to the PIL documentation for more details: https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image
+        - `numpy.ndarray`: Refer to the NumPy documentation for more details:
+            https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html
+        - `PIL.Image.Image`: Refer to the PIL documentation for more details:
+            https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image
         """
         import numpy as np
         from PIL.Image import Image
@@ -1500,7 +1502,7 @@ class MlflowClient:
             # Checks if all required parameters are present
             return any(
                 len(args) >= i and all(key in kwargs for key in param_required[i:])
-                for i in range(len(param_required)+1)
+                for i in range(len(param_required) + 1)
             )
 
         if _check_types(image_over_steps_params, *args, **kwargs) and _check_required(

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1585,11 +1585,13 @@ class MlflowClient:
                 if is_int:
                     raise ValueError(
                         "Integer pixel values out of acceptable range [0, 255]. "
+                        f"Found minimum value {x.min()} and maximum value {x.max()}. "
                         "Ensure all pixel values are within the specified range."
                     )
                 else:
                     raise ValueError(
                         "Float pixel values out of acceptable range [0.0, 1.0]. "
+                        f"Found minimum value {x.min()} and maximum value {x.max()}. "
                         "Ensure all pixel values are within the specified range."
                     )
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1430,12 +1430,14 @@ class MlflowClient:
         Parameters:
         - run_id (str): The ID of the run to log the image to.
         - key (str): The key associated with the image. This is used to identify the image.
-        - image (numpy.ndarray or PIL.Image.Image): The image object to be logged. Supported image objects are `numpy.ndarray` and `PIL.Image.Image`.
+        - image (numpy.ndarray or PIL.Image.Image): The image object to be logged. Supported image objects are
+          `numpy.ndarray` and `PIL.Image.Image`.
         - step (int, optional): The step associated with the image. Defaults to None.
         - artifact_file (str): The path to the artifact file where the image will be saved.
 
         Raises:
-        - TypeError: If unexpected parameters are provided. Please refer to the function documentation for required parameters.
+        - TypeError: If unexpected parameters are provided. Please refer to the function documentation for
+          required parameters.
 
         Example usage:
         ```python
@@ -1513,7 +1515,7 @@ class MlflowClient:
                 timestamp: Optional[int] = None,
             ) -> None:
                 timestamp = timestamp or get_current_time_millis()
-                # millisecond timestamp is used to ensure that the image is logged with a unique name
+                # timestamp ensures that the image is logged with a unique name
                 filename = f"images/{key}_step_{step}_timestamp_{timestamp}"
                 image_filepath = f"{filename}.png"
                 metadata_filepath = f"{filename}.json"
@@ -1531,14 +1533,15 @@ class MlflowClient:
                     )
 
             _log_image(*args, **kwargs)
-        elif _check_types(
-            image_as_artifact_params, *args, **kwargs
-        ) and _check_required(image_as_artifact_required, *args, **kwargs):
+        elif _check_types(image_as_artifact_params, *args, **kwargs) and _check_required(
+            image_as_artifact_required, *args, **kwargs
+        ):
             # log image as artifact file
             self._log_image_as_artifact(run_id, *args, **kwargs)
         else:
             raise TypeError(
-                "Unexpected parameter(s) provided. Please refer to the function documentation for required parameters."
+                "Unexpected parameter(s) provided."
+                "Please refer to the function documentation for required parameters."
             )
 
     def _log_image_as_artifact(

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1540,8 +1540,10 @@ class MlflowClient:
             self._log_image_as_artifact(run_id, *args, **kwargs)
         else:
             raise TypeError(
-                "Unexpected parameter(s) provided."
-                "Please refer to the function documentation for required parameters."
+                "Unexpected parameter(s) provided. "
+                "The `log_image` function can be used in two ways: either as "
+                "`log_image(image, artifact_path)` or as `log_image(key, image, step)`. "
+                "Please refer to the function documentation for additional details."
             )
 
     def _log_image_as_artifact(

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1424,9 +1424,11 @@ class MlflowClient:
         Logs an image in MLflow, supporting two use cases:
 
         1. Time-Stepped Image Logging: Ideal for tracking changes or progressions through iterative
-           processes (e.g., during model training phases).
-        2. Artifact File Image Logging: Best suited for static image logging where the image is
-           saved directly as a file artifact.
+            processes (e.g., during model training phases).
+            - Usage: `log_image(key, image, step, timestamp)`
+        2. Legacy Artifact File Image Logging: Best suited for static image logging where the image
+            is saved directly as a file artifact.
+            - Usage: `log_image(image, artifact_file)`
 
         The following image formats are supported:
         - `numpy.ndarray`_

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1499,8 +1499,8 @@ class MlflowClient:
         def _check_required(param_required, *args, **kwargs):
             # Checks if all required parameters are present
             return any(
-                len(args) == i and all(key in kwargs for key in param_required[i:])
-                for i in range(len(param_required))
+                len(args) >= i and all(key in kwargs for key in param_required[i:])
+                for i in range(len(param_required)+1)
             )
 
         if _check_types(image_over_steps_params, *args, **kwargs) and _check_required(
@@ -1516,7 +1516,7 @@ class MlflowClient:
             ) -> None:
                 timestamp = timestamp or get_current_time_millis()
                 # timestamp ensures that the image is logged with a unique name
-                filename = f"images/{key}_step_{step}_timestamp_{timestamp}"
+                filename = f"images/{key}/{key}_step_{step}_timestamp_{timestamp}"
                 image_filepath = f"{filename}.png"
                 metadata_filepath = f"{filename}.json"
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1531,9 +1531,9 @@ class MlflowClient:
                     )
 
             _log_image(*args, **kwargs)
-        elif _check_types(image_as_artifact_params, *args, **kwargs) and _check_required(
-            image_as_artifact_required, *args, **kwargs
-        ):
+        elif _check_types(
+            image_as_artifact_params, *args, **kwargs
+        ) and _check_required(image_as_artifact_required, *args, **kwargs):
             # log image as artifact file
             self._log_image_as_artifact(run_id, *args, **kwargs)
         else:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -46,6 +46,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_LOGGED_ARTIFACTS,
     MLFLOW_PARENT_RUN_ID,
 )
+from mlflow.utils.time import get_current_time_millis
 from mlflow.utils.uri import is_databricks_unity_catalog_uri, is_databricks_uri
 from mlflow.utils.validation import (
     _validate_model_alias_name,

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1209,10 +1209,10 @@ def log_image(
     """
     Logs an image in MLflow, supporting two use cases:
 
-    1. Time-Stepped Image Logging: Ideal for tracking changes or progressions through iterative
+    1. Time-stepped image logging: ideal for tracking changes or progressions through iterative
         processes (e.g., during model training phases).
         - Usage: `log_image(image, key=key, step=step, timestamp=timestamp)`
-    2. Artifact File Image Logging: Best suited for static image logging where the image
+    2. Artifact file image logging: best suited for static image logging where the image
         is saved directly as a file artifact.
         - Usage: `log_image(image, artifact_file)`
 
@@ -1229,7 +1229,7 @@ def log_image(
     Numpy array support
         - data types:
 
-            - bool
+            - bool (useful for logging image masks)
             - integer [0, 255]
             - unsigned integer [0, 255]
             - float [0.0, 1.0]

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1236,8 +1236,8 @@ def log_image(
 
             .. warning::
 
-                - Out-of-range integer values will be **clipped** to [0, 255].
-                - Out-of-range float values will be **clipped** to [0.0, 1.0].
+                - Out-of-range integer values will raise ValueError.
+                - Out-of-range float values will raise ValueError.
 
         - shape (H: height, W: width):
 

--- a/tests/tracking/test_log_image.py
+++ b/tests/tracking/test_log_image.py
@@ -155,7 +155,7 @@ def test_log_image_raises_exception_for_unsupported_image_object_type():
         mlflow.log_image("not_image", "image.png")
 
 
-def test_log_image_steps():
+def test_log_image_with_steps():
     import numpy as np
     from PIL import Image
 
@@ -168,8 +168,9 @@ def test_log_image_steps():
         artifact_uri = mlflow.get_artifact_uri(logged_path)
         run_artifact_dir = local_file_uri_to_path(artifact_uri)
         files = os.listdir(run_artifact_dir)
-        assert len(files) == 2
 
+        # .png file for the image, and .json file for metadata
+        assert len(files) == 2
         for file in files:
             assert file.startswith("dog_step_0")
             logged_path = os.path.join(run_artifact_dir, file)
@@ -185,7 +186,7 @@ def test_log_image_steps():
                     assert metadata["timestamp"] <= get_current_time_millis()
 
 
-def test_log_image_timestamp():
+def test_log_image_with_timestamp():
     import numpy as np
     from PIL import Image
 
@@ -198,8 +199,9 @@ def test_log_image_timestamp():
         artifact_uri = mlflow.get_artifact_uri(logged_path)
         run_artifact_dir = local_file_uri_to_path(artifact_uri)
         files = os.listdir(run_artifact_dir)
-        assert len(files) == 2
 
+        # .png file for the image, and .json file for metadata
+        assert len(files) == 2
         for file in files:
             assert file.startswith("dog_step_0")
             logged_path = os.path.join(run_artifact_dir, file)
@@ -215,7 +217,11 @@ def test_log_image_timestamp():
                     assert metadata["timestamp"] == 100
 
 
-def test_duplicated_log_image():
+def test_duplicated_log_image_with_step():
+    """
+    Mlflow will save both files if there are multiple calls to log_image
+    with the same key and step.
+    """
     import numpy as np
 
     image1 = np.random.randint(0, 256, size=(100, 100, 3), dtype=np.uint8)
@@ -232,8 +238,11 @@ def test_duplicated_log_image():
         assert len(files) == 4
 
 
-def test_multiple_log_image_same_timestamp():
-    # It will overwrite if the user wants the exact same timestamp for the logged images
+def test_duplicated_log_image_with_timestamp():
+    """
+    Mlflow will save both files if there are multiple calls to log_image
+    with the same key, step, and timestamp.
+    """
     import numpy as np
 
     image1 = np.random.randint(0, 256, size=(100, 100, 3), dtype=np.uint8)

--- a/tests/tracking/test_log_image.py
+++ b/tests/tracking/test_log_image.py
@@ -149,5 +149,5 @@ def test_log_image_numpy_raises_exception_for_invalid_channel_length():
 
 
 def test_log_image_raises_exception_for_unsupported_image_object_type():
-    with mlflow.start_run(), pytest.raises(TypeError, match="Unexpected parameter(s) provided."):
+    with mlflow.start_run(), pytest.raises(TypeError, match="Unexpected parameter\(s\) provided"):
         mlflow.log_image("not_image", "image.png")

--- a/tests/tracking/test_log_image.py
+++ b/tests/tracking/test_log_image.py
@@ -1,11 +1,11 @@
 import os
 import posixpath
-from unittest import mock
 
 import pytest
 
 import mlflow
 from mlflow.utils.file_utils import local_file_uri_to_path
+from mlflow.utils.time import get_current_time_millis
 
 
 @pytest.mark.parametrize("subdir", [None, ".", "dir", "dir1/dir2", "dir/.."])
@@ -116,15 +116,16 @@ def test_log_image_numpy_emits_warning_for_out_of_range_values(array):
     import numpy as np
 
     image = np.array(array).astype(type(array[0][0]))
-
-    with mlflow.start_run(), mock.patch("mlflow.tracking.client._logger.warning") as warn_mock:
-        mlflow.log_image(image, "image.png")
-        range_str = "[0, 255]" if isinstance(array[0][0], int) else "[0, 1]"
-        msg = (
-            "Out-of-range values are detected. Clipping array "
-            f"(dtype: '{image.dtype}') to {range_str}"
-        )
-        assert any(msg in args[0] for args in warn_mock.call_args_list)
+    if isinstance(array[0][0], int):
+        with mlflow.start_run(), pytest.raises(
+            ValueError, match="Integer pixel values out of acceptable range"
+        ):
+            mlflow.log_image(image, "image.png")
+    else:
+        with mlflow.start_run(), pytest.raises(
+            ValueError, match="Float pixel values out of acceptable range"
+        ):
+            mlflow.log_image(image, "image.png")
 
 
 def test_log_image_numpy_raises_exception_for_invalid_array_data_type():
@@ -151,3 +152,133 @@ def test_log_image_numpy_raises_exception_for_invalid_channel_length():
 def test_log_image_raises_exception_for_unsupported_image_object_type():
     with mlflow.start_run(), pytest.raises(TypeError, match="Unsupported image object type"):
         mlflow.log_image("not_image", "image.png")
+
+
+def test_log_image_steps():
+    import json
+
+    import numpy as np
+    from PIL import Image
+
+    image = np.random.randint(0, 256, size=(100, 100, 3), dtype=np.uint8)
+
+    with mlflow.start_run():
+        mlflow.log_image(image, key="dog", step=0)
+
+        logged_path = "images/dog"
+        artifact_uri = mlflow.get_artifact_uri(logged_path)
+        run_artifact_dir = local_file_uri_to_path(artifact_uri)
+        files = os.listdir(run_artifact_dir)
+        assert len(files) == 2
+
+        for file in files:
+            assert file.startswith("dog_step_0")
+            logged_path = os.path.join(run_artifact_dir, file)
+            if file.endswith(".png"):
+                loaded_image = np.asarray(Image.open(logged_path), dtype=np.uint8)
+                np.testing.assert_array_equal(loaded_image, image)
+            elif file.endswith(".json"):
+                with open(logged_path) as f:
+                    metadata = json.load(f)
+                    assert metadata["filepath"].startswith("images/dog/dog_step_0")
+                    assert metadata["key"] == "dog"
+                    assert metadata["step"] == 0
+                    assert metadata["timestamp"] <= get_current_time_millis()
+
+
+def test_log_image_timestamp():
+    import json
+
+    import numpy as np
+    from PIL import Image
+
+    image = np.random.randint(0, 256, size=(100, 100, 3), dtype=np.uint8)
+
+    with mlflow.start_run():
+        mlflow.log_image(image, key="dog", timestamp=100)
+
+        logged_path = "images/dog"
+        artifact_uri = mlflow.get_artifact_uri(logged_path)
+        run_artifact_dir = local_file_uri_to_path(artifact_uri)
+        files = os.listdir(run_artifact_dir)
+        assert len(files) == 2
+
+        for file in files:
+            assert file.startswith("dog_step_0")
+            logged_path = os.path.join(run_artifact_dir, file)
+            if file.endswith(".png"):
+                loaded_image = np.asarray(Image.open(logged_path), dtype=np.uint8)
+                np.testing.assert_array_equal(loaded_image, image)
+            elif file.endswith(".json"):
+                with open(logged_path) as f:
+                    metadata = json.load(f)
+                    assert metadata["filepath"].startswith("images/dog/dog_step_0")
+                    assert metadata["key"] == "dog"
+                    assert metadata["step"] == 0
+                    assert metadata["timestamp"] == 100
+
+
+def test_duplicated_log_image():
+    import numpy as np
+
+    image1 = np.random.randint(0, 256, size=(100, 100, 3), dtype=np.uint8)
+    image2 = np.random.randint(0, 256, size=(100, 100, 3), dtype=np.uint8)
+
+    with mlflow.start_run():
+        mlflow.log_image(image1, key="dog", step=100)
+        mlflow.log_image(image2, key="dog", step=100)
+
+        logged_path = "images/dog"
+        artifact_uri = mlflow.get_artifact_uri(logged_path)
+        run_artifact_dir = local_file_uri_to_path(artifact_uri)
+        files = os.listdir(run_artifact_dir)
+        assert len(files) == 4
+
+
+def test_multiple_log_image_same_timestamp():
+    # It will overwrite if the user wants the exact same timestamp for the logged images
+    import numpy as np
+
+    image1 = np.random.randint(0, 256, size=(100, 100, 3), dtype=np.uint8)
+    image2 = np.random.randint(0, 256, size=(100, 100, 3), dtype=np.uint8)
+
+    with mlflow.start_run():
+        mlflow.log_image(image1, key="dog", step=100, timestamp=100)
+        mlflow.log_image(image2, key="dog", step=100, timestamp=100)
+
+        logged_path = "images/dog"
+        artifact_uri = mlflow.get_artifact_uri(logged_path)
+        run_artifact_dir = local_file_uri_to_path(artifact_uri)
+        files = os.listdir(run_artifact_dir)
+        assert len(files) == 4
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        {"key": "image"},
+        {"step": 0},
+        {"timestamp": 0},
+        {"timestamp": 0, "step": 0},
+        ["image"],
+        ["image", 0],
+    ],
+)
+def test_log_image_raises_exception_for_unexpected_arguments_used(args):
+    # It will overwrite if the user wants the exact same timestamp for the logged images
+    import numpy as np
+
+    exception = "The `artifact_file` parameter cannot be used in conjunction"
+    with mlflow.start_run(), pytest.raises(TypeError, match=exception):
+        if isinstance(args, dict):
+            mlflow.log_image(np.zeros((1,), dtype=np.uint8), "image.png", **args)
+        elif isinstance(args, list):
+            mlflow.log_image(np.zeros((1,), dtype=np.uint8), "image.png", *args)
+
+
+def test_log_image_raises_exception_for_missing_arguments():
+    import numpy as np
+
+    exception = "Invalid arguments: Please specify exactly one of `artifact_file` or `key`"
+    with mlflow.start_run(), pytest.raises(TypeError, match=exception):
+        mlflow.log_image(np.zeros((1,), dtype=np.uint8))

--- a/tests/tracking/test_log_image.py
+++ b/tests/tracking/test_log_image.py
@@ -1,3 +1,4 @@
+import json
 import os
 import posixpath
 
@@ -155,8 +156,6 @@ def test_log_image_raises_exception_for_unsupported_image_object_type():
 
 
 def test_log_image_steps():
-    import json
-
     import numpy as np
     from PIL import Image
 
@@ -187,8 +186,6 @@ def test_log_image_steps():
 
 
 def test_log_image_timestamp():
-    import json
-
     import numpy as np
     from PIL import Image
 
@@ -269,10 +266,11 @@ def test_log_image_raises_exception_for_unexpected_arguments_used(args):
     import numpy as np
 
     exception = "The `artifact_file` parameter cannot be used in conjunction"
-    with mlflow.start_run(), pytest.raises(TypeError, match=exception):
-        if isinstance(args, dict):
+    if isinstance(args, dict):
+        with mlflow.start_run(), pytest.raises(TypeError, match=exception):
             mlflow.log_image(np.zeros((1,), dtype=np.uint8), "image.png", **args)
-        elif isinstance(args, list):
+    elif isinstance(args, list):
+        with mlflow.start_run(), pytest.raises(TypeError, match=exception):
             mlflow.log_image(np.zeros((1,), dtype=np.uint8), "image.png", *args)
 
 

--- a/tests/tracking/test_log_image.py
+++ b/tests/tracking/test_log_image.py
@@ -149,5 +149,5 @@ def test_log_image_numpy_raises_exception_for_invalid_channel_length():
 
 
 def test_log_image_raises_exception_for_unsupported_image_object_type():
-    with mlflow.start_run(), pytest.raises(TypeError, match="Unsupported image object type"):
+    with mlflow.start_run(), pytest.raises(TypeError, match="Unexpected parameter(s) provided."):
         mlflow.log_image("not_image", "image.png")

--- a/tests/tracking/test_log_image.py
+++ b/tests/tracking/test_log_image.py
@@ -149,5 +149,5 @@ def test_log_image_numpy_raises_exception_for_invalid_channel_length():
 
 
 def test_log_image_raises_exception_for_unsupported_image_object_type():
-    with mlflow.start_run(), pytest.raises(TypeError, match=r"Unexpected parameter\(s\) provided"):
+    with mlflow.start_run(), pytest.raises(TypeError, match="Unsupported image object type"):
         mlflow.log_image("not_image", "image.png")

--- a/tests/tracking/test_log_image.py
+++ b/tests/tracking/test_log_image.py
@@ -149,5 +149,5 @@ def test_log_image_numpy_raises_exception_for_invalid_channel_length():
 
 
 def test_log_image_raises_exception_for_unsupported_image_object_type():
-    with mlflow.start_run(), pytest.raises(TypeError, match="Unexpected parameter\(s\) provided"):
+    with mlflow.start_run(), pytest.raises(TypeError, match=r"Unexpected parameter\(s\) provided"):
         mlflow.log_image("not_image", "image.png")

--- a/tests/tracking/test_log_image.py
+++ b/tests/tracking/test_log_image.py
@@ -219,7 +219,7 @@ def test_log_image_with_timestamp():
 
 def test_duplicated_log_image_with_step():
     """
-    Mlflow will save both files if there are multiple calls to log_image
+    MLflow will save both files if there are multiple calls to log_image
     with the same key and step.
     """
     import numpy as np
@@ -240,7 +240,7 @@ def test_duplicated_log_image_with_step():
 
 def test_duplicated_log_image_with_timestamp():
     """
-    Mlflow will save both files if there are multiple calls to log_image
+    MLflow will save both files if there are multiple calls to log_image
     with the same key, step, and timestamp.
     """
     import numpy as np


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jessechancy/mlflow/pull/11243?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11243/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11243
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
