### PR TITLE
Prevent `clean_up_envs` from deleting local development environment

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 import json
 import os
 import posixpath
+import re
 import shutil
 import subprocess
 import sys
@@ -273,7 +274,7 @@ def clean_up_envs():
             conda_info = json.loads(subprocess.check_output(["conda", "info", "--json"], text=True))
             root_prefix = conda_info["root_prefix"]
             for env in conda_info["envs"]:
-                if env != root_prefix:
+                if env != root_prefix and re.search(r"mlflow-\w{16,}$", env):
                     shutil.rmtree(env, ignore_errors=True)
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -274,7 +274,7 @@ def clean_up_envs():
             conda_info = json.loads(subprocess.check_output(["conda", "info", "--json"], text=True))
             root_prefix = conda_info["root_prefix"]
             for env in conda_info["envs"]:
-                if env != root_prefix and re.search(r"mlflow-\w{16,}$", env):
+                if env != root_prefix and re.search(r"mlflow-\w{16,}$", os.path.basename(env)):
                     shutil.rmtree(env, ignore_errors=True)
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -276,7 +276,7 @@ def clean_up_envs():
         if os.name != "nt":
             conda_info = json.loads(subprocess.check_output(["conda", "info", "--json"], text=True))
             root_prefix = conda_info["root_prefix"]
-            regex = re.compile(r"mlflow-\w{16,}")
+            regex = re.compile(r"mlflow-\w{32,}")
             for env in conda_info["envs"]:
                 if env == root_prefix:
                     continue

--- a/conftest.py
+++ b/conftest.py
@@ -264,6 +264,9 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
 @pytest.fixture(scope="module", autouse=True)
 def clean_up_envs():
+    """
+    Clean up virtualenvs and conda environments created during tests to save disk space.
+    """
     yield
 
     if "GITHUB_ACTIONS" in os.environ:
@@ -273,8 +276,11 @@ def clean_up_envs():
         if os.name != "nt":
             conda_info = json.loads(subprocess.check_output(["conda", "info", "--json"], text=True))
             root_prefix = conda_info["root_prefix"]
+            regex = re.compile(r"mlflow-\w{16,}")
             for env in conda_info["envs"]:
-                if env != root_prefix and re.search(r"mlflow-\w{16,}$", os.path.basename(env)):
+                if env == root_prefix:
+                    continue
+                if regex.fullmatch(os.path.basename(env)):
                     shutil.rmtree(env, ignore_errors=True)
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11249?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11249/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11249
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`clean_up_envs` accidentally removed my local dev environment. This PR makes a change to prevent that.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
