### PR TITLE
Wait for async logging to finish in transformers autologging tests

### DIFF
--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -504,7 +504,7 @@ def test_trainer_hyperparameter_tuning_does_not_log_sklearn_model(
     exp = mlflow.set_experiment(experiment_name="hyperparam_trainer")
 
     transformers_hyperparameter_trainer.train()
-    time.sleep(3)  # wait for async logging to finish
+    time.sleep(5)  # wait for async logging to finish
 
     last_run = mlflow.last_active_run()
     assert last_run.data.metrics["epoch"] == 3.0
@@ -531,7 +531,7 @@ def test_trainer_hyperparameter_tuning_functional_does_not_log_sklearn_model(
     exp = mlflow.set_experiment(experiment_name="hyperparam_trainer_functional")
 
     transformers_hyperparameter_functional.train()
-    time.sleep(3)  # wait for async logging to finish
+    time.sleep(5)  # wait for async logging to finish
 
     last_run = mlflow.last_active_run()
     assert last_run.data.metrics["epoch"] == 1.0

--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -1,4 +1,5 @@
 import random
+import time
 
 import numpy as np
 import optuna
@@ -503,6 +504,7 @@ def test_trainer_hyperparameter_tuning_does_not_log_sklearn_model(
     exp = mlflow.set_experiment(experiment_name="hyperparam_trainer")
 
     transformers_hyperparameter_trainer.train()
+    time.sleep(3)  # wait for async logging to finish
 
     last_run = mlflow.last_active_run()
     assert last_run.data.metrics["epoch"] == 3.0
@@ -529,6 +531,7 @@ def test_trainer_hyperparameter_tuning_functional_does_not_log_sklearn_model(
     exp = mlflow.set_experiment(experiment_name="hyperparam_trainer_functional")
 
     transformers_hyperparameter_functional.train()
+    time.sleep(3)  # wait for async logging to finish
 
     last_run = mlflow.last_active_run()
     assert last_run.data.metrics["epoch"] == 1.0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11252?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11252/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11252
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

https://github.com/huggingface/transformers/pull/29195 is related. Wait for async logging to finish in transformers autologging tests. Fix the following test failure:


https://github.com/mlflow/mlflow/actions/runs/8047194768/job/21975987588#step:15:285

```
___ test_trainer_hyperparameter_tuning_functional_does_not_log_sklearn_model ___

transformers_hyperparameter_functional = <transformers.trainer.Trainer object at 0x7f58d0facdf0>

    def test_trainer_hyperparameter_tuning_functional_does_not_log_sklearn_model(
        transformers_hyperparameter_functional,
    ):
        mlflow.autolog()
    
        exp = mlflow.set_experiment(experiment_name="hyperparam_trainer_functional")
    
        transformers_hyperparameter_functional.train()
    
        last_run = mlflow.last_active_run()
>       assert last_run.data.metrics["epoch"] == 1.0
E       KeyError: 'epoch'

exp        = <Experiment: artifact_location='/home/runner/work/mlflow/mlflow/mlruns/1', creation_time=1708943099981, experiment_id='1', last_update_time=1708943099981, lifecycle_stage='active', name='hyperparam_trainer_functional', tags={}>
last_run   = <Run: data=<RunData: metrics={}, params={'_name_or_path': 'distilbert-base-uncased',
 'accelerator_config': "{'split_b...367170ef8c083f', start_time=1708943100348, status='FINISHED', user_id='runner'>, inputs=<RunInputs: dataset_inputs=[]>>
transformers_hyperparameter_functional = <transformers.trainer.Trainer object at 0x7f58d0facdf0>
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
