### PR TITLE
Fix keras autologging test

### DIFF
--- a/mlflow/keras/autologging.py
+++ b/mlflow/keras/autologging.py
@@ -27,33 +27,6 @@ from mlflow.utils.autologging_utils import (
 _logger = logging.getLogger(__name__)
 
 
-def _infer_batch_size(inst, *args, **kwargs):
-    batch_size = None
-    if "batch_size" in kwargs:
-        batch_size = kwargs["batch_size"]
-    else:
-        training_data = kwargs["x"] if "x" in kwargs else args[0]
-        if _batch_size := getattr(training_data, "batch_size", None):
-            batch_size = _batch_size
-        elif _batch_size := getattr(training_data, "_batch_size", None):
-            batch_size = _batch_size if isinstance(_batch_size, int) else _batch_size.numpy()
-        elif is_iterator(training_data):
-            is_single_input_model = isinstance(inst.input_shape, tuple)
-            peek = next(training_data)
-            batch_size = len(peek[0]) if is_single_input_model else len(peek[0][0])
-
-            def _restore_generator(prev_generator):
-                yield peek
-                yield from prev_generator
-
-            restored_generator = _restore_generator(training_data)
-            if "x" in kwargs:
-                kwargs["x"] = restored_generator
-            else:
-                args = (restored_generator,) + args[1:]
-    return batch_size, args, kwargs
-
-
 def _check_existing_mlflow_callback(callbacks):
     for callback in callbacks:
         if isinstance(callback, MLflowCallback):
@@ -224,10 +197,38 @@ def autolog(
         def __init__(self):
             pass
 
+        def _infer_batch_size(self, inst, *args, **kwargs):
+            batch_size = None
+            if "batch_size" in kwargs:
+                batch_size = kwargs["batch_size"]
+            else:
+                training_data = kwargs["x"] if "x" in kwargs else args[0]
+                if _batch_size := getattr(training_data, "batch_size", None):
+                    batch_size = _batch_size
+                elif _batch_size := getattr(training_data, "_batch_size", None):
+                    batch_size = (
+                        _batch_size if isinstance(_batch_size, int) else _batch_size.numpy()
+                    )
+                elif is_iterator(training_data):
+                    is_single_input_model = isinstance(inst.input_shape, tuple)
+                    peek = next(training_data)
+                    batch_size = len(peek[0]) if is_single_input_model else len(peek[0][0])
+
+                    def _restore_generator(prev_generator):
+                        yield peek
+                        yield from prev_generator
+
+                    restored_generator = _restore_generator(training_data)
+                    if "x" in kwargs:
+                        kwargs["x"] = restored_generator
+                    else:
+                        args = (restored_generator,) + args[1:]
+            return batch_size, args, kwargs
+
         def _patch_implementation(self, original, inst, *args, **kwargs):
             unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
 
-            batch_size, args, kwargs = _infer_batch_size(inst, *args, **kwargs)
+            batch_size, args, kwargs = self._infer_batch_size(inst, *args, **kwargs)
 
             if batch_size is not None:
                 mlflow.log_param("batch_size", batch_size)

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -593,7 +593,6 @@ def test_tf_keras_autolog_implicit_batch_size_for_generator_dataset_without_side
 ):
     from tensorflow.keras.layers import Dense
     from tensorflow.keras.models import Sequential
-    # test
 
     data = np.array([[1, 2, 3], [3, 2, 1], [2, 2, 2], [10, 20, 30], [30, 20, 10], [20, 20, 20]])
     target = np.array([[1], [3], [2], [11], [13], [12]])

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -593,6 +593,7 @@ def test_tf_keras_autolog_implicit_batch_size_for_generator_dataset_without_side
 ):
     from tensorflow.keras.layers import Dense
     from tensorflow.keras.models import Sequential
+    # test
 
     data = np.array([[1, 2, 3], [3, 2, 1], [2, 2, 2], [10, 20, 30], [30, 20, 10], [20, 20, 20]])
     target = np.array([[1], [3], [2], [11], [13], [12]])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/11256?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11256/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11256
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
 Resolve [tensorflow autologging dev failing test](https://github.com/mlflow-automation/mlflow/actions/runs/8049486027/job/21994070756)
This only solve the autologging failing tests, not the models one, I'll file another PR to fix models tests failure.

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
