### PR TITLE
Fix ignorance of the default credential file in model registry

### DIFF
--- a/mlflow/deployments/mlflow/__init__.py
+++ b/mlflow/deployments/mlflow/__init__.py
@@ -20,8 +20,8 @@ from mlflow.environment_variables import (
 )
 from mlflow.protos.databricks_pb2 import BAD_REQUEST
 from mlflow.store.entities.paged_list import PagedList
-from mlflow.tracking._tracking_service.utils import _get_default_host_creds
 from mlflow.utils.annotations import experimental
+from mlflow.utils.credentials import get_default_host_creds
 from mlflow.utils.rest_utils import augmented_raise_for_status, http_request
 from mlflow.utils.uri import join_paths
 
@@ -130,7 +130,7 @@ class MlflowDeploymentClient(BaseDeploymentClient):
             call_kwargs["json"] = json_body
 
         response = http_request(
-            host_creds=_get_default_host_creds(self.target_uri),
+            host_creds=get_default_host_creds(self.target_uri),
             endpoint=route,
             method=method,
             timeout=MLFLOW_HTTP_REQUEST_TIMEOUT.get() if timeout is None else timeout,

--- a/mlflow/gateway/client.py
+++ b/mlflow/gateway/client.py
@@ -22,7 +22,7 @@ from mlflow.gateway.utils import (
 )
 from mlflow.protos.databricks_pb2 import BAD_REQUEST
 from mlflow.store.entities.paged_list import PagedList
-from mlflow.tracking._tracking_service.utils import _get_default_host_creds
+from mlflow.utils.credentials import get_default_host_creds
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.rest_utils import augmented_raise_for_status, http_request
 from mlflow.utils.uri import get_uri_scheme
@@ -61,7 +61,7 @@ class MlflowGatewayClient:
         if self._is_databricks_host():
             return get_databricks_host_creds(self._gateway_uri)
         else:
-            return _get_default_host_creds(self._gateway_uri)
+            return get_default_host_creds(self._gateway_uri)
 
     @property
     def gateway_uri(self):

--- a/mlflow/server/auth/client.py
+++ b/mlflow/server/auth/client.py
@@ -14,7 +14,7 @@ from mlflow.server.auth.routes import (
     UPDATE_USER_ADMIN,
     UPDATE_USER_PASSWORD,
 )
-from mlflow.tracking._tracking_service.utils import _get_default_host_creds
+from mlflow.utils.credentials import get_default_host_creds
 from mlflow.utils.rest_utils import http_request_safe
 
 
@@ -33,7 +33,7 @@ class AuthServiceClient:
         self.tracking_uri = tracking_uri
 
     def _request(self, endpoint, method, **kwargs):
-        host_creds = _get_default_host_creds(self.tracking_uri)
+        host_creds = get_default_host_creds(self.tracking_uri)
         resp = http_request_safe(host_creds, endpoint, method, **kwargs)
         return resp.json()
 

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -14,7 +14,7 @@ from mlflow.entities.multipart_upload import (
 from mlflow.environment_variables import MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository, MultipartUploadMixin
-from mlflow.tracking._tracking_service.utils import _get_default_host_creds
+from mlflow.utils.credentials import get_default_host_creds
 
 
 def encode_base64(data: Union[str, bytes]) -> str:
@@ -58,14 +58,14 @@ class AzureBlobArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         if "AZURE_STORAGE_CONNECTION_STRING" in os.environ:
             self.client = BlobServiceClient.from_connection_string(
                 conn_str=os.environ.get("AZURE_STORAGE_CONNECTION_STRING"),
-                connection_verify=_get_default_host_creds(artifact_uri).verify,
+                connection_verify=get_default_host_creds(artifact_uri).verify,
             )
         elif "AZURE_STORAGE_ACCESS_KEY" in os.environ:
             account_url = f"https://{account}.{api_uri_suffix}"
             self.client = BlobServiceClient(
                 account_url=account_url,
                 credential=os.environ.get("AZURE_STORAGE_ACCESS_KEY"),
-                connection_verify=_get_default_host_creds(artifact_uri).verify,
+                connection_verify=get_default_host_creds(artifact_uri).verify,
             )
         else:
             try:
@@ -80,7 +80,7 @@ class AzureBlobArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             self.client = BlobServiceClient(
                 account_url=account_url,
                 credential=DefaultAzureCredential(),
-                connection_verify=_get_default_host_creds(artifact_uri).verify,
+                connection_verify=get_default_host_creds(artifact_uri).verify,
             )
 
     @staticmethod

--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -23,7 +23,7 @@ from mlflow.store.artifact.artifact_repo import (
     verify_artifact_path,
 )
 from mlflow.store.artifact.cloud_artifact_repo import _complete_futures, _compute_num_chunks
-from mlflow.tracking._tracking_service.utils import _get_default_host_creds
+from mlflow.utils.credentials import get_default_host_creds
 from mlflow.utils.file_utils import read_chunk, relative_path_to_artifact_path
 from mlflow.utils.mime_type_utils import _guess_mime_type
 from mlflow.utils.rest_utils import augmented_raise_for_status, http_request
@@ -37,7 +37,7 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
 
     @property
     def _host_creds(self):
-        return _get_default_host_creds(self.artifact_uri)
+        return get_default_host_creds(self.artifact_uri)
 
     def log_artifact(self, local_file, artifact_path=None):
         verify_artifact_path(artifact_path)
@@ -84,7 +84,7 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         url, tail = self.artifact_uri.split(endpoint, maxsplit=1)
         root = tail.lstrip("/")
         params = {"path": posixpath.join(root, path) if path else root}
-        host_creds = _get_default_host_creds(url)
+        host_creds = get_default_host_creds(url)
         resp = http_request(host_creds, endpoint, "GET", params=params)
         augmented_raise_for_status(resp)
         file_infos = []
@@ -115,7 +115,7 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
 
     def create_multipart_upload(self, local_file, num_parts=1, artifact_path=None):
         url, _ = self.artifact_uri.split("/mlflow-artifacts", maxsplit=1)
-        host_creds = _get_default_host_creds(url)
+        host_creds = get_default_host_creds(url)
         base_endpoint = "/mlflow-artifacts/mpu/create"
         endpoint = posixpath.join(base_endpoint, artifact_path) if artifact_path else base_endpoint
         params = {
@@ -128,7 +128,7 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
 
     def complete_multipart_upload(self, local_file, upload_id, parts=None, artifact_path=None):
         url, _ = self.artifact_uri.split("/mlflow-artifacts", maxsplit=1)
-        host_creds = _get_default_host_creds(url)
+        host_creds = get_default_host_creds(url)
         base_endpoint = "/mlflow-artifacts/mpu/complete"
         endpoint = posixpath.join(base_endpoint, artifact_path) if artifact_path else base_endpoint
         params = {
@@ -141,7 +141,7 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
 
     def abort_multipart_upload(self, local_file, upload_id, artifact_path=None):
         url, _ = self.artifact_uri.split("/mlflow-artifacts", maxsplit=1)
-        host_creds = _get_default_host_creds(url)
+        host_creds = get_default_host_creds(url)
         base_endpoint = "/mlflow-artifacts/mpu/abort"
         endpoint = posixpath.join(base_endpoint, artifact_path) if artifact_path else base_endpoint
         params = {

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -1,17 +1,6 @@
-import logging
 from functools import partial
 
-from mlflow.environment_variables import (
-    MLFLOW_REGISTRY_URI,
-    MLFLOW_TRACKING_AUTH,
-    MLFLOW_TRACKING_AWS_SIGV4,
-    MLFLOW_TRACKING_CLIENT_CERT_PATH,
-    MLFLOW_TRACKING_INSECURE_TLS,
-    MLFLOW_TRACKING_PASSWORD,
-    MLFLOW_TRACKING_SERVER_CERT_PATH,
-    MLFLOW_TRACKING_TOKEN,
-    MLFLOW_TRACKING_USERNAME,
-)
+from mlflow.environment_variables import MLFLOW_REGISTRY_URI
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.model_registry.databricks_workspace_model_registry_rest_store import (
     DatabricksWorkspaceModelRegistryRestStore,
@@ -23,16 +12,13 @@ from mlflow.tracking._tracking_service.utils import (
     _resolve_tracking_uri,
     get_tracking_uri,
 )
-from mlflow.utils import rest_utils
 from mlflow.utils._spark_utils import _get_active_spark_session
+from mlflow.utils.credentials import get_default_host_creds
 from mlflow.utils.databricks_utils import (
     get_databricks_host_creds,
     warn_on_deprecated_cross_workspace_registry_uri,
 )
 from mlflow.utils.uri import _DATABRICKS_UNITY_CATALOG_SCHEME
-
-_logger = logging.getLogger(__name__)
-
 
 # NOTE: in contrast to tracking, we do not support the following ways to specify
 # the model registry URI:
@@ -143,20 +129,6 @@ def _get_sqlalchemy_store(store_uri):
     from mlflow.store.model_registry.sqlalchemy_store import SqlAlchemyStore
 
     return SqlAlchemyStore(store_uri)
-
-
-def get_default_host_creds(store_uri):
-    return rest_utils.MlflowHostCreds(
-        host=store_uri,
-        username=MLFLOW_TRACKING_USERNAME.get(),
-        password=MLFLOW_TRACKING_PASSWORD.get(),
-        token=MLFLOW_TRACKING_TOKEN.get(),
-        aws_sigv4=MLFLOW_TRACKING_AWS_SIGV4.get(),
-        auth=MLFLOW_TRACKING_AUTH.get(),
-        ignore_tls_verification=MLFLOW_TRACKING_INSECURE_TLS.get(),
-        client_cert_path=MLFLOW_TRACKING_CLIENT_CERT_PATH.get(),
-        server_cert_path=MLFLOW_TRACKING_SERVER_CERT_PATH.get(),
-    )
 
 
 def _get_rest_store(store_uri, **_):

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -5,22 +5,13 @@ from functools import partial
 from pathlib import Path
 from typing import Union
 
-from mlflow.environment_variables import (
-    MLFLOW_TRACKING_AUTH,
-    MLFLOW_TRACKING_AWS_SIGV4,
-    MLFLOW_TRACKING_CLIENT_CERT_PATH,
-    MLFLOW_TRACKING_INSECURE_TLS,
-    MLFLOW_TRACKING_SERVER_CERT_PATH,
-    MLFLOW_TRACKING_TOKEN,
-    MLFLOW_TRACKING_URI,
-)
+from mlflow.environment_variables import MLFLOW_TRACKING_URI
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.tracking import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
 from mlflow.store.tracking.file_store import FileStore
 from mlflow.store.tracking.rest_store import RestStore
 from mlflow.tracking._tracking_service.registry import TrackingStoreRegistry
-from mlflow.utils import rest_utils
-from mlflow.utils.credentials import read_mlflow_creds
+from mlflow.utils.credentials import get_default_host_creds
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.uri import _DATABRICKS_UNITY_CATALOG_SCHEME
@@ -138,23 +129,8 @@ def _get_sqlalchemy_store(store_uri, artifact_uri):
     return SqlAlchemyStore(store_uri, artifact_uri)
 
 
-def _get_default_host_creds(store_uri):
-    creds = read_mlflow_creds()
-    return rest_utils.MlflowHostCreds(
-        host=store_uri,
-        username=creds.username,
-        password=creds.password,
-        token=MLFLOW_TRACKING_TOKEN.get(),
-        aws_sigv4=MLFLOW_TRACKING_AWS_SIGV4.get(),
-        auth=MLFLOW_TRACKING_AUTH.get(),
-        ignore_tls_verification=MLFLOW_TRACKING_INSECURE_TLS.get(),
-        client_cert_path=MLFLOW_TRACKING_CLIENT_CERT_PATH.get(),
-        server_cert_path=MLFLOW_TRACKING_SERVER_CERT_PATH.get(),
-    )
-
-
 def _get_rest_store(store_uri, **_):
-    return RestStore(partial(_get_default_host_creds, store_uri))
+    return RestStore(partial(get_default_host_creds, store_uri))
 
 
 def _get_databricks_rest_store(store_uri, **_):

--- a/mlflow/utils/credentials.py
+++ b/mlflow/utils/credentials.py
@@ -4,8 +4,18 @@ import logging
 import os
 from typing import NamedTuple, Optional, Tuple
 
-from mlflow.environment_variables import MLFLOW_TRACKING_PASSWORD, MLFLOW_TRACKING_USERNAME
+from mlflow.environment_variables import (
+    MLFLOW_TRACKING_AUTH,
+    MLFLOW_TRACKING_AWS_SIGV4,
+    MLFLOW_TRACKING_CLIENT_CERT_PATH,
+    MLFLOW_TRACKING_INSECURE_TLS,
+    MLFLOW_TRACKING_PASSWORD,
+    MLFLOW_TRACKING_SERVER_CERT_PATH,
+    MLFLOW_TRACKING_TOKEN,
+    MLFLOW_TRACKING_USERNAME,
+)
 from mlflow.exceptions import MlflowException
+from mlflow.utils.rest_utils import MlflowHostCreds
 
 _logger = logging.getLogger(__name__)
 
@@ -45,6 +55,21 @@ def read_mlflow_creds() -> MlflowCreds:
     return MlflowCreds(
         username=username_env or username_file,
         password=password_env or password_file,
+    )
+
+
+def get_default_host_creds(store_uri):
+    creds = read_mlflow_creds()
+    return MlflowHostCreds(
+        host=store_uri,
+        username=creds.username,
+        password=creds.password,
+        token=MLFLOW_TRACKING_TOKEN.get(),
+        aws_sigv4=MLFLOW_TRACKING_AWS_SIGV4.get(),
+        auth=MLFLOW_TRACKING_AUTH.get(),
+        ignore_tls_verification=MLFLOW_TRACKING_INSECURE_TLS.get(),
+        client_cert_path=MLFLOW_TRACKING_CLIENT_CERT_PATH.get(),
+        server_cert_path=MLFLOW_TRACKING_SERVER_CERT_PATH.get(),
     )
 
 

--- a/tests/store/artifact/test_http_artifact_repo.py
+++ b/tests/store/artifact/test_http_artifact_repo.py
@@ -22,7 +22,7 @@ from mlflow.environment_variables import (
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.artifact.http_artifact_repo import HttpArtifactRepository
-from mlflow.tracking._tracking_service.utils import _get_default_host_creds
+from mlflow.utils.credentials import get_default_host_creds
 from mlflow.utils.rest_utils import MlflowHostCreds
 
 
@@ -201,7 +201,7 @@ def test_list_artifacts(http_artifact_repo):
         endpoint = "/mlflow-artifacts/artifacts"
         url, _ = http_artifact_repo.artifact_uri.split(endpoint, maxsplit=1)
         mock_get.assert_called_once_with(
-            _get_default_host_creds(url),
+            get_default_host_creds(url),
             endpoint,
             "GET",
             params={"path": ""},
@@ -435,7 +435,7 @@ def test_complete_multipart_upload(http_artifact_repo, monkeypatch):
         endpoint = "/mlflow-artifacts"
         url, _ = http_artifact_repo.artifact_uri.split(endpoint, maxsplit=1)
         mock_post.assert_called_once_with(
-            _get_default_host_creds(url),
+            get_default_host_creds(url),
             "/mlflow-artifacts/mpu/complete/artifact/path",
             "POST",
             json={
@@ -463,7 +463,7 @@ def test_abort_multipart_upload(http_artifact_repo, monkeypatch):
         endpoint = "/mlflow-artifacts"
         url, _ = http_artifact_repo.artifact_uri.split(endpoint, maxsplit=1)
         mock_post.assert_called_once_with(
-            _get_default_host_creds(url),
+            get_default_host_creds(url),
             "/mlflow-artifacts/mpu/abort/artifact/path",
             "POST",
             json={

--- a/tests/store/artifact/test_mlflow_artifact_repo.py
+++ b/tests/store/artifact/test_mlflow_artifact_repo.py
@@ -7,7 +7,7 @@ import pytest
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.artifact.mlflow_artifacts_repo import MlflowArtifactsRepository
-from mlflow.tracking._tracking_service.utils import _get_default_host_creds
+from mlflow.utils.credentials import get_default_host_creds
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -200,7 +200,7 @@ def test_list_artifacts(mlflow_artifact_repo):
         endpoint = "/mlflow-artifacts/artifacts"
         url, _ = mlflow_artifact_repo.artifact_uri.split(endpoint, maxsplit=1)
         mock_get.assert_called_once_with(
-            _get_default_host_creds(url),
+            get_default_host_creds(url),
             endpoint,
             "GET",
             params={"path": ""},


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11261?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11261/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11261
```

</p>
</details>

### Related Issues/PRs

Resolve #11214 11214

### What changes are proposed in this pull request?

[get_default_host_creds()](https://github.com/mlflow/mlflow/blob/master/mlflow/tracking/_model_registry/utils.py#L148-L159) function in the model registry doesn't read the default credentials from `./mlflow/credentials` file but only from env variables. This should be identical to [the equivalent](https://github.com/mlflow/mlflow/blob/master/mlflow/tracking/_tracking_service/utils.py#L141-L153) in the tracking service. This PR also move them to a shared util to avoid similar discrepancy in the future.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix a bug in Model Registry that doesn't read the default credential defined in the `~/.mlflow/credentials` file.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
