### PR TITLE
Warning for langchain with cloudpickle < 2.1.0

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -15,8 +15,10 @@ import contextlib
 import functools
 import logging
 import os
+import warnings
 from typing import Any, Dict, List, Optional, Union
 
+import cloudpickle
 import pandas as pd
 import yaml
 from packaging.version import Version
@@ -90,7 +92,9 @@ def get_default_pip_requirements():
         Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
         that, at a minimum, contains these requirements.
     """
-    return [_get_pinned_requirement("langchain")]
+    # pin pydantic and cloudpickle version as they are used in langchain
+    # model saving and loading
+    return list(map(_get_pinned_requirement, ["langchain", "pydantic", "cloudpickle"]))
 
 
 def get_default_conda_env():
@@ -462,6 +466,13 @@ def log_model(
 
 
 def _save_model(model, path, loader_fn, persist_dir):
+    if Version(cloudpickle.__version__) < Version("2.1.0"):
+        warnings.warn(
+            "If you are constructing a custom LangChain model, "
+            "please upgrade cloudpickle to version 2.1.0 or later "
+            "using `pip install cloudpickle>=2.1.0` "
+            "to ensure the model can be loaded correctly. "
+        )
     with register_pydantic_v1_serializer_cm():
         if isinstance(model, lc_runnables_types()):
             return _save_runnables(model, path, loader_fn=loader_fn, persist_dir=persist_dir)

--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -117,7 +117,8 @@ def _load_runnable_with_steps(file_path: Union[Path, str], model_type: str):
         )
 
     steps = {}
-    for step in os.listdir(steps_path):
+    # ignore hidden files
+    for step in filter(lambda x: not x.startswith("."), os.listdir(steps_path)):
         config = steps_conf.get(step)
         # load model from the folder of the step
         runnable = _load_model_from_path(os.path.join(steps_path, step), config)

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -624,6 +624,7 @@ langchain:
       LANGCHAIN_NEW=$(python -c "from packaging.version import Version;import langchain;print(Version(langchain.__version__) >= Version('0.0.267'))")
       if [[ $PYDANTIC_VERSION == 1.* && $LANGCHAIN_NEW = "True" ]]; then
         pip install 'pydantic>2'
+        echo "Testing langchain model export with pydantic v2"
         pytest tests/langchain/test_langchain_model_export.py
       fi
   autologging:


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Langchain with cloudpickle 2.0.0 has some hidden problems when loading the model back in a new context. After some investigation, it's because if we create a customized model and save it with cloudpickle, it doesn't save the class/module/function so if we load it back within the same context there's no problem, while if we use spark_udf or model serving the model is not correctly loaded thus causing some validation errors during model invocation.
Try to fix this problem: cloudpickle.register_pickle_by_value(my_module) should reigster the module, while in a new context even if I re-import the module, it doesn't work. (while this might work with spark_udf if we register the class on workers when creating them)
Comparison of pickle file saved between cloudpickle 2.0.0 and 2.2.1: Take a customized model extending SimpleChatModel as an example, for 2.0.0 it serialized the base class of SimpleChatModel instead of itself, so I can only see `langchain_core.language_models.base` and `BaseLanguageModel`, while in 2.2.1 I can see `langchain_core.language_models.chat_models` and `SimpleChatModel`. I'm not sure how to dig deeper but this problem only happens on 2.0.0 (not 2.1.0 and above) so my workaround is to ask user to upgrade cloudpickle if they're creating a customized langchain model.

Other changes in this PR: pin pydantic + cloudpickle version in inferred pip requirements for model serving and spark_udf usage.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
