### PR TITLE
Pin python-rapidjson

### DIFF
--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -95,7 +95,13 @@ def _install_pyfunc_deps(
     # dependency of mlflow on pip and we expect mlflow to be part of the environment.
     server_deps = ["gunicorn[gevent]"]
     if enable_mlserver:
-        server_deps = ["'mlserver>=1.2.0,!=1.3.1'", "'mlserver-mlflow>=1.2.0,!=1.3.1'"]
+        server_deps = [
+            "'mlserver>=1.2.0,!=1.3.1'",
+            "'mlserver-mlflow>=1.2.0,!=1.3.1'",
+            # Pin mlserver's dependency python-rapidjson, v1.15 drops support for python 3.8
+            # https://github.com/python-rapidjson/python-rapidjson/commit/47052cf7b62ff718d17a1d6dfc243c7a66fae8f9
+            "'python-rapidjson!=1.15'",
+        ]
 
     install_server_deps = [f"pip install {' '.join(server_deps)}"]
     if Popen(["bash", "-c", " && ".join(activate_cmd + install_server_deps)]).wait() != 0:

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -26,6 +26,10 @@ huggingface_hub
 # Pinned due to protobuf requirement pinning in 1.3.0 of ml-server that is incompatible
 mlserver>=1.2.0,!=1.3.1
 mlserver-mlflow>=1.2.0,!=1.3.1
+# Pin python-rapidjson as v1.15 drops support for python 3.8
+# https://github.com/python-rapidjson/python-rapidjson/commit/47052cf7b62ff718d17a1d6dfc243c7a66fae8f9
+# This is the dependency of mlserver
+python-rapidjson!=1.15
 # Required by evaluator tests
 shap
 # Required to evaluate language models in `mlflow.evaluate`

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -26,9 +26,8 @@ huggingface_hub
 # Pinned due to protobuf requirement pinning in 1.3.0 of ml-server that is incompatible
 mlserver>=1.2.0,!=1.3.1
 mlserver-mlflow>=1.2.0,!=1.3.1
-# Pin python-rapidjson as v1.15 drops support for python 3.8
+# Pin mlserver's dependency python-rapidjson, v1.15 drops support for python 3.8
 # https://github.com/python-rapidjson/python-rapidjson/commit/47052cf7b62ff718d17a1d6dfc243c7a66fae8f9
-# This is the dependency of mlserver
 python-rapidjson!=1.15
 # Required by evaluator tests
 shap

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(
             "mlserver-mlflow>=1.2.0,!=1.3.1",
             # Pin mlserver's dependency python-rapidjson, v1.15 drops support for python 3.8
             # https://github.com/python-rapidjson/python-rapidjson/commit/47052cf7b62ff718d17a1d6dfc243c7a66fae8f9
-            "'python-rapidjson!=1.15'",
+            "python-rapidjson!=1.15",
             "virtualenv",
             # Required for exporting metrics from the MLflow server to Prometheus
             # as part of the MLflow server monitoring add-on

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,9 @@ setup(
             # Reference issue: https://github.com/SeldonIO/MLServer/issues/1089
             "mlserver>=1.2.0,!=1.3.1",
             "mlserver-mlflow>=1.2.0,!=1.3.1",
+            # Pin mlserver's dependency python-rapidjson, v1.15 drops support for python 3.8
+            # https://github.com/python-rapidjson/python-rapidjson/commit/47052cf7b62ff718d17a1d6dfc243c7a66fae8f9
+            "'python-rapidjson!=1.15'",
             "virtualenv",
             # Required for exporting metrics from the MLflow server to Prometheus
             # as part of the MLflow server monitoring add-on

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -33,6 +33,9 @@ from mlflow.utils.file_utils import read_yaml, write_yaml
 AWS_METADATA_IP = "169.254.169.254"  # Used to fetch AWS Instance and User metadata.
 LOCALHOST = "127.0.0.1"
 PROTOBUF_REQUIREMENT = "protobuf<4.0.0"
+# Pin mlserver's dependency python-rapidjson, v1.15 drops support for python 3.8
+# https://github.com/python-rapidjson/python-rapidjson/commit/47052cf7b62ff718d17a1d6dfc243c7a66fae8f9
+PYTHON_RAPIDJSON_REQUIREMENT = "python-rapidjson!=1.15"
 
 _logger = logging.getLogger(__name__)
 

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -604,7 +604,13 @@ def test_build_docker(iris_data, sk_model, enable_mlserver):
     with mlflow.start_run() as active_run:
         if enable_mlserver:
             mlflow.sklearn.log_model(
-                sk_model, "model", extra_pip_requirements=["/opt/mlflow", PROTOBUF_REQUIREMENT]
+                sk_model,
+                "model",
+                extra_pip_requirements=[
+                    "/opt/mlflow",
+                    PROTOBUF_REQUIREMENT,
+                    PYTHON_RAPIDJSON_REQUIREMENT,
+                ],
             )
         else:
             mlflow.sklearn.log_model(sk_model, "model", extra_pip_requirements=["/opt/mlflow"])
@@ -684,9 +690,7 @@ def test_build_docker_with_env_override(iris_data, sk_model, enable_mlserver):
 
 def test_build_docker_without_model_uri(iris_data, sk_model, tmp_path):
     model_path = tmp_path.joinpath("model")
-    mlflow.sklearn.save_model(
-        sk_model, model_path, extra_pip_requirements=["/opt/mlflow", PYTHON_RAPIDJSON_REQUIREMENT]
-    )
+    mlflow.sklearn.save_model(sk_model, model_path, extra_pip_requirements=["/opt/mlflow"])
     image_name = pyfunc_build_image(model_uri=None)
     host_port = get_safe_port()
     scoring_proc = pyfunc_serve_from_docker_image_with_env_override(

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -43,6 +43,7 @@ from mlflow.utils.process import ShellCommandException
 
 from tests.helper_functions import (
     PROTOBUF_REQUIREMENT,
+    PYTHON_RAPIDJSON_REQUIREMENT,
     RestEndpoint,
     get_safe_port,
     pyfunc_build_image,
@@ -60,11 +61,6 @@ install_mlflow = ["--install-mlflow"] if not no_conda else []
 
 extra_options = no_conda + install_mlflow
 gunicorn_options = "--timeout 60 -w 5"
-
-# Pin python-rapidjson as v1.15 drops support for python 3.8
-# https://github.com/python-rapidjson/python-rapidjson/commit/47052cf7b62ff718d17a1d6dfc243c7a66fae8f9
-# This is the dependency of mlserver
-PYTHON_RAPIDJSON_REQUIREMENT = "python-rapidjson!=1.15"
 
 
 def env_with_tracking_uri():
@@ -576,7 +572,13 @@ def test_generate_dockerfile(sk_model, enable_mlserver, tmp_path):
     with mlflow.start_run() as active_run:
         if enable_mlserver:
             mlflow.sklearn.log_model(
-                sk_model, "model", extra_pip_requirements=["/opt/mlflow", PROTOBUF_REQUIREMENT]
+                sk_model,
+                "model",
+                extra_pip_requirements=[
+                    "/opt/mlflow",
+                    PROTOBUF_REQUIREMENT,
+                    PYTHON_RAPIDJSON_REQUIREMENT,
+                ],
             )
         else:
             mlflow.sklearn.log_model(sk_model, "model")

--- a/tests/pyfunc/docker/test_docker.py
+++ b/tests/pyfunc/docker/test_docker.py
@@ -18,12 +18,8 @@ from mlflow.utils import PYTHON_VERSION
 from mlflow.utils.env_manager import VIRTUALENV
 from mlflow.version import VERSION
 
+from tests.helper_functions import PYTHON_RAPIDJSON_REQUIREMENT
 from tests.pyfunc.docker.conftest import RESOURCE_DIR, get_released_mlflow_version
-
-# Pin python-rapidjson as v1.15 drops support for python 3.8
-# https://github.com/python-rapidjson/python-rapidjson/commit/47052cf7b62ff718d17a1d6dfc243c7a66fae8f9
-# This is the dependency of mlserver
-PYTHON_RAPIDJSON_REQUIREMENT = "python-rapidjson!=1.15"
 
 
 def assert_dockerfiles_equal(actual_dockerfile_path: Path, expected_dockerfile_path: Path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,12 @@ from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 from mlflow.utils.rest_utils import augmented_raise_for_status
 from mlflow.utils.time import get_current_time_millis
 
-from tests.helper_functions import PROTOBUF_REQUIREMENT, get_safe_port, pyfunc_serve_and_score_model
+from tests.helper_functions import (
+    PROTOBUF_REQUIREMENT,
+    PYTHON_RAPIDJSON_REQUIREMENT,
+    get_safe_port,
+    pyfunc_serve_and_score_model,
+)
 from tests.tracking.integration_test_utils import _await_server_up_or_die
 
 
@@ -415,6 +420,7 @@ def test_mlflow_models_serve(enable_mlserver):
                     "mlserver>=1.2.0,!=1.3.1",
                     "mlserver-mlflow>=1.2.0,!=1.3.1",
                     PROTOBUF_REQUIREMENT,
+                    PYTHON_RAPIDJSON_REQUIREMENT,
                 ],
             )
         else:


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> Fix https://github.com/mlflow/mlflow/actions/runs/8077661962/job/22068402614#step:10:613

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
