### PR TITLE
Move non-util functions in `mlflow/data/digest_utils.py` into its own module

### DIFF
--- a/mlflow/data/digest_utils.py
+++ b/mlflow/data/digest_utils.py
@@ -1,7 +1,5 @@
 from typing import Any, List
 
-from packaging.version import Version
-
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.utils import insecure_hash
@@ -17,7 +15,6 @@ def compute_pandas_digest(df) -> str:
 
     Returns:
         A string digest.
-
     """
     import numpy as np
     import pandas as pd
@@ -50,7 +47,6 @@ def compute_numpy_digest(features, targets=None) -> str:
 
     Returns:
         A string digest.
-
     """
     import numpy as np
     import pandas as pd
@@ -84,82 +80,6 @@ def compute_numpy_digest(features, targets=None) -> str:
     return get_normalized_md5_digest(hashable_elements)
 
 
-def compute_tensorflow_dataset_digest(dataset, targets=None) -> str:
-    """Computes a digest for the given Tensorflow dataset.
-
-    Args:
-        dataset: A Tensorflow dataset.
-
-    Returns:
-        A string digest.
-
-    """
-    import numpy as np
-    import pandas as pd
-    import tensorflow as tf
-
-    hashable_elements = []
-
-    def hash_tf_dataset_iterator_element(element):
-        if element is None:
-            return
-        flat_element = tf.nest.flatten(element)
-        flattened_array = np.concatenate([x.flatten() for x in flat_element])
-        trimmed_array = flattened_array[0:MAX_ROWS]
-        try:
-            hashable_elements.append(pd.util.hash_array(trimmed_array))
-        except TypeError:
-            hashable_elements.append(np.int64(trimmed_array.size))
-
-    for element in dataset.as_numpy_iterator():
-        hash_tf_dataset_iterator_element(element)
-    if targets is not None:
-        for element in targets.as_numpy_iterator():
-            hash_tf_dataset_iterator_element(element)
-
-    return get_normalized_md5_digest(hashable_elements)
-
-
-def compute_tensor_digest(tensor_data, tensor_targets) -> str:
-    """Computes a digest for the given Tensorflow tensor.
-
-    Args:
-        tensor: A Tensorflow tensor.
-
-    Returns:
-        A string digest.
-
-    """
-    if tensor_targets is None:
-        return compute_numpy_digest(tensor_data.numpy())
-    else:
-        return compute_numpy_digest(tensor_data.numpy(), tensor_targets.numpy())
-
-
-def compute_spark_df_digest(df) -> str:
-    """Computes a digest for the given Spark DataFrame. Retrieve a semantic hash of the
-    DataFrame's logical plan, which is much more efficient and deterministic than hashing
-    DataFrame records
-
-    Args:
-        df: A Spark DataFrame.
-
-    Returns:
-        A string digest.
-
-    """
-
-    import numpy as np
-    import pyspark
-
-    # Spark 3.1.0+ has a semanticHash() method on DataFrame
-    if Version(pyspark.__version__) >= Version("3.1.0"):
-        semantic_hash = df.semanticHash()
-    else:
-        semantic_hash = df._jdf.queryExecution().analyzed().semanticHash()
-    return get_normalized_md5_digest([np.int64(semantic_hash)])
-
-
 def get_normalized_md5_digest(elements: List[Any]) -> str:
     """Computes a normalized digest for a list of hashable elements.
 
@@ -168,7 +88,6 @@ def get_normalized_md5_digest(elements: List[Any]) -> str:
 
     Returns:
         An 8-character, truncated md5 digest.
-
     """
 
     if not elements:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/11269?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11269/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11269
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

A few changes:
- Move non-util functions in `mlflow/data/digest_utils.py` into its own module
- Some docstring is wrong, fixed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
