### PR TITLE
Move config APIs to mlflow/config

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -86,23 +86,24 @@ if MLFLOW_CONFIGURE_LOGGING.get() is True:
     _configure_mlflow_loggers(root_module_name=__name__)
 
 from mlflow.client import MlflowClient
-from mlflow.exceptions import MlflowException
-from mlflow.models import evaluate
-from mlflow.projects import run
-from mlflow.system_metrics import (
+
+# For backward compatibility, we expose the following functions and classes at the top level in
+# addition to `mlflow.config`.
+from mlflow.config import (
     disable_system_metrics_logging,
     enable_system_metrics_logging,
-    set_system_metrics_node_id,
-    set_system_metrics_samples_before_logging,
-    set_system_metrics_sampling_interval,
-)
-from mlflow.tracking import (
     get_registry_uri,
     get_tracking_uri,
     is_tracking_uri_set,
     set_registry_uri,
+    set_system_metrics_node_id,
+    set_system_metrics_samples_before_logging,
+    set_system_metrics_sampling_interval,
     set_tracking_uri,
 )
+from mlflow.exceptions import MlflowException
+from mlflow.models import evaluate
+from mlflow.projects import run
 from mlflow.tracking._model_registry.fluent import (
     register_model,
     search_model_versions,

--- a/mlflow/config/__init__.py
+++ b/mlflow/config/__init__.py
@@ -1,4 +1,18 @@
 from mlflow.environment_variables import MLFLOW_ENABLE_ASYNC_LOGGING
+from mlflow.system_metrics import (
+    disable_system_metrics_logging,
+    enable_system_metrics_logging,
+    set_system_metrics_node_id,
+    set_system_metrics_samples_before_logging,
+    set_system_metrics_sampling_interval,
+)
+from mlflow.tracking import (
+    get_registry_uri,
+    get_tracking_uri,
+    is_tracking_uri_set,
+    set_registry_uri,
+    set_tracking_uri,
+)
 
 
 def enable_async_logging(enable=True):
@@ -27,3 +41,18 @@ def enable_async_logging(enable=True):
     """
 
     MLFLOW_ENABLE_ASYNC_LOGGING.set(enable)
+
+
+__all__ = [
+    "enable_system_metrics_logging",
+    "disable_system_metrics_logging",
+    "enable_async_logging",
+    "get_registry_uri",
+    "get_tracking_uri",
+    "is_tracking_uri_set",
+    "set_registry_uri",
+    "set_system_metrics_sampling_interval",
+    "set_system_metrics_samples_before_logging",
+    "set_system_metrics_node_id",
+    "set_tracking_uri",
+]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/11270?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11270/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11270
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

A few APIs are moved to `mlflow/config`, and don't worry, we keep the original path for backward compatibility. See the list below:
- disable_system_metrics_logging
- enable_system_metrics_logging
- set_system_metrics_node_id
- set_system_metrics_samples_before_logging
- set_system_metrics_sampling_interval
- get_registry_uri
- get_tracking_uri
- is_tracking_uri_set
- set_registry_uri
- set_tracking_uri


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
