### PR TITLE
Avoid pandas warning in schema enforcement

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -669,7 +669,7 @@ def _enforce_unnamed_col_schema(pf_input: pd.DataFrame, input_schema: Schema):
     """Enforce the input columns conform to the model's column-based signature."""
     input_names = pf_input.columns[: len(input_schema.inputs)]
     input_types = input_schema.input_types()
-    new_pf_input = pf_input.iloc[:, : len(input_names)].copy()
+    new_pf_input = {}
     for i, x in enumerate(input_names):
         if isinstance(input_types[i], DataType):
             new_pf_input[x] = _enforce_mlflow_datatype(x, pf_input[x], input_types[i])
@@ -683,15 +683,14 @@ def _enforce_unnamed_col_schema(pf_input: pd.DataFrame, input_schema: Schema):
             new_pf_input[x] = pd.Series(
                 [_enforce_array(arr, input_types[i]) for arr in pf_input[x]], name=x
             )
-    return new_pf_input
+    return pd.DataFrame(new_pf_input)
 
 
 def _enforce_named_col_schema(pf_input: pd.DataFrame, input_schema: Schema):
     """Enforce the input columns conform to the model's column-based signature."""
     input_names = input_schema.input_names()
     input_dict = input_schema.input_dict()
-    keep_cols = [col for col in input_names if col in pf_input.columns]
-    new_pf_input = pf_input[keep_cols].copy()
+    new_pf_input = {}
     for name in input_names:
         input_type = input_dict[name].type
         required = input_dict[name].required
@@ -715,7 +714,7 @@ def _enforce_named_col_schema(pf_input: pd.DataFrame, input_schema: Schema):
             new_pf_input[name] = pd.Series(
                 [_enforce_array(arr, input_type, required) for arr in pf_input[name]], name=name
             )
-    return new_pf_input
+    return pd.DataFrame(new_pf_input)
 
 
 def _reshape_and_cast_pandas_column_values(name, pd_series, tensor_spec):

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -690,7 +690,8 @@ def _enforce_named_col_schema(pf_input: pd.DataFrame, input_schema: Schema):
     """Enforce the input columns conform to the model's column-based signature."""
     input_names = input_schema.input_names()
     input_dict = input_schema.input_dict()
-    new_pf_input = pf_input.loc[:, pf_input.columns.isin(input_names)].copy()
+    keep_cols = [col for col in input_names if col in pf_input.columns]
+    new_pf_input = pf_input[keep_cols].copy()
     for name in input_names:
         input_type = input_dict[name].type
         required = input_dict[name].required

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -665,11 +665,11 @@ def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
         )
 
 
-def _enforce_unnamed_col_schema(pf_input: PyFuncInput, input_schema: Schema):
+def _enforce_unnamed_col_schema(pf_input: pd.DataFrame, input_schema: Schema):
     """Enforce the input columns conform to the model's column-based signature."""
     input_names = pf_input.columns[: len(input_schema.inputs)]
     input_types = input_schema.input_types()
-    new_pf_input = pd.DataFrame()
+    new_pf_input = pf_input.iloc[:, : len(input_names)].copy()
     for i, x in enumerate(input_names):
         if isinstance(input_types[i], DataType):
             new_pf_input[x] = _enforce_mlflow_datatype(x, pf_input[x], input_types[i])
@@ -686,11 +686,11 @@ def _enforce_unnamed_col_schema(pf_input: PyFuncInput, input_schema: Schema):
     return new_pf_input
 
 
-def _enforce_named_col_schema(pf_input: PyFuncInput, input_schema: Schema):
+def _enforce_named_col_schema(pf_input: pd.DataFrame, input_schema: Schema):
     """Enforce the input columns conform to the model's column-based signature."""
     input_names = input_schema.input_names()
     input_dict = input_schema.input_dict()
-    new_pf_input = pd.DataFrame()
+    new_pf_input = pf_input.loc[:, pf_input.columns.isin(input_names)].copy()
     for name in input_names:
         input_type = input_dict[name].type
         required = input_dict[name].required
@@ -997,10 +997,13 @@ def _enforce_schema(pf_input: PyFuncInput, input_schema: Schema, flavor: Optiona
         return _enforce_pyspark_dataframe_schema(
             original_pf_input, pf_input, input_schema, flavor=flavor
         )
-    elif input_schema.has_input_names():
-        return _enforce_named_col_schema(pf_input, input_schema)
     else:
-        return _enforce_unnamed_col_schema(pf_input, input_schema)
+        # pf_input must be a pandas Dataframe at this point
+        return (
+            _enforce_named_col_schema(pf_input, input_schema)
+            if input_schema.has_input_names()
+            else _enforce_unnamed_col_schema(pf_input, input_schema)
+        )
 
 
 def _enforce_pyspark_dataframe_schema(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/11276?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11276/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11276
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Avoid the warning emitted from pandas when constructing an extremely wide DataFrame when doing schema enforcement

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested here: https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/4251634304385475 

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
