### PR TITLE
Fix endpoint construction for proxy MPU

### DIFF
--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -113,11 +113,19 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         resp = http_request(self._host_creds, endpoint, "DELETE", stream=True)
         augmented_raise_for_status(resp)
 
+    def _mpu_path(self, base_endpoint, artifact_path):
+        uri, path = self.artifact_uri.split("/mlflow-artifacts/artifacts", maxsplit=1)
+        path = path.strip("/")
+        endpoint = (
+            posixpath.join(base_endpoint, path, artifact_path)
+            if artifact_path
+            else posixpath.join(base_endpoint, path)
+        )
+        return uri, endpoint
+
     def create_multipart_upload(self, local_file, num_parts=1, artifact_path=None):
-        url, _ = self.artifact_uri.split("/mlflow-artifacts", maxsplit=1)
-        host_creds = get_default_host_creds(url)
-        base_endpoint = "/mlflow-artifacts/mpu/create"
-        endpoint = posixpath.join(base_endpoint, artifact_path) if artifact_path else base_endpoint
+        uri, endpoint = self._mpu_path("/mlflow-artifacts/mpu/create", artifact_path)
+        host_creds = get_default_host_creds(uri)
         params = {
             "path": local_file,
             "num_parts": num_parts,
@@ -127,10 +135,8 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         return CreateMultipartUploadResponse.from_dict(resp.json())
 
     def complete_multipart_upload(self, local_file, upload_id, parts=None, artifact_path=None):
-        url, _ = self.artifact_uri.split("/mlflow-artifacts", maxsplit=1)
-        host_creds = get_default_host_creds(url)
-        base_endpoint = "/mlflow-artifacts/mpu/complete"
-        endpoint = posixpath.join(base_endpoint, artifact_path) if artifact_path else base_endpoint
+        uri, endpoint = self._mpu_path("/mlflow-artifacts/mpu/complete", artifact_path)
+        host_creds = get_default_host_creds(uri)
         params = {
             "path": local_file,
             "upload_id": upload_id,
@@ -140,10 +146,8 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         augmented_raise_for_status(resp)
 
     def abort_multipart_upload(self, local_file, upload_id, artifact_path=None):
-        url, _ = self.artifact_uri.split("/mlflow-artifacts", maxsplit=1)
-        host_creds = get_default_host_creds(url)
-        base_endpoint = "/mlflow-artifacts/mpu/abort"
-        endpoint = posixpath.join(base_endpoint, artifact_path) if artifact_path else base_endpoint
+        uri, endpoint = self._mpu_path("/mlflow-artifacts/mpu/abort", artifact_path)
+        host_creds = get_default_host_creds(uri)
         params = {
             "path": local_file,
             "upload_id": upload_id,

--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -113,7 +113,7 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         resp = http_request(self._host_creds, endpoint, "DELETE", stream=True)
         augmented_raise_for_status(resp)
 
-    def _mpu_path(self, base_endpoint, artifact_path):
+    def _construct_mpu_uri_and_path(self, base_endpoint, artifact_path):
         uri, path = self.artifact_uri.split("/mlflow-artifacts/artifacts", maxsplit=1)
         path = path.strip("/")
         endpoint = (
@@ -124,7 +124,9 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         return uri, endpoint
 
     def create_multipart_upload(self, local_file, num_parts=1, artifact_path=None):
-        uri, endpoint = self._mpu_path("/mlflow-artifacts/mpu/create", artifact_path)
+        uri, endpoint = self._construct_mpu_uri_and_path(
+            "/mlflow-artifacts/mpu/create", artifact_path
+        )
         host_creds = get_default_host_creds(uri)
         params = {
             "path": local_file,
@@ -135,7 +137,9 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         return CreateMultipartUploadResponse.from_dict(resp.json())
 
     def complete_multipart_upload(self, local_file, upload_id, parts=None, artifact_path=None):
-        uri, endpoint = self._mpu_path("/mlflow-artifacts/mpu/complete", artifact_path)
+        uri, endpoint = self._construct_mpu_uri_and_path(
+            "/mlflow-artifacts/mpu/complete", artifact_path
+        )
         host_creds = get_default_host_creds(uri)
         params = {
             "path": local_file,
@@ -146,7 +150,9 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         augmented_raise_for_status(resp)
 
     def abort_multipart_upload(self, local_file, upload_id, artifact_path=None):
-        uri, endpoint = self._mpu_path("/mlflow-artifacts/mpu/abort", artifact_path)
+        uri, endpoint = self._construct_mpu_uri_and_path_(
+            "/mlflow-artifacts/mpu/abort", artifact_path
+        )
         host_creds = get_default_host_creds(uri)
         params = {
             "path": local_file,

--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -150,7 +150,7 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         augmented_raise_for_status(resp)
 
     def abort_multipart_upload(self, local_file, upload_id, artifact_path=None):
-        uri, endpoint = self._construct_mpu_uri_and_path_(
+        uri, endpoint = self._construct_mpu_uri_and_path(
             "/mlflow-artifacts/mpu/abort", artifact_path
         )
         host_creds = get_default_host_creds(uri)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11284?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11284/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11284
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Fix #11268
Fix #11225

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix endpoint construction for proxy MPU.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```python
import tempfile
import mlflow
import os


bucket = "harutaka-multi-upload-test"

os.environ["MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD"] = "true"

mlflow.set_tracking_uri("http://localhost:5000")
mlflow.set_experiment("test")

with tempfile.TemporaryDirectory() as tmpdir:
    # Log a small file
    mlflow.log_artifact(__file__)

    # Log a large file
    with open(f"{tmpdir}/dummy.txt", "wb") as f:
        f.write(b"0" * 500 * 1024 * 1024)
    mlflow.log_artifact(f"{tmpdir}/dummy.txt")

```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
