### PR TITLE
Add more helpful pickle error when saving custom pyfuncs

### DIFF
--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -295,7 +295,7 @@ def _save_model_with_class_artifacts_params(
             raise MlflowException(
                 "Failed to serialize Python model. Please audit your "
                 "class variables (e.g. in `__init__()`).\n\n"
-                "Full serialization error: {e}"
+                f"Full serialization error: {e}"
             ) from None
         else:
             raise e

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -294,8 +294,8 @@ def _save_model_with_class_artifacts_params(
         if "cannot pickle" in str(e).lower():
             raise MlflowException(
                 "Failed to serialize Python model. Please audit your "
-                "class variables (e.g. in `__init__()`).\n\n"
-                f"Full serialization error: {e}"
+                "class variables (e.g. in `__init__()`) for any "
+                f"unpicklable objects.\n\nFull serialization error: {e}"
             ) from None
         else:
             raise e

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -295,7 +295,18 @@ def _save_model_with_class_artifacts_params(
             raise MlflowException(
                 "Failed to serialize Python model. Please audit your "
                 "class variables (e.g. in `__init__()`) for any "
-                f"unpicklable objects.\n\nFull serialization error: {e}"
+                "unpicklable objects. If you're trying to save an external model "
+                "in your custom pyfunc, Please use the `artifacts` parameter "
+                "in `mlflow.pyfunc.save_model()`, and load your external model "
+                "in the `load_context()` method instead. For example:\n\n"
+                "class MyModel(mlflow.pyfunc.PythonModel):\n"
+                "    def load_context(self, context):\n"
+                "        model_path = context.artifacts['my_model_path']\n"
+                "        // custom load logic here\n"
+                "        self.model = load_model(model_path)\n\n"
+                "For more information, see our full tutorial at: "
+                "https://mlflow.org/docs/latest/traditional-ml/creating-custom-pyfunc/index.html"
+                f"\n\nFull serialization error: {e}"
             ) from None
         else:
             raise e

--- a/tests/pyfunc/test_pyfunc_exceptions.py
+++ b/tests/pyfunc/test_pyfunc_exceptions.py
@@ -1,0 +1,19 @@
+import pytest
+
+import mlflow
+from mlflow.exceptions import MlflowException
+
+
+class UnpicklableModel(mlflow.pyfunc.PythonModel):
+    def __init__(self, path):
+        with open(path, "w+") as f:
+            pass
+
+        self.not_a_file = f
+
+
+def test_pyfunc_unpicklable_exception(tmp_path):
+    model = UnpicklableModel(tmp_path / "model.pkl")
+
+    with pytest.raises(MlflowException, match="Please audit your class variables"):
+        mlflow.pyfunc.save_model(python_model=model, path=tmp_path / "model")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11290?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11290/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11290
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds a more helpful message for custom pyfunc serialization errors. It asks the user to look at their `__init__` method for any unpicklable objects.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

added `tests/pyfunc/test_pyfunc_exceptions.py`

code
```python
import torch.backends.cudnn

import mlflow


class MyModel(mlflow.pyfunc.PythonModel):
    def __init__(self):
        self.backend = torch.backends.cudnn

    def predict(self, context, model_input):
        return 5

mlflow.pyfunc.save_model(
    path="broken",
    python_model=MyModel(),
)
```

exception
```
Traceback (most recent call last):
  File "/Users/daniel.lok/mlflow/random-scripts/load.py", line 11, in <module>
    mlflow.pyfunc.save_model(
  File "/Users/daniel.lok/mlflow/mlflow/pyfunc/__init__.py", line 2114, in save_model
    return mlflow.pyfunc.model._save_model_with_class_artifacts_params(
  File "/Users/daniel.lok/mlflow/mlflow/pyfunc/model.py", line 295, in _save_model_with_class_artifacts_params
    raise MlflowException(
mlflow.exceptions.MlflowException: Failed to serialize Python model. Please audit your class variables (e.g. in `__init__()`) for any unpicklable objects. If you're trying to save an external model in your custom pyfunc, Please use the `artifacts` parameter in `mlflow.pyfunc.save_model()`, and load your external model in the `load_context()` method instead. For example:

class MyModel(mlflow.pyfunc.PythonModel):
    def load_context(self, context):
        model_path = context.artifacts['my_model_path']
        // custom load logic here
        self.model = load_model(model_path)

For more information, see our full tutorial at: https://mlflow.org/docs/latest/traditional-ml/creating-custom-pyfunc/index.html

Full serialization error: cannot pickle 'CudnnModule' object
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Custom pyfuncs now throw a more helpful message when encountering pickling errors.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
