### PR TITLE
Update documentation for system tags

### DIFF
--- a/docs/source/tracking/tracking-api.rst
+++ b/docs/source/tracking/tracking-api.rst
@@ -334,11 +334,11 @@ The following tags are set automatically by MLflow, when appropriate:
    * - ``mlflow.source.name``
      - Source identifier (e.g., GitHub URL, local Python filename, name of notebook)
    * - ``mlflow.source.git.commit``
-     - Commit hash of the executed code, if in a git repository.
+     - Commit hash of the executed code, if in a git repository. This tag is only logged when the code is executed as a Python script like ``python train.py`` or as a project. If the code is executed in a notebook, this tag is not logged.
    * - ``mlflow.source.git.branch``
-     - Name of the branch of the executed code, if in a git repository.
+     - Name of the branch of the executed code, if in a git repository. This tag is only logged within the context of `MLflow Projects <../projects.html>`_ and `MLflow Recipe <../recipes.html>`_.
    * - ``mlflow.source.git.repoURL``
-     - URL that the executed code was cloned from.
+     - URL that the executed code was cloned from. This tag is only logged within the context of `MLflow Projects <../projects.html>`_ and `MLflow Recipe <../recipes.html>`_.
    * - ``mlflow.project.env``
      - The runtime context used by the MLflow project. Possible values: ``"docker"`` and ``"conda"``.
    * - ``mlflow.project.entryPoint``

--- a/docs/source/tracking/tracking-api.rst
+++ b/docs/source/tracking/tracking-api.rst
@@ -317,41 +317,39 @@ The following tags are set automatically by MLflow, when appropriate:
 .. note:: 
     ``mlflow.note.content`` is an exceptional case where the tag is **not set automatically** and can be overridden by the user to include additional information about the run.
 
-+-------------------------------+----------------------------------------------------------------------------------------+
-| Key                           | Description                                                                            |
-+===============================+========================================================================================+
-| ``mlflow.note.content``       | A descriptive note about this run. This reserved tag is **not set automatically** and  |
-|                               | can be overridden by the user to include additional information about the run. The     |
-|                               | content is displayed on the run's page under the Notes section.                        |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.parentRunId``        | The ID of the parent run, if this is a nested run.                                     |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.user``               | Identifier of the user who created the run.                                            |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.source.type``        | Source type. Possible values: ``"NOTEBOOK"``, ``"JOB"``, ``"PROJECT"``,                |
-|                               | ``"LOCAL"``, and ``"UNKNOWN"``                                                         |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.source.name``        | Source identifier (e.g., GitHub URL, local Python filename, name of notebook)          |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.source.git.commit``  | Commit hash of the executed code, if in a git repository.                              |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.source.git.branch``  | Name of the branch of the executed code, if in a git repository.                       |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.source.git.repoURL`` | URL that the executed code was cloned from.                                            |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.project.env``        | The runtime context used by the MLflow project.                                        |
-|                               | Possible values: ``"docker"`` and ``"conda"``.                                         |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.project.entryPoint`` | Name of the project entry point associated with the current run, if any.               |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.docker.image.name``  | Name of the Docker image used to execute this run.                                     |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.docker.image.id``    | ID of the Docker image used to execute this run.                                       |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.log-model.history``  | Model metadata collected by log-model calls. Includes the serialized                   |
-|                               | form of the MLModel model files logged to a run, although the exact format and         |
-|                               | information captured is subject to change.                                             |
-+-------------------------------+----------------------------------------------------------------------------------------+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Key
+     - Description
+   * - ``mlflow.note.content``
+     - A descriptive note about this run. This reserved tag is **not set automatically** and can be overridden by the user to include additional information about the run. The content is displayed on the run's page under the Notes section.
+   * - ``mlflow.parentRunId``
+     - The ID of the parent run, if this is a nested run.
+   * - ``mlflow.user``
+     - Identifier of the user who created the run.
+   * - ``mlflow.source.type``
+     - Source type. Possible values: ``"NOTEBOOK"``, ``"JOB"``, ``"PROJECT"``, ``"LOCAL"``, and ``"UNKNOWN"``
+   * - ``mlflow.source.name``
+     - Source identifier (e.g., GitHub URL, local Python filename, name of notebook)
+   * - ``mlflow.source.git.commit``
+     - Commit hash of the executed code, if in a git repository.
+   * - ``mlflow.source.git.branch``
+     - Name of the branch of the executed code, if in a git repository.
+   * - ``mlflow.source.git.repoURL``
+     - URL that the executed code was cloned from.
+   * - ``mlflow.project.env``
+     - The runtime context used by the MLflow project. Possible values: ``"docker"`` and ``"conda"``.
+   * - ``mlflow.project.entryPoint``
+     - Name of the project entry point associated with the current run, if any.
+   * - ``mlflow.docker.image.name``
+     - Name of the Docker image used to execute this run.
+   * - ``mlflow.docker.image.id``
+     - ID of the Docker image used to execute this run.
+   * - ``mlflow.log-model.history``
+     - Model metadata collected by log-model calls. Includes the serialized form of the MLModel model files logged to a run, although the exact format and information captured is subject to change.
+
 
 Custom Tags
 ~~~~~~~~~~~


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11292?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11292/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11292
```

</p>
</details>

### Related Issues/PRs

Follow up for #11238 

### What changes are proposed in this pull request?

Git related system tags are only logged under special circumstances, but they are not documented in the [system tag page](https://mlflow.org/docs/latest/tracking/tracking-api.html#system-tags).

The first commit is updating the table syntax to use `list-table`  directive, since the original ascii-art style table was so hard to edit (confuse IDE a lot). You can check the effective change in the second commit.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
