### PR TITLE
Cast `torch.dtype` name to `torch.dtype`

### DIFF
--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -145,6 +145,13 @@ def _load_model(model_name_or_path, flavor_conf, accelerate_conf, device, revisi
     if torch_dtype := flavor_conf.get(FlavorKey.TORCH_DTYPE):
         load_kwargs[FlavorKey.TORCH_DTYPE] = torch_dtype
 
+    if torch_dtype := flavor_conf.get(FlavorKey.TORCH_DTYPE):
+        import torch
+
+        attr = torch_dtype.rsplit(".", 1)[-1]
+        if attr := getattr(torch, attr):
+            load_kwargs[FlavorKey.TORCH_DTYPE] = attr
+
     if model := _try_load_model_with_device(cls, model_name_or_path, load_kwargs):
         return model
     _logger.warning(

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -7,6 +7,7 @@ from mlflow.environment_variables import (
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_STATE
 from mlflow.transformers.flavor_config import FlavorKey, get_peft_base_model, is_peft_model
+from mlflow.transformers.torch_utils import _deserialize_torch_dtype
 
 _logger = logging.getLogger(__name__)
 
@@ -143,14 +144,7 @@ def _load_model(model_name_or_path, flavor_conf, accelerate_conf, device, revisi
 
     load_kwargs["device"] = device
     if torch_dtype := flavor_conf.get(FlavorKey.TORCH_DTYPE):
-        load_kwargs[FlavorKey.TORCH_DTYPE] = torch_dtype
-
-    if torch_dtype := flavor_conf.get(FlavorKey.TORCH_DTYPE):
-        import torch
-
-        attr = torch_dtype.rsplit(".", 1)[-1]
-        if attr := getattr(torch, attr):
-            load_kwargs[FlavorKey.TORCH_DTYPE] = attr
+        load_kwargs[FlavorKey.TORCH_DTYPE] = _deserialize_torch_dtype(torch_dtype)
 
     if model := _try_load_model_with_device(cls, model_name_or_path, load_kwargs):
         return model


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

While investigating #11288, I hit the following error in `docs/source/llms/llm-evaluate/notebooks/huggingface-evaluation.ipynb`. The error implies transformers only accepts `"auto"`  when `torch_dtype` is a string.

```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[9], line 2
      1 with mlflow.start_run():
----> 2     results = mlflow.evaluate(
      3         model_info.model_uri,
      4         eval_df.head(10),
      5         evaluators="default",
      6         model_type="text",
      7         targets="output",
      8         extra_metrics=[answer_correctness_metric, answer_quality_metric],
      9         evaluator_config={"col_mapping": {"inputs": "instruction"}},
     10     )

File ~/Desktop/repositories/mlflow/mlflow/models/evaluation/base.py:1978, in evaluate(model, data, model_type, targets, predictions, dataset_path, feature_names, evaluators, evaluator_config, custom_metrics, extra_metrics, custom_artifacts, validation_thresholds, baseline_model, env_manager, model_config, baseline_config, inference_params)
   1976         model = _get_model_from_deployment_endpoint_uri(model, inference_params)
   1977     else:
-> 1978         model = _load_model_or_server(model, env_manager, model_config)
   1979 elif env_manager != _EnvManager.LOCAL:
   1980     raise MlflowException(
   1981         message="The model argument must be a string URI referring to an MLflow model when a "
   1982         "non-local env_manager is specified.",
   1983         error_code=INVALID_PARAMETER_VALUE,
   1984     )

File ~/Desktop/repositories/mlflow/mlflow/pyfunc/__init__.py:760, in _load_model_or_server(model_uri, env_manager, model_config)
    754 from mlflow.pyfunc.scoring_server.client import (
    755     ScoringServerClient,
    756     StdinScoringServerClient,
    757 )
    759 if env_manager == _EnvManager.LOCAL:
--> 760     return load_model(model_uri, model_config=model_config)
    762 _logger.info("Starting model server for model environment restoration.")
    764 local_path = _download_artifact_from_uri(artifact_uri=model_uri)

File ~/Desktop/repositories/mlflow/mlflow/pyfunc/__init__.py:681, in load_model(model_uri, suppress_warnings, dst_path, model_config)
    679         model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path, model_config)
    680     else:
--> 681         model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
    682 except ModuleNotFoundError as e:
    683     # This error message is particularly for the case when the error is caused by module
    684     # "databricks.feature_store.mlflow_model". But depending on the environment, the offending
    685     # module might be "databricks", "databricks.feature_store" or full package. So we will
    686     # raise the error with the following note if "databricks" presents in the error. All non-
    687     # databricks moduel errors will just be re-raised.
    688     if conf[MAIN] == _DATABRICKS_FS_LOADER_MODULE and e.name.startswith("databricks"):

File ~/Desktop/repositories/mlflow/mlflow/transformers/__init__.py:1434, in _load_pyfunc(path, model_config)
   1430 model_config = _get_model_config(local_path.joinpath(_COMPONENTS_BINARY_DIR_NAME), model_config)
   1431 prompt_template = _get_prompt_template(local_path)
   1433 return _TransformersWrapper(
-> 1434     _load_model(str(local_path), flavor_configuration, "pipeline"),
   1435     flavor_configuration,
   1436     model_config,
   1437     prompt_template,
   1438 )

File ~/Desktop/repositories/mlflow/mlflow/transformers/__init__.py:1162, in _load_model(path, flavor_config, return_type, device, **kwargs)
   1158 # Load model and components either from local or from HuggingFace Hub. We check for the
   1159 # presence of the model revision (a commit hash of the hub repository) that is only present
   1160 # in the model logged with `save_pretrained=False
   1161 if FlavorKey.MODEL_REVISION not in flavor_config:
-> 1162     model_and_components = load_model_and_components_from_local(
   1163         path=pathlib.Path(path),
   1164         flavor_conf=flavor_config,
   1165         accelerate_conf=accelerate_model_conf,
   1166         device=device,
   1167     )
   1168 else:
   1169     model_and_components = load_model_and_components_from_huggingface_hub(
   1170         flavor_conf=flavor_config, accelerate_conf=accelerate_model_conf, device=device
   1171     )

File ~/Desktop/repositories/mlflow/mlflow/transformers/model_io.py:62, in load_model_and_components_from_local(path, flavor_conf, accelerate_conf, device)
     56 # NB: Path resolution for models that were saved prior to 2.4.1 release when the patching for
     57 #     the saved pipeline or component artifacts was handled by duplicate entries for components
     58 #     (artifacts/pipeline/* and artifacts/components/*) and pipelines were saved via the
     59 #     "artifacts/pipeline/*" path. In order to load the older formats after the change, the
     60 #     presence of the new path key is checked.
     61 model_path = path.joinpath(flavor_conf.get(FlavorKey.MODEL_BINARY, "pipeline"))
---> 62 loaded[FlavorKey.MODEL] = _load_model(model_path, flavor_conf, accelerate_conf, device)
     64 components = flavor_conf.get(FlavorKey.COMPONENTS, [])
     65 if FlavorKey.PROCESSOR_TYPE in flavor_conf:

File ~/Desktop/repositories/mlflow/mlflow/transformers/model_io.py:156, in _load_model(model_name_or_path, flavor_conf, accelerate_conf, device, revision)
    150 _logger.warning(
    151     "Could not specify device parameter for this pipeline type."
    152     "Falling back to loading the model with the default device."
    153 )
    155 load_kwargs.pop("device", None)
--> 156 return cls.from_pretrained(model_name_or_path, **load_kwargs)

File ~/.pyenv/versions/miniconda3-latest/envs/mlflow/lib/python3.8/site-packages/transformers/modeling_utils.py:3335, in PreTrainedModel.from_pretrained(cls, pretrained_model_name_or_path, config, cache_dir, ignore_mismatched_sizes, force_download, local_files_only, token, revision, use_safetensors, *model_args, **kwargs)
   3330                 logger.info(
   3331                     "Since the `torch_dtype` attribute can't be found in model's config object, "
   3332                     "will use torch_dtype={torch_dtype} as derived from model's weights"
   3333                 )
   3334         else:
-> 3335             raise ValueError(
   3336                 f'`torch_dtype` can be either `torch.dtype` or `"auto"`, but received {torch_dtype}'
   3337             )
   3338     dtype_orig = cls._set_default_torch_dtype(torch_dtype)
   3340 # Check if `_keep_in_fp32_modules` is not None

ValueError: `torch_dtype` can be either `torch.dtype` or `"auto"`, but received torch.bfloat16
```

Package versions:

```
% pip list | grep '^torch \|^transformers '
torch                         2.2.0
transformers                  4.38.2
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
