### PR TITLE
Cherry picks for MLflow 2.11

### DIFF
--- a/docs/source/python_api/mlflow.metrics.rst
+++ b/docs/source/python_api/mlflow.metrics.rst
@@ -163,8 +163,6 @@ Parameters:
         # with a static dataset and using `extra_metrics`
         mlflow.evaluate(
             data=data,
-            predictions="retrieved_docs",
-            targets="ground_truth_docs",
             predictions="predictions_param",
             targets="targets_param",
             model_type="retriever",

--- a/docs/source/tracking/tracking-api.rst
+++ b/docs/source/tracking/tracking-api.rst
@@ -317,41 +317,39 @@ The following tags are set automatically by MLflow, when appropriate:
 .. note:: 
     ``mlflow.note.content`` is an exceptional case where the tag is **not set automatically** and can be overridden by the user to include additional information about the run.
 
-+-------------------------------+----------------------------------------------------------------------------------------+
-| Key                           | Description                                                                            |
-+===============================+========================================================================================+
-| ``mlflow.note.content``       | A descriptive note about this run. This reserved tag is **not set automatically** and  |
-|                               | can be overridden by the user to include additional information about the run. The     |
-|                               | content is displayed on the run's page under the Notes section.                        |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.parentRunId``        | The ID of the parent run, if this is a nested run.                                     |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.user``               | Identifier of the user who created the run.                                            |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.source.type``        | Source type. Possible values: ``"NOTEBOOK"``, ``"JOB"``, ``"PROJECT"``,                |
-|                               | ``"LOCAL"``, and ``"UNKNOWN"``                                                         |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.source.name``        | Source identifier (e.g., GitHub URL, local Python filename, name of notebook)          |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.source.git.commit``  | Commit hash of the executed code, if in a git repository.                              |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.source.git.branch``  | Name of the branch of the executed code, if in a git repository.                       |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.source.git.repoURL`` | URL that the executed code was cloned from.                                            |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.project.env``        | The runtime context used by the MLflow project.                                        |
-|                               | Possible values: ``"docker"`` and ``"conda"``.                                         |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.project.entryPoint`` | Name of the project entry point associated with the current run, if any.               |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.docker.image.name``  | Name of the Docker image used to execute this run.                                     |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.docker.image.id``    | ID of the Docker image used to execute this run.                                       |
-+-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.log-model.history``  | Model metadata collected by log-model calls. Includes the serialized                   |
-|                               | form of the MLModel model files logged to a run, although the exact format and         |
-|                               | information captured is subject to change.                                             |
-+-------------------------------+----------------------------------------------------------------------------------------+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Key
+     - Description
+   * - ``mlflow.note.content``
+     - A descriptive note about this run. This reserved tag is **not set automatically** and can be overridden by the user to include additional information about the run. The content is displayed on the run's page under the Notes section.
+   * - ``mlflow.parentRunId``
+     - The ID of the parent run, if this is a nested run.
+   * - ``mlflow.user``
+     - Identifier of the user who created the run.
+   * - ``mlflow.source.type``
+     - Source type. Possible values: ``"NOTEBOOK"``, ``"JOB"``, ``"PROJECT"``, ``"LOCAL"``, and ``"UNKNOWN"``
+   * - ``mlflow.source.name``
+     - Source identifier (e.g., GitHub URL, local Python filename, name of notebook)
+   * - ``mlflow.source.git.commit``
+     - Commit hash of the executed code, if in a git repository. This tag is only logged when the code is executed as a Python script like ``python train.py`` or as a project. If the code is executed in a notebook, this tag is not logged.
+   * - ``mlflow.source.git.branch``
+     - Name of the branch of the executed code, if in a git repository. This tag is only logged within the context of `MLflow Projects <../projects.html>`_ and `MLflow Recipe <../recipes.html>`_.
+   * - ``mlflow.source.git.repoURL``
+     - URL that the executed code was cloned from. This tag is only logged within the context of `MLflow Projects <../projects.html>`_ and `MLflow Recipe <../recipes.html>`_.
+   * - ``mlflow.project.env``
+     - The runtime context used by the MLflow project. Possible values: ``"docker"`` and ``"conda"``.
+   * - ``mlflow.project.entryPoint``
+     - Name of the project entry point associated with the current run, if any.
+   * - ``mlflow.docker.image.name``
+     - Name of the Docker image used to execute this run.
+   * - ``mlflow.docker.image.id``
+     - ID of the Docker image used to execute this run.
+   * - ``mlflow.log-model.history``
+     - Model metadata collected by log-model calls. Includes the serialized form of the MLModel model files logged to a run, although the exact format and information captured is subject to change.
+
 
 Custom Tags
 ~~~~~~~~~~~

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1151,6 +1151,7 @@ def _load_model(path: str, flavor_config, return_type: str, device=None, **kwarg
         if isinstance(dtype_val, str):
             dtype_val = _deserialize_torch_dtype(dtype_val)
         conf[_TORCH_DTYPE_KEY] = dtype_val
+        flavor_config[_TORCH_DTYPE_KEY] = dtype_val
         accelerate_model_conf[_TORCH_DTYPE_KEY] = dtype_val
 
     accelerate_model_conf["low_cpu_mem_usage"] = MLFLOW_HUGGINGFACE_USE_LOW_CPU_MEM_USAGE.get()

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -7,6 +7,7 @@ from mlflow.environment_variables import (
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_STATE
 from mlflow.transformers.flavor_config import FlavorKey, get_peft_base_model, is_peft_model
+from mlflow.transformers.torch_utils import _deserialize_torch_dtype
 
 _logger = logging.getLogger(__name__)
 
@@ -143,7 +144,7 @@ def _load_model(model_name_or_path, flavor_conf, accelerate_conf, device, revisi
 
     load_kwargs["device"] = device
     if torch_dtype := flavor_conf.get(FlavorKey.TORCH_DTYPE):
-        load_kwargs[FlavorKey.TORCH_DTYPE] = torch_dtype
+        load_kwargs[FlavorKey.TORCH_DTYPE] = _deserialize_torch_dtype(torch_dtype)
 
     if model := _try_load_model_with_device(cls, model_name_or_path, load_kwargs):
         return model

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -7,7 +7,6 @@ from mlflow.environment_variables import (
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_STATE
 from mlflow.transformers.flavor_config import FlavorKey, get_peft_base_model, is_peft_model
-from mlflow.transformers.torch_utils import _deserialize_torch_dtype
 
 _logger = logging.getLogger(__name__)
 
@@ -144,7 +143,7 @@ def _load_model(model_name_or_path, flavor_conf, accelerate_conf, device, revisi
 
     load_kwargs["device"] = device
     if torch_dtype := flavor_conf.get(FlavorKey.TORCH_DTYPE):
-        load_kwargs[FlavorKey.TORCH_DTYPE] = _deserialize_torch_dtype(torch_dtype)
+        load_kwargs[FlavorKey.TORCH_DTYPE] = torch_dtype
 
     if model := _try_load_model_with_device(cls, model_name_or_path, load_kwargs):
         return model


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11296?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11296/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11296
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Cherry picks for MLflow 2.11.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
