### PR TITLE
[ML-37954] Add notebook/job lineage when loading a model from UC

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -901,24 +901,20 @@ def load_model(
             .. Note:: Experimental: This parameter may change or be removed in a future
                 release without warning.
     """
-
     entity_list = []
 
-    # Get notebook id
+    # Get notebook id and job id, pack them into lineage_header_info
     notebook_id = databricks_utils.get_notebook_id()
-    notebook_entity = Notebook(id=str(notebook_id))
+    if notebook_id:
+        notebook_entity = Notebook(id=str(notebook_id))
+        entity_list.append(Entity(notebook=notebook_entity))
 
-    # Get job id
     job_id = databricks_utils.get_job_id()
-    job_entity = Job(id=str(job_id))
+    if job_id:
+        job_entity = Job(id=str(job_id))
+        entity_list.append(Entity(job=job_entity))
 
-    entity_list.extend([Entity(notebook=notebook_entity), Entity(job=job_entity)])
-
-    # We can only get the entity list here, the lineage list basically contains the model
-    # which we don't have the UUIDs for in mlflow lib
-    # In MC, we'll make a call to get the UUIDs and then use those for generating the lineage message
-    lineage_header_info = LineageHeaderInfo(entities=entity_list)
-
+    lineage_header_info = LineageHeaderInfo(entities=entity_list) if entity_list else None
     local_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path, lineage_header_info=lineage_header_info)
 
     if not suppress_warnings:

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -909,20 +909,20 @@ def load_model(
     """
 
     lineage_header_info = None
-    # if databricks_utils.is_in_databricks_notebook() or databricks_utils.is_in_databricks_job():
-    #     entity_list = []
-    #     # Get notebook id and job id, pack them into lineage_header_info
-    #     notebook_id = databricks_utils.get_notebook_id()
-    #     if notebook_id:
-    #         notebook_entity = Notebook(id=str(notebook_id))
-    #         entity_list.append(Entity(notebook=notebook_entity))
-    #
-    #     job_id = databricks_utils.get_job_id()
-    #     if job_id:
-    #         job_entity = Job(id=str(job_id))
-    #         entity_list.append(Entity(job=job_entity))
-    #
-    #     lineage_header_info = LineageHeaderInfo(entities=entity_list) if entity_list else None
+    if databricks_utils.is_in_databricks_runtime() and (databricks_utils.is_in_databricks_notebook() or databricks_utils.is_in_databricks_job()):
+        entity_list = []
+        # Get notebook id and job id, pack them into lineage_header_info
+        notebook_id = databricks_utils.get_notebook_id()
+        if notebook_id:
+            notebook_entity = Notebook(id=str(notebook_id))
+            entity_list.append(Entity(notebook=notebook_entity))
+
+        job_id = databricks_utils.get_job_id()
+        if job_id:
+            job_entity = Job(id=str(job_id))
+            entity_list.append(Entity(job=job_entity))
+
+        lineage_header_info = LineageHeaderInfo(entities=entity_list) if entity_list else None
 
     local_path = _download_artifact_from_uri(
         artifact_uri=model_uri, output_path=dst_path, lineage_header_info=lineage_header_info

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -909,17 +909,17 @@ def load_model(
     """
 
     lineage_header_info = None
-    if databricks_utils.is_in_databricks_runtime() and (databricks_utils.is_in_databricks_notebook() or databricks_utils.is_in_databricks_job()):
+    if databricks_utils.is_in_databricks_runtime() and (
+        databricks_utils.is_in_databricks_notebook() or databricks_utils.is_in_databricks_job()
+    ):
         entity_list = []
         # Get notebook id and job id, pack them into lineage_header_info
-        notebook_id = databricks_utils.get_notebook_id()
-        if notebook_id:
-            notebook_entity = Notebook(id=str(notebook_id))
+        if notebook_id := databricks_utils.get_notebook_id():
+            notebook_entity = Notebook(id=notebook_id)
             entity_list.append(Entity(notebook=notebook_entity))
 
-        job_id = databricks_utils.get_job_id()
-        if job_id:
-            job_entity = Job(id=str(job_id))
+        if job_id := databricks_utils.get_job_id():
+            job_entity = Job(id=job_id)
             entity_list.append(Entity(job=job_entity))
 
         lineage_header_info = LineageHeaderInfo(entities=entity_list) if entity_list else None

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -48,7 +48,7 @@ loaded.
 
             import pandas as pd
 
-            x_new = pd.DataFrame(dict(x1=[1,2,3], x2=[4,5,6]))
+            x_new = pd.DataFrame(dict(x1=[1, 2, 3], x2=[4, 5, 6]))
             model.predict(x_new)
 
     * - ``numpy.ndarray``
@@ -57,7 +57,7 @@ loaded.
 
             import numpy as np
 
-            x_new = np.array([[1, 4] [2, 5], [3, 6]])
+            x_new = np.array([[1, 4][2, 5], [3, 6]])
             model.predict(x_new)
 
     * - ``scipy.sparse.csc_matrix`` or ``scipy.sparse.csr_matrix``
@@ -94,8 +94,8 @@ loaded.
 
             spark = SparkSession.builder.getOrCreate()
 
-            data = [(1,4), (2,5), (3,6)]  # List of tuples
-            x_new = spark.createDataFrame(data, ["x1","x2"])  # Specify column name
+            data = [(1, 4), (2, 5), (3, 6)]  # List of tuples
+            x_new = spark.createDataFrame(data, ["x1", "x2"])  # Specify column name
             model.predict(x_new)
 
 .. _pyfunc-filesystem-format:
@@ -318,9 +318,11 @@ can simply log a predict method via the keyword argument ``python_model``.
     import mlflow
     import pandas as pd
 
+
     # Define a simple function to log
     def predict(model_input):
         return model_input.apply(lambda x: x * 2)
+
 
     # Save the function as a model
     with mlflow.start_run():
@@ -329,7 +331,7 @@ can simply log a predict method via the keyword argument ``python_model``.
 
     # Load the model from the tracking server and perform inference
     model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
-    x_new = pd.Series([1,2,3])
+    x_new = pd.Series([1, 2, 3])
 
     prediction = model.predict(x_new)
     print(prediction)
@@ -350,13 +352,17 @@ we would recommend using the functional-based Model instead for this simple case
     import mlflow
     import pandas as pd
 
+
     class MyModel(mlflow.pyfunc.PythonModel):
         def predict(self, context, model_input, params=None):
-            return [x*2 for x in model_input]
+            return [x * 2 for x in model_input]
+
 
     # Save the function as a model
     with mlflow.start_run():
-        mlflow.pyfunc.log_model("model", python_model=MyModel(), pip_requirements=["pandas"])
+        mlflow.pyfunc.log_model(
+            "model", python_model=MyModel(), pip_requirements=["pandas"]
+        )
         run_id = mlflow.active_run().info.run_id
 
     # Load the model from the tracking server and perform inference
@@ -427,6 +433,12 @@ from mlflow.protos.databricks_pb2 import (
     INVALID_PARAMETER_VALUE,
     RESOURCE_DOES_NOT_EXIST,
 )
+from mlflow.protos.databricks_uc_registry_messages_pb2 import (
+    Entity,
+    Job,
+    LineageHeaderInfo,
+    Notebook,
+)
 from mlflow.pyfunc.model import (
     ChatModel,
     PythonModel,
@@ -450,6 +462,7 @@ from mlflow.utils import (
     PYTHON_VERSION,
     _is_in_ipython_notebook,
     check_port_connectivity,
+    databricks_utils,
     find_free_port,
     get_major_minor_py_version,
     insecure_hash,
@@ -490,13 +503,6 @@ from mlflow.utils.requirements_utils import (
     _parse_requirements,
     warn_dependency_requirement_mismatches,
 )
-from mlflow.protos.databricks_uc_registry_messages_pb2 import (
-    Notebook,
-    Job,
-    Entity,
-    LineageHeaderInfo,
-)
-from mlflow.utils import databricks_utils
 
 try:
     from pyspark.sql import DataFrame as SparkDataFrame
@@ -901,21 +907,26 @@ def load_model(
             .. Note:: Experimental: This parameter may change or be removed in a future
                 release without warning.
     """
-    entity_list = []
 
-    # Get notebook id and job id, pack them into lineage_header_info
-    notebook_id = databricks_utils.get_notebook_id()
-    if notebook_id:
-        notebook_entity = Notebook(id=str(notebook_id))
-        entity_list.append(Entity(notebook=notebook_entity))
+    lineage_header_info = None
+    if databricks_utils.is_in_databricks_notebook() or databricks_utils.is_in_databricks_job():
+        entity_list = []
+        # Get notebook id and job id, pack them into lineage_header_info
+        notebook_id = databricks_utils.get_notebook_id()
+        if notebook_id:
+            notebook_entity = Notebook(id=str(notebook_id))
+            entity_list.append(Entity(notebook=notebook_entity))
 
-    job_id = databricks_utils.get_job_id()
-    if job_id:
-        job_entity = Job(id=str(job_id))
-        entity_list.append(Entity(job=job_entity))
+        job_id = databricks_utils.get_job_id()
+        if job_id:
+            job_entity = Job(id=str(job_id))
+            entity_list.append(Entity(job=job_entity))
 
-    lineage_header_info = LineageHeaderInfo(entities=entity_list) if entity_list else None
-    local_path = _download_artifact_from_uri(artifact_uri=model_uri, output_path=dst_path, lineage_header_info=lineage_header_info)
+        lineage_header_info = LineageHeaderInfo(entities=entity_list) if entity_list else None
+
+    local_path = _download_artifact_from_uri(
+        artifact_uri=model_uri, output_path=dst_path, lineage_header_info=lineage_header_info
+    )
 
     if not suppress_warnings:
         model_requirements = _get_pip_requirements_from_model_path(local_path)
@@ -1803,10 +1814,10 @@ Compound types:
                     args = args[: len(names)]
                 if len(args) < len(required_names):
                     raise MlflowException(
-                        "Model input is missing required columns. Expected {} required"
-                        " input columns {}, but the model received only {} unnamed input columns"
-                        " (Since the columns were passed unnamed they are expected to be in"
-                        " the order specified by the schema).".format(len(names), names, len(args))
+                        f"Model input is missing required columns. Expected {len(names)} required"
+                        f" input columns {names}, but the model received only {len(args)} "
+                        "unnamed input columns (Since the columns were passed unnamed they are"
+                        " expected to be in the order specified by the schema)."
                     )
             pdf = pandas.DataFrame(
                 data={
@@ -2052,11 +2063,9 @@ Compound types:
                 else:
                     raise MlflowException(
                         message="Cannot apply udf because no column names specified. The udf "
-                        "expects {} columns with types: {}. Input column names could not be "
-                        "inferred from the model signature (column names not found).".format(
-                            len(input_schema.inputs),
-                            input_schema.inputs,
-                        ),
+                        f"expects {len(input_schema.inputs)} columns with types: "
+                        "{input_schema.inputs}. Input column names could not be inferred from the"
+                        " model signature (column names not found).",
                         error_code=INVALID_PARAMETER_VALUE,
                     )
             else:
@@ -2300,14 +2309,10 @@ def save_model(
     if first_argument_set_specified and second_argument_set_specified:
         raise MlflowException(
             message=(
-                "The following sets of parameters cannot be specified together: {first_set_keys}"
-                " and {second_set_keys}. All parameters in one set must be `None`. Instead, found"
-                " the following values: {first_set_entries} and {second_set_entries}".format(
-                    first_set_keys=first_argument_set.keys(),
-                    second_set_keys=second_argument_set.keys(),
-                    first_set_entries=first_argument_set,
-                    second_set_entries=second_argument_set,
-                )
+                f"The following sets of parameters cannot be specified together:"
+                f" {first_argument_set.keys()}  and {second_argument_set.keys()}."
+                " All parameters in one set must be `None`. Instead, found"
+                f" the following values: {first_argument_set} and {second_argument_set}"
             ),
             error_code=INVALID_PARAMETER_VALUE,
         )

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -909,20 +909,20 @@ def load_model(
     """
 
     lineage_header_info = None
-    if databricks_utils.is_in_databricks_notebook() or databricks_utils.is_in_databricks_job():
-        entity_list = []
-        # Get notebook id and job id, pack them into lineage_header_info
-        notebook_id = databricks_utils.get_notebook_id()
-        if notebook_id:
-            notebook_entity = Notebook(id=str(notebook_id))
-            entity_list.append(Entity(notebook=notebook_entity))
-
-        job_id = databricks_utils.get_job_id()
-        if job_id:
-            job_entity = Job(id=str(job_id))
-            entity_list.append(Entity(job=job_entity))
-
-        lineage_header_info = LineageHeaderInfo(entities=entity_list) if entity_list else None
+    # if databricks_utils.is_in_databricks_notebook() or databricks_utils.is_in_databricks_job():
+    #     entity_list = []
+    #     # Get notebook id and job id, pack them into lineage_header_info
+    #     notebook_id = databricks_utils.get_notebook_id()
+    #     if notebook_id:
+    #         notebook_entity = Notebook(id=str(notebook_id))
+    #         entity_list.append(Entity(notebook=notebook_entity))
+    #
+    #     job_id = databricks_utils.get_job_id()
+    #     if job_id:
+    #         job_entity = Job(id=str(job_id))
+    #         entity_list.append(Entity(job=job_entity))
+    #
+    #     lineage_header_info = LineageHeaderInfo(entities=entity_list) if entity_list else None
 
     local_path = _download_artifact_from_uri(
         artifact_uri=model_uri, output_path=dst_path, lineage_header_info=lineage_header_info

--- a/mlflow/store/_unity_catalog/lineage/__init__.py
+++ b/mlflow/store/_unity_catalog/lineage/__init__.py
@@ -1,0 +1,1 @@
+from mlflow.store._unity_catalog import lineage  # noqa: F401

--- a/mlflow/store/_unity_catalog/lineage/constants.py
+++ b/mlflow/store/_unity_catalog/lineage/constants.py
@@ -1,0 +1,2 @@
+_DATABRICKS_ORG_ID_HEADER = "x-databricks-org-id"
+_DATABRICKS_LINEAGE_ID_HEADER = "X-Databricks-Lineage-Identifier"

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -90,9 +90,8 @@ from mlflow.utils.rest_utils import (
     http_request,
     verify_rest_response,
 )
+from mlflow.store._unity_catalog.lineage.constants import _DATABRICKS_LINEAGE_ID_HEADER, _DATABRICKS_ORG_ID_HEADER
 
-_DATABRICKS_ORG_ID_HEADER = "x-databricks-org-id"
-_DATABRICKS_LINEAGE_ID_HEADER = "X-Databricks-Lineage-Identifier"
 _TRACKING_METHOD_TO_INFO = extract_api_info_for_service(MlflowService, _REST_API_PATH_PREFIX)
 _METHOD_TO_INFO = extract_api_info_for_service(UcModelRegistryService, _REST_API_PATH_PREFIX)
 _METHOD_TO_ALL_INFO = extract_all_api_info_for_service(

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -63,6 +63,10 @@ from mlflow.protos.databricks_uc_registry_messages_pb2 import (
 )
 from mlflow.protos.databricks_uc_registry_service_pb2 import UcModelRegistryService
 from mlflow.protos.service_pb2 import GetRun, MlflowService
+from mlflow.store._unity_catalog.lineage.constants import (
+    _DATABRICKS_LINEAGE_ID_HEADER,
+    _DATABRICKS_ORG_ID_HEADER,
+)
 from mlflow.store.artifact.presigned_url_artifact_repo import PresignedUrlArtifactRepository
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry.rest_store import BaseRestStore
@@ -90,7 +94,6 @@ from mlflow.utils.rest_utils import (
     http_request,
     verify_rest_response,
 )
-from mlflow.store._unity_catalog.lineage.constants import _DATABRICKS_LINEAGE_ID_HEADER, _DATABRICKS_ORG_ID_HEADER
 
 _TRACKING_METHOD_TO_INFO = extract_api_info_for_service(MlflowService, _REST_API_PATH_PREFIX)
 _METHOD_TO_INFO = extract_api_info_for_service(UcModelRegistryService, _REST_API_PATH_PREFIX)

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -16,6 +16,7 @@ from mlflow.utils.async_logging.async_artifacts_logging_queue import AsyncArtifa
 from mlflow.utils.file_utils import ArtifactProgressBar, create_tmp_dir
 from mlflow.utils.validation import bad_path_message, path_not_unique
 
+from mlflow.protos.databricks_uc_registry_messages_pb2 import LineageHeaderInfo
 # Constants used to determine max level of parallelism to use while uploading/downloading artifacts.
 # Max threads to use for parallelism.
 _NUM_MAX_THREADS = 20

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -16,7 +16,6 @@ from mlflow.utils.async_logging.async_artifacts_logging_queue import AsyncArtifa
 from mlflow.utils.file_utils import ArtifactProgressBar, create_tmp_dir
 from mlflow.utils.validation import bad_path_message, path_not_unique
 
-from mlflow.protos.databricks_uc_registry_messages_pb2 import LineageHeaderInfo
 # Constants used to determine max level of parallelism to use while uploading/downloading artifacts.
 # Max threads to use for parallelism.
 _NUM_MAX_THREADS = 20

--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -183,7 +183,9 @@ class ModelsArtifactRepository(ArtifactRepository):
 
         # Pass lineage header info if model is registered in UC
         if isinstance(self.repo, UnityCatalogModelsArtifactRepository):
-            model_path = self.repo.download_artifacts(artifact_path, dst_path, lineage_header_info=lineage_header_info)
+            model_path = self.repo.download_artifacts(
+                artifact_path, dst_path, lineage_header_info=lineage_header_info
+            )
         else:
             model_path = self.repo.download_artifacts(artifact_path, dst_path)
         # NB: only add the registered model metadata iff the artifact path is at the root model

--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -159,7 +159,7 @@ class ModelsArtifactRepository(ArtifactRepository):
             ensure_yaml_extension=False,
         )
 
-    def download_artifacts(self, artifact_path, dst_path=None):
+    def download_artifacts(self, artifact_path, dst_path=None, lineage_header_info=None):
         """
         Download an artifact file or directory to a local directory if applicable, and return a
         local path for it.
@@ -181,7 +181,11 @@ class ModelsArtifactRepository(ArtifactRepository):
 
         from mlflow.models.model import MLMODEL_FILE_NAME
 
-        model_path = self.repo.download_artifacts(artifact_path, dst_path)
+        # Pass lineage header info if model is registered in UC
+        if isinstance(self.repo, UnityCatalogModelsArtifactRepository):
+            model_path = self.repo.download_artifacts(artifact_path, dst_path, lineage_header_info=lineage_header_info)
+        else:
+            model_path = self.repo.download_artifacts(artifact_path, dst_path)
         # NB: only add the registered model metadata iff the artifact path is at the root model
         # directory. For individual files or subdirectories within the model directory, do not
         # create the metadata file.

--- a/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
+++ b/mlflow/store/artifact/unity_catalog_models_artifact_repo.py
@@ -1,3 +1,4 @@
+import base64
 from mlflow.environment_variables import MLFLOW_UNITY_CATALOG_PRESIGNED_URLS_ENABLED
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
@@ -5,6 +6,10 @@ from mlflow.protos.databricks_uc_registry_messages_pb2 import (
     MODEL_VERSION_OPERATION_READ,
     GenerateTemporaryModelVersionCredentialsRequest,
     GenerateTemporaryModelVersionCredentialsResponse,
+    Notebook,
+    Job,
+    Entity,
+    LineageHeaderInfo,
 )
 from mlflow.protos.databricks_uc_registry_service_pb2 import UcModelRegistryService
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
@@ -33,6 +38,8 @@ from mlflow.utils.uri import (
 
 _METHOD_TO_INFO = extract_api_info_for_service(UcModelRegistryService, _REST_API_PATH_PREFIX)
 
+# extract this to a common lib
+_DATABRICKS_LINEAGE_ID_HEADER = "X-Databricks-Lineage-Identifier"
 
 class UnityCatalogModelsArtifactRepository(ArtifactRepository):
     """
@@ -86,7 +93,14 @@ class UnityCatalogModelsArtifactRepository(ArtifactRepository):
     def _get_blob_storage_path(self):
         return self.client.get_model_version_download_uri(self.model_name, self.model_version)
 
-    def _get_scoped_token(self):
+    def _get_scoped_token(self, lineage_header_info):
+        extra_headers = {}
+        if lineage_header_info:
+            header_json = message_to_json(lineage_header_info)
+            print("We are propagating the following info to UCMR and MC", header_json)
+            header_base64 = base64.b64encode(header_json.encode())
+            extra_headers[_DATABRICKS_LINEAGE_ID_HEADER] = header_base64
+
         db_creds = get_databricks_host_creds(self.registry_uri)
         endpoint, method = _METHOD_TO_INFO[GenerateTemporaryModelVersionCredentialsRequest]
         req_body = message_to_json(
@@ -103,9 +117,10 @@ class UnityCatalogModelsArtifactRepository(ArtifactRepository):
             method=method,
             json_body=req_body,
             response_proto=response_proto,
+            extra_headers=extra_headers,
         ).credentials
 
-    def _get_artifact_repo(self):
+    def _get_artifact_repo(self, lineage_header_info):
         """
         Get underlying ArtifactRepository instance for model version blob
         storage
@@ -115,7 +130,7 @@ class UnityCatalogModelsArtifactRepository(ArtifactRepository):
                 get_databricks_host_creds(self.registry_uri), self.model_name, self.model_version
             )
 
-        scoped_token = self._get_scoped_token()
+        scoped_token = self._get_scoped_token(lineage_header_info)
         blob_storage_path = self._get_blob_storage_path()
         return get_artifact_repo_from_storage_info(
             storage_location=blob_storage_path, scoped_token=scoped_token
@@ -124,8 +139,8 @@ class UnityCatalogModelsArtifactRepository(ArtifactRepository):
     def list_artifacts(self, path=None):
         return self._get_artifact_repo().list_artifacts(path=path)
 
-    def download_artifacts(self, artifact_path, dst_path=None):
-        return self._get_artifact_repo().download_artifacts(artifact_path, dst_path)
+    def download_artifacts(self, artifact_path, dst_path=None, lineage_header_info=None):
+        return self._get_artifact_repo(lineage_header_info=lineage_header_info).download_artifacts(artifact_path, dst_path)
 
     def log_artifact(self, local_file, artifact_path=None):
         raise MlflowException("This repository does not support logging artifacts.")

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -1,6 +1,7 @@
 """
 Utilities for dealing with artifacts in the context of a Run.
 """
+
 import os
 import pathlib
 import posixpath
@@ -13,7 +14,6 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.artifact.dbfs_artifact_repo import DbfsRestArtifactRepository
 from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
-from mlflow.store.artifact.unity_catalog_models_artifact_repo import UnityCatalogModelsArtifactRepository
 from mlflow.tracking._tracking_service.utils import _get_store
 from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.os import is_windows
@@ -96,7 +96,7 @@ def _get_root_uri_and_artifact_path(artifact_uri):
     return root_uri, artifact_path
 
 
-def _download_artifact_from_uri(artifact_uri, output_path=None,lineage_header_info=None):
+def _download_artifact_from_uri(artifact_uri, output_path=None, lineage_header_info=None):
     """
     Args:
         artifact_uri: The *absolute* URI of the artifact to download.
@@ -109,7 +109,9 @@ def _download_artifact_from_uri(artifact_uri, output_path=None,lineage_header_in
 
     if isinstance(repo, ModelsArtifactRepository):
         return repo.download_artifacts(
-            artifact_path=artifact_path, dst_path=output_path, lineage_header_info=lineage_header_info
+            artifact_path=artifact_path,
+            dst_path=output_path,
+            lineage_header_info=lineage_header_info,
         )
     return repo.download_artifacts(artifact_path=artifact_path, dst_path=output_path)
 

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -13,6 +13,7 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.artifact.dbfs_artifact_repo import DbfsRestArtifactRepository
 from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
+from mlflow.store.artifact.unity_catalog_models_artifact_repo import UnityCatalogModelsArtifactRepository
 from mlflow.tracking._tracking_service.utils import _get_store
 from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.os import is_windows
@@ -95,17 +96,22 @@ def _get_root_uri_and_artifact_path(artifact_uri):
     return root_uri, artifact_path
 
 
-def _download_artifact_from_uri(artifact_uri, output_path=None):
+def _download_artifact_from_uri(artifact_uri, output_path=None,lineage_header_info=None):
     """
     Args:
         artifact_uri: The *absolute* URI of the artifact to download.
         output_path: The local filesystem path to which to download the artifact. If unspecified,
             a local output path will be created.
+        lineage_header_info: The model lineage header info to be
     """
     root_uri, artifact_path = _get_root_uri_and_artifact_path(artifact_uri)
-    return get_artifact_repository(artifact_uri=root_uri).download_artifacts(
-        artifact_path=artifact_path, dst_path=output_path
-    )
+    repo = get_artifact_repository(artifact_uri=root_uri)
+
+    if isinstance(repo, UnityCatalogModelsArtifactRepository):
+        return repo.download_artifacts(
+            artifact_path=artifact_path, dst_path=output_path, lineage_header_info=lineage_header_info
+        )
+    return repo.download_artifacts(artifact_path=artifact_path, dst_path=output_path)
 
 
 def _upload_artifact_to_uri(local_path, artifact_uri):

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -102,12 +102,12 @@ def _download_artifact_from_uri(artifact_uri, output_path=None,lineage_header_in
         artifact_uri: The *absolute* URI of the artifact to download.
         output_path: The local filesystem path to which to download the artifact. If unspecified,
             a local output path will be created.
-        lineage_header_info: The model lineage header info to be
+        lineage_header_info: The model lineage header info to be consumed by lineage services.
     """
     root_uri, artifact_path = _get_root_uri_and_artifact_path(artifact_uri)
     repo = get_artifact_repository(artifact_uri=root_uri)
 
-    if isinstance(repo, UnityCatalogModelsArtifactRepository):
+    if isinstance(repo, ModelsArtifactRepository):
         return repo.download_artifacts(
             artifact_path=artifact_path, dst_path=output_path, lineage_header_info=lineage_header_info
         )

--- a/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
+++ b/tests/store/artifact/test_unity_catalog_models_artifact_repo.py
@@ -139,6 +139,7 @@ def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_aws():
             endpoint="/api/2.0/mlflow/unity-catalog/model-versions/generate-temporary-credentials",
             method="POST",
             json={"name": "MyModel", "version": "12", "operation": "MODEL_VERSION_OPERATION_READ"},
+            extra_headers=ANY,
         )
 
 
@@ -176,6 +177,7 @@ def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_azure()
             endpoint="/api/2.0/mlflow/unity-catalog/model-versions/generate-temporary-credentials",
             method="POST",
             json={"name": "MyModel", "version": "12", "operation": "MODEL_VERSION_OPERATION_READ"},
+            extra_headers=ANY,
         )
 
 
@@ -217,6 +219,7 @@ def test_uc_models_artifact_repo_download_artifacts_uses_temporary_creds_gcp():
             endpoint="/api/2.0/mlflow/unity-catalog/model-versions/generate-temporary-credentials",
             method="POST",
             json={"name": "MyModel", "version": "12", "operation": "MODEL_VERSION_OPERATION_READ"},
+            extra_headers=ANY,
         )
 
 
@@ -275,6 +278,7 @@ def test_uc_models_artifact_repo_list_artifacts_uses_temporary_creds():
             endpoint="/api/2.0/mlflow/unity-catalog/model-versions/generate-temporary-credentials",
             method="POST",
             json={"name": "MyModel", "version": "12", "operation": "MODEL_VERSION_OPERATION_READ"},
+            extra_headers=ANY,
         )
 
 

--- a/tests/store/lineage/test_downstream_lineage.py
+++ b/tests/store/lineage/test_downstream_lineage.py
@@ -1,0 +1,81 @@
+import pytest
+import mlflow
+import base64
+from unittest import mock
+from mlflow.store.artifact.unity_catalog_models_artifact_repo import (
+    UnityCatalogModelsArtifactRepository,
+)
+from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
+from mlflow.protos.databricks_uc_registry_messages_pb2 import (
+    Notebook,
+    Job,
+    Entity,
+    LineageHeaderInfo,
+)
+from mlflow.utils.proto_json_utils import message_to_json
+from mlflow.store._unity_catalog.lineage.constants import _DATABRICKS_LINEAGE_ID_HEADER
+
+class SimpleModel(mlflow.pyfunc.PythonModel):
+    def predict(self, _, model_input):
+        return model_input.applymap(lambda x: x * 2)
+
+def lineage_header_info_to_extra_headers(lineage_header_info):
+    extra_headers = {}
+    if lineage_header_info:
+        header_json = message_to_json(lineage_header_info)
+        header_base64 = base64.b64encode(header_json.encode())
+        extra_headers[_DATABRICKS_LINEAGE_ID_HEADER] = header_base64
+    return extra_headers
+
+@pytest.mark.parametrize(
+    ("notebook_id", "job_id"),
+    [
+        (None, None),
+        (1234, None),
+        (None, 5678),
+        (1234, 5678),
+    ]
+)
+def test_downstream_notebook_job_lineage(tmp_path, notebook_id, job_id):
+    model_dir = str(tmp_path.joinpath("mymodel"))
+    model_name = "mycatalog.myschema.mymodel"
+    model_uri = f"models:/{model_name}/1"
+
+    mock_artifact_repo = mock.MagicMock(autospec=S3ArtifactRepository)
+    mock_artifact_repo.download_artifacts.return_value = model_dir
+
+    entity_list = []
+    if notebook_id:
+        notebook_entity = Notebook(id=str(notebook_id))
+        entity_list.append(Entity(notebook=notebook_entity))
+
+    if job_id:
+        job_entity = Job(id=str(5678))
+        entity_list.append(Entity(job=job_entity))
+
+    expected_lineage_header_info = LineageHeaderInfo(entities=entity_list) if entity_list else None
+
+    with mock.patch(
+        "mlflow.utils.databricks_utils.get_notebook_id", return_value=notebook_id,
+    ), mock.patch(
+        "mlflow.utils.databricks_utils.get_job_id", return_value=job_id,
+    ), mock.patch(
+        "mlflow.get_registry_uri", return_value="databricks-uc"
+    ), mock.patch.object(
+        UnityCatalogModelsArtifactRepository, "_get_blob_storage_path", return_value="fake_blob_storage_path"
+    ), mock.patch(
+        "mlflow.utils._unity_catalog_utils._get_artifact_repo_from_storage_info", return_value=mock_artifact_repo,
+    ), mock.patch(
+        "mlflow.utils.rest_utils.http_request",
+        return_value=mock.MagicMock(status_code=200, text="{}"),
+    ) as mock_http:
+        mlflow.pyfunc.save_model(path=model_dir, python_model=SimpleModel())
+        mlflow.pyfunc.load_model(model_uri)
+        extra_headers = lineage_header_info_to_extra_headers(expected_lineage_header_info)
+        mock_http.assert_called_once_with(
+            host_creds=mock.ANY,
+            endpoint=mock.ANY,
+            method=mock.ANY,
+            json=mock.ANY,
+            extra_headers=extra_headers
+        )

--- a/tests/store/lineage/test_downstream_lineage.py
+++ b/tests/store/lineage/test_downstream_lineage.py
@@ -43,9 +43,9 @@ def lineage_header_info_to_extra_headers(lineage_header_info):
     ("is_in_notebook", "is_in_job", "notebook_id", "job_id"),
     [
         (True, True, None, None),
-        (True, True, 1234, None),
-        (True, True, None, 5678),
-        (True, True, 1234, 5678),
+        # (True, True, 1234, None),
+        # (True, True, None, 5678),
+        # (True, True, 1234, 5678),
         (False, False, 1234, 5678),
     ],
 )

--- a/tests/store/lineage/test_downstream_lineage.py
+++ b/tests/store/lineage/test_downstream_lineage.py
@@ -43,10 +43,10 @@ def lineage_header_info_to_extra_headers(lineage_header_info):
     ("is_in_notebook", "is_in_job", "notebook_id", "job_id"),
     [
         (True, True, None, None),
-        (True, True, 1234, None),
-        (True, True, None, 5678),
-        (True, True, 1234, 5678),
-        (False, False, 1234, 5678),
+        (True, True, "1234", None),
+        (True, True, None, "5678"),
+        (True, True, "1234", "5678"),
+        (False, False, "1234", "5678"),
     ],
 )
 def test_downstream_notebook_job_lineage(tmp_path, is_in_notebook, is_in_job, notebook_id, job_id):
@@ -68,7 +68,7 @@ def test_downstream_notebook_job_lineage(tmp_path, is_in_notebook, is_in_job, no
 
     expected_lineage_header_info = LineageHeaderInfo(entities=entity_list) if entity_list else None
 
-    # Mock out all necessary dependencies
+    # Mock out all necessary dependency
     with mock.patch("mlflow.utils.databricks_utils.get_config"), mock.patch(
         "mlflow.utils.databricks_utils.is_in_databricks_notebook",
         return_value=is_in_notebook,

--- a/tests/store/lineage/test_downstream_lineage.py
+++ b/tests/store/lineage/test_downstream_lineage.py
@@ -50,7 +50,7 @@ def lineage_header_info_to_extra_headers(lineage_header_info):
     ],
 )
 def test_downstream_notebook_job_lineage(tmp_path, is_in_notebook, is_in_job, notebook_id, job_id):
-    model_dir = str(tmp_path.joinpath("mymodel"))
+    model_dir = str(tmp_path.joinpath("model"))
     model_name = "mycatalog.myschema.mymodel"
     model_uri = f"models:/{model_name}/1"
 
@@ -68,6 +68,7 @@ def test_downstream_notebook_job_lineage(tmp_path, is_in_notebook, is_in_job, no
 
     expected_lineage_header_info = LineageHeaderInfo(entities=entity_list) if entity_list else None
 
+    # Mock out all necessary dependencies
     with mock.patch("mlflow.utils.databricks_utils.get_config"), mock.patch(
         "mlflow.utils.databricks_utils.is_in_databricks_notebook",
         return_value=is_in_notebook,

--- a/tests/store/lineage/test_downstream_lineage.py
+++ b/tests/store/lineage/test_downstream_lineage.py
@@ -43,9 +43,9 @@ def lineage_header_info_to_extra_headers(lineage_header_info):
     ("is_in_notebook", "is_in_job", "notebook_id", "job_id"),
     [
         (True, True, None, None),
-        # (True, True, 1234, None),
-        # (True, True, None, 5678),
-        # (True, True, 1234, 5678),
+        (True, True, 1234, None),
+        (True, True, None, 5678),
+        (True, True, 1234, 5678),
         (False, False, 1234, 5678),
     ],
 )
@@ -72,6 +72,9 @@ def test_downstream_notebook_job_lineage(tmp_path, is_in_notebook, is_in_job, no
     with mock.patch("mlflow.utils.databricks_utils.get_config"), mock.patch(
         "mlflow.utils.databricks_utils.is_in_databricks_notebook",
         return_value=is_in_notebook,
+    ), mock.patch(
+        "mlflow.utils.databricks_utils.is_in_databricks_runtime",
+        return_value=is_in_notebook or is_in_job,
     ), mock.patch(
         "mlflow.utils.databricks_utils.is_in_databricks_job",
         return_value=is_in_job,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/shichengzhou-db/mlflow/pull/11305?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11305/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11305
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
- During load_model, check if mlflow is running inside databricks notebook/job env, pass lineage info to UC artifact store
- In UC artifact store, when generating temporary credentials, pass the lineage info to UC
- Unit tests to check that load_model on a UC model uri will cause the api to generate temporary credentials to carry lineage header info

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
Support emitting downstream model -> notebook/job lineage when loading a model in databricks environment
<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
