### PR TITLE
Fix databricks_utils.py for the "client" image key

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -803,7 +803,13 @@ def get_databricks_runtime_major_minor_version():
     try:
         dbr_version_splits = dbr_version.split(".", maxsplit=2)
         # don't int-ify the major version, as "client" is a valid major key
-        return dbr_version_splits[0], int(dbr_version_splits[1])
+        major = (
+            int(dbr_version_splits[0])
+            if dbr_version_splits[0].isnumeric()
+            else dbr_version_splits[0]
+        )
+        minor = int(dbr_version_splits[1])
+        return major, minor
     except Exception:
         raise MlflowException(f"Failed to parse databricks runtime version '{dbr_version}'.")
 
@@ -817,13 +823,9 @@ def _init_databricks_cli_config_provider(entry_point):
     """
     notebook_utils = entry_point.getDbutils().notebook()
 
-    (dbr_major_version, dbr_minor_version) = get_databricks_runtime_major_minor_version()
-    dbr_major_version = (
-        int(dbr_major_version) if dbr_major_version.isnumeric() else dbr_major_version
-    )
-    dbr_major_minor_version = (dbr_major_version, dbr_minor_version)
+    dbr_major_minor_version = get_databricks_runtime_major_minor_version()
 
-    if dbr_major_version == "client" or dbr_major_minor_version >= (13, 2):
+    if dbr_major_minor_version[0] == "client" or dbr_major_minor_version >= (13, 2):
 
         class DynamicConfigProvider(DatabricksConfigProvider):
             def get_config(self):

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -825,6 +825,7 @@ def _init_databricks_cli_config_provider(entry_point):
 
     dbr_major_minor_version = get_databricks_runtime_major_minor_version()
 
+    # the CLI code in client-branch-1.0 is the same as in the 15.0 runtime branch
     if dbr_major_minor_version[0] == "client" or dbr_major_minor_version >= (13, 2):
 
         class DynamicConfigProvider(DatabricksConfigProvider):

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -802,7 +802,8 @@ def get_databricks_runtime_major_minor_version():
     dbr_version = os.environ["DATABRICKS_RUNTIME_VERSION"]
     try:
         dbr_version_splits = dbr_version.split(".", maxsplit=2)
-        return int(dbr_version_splits[0]), int(dbr_version_splits[1])
+        # don't int-ify the major version, as "client" is a valid major key
+        return dbr_version_splits[0], int(dbr_version_splits[1])
     except Exception:
         raise MlflowException(f"Failed to parse databricks runtime version '{dbr_version}'.")
 
@@ -816,9 +817,13 @@ def _init_databricks_cli_config_provider(entry_point):
     """
     notebook_utils = entry_point.getDbutils().notebook()
 
-    dbr_major_minor_version = get_databricks_runtime_major_minor_version()
+    (dbr_major_version, dbr_minor_version) = get_databricks_runtime_major_minor_version()
+    dbr_major_version = (
+        int(dbr_major_version) if dbr_major_version.isnumeric() else dbr_major_version
+    )
+    dbr_major_minor_version = (dbr_major_version, dbr_minor_version)
 
-    if dbr_major_minor_version >= (13, 2):
+    if dbr_major_version == "client" or dbr_major_minor_version >= (13, 2):
 
         class DynamicConfigProvider(DatabricksConfigProvider):
             def get_config(self):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11306?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11306/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11306
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

At the moment, the `get_databricks_runtime_major_minor_version()` function performs an int cast of the major version. However, "client" is a valid major version image key. This PR changes the behavior to only cast if the string is numeric.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
