### PR TITLE
Fix test suites in pytest 8.1

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -153,7 +153,7 @@ def pytest_report_teststatus(report, config):
 
 
 @pytest.hookimpl(hookwrapper=True)
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect(collection_path, config):
     outcome = yield
     if not outcome.get_result() and config.getoption("ignore_flavors"):
         # If not ignored by the default hook and `--ignore-flavors` specified
@@ -208,7 +208,7 @@ def pytest_ignore_collect(path, config):
             "tests/gateway",
         ]
 
-        relpath = os.path.relpath(str(path))
+        relpath = os.path.relpath(str(collection_path))
         relpath = relpath.replace(os.sep, posixpath.sep)  # for Windows
 
         if relpath in model_flavors:

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -2,7 +2,7 @@
 # Required for testing utilities for parsing pip requirements
 pip>=20.1
 ## Test-only dependencies
-pytest
+pytest==2.8.0
 pytest-cov
 pytest-timeout
 pytest-localserver==0.5.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -2,7 +2,7 @@
 # Required for testing utilities for parsing pip requirements
 pip>=20.1
 ## Test-only dependencies
-pytest==2.8.0
+pytest==8.1.0
 pytest-cov
 pytest-timeout
 pytest-localserver==0.5.0

--- a/tests/models/test_python_api.py
+++ b/tests/models/test_python_api.py
@@ -62,6 +62,7 @@ def test_predict(input_data, expected_data, content_type):
         mlflow.pyfunc.log_model(
             artifact_path="model",
             python_model=TestModel(),
+            extra_pip_requirements=["pytest"],
         )
         run_id = run.info.run_id
 
@@ -97,7 +98,7 @@ def test_predict_with_pip_requirements_override(env_manager):
         mlflow.pyfunc.log_model(
             artifact_path="model",
             python_model=TestModel(),
-            extra_pip_requirements=["scikit-learn==1.3.2"],
+            extra_pip_requirements=["scikit-learn==1.3.2", "pytest"],
         )
         run_id = run.info.run_id
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11307?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11307/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11307
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Pytest 8.1 removes the `path` hook in `pytest_ignore_collect`. It has been replaced with `collection_path`. See the following comment for context:

https://github.com/pytest-dev/pytest/issues/11779#issuecomment-1879387034

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
