### PR TITLE
Add Commit Hash back to UI

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewSourceBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewSourceBox.tsx
@@ -1,4 +1,4 @@
-import { BranchIcon, Tag, Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { BranchIcon, GitCommitIcon, Tag, Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import Utils from '../../../../common/utils/Utils';
 import type { KeyValueEntity } from '../../../types';
 import { MLFLOW_RUN_GIT_SOURCE_BRANCH_TAG } from '../../../constants';
@@ -13,6 +13,7 @@ export const RunViewSourceBox = ({
   search: string;
 }) => {
   const branchName = tags?.[MLFLOW_RUN_GIT_SOURCE_BRANCH_TAG]?.value;
+  const commitName = tags?.[Utils.gitCommitTag]?.value;
   const runSource = Utils.renderSource(tags, search, runUuid, branchName);
 
   const { theme } = useDesignSystemTheme();
@@ -33,6 +34,15 @@ export const RunViewSourceBox = ({
           <Tag>
             <div css={{ display: 'flex', gap: 4, whiteSpace: 'nowrap' }}>
               <BranchIcon /> {branchName}
+            </div>
+          </Tag>
+        </Tooltip>
+      )}
+      {commitName && (
+        <Tooltip title={commitName}>
+          <Tag>
+            <div css={{ display: 'flex', gap: 4, whiteSpace: 'nowrap' }}>
+              <GitCommitIcon /> {commitName}
             </div>
           </Tag>
         </Tooltip>


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11324?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11324/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11324
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Fix #11317

### What changes are proposed in this pull request?

Looks like this wasn't implemented as part of the new run page UI

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<img width="1728" alt="Screenshot 2024-03-05 at 10 53 19 AM" src="https://github.com/mlflow/mlflow/assets/148037680/f181d015-3014-4534-9932-f9f0b219d125">


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
