### PR TITLE
Modify DBR version parsing logic

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -803,22 +803,26 @@ class DatabricksRuntimeVersion(NamedTuple):
     major: int
     minor: int
 
+    @classmethod
+    def parse(cls):
+        dbr_version = os.environ["DATABRICKS_RUNTIME_VERSION"]
+        try:
+            dbr_version_splits = dbr_version.split(".", maxsplit=2)
+            if dbr_version_splits[0] == "client":
+                is_client_image = True
+                major = int(dbr_version_splits[1])
+                minor = int(dbr_version_splits[2]) if len(dbr_version_splits) > 2 else 0
+            else:
+                is_client_image = False
+                major = int(dbr_version_splits[0])
+                minor = int(dbr_version_splits[1])
+            return cls(is_client_image, major, minor)
+        except Exception:
+            raise MlflowException(f"Failed to parse databricks runtime version '{dbr_version}'.")
+
 
 def get_databricks_runtime_major_minor_version():
-    dbr_version = os.environ["DATABRICKS_RUNTIME_VERSION"]
-    try:
-        dbr_version_splits = dbr_version.split(".", maxsplit=2)
-        if dbr_version_splits[0] == "client":
-            is_client_image = True
-            major = int(dbr_version_splits[1])
-            minor = int(dbr_version_splits[2]) if len(dbr_version_splits) > 2 else 0
-        else:
-            is_client_image = False
-            major = int(dbr_version_splits[0])
-            minor = int(dbr_version_splits[1])
-        return DatabricksRuntimeVersion(is_client_image, major, minor)
-    except Exception:
-        raise MlflowException(f"Failed to parse databricks runtime version '{dbr_version}'.")
+    return DatabricksRuntimeVersion.parse()
 
 
 def _init_databricks_cli_config_provider(entry_point):

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import time
 from sys import stderr
-from typing import Optional, TypeVar
+from typing import NamedTuple, Optional, TypeVar
 
 import mlflow.utils
 from mlflow.environment_variables import MLFLOW_TRACKING_URI
@@ -798,18 +798,25 @@ def get_databricks_env_vars(tracking_uri):
     return env_vars
 
 
+class DatabricksRuntimeVersion(NamedTuple):
+    is_client_image: bool
+    major: int
+    minor: int
+
+
 def get_databricks_runtime_major_minor_version():
     dbr_version = os.environ["DATABRICKS_RUNTIME_VERSION"]
     try:
         dbr_version_splits = dbr_version.split(".", maxsplit=2)
-        # don't int-ify the major version, as "client" is a valid major key
-        major = (
-            int(dbr_version_splits[0])
-            if dbr_version_splits[0].isnumeric()
-            else dbr_version_splits[0]
-        )
-        minor = int(dbr_version_splits[1])
-        return major, minor
+        if dbr_version_splits[0] == "client":
+            is_client_image = True
+            major = int(dbr_version_splits[1])
+            minor = int(dbr_version_splits[2]) if len(dbr_version_splits) > 2 else 0
+        else:
+            is_client_image = False
+            major = int(dbr_version_splits[0])
+            minor = int(dbr_version_splits[1])
+        return DatabricksRuntimeVersion(is_client_image, major, minor)
     except Exception:
         raise MlflowException(f"Failed to parse databricks runtime version '{dbr_version}'.")
 
@@ -823,10 +830,11 @@ def _init_databricks_cli_config_provider(entry_point):
     """
     notebook_utils = entry_point.getDbutils().notebook()
 
-    dbr_major_minor_version = get_databricks_runtime_major_minor_version()
+    dbr_version = get_databricks_runtime_major_minor_version()
+    dbr_major_minor_version = (dbr_version.major, dbr_version.minor)
 
     # the CLI code in client-branch-1.0 is the same as in the 15.0 runtime branch
-    if dbr_major_minor_version[0] == "client" or dbr_major_minor_version >= (13, 2):
+    if dbr_version.is_client_image or dbr_major_minor_version >= (13, 2):
 
         class DynamicConfigProvider(DatabricksConfigProvider):
             def get_config(self):

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -453,14 +453,10 @@ def test_check_databricks_secret_scope_access_error():
         ("client.1.6", True, 1, 6),
         ("15.1", False, 15, 1),
         ("12.1.1", False, 12, 1),
-    ]
+    ],
 )
 def test_get_databricks_runtime_major_minor_version(
-    monkeypatch,
-    version_str,
-    is_client_image,
-    major,
-    minor
+    monkeypatch, version_str, is_client_image, major, minor
 ):
     monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", version_str)
     dbr_version = get_databricks_runtime_major_minor_version()

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -445,13 +445,32 @@ def test_check_databricks_secret_scope_access_error():
         mock_dbutils.secrets.list.assert_called_once_with("scope")
 
 
-def test_get_databricks_runtime_major_minor_version(monkeypatch):
-    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "client.0")
-    assert get_databricks_runtime_major_minor_version() == ("client", 0)
+@pytest.mark.parametrize(
+    ("version_str", "is_client_image", "major", "minor"),
+    [
+        ("client.0", True, 0, 0),
+        ("client.1", True, 1, 0),
+        ("client.1.6", True, 1, 6),
+        ("15.1", False, 15, 1),
+        ("12.1.1", False, 12, 1),
+    ]
+)
+def test_get_databricks_runtime_major_minor_version(
+    monkeypatch,
+    version_str,
+    is_client_image,
+    major,
+    minor
+):
+    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", version_str)
+    dbr_version = get_databricks_runtime_major_minor_version()
 
-    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "15.1")
-    assert get_databricks_runtime_major_minor_version() == (15, 1)
+    assert dbr_version.is_client_image == is_client_image
+    assert dbr_version.major == major
+    assert dbr_version.minor == minor
 
+
+def test_get_dbr_major_minor_version_throws_on_invalid_version_key(monkeypatch):
     # minor version is not allowed to be a string
     monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "12.x")
     with pytest.raises(MlflowException, match="Failed to parse databricks runtime version"):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11328?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11328/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11328
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR makes the DBR version parsing logic more robust, in case we need to change it in the future.

It changes the return type of `get_databricks_runtime_major_minor_version` to a `NamedTuple`, and supports keys like `client.1.0` instead of just `client.0`

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

[x] Installing from this PR in a databricks notebook, dbutils can be initialized
[x] ran the failing spark test by installing this PR, it passes

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
