### PR TITLE
Make `mlflow.utils.proto_json_utils.convert_data_type` support map type

### DIFF
--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -379,8 +379,8 @@ def convert_data_type(data, spec):
     """
     import numpy as np
 
-    from mlflow.models.utils import _enforce_array, _enforce_object
-    from mlflow.types.schema import Array, ColSpec, DataType, Object, TensorSpec
+    from mlflow.models.utils import _enforce_array, _enforce_object, _enforce_map
+    from mlflow.types.schema import Array, ColSpec, DataType, Map, Object, TensorSpec
 
     try:
         if spec is None:
@@ -399,6 +399,8 @@ def convert_data_type(data, spec):
                 return np.array(_enforce_array(data, spec.type))
             elif isinstance(spec.type, Object):
                 return _enforce_object(data, spec.type)
+            elif isinstance(spec.type, Map):
+                return _enforce_map(data, spec.type)
     except MlflowException as e:
         raise MlflowInvalidInputException(e.message)
     except Exception as ex:

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -213,7 +213,7 @@ class MlflowFailedTypeConversion(MlflowInvalidInputException):
 def cast_df_types_according_to_schema(pdf, schema):
     import numpy as np
 
-    from mlflow.models.utils import _enforce_array, _enforce_object, _enforce_map
+    from mlflow.models.utils import _enforce_array, _enforce_map, _enforce_object
     from mlflow.types.schema import Array, DataType, Map, Object
 
     actual_cols = set(pdf.columns)
@@ -381,7 +381,7 @@ def convert_data_type(data, spec):
     """
     import numpy as np
 
-    from mlflow.models.utils import _enforce_array, _enforce_object, _enforce_map
+    from mlflow.models.utils import _enforce_array, _enforce_map, _enforce_object
     from mlflow.types.schema import Array, ColSpec, DataType, Map, Object, TensorSpec
 
     try:

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -213,8 +213,8 @@ class MlflowFailedTypeConversion(MlflowInvalidInputException):
 def cast_df_types_according_to_schema(pdf, schema):
     import numpy as np
 
-    from mlflow.models.utils import _enforce_array, _enforce_object
-    from mlflow.types.schema import Array, DataType, Object
+    from mlflow.models.utils import _enforce_array, _enforce_object, _enforce_map
+    from mlflow.types.schema import Array, DataType, Map, Object
 
     actual_cols = set(pdf.columns)
     if schema.has_input_names():
@@ -250,6 +250,8 @@ def cast_df_types_according_to_schema(pdf, schema):
                     pdf[col_name] = pdf[col_name].map(lambda x: _enforce_array(x, col_type_spec))
                 elif isinstance(col_type_spec, Object):
                     pdf[col_name] = pdf[col_name].map(lambda x: _enforce_object(x, col_type_spec))
+                elif isinstance(col_type_spec, Map):
+                    pdf[col_name] = pdf[col_name].map(lambda x: _enforce_map(x, col_type_spec))
                 else:
                     pdf[col_name] = pdf[col_name].astype(col_type, copy=False)
             except Exception as ex:

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -2659,7 +2659,8 @@ def test_pyfunc_model_schema_enforcement_nested_array(data, schema):
         ),
     ],
 )
-def test_pyfunc_model_schema_enforcement_map_type(data, schema):
+@pytest.mark.parametrize("format_key", ["dataframe_split", "dataframe_records"])
+def test_pyfunc_model_schema_enforcement_map_type(data, schema, format_key):
     class MyModel(mlflow.pyfunc.PythonModel):
         def predict(self, context, model_input, params=None):
             return model_input
@@ -2675,6 +2676,30 @@ def test_pyfunc_model_schema_enforcement_map_type(data, schema):
     loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
     prediction = loaded_model.predict(df)
     pd.testing.assert_frame_equal(prediction, df)
+
+    if format_key == "dataframe_split":
+        payload = {format_key: df.to_dict(orient="split")}
+    elif format_key == "dataframe_records":
+        payload = {format_key: df.to_dict(orient="records")}
+
+    class CustomJsonEncoder(json.JSONEncoder):
+        def default(self, o):
+            import numpy as np
+            if isinstance(o, np.int64):
+                return int(o)
+
+            return super().default(o)
+
+    response = pyfunc_serve_and_score_model(
+        model_info.model_uri,
+        data=json.dumps(payload, cls=CustomJsonEncoder),
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+    assert response.status_code == 200, response.content
+    result = json.loads(response.content.decode("utf-8"))["predictions"]
+    expected_result = df.to_dict(orient="records")
+    np.testing.assert_equal(result, expected_result)
 
 
 @pytest.mark.parametrize(

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -2685,6 +2685,7 @@ def test_pyfunc_model_schema_enforcement_map_type(data, schema, format_key):
     class CustomJsonEncoder(json.JSONEncoder):
         def default(self, o):
             import numpy as np
+
             if isinstance(o, np.int64):
                 return int(o)
 

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -14,7 +14,7 @@ from mlflow.protos.model_registry_pb2 import RegisteredModel as ProtoRegisteredM
 from mlflow.protos.service_pb2 import Experiment as ProtoExperiment
 from mlflow.protos.service_pb2 import Metric as ProtoMetric
 from mlflow.types import ColSpec, DataType, Schema, TensorSpec
-from mlflow.types.schema import Array, Object, Property
+from mlflow.types.schema import Array, Map, Object, Property
 from mlflow.types.utils import _infer_schema
 from mlflow.utils.proto_json_utils import (
     MlflowFailedTypeConversion,
@@ -713,9 +713,27 @@ def test_cast_df_types_according_to_schema_error_message(dataframe, schema, erro
                 "table": ["some_table", "some_table"],
             },
         ),
+        (
+            {
+                "query": [{"name": "value", "age": "10"}, {"name": "value"}],
+                "table": {"k": "some_table"},
+                "data": {"k1": ["a", "b"], "k2": ["c"]}
+            },
+            Schema(
+                [
+                    ColSpec(
+                        Array(Map(value_type=DataType.string)),
+                        name="query",
+                    ),
+                    ColSpec(Map(value_type=DataType.string), name="table"),
+                    ColSpec(Map(value_type=Array(DataType.string)), name="data"),
+                ]
+            ),
+            None,
+        ),
     ],
 )
-def test_parse_tf_serving_input_for_dictionaries_and_lists(data, schema, instances_data):
+def test_parse_tf_serving_input_for_dictionaries_and_lists_and_maps(data, schema, instances_data):
     np.testing.assert_equal(parse_tf_serving_input({"inputs": data}, schema), data)
     if instances_data is None:
         np.testing.assert_equal(parse_tf_serving_input({"instances": data}, schema), data)

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -717,7 +717,7 @@ def test_cast_df_types_according_to_schema_error_message(dataframe, schema, erro
             {
                 "query": [{"name": "value", "age": "10"}, {"name": "value"}],
                 "table": {"k": "some_table"},
-                "data": {"k1": ["a", "b"], "k2": ["c"]}
+                "data": {"k1": ["a", "b"], "k2": ["c"]},
             },
             Schema(
                 [


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/11343?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11343/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11343
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Make `mlflow.utils.proto_json_utils.convert_data_type` support map type

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
