### PR TITLE
Make async logging faster

### DIFF
--- a/mlflow/utils/async_logging/async_logging_queue.py
+++ b/mlflow/utils/async_logging/async_logging_queue.py
@@ -50,6 +50,7 @@ class AsyncLoggingQueue:
             self._stop_data_logging_thread_event.set()
             # Waits till logging queue is drained.
             self._batch_logging_thread.join()
+            self._batch_logging_worker_threadpool.shutdown(wait=False)
             self._batch_status_check_threadpool.shutdown(wait=False)
         except Exception as e:
             _logger.error(f"Encountered error while trying to finish logging: {e}")
@@ -63,6 +64,7 @@ class AsyncLoggingQueue:
         self._stop_data_logging_thread_event.set()
         # Waits till logging queue is drained.
         self._batch_logging_thread.join()
+        self._batch_logging_worker_threadpool.shutdown(wait=True)
         self._batch_status_check_threadpool.shutdown(wait=True)
 
         # Restart the thread to listen to incoming data after flushing.
@@ -103,21 +105,25 @@ class AsyncLoggingQueue:
         except Empty:
             # Ignore empty queue exception
             return
-        try:
-            self._logging_func(
-                run_id=run_batch.run_id,
-                metrics=run_batch.metrics,
-                params=run_batch.params,
-                tags=run_batch.tags,
-            )
 
-            # Signal the batch processing is done.
-            run_batch.completion_event.set()
+        def logging_func(run_batch):
+            try:
+                self._logging_func(
+                    run_id=run_batch.run_id,
+                    metrics=run_batch.metrics,
+                    params=run_batch.params,
+                    tags=run_batch.tags,
+                )
 
-        except Exception as e:
-            _logger.error(f"Run Id {run_batch.run_id}: Failed to log run data: Exception: {e}")
-            run_batch.exception = e
-            run_batch.completion_event.set()
+                # Signal the batch processing is done.
+                run_batch.completion_event.set()
+
+            except Exception as e:
+                _logger.error(f"Run Id {run_batch.run_id}: Failed to log run data: Exception: {e}")
+                run_batch.exception = e
+                run_batch.completion_event.set()
+
+        self._batch_logging_worker_threadpool.submit(logging_func, run_batch)
 
     def _wait_for_batch(self, batch: RunBatch) -> None:
         """Wait for the given batch to be processed by the logging thread.
@@ -152,6 +158,8 @@ class AsyncLoggingQueue:
             del state["_stop_data_logging_thread_event"]
         if "_batch_logging_thread" in state:
             del state["_batch_logging_thread"]
+        if "_batch_logging_worker_threadpool" in state:
+            del state["_batch_logging_worker_threadpool"]
         if "_batch_status_check_threadpool" in state:
             del state["_batch_status_check_threadpool"]
 
@@ -173,6 +181,7 @@ class AsyncLoggingQueue:
         self._lock = threading.RLock()
         self._is_activated = False
         self._batch_logging_thread = None
+        self._batch_logging_worker_threadpool = None
         self._batch_status_check_threadpool = None
         self._stop_data_logging_thread_event = threading.Event()
 
@@ -222,6 +231,10 @@ class AsyncLoggingQueue:
                 target=self._logging_loop,
                 name="MLflowAsyncLoggingLoop",
                 daemon=True,
+            )
+            self._batch_logging_worker_threadpool = ThreadPoolExecutor(
+                max_workers=10,
+                thread_name_prefix="MLflowBatchLoggingWorkerPool",
             )
 
             self._batch_status_check_threadpool = ThreadPoolExecutor(

--- a/mlflow/utils/async_logging/async_logging_queue.py
+++ b/mlflow/utils/async_logging/async_logging_queue.py
@@ -50,8 +50,8 @@ class AsyncLoggingQueue:
             self._stop_data_logging_thread_event.set()
             # Waits till logging queue is drained.
             self._batch_logging_thread.join()
-            self._batch_logging_worker_threadpool.shutdown(wait=False)
-            self._batch_status_check_threadpool.shutdown(wait=False)
+            self._batch_logging_worker_threadpool.shutdown(wait=True)
+            self._batch_status_check_threadpool.shutdown(wait=True)
         except Exception as e:
             _logger.error(f"Encountered error while trying to finish logging: {e}")
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -1361,12 +1361,12 @@ def test_log_param_async():
 
 def test_log_param_async_throws():
     with mlflow.start_run():
-        mlflow.log_param("async single param", value="1", synchronous=False)
-        with pytest.raises(MlflowException, match="Changing param values is not allowed"):
+        mlflow.log_param("async single param", value="1", synchronous=False).wait()
+        with pytest.raises(MlflowException, match=".*Changing param values is not allowed.*"):
             mlflow.log_param("async single param", value="2", synchronous=False).wait()
 
-        mlflow.log_params({"async batch param": "2"}, synchronous=False)
-        with pytest.raises(MlflowException, match="Changing param values is not allowed"):
+        mlflow.log_params({"async batch param": "2"}, synchronous=False).wait()
+        with pytest.raises(MlflowException, match=".*Changing param values is not allowed.*"):
             mlflow.log_params({"async batch param": "3"}, synchronous=False).wait()
 
 

--- a/tests/utils/test_async_logging_queue.py
+++ b/tests/utils/test_async_logging_queue.py
@@ -203,8 +203,6 @@ def test_async_logging_queue_pickle():
             )
         )
 
-    assert not async_logging_queue._queue.empty()
-
     # Pickle the queue
     buffer = io.BytesIO()
     pickle.dump(async_logging_queue, buffer)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/11346?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11346/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11346
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The current control is a bit weird, as we are still blocking the logging loop when actually logging. This PR moves the logging into it's own threadpool. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
