### PR TITLE
Avoid lazy import issues

### DIFF
--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -141,7 +141,7 @@ def _detect_databricks_dependencies(lc_model, log_errors_as_warnings=True) -> Di
     except Exception:
         if log_errors_as_warnings:
             _logger.warning(
-                "Unable to detect databricks dependencies. "
+                "Unable to detect Databricks dependencies. "
                 "Set logging level to DEBUG to see the full traceback."
             )
             _logger.debug("", exc_info=True)

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1664,6 +1664,30 @@ def test_databricks_dependency_extraction_from_retrieval_qa_chain(tmp_path):
     }
 
 
+def _error_func(*args, **kwargs):
+    raise ValueError("error")
+
+
+@mock.patch(
+    "mlflow.langchain.databricks_dependencies._traverse_runnable",
+    _error_func,
+)
+def test_databricks_dependency_extraction_log_errors_as_warnings():
+    from mlflow.langchain.databricks_dependencies import (
+        _DATABRICKS_DEPENDENCY_KEY,
+        _detect_databricks_dependencies,
+    )
+
+    model = create_openai_llmchain()
+
+    with pytest.raises(ValueError, match="error"):
+        _detect_databricks_dependencies(model, log_errors_as_warnings=False)
+
+    with mlflow.start_run():
+        logged_model = mlflow.langchain.log_model(model, "langchain_model")
+    assert logged_model.flavors["langchain"].get(_DATABRICKS_DEPENDENCY_KEY) is None
+
+
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1672,13 +1672,20 @@ def _error_func(*args, **kwargs):
     "mlflow.langchain.databricks_dependencies._traverse_runnable",
     _error_func,
 )
-def test_databricks_dependency_extraction_log_errors_as_warnings():
+@mock.patch("mlflow.langchain.databricks_dependencies._logger.warning")
+def test_databricks_dependency_extraction_log_errors_as_warnings(mock_warning):
     from mlflow.langchain.databricks_dependencies import (
         _DATABRICKS_DEPENDENCY_KEY,
         _detect_databricks_dependencies,
     )
 
     model = create_openai_llmchain()
+
+    _detect_databricks_dependencies(model, log_errors_as_warnings=True)
+    mock_warning.assert_called_once_with(
+        "Unable to detect Databricks dependencies. "
+        "Set logging level to DEBUG to see the full traceback."
+    )
 
     with pytest.raises(ValueError, match="error"):
         _detect_databricks_dependencies(model, log_errors_as_warnings=False)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/liangz1/mlflow/pull/11350?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11350/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11350
```

</p>
</details>

### Related Issues/PRs

https://github.com/mlflow/mlflow/pull/11334

### What changes are proposed in this pull request?

Directly import and refer to the class to avoid lazy import errors.
Make dependency inference fail as warnings.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests: Added a unit test to make sure dependency inference fails with warnings
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
