### PR TITLE
Fix `update_mlflow_versions.py` for XML files

### DIFF
--- a/dev/update_mlflow_versions.py
+++ b/dev/update_mlflow_versions.py
@@ -65,11 +65,52 @@ def update_versions(new_py_version: str) -> None:
     )
 
     # Java
-    for java_extension in ["xml", "java"]:
+    for java_extension in ["java"]:
         replace_occurrences(
             files=Path("mlflow", "java").rglob(f"*.{java_extension}"),
             pattern=rf"{re.escape(current_py_version_without_suffix)}(-SNAPSHOT)?",
             repl=replace_dev_suffix_with(new_py_version, "-SNAPSHOT"),
+        )
+
+    for xml_extension in ["xml"]:
+        # the pom.XML files define versions of dependencies as well.
+        # this causes issues when the mlflow version matches the
+        # version of a dependency. to work around, we make sure to
+        # match only the correct keys
+        old_py_version_pattern = rf"{re.escape(current_py_version_without_suffix)}(-SNAPSHOT)?"
+        dev_suffix_replaced = replace_dev_suffix_with(new_py_version, "-SNAPSHOT")
+
+        # group 1: everything before the version
+        # group 2: optional -SNAPSHOT
+        # group 3: everything after the version
+        replace_str = f"\\g<1>{dev_suffix_replaced}\\g<3>"
+
+        mlflow_version_tag_pattern = rf"""(<mlflow.version>){
+            old_py_version_pattern
+        }(</mlflow.version>)"""
+        replace_occurrences(
+            files=Path("mlflow", "java").rglob(f"*.{xml_extension}"),
+            pattern=mlflow_version_tag_pattern,
+            repl=replace_str,
+        )
+
+        mlflow_parent_pattern = rf"""(<artifactId>mlflow-parent</artifactId>\s+<version>){
+            old_py_version_pattern
+        }(</version>)"""
+        replace_occurrences(
+            files=Path("mlflow", "java").rglob(f"*.{xml_extension}"),
+            pattern=mlflow_parent_pattern,
+            repl=replace_str,
+        )
+
+        mlflow_spark_pattern = (
+            r"(<artifactId>mlflow-spark_\${scala\.compat\.version}</artifactId>\s+"
+            + rf"<version>){old_py_version_pattern}(</version>)"
+        )
+        replace_occurrences(
+            files=Path("mlflow", "java").rglob(f"*.{xml_extension}"),
+            pattern=mlflow_spark_pattern,
+            repl=replace_str,
         )
 
     # R


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11351?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11351/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11351
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR edits the regexes used for replacing the MLflow version in the various `pom.xml` files. There was an issue recently caused by the fact that the new mlflow version (`2.11.1`) matches the version of a dependency (`spark 2.11.12`). This caused the spark dependency to be updated to `spark 2.11.2-SNAPSHOT2`, causing builds to fail.

This PR matches specifically three tags formats to prevent editing dependencies:
1. `<mlflow-version>`
2. `<version>` preceded by `<artifactId>mlflow-parent</artifactId>`
3. `<version>` preceded by `<artifactId>mlflow-spark_${scala.compat.version}</artifactId>`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

See https://github.com/mlflow/mlflow/pull/11353/files for sample output from:

```
python3 dev/update_mlflow_versions.py post-release --new-version 2.11.1
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
