### PR TITLE
Fix langchain X-version tests

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -11,6 +11,7 @@ LangChain (native) format
 .. _LangChain:
     https://python.langchain.com/en/latest/index.html
 """
+
 import contextlib
 import functools
 import logging
@@ -189,6 +190,9 @@ def save_model(
             Here is the code snippet for logging a RetrievalQA chain with `loader_fn`
             and `persist_dir`:
 
+            .. Note:: In langchain_community >= 0.0.27, loading pickled data requires providing the
+                ``allow_dangerous_deserialization`` argument.
+
             .. code-block:: python
 
                 qa = RetrievalQA.from_llm(llm=OpenAI(), retriever=db.as_retriever())
@@ -196,7 +200,13 @@ def save_model(
 
                 def load_retriever(persist_directory):
                     embeddings = OpenAIEmbeddings()
-                    vectorstore = FAISS.load_local(persist_directory, embeddings)
+                    vectorstore = FAISS.load_local(
+                        persist_directory,
+                        embeddings,
+                        # you may need to add the line below
+                        # for langchain_community >= 0.0.27
+                        allow_dangerous_deserialization=True,
+                    )
                     return vectorstore.as_retriever()
 
 
@@ -414,6 +424,9 @@ def log_model(
             Here is the code snippet for logging a RetrievalQA chain with `loader_fn`
             and `persist_dir`:
 
+            .. Note:: In langchain_community >= 0.0.27, loading pickled data requires providing the
+                ``allow_dangerous_deserialization`` argument.
+
             .. code-block:: python
 
                 qa = RetrievalQA.from_llm(llm=OpenAI(), retriever=db.as_retriever())
@@ -421,7 +434,13 @@ def log_model(
 
                 def load_retriever(persist_directory):
                     embeddings = OpenAIEmbeddings()
-                    vectorstore = FAISS.load_local(persist_directory, embeddings)
+                    vectorstore = FAISS.load_local(
+                        persist_directory,
+                        embeddings,
+                        # you may need to add the line below
+                        # for langchain_community >= 0.0.27
+                        allow_dangerous_deserialization=True,
+                    )
                     return vectorstore.as_retriever()
 
 

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -9,7 +9,6 @@ from typing import Any, DefaultDict, Dict, List, Mapping, Optional
 from unittest import mock
 
 import langchain
-import langchain_community
 import numpy as np
 import openai
 import pytest
@@ -62,13 +61,18 @@ from mlflow.utils.openai_utils import (
 
 from tests.helper_functions import pyfunc_serve_and_score_model
 
-# this kwarg was added in langchain_community 0.0.27, and
-# prevents the use of pickled objects if not provided.
-VECTORSTORE_KWARGS = kwargs = (
-    {"allow_dangerous_deserialization": True}
-    if Version(langchain_community.__version__) >= Version("0.0.27")
-    else {}
-)
+try:
+    import langchain_community
+
+    # this kwarg was added in langchain_community 0.0.27, and
+    # prevents the use of pickled objects if not provided.
+    VECTORSTORE_KWARGS = kwargs = (
+        {"allow_dangerous_deserialization": True}
+        if Version(langchain_community.__version__) >= Version("0.0.27")
+        else {}
+    )
+except ImportError:
+    VECTORSTORE_KWARGS = {}
 
 
 @contextmanager

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -427,7 +427,11 @@ def test_log_and_load_retrieval_qa_chain(tmp_path):
     # Log the RetrievalQA chain
     def load_retriever(persist_directory):
         embeddings = FakeEmbeddings(size=5)
-        vectorstore = FAISS.load_local(persist_directory, embeddings)
+        vectorstore = FAISS.load_local(
+            persist_directory,
+            embeddings,
+            allow_dangerous_deserialization=True,
+        )
         return vectorstore.as_retriever()
 
     with mlflow.start_run():
@@ -490,7 +494,11 @@ def test_log_and_load_retrieval_qa_chain_multiple_output(tmp_path):
     # Log the RetrievalQA chain
     def load_retriever(persist_directory):
         embeddings = FakeEmbeddings(size=5)
-        vectorstore = FAISS.load_local(persist_directory, embeddings)
+        vectorstore = FAISS.load_local(
+            persist_directory,
+            embeddings,
+            allow_dangerous_deserialization=True,
+        )
         return vectorstore.as_retriever()
 
     with mlflow.start_run():
@@ -597,7 +605,11 @@ def test_log_and_load_retriever_chain(tmp_path):
                 return self._get_embedding(text)
 
         embeddings = DeterministicDummyEmbeddings(size=5)
-        vectorstore = FAISS.load_local(persist_directory, embeddings)
+        vectorstore = FAISS.load_local(
+            persist_directory,
+            embeddings,
+            allow_dangerous_deserialization=True,
+        )
         return vectorstore.as_retriever()
 
     # Log the retriever
@@ -1318,7 +1330,11 @@ def test_save_load_rag(tmp_path, spark, fake_chat_model):
 
     def load_retriever(persist_directory):
         embeddings = FakeEmbeddings(size=5)
-        vectorstore = FAISS.load_local(persist_directory, embeddings)
+        vectorstore = FAISS.load_local(
+            persist_directory,
+            embeddings,
+            allow_dangerous_deserialization=True,
+        )
         return vectorstore.as_retriever()
 
     prompt = ChatPromptTemplate.from_template(

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -9,6 +9,7 @@ from typing import Any, DefaultDict, Dict, List, Mapping, Optional
 from unittest import mock
 
 import langchain
+import langchain_community
 import numpy as np
 import openai
 import pytest
@@ -60,6 +61,14 @@ from mlflow.utils.openai_utils import (
 )
 
 from tests.helper_functions import pyfunc_serve_and_score_model
+
+# this kwarg was added in langchain_community 0.0.27, and
+# prevents the use of pickled objects if not provided.
+VECTORSTORE_KWARGS = kwargs = (
+    {"allow_dangerous_deserialization": True}
+    if Version(langchain_community.__version__) >= Version("0.0.27")
+    else {}
+)
 
 
 @contextmanager
@@ -430,7 +439,7 @@ def test_log_and_load_retrieval_qa_chain(tmp_path):
         vectorstore = FAISS.load_local(
             persist_directory,
             embeddings,
-            allow_dangerous_deserialization=True,
+            **VECTORSTORE_KWARGS,
         )
         return vectorstore.as_retriever()
 
@@ -497,7 +506,7 @@ def test_log_and_load_retrieval_qa_chain_multiple_output(tmp_path):
         vectorstore = FAISS.load_local(
             persist_directory,
             embeddings,
-            allow_dangerous_deserialization=True,
+            **VECTORSTORE_KWARGS,
         )
         return vectorstore.as_retriever()
 
@@ -608,7 +617,7 @@ def test_log_and_load_retriever_chain(tmp_path):
         vectorstore = FAISS.load_local(
             persist_directory,
             embeddings,
-            allow_dangerous_deserialization=True,
+            **VECTORSTORE_KWARGS,
         )
         return vectorstore.as_retriever()
 
@@ -1333,7 +1342,7 @@ def test_save_load_rag(tmp_path, spark, fake_chat_model):
         vectorstore = FAISS.load_local(
             persist_directory,
             embeddings,
-            allow_dangerous_deserialization=True,
+            **VECTORSTORE_KWARGS,
         )
         return vectorstore.as_retriever()
 

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -66,7 +66,7 @@ try:
 
     # this kwarg was added in langchain_community 0.0.27, and
     # prevents the use of pickled objects if not provided.
-    VECTORSTORE_KWARGS = kwargs = (
+    VECTORSTORE_KWARGS = (
         {"allow_dangerous_deserialization": True}
         if Version(langchain_community.__version__) >= Version("0.0.27")
         else {}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11355?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11355/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11355
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

X-version tests are broken due to https://github.com/langchain-ai/langchain/pull/18696

The PR above added a parameter that needs to be included if we use pickle.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
