### PR TITLE
Copy Model Metadata into subdirectory within artifact store for UC sharing

### DIFF
--- a/mlflow/catboost/__init__.py
+++ b/mlflow/catboost/__init__.py
@@ -61,6 +61,8 @@ _SAVE_FORMAT_KEY = "save_format"
 _MODEL_BINARY_KEY = "data"
 _MODEL_BINARY_FILE_NAME = "model.cb"
 
+model_data_artifact_paths = [_MODEL_BINARY_FILE_NAME]
+
 _logger = logging.getLogger(__name__)
 
 

--- a/mlflow/diviner/__init__.py
+++ b/mlflow/diviner/__init__.py
@@ -68,6 +68,8 @@ _MODEL_TYPE_KEY = "model_type"
 _FLAVOR_KEY = "flavors"
 _SPARK_MODEL_INDICATOR = "fit_with_spark"
 
+model_data_artifact_paths = [_MODEL_BINARY_FILE_NAME]
+
 _logger = logging.getLogger(__name__)
 
 

--- a/mlflow/fastai/__init__.py
+++ b/mlflow/fastai/__init__.py
@@ -58,6 +58,9 @@ from mlflow.utils.requirements_utils import _get_pinned_requirement
 
 FLAVOR_NAME = "fastai"
 
+_MODEL_DATA_SUBPATH = "model.fastai"
+model_data_artifact_paths = [_MODEL_DATA_SUBPATH]
+
 _logger = logging.getLogger(__name__)
 
 
@@ -158,7 +161,7 @@ def save_model(
 
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
-    model_data_subpath = "model.fastai"
+    model_data_subpath = _MODEL_DATA_SUBPATH
     model_data_path = os.path.join(path, model_data_subpath)
     model_data_path = Path(model_data_path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)

--- a/mlflow/gluon/__init__.py
+++ b/mlflow/gluon/__init__.py
@@ -44,6 +44,11 @@ FLAVOR_NAME = "gluon"
 _MODEL_SAVE_PATH = "net"
 
 
+_MODEL_DATA_PATH = "data"
+
+model_data_artifact_paths = [_MODEL_DATA_PATH]
+
+
 @deprecated(since="2.5.0")
 def load_model(model_uri, ctx, dst_path=None):
     """
@@ -224,7 +229,7 @@ def save_model(
     _validate_env_arguments(conda_env, pip_requirements, extra_pip_requirements)
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
-    data_subpath = "data"
+    data_subpath = _MODEL_DATA_PATH
     data_path = os.path.join(path, data_subpath)
     os.makedirs(data_path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)

--- a/mlflow/h2o/__init__.py
+++ b/mlflow/h2o/__init__.py
@@ -47,6 +47,9 @@ from mlflow.utils.requirements_utils import _get_pinned_requirement
 
 FLAVOR_NAME = "h2o"
 
+_MODEL_DATA_SUBPATH = "model.h2o"
+model_data_artifact_paths = [_MODEL_DATA_SUBPATH]
+
 _logger = logging.getLogger(__name__)
 
 
@@ -108,7 +111,7 @@ def save_model(
 
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
-    model_data_subpath = "model.h2o"
+    model_data_subpath = _MODEL_DATA_SUBPATH
     model_data_path = os.path.join(path, model_data_subpath)
     os.makedirs(model_data_path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)

--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -115,6 +115,8 @@ _JOHNSNOWLABS_ENV_VISUAL_SECRET = "VISUAL_SECRET"
 _JOHNSNOWLABS_MODEL_PATH_SUB = "jsl-model"
 _logger = logging.getLogger(__name__)
 
+model_data_artifact_paths = [_JOHNSNOWLABS_MODEL_PATH_SUB]
+
 
 def _validate_env_vars():
     if _JOHNSNOWLABS_ENV_JSON_LICENSE_KEY not in os.environ:

--- a/mlflow/keras/__init__.py
+++ b/mlflow/keras/__init__.py
@@ -29,6 +29,7 @@ else:
         get_default_pip_requirements,
         log_model,
         save_model,
+        model_data_artifact_paths,
     )
 
     FLAVOR_NAME = "keras"
@@ -42,4 +43,5 @@ else:
         "log_model",
         "get_default_pip_requirements",
         "get_default_conda_env",
+        "model_data_artifact_paths",
     ]

--- a/mlflow/keras/__init__.py
+++ b/mlflow/keras/__init__.py
@@ -28,8 +28,8 @@ else:
         get_default_conda_env,
         get_default_pip_requirements,
         log_model,
-        save_model,
         model_data_artifact_paths,
+        save_model,
     )
 
     FLAVOR_NAME = "keras"

--- a/mlflow/keras/save.py
+++ b/mlflow/keras/save.py
@@ -45,6 +45,11 @@ _KERAS_MODULE_SPEC_PATH = "keras_module.txt"
 _logger = logging.getLogger(__name__)
 
 
+_MODEL_DATA_PATH = "data"
+
+model_data_artifact_paths = [_MODEL_DATA_PATH]
+
+
 def get_default_pip_requirements():
     """
     Returns:
@@ -187,7 +192,7 @@ def save_model(
 
     save_model_kwargs = save_model_kwargs or {}
 
-    data_subpath = "data"
+    data_subpath = _MODEL_DATA_PATH
     # Construct new data folder in existing path.
     data_path = os.path.join(path, data_subpath)
     os.makedirs(data_path)

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -46,6 +46,7 @@ from mlflow.langchain.utils import (
     _validate_and_wrap_lc_model,
     lc_runnables_types,
     register_pydantic_v1_serializer_cm,
+    _PERSIST_DIR_NAME,
 )
 from mlflow.models import Model, ModelInputExample, ModelSignature, get_model_info
 from mlflow.models.model import MLMODEL_FILE_NAME
@@ -87,7 +88,7 @@ FLAVOR_NAME = "langchain"
 _MODEL_TYPE_KEY = "model_type"
 
 
-model_data_artifact_paths = [_MODEL_DATA_FOLDER_NAME, _MODEL_DATA_PKL_FILE_NAME]
+model_data_artifact_paths = [_MODEL_DATA_FOLDER_NAME, _MODEL_DATA_PKL_FILE_NAME, _PERSIST_DIR_NAME]
 
 
 def get_default_pip_requirements():

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -36,6 +36,8 @@ from mlflow.langchain.databricks_dependencies import (
 )
 from mlflow.langchain.runnables import _load_runnables, _save_runnables
 from mlflow.langchain.utils import (
+    _MODEL_DATA_PKL_FILE_NAME,
+    _MODEL_DATA_FOLDER_NAME,
     _BASE_LOAD_KEY,
     _MODEL_LOAD_KEY,
     _RUNNABLE_LOAD_KEY,
@@ -83,6 +85,9 @@ logger = logging.getLogger(mlflow.__name__)
 
 FLAVOR_NAME = "langchain"
 _MODEL_TYPE_KEY = "model_type"
+
+
+model_data_artifact_paths = [_MODEL_DATA_FOLDER_NAME, _MODEL_DATA_PKL_FILE_NAME]
 
 
 def get_default_pip_requirements():

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -37,17 +37,17 @@ from mlflow.langchain.databricks_dependencies import (
 )
 from mlflow.langchain.runnables import _load_runnables, _save_runnables
 from mlflow.langchain.utils import (
-    _MODEL_DATA_PKL_FILE_NAME,
-    _MODEL_DATA_FOLDER_NAME,
     _BASE_LOAD_KEY,
+    _MODEL_DATA_FOLDER_NAME,
+    _MODEL_DATA_PKL_FILE_NAME,
     _MODEL_LOAD_KEY,
+    _PERSIST_DIR_NAME,
     _RUNNABLE_LOAD_KEY,
     _load_base_lcs,
     _save_base_lcs,
     _validate_and_wrap_lc_model,
     lc_runnables_types,
     register_pydantic_v1_serializer_cm,
-    _PERSIST_DIR_NAME,
 )
 from mlflow.models import Model, ModelInputExample, ModelSignature, get_model_info
 from mlflow.models.model import MLMODEL_FILE_NAME

--- a/mlflow/lightgbm/__init__.py
+++ b/mlflow/lightgbm/__init__.py
@@ -83,6 +83,9 @@ from mlflow.utils.requirements_utils import _get_pinned_requirement
 
 FLAVOR_NAME = "lightgbm"
 
+model_data_artifact_paths = ["model.lgb", "model.pkl"]
+
+
 _logger = logging.getLogger(__name__)
 
 

--- a/mlflow/mleap/__init__.py
+++ b/mlflow/mleap/__init__.py
@@ -29,6 +29,8 @@ from mlflow.utils.file_utils import path_to_local_file_uri
 
 FLAVOR_NAME = "mleap"
 
+model_data_artifact_paths = ["mleap"]
+
 _logger = logging.getLogger(__name__)
 
 

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -14,7 +14,6 @@ import yaml
 import mlflow
 from mlflow.artifacts import download_artifacts
 from mlflow.exceptions import MlflowException
-from mlflow.models.utils import EXAMPLE_FILENAME
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
@@ -26,8 +25,6 @@ from mlflow.utils.databricks_utils import get_databricks_runtime
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
-    _CONSTRAINTS_FILE_NAME,
-    _PYTHON_ENV_FILE_NAME,
     _REQUIREMENTS_FILE_NAME,
     _add_or_overwrite_requirements,
     _get_requirements_from_file,

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -26,6 +26,7 @@ from mlflow.utils.databricks_utils import get_databricks_runtime
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
+    _CONSTRAINTS_FILE_NAME,
     _PYTHON_ENV_FILE_NAME,
     _REQUIREMENTS_FILE_NAME,
     _add_or_overwrite_requirements,
@@ -65,6 +66,7 @@ _model_metadata_file_list = [
     MLMODEL_FILE_NAME,
     _CONDA_ENV_FILE_NAME,
     _REQUIREMENTS_FILE_NAME,
+    _CONSTRAINTS_FILE_NAME,
     _PYTHON_ENV_FILE_NAME,
     EXAMPLE_FILENAME,
 ]

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -625,7 +625,11 @@ class Model:
                 if subpath_name not in non_metadata_subpaths:
                     src_file_path = os.path.join(local_path, subpath_name)
                     dest_file_path = os.path.join(metadata_path, subpath_name)
-                    shutil.copyfile(src_file_path, dest_file_path)
+
+                    if os.path.isfile(src_file_path):
+                        shutil.copyfile(src_file_path, dest_file_path)
+                    else:
+                        shutil.copytree(src_file_path, dest_file_path)
 
             tracking_uri = _resolve_tracking_uri()
             # We check signature presence here as some flavors have a default signature as a

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -619,8 +619,9 @@ class Model:
             metadata_path = os.path.join(local_path, "metadata")
             model_data_subpaths = flavor.model_data_artifact_paths
             non_metadata_subpaths = ["code", *model_data_subpaths]
+            subpaths_list = os.listdir(local_path)
             os.mkdir(path=metadata_path)
-            for subpath_name in os.listdir(local_path):
+            for subpath_name in subpaths_list:
                 if subpath_name not in non_metadata_subpaths:
                     src_file_path = os.path.join(local_path, subpath_name)
                     dest_file_path = os.path.join(metadata_path, subpath_name)

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -25,9 +25,8 @@ from mlflow.utils.databricks_utils import get_databricks_runtime
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
-    _REQUIREMENTS_FILE_NAME,
     _PYTHON_ENV_FILE_NAME,
-    _CONSTRAINTS_FILE_NAME,
+    _REQUIREMENTS_FILE_NAME,
     _add_or_overwrite_requirements,
     _get_requirements_from_file,
     _remove_requirements,
@@ -610,7 +609,7 @@ class Model:
             A :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
             metadata of the logged model.
         """
-        from mlflow.models.wheeled_model import WheeledModel, _ORIGINAL_REQ_FILE_NAME
+        from mlflow.models.wheeled_model import _ORIGINAL_REQ_FILE_NAME, WheeledModel
 
         with TempDir() as tmp:
             local_path = tmp.path("model")

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -61,17 +61,6 @@ _LOG_MODEL_MISSING_SIGNATURE_WARNING = (
 _MLFLOW_VERSION_KEY = "mlflow_version"
 
 
-# When logging model, these files (if exist) will be copied to 'metadata' sub-directory.
-_model_metadata_file_list = [
-    MLMODEL_FILE_NAME,
-    _CONDA_ENV_FILE_NAME,
-    _REQUIREMENTS_FILE_NAME,
-    _CONSTRAINTS_FILE_NAME,
-    _PYTHON_ENV_FILE_NAME,
-    EXAMPLE_FILENAME,
-]
-
-
 class ModelInfo:
     """
     The metadata of a logged MLflow Model.
@@ -631,11 +620,13 @@ class Model:
 
             # Copy metadata files to the 'metadata' subdirectory
             metadata_path = os.path.join(local_path, "metadata")
+            model_data_subpaths = flavor.model_data_artifact_paths
+            non_metadata_subpaths = ["code", *model_data_subpaths]
             os.mkdir(path=metadata_path)
-            for file_name in _model_metadata_file_list:
-                src_file_path = os.path.join(local_path, file_name)
-                if os.path.exists(src_file_path):
-                    dest_file_path = os.path.join(metadata_path, file_name)
+            for subpath_name in os.listdir(local_path):
+                if subpath_name not in non_metadata_subpaths:
+                    src_file_path = os.path.join(local_path, subpath_name)
+                    dest_file_path = os.path.join(metadata_path, subpath_name)
                     shutil.copyfile(src_file_path, dest_file_path)
 
             tracking_uri = _resolve_tracking_uri()

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -622,10 +622,10 @@ class Model:
             # Copy model metadata files to a sub-directory 'metadata',
             # For UC sharing use-cases.
             metadata_path = os.path.join(local_path, "metadata")
-            os.makedirs(metadata_path, exist_ok=True)
             if isinstance(flavor, WheeledModel):
                 # wheeled model updates several metadata files in original model directory
                 # copy these updated metadata files to the 'metadata' subdirectory
+                os.makedirs(metadata_path, exist_ok=True)
                 for file_name in [
                     MLMODEL_FILE_NAME,
                     _CONDA_ENV_FILE_NAME,
@@ -641,6 +641,7 @@ class Model:
                 model_data_subpaths = flavor.model_data_artifact_paths
                 non_metadata_subpaths = ["code", *model_data_subpaths]
                 subpaths_list = os.listdir(local_path)
+                os.makedirs(metadata_path, exist_ok=True)
                 for subpath_name in subpaths_list:
                     if subpath_name not in non_metadata_subpaths:
                         src_file_path = os.path.join(local_path, subpath_name)

--- a/mlflow/onnx/__init__.py
+++ b/mlflow/onnx/__init__.py
@@ -53,6 +53,11 @@ ONNX_EXECUTION_PROVIDERS = ["CUDAExecutionProvider", "CPUExecutionProvider"]
 _logger = logging.getLogger(__name__)
 
 
+_MODEL_DATA_SUBPATH = "model.onnx"
+
+model_data_artifact_paths = [_MODEL_DATA_SUBPATH]
+
+
 def get_default_pip_requirements():
     """
     Returns:
@@ -170,7 +175,7 @@ def save_model(
         _save_example(mlflow_model, input_example, path)
     if metadata is not None:
         mlflow_model.metadata = metadata
-    model_data_subpath = "model.onnx"
+    model_data_subpath = _MODEL_DATA_SUBPATH
     model_data_path = os.path.join(path, model_data_subpath)
 
     # Save onnx-model

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -91,6 +91,8 @@ FLAVOR_NAME = "openai"
 MODEL_FILENAME = "model.yaml"
 _PYFUNC_SUPPORTED_TASKS = ("chat.completions", "embeddings", "completions")
 
+model_data_artifact_paths = []
+
 _logger = logging.getLogger(__name__)
 
 

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -49,6 +49,9 @@ from mlflow.utils.requirements_utils import _get_pinned_requirement
 
 FLAVOR_NAME = "paddle"
 
+_MODEL_DATA_SUBPATH = "model"
+model_data_artifact_paths = [_MODEL_DATA_SUBPATH]
+
 _logger = logging.getLogger(__name__)
 
 
@@ -208,7 +211,7 @@ def save_model(
     if metadata is not None:
         mlflow_model.metadata = metadata
 
-    model_data_subpath = "model"
+    model_data_subpath = _MODEL_DATA_SUBPATH
     output_path = os.path.join(path, model_data_subpath)
 
     if isinstance(pd_model, paddle.Model):

--- a/mlflow/pmdarima/__init__.py
+++ b/mlflow/pmdarima/__init__.py
@@ -102,6 +102,9 @@ _MODEL_BINARY_KEY = "data"
 _MODEL_BINARY_FILE_NAME = "model.pmd"
 _MODEL_TYPE_KEY = "model_type"
 
+model_data_artifact_paths = [_MODEL_BINARY_FILE_NAME]
+
+
 _logger = logging.getLogger(__name__)
 
 

--- a/mlflow/prophet/__init__.py
+++ b/mlflow/prophet/__init__.py
@@ -52,6 +52,8 @@ _MODEL_BINARY_KEY = "data"
 _MODEL_BINARY_FILE_NAME = "model.pr"
 _MODEL_TYPE_KEY = "model_type"
 
+model_data_artifact_paths = [_MODEL_BINARY_FILE_NAME]
+
 _logger = logging.getLogger(__name__)
 
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -255,6 +255,7 @@ from mlflow.protos.databricks_pb2 import (
     RESOURCE_DOES_NOT_EXIST,
 )
 from mlflow.pyfunc.model import (
+    _SAVED_PYTHON_MODEL_SUBPATH,
     ChatModel,
     PythonModel,
     PythonModelContext,
@@ -262,7 +263,6 @@ from mlflow.pyfunc.model import (
     _PythonModelPyfuncWrapper,
     get_default_conda_env,  # noqa: F401
     get_default_pip_requirements,
-    _SAVED_PYTHON_MODEL_SUBPATH,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -262,6 +262,7 @@ from mlflow.pyfunc.model import (
     _PythonModelPyfuncWrapper,
     get_default_conda_env,  # noqa: F401
     get_default_pip_requirements,
+    _SAVED_PYTHON_MODEL_SUBPATH,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -330,6 +331,13 @@ CODE = "code"
 DATA = "data"
 ENV = "env"
 MODEL_CONFIG = "config"
+
+_MODEL_DATA_SUBPATH = "data"
+
+model_data_artifact_paths = [
+    _MODEL_DATA_SUBPATH,
+    _SAVED_PYTHON_MODEL_SUBPATH,
+]
 
 
 class EnvType:

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -42,6 +42,7 @@ CONFIG_KEY_ARTIFACT_RELATIVE_PATH = "path"
 CONFIG_KEY_ARTIFACT_URI = "uri"
 CONFIG_KEY_PYTHON_MODEL = "python_model"
 CONFIG_KEY_CLOUDPICKLE_VERSION = "cloudpickle_version"
+_SAVED_PYTHON_MODEL_SUBPATH = "python_model.pkl"
 
 
 _logger = logging.getLogger(__name__)
@@ -283,7 +284,7 @@ def _save_model_with_class_artifacts_params(
     }
     if callable(python_model):
         python_model = _FunctionPythonModel(python_model, hints, signature)
-    saved_python_model_subpath = "python_model.pkl"
+    saved_python_model_subpath = _SAVED_PYTHON_MODEL_SUBPATH
 
     try:
         with open(os.path.join(path, saved_python_model_subpath), "wb") as out:

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -78,6 +78,10 @@ MIN_REQ_VERSION = Version(_ML_PACKAGE_VERSIONS["pytorch-lightning"]["autologging
 MAX_REQ_VERSION = Version(_ML_PACKAGE_VERSIONS["pytorch-lightning"]["autologging"]["maximum"])
 
 
+_MODEL_DATA_SUBPATH = "data"
+model_data_artifact_paths = [_MODEL_DATA_SUBPATH]
+
+
 def get_default_pip_requirements():
     """
     Returns:
@@ -464,7 +468,7 @@ def save_model(
 
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
 
-    model_data_subpath = "data"
+    model_data_subpath = _MODEL_DATA_SUBPATH
     model_data_path = os.path.join(path, model_data_subpath)
     os.makedirs(model_data_path)
 

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -79,7 +79,7 @@ MAX_REQ_VERSION = Version(_ML_PACKAGE_VERSIONS["pytorch-lightning"]["autologging
 
 
 _MODEL_DATA_SUBPATH = "data"
-model_data_artifact_paths = [_MODEL_DATA_SUBPATH]
+model_data_artifact_paths = [_MODEL_DATA_SUBPATH, _EXTRA_FILES_KEY]
 
 
 def get_default_pip_requirements():

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -53,6 +53,8 @@ _INFERENCE_CONFIG_PATH = "inference_config"
 _LLM_INFERENCE_TASK_EMBEDDING = "llm/v1/embeddings"
 _LLM_V1_EMBEDDING_INPUT_KEY = "input"
 
+model_data_artifact_paths = [SENTENCE_TRANSFORMERS_DATA_PATH]
+
 _logger = logging.getLogger(__name__)
 
 

--- a/mlflow/shap/__init__.py
+++ b/mlflow/shap/__init__.py
@@ -49,6 +49,8 @@ _SHAP_VALUES_FILE_NAME = "shap_values.npy"
 _UNKNOWN_MODEL_FLAVOR = "unknown"
 _UNDERLYING_MODEL_SUBPATH = "underlying_model"
 
+model_data_artifact_paths = []
+
 
 def get_underlying_model_flavor(model):
     """

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -88,6 +88,9 @@ SUPPORTED_SERIALIZATION_FORMATS = [SERIALIZATION_FORMAT_PICKLE, SERIALIZATION_FO
 _logger = logging.getLogger(__name__)
 _SklearnTrainingSession = _get_new_training_session_class()
 
+_MODEL_DATA_SUBPATH = "model.pkl"
+model_data_artifact_paths = [_MODEL_DATA_SUBPATH]
+
 
 def _gen_estimators_to_patch():
     from mlflow.sklearn.utils import (
@@ -260,7 +263,7 @@ def save_model(
     if metadata is not None:
         mlflow_model.metadata = metadata
 
-    model_data_subpath = "model.pkl"
+    model_data_subpath = _MODEL_DATA_SUBPATH
     model_data_path = os.path.join(path, model_data_subpath)
     _save_model(
         sk_model=sk_model,

--- a/mlflow/spacy/__init__.py
+++ b/mlflow/spacy/__init__.py
@@ -46,6 +46,9 @@ from mlflow.utils.requirements_utils import _get_pinned_requirement
 
 FLAVOR_NAME = "spacy"
 
+_MODEL_DATA_SUBPATH = "model.spacy"
+model_data_artifact_paths = [_MODEL_DATA_SUBPATH]
+
 _logger = logging.getLogger(__name__)
 
 
@@ -121,7 +124,7 @@ def save_model(
     path = os.path.abspath(path)
     _validate_and_prepare_target_save_path(path)
 
-    model_data_subpath = "model.spacy"
+    model_data_subpath = _MODEL_DATA_SUBPATH
     model_data_path = os.path.join(path, model_data_subpath)
     os.makedirs(model_data_path)
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)

--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -86,6 +86,9 @@ FLAVOR_NAME = "spark"
 _SPARK_MODEL_PATH_SUB = "sparkml"
 _MLFLOWDBFS_SCHEME = "mlflowdbfs"
 
+model_data_artifact_paths = [_SPARK_MODEL_PATH_SUB]
+
+
 _logger = logging.getLogger(__name__)
 
 

--- a/mlflow/statsmodels/__init__.py
+++ b/mlflow/statsmodels/__init__.py
@@ -59,6 +59,8 @@ from mlflow.utils.validation import _is_numeric
 
 FLAVOR_NAME = "statsmodels"
 STATSMODELS_DATA_SUBPATH = "model.statsmodels"
+model_data_artifact_paths = [STATSMODELS_DATA_SUBPATH]
+
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -92,9 +92,10 @@ _MODEL_TYPE_TF1_ESTIMATOR = "tf1-estimator"
 _MODEL_TYPE_TF2_MODULE = "tf2-module"
 
 
-_MODEL_DATA_PATH = "data"
+_KERAS_MODEL_DATA_PATH = "data"
+_TF2MODEL_SUBPATH = "tf2model"
 
-model_data_artifact_paths = [_MODEL_DATA_PATH]
+model_data_artifact_paths = [_KERAS_MODEL_DATA_PATH, _TF2MODEL_SUBPATH]
 
 
 def get_default_pip_requirements(include_cloudpickle=False):
@@ -391,7 +392,7 @@ def save_model(
     if isinstance(model, KerasModel):
         keras_model_kwargs = keras_model_kwargs or {}
 
-        data_subpath = _MODEL_DATA_PATH
+        data_subpath = _KERAS_MODEL_DATA_PATH
         # construct new data folder in existing path
         data_path = os.path.join(path, data_subpath)
         os.makedirs(data_path)
@@ -453,7 +454,7 @@ def save_model(
         }
     elif isinstance(model, tf.Module):
         saved_model_kwargs = saved_model_kwargs or {}
-        model_dir_subpath = "tf2model"
+        model_dir_subpath = _TF2MODEL_SUBPATH
         model_path = os.path.join(path, model_dir_subpath)
         tf.saved_model.save(model, model_path, **saved_model_kwargs)
         pyfunc_options = {}

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -92,6 +92,11 @@ _MODEL_TYPE_TF1_ESTIMATOR = "tf1-estimator"
 _MODEL_TYPE_TF2_MODULE = "tf2-module"
 
 
+_MODEL_DATA_PATH = "data"
+
+model_data_artifact_paths = [_MODEL_DATA_PATH]
+
+
 def get_default_pip_requirements(include_cloudpickle=False):
     """
     Returns
@@ -386,7 +391,7 @@ def save_model(
     if isinstance(model, KerasModel):
         keras_model_kwargs = keras_model_kwargs or {}
 
-        data_subpath = "data"
+        data_subpath = _MODEL_DATA_PATH
         # construct new data folder in existing path
         data_path = os.path.join(path, data_subpath)
         os.makedirs(data_path)

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -172,6 +172,7 @@ model_data_artifact_paths = [
     _MODEL_BINARY_FILE_NAME,
     _COMPONENTS_BINARY_DIR_NAME,
     _PROCESSOR_BINARY_DIR_NAME,
+    _PEFT_ADAPTOR_DIR_NAME,
 ]
 
 

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -68,6 +68,7 @@ from mlflow.transformers.llm_inference_utils import (
 from mlflow.transformers.model_io import (
     _COMPONENTS_BINARY_DIR_NAME,
     _MODEL_BINARY_FILE_NAME,
+    _PROCESSOR_BINARY_DIR_NAME,
     load_model_and_components_from_huggingface_hub,
     load_model_and_components_from_local,
     save_pipeline_pretrained_weights,
@@ -165,6 +166,13 @@ _PROMPT_TEMPLATE_RETURN_FULL_TEXT_INFO = (
 
 
 _logger = logging.getLogger(__name__)
+
+
+model_data_artifact_paths = [
+    _MODEL_BINARY_FILE_NAME,
+    _COMPONENTS_BINARY_DIR_NAME,
+    _PROCESSOR_BINARY_DIR_NAME,
+]
 
 
 @experimental

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -86,6 +86,8 @@ FLAVOR_NAME = "xgboost"
 
 _logger = logging.getLogger(__name__)
 
+model_data_artifact_paths = ["model.xgb", "model.json", "model.ubj"]
+
 
 def get_default_pip_requirements():
     """

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -105,6 +105,8 @@ def test_model_load_remote(tmp_path, mock_s3_bucket):
 
 
 class TestFlavor:
+    model_data_artifact_paths = []
+
     @classmethod
     def save_model(cls, path, mlflow_model, signature=None, input_example=None):
         mlflow_model.flavors["flavor1"] = {"a": 1, "b": 2}

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -488,3 +488,12 @@ def test_model_saved_by_save_model_can_be_loaded(tmp_path, sklearn_knn_model):
     info = Model.load(tmp_path).get_model_info()
     assert info.run_id is None
     assert info.artifact_path is None
+
+
+def test_copy_metadata(tmp_path, sklearn_knn_model):
+    with mlflow.start_run():
+        model_info = mlflow.sklearn.log_model(sklearn_knn_model, "model")
+        artifact_path = mlflow.artifacts.download_artifacts(model_info.model_uri)
+        assert set(os.listdir(os.path.join(artifact_path, "metadata"))) == {
+            "MLmodel", "conda.yaml", "python_env.yaml", "requirements.txt"
+        }

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -495,5 +495,8 @@ def test_copy_metadata(tmp_path, sklearn_knn_model):
         model_info = mlflow.sklearn.log_model(sklearn_knn_model, "model")
         artifact_path = mlflow.artifacts.download_artifacts(model_info.model_uri)
         assert set(os.listdir(os.path.join(artifact_path, "metadata"))) == {
-            "MLmodel", "conda.yaml", "python_env.yaml", "requirements.txt"
+            "MLmodel",
+            "conda.yaml",
+            "python_env.yaml",
+            "requirements.txt",
         }

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3652,3 +3652,39 @@ def test_persist_pretrained_model(mock_tmpdir, small_seq2seq_pipeline):
     mock_tmpdir.reset_mock()
     mlflow.transformers.persist_pretrained_model(model_info.model_uri)
     mock_tmpdir.assert_not_called()
+
+
+def test_small_qa_pipeline_copy_metadata(small_qa_pipeline, tmp_path):
+    artifact_path = "transformers"
+
+    with mlflow.start_run():
+        model_info = mlflow.transformers.log_model(
+            transformers_model=small_qa_pipeline,
+            artifact_path=artifact_path,
+        )
+        artifact_path = mlflow.artifacts.download_artifacts(
+            artifact_uri=model_info.model_uri,
+            dst_path=tmp_path.as_posix()
+        )
+        assert set(os.listdir(os.path.join(artifact_path, "metadata"))) == {
+            'LICENSE.txt', 'MLmodel', 'conda.yaml', 'model_card.md', 'model_card_data.yaml',
+            'python_env.yaml', 'requirements.txt'
+        }
+
+
+def test_peft_pipeline_copy_metadata(peft_pipeline, tmp_path):
+    artifact_path = "transformers"
+
+    with mlflow.start_run():
+        model_info = mlflow.transformers.log_model(
+            transformers_model=peft_pipeline,
+            artifact_path=artifact_path,
+        )
+        artifact_path = mlflow.artifacts.download_artifacts(
+            artifact_uri=model_info.model_uri,
+            dst_path=tmp_path.as_posix()
+        )
+        assert set(os.listdir(os.path.join(artifact_path, "metadata"))) == {
+            'LICENSE.txt', 'MLmodel', 'conda.yaml', 'model_card.md', 'model_card_data.yaml',
+            'python_env.yaml', 'requirements.txt'
+        }

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3663,12 +3663,16 @@ def test_small_qa_pipeline_copy_metadata(small_qa_pipeline, tmp_path):
             artifact_path=artifact_path,
         )
         artifact_path = mlflow.artifacts.download_artifacts(
-            artifact_uri=model_info.model_uri,
-            dst_path=tmp_path.as_posix()
+            artifact_uri=model_info.model_uri, dst_path=tmp_path.as_posix()
         )
         assert set(os.listdir(os.path.join(artifact_path, "metadata"))) == {
-            'LICENSE.txt', 'MLmodel', 'conda.yaml', 'model_card.md', 'model_card_data.yaml',
-            'python_env.yaml', 'requirements.txt'
+            "LICENSE.txt",
+            "MLmodel",
+            "conda.yaml",
+            "model_card.md",
+            "model_card_data.yaml",
+            "python_env.yaml",
+            "requirements.txt",
         }
 
 
@@ -3681,10 +3685,14 @@ def test_peft_pipeline_copy_metadata(peft_pipeline, tmp_path):
             artifact_path=artifact_path,
         )
         artifact_path = mlflow.artifacts.download_artifacts(
-            artifact_uri=model_info.model_uri,
-            dst_path=tmp_path.as_posix()
+            artifact_uri=model_info.model_uri, dst_path=tmp_path.as_posix()
         )
         assert set(os.listdir(os.path.join(artifact_path, "metadata"))) == {
-            'LICENSE.txt', 'MLmodel', 'conda.yaml', 'model_card.md', 'model_card_data.yaml',
-            'python_env.yaml', 'requirements.txt'
+            "LICENSE.txt",
+            "MLmodel",
+            "conda.yaml",
+            "model_card.md",
+            "model_card_data.yaml",
+            "python_env.yaml",
+            "requirements.txt",
         }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/11357?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11357/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11357
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Design doc: https://docs.google.com/document/d/1t6zx_S12N9iDM2cRpeLJrzMtJu-awVdZmpgMFzAPJ_4/edit

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

Test notebook: https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/163479681474512

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

When logging model, we copy all model metadata files (MLmodel, python requirements files, input example, model card, etc) to a sub-directory 'metadata'.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
