### PR TITLE
Fix RunnableAssign save/load

### DIFF
--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -25,6 +25,7 @@ from mlflow.langchain.utils import (
     _validate_and_wrap_lc_model,
     base_lc_types,
     custom_type_to_loader_dict,
+    lc_runnable_assign_type,
     lc_runnable_branch_type,
     lc_runnable_with_steps_types,
     lc_runnables_types,
@@ -34,6 +35,7 @@ from mlflow.langchain.utils import (
 _STEPS_FOLDER_NAME = "steps"
 _RUNNABLE_STEPS_FILE_NAME = "steps.yaml"
 _BRANCHES_FOLDER_NAME = "branches"
+_MAPPER_FOLDER_NAME = "mapper"
 _RUNNABLE_BRANCHES_FILE_NAME = "branches.yaml"
 _DEFAULT_BRANCH_NAME = "default"
 
@@ -146,12 +148,11 @@ def runnable_sequence_from_steps(steps):
     return RunnableSequence(first=first, middle=middle, last=last)
 
 
-def _load_runnable_branch(file_path: Union[Path, str], model_type: str):
+def _load_runnable_branch(file_path: Union[Path, str]):
     """Load the model
 
     Args:
         file_path: Path to file to load the model from.
-        model_type: Type of the model to load.
     """
     from langchain.schema.runnable import RunnableBranch
 
@@ -200,14 +201,36 @@ def _load_runnable_branch(file_path: Union[Path, str], model_type: str):
     return RunnableBranch(*branches)
 
 
+def _load_runnable_assign(file_path: Union[Path, str]):
+    """Load the model
+
+    Args:
+        file_path: Path to file to load the model from.
+    """
+    from langchain.schema.runnable.passthrough import RunnableAssign
+
+    # Convert file to Path object.
+    load_path = Path(file_path) if isinstance(file_path, str) else file_path
+    if not load_path.exists() or not load_path.is_dir():
+        raise MlflowException(
+            f"File {load_path} must exist and must be a directory " "in order to load runnable."
+        )
+
+    mapper_file = load_path / _MAPPER_FOLDER_NAME
+    if not mapper_file.exists() or not mapper_file.is_dir():
+        raise MlflowException(
+            f"Folder {mapper_file} must exist and must be a directory "
+            "in order to load runnable assign with mapper."
+        )
+    mapper = _load_runnable_with_steps(mapper_file, "RunnableParallel")
+    return RunnableAssign(mapper)
+
+
 def _save_internal_runnables(runnable, path, loader_fn, persist_dir):
     conf = {}
     if isinstance(runnable, lc_runnables_types()):
         conf[_MODEL_TYPE_KEY] = runnable.__class__.__name__
         conf.update(_save_runnables(runnable, path, loader_fn, persist_dir))
-    elif isinstance(runnable, lc_runnable_branch_type()):
-        conf[_MODEL_TYPE_KEY] = runnable.__class__.__name__
-        conf.update(_save_runnable_branch(runnable, path, loader_fn, persist_dir))
     elif isinstance(runnable, base_lc_types()):
         lc_model = _validate_and_wrap_lc_model(runnable, loader_fn)
         conf[_MODEL_TYPE_KEY] = lc_model.__class__.__name__
@@ -232,7 +255,7 @@ def _save_internal_runnables(runnable, path, loader_fn, persist_dir):
     return conf
 
 
-def _save_runnable_with_steps(steps, file_path: Union[Path, str], loader_fn=None, persist_dir=None):
+def _save_runnable_with_steps(model, file_path: Union[Path, str], loader_fn=None, persist_dir=None):
     """Save the model with steps. Currently it supports saving RunnableSequence and
     RunnableParallel.
 
@@ -258,7 +281,7 @@ def _save_runnable_with_steps(steps, file_path: Union[Path, str], loader_fn=None
     We save steps.yaml file to the model folder. It contains each step's model's configuration.
 
     Args:
-        steps: Steps of the runnable.
+        model: Runnable to be saved.
         file_path: Path to file to save the model to.
     """
     # Convert file to Path object.
@@ -269,10 +292,15 @@ def _save_runnable_with_steps(steps, file_path: Union[Path, str], loader_fn=None
     steps_path = save_path / _STEPS_FOLDER_NAME
     steps_path.mkdir()
 
+    steps = model.steps
     if isinstance(steps, list):
         generator = enumerate(steps)
     elif isinstance(steps, dict):
         generator = steps.items()
+    else:
+        raise MlflowException(
+            f"steps for must be either a list or a dictionary. Got {type(steps).__name__}."
+        )
     unsaved_runnables = {}
     steps_conf = {}
     for key, runnable in generator:
@@ -344,6 +372,23 @@ def _save_runnable_branch(model, file_path, loader_fn, persist_dir):
         yaml.dump(branches_conf, f, default_flow_style=False)
 
 
+def _save_runnable_assign(model, file_path, loader_fn=None, persist_dir=None):
+    from langchain.schema.runnable import RunnableParallel
+
+    save_path = Path(file_path) if isinstance(file_path, str) else file_path
+    save_path.mkdir(parents=True, exist_ok=True)
+    # save mapper into a folder
+    mapper_path = save_path / _MAPPER_FOLDER_NAME
+    mapper_path.mkdir()
+
+    if not isinstance(model.mapper, RunnableParallel):
+        raise MlflowException(
+            f"Failed to save model {model} with type {model.__class__.__name__}. "
+            "RunnableAssign's mapper must be a RunnableParallel."
+        )
+    _save_runnable_with_steps(model.mapper, mapper_path, loader_fn, persist_dir)
+
+
 def _save_picklable_runnable(model, path):
     if not path.endswith(".pkl"):
         raise ValueError(f"File path must end with .pkl, got {path}.")
@@ -356,7 +401,7 @@ def _save_runnables(model, path, loader_fn=None, persist_dir=None):
     if isinstance(model, lc_runnable_with_steps_types()):
         model_data_path = _MODEL_DATA_FOLDER_NAME
         _save_runnable_with_steps(
-            model.steps, os.path.join(path, model_data_path), loader_fn, persist_dir
+            model, os.path.join(path, model_data_path), loader_fn, persist_dir
         )
     elif isinstance(model, picklable_runnable_types()):
         model_data_path = _MODEL_DATA_PKL_FILE_NAME
@@ -364,6 +409,9 @@ def _save_runnables(model, path, loader_fn=None, persist_dir=None):
     elif isinstance(model, lc_runnable_branch_type()):
         model_data_path = _MODEL_DATA_FOLDER_NAME
         _save_runnable_branch(model, os.path.join(path, model_data_path), loader_fn, persist_dir)
+    elif isinstance(model, lc_runnable_assign_type()):
+        model_data_path = _MODEL_DATA_FOLDER_NAME
+        _save_runnable_assign(model, os.path.join(path, model_data_path), loader_fn, persist_dir)
     else:
         raise MlflowException.invalid_parameter_value(
             _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=type(model).__name__)
@@ -383,7 +431,9 @@ def _load_runnables(path, conf):
     ):
         return _load_from_pickle(os.path.join(path, model_data))
     if model_type in (x.__name__ for x in lc_runnable_branch_type()):
-        return _load_runnable_branch(os.path.join(path, model_data), model_type)
+        return _load_runnable_branch(os.path.join(path, model_data))
+    if model_type in (x.__name__ for x in lc_runnable_assign_type()):
+        return _load_runnable_assign(os.path.join(path, model_data))
     raise MlflowException.invalid_parameter_value(
         _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=model_type)
     )

--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -98,7 +98,7 @@ def _load_runnable_with_steps(file_path: Union[Path, str], model_type: str):
     from langchain.schema.runnable import RunnableParallel, RunnableSequence
 
     # Convert file to Path object.
-    load_path = Path(file_path) if isinstance(file_path, str) else file_path
+    load_path = Path(file_path)
     if not load_path.exists() or not load_path.is_dir():
         raise MlflowException(
             f"File {load_path} must exist and must be a directory "
@@ -157,7 +157,7 @@ def _load_runnable_branch(file_path: Union[Path, str]):
     from langchain.schema.runnable import RunnableBranch
 
     # Convert file to Path object.
-    load_path = Path(file_path) if isinstance(file_path, str) else file_path
+    load_path = Path(file_path)
     if not load_path.exists() or not load_path.is_dir():
         raise MlflowException(
             f"File {load_path} must exist and must be a directory "
@@ -210,7 +210,7 @@ def _load_runnable_assign(file_path: Union[Path, str]):
     from langchain.schema.runnable.passthrough import RunnableAssign
 
     # Convert file to Path object.
-    load_path = Path(file_path) if isinstance(file_path, str) else file_path
+    load_path = Path(file_path)
     if not load_path.exists() or not load_path.is_dir():
         raise MlflowException(
             f"File {load_path} must exist and must be a directory in order to load runnable."
@@ -285,7 +285,7 @@ def _save_runnable_with_steps(model, file_path: Union[Path, str], loader_fn=None
         file_path: Path to file to save the model to.
     """
     # Convert file to Path object.
-    save_path = Path(file_path) if isinstance(file_path, str) else file_path
+    save_path = Path(file_path)
     save_path.mkdir(parents=True, exist_ok=True)
 
     # Save steps into a folder
@@ -299,7 +299,8 @@ def _save_runnable_with_steps(model, file_path: Union[Path, str], loader_fn=None
         generator = steps.items()
     else:
         raise MlflowException(
-            f"steps for must be either a list or a dictionary. Got {type(steps).__name__}."
+            f"Runnable {model} steps attribute must be either a list or a dictionary. "
+            f"Got {type(steps).__name__}."
         )
     unsaved_runnables = {}
     steps_conf = {}
@@ -328,7 +329,7 @@ def _save_runnable_branch(model, file_path, loader_fn, persist_dir):
     """
     Save runnable branch in to path.
     """
-    save_path = Path(file_path) if isinstance(file_path, str) else file_path
+    save_path = Path(file_path)
     save_path.mkdir(parents=True, exist_ok=True)
     # save branches into a folder
     branches_path = save_path / _BRANCHES_FOLDER_NAME
@@ -375,7 +376,7 @@ def _save_runnable_branch(model, file_path, loader_fn, persist_dir):
 def _save_runnable_assign(model, file_path, loader_fn=None, persist_dir=None):
     from langchain.schema.runnable import RunnableParallel
 
-    save_path = Path(file_path) if isinstance(file_path, str) else file_path
+    save_path = Path(file_path)
     save_path.mkdir(parents=True, exist_ok=True)
     # save mapper into a folder
     mapper_path = save_path / _MAPPER_FOLDER_NAME

--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -25,8 +25,8 @@ from mlflow.langchain.utils import (
     _validate_and_wrap_lc_model,
     base_lc_types,
     custom_type_to_loader_dict,
-    lc_runnable_assign_type,
-    lc_runnable_branch_type,
+    lc_runnable_assign_types,
+    lc_runnable_branch_types,
     lc_runnable_with_steps_types,
     lc_runnables_types,
     picklable_runnable_types,
@@ -213,7 +213,7 @@ def _load_runnable_assign(file_path: Union[Path, str]):
     load_path = Path(file_path) if isinstance(file_path, str) else file_path
     if not load_path.exists() or not load_path.is_dir():
         raise MlflowException(
-            f"File {load_path} must exist and must be a directory " "in order to load runnable."
+            f"File {load_path} must exist and must be a directory in order to load runnable."
         )
 
     mapper_file = load_path / _MAPPER_FOLDER_NAME
@@ -406,10 +406,10 @@ def _save_runnables(model, path, loader_fn=None, persist_dir=None):
     elif isinstance(model, picklable_runnable_types()):
         model_data_path = _MODEL_DATA_PKL_FILE_NAME
         _save_picklable_runnable(model, os.path.join(path, model_data_path))
-    elif isinstance(model, lc_runnable_branch_type()):
+    elif isinstance(model, lc_runnable_branch_types()):
         model_data_path = _MODEL_DATA_FOLDER_NAME
         _save_runnable_branch(model, os.path.join(path, model_data_path), loader_fn, persist_dir)
-    elif isinstance(model, lc_runnable_assign_type()):
+    elif isinstance(model, lc_runnable_assign_types()):
         model_data_path = _MODEL_DATA_FOLDER_NAME
         _save_runnable_assign(model, os.path.join(path, model_data_path), loader_fn, persist_dir)
     else:
@@ -430,9 +430,9 @@ def _load_runnables(path, conf):
         or model_data == _MODEL_DATA_PKL_FILE_NAME
     ):
         return _load_from_pickle(os.path.join(path, model_data))
-    if model_type in (x.__name__ for x in lc_runnable_branch_type()):
+    if model_type in (x.__name__ for x in lc_runnable_branch_types()):
         return _load_runnable_branch(os.path.join(path, model_data))
-    if model_type in (x.__name__ for x in lc_runnable_assign_type()):
+    if model_type in (x.__name__ for x in lc_runnable_assign_types()):
         return _load_runnable_assign(os.path.join(path, model_data))
     raise MlflowException.invalid_parameter_value(
         _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=model_type)

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -121,7 +121,7 @@ def lc_runnable_with_steps_types():
     return types
 
 
-def lc_runnable_assign_type():
+def lc_runnable_assign_types():
     try:
         from langchain.schema.runnable.passthrough import RunnableAssign
 
@@ -130,7 +130,7 @@ def lc_runnable_assign_type():
         return ()
 
 
-def lc_runnable_branch_type():
+def lc_runnable_branch_types():
     try:
         from langchain.schema.runnable import RunnableBranch
 
@@ -143,8 +143,8 @@ def lc_runnables_types():
     return (
         picklable_runnable_types()
         + lc_runnable_with_steps_types()
-        + lc_runnable_branch_type()
-        + lc_runnable_assign_type()
+        + lc_runnable_branch_types()
+        + lc_runnable_assign_types()
     )
 
 

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -97,14 +97,6 @@ def picklable_runnable_types():
     except ImportError:
         pass
 
-    try:
-        # TODO: fix this, RunnableAssign is not picklable
-        from langchain.schema.runnable.passthrough import RunnableAssign
-
-        types += (RunnableAssign,)
-    except ImportError:
-        pass
-
     return types
 
 
@@ -129,6 +121,15 @@ def lc_runnable_with_steps_types():
     return types
 
 
+def lc_runnable_assign_type():
+    try:
+        from langchain.schema.runnable.passthrough import RunnableAssign
+
+        return (RunnableAssign,)
+    except ImportError:
+        return ()
+
+
 def lc_runnable_branch_type():
     try:
         from langchain.schema.runnable import RunnableBranch
@@ -139,7 +140,12 @@ def lc_runnable_branch_type():
 
 
 def lc_runnables_types():
-    return picklable_runnable_types() + lc_runnable_with_steps_types() + lc_runnable_branch_type()
+    return (
+        picklable_runnable_types()
+        + lc_runnable_with_steps_types()
+        + lc_runnable_branch_type()
+        + lc_runnable_assign_type()
+    )
 
 
 def supported_lc_types():

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -1174,6 +1174,52 @@ def test_save_load_runnable_parallel_and_assign_in_sequence():
 
 
 @pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.0.311"),
+    reason="feature not existing",
+)
+def test_save_load_complex_runnable_assign(fake_chat_model):
+    from langchain.prompts import ChatPromptTemplate
+    from langchain.schema.output_parser import StrOutputParser
+    from langchain.schema.runnable import RunnableParallel
+    from langchain.schema.runnable.passthrough import RunnableAssign
+
+    prompt = ChatPromptTemplate.from_template(
+        "What is a good name for a company that makes {product}?"
+    )
+    chain = prompt | fake_chat_model | StrOutputParser()
+
+    def fake_llm(prompt: str) -> str:
+        return "completion"
+
+    runnable_assign = RunnableAssign(mapper=RunnableParallel({"product": chain, "test": fake_llm}))
+    expected_result = {
+        "product": "Databricks",
+        "test": "completion",
+    }
+    input_example = {"product": "MLflow", "test": "test"}
+    assert runnable_assign.invoke(input_example) == expected_result
+
+    with mlflow.start_run():
+        model_info = mlflow.langchain.log_model(
+            runnable_assign, "model_path", input_example=input_example
+        )
+    loaded_model = mlflow.langchain.load_model(model_info.model_uri)
+    assert loaded_model.invoke(input_example) == expected_result
+    pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    assert pyfunc_loaded_model.predict([input_example]) == [expected_result]
+
+    response = pyfunc_serve_and_score_model(
+        model_info.model_uri,
+        data=json.dumps({"inputs": input_example}),
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+    assert PredictionsResponse.from_json(response.content.decode("utf-8")) == {
+        "predictions": [expected_result]
+    }
+
+
+@pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
 def test_save_load_runnable_sequence():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/11358?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11358/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11358
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Previously we assume RunnableAssign as a picklable object, but if the function is not an picklable object, it doesn't work. We should save the mapper of RunnableAssign and use it when loading.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
