### PR TITLE
Fix misuse of private method in mlflow.data module

### DIFF
--- a/mlflow/data/artifact_dataset_sources.py
+++ b/mlflow/data/artifact_dataset_sources.py
@@ -140,7 +140,7 @@ def _create_dataset_source_for_artifact_repo(scheme: str, dataset_source_name: s
         def _resolve(cls, raw_source: Any) -> DatasetForArtifactRepoSourceType:
             return cls(str(raw_source))
 
-        def _to_dict(self) -> Dict[Any, Any]:
+        def to_dict(self) -> Dict[Any, Any]:
             """
             Returns:
                 A JSON-compatible dictionary representation of the {dataset_source_name}.
@@ -150,7 +150,7 @@ def _create_dataset_source_for_artifact_repo(scheme: str, dataset_source_name: s
             }
 
         @classmethod
-        def _from_dict(cls, source_dict: Dict[Any, Any]) -> DatasetForArtifactRepoSourceType:
+        def from_dict(cls, source_dict: Dict[Any, Any]) -> DatasetForArtifactRepoSourceType:
             uri = source_dict.get("uri")
             if uri is None:
                 raise MlflowException(
@@ -163,7 +163,7 @@ def _create_dataset_source_for_artifact_repo(scheme: str, dataset_source_name: s
     ArtifactRepoSource.__name__ = dataset_source_name
     ArtifactRepoSource.__qualname__ = dataset_source_name
     ArtifactRepoSource.__doc__ = class_docstring
-    ArtifactRepoSource._to_dict.__doc__ = ArtifactRepoSource._to_dict.__doc__.format(
+    ArtifactRepoSource.to_dict.__doc__ = ArtifactRepoSource.to_dict.__doc__.format(
         dataset_source_name=dataset_source_name
     )
     ArtifactRepoSource.uri.__doc__ = ArtifactRepoSource.uri.__doc__.format(scheme=scheme)

--- a/mlflow/data/code_dataset_source.py
+++ b/mlflow/data/code_dataset_source.py
@@ -28,11 +28,11 @@ class CodeDatasetSource(DatasetSource):
     def _resolve(cls, raw_source: str) -> "CodeDatasetSource":
         raise NotImplementedError
 
-    def _to_dict(self) -> Dict[Any, Any]:
+    def to_dict(self) -> Dict[Any, Any]:
         return {"tags": self._tags}
 
     @classmethod
-    def _from_dict(cls, source_dict: Dict[Any, Any]) -> "CodeDatasetSource":
+    def from_dict(cls, source_dict: Dict[Any, Any]) -> "CodeDatasetSource":
         return cls(
             tags=source_dict.get("tags"),
         )

--- a/mlflow/data/dataset_source.py
+++ b/mlflow/data/dataset_source.py
@@ -64,7 +64,7 @@ class DatasetSource:
         """
 
     @abstractmethod
-    def _to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         """Obtains a JSON-compatible dictionary representation of the DatasetSource.
 
         Returns:
@@ -81,11 +81,11 @@ class DatasetSource:
             A JSON string representation of the
             :py:class:`DatasetSource <mlflow.data.dataset_source.DatasetSource>`.
         """
-        return json.dumps(self._to_dict())
+        return json.dumps(self.to_dict())
 
     @classmethod
     @abstractmethod
-    def _from_dict(cls, source_dict: Dict[Any, Any]) -> "DatasetSource":
+    def from_dict(cls, source_dict: Dict[Any, Any]) -> "DatasetSource":
         """Constructs an instance of the DatasetSource from a dictionary representation.
 
         Args:
@@ -107,4 +107,4 @@ class DatasetSource:
             A DatasetSource instance.
 
         """
-        return cls._from_dict(json.loads(source_json))
+        return cls.from_dict(json.loads(source_json))

--- a/mlflow/data/delta_dataset_source.py
+++ b/mlflow/data/delta_dataset_source.py
@@ -137,7 +137,7 @@ class DeltaDatasetSource(DatasetSource):
         except Exception:
             return None
 
-    def _to_dict(self) -> Dict[Any, Any]:
+    def to_dict(self) -> Dict[Any, Any]:
         info = {}
         if self._path:
             info["path"] = self._path
@@ -154,7 +154,7 @@ class DeltaDatasetSource(DatasetSource):
         return info
 
     @classmethod
-    def _from_dict(cls, source_dict: Dict[Any, Any]) -> "DeltaDatasetSource":
+    def from_dict(cls, source_dict: Dict[Any, Any]) -> "DeltaDatasetSource":
         return cls(
             path=source_dict.get("path"),
             delta_table_name=source_dict.get("delta_table_name"),

--- a/mlflow/data/filesystem_dataset_source.py
+++ b/mlflow/data/filesystem_dataset_source.py
@@ -66,7 +66,7 @@ class FileSystemDatasetSource(DatasetSource):
         """
 
     @abstractmethod
-    def _to_dict(self) -> Dict[Any, Any]:
+    def to_dict(self) -> Dict[Any, Any]:
         """
         Returns:
             A JSON-compatible dictionary representation of the FileSystemDatasetSource.
@@ -74,7 +74,7 @@ class FileSystemDatasetSource(DatasetSource):
 
     @classmethod
     @abstractmethod
-    def _from_dict(cls, source_dict: Dict[Any, Any]) -> "FileSystemDatasetSource":
+    def from_dict(cls, source_dict: Dict[Any, Any]) -> "FileSystemDatasetSource":
         """
         Args:
             source_dict: A dictionary representation of the FileSystemDatasetSource.

--- a/mlflow/data/http_dataset_source.py
+++ b/mlflow/data/http_dataset_source.py
@@ -120,7 +120,7 @@ class HTTPDatasetSource(DatasetSource):
         """
         return HTTPDatasetSource(raw_source)
 
-    def _to_dict(self) -> Dict[Any, Any]:
+    def to_dict(self) -> Dict[Any, Any]:
         """
         Returns:
             A JSON-compatible dictionary representation of the HTTPDatasetSource.
@@ -130,7 +130,7 @@ class HTTPDatasetSource(DatasetSource):
         }
 
     @classmethod
-    def _from_dict(cls, source_dict: Dict[Any, Any]) -> "HTTPDatasetSource":
+    def from_dict(cls, source_dict: Dict[Any, Any]) -> "HTTPDatasetSource":
         """
         Args:
             source_dict: A dictionary representation of the HTTPDatasetSource.

--- a/mlflow/data/huggingface_dataset_source.py
+++ b/mlflow/data/huggingface_dataset_source.py
@@ -87,7 +87,7 @@ class HuggingFaceDatasetSource(DatasetSource):
     def _resolve(cls, raw_source: str) -> "HuggingFaceDatasetSource":
         raise NotImplementedError
 
-    def _to_dict(self) -> Dict[Any, Any]:
+    def to_dict(self) -> Dict[Any, Any]:
         return {
             "path": self.path,
             "config_name": self.config_name,
@@ -98,7 +98,7 @@ class HuggingFaceDatasetSource(DatasetSource):
         }
 
     @classmethod
-    def _from_dict(cls, source_dict: Dict[Any, Any]) -> "HuggingFaceDatasetSource":
+    def from_dict(cls, source_dict: Dict[Any, Any]) -> "HuggingFaceDatasetSource":
         return cls(
             path=source_dict.get("path"),
             config_name=source_dict.get("config_name"),

--- a/mlflow/data/spark_dataset_source.py
+++ b/mlflow/data/spark_dataset_source.py
@@ -55,7 +55,7 @@ class SparkDatasetSource(DatasetSource):
     def _resolve(cls, raw_source: str) -> "SparkDatasetSource":
         raise NotImplementedError
 
-    def _to_dict(self) -> Dict[Any, Any]:
+    def to_dict(self) -> Dict[Any, Any]:
         info = {}
         if self._path is not None:
             info["path"] = self._path
@@ -66,7 +66,7 @@ class SparkDatasetSource(DatasetSource):
         return info
 
     @classmethod
-    def _from_dict(cls, source_dict: Dict[Any, Any]) -> "SparkDatasetSource":
+    def from_dict(cls, source_dict: Dict[Any, Any]) -> "SparkDatasetSource":
         return cls(
             path=source_dict.get("path"),
             table_name=source_dict.get("table_name"),

--- a/mlflow/data/uc_volume_dataset_source.py
+++ b/mlflow/data/uc_volume_dataset_source.py
@@ -65,9 +65,9 @@ class UCVolumeDatasetSource(DatasetSource):
     def _resolve(cls, raw_source: str):
         raise NotImplementedError
 
-    def _to_dict(self) -> Dict[Any, Any]:
+    def to_dict(self) -> Dict[Any, Any]:
         return {"path": self.path}
 
     @classmethod
-    def _from_dict(cls, source_dict: Dict[Any, Any]) -> "UCVolumeDatasetSource":
+    def from_dict(cls, source_dict: Dict[Any, Any]) -> "UCVolumeDatasetSource":
         return cls(**source_dict)

--- a/tests/data/test_code_dataset_source.py
+++ b/tests/data/test_code_dataset_source.py
@@ -7,7 +7,7 @@ def test_code_dataset_source_from_path():
         "mlflow_source_name": "some_random_notebook_path",
     }
     code_datasource = CodeDatasetSource(tags)
-    assert code_datasource._to_dict() == {
+    assert code_datasource.to_dict() == {
         "tags": tags,
     }
 

--- a/tests/resources/data/dataset_source.py
+++ b/tests/resources/data/dataset_source.py
@@ -39,11 +39,11 @@ class SampleDatasetSource(DatasetSource):
     def _resolve(cls, raw_source: Any) -> DatasetSource:
         return cls(raw_source)
 
-    def _to_dict(self) -> Dict[Any, Any]:
+    def to_dict(self) -> Dict[Any, Any]:
         return {"uri": self.uri}
 
     @classmethod
-    def _from_dict(cls, source_dict: Dict[Any, Any]) -> DatasetSource:
+    def from_dict(cls, source_dict: Dict[Any, Any]) -> DatasetSource:
         uri = source_dict.get("uri")
         if uri is None:
             raise MlflowException(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/11369?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11369/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11369
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Methods that are supposed to be override in child classes should be public. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
