### PR TITLE
Add doc for sentence-transformers OpenAI-compatible API

### DIFF
--- a/docs/source/llms/sentence-transformers/guide/index.rst
+++ b/docs/source/llms/sentence-transformers/guide/index.rst
@@ -53,6 +53,42 @@ You can save and log sentence-transformers models in MLflow. Here's an example o
             sentence_transformers_model=model, artifact_path="model_artifact_path"
         )
 
+Saving Sentence Transformers Models with an OpenAI-Compatible Inference Interface
+---------------------------------------------------------------------------------
+
+.. note::
+
+    This feature is only available in MLflow 2.11.0 and above.
+
+MLflow's ``sentence_transformers`` flavor allows you to pass in the ``task`` param with the string value ``"llm/v1/embeddings"`` 
+when saving a model with :py:func:`mlflow.sentence_transformers.save_model()` and :py:func:`mlflow.sentence_transformers.log_model()`.
+
+For example:
+
+.. code-block:: python
+    import mlflow
+    from sentence_transformers import SentenceTransformer
+
+    model = SentenceTransformer("all-MiniLM-L6-v2")
+
+    mlflow.sentence_transformers.save_model(
+        model=model, path="path/to/save/directory", task="llm/v1/embeddings"
+    )
+
+When ``task`` is set as ``"llm/v1/embeddings"``, MLflow handles the following for you:
+
+- Setting an embeddings compatible signature for the model
+- Performing data pre- and post-processing to ensure the inputs and outputs conform to 
+  the `Embeddings API spec <https://mlflow.org/docs/latest/llms/deployments/index.html#embeddings>`_, 
+  which is compatible with OpenAI's API spec.
+
+Note that these modifications only apply when the model is loaded with :py:func:`mlflow.pyfunc.load_model()` (e.g. when 
+serving the model with the ``mlflow models serve`` CLI tool). If you want to load just the base pipeline, you can
+always do so via :py:func:`mlflow.sentence_transformers.load_model()`.
+
+Aside from the ``sentence-transformers`` flavor, the ``transformers`` flavor also support OpenAI-compatible inference interface (``"llm/v1/chat"`` and ``"llm/v1/completions"``). Refer to 
+`the Transformers flavor guide <https://mlflow.org/docs/latest/llms/transformers/guide/index.html#saving-transformer-pipelines-with-an-openai-compatible-inference-interface>`_ for more information.
+
 Custom Python Function Implementation
 -------------------------------------
 

--- a/docs/source/llms/sentence-transformers/guide/index.rst
+++ b/docs/source/llms/sentence-transformers/guide/index.rst
@@ -66,6 +66,7 @@ when saving a model with :py:func:`mlflow.sentence_transformers.save_model()` an
 For example:
 
 .. code-block:: python
+    
     import mlflow
     from sentence_transformers import SentenceTransformer
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/es94129/mlflow/pull/11373?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11373/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11373
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add a section for the `sentence-transformers` flavor about the embeddings format API implemented in https://github.com/mlflow/mlflow/pull/11019. The section is similar as https://github.com/mlflow/mlflow/pull/11239.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Checked that the built doc (https://output.circle-artifacts.com/output/job/cc246e88-c15f-442e-af87-b6434191f095/artifacts/0/docs/build/html/llms/sentence-transformers/guide/index.html) looks as expected.

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

A section has been added to the `sentence-transformers` flavor guide about the `task` parameter.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
