### PR TITLE
Move notebook download buttons from the index page to each notebook

### DIFF
--- a/docs/source/deep-learning/keras/index.rst
+++ b/docs/source/deep-learning/keras/index.rst
@@ -17,19 +17,25 @@ log parameters and metrics during model training. Model logging is not currently
 5 Minute Quick Start with MLflow + Keras 3.0
 --------------------------------------------
 
-To get a quick overview of how to use MLflow + Keras 3.0, please read the quickstart guide. It will walk
-you through how to use the callback for tracking experiments, as well as how to customize it.
+To get a quick overview of how to use MLflow + Keras 3.0, please read the quickstart guide.
+
 
 .. raw:: html
 
-    <a href="quickstart/quickstart_keras.html" class="download-btn">View the Quickstart</a>
-
-To download the Keras 3.0 tutorial notebook to run in your environment, click the link below:
-
-.. raw:: html
-
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/deep-learning/keras/quickstart/quickstart_keras.ipynb"
-    class="notebook-download-btn">Download the Quickstart of MLflow Keras Integration</a><br>
+    <section>
+        <article class="simple-grid">
+            <div class="simple-card">
+                <a href="quickstart/quickstart_keras.html">
+                    <div class="header">
+                        Get Started with Keras 3.0 + MLflow
+                    </div>
+                    <p>
+                        Learn how to leverage the MLflow Keras callback for tracking experiments, as well as how to customize it.
+                    </p>
+                </a>
+            </div>
+        </article>
+    </section>
 
 
 .. toctree::

--- a/docs/source/deep-learning/keras/quickstart/quickstart_keras.ipynb
+++ b/docs/source/deep-learning/keras/quickstart/quickstart_keras.ipynb
@@ -12,6 +12,14 @@
    ]
   },
   {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "    <a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/deep-learning/keras/quickstart/quickstart_keras.ipynb\"\n",
+    "    class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/source/deep-learning/pytorch/index.rst
+++ b/docs/source/deep-learning/pytorch/index.rst
@@ -21,19 +21,22 @@ in MLflow we provide a set of APIs for:
 5 Minute Quick Start with the MLflow PyTorch Flavor
 ----------------------------------------------------
 
-To get a quick overview of how to use the MLflow PyTorch flavor, please read the quickstart guide. It
-will walk you through the basics of tracking PyTorch experiments.
-
 .. raw:: html
 
-    <a href="quickstart/pytorch_quickstart.html" class="download-btn">View the Quickstart</a>
-
-To download the PyTorch quickstart notebook to run in your environment, click the respective link below:
-
-.. raw:: html
-
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/deep-learning/pytorch/quickstart/pytorch_quickstart.ipynb"
-    class="notebook-download-btn">Download the Quickstart of MLflow's PyTorch Integration</a><br>
+     <section>
+        <article class="simple-grid">
+            <div class="simple-card">
+                <a href="quickstart/pytorch_quickstart.html">
+                    <div class="header">
+                        Quickstart with MLflow PyTorch Flavor
+                    </div>
+                    <p>
+                        Learn how to leverage MLflow for tracking PyTorch experiments and models.
+                    </p>
+                </a>
+            </div>
+        </article>
+    </section>
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/deep-learning/pytorch/quickstart/pytorch_quickstart.ipynb
+++ b/docs/source/deep-learning/pytorch/quickstart/pytorch_quickstart.ipynb
@@ -14,6 +14,13 @@
    ]
   },
   {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/deep-learning/pytorch/quickstart/pytorch_quickstart.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "id": "CZwvVcIg0Z1P"

--- a/docs/source/deep-learning/tensorflow/index.rst
+++ b/docs/source/deep-learning/tensorflow/index.rst
@@ -18,19 +18,23 @@ in MLflow we provide a set of APIs for:
 5 Minute Quick Start with the MLflow Tensorflow Flavor
 -------------------------------------------------------
 
-To get a quick overview of how to use the MLflow Tensorflow flavor, please read the quickstart guide. It
-will walk you through the basics of tracking Tensorflow experiments.
-
 .. raw:: html
 
-    <a href="quickstart/quickstart_tensorflow.html" class="download-btn">View the Quickstart</a>
+     <section>
+        <article class="simple-grid">
+            <div class="simple-card">
+                <a href="quickstart/quickstart_tensorflow.html">
+                    <div class="header">
+                        Quickstart with MLflow Tensorflow Flavor
+                    </div>
+                    <p>
+                        Learn how to leverage MLflow for tracking Tensorflow experiments and models.
+                    </p>
+                </a>
+            </div>
+        </article>
+    </section>
 
-To download the tensorflow tutorial notebooks to run in your environment, click the respective links below:
-
-.. raw:: html
-
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/deep-learning/tensorflow/quickstart/quickstart_tensorflow.ipynb"
-    class="notebook-download-btn">Download the Quickstart of MLflow Tensorflow Integration</a><br>
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/deep-learning/tensorflow/quickstart/quickstart_tensorflow.ipynb
+++ b/docs/source/deep-learning/tensorflow/quickstart/quickstart_tensorflow.ipynb
@@ -16,6 +16,13 @@
    ]
   },
   {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/deep-learning/tensorflow/quickstart/quickstart_tensorflow.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "id": "9btw8G129PH9"

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -86,13 +86,6 @@ a model training event to an MLflow run.
         </article>
     </section>
 
-If you would like to get started immediately by downloading and running a notebook yourself:
-
-.. raw:: html
-
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/getting-started/intro-quickstart/notebooks/tracking_quickstart.ipynb" class="notebook-download-btn">
-        <i class="fas fa-download"></i>Download the Tracking Quickstart Notebook</a><br/>
-
 .. toctree::
     :maxdepth: 1
     :hidden:

--- a/docs/source/getting-started/intro-quickstart/index.rst
+++ b/docs/source/getting-started/intro-quickstart/index.rst
@@ -26,7 +26,20 @@ If you would like to see this quickstart in a purely notebook format, we have a 
 
 .. raw:: html
 
-    <a href="notebooks/index.html" class="download-btn">View the Notebook</a>
+     <section>
+        <article class="simple-grid">
+            <div class="simple-card">
+                <a href="notebooks/tracking_quickstart.html" >
+                    <div class="header">
+                        MLflow Tracking Quickstart Guide
+                    </div>
+                    <p>
+                    Learn the basics of MLflow Tracking in a fast-paced guide with a focus on seeing your first model in the MLflow UI
+                    </p>
+                </a>
+            </div>
+        </article>
+    </section>
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/getting-started/intro-quickstart/notebooks/index.rst
+++ b/docs/source/getting-started/intro-quickstart/notebooks/index.rst
@@ -11,23 +11,28 @@ of MLflow, including:
 - Loading a logged model for inference using MLflow's `pyfunc` flavor.
 - Viewing the experiment results in the MLflow UI.
 
+If you are new to MLflow, we recommend starting with this quickstart to familiarize yourself with the most commonly used 
+MLflow APIs before diving into more detailed tutorials.
+
+.. raw:: html
+
+     <section>
+        <article class="simple-grid">
+            <div class="simple-card">
+                <a href="tracking_quickstart.html" >
+                    <div class="header">
+                        MLflow Tracking Quickstart Guide
+                    </div>
+                    <p>
+                    Learn the basics of MLflow Tracking in a fast-paced guide with a focus on seeing your first model in the MLflow UI
+                    </p>
+                </a>
+            </div>
+        </article>
+    </section>
+
 .. toctree::
     :maxdepth: 1
     :hidden:
 
     tracking_quickstart.ipynb
-
-You can view the full notebook:
-
-.. raw:: html
-
-    <a href="tracking_quickstart.html" class="download-btn">View the MLflow Tracking Quickstart Notebook</a>
-
-If you prefer to run the quickstart in your own environment, you can download the notebook:
-
-.. raw:: html
-
-   <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/getting-started/intro-quickstart/notebooks/tracking_quickstart.ipynb" class="notebook-download-btn">Download the MLflow Tracking Quickstart Notebook</a>
-
-If you are new to MLflow, we recommend starting with this quickstart to familiarize yourself with the most commonly used 
-MLflow APIs before diving into more detailed tutorials.

--- a/docs/source/getting-started/intro-quickstart/notebooks/tracking_quickstart.ipynb
+++ b/docs/source/getting-started/intro-quickstart/notebooks/tracking_quickstart.ipynb
@@ -4,8 +4,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## MLflow 5 minute Tracking Quickstart\n",
-    "\n",
+    "## MLflow 5 minute Tracking Quickstart"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/getting-started/intro-quickstart/notebooks/tracking_quickstart.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "This notebook demonstrates using a local MLflow Tracking Server to log, register, and then load a model as a generic Python Function (pyfunc) to perform inference on a Pandas DataFrame.\n",
     "\n",
     "Throughout this notebook, we'll be using the MLflow fluent API to perform all interactions with the MLflow Tracking Server."

--- a/docs/source/getting-started/logging-first-model/notebooks/index.rst
+++ b/docs/source/getting-started/logging-first-model/notebooks/index.rst
@@ -5,23 +5,17 @@ If you would like to view the full notebook:
 
 .. raw:: html
 
-     <section>
-        <article class="simple-grid">
-            <div class="simple-card">
-                <a href="logging-first-model/index.html" >
-                    <div class="header">
-                        In-depth Tutorial for MLflow Tracking
-                    </div>
-                    <p>
-                        Learn the nuances of interfacing with the MLflow Tracking Server in an in-depth tutorial
-                    </p>
-                </a>
-            </div>
-        </article>
-    </section>
+    <a href="logging-first-model.html" class="download-btn">View the Logging your first MLflow Model notebook</a>
 
 .. toctree::
     :maxdepth: 1
     :hidden:
 
     logging-first-model.ipynb
+
+Additionally, if you would like to download a copy locally to run in your own environment, you can download by
+clicking this link:
+
+.. raw:: html
+
+   <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/getting-started/logging-first-model/notebooks/logging-first-model.ipynb" class="notebook-download-btn">Download the notebook</a>

--- a/docs/source/getting-started/logging-first-model/notebooks/index.rst
+++ b/docs/source/getting-started/logging-first-model/notebooks/index.rst
@@ -5,17 +5,23 @@ If you would like to view the full notebook:
 
 .. raw:: html
 
-    <a href="logging-first-model.html" class="download-btn">View the Logging your first MLflow Model notebook</a>
+     <section>
+        <article class="simple-grid">
+            <div class="simple-card">
+                <a href="logging-first-model/index.html" >
+                    <div class="header">
+                        In-depth Tutorial for MLflow Tracking
+                    </div>
+                    <p>
+                        Learn the nuances of interfacing with the MLflow Tracking Server in an in-depth tutorial
+                    </p>
+                </a>
+            </div>
+        </article>
+    </section>
 
 .. toctree::
     :maxdepth: 1
     :hidden:
 
     logging-first-model.ipynb
-
-Additionally, if you would like to download a copy locally to run in your own environment, you can download by
-clicking this link:
-
-.. raw:: html
-
-   <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/getting-started/logging-first-model/notebooks/logging-first-model.ipynb" class="notebook-download-btn">Download the notebook</a>

--- a/docs/source/getting-started/logging-first-model/notebooks/logging-first-model.ipynb
+++ b/docs/source/getting-started/logging-first-model/notebooks/logging-first-model.ipynb
@@ -1,6 +1,22 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "06eb13f1",
+   "metadata": {},
+   "source": [
+    "# Logging Your First MLflow Model"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "e3eca2b8",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/getting-started/logging-first-model/notebooks/logging-first-model.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this notebook</a>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "20cc39b3",

--- a/docs/source/getting-started/logging-first-model/notebooks/logging-first-model.ipynb
+++ b/docs/source/getting-started/logging-first-model/notebooks/logging-first-model.ipynb
@@ -1,22 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "id": "06eb13f1",
-   "metadata": {},
-   "source": [
-    "# Logging Your First MLflow Model"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "id": "e3eca2b8",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/getting-started/logging-first-model/notebooks/logging-first-model.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this notebook</a>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "20cc39b3",

--- a/docs/source/llms/custom-pyfunc-for-llms/index.rst
+++ b/docs/source/llms/custom-pyfunc-for-llms/index.rst
@@ -27,7 +27,20 @@ Explore the Tutorial
 
 .. raw:: html
 
-    <a href="notebooks/index.html" class="download-btn">View the Custom Pyfunc for LLMs Tutorial</a><br/>
+     <section>
+        <article class="simple-grid">
+            <div class="simple-card">
+                <a href="notebooks/custom-pyfunc-advanced-llm.html" >
+                    <div class="header">
+                        Serving LLMs with MLflow: Leveraging Custom PyFunc
+                    </div>
+                    <p>
+                        Learn how to use the MLflow Custom Pyfunc Model to serve Large Language Models (LLMs) in a RESTful environment.
+                    </p>
+                </a>
+            </div>
+        </article>
+    </section>
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/llms/custom-pyfunc-for-llms/notebooks/custom-pyfunc-advanced-llm.ipynb
+++ b/docs/source/llms/custom-pyfunc-for-llms/notebooks/custom-pyfunc-advanced-llm.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/custom-pyfunc-for-llms/notebooks/custom-pyfunc-advanced-llm.ipynb\" class=\"notebook-download-btn\">Download this Notebook</a>"
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/custom-pyfunc-for-llms/notebooks/custom-pyfunc-advanced-llm.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a>"
    ]
   },
   {

--- a/docs/source/llms/custom-pyfunc-for-llms/notebooks/index.rst
+++ b/docs/source/llms/custom-pyfunc-for-llms/notebooks/index.rst
@@ -54,17 +54,20 @@ With the complexities of advanced LLM deployment unraveled, this tutorial showca
 
 .. raw:: html
 
-    <a href="custom-pyfunc-advanced-llm.html" class="download-btn">View the Notebook</a>
-
-
-Run the Notebooks in your Environment
--------------------------------------
-
-If you'd like to run a copy of the notebooks locally in your environment, you can download them by clicking the respective links:
-
-.. raw:: html
-
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/custom-pyfunc-for-llms/notebooks/custom-pyfunc-advanced-llm.ipynb" class="notebook-download-btn">Download the LLM Custom Pyfunc notebook</a><br/>
+     <section>
+        <article class="simple-grid">
+            <div class="simple-card">
+                <a href="logging-first-model/index.html" >
+                    <div class="header">
+                        Serving LLMs with MLflow: Leveraging Custom PyFunc
+                    </div>
+                    <p>
+                        Learn how to use the MLflow Custom Pyfunc Model to serve Large Language Models (LLMs) in a RESTful environment.
+                    </p>
+                </a>
+            </div>
+        </article>
+    </section>
 
 .. note::
     To execute the notebooks, ensure you either have a local MLflow Tracking Server running or adjust the ``mlflow.set_tracking_uri()`` to point to an active MLflow Tracking Server instance. 

--- a/docs/source/llms/custom-pyfunc-for-llms/notebooks/index.rst
+++ b/docs/source/llms/custom-pyfunc-for-llms/notebooks/index.rst
@@ -57,7 +57,7 @@ With the complexities of advanced LLM deployment unraveled, this tutorial showca
      <section>
         <article class="simple-grid">
             <div class="simple-card">
-                <a href="logging-first-model/index.html" >
+                <a href="custom-pyfunc-advanced-llm.html" >
                     <div class="header">
                         Serving LLMs with MLflow: Leveraging Custom PyFunc
                     </div>

--- a/docs/source/llms/langchain/index.rst
+++ b/docs/source/llms/langchain/index.rst
@@ -71,6 +71,14 @@ is included with each subsequent input. Preserving conversational context in thi
 Getting Started with the MLflow LangChain Flavor - Tutorials and Guides
 -----------------------------------------------------------------------
 
+.. toctree::
+    :maxdepth: 2
+    :hidden:
+
+    notebooks/langchain-quickstart.ipynb
+    notebooks/langchain-agent.ipynb
+    notebooks/langchain-retriever.ipynb
+
 Introductory Tutorial
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -94,10 +102,6 @@ use a chain.
             </div>
         </article>
     </section>
-
-.. raw:: html
-
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/langchain/notebooks/langchain-quickstart.ipynb" class="notebook-download-btn">Download the Introductory Notebook</a><br>
 
 
 Advanced Tutorials
@@ -133,18 +137,6 @@ exploring these more advanced use cases.
         </article>
     </section>
 
-.. raw:: html
-
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/langchain/notebooks/langchain-agent.ipynb" class="notebook-download-btn">Download the LangChain Agents Notebook</a><br>
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/langchain/notebooks/langchain-retriever.ipynb" class="notebook-download-btn">Download the LangChain Retriever Notebook</a><br>
-
-.. toctree::
-    :maxdepth: 2
-    :hidden:
-
-    notebooks/langchain-quickstart.ipynb
-    notebooks/langchain-agent.ipynb
-    notebooks/langchain-retriever.ipynb
 
 `Detailed Documentation <guide/index.html>`_
 --------------------------------------------

--- a/docs/source/llms/langchain/notebooks/langchain-agent.ipynb
+++ b/docs/source/llms/langchain/notebooks/langchain-agent.ipynb
@@ -6,8 +6,20 @@
    "source": [
     "## Using LangChain Agents with MLflow\n",
     "\n",
-    "Welcome to an engaging and educational tutorial designed to dive deep into the world of LangChain agents and their integration with MLflow. This notebook-based tutorial is tailored to offer a practical and comprehensive understanding of LangChain agents and their practical applications with a modest dose of absurdity.\n",
-    "\n",
+    "Welcome to an engaging and educational tutorial designed to dive deep into the world of LangChain agents and their integration with MLflow. This notebook-based tutorial is tailored to offer a practical and comprehensive understanding of LangChain agents and their practical applications with a modest dose of absurdity."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/langchain/notebooks/langchain-agent.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### What This Tutorial Covers\n",
     "\n",
     "- **Understanding LangChain Agents**: Gain insights into what LangChain agents are and how they function in complex decision-making scenarios.\n",

--- a/docs/source/llms/langchain/notebooks/langchain-quickstart.ipynb
+++ b/docs/source/llms/langchain/notebooks/langchain-quickstart.ipynb
@@ -6,8 +6,20 @@
    "source": [
     "## Introduction to Using LangChain with MLflow\n",
     "\n",
-    "Welcome to this interactive tutorial designed to introduce you to [LangChain](https://python.langchain.com/docs/get_started/introduction) and its integration with MLflow. This tutorial is structured as a notebook to provide a hands-on, practical learning experience with the simplest and most core features of LangChain.\n",
-    "\n",
+    "Welcome to this interactive tutorial designed to introduce you to [LangChain](https://python.langchain.com/docs/get_started/introduction) and its integration with MLflow. This tutorial is structured as a notebook to provide a hands-on, practical learning experience with the simplest and most core features of LangChain."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/langchain/notebooks/langchain-quickstart.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### What You Will Learn\n",
     "\n",
     "- **Understanding LangChain**: Get to know the basics of LangChain and how it is used in developing applications powered by language models.\n",

--- a/docs/source/llms/langchain/notebooks/langchain-retriever.ipynb
+++ b/docs/source/llms/langchain/notebooks/langchain-retriever.ipynb
@@ -4,8 +4,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Introduction to RAG with MLflow and LangChain\n",
-    "\n",
+    "## Introduction to RAG with MLflow and LangChain"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/langchain/notebooks/langchain-retriever.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Tutorial Overview\n",
     "Welcome to this tutorial, where we explore the integration of Retrieval Augmented Generation (RAG) with MLflow and LangChain. Our focus is on demonstrating how to create advanced RAG systems and showcasing the unique capabilities enabled by MLflow in these applications.\n",
     "\n",

--- a/docs/source/llms/openai/index.rst
+++ b/docs/source/llms/openai/index.rst
@@ -119,6 +119,16 @@ The diagram below shows the basic scope of the level of complexity that the tuto
 
    The range of content within the tutorials for the OpenAI flavor
 
+
+.. toctree::
+    :maxdepth: 2
+    :hidden:
+
+    notebooks/openai-quickstart.ipynb
+    notebooks/openai-chat-completions.ipynb
+    notebooks/openai-code-helper.ipynb
+    notebooks/openai-embeddings-generation.ipynb
+
 Introductory Tutorial
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -189,27 +199,6 @@ to understand in order to get the notebooks in this section to work.
             </div>
         </article>
     </section>
-
-
-Download the Advanced Tutorial Notebooks
-----------------------------------------
-
-To download the advanced OpenAI tutorial notebooks to run in your environment, click the respective links below:
-
-.. raw:: html
-
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-chat-completions.ipynb" class="notebook-download-btn">Download the ChatCompletions Notebook</a><br>
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-code-helper.ipynb" class="notebook-download-btn">Download the Code Helper Notebook</a><br>
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-embeddings-generation.ipynb" class="notebook-download-btn">Download the Embeddings Notebook</a><br>
-
-.. toctree::
-    :maxdepth: 2
-    :hidden:
-
-    notebooks/openai-quickstart.ipynb
-    notebooks/openai-chat-completions.ipynb
-    notebooks/openai-code-helper.ipynb
-    notebooks/openai-embeddings-generation.ipynb
 
 `Detailed Documentation <guide/index.html>`_
 --------------------------------------------

--- a/docs/source/llms/openai/index.rst
+++ b/docs/source/llms/openai/index.rst
@@ -150,10 +150,6 @@ Introductory Tutorial
         </article>
     </section>
 
-.. raw:: html
-
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-quickstart.ipynb" class="notebook-download-btn">Download the Introductory Notebook</a><br>
-
 
 Advanced Tutorials
 ^^^^^^^^^^^^^^^^^^

--- a/docs/source/llms/openai/notebooks/openai-chat-completions.ipynb
+++ b/docs/source/llms/openai/notebooks/openai-chat-completions.ipynb
@@ -6,8 +6,20 @@
    "source": [
     "## Introduction: Advancing Communication with GPT-4 and MLflow\n",
     "\n",
-    "Welcome to our advanced tutorial, where we delve into the cutting-edge capabilities of OpenAI's GPT-4, particularly exploring its Chat Completions feature. In this session, we will combine the advanced linguistic prowess of GPT-4 with the robust experiment tracking and deployment framework of MLflow to create an innovative application: The Text Message Angel.\n",
-    "\n",
+    "Welcome to our advanced tutorial, where we delve into the cutting-edge capabilities of OpenAI's GPT-4, particularly exploring its Chat Completions feature. In this session, we will combine the advanced linguistic prowess of GPT-4 with the robust experiment tracking and deployment framework of MLflow to create an innovative application: The Text Message Angel.\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-chat-completions.ipynb\" class=\"notebook-download-btn\">Download this Notebook</a><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Tutorial Overview\n",
     "\n",
     "In this tutorial, we will:\n",

--- a/docs/source/llms/openai/notebooks/openai-chat-completions.ipynb
+++ b/docs/source/llms/openai/notebooks/openai-chat-completions.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-chat-completions.ipynb\" class=\"notebook-download-btn\">Download this Notebook</a><br>"
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-chat-completions.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
    ]
   },
   {

--- a/docs/source/llms/openai/notebooks/openai-code-helper.ipynb
+++ b/docs/source/llms/openai/notebooks/openai-code-helper.ipynb
@@ -15,7 +15,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-code-helper.ipynb\" class=\"notebook-download-btn\">Download this Notebook</a><br>"
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-code-helper.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
    ]
   },
   {

--- a/docs/source/llms/openai/notebooks/openai-code-helper.ipynb
+++ b/docs/source/llms/openai/notebooks/openai-code-helper.ipynb
@@ -8,8 +8,20 @@
     "\n",
     "### Overview\n",
     "\n",
-    "Welcome to this comprehensive tutorial, where you'll embark on a fascinating journey through the integration of OpenAI's powerful language models with MLflow, where we'll be building an actually useful tool that can, with the simple addition of a decorator to any function that we declare, get immediate feedback within an interactive environment on code under active development.\n",
-    "\n",
+    "Welcome to this comprehensive tutorial, where you'll embark on a fascinating journey through the integration of OpenAI's powerful language models with MLflow, where we'll be building an actually useful tool that can, with the simple addition of a decorator to any function that we declare, get immediate feedback within an interactive environment on code under active development.\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-code-helper.ipynb\" class=\"notebook-download-btn\">Download this Notebook</a><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Learning Objectives\n",
     "\n",
     "By the end of this tutorial, you will:\n",

--- a/docs/source/llms/openai/notebooks/openai-embeddings-generation.ipynb
+++ b/docs/source/llms/openai/notebooks/openai-embeddings-generation.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-embeddings-generation.ipynb\" class=\"notebook-download-btn\">Download this Notebook</a><br>"
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-embeddings-generation.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
    ]
   },
   {

--- a/docs/source/llms/openai/notebooks/openai-embeddings-generation.ipynb
+++ b/docs/source/llms/openai/notebooks/openai-embeddings-generation.ipynb
@@ -6,8 +6,20 @@
    "source": [
     "## Advanced Tutorial: Embeddings Support with OpenAI in MLflow\n",
     "\n",
-    "Welcome to this advanced guide on implementing OpenAI embeddings within the MLflow framework. This tutorial delves into the configuration and utilization of OpenAI's powerful embeddings, a key component in modern machine learning models.\n",
-    "\n",
+    "Welcome to this advanced guide on implementing OpenAI embeddings within the MLflow framework. This tutorial delves into the configuration and utilization of OpenAI's powerful embeddings, a key component in modern machine learning models.\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-embeddings-generation.ipynb\" class=\"notebook-download-btn\">Download this Notebook</a><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Understanding Embeddings\n",
     "\n",
     "Embeddings are a form of representation learning where words, phrases, or even entire documents are converted into vectors in a high-dimensional space. These vectors capture semantic meaning, enabling models to understand and process language more effectively. Embeddings are extensively used in natural language processing (NLP) for tasks like text classification, sentiment analysis, and language translation.\n",

--- a/docs/source/llms/openai/notebooks/openai-quickstart.ipynb
+++ b/docs/source/llms/openai/notebooks/openai-quickstart.ipynb
@@ -6,7 +6,20 @@
    "source": [
     "## Introduction to Using the OpenAI Flavor in MLflow\n",
     "\n",
-    "Welcome to our tutorial on harnessing the power of OpenAI's GPT models through the MLflow `openai` flavor. In this session, we embark on a journey to explore the intriguing world of AI-powered text analysis and modification. As we delve into the capabilities of GPT models, you'll discover the nuances of their API and understand the evolution from the older Completions API to the more advanced ChatCompletions, which offers a conversational style interaction.\n",
+    "Welcome to our tutorial on harnessing the power of OpenAI's GPT models through the MLflow `openai` flavor. In this session, we embark on a journey to explore the intriguing world of AI-powered text analysis and modification. As we delve into the capabilities of GPT models, you'll discover the nuances of their API and understand the evolution from the older Completions API to the more advanced ChatCompletions, which offers a conversational style interaction.\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-chat-completions.ipynb\" class=\"notebook-download-btn\">Download this Notebook</a><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
     "### What You Will Learn:\n",
     "- **Interfacing with GPT Models**: Understand how to interact with different model families like GPT-3.5 and GPT-4.\n",

--- a/docs/source/llms/openai/notebooks/openai-quickstart.ipynb
+++ b/docs/source/llms/openai/notebooks/openai-quickstart.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-chat-completions.ipynb\" class=\"notebook-download-btn\">Download this Notebook</a><br>"
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/openai/notebooks/openai-chat-completions.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
    ]
   },
   {

--- a/docs/source/llms/sentence-transformers/index.rst
+++ b/docs/source/llms/sentence-transformers/index.rst
@@ -98,6 +98,16 @@ Getting Started with the MLflow Sentence Transformers Flavor - Tutorials and Gui
 Below, you will find a number of guides that focus on different ways that you can leverage the power of the `sentence-transformers` library, leveraging MLflow's 
 APIs for tracking and inference capabilities. 
 
+
+.. toctree::
+    :maxdepth: 2
+    :hidden:
+
+    tutorials/quickstart/sentence-transformers-quickstart.ipynb
+    tutorials/paraphrase-mining/paraphrase-mining-sentence-transformers.ipynb
+    tutorials/semantic-search/semantic-search-sentence-transformers.ipynb
+    tutorials/semantic-similarity/semantic-similarity-sentence-transformers.ipynb
+
 Introductory Tutorial
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -118,11 +128,6 @@ Introductory Tutorial
             </div>
         </article>
     </section>
-
-.. raw:: html
-
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/sentence-transformers/tutorials/quickstart/sentence-transformers-quickstart.ipynb" class="notebook-download-btn">Download the Introductory Notebook</a><br>
-
 
 Advanced Tutorials
 ^^^^^^^^^^^^^^^^^^
@@ -163,27 +168,6 @@ Advanced Tutorials
             </div>
         </article>
     </section>
-
-Download the Advanced Tutorial Notebooks
-----------------------------------------
-
-To download the advanced sentence transformers tutorial notebooks to run in your environment, click the respective links below:
-
-.. raw:: html
-
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/sentence-transformers/tutorials/semantic-search/semantic-similarity-sentence-transformers.ipynb" class="notebook-download-btn">Download the Semantic Similarity Notebook</a><br>
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/sentence-transformers/tutorials/quickstart/semantic-search-sentence-transformers.ipynb" class="notebook-download-btn">Download the Semantic Search Notebook</a><br>        
-    <a href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/sentence-transformers/tutorials/quickstart/paraphrase-mining-sentence-transformers.ipynb" class="notebook-download-btn">Download the Paraphrase Mining Notebook</a><br>
-
-
-.. toctree::
-    :maxdepth: 2
-    :hidden:
-
-    tutorials/quickstart/sentence-transformers-quickstart.ipynb
-    tutorials/paraphrase-mining/paraphrase-mining-sentence-transformers.ipynb
-    tutorials/semantic-search/semantic-search-sentence-transformers.ipynb
-    tutorials/semantic-similarity/semantic-similarity-sentence-transformers.ipynb
 
 
 `Detailed Documentation <guide/index.html>`_

--- a/docs/source/llms/sentence-transformers/tutorials/paraphrase-mining/paraphrase-mining-sentence-transformers.ipynb
+++ b/docs/source/llms/sentence-transformers/tutorials/paraphrase-mining/paraphrase-mining-sentence-transformers.ipynb
@@ -6,8 +6,20 @@
    "source": [
     "## Advanced Paraphrase Mining with Sentence Transformers and MLflow\n",
     "\n",
-    "Embark on an enriching journey through advanced paraphrase mining using Sentence Transformers, enhanced by MLflow.\n",
-    "\n",
+    "Embark on an enriching journey through advanced paraphrase mining using Sentence Transformers, enhanced by MLflow."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/sentence-transformers/tutorials/quickstart/paraphrase-mining-sentence-transformers.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Learning Objectives\n",
     "\n",
     "- Apply `sentence-transformers` for advanced paraphrase mining.\n",

--- a/docs/source/llms/sentence-transformers/tutorials/quickstart/sentence-transformers-quickstart.ipynb
+++ b/docs/source/llms/sentence-transformers/tutorials/quickstart/sentence-transformers-quickstart.ipynb
@@ -6,8 +6,20 @@
    "source": [
     "## Introduction to Sentence Transformers and MLflow\n",
     "\n",
-    "Welcome to our tutorial on leveraging **Sentence Transformers** with **MLflow** for advanced natural language processing and model management.\n",
-    "\n",
+    "Welcome to our tutorial on leveraging **Sentence Transformers** with **MLflow** for advanced natural language processing and model management."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/sentence-transformers/tutorials/quickstart/sentence-transformers-quickstart.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Learning Objectives\n",
     "\n",
     "- Set up a pipeline for sentence embeddings with `sentence-transformers`.\n",

--- a/docs/source/llms/sentence-transformers/tutorials/semantic-search/semantic-search-sentence-transformers.ipynb
+++ b/docs/source/llms/sentence-transformers/tutorials/semantic-search/semantic-search-sentence-transformers.ipynb
@@ -6,8 +6,20 @@
    "source": [
     "## Advanced Semantic Search with Sentence Transformers and MLflow\n",
     "\n",
-    "Embark on a hands-on journey exploring Advanced Semantic Search using Sentence Transformers and MLflow.\n",
-    "\n",
+    "Embark on a hands-on journey exploring Advanced Semantic Search using Sentence Transformers and MLflow.\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/sentence-transformers/tutorials/quickstart/semantic-search-sentence-transformers.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### What You Will Learn\n",
     "\n",
     "- Implement advanced semantic search with `sentence-transformers`.\n",

--- a/docs/source/llms/sentence-transformers/tutorials/semantic-similarity/semantic-similarity-sentence-transformers.ipynb
+++ b/docs/source/llms/sentence-transformers/tutorials/semantic-similarity/semantic-similarity-sentence-transformers.ipynb
@@ -6,8 +6,20 @@
    "source": [
     "## Introduction to Advanced Semantic Similarity Analysis with Sentence Transformers and MLflow\n",
     "\n",
-    "Dive into advanced Semantic Similarity Analysis using Sentence Transformers and MLflow in this comprehensive tutorial.\n",
-    "\n",
+    "Dive into advanced Semantic Similarity Analysis using Sentence Transformers and MLflow in this comprehensive tutorial."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://raw.githubusercontent.com/mlflow/mlflow/master/docs/source/llms/sentence-transformers/tutorials/semantic-search/semantic-similarity-sentence-transformers.ipynb\" class=\"notebook-download-btn\"><i class=\"fas fa-download\"></i>Download this Notebook</a><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Learning Objectives\n",
     "\n",
     "- Configure `sentence-transformers` for semantic similarity analysis.\n",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11378?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11378/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11378
```

</p>
</details>

### Related Issues/PRs

Follow-up for https://github.com/mlflow/mlflow/pull/11216#discussion_r1498688096

### What changes are proposed in this pull request?

"Download xxx Notebook" buttons were listed inside the index page like [this](https://mlflow.org/docs/latest/llms/openai/index.html#download-the-advanced-tutorial-notebooks).
![Screenshot 2024-03-11 at 11 43 19](https://github.com/mlflow/mlflow/assets/31463517/78f1d1ee-3231-4cd4-932b-cdc720df04b7)

However, this is probably not the best place to put the buttons because
* Users who landed on the notebook page first won't find the button.
* As the number of notebook increases, it might be frustrating to find the corresponding button from the list.

Therefore, this PR simply move the link inside each notebook (similar to what we did for Transformers doc).

<img width="1277" alt="Screenshot 2024-03-11 at 11 47 31" src="https://github.com/mlflow/mlflow/assets/31463517/c49b1926-98f7-4f6e-9952-fc508ec81f58">

**Note**
Please use "Changed pages" link in the comment for reviewing, this PR would be the best use case for that cool feature:)

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
