### PR TITLE
Fix keras 3 autologging signature test failure

### DIFF
--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -47,7 +47,7 @@ def clear_session():
 
 @pytest.fixture
 def random_train_data():
-    return np.random.random((150, 4)).astype(dtype=np.float32)
+    return np.random.random((150, 4))
 
 
 @pytest.fixture
@@ -157,7 +157,8 @@ def clear_autologging_config():
 
 def create_tf_keras_model():
     model = tf.keras.Sequential()
-    model.add(layers.Dense(16, activation="relu", input_shape=(4,)))
+    model.add(tf.keras.Input(shape=(4,), dtype="float64"))
+    model.add(layers.Dense(16, activation="relu"))
     model.add(layers.Dense(3, activation="softmax"))
 
     model.compile(
@@ -1257,7 +1258,7 @@ def test_keras_autolog_logs_model_signature_by_default(keras_data_gen_sequence):
     assert "inputs" in signature
     assert "outputs" in signature
     assert json.loads(signature["inputs"]) == [
-        {"type": "tensor", "tensor-spec": {"dtype": "float32", "shape": [-1, 4]}}
+        {"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1, 4]}}
     ]
     assert json.loads(signature["outputs"]) == [
         {"type": "tensor", "tensor-spec": {"dtype": "float32", "shape": [-1, 3]}}

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -47,7 +47,7 @@ def clear_session():
 
 @pytest.fixture
 def random_train_data():
-    return np.random.random((150, 4))
+    return np.random.random((150, 4), dtype=np.float32)
 
 
 @pytest.fixture

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -47,7 +47,7 @@ def clear_session():
 
 @pytest.fixture
 def random_train_data():
-    return np.random.random((150, 4), dtype=np.float32)
+    return np.random.random((150, 4)).astype(dtype=np.float32)
 
 
 @pytest.fixture

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1257,7 +1257,7 @@ def test_keras_autolog_logs_model_signature_by_default(keras_data_gen_sequence):
     assert "inputs" in signature
     assert "outputs" in signature
     assert json.loads(signature["inputs"]) == [
-        {"type": "tensor", "tensor-spec": {"dtype": "float64", "shape": [-1, 4]}}
+        {"type": "tensor", "tensor-spec": {"dtype": "float32", "shape": [-1, 4]}}
     ]
     assert json.loads(signature["outputs"]) == [
         {"type": "tensor", "tensor-spec": {"dtype": "float32", "shape": [-1, 3]}}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/11386?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11386/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11386
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix: tests/tensorflow/test_tensorflow2_autolog.py::test_keras_autolog_logs_model_signature_by_default

For Keras3, MLflow infers Keras3 model signiture input type by `model.input_dtype`,
but for Keras < 3, MLflow infers model signiture input type from input dataset, this leads to different results in current test case.

`create_tf_keras_model` creates a keras model, in Keras 3, if we don't specify InputLayer, the model input type `model.input_dtype` will be set to float32 by default

But the `keras_data_gen_sequence` testing dataset in the suite generates input dataset of `np.random.random((150, 4))` which is `np.float64` types, this makes Keras < 3 autologging infers the model input type as `float32`.

So this test succeeds before, but it started to fail in cross test Tensorflow >= 2.16 (which is released 1 day ago and depends on Keras 3)

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
