### PR TITLE
Skip copying metadata for legacy flavor module without `model_data_artifact_paths` attribute

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -635,7 +635,7 @@ class Model:
                     src_file_path = os.path.join(local_path, file_name)
                     dest_file_path = os.path.join(metadata_path, file_name)
                     shutil.copyfile(src_file_path, dest_file_path)
-            else:
+            elif hasattr(flavor, "model_data_artifact_paths"):
                 # Copy metadata files to the 'metadata' subdirectory
                 model_data_subpaths = flavor.model_data_artifact_paths
                 non_metadata_subpaths = ["code", *model_data_subpaths]

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -503,7 +503,6 @@ def test_copy_metadata(tmp_path, sklearn_knn_model):
 
 
 class LegacyTestFlavor:
-
     @classmethod
     def save_model(cls, path, mlflow_model):
         mlflow_model.flavors["flavor1"] = {"a": 1, "b": 2}
@@ -517,7 +516,5 @@ def test_legacy_flavor():
         model_info = Model.log("some/path", LegacyTestFlavor)
 
     with TempDir(chdr=True) as tmp:
-        artifact_path = _download_artifact_from_uri(
-            model_info.model_uri, output_path=tmp.path()
-        )
-        assert set(os.listdir(artifact_path)) == {'MLmodel'}
+        artifact_path = _download_artifact_from_uri(model_info.model_uri, output_path=tmp.path())
+        assert set(os.listdir(artifact_path)) == {"MLmodel"}

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -500,3 +500,24 @@ def test_copy_metadata(tmp_path, sklearn_knn_model):
             "python_env.yaml",
             "requirements.txt",
         }
+
+
+class LegacyTestFlavor:
+
+    @classmethod
+    def save_model(cls, path, mlflow_model):
+        mlflow_model.flavors["flavor1"] = {"a": 1, "b": 2}
+        mlflow_model.flavors["flavor2"] = {"x": 1, "y": 2}
+        _validate_and_prepare_target_save_path(path)
+        mlflow_model.save(os.path.join(path, "MLmodel"))
+
+
+def test_legacy_flavor():
+    with mlflow.start_run():
+        model_info = Model.log("some/path", LegacyTestFlavor)
+
+    with TempDir(chdr=True) as tmp:
+        artifact_path = _download_artifact_from_uri(
+            model_info.model_uri, output_path=tmp.path()
+        )
+        assert set(os.listdir(artifact_path)) == {'MLmodel'}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/11392?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11392/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11392
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Skip copying metadata for legacy flavor module without `model_data_artifact_paths` attribute

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
