### PR TITLE
[WIP] demo for supporting models with remote code

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -575,7 +575,9 @@ def save_model(
 
     # Save pipeline model and components weights
     if save_pretrained:
-        save_pipeline_pretrained_weights(path, built_pipeline, flavor_conf, processor)
+        save_pipeline_pretrained_weights(
+            path, built_pipeline, flavor_conf, processor, code_dir_subpath
+        )
     else:
         repo = built_pipeline.model.name_or_path
         _logger.info(

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -120,7 +120,6 @@ from mlflow.utils.model_utils import (
     _validate_and_prepare_target_save_path,
 )
 from mlflow.utils.requirements_utils import _get_pinned_requirement
-from mlflow.utils.uri import append_to_uri_path
 
 # The following import is only used for type hinting
 if TYPE_CHECKING:
@@ -988,15 +987,6 @@ def load_model(
 
     flavor_config = _get_flavor_configuration_from_uri(model_uri, FLAVOR_NAME, _logger)
 
-    # just temp code to fetch the HF config file
-    hf_config = json.loads(
-        pathlib.Path(
-            _download_artifact_from_uri(
-                artifact_uri=append_to_uri_path(model_uri, _MODEL_BINARY_FILE_NAME, "config.json")
-            )
-        ).read_text()
-    )
-
     if return_type == "pipeline" and FlavorKey.PROCESSOR_TYPE in flavor_config:
         raise MlflowException(
             "This model has been saved with a processor. Processor objects are "
@@ -1007,7 +997,7 @@ def load_model(
 
     _add_code_from_conf_to_system_path(local_model_path, flavor_config)
 
-    return _load_model(local_model_path, hf_config, flavor_config, return_type, device, **kwargs)
+    return _load_model(local_model_path, flavor_config, return_type, device, **kwargs)
 
 
 def persist_pretrained_model(model_uri: str) -> None:
@@ -1135,7 +1125,7 @@ def is_gpu_available():
     return is_gpu
 
 
-def _load_model(path: str, hf_config, flavor_config, return_type: str, device=None, **kwargs):
+def _load_model(path: str, flavor_config, return_type: str, device=None, **kwargs):
     """
     Loads components from a locally serialized ``Pipeline`` object.
     """
@@ -1185,7 +1175,6 @@ def _load_model(path: str, hf_config, flavor_config, return_type: str, device=No
         model_and_components = load_model_and_components_from_local(
             path=pathlib.Path(path),
             flavor_conf=flavor_config,
-            hf_config=hf_config,
             accelerate_conf=accelerate_model_conf,
             device=device,
         )

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -190,7 +190,10 @@ def save_remote_code_to_code_path(built_pipeline: transformers.Pipeline, code_pa
 
 
 def init_custom_module_directory(model_path: Path, flavor_conf: dict):
-    code_subpath = flavor_conf.get(FLAVOR_CONFIG_CODE, DEFAULT_CODE_SUBPATH)
+    config_code_subpath = flavor_conf.get(FLAVOR_CONFIG_CODE, DEFAULT_CODE_SUBPATH)
+
+    # there seems to be a bug where we save `code: null` in the config
+    code_subpath = DEFAULT_CODE_SUBPATH if config_code_subpath is None else config_code_subpath
     full_code_path = model_path.parent / code_subpath
     custom_module_path = full_code_path / _MLFLOW_PYFUNC_CUSTOM_MODULES_NAME
     custom_module_path.mkdir(parents=True, exist_ok=True)

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -255,9 +255,10 @@ def _load_model(model_name_or_path, flavor_conf, hf_config, accelerate_conf, dev
     """
     import transformers
 
-    try:
-        cls = getattr(transformers, flavor_conf[FlavorKey.MODEL_TYPE])
-    except AttributeError:
+    model_classname = flavor_conf[FlavorKey.MODEL_TYPE]
+    if hasattr(transformers, model_classname):
+        cls = getattr(transformers, model_classname)
+    else:
         try:
             init_custom_module_directory(model_name_or_path, flavor_conf)
             cls = _load_model_from_code_paths(flavor_conf[FlavorKey.MODEL_TYPE], hf_config)

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 import logging
 import os
 import shutil
@@ -66,9 +67,7 @@ def save_pipeline_pretrained_weights(
         processor.save_pretrained(component_dir.joinpath(_PROCESSOR_BINARY_DIR_NAME))
 
 
-def load_model_and_components_from_local(
-    path, flavor_conf, hf_config, accelerate_conf, device=None
-):
+def load_model_and_components_from_local(path, flavor_conf, accelerate_conf, device=None):
     """
     Load the model and components of a Transformer pipeline from the specified local path.
 
@@ -86,6 +85,7 @@ def load_model_and_components_from_local(
     #     "artifacts/pipeline/*" path. In order to load the older formats after the change, the
     #     presence of the new path key is checked.
     model_path = path.joinpath(flavor_conf.get(FlavorKey.MODEL_BINARY, "pipeline"))
+    hf_config = json.loads(path.joinpath(_MODEL_BINARY_FILE_NAME, "config.json").read_text())
     loaded[FlavorKey.MODEL] = _load_model(
         model_path, flavor_conf, hf_config, accelerate_conf, device
     )

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -263,8 +263,10 @@ def _load_model(model_name_or_path, flavor_conf, hf_config, accelerate_conf, dev
             init_custom_module_directory(model_name_or_path, flavor_conf)
             cls = _load_model_from_code_paths(flavor_conf[FlavorKey.MODEL_TYPE], hf_config)
         except Exception as e:
-            _logger.error(f"Error loading model from code paths: {e}")
-            raise e
+            raise MlflowException(
+                "Encountered unexpected error while loading model from code paths. "
+                f"Full exception trace: {e}"
+            )
 
     load_kwargs = {"revision": revision} if revision else {}
 

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -20,6 +20,7 @@ from mlflow.utils.file_utils import _copy_file_or_tree
 from mlflow.utils.uri import append_to_uri_path
 
 FLAVOR_CONFIG_CODE = "code"
+DEFAULT_CODE_SUBPATH = "code"
 
 
 def _get_all_flavor_configurations(model_path):
@@ -128,7 +129,7 @@ def _validate_code_paths(code_paths):
             raise TypeError(f"Argument code_paths should be a list, not {type(code_paths)}")
 
 
-def _validate_and_copy_code_paths(code_paths, path, default_subpath="code"):
+def _validate_and_copy_code_paths(code_paths, path, default_subpath=DEFAULT_CODE_SUBPATH):
     """Validates that a code path is a valid list and copies the code paths to a directory. This
     can later be used to log custom code as an artifact.
 


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
