### PR TITLE
Support transformers models with custom code (models requiring `trust_remote_code=True`)

### DIFF
--- a/docs/source/llms/transformers/guide/index.rst
+++ b/docs/source/llms/transformers/guide/index.rst
@@ -403,6 +403,9 @@ Pipelines vs. Component Logging
 
 The transformers flavor has two different primary mechanisms for saving and loading models: pipelines and components.
 
+.. note::
+    Saving transformers models with custom code (i.e. models that require ``trust_remote_code=True``) requires ``transformers >= 4.26.0``.
+
 **Pipelines**
 
 Pipelines, in the context of the Transformers library, are high-level objects that combine pre-trained models and tokenizers 

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1,4 +1,5 @@
 """MLflow module for HuggingFace/transformer support."""
+
 from __future__ import annotations
 
 import ast
@@ -280,7 +281,9 @@ def save_model(
     **kwargs,  # pylint: disable=unused-argument
 ) -> None:
     """
-    Save a trained transformers model to a path on the local file system.
+    Save a trained transformers model to a path on the local file system. Note that
+    saving transformers models with custom code (i.e. models that require
+    ``trust_remote_code=True``) requires ``transformers >= 4.26.0``.
 
     Args:
         transformers_model:
@@ -708,7 +711,9 @@ def log_model(
     **kwargs,
 ):
     """
-    Log a ``transformers`` object as an MLflow artifact for the current run.
+    Log a ``transformers`` object as an MLflow artifact for the current run. Note that
+    logging ``transformers`` models with custom code (i.e. models that require
+    ``trust_remote_code=True``) requires ``transformers >= 4.26.0``.
 
     Args:
         transformers_model:

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -712,7 +712,7 @@ def log_model(
 ):
     """
     Log a ``transformers`` object as an MLflow artifact for the current run. Note that
-    logging ``transformers`` models with custom code (i.e. models that require
+    logging transformers models with custom code (i.e. models that require
     ``trust_remote_code=True``) requires ``transformers >= 4.26.0``.
 
     Args:

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -135,6 +135,7 @@ def _load_model(model_name_or_path, flavor_conf, accelerate_conf, device, revisi
 
     if hasattr(transformers, flavor_conf[FlavorKey.MODEL_TYPE]):
         cls = getattr(transformers, flavor_conf[FlavorKey.MODEL_TYPE])
+        trust_remote = False
     else:
         config = AutoConfig.from_pretrained(
             model_name_or_path, revision=revision, trust_remote_code=True

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -59,7 +59,7 @@ def load_model_and_components_from_local(path, flavor_conf, accelerate_conf, dev
     #     "artifacts/pipeline/*" path. In order to load the older formats after the change, the
     #     presence of the new path key is checked.
     model_path = path.joinpath(flavor_conf.get(FlavorKey.MODEL_BINARY, "pipeline"))
-    loaded[FlavorKey.MODEL] = _load_model(model_path)
+    loaded[FlavorKey.MODEL] = _load_model(model_path, flavor_conf, accelerate_conf, device)
 
     components = flavor_conf.get(FlavorKey.COMPONENTS, [])
     if FlavorKey.PROCESSOR_TYPE in flavor_conf:
@@ -93,7 +93,9 @@ def load_model_and_components_from_huggingface_hub(flavor_conf, accelerate_conf,
             error_code=INVALID_STATE,
         )
 
-    loaded[FlavorKey.MODEL] = _load_model(model_repo, revision=model_revision)
+    loaded[FlavorKey.MODEL] = _load_model(
+        model_repo, flavor_conf, accelerate_conf, device, revision=model_revision
+    )
 
     components = flavor_conf.get(FlavorKey.COMPONENTS, [])
     if FlavorKey.PROCESSOR_TYPE in flavor_conf:
@@ -121,7 +123,7 @@ def _load_component(flavor_conf, name, local_path=None):
         return cls.from_pretrained(repo, revision=revision)
 
 
-def _load_model(model_name_or_path, revision=None):
+def _load_model(model_name_or_path, flavor_conf, accelerate_conf, device, revision=None):
     """
     Try to load a model with various loading strategies.
       1. Try to load the model with accelerate

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -160,7 +160,7 @@ def _load_class_from_transformers_config(model_name_or_path, revision=None):
         auto_classes = [
             auto_class
             for auto_class, module in config.auto_map.items()
-            if module.endswith(class_name)
+            if module.split(".")[-1] == class_name
         ]
 
         if len(auto_classes) == 0:

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -123,6 +123,56 @@ def _load_component(flavor_conf, name, local_path=None):
         return cls.from_pretrained(repo, revision=revision)
 
 
+def _load_class_from_transformers_config(model_name_or_path, revision=None):
+    """
+    This method retrieves the Transformers AutoClass from the transformers config.
+    Using the correct AutoClass allows us to leverage Transformers' model loading
+    machinery, which is necessary for supporting models using custom code.
+    """
+    import transformers
+    from transformers import AutoConfig
+
+    config = AutoConfig.from_pretrained(
+        model_name_or_path,
+        revision=revision,
+        # trust_remote_code is set to True in order to
+        # make sure the config gets loaded as the correct
+        # class. if this is not set for custom models, the
+        # base class will be loaded instead of the custom one.
+        trust_remote_code=True,
+    )
+
+    # the model's class name (e.g. "MPTForCausalLM")
+    # is stored in the `architectures` field. it
+    # seems to usually just have one element.
+    class_name = config.architectures[0]
+
+    # if the class is available in transformers natively,
+    # then we don't need to execute any custom code.
+    if hasattr(transformers, class_name):
+        cls = getattr(transformers, class_name)
+        return cls, False
+    else:
+        # else, we need to fetch the correct AutoClass.
+        # this is defined in the `auto_map` field. there
+        # should only be one AutoClass that maps to the
+        # model's class name.
+        auto_classes = [
+            auto_class
+            for auto_class, module in config.auto_map.items()
+            if module.endswith(class_name)
+        ]
+
+        if len(auto_classes) == 0:
+            raise MlflowException(f"Couldn't find a loader class for {class_name}")
+
+        auto_class = auto_classes[0]
+        cls = getattr(transformers, auto_class)
+
+        # we will need to trust remote code when loading the model
+        return cls, True
+
+
 def _load_model(model_name_or_path, flavor_conf, accelerate_conf, device, revision=None):
     """
     Try to load a model with various loading strategies.
@@ -131,29 +181,14 @@ def _load_model(model_name_or_path, flavor_conf, accelerate_conf, device, revisi
       3. Load the model without the device
     """
     import transformers
-    from transformers import AutoConfig
 
     if hasattr(transformers, flavor_conf[FlavorKey.MODEL_TYPE]):
         cls = getattr(transformers, flavor_conf[FlavorKey.MODEL_TYPE])
         trust_remote = False
     else:
-        config = AutoConfig.from_pretrained(
-            model_name_or_path, revision=revision, trust_remote_code=True
+        cls, trust_remote = _load_class_from_transformers_config(
+            model_name_or_path, revision=revision
         )
-        class_name = config.architectures[0]
-
-        if hasattr(transformers, class_name):
-            cls = getattr(transformers, class_name)
-            trust_remote = False
-        else:
-            auto_classes = [
-                auto_class for auto_class, module in config.auto_map.items() if class_name in module
-            ]
-            if len(auto_classes) == 0:
-                raise MlflowException(f"Couldn't find a loader class for {class_name}")
-            auto_class = auto_classes[0]
-            cls = getattr(transformers, auto_class)
-            trust_remote = True
 
     load_kwargs = {"revision": revision} if revision else {}
     if trust_remote:

--- a/tests/transformers/conftest.py
+++ b/tests/transformers/conftest.py
@@ -4,6 +4,7 @@ from tests.transformers.helper import (
     load_audio_classification_pipeline,
     load_component_multi_modal,
     load_conversational_pipeline,
+    load_custom_code_pipeline,
     load_feature_extraction_pipeline,
     load_fill_mask_pipeline,
     load_ner_pipeline,
@@ -48,6 +49,11 @@ def small_multi_modal_pipeline():
 @pytest.fixture
 def component_multi_modal():
     return load_component_multi_modal()
+
+
+@pytest.fixture
+def custom_code_pipeline():
+    return load_custom_code_pipeline()
 
 
 @pytest.fixture

--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -287,6 +287,20 @@ def load_peft_pipeline():
         )
 
 
+@prefetch
+@flaky()
+def load_custom_code_pipeline():
+    model = transformers.AutoModel.from_pretrained(
+        "hf-internal-testing/test_dynamic_model_with_util", trust_remote_code=True
+    )
+    tokenizer = transformers.AutoTokenizer.from_pretrained("google-bert/bert-base-uncased")
+    return transformers.pipeline(
+        task="feature-extraction",
+        model=model,
+        tokenizer=tokenizer,
+    )
+
+
 def prefetch_models():
     """
     Prefetches models used in the test suite to avoid downloading them during the test run.

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1369,6 +1369,9 @@ def test_table_question_answering_pipeline(
     assert pd_inference == result
 
 
+@pytest.mark.skipif(
+    Version(transformers.__version__) < Version("4.26"), reason="Feature is not available"
+)
 def test_custom_code_pipeline(custom_code_pipeline, model_path):
     data = "hello"
 

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1369,6 +1369,29 @@ def test_table_question_answering_pipeline(
     assert pd_inference == result
 
 
+def test_custom_code_pipeline(custom_code_pipeline, model_path):
+    data = "hello"
+
+    signature = infer_signature(
+        data, mlflow.transformers.generate_signature_output(custom_code_pipeline, data)
+    )
+
+    mlflow.transformers.save_model(
+        custom_code_pipeline,
+        path=model_path,
+        signature=signature,
+    )
+
+    # just test that it doens't blow up when performing inference
+    pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
+    pyfunc_pred = pyfunc_loaded.predict(data)
+    assert isinstance(pyfunc_pred[0][0], float)
+
+    transformers_loaded = mlflow.transformers.load_model(model_path)
+    transformers_pred = transformers_loaded(data)
+    assert pyfunc_pred[0][0] == transformers_pred[0][0][0]
+
+
 @pytest.mark.parametrize(
     ("data", "result"),
     [
@@ -2846,8 +2869,8 @@ def test_whisper_model_with_malformed_audio(whisper_pipeline):
 def test_save_model_card_with_non_utf_characters(tmp_path, model_name):
     # non-ascii unicode characters
     test_text = (
-        "Emoji testing! \u2728 \U0001F600 \U0001F609 \U0001F606 "
-        "\U0001F970 \U0001F60E \U0001F917 \U0001F9D0"
+        "Emoji testing! \u2728 \U0001f600 \U0001f609 \U0001f606 "
+        "\U0001f970 \U0001f60e \U0001f917 \U0001f9d0"
     )
 
     card_data: ModelCard = huggingface_hub.ModelCard.load(model_name)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11412?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11412/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11412
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Closes #10887

### What changes are proposed in this pull request?

Disregard my other PR, this one is way better. Just rely on transformers to do what they do. All this PR does is fetch the correct transformers class from the config.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.transformers.save_model()` and `log_model()` now support models that require custom code.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
