### PR TITLE
Fix docs for system metric logging

### DIFF
--- a/docs/source/system-metrics/index.rst
+++ b/docs/source/system-metrics/index.rst
@@ -29,7 +29,7 @@ Turn on/off System Metrics Logging
 
 There are three ways to enable or disable system metrics logging:
 
-- Set the environment variable ``MLFLOW_LOG_SYSTEM_METRICS`` to `false` to turn off system metrics logging,
+- Set the environment variable ``MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING`` to `false` to turn off system metrics logging,
   or `true` to enable it for all MLflow runs.
 - Use :py:func:`mlflow.enable_system_metrics_logging()` to enable and
   :py:func:`mlflow.disable_system_metrics_logging()` to disable system metrics logging for all MLflow runs.
@@ -39,7 +39,7 @@ There are three ways to enable or disable system metrics logging:
 Using the Environment Variable to Control System Metrics Logging
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can set the environment variable ``MLFLOW_LOG_SYSTEM_METRICS`` to ``true`` to turn on system metrics
+You can set the environment variable ``MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING`` to ``true`` to turn on system metrics
 logging globally, as shown below:
 
 .. code-block:: bash


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/GuyAglionby/mlflow/pull/11413?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11413/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11413
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Fix documentation to refer to `MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING` as the correct environment variable for controlling whether system metrics are logged.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [X] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix the documented environment variable for logging system metrics to MLflow.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
