### PR TITLE
Include java version in matrix for cross version tests

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -142,24 +142,9 @@ jobs:
         with:
           python-version: ${{ steps.get-python-version.outputs.version }}
       - uses: ./.github/actions/setup-pyenv
-      - name: Get Java version
-        id: get-java-version
-        run: |
-          if [ "${{ matrix.package }}" = "pyspark" ]; then
-            pip install packaging
-            use_java17=$(python -c "from packaging.version import parse; print('${{ matrix.version }}' == 'dev' or parse('${{ matrix.version }}') > parse('3.4.1'))")
-            if [ "$use_java17" = "True" ]; then
-              java_version=17
-            else
-              java_version=11
-            fi
-          else
-            java_version=11
-          fi
-          echo "version=$java_version" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/setup-java
         with:
-          java-version: ${{ steps.get-java-version.outputs.version }}
+          java-version: ${{ matrix.java }}
           distribution: "adopt"
       - name: Install mlflow & test dependencies
         run: |

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -70,6 +70,7 @@ class TestConfig(BaseModel):
     maximum: Version
     unsupported: t.Optional[t.List[Version]] = None
     requirements: t.Optional[t.Dict[str, t.List[str]]] = None
+    java: t.Optional[t.Dict[str, str]] = None
     run: str
     allow_unreleased_max_version: t.Optional[bool] = None
 
@@ -99,6 +100,7 @@ class MatrixItem(BaseModel):
     package: str
     version: Version
     supported: bool
+    java: str
 
     class Config:
         arbitrary_types_allowed = True
@@ -228,6 +230,19 @@ def get_matched_requirements(requirements, version=None):
     return sorted(reqs)
 
 
+def get_java_version(java: t.Optional[t.Dict[str, str]], version: str) -> str:
+    default = "11"
+    if java is None:
+        return default
+
+    for specifier, java_ver in java.items():
+        specifier_set = SpecifierSet(specifier.replace(DEV_VERSION, DEV_NUMERIC))
+        if specifier_set.contains(DEV_NUMERIC if version == DEV_VERSION else version):
+            return java_ver
+
+    return default
+
+
 def remove_comments(s):
     return "\n".join(l for l in s.strip().split("\n") if not l.strip().startswith("#"))
 
@@ -343,6 +358,7 @@ def expand_config(config):
                 requirements.extend(get_matched_requirements(cfg.requirements or {}, str(ver)))
                 install = make_pip_install_command(requirements)
                 run = remove_comments(cfg.run)
+                java = get_java_version(cfg.java, str(ver))
 
                 matrix.add(
                     MatrixItem(
@@ -355,6 +371,7 @@ def expand_config(config):
                         package=package_info.pip_release,
                         version=ver,
                         supported=ver <= cfg.maximum,
+                        java=java,
                     )
                 )
 
@@ -365,6 +382,7 @@ def expand_config(config):
                     install = make_pip_install_command(requirements) + "\n" + install_dev
                 else:
                     install = install_dev
+                java = get_java_version(cfg.java, DEV_VERSION)
 
                 run = remove_comments(cfg.run)
                 dev_version = Version.create_dev()
@@ -379,6 +397,7 @@ def expand_config(config):
                         package=package_info.pip_release,
                         version=dev_version,
                         supported=False,
+                        java=java,
                     )
                 )
     return matrix

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -99,8 +99,8 @@ class MatrixItem(BaseModel):
     run: str
     package: str
     version: Version
-    supported: bool
     java: str
+    supported: bool
 
     class Config:
         arbitrary_types_allowed = True
@@ -370,8 +370,8 @@ def expand_config(config):
                         run=run,
                         package=package_info.pip_release,
                         version=ver,
-                        supported=ver <= cfg.maximum,
                         java=java,
+                        supported=ver <= cfg.maximum,
                     )
                 )
 
@@ -396,8 +396,8 @@ def expand_config(config):
                         run=run,
                         package=package_info.pip_release,
                         version=dev_version,
-                        supported=False,
                         java=java,
+                        supported=False,
                     )
                 )
     return matrix

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -350,6 +350,8 @@ spark:
   models:
     minimum: "3.1.2"
     maximum: "3.5.1"
+    java:
+      "> 3.4.1": "17"
     # NB: Allow unreleased maximum versions for the pyspark package to support models and
     # autologging use cases in environments where newer versions of pyspark are available
     # prior to their release on PyPI (e.g. Databricks)
@@ -377,6 +379,8 @@ spark:
   autologging:
     minimum: "3.1.2"
     maximum: "3.5.1"
+    java:
+      ">= 3.4.1": "17"
     # NB: Allow unreleased maximum versions for the pyspark package to support models and
     # autologging use cases in environments where newer versions of pyspark are available
     # prior to their release on PyPI (e.g. Databricks)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11419?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11419/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11419
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Include the java version to use in the matrix for cross version tests.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
