### PR TITLE
Pretty print JSON in traces

### DIFF
--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -103,7 +103,7 @@ class DummyTraceClientWithHTMLDisplay(TraceClient):
         """
 
         def _pretty_print_dict(dict):
-            return f"<pre>{json.dumps(dict, default=lambda obj: str(obj), indent=2)}</pre>"
+            return f"<pre>{json.dumps(dict, default=str, indent=2)}</pre>"
 
         # Function to recursively generate HTML for each span event with depth-based indentation
         def _generate_span_html(node, depth=0):

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -1,4 +1,5 @@
 import colorsys
+import json
 import random
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -88,6 +89,10 @@ class DummyTraceClientWithHTMLDisplay(TraceClient):
             .expanded .metadata {
                 display: block;
             }
+
+            pre {
+                white-space: pre-wrap;
+            }
         </style>
         <script>
             function toggleExpand(event) {
@@ -96,6 +101,9 @@ class DummyTraceClientWithHTMLDisplay(TraceClient):
             }
         </script>
         """
+
+        def _pretty_print_dict(dict):
+            return f"<pre>{json.dumps(dict, default=lambda obj: str(obj), indent=2)}</pre>"
 
         # Function to recursively generate HTML for each span event with depth-based indentation
         def _generate_span_html(node, depth=0):
@@ -112,9 +120,9 @@ class DummyTraceClientWithHTMLDisplay(TraceClient):
                 <div class="metadata">
                     <p><b>Trace ID</b>: {span.context.trace_id}</p>
                     <p><b>Span ID</b>: {span.context.span_id}</p>
-                    <p><b>Inputs</b>: {span.inputs}</p>
-                    <p><b>Outputs</b>: {span.outputs}</p>
-                    <p><b>Attributes</b>: {span.attributes}</p>
+                    <p><b>Inputs</b>: {_pretty_print_dict(span.inputs)}</p>
+                    <p><b>Outputs</b>: {_pretty_print_dict(span.outputs)}</p>
+                    <p><b>Attributes</b>: {_pretty_print_dict(span.attributes)}</p>
                 </div>
             </div>
             """


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11422?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11422/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11422
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Pretty-print the JSON fields in the HTML traces. I think the attributes are rendering weird because I just default to `str(obj)` if the object is non-serializable. It's not perfect, just a quick thing to make the display a little more readable:

<img width="1030" alt="Screenshot 2024-03-14 at 9 45 36 PM" src="https://github.com/mlflow/mlflow/assets/148037680/97599dad-bee6-4418-bb06-c14a67dd7dcb">


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
