### PR TITLE
Fix loading components in transformers models

### DIFF
--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -136,7 +136,7 @@ def _load_component(flavor_conf, name, local_path=None):
         # Load component from HuggingFace Hub
         repo = flavor_conf[FlavorKey.COMPONENT_NAME.format(name)]
         revision = flavor_conf.get(FlavorKey.COMPONENT_REVISION.format(name))
-        return cls.from_pretrained(repo, revision=revision)
+        return cls.from_pretrained(repo, revision=revision, trust_remote_code=trust_remote)
 
 
 def _load_class_from_transformers_config(model_name_or_path, revision=None):

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -114,6 +114,7 @@ def _load_component(flavor_conf, name, local_path=None):
         FlavorKey.TOKENIZER: transformers.AutoTokenizer,
         FlavorKey.FEATURE_EXTRACTOR: transformers.AutoFeatureExtractor,
         FlavorKey.PROCESSOR: transformers.AutoProcessor,
+        FlavorKey.IMAGE_PROCESSOR: transformers.AutoImageProcessor,
     }
 
     component_name = flavor_conf[FlavorKey.COMPONENT_TYPE.format(name)]

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -124,10 +124,10 @@ def _load_component(flavor_conf, name, local_path=None):
     else:
         if local_path is None:
             raise MlflowException(
-                "A custom component `{}` is specified, but no "
-                "local config file was found to retrieve the "
-                "definition. Make sure your model was saved "
-                "correctly."
+                f"A custom component `{component_name}` was specified, "
+                "but no local config file was found to retrieve the "
+                "definition. Make sure your model was saved with "
+                "save_pretrained=True."
             )
         cls = _COMPONENT_TO_AUTOCLASS_MAP[name]
         trust_remote = True

--- a/tests/transformers/conftest.py
+++ b/tests/transformers/conftest.py
@@ -5,6 +5,7 @@ from tests.transformers.helper import (
     load_component_multi_modal,
     load_conversational_pipeline,
     load_custom_code_pipeline,
+    load_custom_components_pipeline,
     load_feature_extraction_pipeline,
     load_fill_mask_pipeline,
     load_ner_pipeline,
@@ -54,6 +55,11 @@ def component_multi_modal():
 @pytest.fixture
 def custom_code_pipeline():
     return load_custom_code_pipeline()
+
+
+@pytest.fixture
+def custom_components_pipeline():
+    return load_custom_components_pipeline()
 
 
 @pytest.fixture

--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -301,6 +301,27 @@ def load_custom_code_pipeline():
     )
 
 
+@prefetch
+@flaky()
+def load_custom_components_pipeline():
+    model = transformers.AutoModel.from_pretrained(
+        "hf-internal-testing/test_dynamic_model_with_tokenizer", trust_remote_code=True
+    )
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        "hf-internal-testing/test_dynamic_processor", trust_remote_code=True
+    )
+    feature_extractor = transformers.AutoFeatureExtractor.from_pretrained(
+        "hf-internal-testing/test_dynamic_processor",
+        trust_remote_code=True,
+    )
+    return transformers.pipeline(
+        task="feature-extraction",
+        model=model,
+        tokenizer=tokenizer,
+        feature_extractor=feature_extractor,
+    )
+
+
 def prefetch_models():
     """
     Prefetches models used in the test suite to avoid downloading them during the test run.

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1423,9 +1423,10 @@ def test_custom_components_pipeline(custom_components_pipeline, model_path):
     transformers_pred = transformers_loaded(data)
     assert pyfunc_pred[0][0] == transformers_pred[0][0][0]
 
-    # assert that all the reloaded components exist and have the same class as pre-save
+    # assert that all the reloaded components exist
+    # and have the same class name as pre-save
     for name, component in components.items():
-        assert component.__class__ == getattr(transformers_loaded, name).__class__
+        assert component.__class__.__name__ == getattr(transformers_loaded, name).__class__.__name__
 
 
 @pytest.mark.parametrize(

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1395,6 +1395,39 @@ def test_custom_code_pipeline(custom_code_pipeline, model_path):
     assert pyfunc_pred[0][0] == transformers_pred[0][0][0]
 
 
+@pytest.mark.skipif(
+    Version(transformers.__version__) < Version("4.26"), reason="Feature is not available"
+)
+def test_custom_components_pipeline(custom_components_pipeline, model_path):
+    data = "hello"
+
+    signature = infer_signature(
+        data, mlflow.transformers.generate_signature_output(custom_components_pipeline, data)
+    )
+
+    components = {
+        "model": custom_components_pipeline.model,
+        "tokenizer": custom_components_pipeline.tokenizer,
+        "feature_extractor": custom_components_pipeline.feature_extractor,
+    }
+
+    mlflow.transformers.save_model(
+        transformers_model=components, path=model_path, signature=signature
+    )
+
+    pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
+    pyfunc_pred = pyfunc_loaded.predict(data)
+    assert isinstance(pyfunc_pred[0][0], float)
+
+    transformers_loaded = mlflow.transformers.load_model(model_path)
+    transformers_pred = transformers_loaded(data)
+    assert pyfunc_pred[0][0] == transformers_pred[0][0][0]
+
+    # assert that all the reloaded components exist and have the same class as pre-save
+    for name, component in components.items():
+        assert component.__class__ == getattr(transformers_loaded, name).__class__
+
+
 @pytest.mark.parametrize(
     ("data", "result"),
     [


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11428?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11428/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11428
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Apply same fix from #11427 to components as well.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
