### PR TITLE
Fix example signature code block typos

### DIFF
--- a/docs/source/model/signatures.rst
+++ b/docs/source/model/signatures.rst
@@ -206,7 +206,7 @@ Columns that contain `None` or `np.nan` values within the input data will be inf
  |       pd.DataFrame({                          |       ]'                                                                  |
  |           "col": [1.0, 2.0, None]             |       output: null                                                        |
  |       })                                      |       params: null                                                        |
- |   })                                          |                                                                           |
+ |   )                                           |                                                                           |
  +-----------------------------------------------+---------------------------------------------------------------------------+
 
 .. note::
@@ -271,7 +271,7 @@ Tensor-based schemas support `numpy data types <https://numpy.org/devdocs/user/b
  |   infer_signature(model_input=np.array([      |       output: None                                                        |
  |       [[1, 2, 3], [4, 5, 6]],                 |       params: None                                                        |
  |       [[7, 8, 9], [1, 2, 3]],                 |                                                                           |
- |   ])                                          |                                                                           |
+ |   ]))                                         |                                                                           |
  +-----------------------------------------------+---------------------------------------------------------------------------+
 
 .. note::

--- a/docs/source/model/signatures.rst
+++ b/docs/source/model/signatures.rst
@@ -166,27 +166,54 @@ Column-based signature also support composite data types of these primitives.
 
 Additional examples for composite data types can be seen by viewing the `signature examples notebook <notebooks/signature_examples.html>`_.
 
- +-----------------------------------------------+----------------------------------------------------------------------------------------+
- | Input (Python)                                | Inferred Signature                                                                     |
- +-----------------------------------------------+----------------------------------------------------------------------------------------+
- | .. code-block:: python                        | .. code-block:: yaml                                                                   |
- |                                               |                                                                                        |
- |   from mlflow.models import infer_signature   |   signature:                                                                           |
- |                                               |       input: '[                                                                        |
- |   infer_signature(model_input={               |           {"name": "list_col", "type": "Array(string)", "required": "true"},           |
- |       # Python list                           |           {"name": "numpy_col", "type": "Array(Array(long))", "required": "true"},     |
- |       "list_col": ["a", "b", "c"],            |           {                                                                            |
- |       # Numpy array                           |               "name": "obj_col",                                                       |
- |       "numpy_col": np.array([[1, 2], [3, 4]]),|               "type": {                                                                |
- |       # Dictionary                            |                   "long_prop":  long (required)                                        |
- |       "obj_col": {                            |                   "array_prop": Array(str) (required)                                  |
- |           "long_prop": 1,                     |               }                                                                        |
- |           "array_prop": ["a", "b", "c"],      |               "required": "true"                                                       |
- |       },                                      |           }                                                                            |
- |   })                                          |       ]'                                                                               |
- |                                               |       output: null                                                                     |
- |                                               |       params: null                                                                     |
- +-----------------------------------------------+----------------------------------------------------------------------------------------+
+ +-----------------------------------------------+--------------------------------------------+
+ | Input (Python)                                | Inferred Signature                         |
+ +-----------------------------------------------+--------------------------------------------+
+ | .. code-block:: python                        | .. code-block:: yaml                       |
+ |                                               |                                            |
+ |   from mlflow.models import infer_signature   |   signature:                               |
+ |                                               |       input: '[                            |
+ |   infer_signature(model_input={               |          {                                 |
+ |       # Python list                           |              "name": "list_col",           |
+ |       "list_col": ["a", "b", "c"],            |              "type": "array",              |
+ |       # Numpy array                           |              "items": {                    |                                               
+ |       "numpy_col": np.array([[1, 2], [3, 4]]),|                  "type": "string"          |
+ |       # Dictionary                            |              },                            |
+ |       "obj_col": {                            |              "required": "true"            |
+ |           "long_prop": 1,                     |          },                                |
+ |            "array_prop": ["a", "b", "c"],     |          {                                 |
+ |       },                                      |              "name": "numpy_col",          |
+ |    })                                         |              "type": "array",              |
+ |                                               |              "items": {                    |
+ |                                               |                  "type": "array",          |
+ |                                               |                  "items": {                |
+ |                                               |                      "type": "long"        |
+ |                                               |                  }                         |
+ |                                               |              },                            |
+ |                                               |              "required": "true"            |
+ |                                               |          },                                |
+ |                                               |          {                                 |
+ |                                               |              "name": "obj_col",            |
+ |                                               |              "type": "object",             |
+ |                                               |              "properties": {               |
+ |                                               |                  "array_prop": {           |
+ |                                               |                      "type": "array",      |
+ |                                               |                       "items": {           |
+ |                                               |                           "type": "string" |
+ |                                               |                      },                    |
+ |                                               |                      "required": "true"    |
+ |                                               |                  },                        |
+ |                                               |                  "long_prop": {            |
+ |                                               |                      "type": "long",       |
+ |                                               |                      "required": "true"    |
+ |                                               |                  }                         |
+ |                                               |              },                            |
+ |                                               |              "required": "true"            |
+ |                                               |          }                                 |
+ |                                               |       ]'                                   |
+ |                                               |       output: null                         |
+ |                                               |       params: null                         |
+ +-----------------------------------------------+--------------------------------------------+
 
 .. _optional-column:
 
@@ -250,8 +277,8 @@ to handle batches of varying sizes.
 .. code-block:: yaml
 
   signature:
-      inputs: '[{"name": "images", "dtype": "uint8", "shape": [-1, 28, 28, 1]}]'
-      outputs: '[{"shape": [-1, 10], "dtype": "float32"}]'
+      inputs: '[{"name": "images", "type": "tensor", "tensor-spec": {"dtype": "uint8", "shape": [-1, 28, 28, 1]}}]'
+      outputs: '[{"type": "tensor", "tensor-spec": {"shape": [-1, 10], "dtype": "float32"}}]'
       params: null
 
 .. _supported-data-types-tensor:
@@ -261,18 +288,18 @@ Supported Data Types
 
 Tensor-based schemas support `numpy data types <https://numpy.org/devdocs/user/basics.types.html>`_.
 
- +-----------------------------------------------+---------------------------------------------------------------------------+
- | Input (Python)                                | Inferred Signature                                                        |
- +-----------------------------------------------+---------------------------------------------------------------------------+
- | .. code-block:: python                        | .. code-block:: yaml                                                      |
- |                                               |                                                                           |
- |   from mlflow.models import infer_signature   |   signature:                                                              |
- |                                               |       input: '["dtype": "int64", "shape": [-1, 2, 3]}]'                   |
- |   infer_signature(model_input=np.array([      |       output: None                                                        |
- |       [[1, 2, 3], [4, 5, 6]],                 |       params: None                                                        |
- |       [[7, 8, 9], [1, 2, 3]],                 |                                                                           |
- |   ]))                                         |                                                                           |
- +-----------------------------------------------+---------------------------------------------------------------------------+
+ +-----------------------------------------------+---------------------------------------------------------------------------------------------+
+ | Input (Python)                                | Inferred Signature                                                                          |
+ +-----------------------------------------------+---------------------------------------------------------------------------------------------+
+ | .. code-block:: python                        | .. code-block:: yaml                                                                        |
+ |                                               |                                                                                             |
+ |   from mlflow.models import infer_signature   |   signature:                                                                                |
+ |                                               |       input: '[{"type": "tensor", "tensor-spec": {"dtype": "int64", "shape": [-1, 2, 3]}}]' |
+ |   infer_signature(model_input=np.array([      |       output: None                                                                          |
+ |       [[1, 2, 3], [4, 5, 6]],                 |       params: None                                                                          |
+ |       [[7, 8, 9], [1, 2, 3]],                 |                                                                                             |
+ |   ]))                                         |                                                                                             |
+ +-----------------------------------------------+---------------------------------------------------------------------------------------------+
 
 .. note::
     Tensor-based schemas do not support optional inputs. You can pass an array with `None` or `np.nan` values,

--- a/docs/source/model/signatures.rst
+++ b/docs/source/model/signatures.rst
@@ -166,54 +166,25 @@ Column-based signature also support composite data types of these primitives.
 
 Additional examples for composite data types can be seen by viewing the `signature examples notebook <notebooks/signature_examples.html>`_.
 
- +-----------------------------------------------+--------------------------------------------+
- | Input (Python)                                | Inferred Signature                         |
- +-----------------------------------------------+--------------------------------------------+
- | .. code-block:: python                        | .. code-block:: yaml                       |
- |                                               |                                            |
- |   from mlflow.models import infer_signature   |   signature:                               |
- |                                               |       input: '[                            |
- |   infer_signature(model_input={               |          {                                 |
- |       # Python list                           |              "name": "list_col",           |
- |       "list_col": ["a", "b", "c"],            |              "type": "array",              |
- |       # Numpy array                           |              "items": {                    |                                               
- |       "numpy_col": np.array([[1, 2], [3, 4]]),|                  "type": "string"          |
- |       # Dictionary                            |              },                            |
- |       "obj_col": {                            |              "required": "true"            |
- |           "long_prop": 1,                     |          },                                |
- |            "array_prop": ["a", "b", "c"],     |          {                                 |
- |       },                                      |              "name": "numpy_col",          |
- |    })                                         |              "type": "array",              |
- |                                               |              "items": {                    |
- |                                               |                  "type": "array",          |
- |                                               |                  "items": {                |
- |                                               |                      "type": "long"        |
- |                                               |                  }                         |
- |                                               |              },                            |
- |                                               |              "required": "true"            |
- |                                               |          },                                |
- |                                               |          {                                 |
- |                                               |              "name": "obj_col",            |
- |                                               |              "type": "object",             |
- |                                               |              "properties": {               |
- |                                               |                  "array_prop": {           |
- |                                               |                      "type": "array",      |
- |                                               |                       "items": {           |
- |                                               |                           "type": "string" |
- |                                               |                      },                    |
- |                                               |                      "required": "true"    |
- |                                               |                  },                        |
- |                                               |                  "long_prop": {            |
- |                                               |                      "type": "long",       |
- |                                               |                      "required": "true"    |
- |                                               |                  }                         |
- |                                               |              },                            |
- |                                               |              "required": "true"            |
- |                                               |          }                                 |
- |                                               |       ]'                                   |
- |                                               |       output: null                         |
- |                                               |       params: null                         |
- +-----------------------------------------------+--------------------------------------------+
+ +-----------------------------------------------+-------------------------------------------------------------------------------------------------------+
+ | Input (Python)                                | Inferred Signature                                                                                    |
+ +-----------------------------------------------+-------------------------------------------------------------------------------------------------------+
+ | .. code-block:: python                        | .. code-block:: yaml                                                                                  |
+ |                                               |                                                                                                       |
+ |   from mlflow.models import infer_signature   |   signature:                                                                                          |
+ |                                               |       input: '[                                                                                       |
+ |   infer_signature(model_input={               |            {"list_col": Array(string) (required)},                                                    |
+ |       # Python list                           |            {"numpy_col": Array(Array(long)) (required)},                                              |
+ |       "list_col": ["a", "b", "c"],            |            {"obj_col": {array_prop: Array(string) (required), long_prop: long (required)} (required)} |
+ |       # Numpy array                           |       ]'                                                                                              |                                               
+ |       "numpy_col": np.array([[1, 2], [3, 4]]),|       output: null                                                                                    |
+ |       # Dictionary                            |       params: null                                                                                    |
+ |       "obj_col": {                            |                                                                                                       |
+ |           "long_prop": 1,                     |                                                                                                       |
+ |            "array_prop": ["a", "b", "c"],     |                                                                                                       |
+ |       },                                      |                                                                                                       |
+ |    })                                         |                                                                                                       |
+ +-----------------------------------------------+-------------------------------------------------------------------------------------------------------+
 
 .. _optional-column:
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/11429?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11429/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11429
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix minor typos in the signature code block examples

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
