### PR TITLE
Fix replace deprecated usage of datetime.utcnow

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1,10 +1,10 @@
+import datetime
 import json
 import logging
 import os
 import shutil
 import uuid
 import warnings
-from datetime import datetime
 from pathlib import Path
 from pprint import pformat
 from typing import Any, Callable, Dict, List, Literal, NamedTuple, Optional, Union
@@ -296,7 +296,9 @@ class Model:
         # store model id instead of run_id and path to avoid confusion when model gets exported
         self.run_id = run_id
         self.artifact_path = artifact_path
-        self.utc_time_created = str(utc_time_created or datetime.utcnow())
+        self.utc_time_created = str(
+            utc_time_created or datetime.datetime.now(datetime.timezone.utc)
+        )
         self.flavors = flavors if flavors is not None else {}
         self.signature = signature
         self.saved_input_example_info = saved_input_example_info

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -215,7 +215,7 @@ class AzureBlobArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             blob_name=dest_path,
             account_key=self.client.credential.account_key,
             permission=BlobSasPermissions(read=True, write=True),
-            expiry=datetime.datetime.utcnow() + datetime.timedelta(hours=1),
+            expiry=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1),
         )
         credentials = []
         for i in range(1, num_parts + 1):

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -1,8 +1,8 @@
+import datetime
 import json
 import os
 import posixpath
 import urllib.parse
-from datetime import datetime
 from functools import lru_cache
 from mimetypes import guess_type
 
@@ -27,7 +27,7 @@ _MAX_CACHE_SECONDS = 300
 
 
 def _get_utcnow_timestamp():
-    return datetime.utcnow().timestamp()
+    return datetime.datetime.now(datetime.timezone.utc).timestamp()
 
 
 @lru_cache(maxsize=64)

--- a/mlflow/utils/promptlab_utils.py
+++ b/mlflow/utils/promptlab_utils.py
@@ -1,8 +1,8 @@
+import datetime
 import json
 import os
 import tempfile
 import time
-from datetime import datetime
 from typing import List
 
 from mlflow.entities.param import Param
@@ -77,7 +77,9 @@ def _create_promptlab_run_impl(
 
         artifact_dir = store.get_run(run_id).info.artifact_uri
 
-        utc_time_created = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f")
+        utc_time_created = datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S.%f"
+        )
         promptlab_model = Model(
             artifact_path="model",
             run_id=run_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ select = [
   "B015",    # useless-comparison
   "D209",    # new-line-after-last-paragraph
   "D411",    # no-blank-line-before-section
+  "DTZ003",  # call-datetime-utcnow
   "E",       # error
   "F",       # Pyflakes
   "C4",      # flake8-comprehensions

--- a/tests/store/artifact/test_optimized_s3_artifact_repo.py
+++ b/tests/store/artifact/test_optimized_s3_artifact_repo.py
@@ -1,6 +1,6 @@
+import datetime
 import os
 import posixpath
-from datetime import datetime
 from unittest import mock
 from unittest.mock import ANY
 
@@ -67,7 +67,8 @@ def test_get_s3_client_hits_cache(s3_artifact_root, monkeypatch):
 
         with mock.patch(
             "mlflow.store.artifact.s3_artifact_repo._get_utcnow_timestamp",
-            return_value=datetime.utcnow().timestamp() + _MAX_CACHE_SECONDS,
+            return_value=datetime.datetime.now(datetime.timezone.utc).timestamp()
+            + _MAX_CACHE_SECONDS,
         ):
             repo._get_s3_client()
         cache_info = _cached_get_s3_client.cache_info()

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -1,8 +1,8 @@
+import datetime
 import json
 import os
 import posixpath
 import tarfile
-from datetime import datetime
 from unittest import mock
 from unittest.mock import ANY
 
@@ -99,7 +99,7 @@ def test_get_s3_client_hits_cache(s3_artifact_root, monkeypatch):
 
     with mock.patch(
         "mlflow.store.artifact.s3_artifact_repo._get_utcnow_timestamp",
-        return_value=datetime.utcnow().timestamp() + _MAX_CACHE_SECONDS,
+        return_value=datetime.datetime.now(datetime.timezone.utc).timestamp() + _MAX_CACHE_SECONDS,
     ):
         repo._get_s3_client()
     cache_info = _cached_get_s3_client.cache_info()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jmahlik/mlflow/pull/11435?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11435/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11435
```

</p>
</details>

### Related Issues/PRs
#11414

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #11414

### What changes are proposed in this pull request?
Remove deprecations. There is some discussion in the issue around if the datetime objects should be made "aware" or kept "naïve".

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
