### PR TITLE
Fix typing imports

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -31,8 +31,8 @@ import os
 import re
 import shutil
 import sys
-import typing as t
 from collections import defaultdict
+from typing import Any, Dict, List, Optional
 
 import requests
 import yaml
@@ -62,19 +62,19 @@ class Version(OriginalVersion):
 
 class PackageInfo(BaseModel):
     pip_release: str
-    install_dev: t.Optional[str] = None
+    install_dev: Optional[str] = None
 
 
 class TestConfig(BaseModel):
     minimum: Version
     maximum: Version
-    unsupported: t.Optional[t.List[Version]] = None
-    requirements: t.Optional[t.Dict[str, t.List[str]]] = None
-    python: t.Optional[t.Dict[str, str]] = None
-    java: t.Optional[t.Dict[str, str]] = None
+    unsupported: Optional[List[Version]] = None
+    requirements: Optional[Dict[str, List[str]]] = None
+    python: Optional[Dict[str, str]] = None
+    java: Optional[Dict[str, str]] = None
     run: str
-    allow_unreleased_max_version: t.Optional[bool] = None
-    pre_test: t.Optional[str] = None
+    allow_unreleased_max_version: Optional[bool] = None
+    pre_test: Optional[str] = None
 
     class Config:
         arbitrary_types_allowed = True
@@ -105,7 +105,7 @@ class MatrixItem(BaseModel):
     java: str
     supported: bool
     free_disk_space: bool
-    pre_test: t.Optional[str] = None
+    pre_test: Optional[str] = None
 
     class Config:
         arbitrary_types_allowed = True
@@ -231,7 +231,7 @@ def get_matched_requirements(requirements, version=None):
     return sorted(reqs)
 
 
-def get_java_version(java: t.Optional[t.Dict[str, str]], version: str) -> str:
+def get_java_version(java: Optional[Dict[str, str]], version: str) -> str:
     default = "11"
     if java is None:
         return default
@@ -245,7 +245,7 @@ def get_java_version(java: t.Optional[t.Dict[str, str]], version: str) -> str:
 
 
 @functools.lru_cache(maxsize=128)
-def pypi_json(package: str) -> t.Dict[str, t.Any]:
+def pypi_json(package: str) -> Dict[str, Any]:
     resp = requests.get(f"https://pypi.org/pypi/{package}/json")
     resp.raise_for_status()
     return resp.json()
@@ -269,7 +269,7 @@ def get_requires_python(package: str, version: str) -> str:
     return next((c for c in candidates if spec.contains(c)), None) or candidates[0]
 
 
-def get_python_version(python: t.Optional[t.Dict[str, str]], package: str, version: str) -> str:
+def get_python_version(python: Optional[Dict[str, str]], package: str, version: str) -> str:
     if python:
         for specifier, py_ver in python.items():
             specifier_set = SpecifierSet(specifier.replace(DEV_VERSION, DEV_NUMERIC))


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11443?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11443/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11443
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Refactoring.

Fix typing imports.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
