### PR TITLE
Replace `openjdk-8-jdk` with `openjdk-11-jdk`

### DIFF
--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -98,8 +98,8 @@ def generate_dockerfile(
 
         setup_java_steps = (
             "# Setup Java\n"
-            "RUN apt-get install -y --no-install-recommends openjdk-8-jdk maven\n"
-            "ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64"
+            "RUN apt-get install -y --no-install-recommends openjdk-11-jdk maven\n"
+            "ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64"
         )
 
         install_mlflow_steps = _pip_mlflow_install_step(output_dir, mlflow_home)

--- a/tests/resources/dockerfile/Dockerfile_java_flavor
+++ b/tests/resources/dockerfile/Dockerfile_java_flavor
@@ -21,8 +21,8 @@ RUN pip install virtualenv
 
 
 # Setup Java
-RUN apt-get install -y --no-install-recommends openjdk-8-jdk maven
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+RUN apt-get install -y --no-install-recommends openjdk-11-jdk maven
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
 WORKDIR /opt/mlflow
 

--- a/tests/resources/dockerfile/Dockerfile_no_model_uri
+++ b/tests/resources/dockerfile/Dockerfile_no_model_uri
@@ -21,8 +21,8 @@ RUN pip install virtualenv
 
 
 # Setup Java
-RUN apt-get install -y --no-install-recommends openjdk-8-jdk maven
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+RUN apt-get install -y --no-install-recommends openjdk-11-jdk maven
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
 WORKDIR /opt/mlflow
 

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_conda
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_conda
@@ -10,8 +10,8 @@ ENV PATH="/miniconda/bin:$PATH"
 
 
 # Setup Java
-RUN apt-get install -y --no-install-recommends openjdk-8-jdk maven
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+RUN apt-get install -y --no-install-recommends openjdk-11-jdk maven
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
 WORKDIR /opt/mlflow
 

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
@@ -21,8 +21,8 @@ RUN pip install virtualenv
 
 
 # Setup Java
-RUN apt-get install -y --no-install-recommends openjdk-8-jdk maven
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+RUN apt-get install -y --no-install-recommends openjdk-11-jdk maven
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
 WORKDIR /opt/mlflow
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11445?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11445/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11445
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix https://github.com/mlflow/mlflow/actions/runs/8322068261/job/22769292883

```
    def build_image_from_context(context_dir: str, image_name: str):
        import docker
    
        client = docker.from_env()
        # In Docker < 19, `docker build` doesn't support the `--platform` option
        is_platform_supported = int(client.version()["Version"].split(".")[0]) >= 19
        # Enforcing the AMD64 architecture build for Apple M1 users
        platform_option = ["--platform", "linux/amd64"] if is_platform_supported else []
        commands = [
            "docker",
            "build",
            "-t",
            image_name,
            "-f",
            "Dockerfile",
            *platform_option,
            ".",
        ]
        proc = Popen(commands, cwd=context_dir, stdout=PIPE, stderr=STDOUT, text=True, encoding="utf-8")
        for x in iter(proc.stdout.readline, ""):
            eprint(x, end="")
    
        if proc.wait():
>           raise RuntimeError("Docker build failed.")
E           RuntimeError: Docker build failed.

client     = <docker.client.DockerClient object at 0x732e57714ca0>
commands   = ['docker', 'build', '-t', 'test-sagemaker-image', '-f', 'Dockerfile', ...]
context_dir = '/tmp/tmp527td4mu'
docker     = <module 'docker' from '/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/docker/__init__.py'>
image_name = 'test-sagemaker-image'
is_platform_supported = True
platform_option = ['--platform', 'linux/amd64']
proc       = <subprocess.Popen object at 0x732e57714fd0>
x          = 'ERROR: failed to solve: process "/bin/sh -c apt-get install -y --no-install-recommends openjdk-8-jdk maven" did not complete successfully: exit code: 100\n'
```

Full failure logs (#11446):

```
------
 > [ 5/12] RUN apt-get install -y --no-install-recommends openjdk-8-jdk maven:
23.25 update-alternatives: using /usr/lib/jvm/java-11-openjdk-amd64/bin/pack200 to provide /usr/bin/pack200 (pack200) in auto mode
23.25 update-alternatives: using /usr/lib/jvm/java-11-openjdk-amd64/bin/unpack200 to provide /usr/bin/unpack200 (unpack200) in auto mode
23.25 update-alternatives: using /usr/lib/jvm/java-11-openjdk-amd64/lib/jexec to provide /usr/bin/jexec (jexec) in auto mode
23.25 update-alternatives: error: error creating symbolic link '/usr/share/binfmts/jar.dpkg-tmp': No such file or directory
23.25 dpkg: error processing package openjdk-11-jre-headless:amd64 (--configure):
23.25  installed openjdk-11-jre-headless:amd64 package post-installation script subprocess returned error exit status 2
23.25 Processing triggers for libgdk-pixbuf2.0-0:amd64 (2.40.0+dfsg-3ubuntu0.4) ...
23.28 Errors were encountered while processing:
23.28  openjdk-11-jre-headless:amd64
23.31 E: Sub-process /usr/bin/dpkg returned an error code (1)
------
Dockerfile:13
--------------------
  11 |     
  12 |     # Setup Java
  13 | >>> RUN apt-get install -y --no-install-recommends openjdk-8-jdk maven
  14 |     ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
  15 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get install -y --no-install-recommends openjdk-8-jdk maven" did not complete successfully: exit code: 100
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
