### PR TITLE
Ability to check for both imports of langchain and lanchain_community dependency

### DIFF
--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -16,18 +16,22 @@ _logger = logging.getLogger(__name__)
 def _extract_databricks_dependencies_from_retriever(
     retriever, dependency_dict: DefaultDict[str, List[Any]]
 ):
-    from langchain.embeddings import DatabricksEmbeddings
-    from langchain.vectorstores import DatabricksVectorSearch
+    from langchain.embeddings import DatabricksEmbeddings as OldDatabricksEmbeddings
+    from langchain.vectorstores import (
+        DatabricksVectorSearch as OldDatabricksVectorSearch,
+    )
+    from langchain_community.embeddings import DatabricksEmbeddings
+    from langchain_community.vectorstores import DatabricksVectorSearch
 
     vectorstore = getattr(retriever, "vectorstore", None)
     if vectorstore:
-        if isinstance(vectorstore, DatabricksVectorSearch):
+        if isinstance(vectorstore, (DatabricksVectorSearch, OldDatabricksVectorSearch)):
             index = vectorstore.index
             dependency_dict[_DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY].append(index.name)
             dependency_dict[_DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY].append(index.endpoint_name)
 
         embeddings = getattr(vectorstore, "embeddings", None)
-        if isinstance(embeddings, DatabricksEmbeddings):
+        if isinstance(embeddings, (DatabricksEmbeddings, OldDatabricksEmbeddings)):
             dependency_dict[_DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY].append(embeddings.endpoint)
         elif (
             callable(getattr(vectorstore, "_is_databricks_managed_embeddings", None))
@@ -39,18 +43,20 @@ def _extract_databricks_dependencies_from_retriever(
 
 
 def _extract_databricks_dependencies_from_llm(llm, dependency_dict: DefaultDict[str, List[Any]]):
-    from langchain.llms import Databricks
+    from langchain.llms import Databricks as OldDatabricks
+    from langchain_community.llms import Databricks
 
-    if isinstance(llm, Databricks):
+    if isinstance(llm, (OldDatabricks, Databricks)):
         dependency_dict[_DATABRICKS_LLM_ENDPOINT_NAME_KEY].append(llm.endpoint_name)
 
 
 def _extract_databricks_dependencies_from_chat_model(
     chat_model, dependency_dict: DefaultDict[str, List[Any]]
 ):
-    from langchain.chat_models import ChatDatabricks
+    from langchain.chat_models import ChatDatabricks as OldChatDatabricks
+    from langchain_community.chat_models import ChatDatabricks
 
-    if isinstance(chat_model, ChatDatabricks):
+    if isinstance(chat_model, (OldChatDatabricks, ChatDatabricks)):
         dependency_dict[_DATABRICKS_CHAT_ENDPOINT_NAME_KEY].append(chat_model.endpoint)
 
 

--- a/mlflow/langchain/databricks_dependencies.py
+++ b/mlflow/langchain/databricks_dependencies.py
@@ -16,22 +16,31 @@ _logger = logging.getLogger(__name__)
 def _extract_databricks_dependencies_from_retriever(
     retriever, dependency_dict: DefaultDict[str, List[Any]]
 ):
-    from langchain.embeddings import DatabricksEmbeddings as OldDatabricksEmbeddings
-    from langchain.vectorstores import (
-        DatabricksVectorSearch as OldDatabricksVectorSearch,
-    )
+    try:
+        from langchain.embeddings import DatabricksEmbeddings as LegacyDatabricksEmbeddings
+        from langchain.vectorstores import (
+            DatabricksVectorSearch as LegacyDatabricksVectorSearch,
+        )
+    except ImportError:
+        from langchain_community.embeddings import (
+            DatabricksEmbeddings as LegacyDatabricksEmbeddings,
+        )
+        from langchain_community.vectorstores import (
+            DatabricksVectorSearch as LegacyDatabricksVectorSearch,
+        )
+
     from langchain_community.embeddings import DatabricksEmbeddings
     from langchain_community.vectorstores import DatabricksVectorSearch
 
     vectorstore = getattr(retriever, "vectorstore", None)
     if vectorstore:
-        if isinstance(vectorstore, (DatabricksVectorSearch, OldDatabricksVectorSearch)):
+        if isinstance(vectorstore, (DatabricksVectorSearch, LegacyDatabricksVectorSearch)):
             index = vectorstore.index
             dependency_dict[_DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY].append(index.name)
             dependency_dict[_DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY].append(index.endpoint_name)
 
         embeddings = getattr(vectorstore, "embeddings", None)
-        if isinstance(embeddings, (DatabricksEmbeddings, OldDatabricksEmbeddings)):
+        if isinstance(embeddings, (DatabricksEmbeddings, LegacyDatabricksEmbeddings)):
             dependency_dict[_DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY].append(embeddings.endpoint)
         elif (
             callable(getattr(vectorstore, "_is_databricks_managed_embeddings", None))
@@ -43,20 +52,30 @@ def _extract_databricks_dependencies_from_retriever(
 
 
 def _extract_databricks_dependencies_from_llm(llm, dependency_dict: DefaultDict[str, List[Any]]):
-    from langchain.llms import Databricks as OldDatabricks
+    try:
+        from langchain.llms import Databricks as LegacyDatabricks
+    except ImportError:
+        from langchain_community.llms import Databricks as LegacyDatabricks
+
     from langchain_community.llms import Databricks
 
-    if isinstance(llm, (OldDatabricks, Databricks)):
+    if isinstance(llm, (LegacyDatabricks, Databricks)):
         dependency_dict[_DATABRICKS_LLM_ENDPOINT_NAME_KEY].append(llm.endpoint_name)
 
 
 def _extract_databricks_dependencies_from_chat_model(
     chat_model, dependency_dict: DefaultDict[str, List[Any]]
 ):
-    from langchain.chat_models import ChatDatabricks as OldChatDatabricks
+    try:
+        from langchain.chat_models import ChatDatabricks as LegacyChatDatabricks
+    except ImportError:
+        from langchain_community.chat_models import (
+            ChatDatabricks as LegacyChatDatabricks,
+        )
+
     from langchain_community.chat_models import ChatDatabricks
 
-    if isinstance(chat_model, (OldChatDatabricks, ChatDatabricks)):
+    if isinstance(chat_model, (LegacyChatDatabricks, ChatDatabricks)):
         dependency_dict[_DATABRICKS_CHAT_ENDPOINT_NAME_KEY].append(chat_model.endpoint)
 
 

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -105,9 +105,7 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
     from langchain_community.vectorstores import DatabricksVectorSearch
 
     vsc = MockVectorSearchClient()
-    vs_index = vsc.get_index(
-        endpoint_name="dbdemos_vs_endpoint", index_name="mlflow.rag.vs_index"
-    )
+    vs_index = vsc.get_index(endpoint_name="dbdemos_vs_endpoint", index_name="mlflow.rag.vs_index")
     mock_get_deploy_client = MagicMock()
 
     monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
@@ -118,15 +116,11 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
 
     monkeypatch.setitem(sys.modules, "databricks.vector_search.client", mock_module)
 
-    vectorstore = DatabricksVectorSearch(
-        vs_index, text_column="content", embedding=embedding_model
-    )
+    vectorstore = DatabricksVectorSearch(vs_index, text_column="content", embedding=embedding_model)
     retriever = vectorstore.as_retriever()
     d = defaultdict(list)
     _extract_databricks_dependencies_from_retriever(retriever, d)
-    assert d.get(_DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY) == [
-        "databricks-bge-large-en"
-    ]
+    assert d.get(_DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY) == ["databricks-bge-large-en"]
     assert d.get(_DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY) == ["mlflow.rag.vs_index"]
     assert d.get(_DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY) == ["dbdemos_vs_endpoint"]
 

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -100,8 +100,58 @@ def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.Monkey
 @pytest.mark.skipif(
     Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
 )
+def test_parsing_dependency_from_databricks_retriever(monkeypatch: pytest.MonkeyPatch):
+    from langchain_community.embeddings import DatabricksEmbeddings
+    from langchain_community.vectorstores import DatabricksVectorSearch
+
+    vsc = MockVectorSearchClient()
+    vs_index = vsc.get_index(
+        endpoint_name="dbdemos_vs_endpoint", index_name="mlflow.rag.vs_index"
+    )
+    mock_get_deploy_client = MagicMock()
+
+    monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
+    embedding_model = DatabricksEmbeddings(endpoint="databricks-bge-large-en")
+
+    mock_module = MagicMock()
+    mock_module.VectorSearchIndex = MockVectorSearchIndex
+
+    monkeypatch.setitem(sys.modules, "databricks.vector_search.client", mock_module)
+
+    vectorstore = DatabricksVectorSearch(
+        vs_index, text_column="content", embedding=embedding_model
+    )
+    retriever = vectorstore.as_retriever()
+    d = defaultdict(list)
+    _extract_databricks_dependencies_from_retriever(retriever, d)
+    assert d.get(_DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY) == [
+        "databricks-bge-large-en"
+    ]
+    assert d.get(_DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY) == ["mlflow.rag.vs_index"]
+    assert d.get(_DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME_KEY) == ["dbdemos_vs_endpoint"]
+
+
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
+)
 def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch):
     from langchain.chat_models import ChatDatabricks
+
+    mock_get_deploy_client = MagicMock()
+
+    monkeypatch.setattr("mlflow.deployments.get_deploy_client", mock_get_deploy_client)
+
+    chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
+    d = defaultdict(list)
+    _extract_databricks_dependencies_from_chat_model(chat_model, d)
+    assert d.get(_DATABRICKS_CHAT_ENDPOINT_NAME_KEY) == ["databricks-llama-2-70b-chat"]
+
+
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
+)
+def test_parsing_dependency_from_databricks_chat(monkeypatch: pytest.MonkeyPatch):
+    from langchain_community.chat_models import ChatDatabricks
 
     mock_get_deploy_client = MagicMock()
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sunishsheth2009/mlflow/pull/11450?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11450/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11450
```

</p>
</details>

### What changes are proposed in this pull request?
Ability to check for both imports of langchain and lanchain_community dependency

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Ability to check for both imports of langchain and lanchain_community dependency

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
