### PR TITLE
Make client API for CreateTrace

### DIFF
--- a/mlflow/entities/__init__.py
+++ b/mlflow/entities/__init__.py
@@ -20,6 +20,10 @@ from mlflow.entities.run_inputs import RunInputs
 from mlflow.entities.run_status import RunStatus
 from mlflow.entities.run_tag import RunTag
 from mlflow.entities.source_type import SourceType
+from mlflow.entities.trace_attribute import TraceAttribute
+from mlflow.entities.trace_info import TraceInfo
+from mlflow.entities.trace_status import TraceStatus
+from mlflow.entities.trace_tag import TraceTag
 from mlflow.entities.view_type import ViewType
 
 __all__ = [
@@ -40,5 +44,9 @@ __all__ = [
     "InputTag",
     "DatasetInput",
     "RunInputs",
+    "TraceAttribute",
+    "TraceInfo",
+    "TraceStatus",
+    "TraceTag",
     "_DatasetSummary",
 ]

--- a/mlflow/entities/trace_attribute.py
+++ b/mlflow/entities/trace_attribute.py
@@ -1,0 +1,36 @@
+from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.protos.service_pb2 import TraceAttribute as ProtoTraceAttribute
+
+
+class TraceAttribute(_MLflowObject):
+    """Tag object associated with a trace."""
+
+    def __init__(self, key, value):
+        self._key = key
+        self._value = value
+
+    def __eq__(self, other):
+        if type(other) is type(self):
+            # TODO deep equality here?
+            return self.__dict__ == other.__dict__
+        return False
+
+    @property
+    def key(self):
+        """String name of the tag."""
+        return self._key
+
+    @property
+    def value(self):
+        """String value of the tag."""
+        return self._value
+
+    def to_proto(self):
+        param = ProtoTraceAttribute()
+        param.key = self.key
+        param.value = self.value
+        return param
+
+    @classmethod
+    def from_proto(cls, proto):
+        return cls(proto.key, proto.value)

--- a/mlflow/entities/trace_info.py
+++ b/mlflow/entities/trace_info.py
@@ -1,11 +1,10 @@
+from typing import List, Optional
+
 from mlflow.entities._mlflow_object import _MLflowObject
-from typing import Any, Dict, Optional, List
-from mlflow.entities.lifecycle_stage import LifecycleStage
+from mlflow.entities.trace_attribute import TraceAttribute
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.entities.trace_tag import TraceTag
-from mlflow.entities.trace_attribute import TraceAttribute
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.protos.service_pb2 import TraceInfo as ProtoTraceInfo
 
 

--- a/mlflow/entities/trace_info.py
+++ b/mlflow/entities/trace_info.py
@@ -1,0 +1,80 @@
+from mlflow.entities._mlflow_object import _MLflowObject
+from typing import Any, Dict, Optional, List
+from mlflow.entities.lifecycle_stage import LifecycleStage
+from mlflow.entities.trace_status import TraceStatus
+from mlflow.entities.trace_tag import TraceTag
+from mlflow.entities.trace_attribute import TraceAttribute
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.protos.service_pb2 import TraceInfo as ProtoTraceInfo
+
+
+class TraceInfo(_MLflowObject):
+    """Metadata about a trace.
+
+    Args:
+        trace_id: id of the trace.
+        experiment_id: id of the experiment.
+        start_time: start time of the trace.
+        end_time: end time of the trace.
+        status: status of the trace.
+        attributes: attributes associated with the trace.
+        tags: tags associated with the trace.
+    """
+
+    def __init__(
+        self,
+        trace_id: str,
+        experiment_id: str,
+        start_time: int,
+        end_time: int,
+        status: TraceStatus,
+        attributes: Optional[List[TraceAttribute]] = None,
+        tags: Optional[List[TraceTag]] = None,
+    ):
+        if trace_id is None:
+            raise MlflowException("`trace_id` cannot be None.")
+        if experiment_id is None:
+            raise MlflowException("`experiment_id` cannot be None.")
+        if start_time is None:
+            raise MlflowException("`start_time` cannot be None.")
+        if end_time is None:
+            raise MlflowException("`end_time` cannot be None.")
+        if status is None:
+            raise MlflowException("`status` cannot be None.")
+
+        self.trace_id = trace_id
+        self.experiment_id = experiment_id
+        self.start_time = start_time
+        self.end_time = end_time
+        self.status = status
+        self.attributes = attributes
+        self.tags = tags
+
+    def __eq__(self, other):
+        if type(other) is type(self):
+            return self.__dict__ == other.__dict__
+        return False
+
+    def to_proto(self):
+        proto = ProtoTraceInfo()
+        proto.trace_id = self.trace_id
+        proto.experiment_id = self.experiment_id
+        proto.start_time = self.start_time
+        proto.end_time = self.end_time
+        proto.status = TraceStatus.from_string(self.status)
+        proto.attributes.extend([attr.to_proto() for attr in self.attributes])
+        proto.tags.extend([tag.to_proto() for tag in self.tags])
+        return proto
+
+    @classmethod
+    def from_proto(cls, proto):
+        return cls(
+            trace_id=proto.trace_id,
+            experiment_id=proto.experiment_id,
+            start_time=proto.start_time,
+            end_time=proto.end_time,
+            status=TraceStatus.to_string(proto.status),
+            attributes=[TraceAttribute.from_proto(attr) for attr in proto.attributes],
+            tags=[TraceTag.from_proto(tag) for tag in proto.tags],
+        )

--- a/mlflow/entities/trace_status.py
+++ b/mlflow/entities/trace_status.py
@@ -1,0 +1,34 @@
+from mlflow.protos.service_pb2 import TraceStatus as ProtoTraceStatus
+
+
+class TraceStatus:
+    """Enum for status of an :py:class:`mlflow.entities.TraceInfo`."""
+
+    UNSPECIFIED = ProtoTraceStatus.Value("TRACE_STATUS_UNSPECIFIED")
+    OK = ProtoTraceStatus.Value("OK")
+    ERROR = ProtoTraceStatus.Value("ERROR")
+
+    _STRING_TO_STATUS = {k: ProtoTraceStatus.Value(k) for k in ProtoTraceStatus.keys()}
+    _STATUS_TO_STRING = {value: key for key, value in _STRING_TO_STATUS.items()}
+
+    @staticmethod
+    def from_string(status_str):
+        if status_str not in TraceStatus._STRING_TO_STATUS:
+            raise Exception(
+                f"Could not get trace status corresponding to string {status_str}. Valid trace "
+                f"status strings: {list(TraceStatus._STRING_TO_STATUS.keys())}"
+            )
+        return TraceStatus._STRING_TO_STATUS[status_str]
+
+    @staticmethod
+    def to_string(status):
+        if status not in TraceStatus._STATUS_TO_STRING:
+            raise Exception(
+                f"Could not get string corresponding to trace status {status}. Valid trace "
+                f"statuses: {list(TraceStatus._STATUS_TO_STRING.keys())}"
+            )
+        return TraceStatus._STATUS_TO_STRING[status]
+
+    @staticmethod
+    def all_status():
+        return list(TraceStatus._STATUS_TO_STRING.keys())

--- a/mlflow/entities/trace_tag.py
+++ b/mlflow/entities/trace_tag.py
@@ -1,0 +1,36 @@
+from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.protos.service_pb2 import TraceTag as ProtoTraceTag
+
+
+class TraceTag(_MLflowObject):
+    """Tag object associated with a trace."""
+
+    def __init__(self, key, value):
+        self._key = key
+        self._value = value
+
+    def __eq__(self, other):
+        if type(other) is type(self):
+            # TODO deep equality here?
+            return self.__dict__ == other.__dict__
+        return False
+
+    @property
+    def key(self):
+        """String name of the tag."""
+        return self._key
+
+    @property
+    def value(self):
+        """String value of the tag."""
+        return self._value
+
+    def to_proto(self):
+        param = ProtoTraceTag()
+        param.key = self.key
+        param.value = self.value
+        return param
+
+    @classmethod
+    def from_proto(cls, proto):
+        return cls(proto.key, proto.value)

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -234,6 +234,24 @@ class AbstractStore:
         """
         pass
 
+    @abstractmethod
+    def create_trace(self, experiment_id, start_time, end_time, status, attributes, tags):
+        """
+        Create a trace under the specified experiment ID.
+
+        Args:
+            experiment_id: String id of the experiment for this run.
+            start_time: int, start time of the trace.
+            end_time: int, end time of the trace.
+            status: `TraceStatus`, status of the trace.
+            attributes: list of `TraceAttribute`, attributes of the trace.
+            tags: list of `TraceTag`, tags of the trace.
+
+        Returns:
+            The created Trace object
+        """
+        pass
+
     def log_metric(self, run_id, metric):
         """
         Log a metric for the specified run

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from mlflow.entities import DatasetInput, Experiment, Metric, Run, RunInfo, ViewType
+from mlflow.entities import DatasetInput, Experiment, Metric, Run, RunInfo, TraceInfo, ViewType
 from mlflow.exceptions import MlflowException
 from mlflow.protos import databricks_pb2
 from mlflow.protos.service_pb2 import (
@@ -26,7 +26,6 @@ from mlflow.protos.service_pb2 import (
     SearchRuns,
     SetExperimentTag,
     SetTag,
-    TraceInfo,
     UpdateExperiment,
     UpdateRun,
 )

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -6,6 +6,7 @@ from mlflow.protos import databricks_pb2
 from mlflow.protos.service_pb2 import (
     CreateExperiment,
     CreateRun,
+    CreateTrace,
     DeleteExperiment,
     DeleteRun,
     DeleteTag,
@@ -25,6 +26,7 @@ from mlflow.protos.service_pb2 import (
     SearchRuns,
     SetExperimentTag,
     SetTag,
+    TraceInfo,
     UpdateExperiment,
     UpdateRun,
 )
@@ -186,6 +188,36 @@ class RestStore(AbstractStore):
         )
         response_proto = self._call_endpoint(CreateRun, req_body)
         return Run.from_proto(response_proto.run)
+
+    def create_trace(self, experiment_id, start_time, end_time, status, attributes, tags):
+        """
+        Create a trace under the specified experiment ID.
+
+        Args:
+            experiment_id: String id of the experiment for this run.
+            start_time: int, start time of the trace.
+            end_time: int, end time of the trace.
+            status: `TraceStatus`, status of the trace.
+            attributes: list of `TraceAttribute`, attributes of the trace.
+            tags: list of `TraceTag`, tags of the trace.
+
+        Returns:
+            The created Trace object.
+        """
+        attributes = [attr.to_proto() for attr in attributes]
+        tags = [tag.to_proto() for tag in tags]
+        req_body = message_to_json(
+            CreateTrace(
+                experiment_id=str(experiment_id),
+                start_time=start_time,
+                end_time=end_time,
+                status=status,
+                attributes=attributes,
+                tags=tags,
+            )
+        )
+        response_proto = self._call_endpoint(CreateTrace, req_body)
+        return TraceInfo.from_proto(response_proto.trace_info)
 
     def log_metric(self, run_id, metric):
         """

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -1,5 +1,4 @@
 import colorsys
-import json
 import random
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -89,10 +88,6 @@ class DummyTraceClientWithHTMLDisplay(TraceClient):
             .expanded .metadata {
                 display: block;
             }
-
-            pre {
-                white-space: pre-wrap;
-            }
         </style>
         <script>
             function toggleExpand(event) {
@@ -101,9 +96,6 @@ class DummyTraceClientWithHTMLDisplay(TraceClient):
             }
         </script>
         """
-
-        def _pretty_print_dict(dict):
-            return f"<pre>{json.dumps(dict, default=str, indent=2)}</pre>"
 
         # Function to recursively generate HTML for each span event with depth-based indentation
         def _generate_span_html(node, depth=0):
@@ -120,9 +112,9 @@ class DummyTraceClientWithHTMLDisplay(TraceClient):
                 <div class="metadata">
                     <p><b>Trace ID</b>: {span.context.trace_id}</p>
                     <p><b>Span ID</b>: {span.context.span_id}</p>
-                    <p><b>Inputs</b>: {_pretty_print_dict(span.inputs)}</p>
-                    <p><b>Outputs</b>: {_pretty_print_dict(span.outputs)}</p>
-                    <p><b>Attributes</b>: {_pretty_print_dict(span.attributes)}</p>
+                    <p><b>Inputs</b>: {span.inputs}</p>
+                    <p><b>Outputs</b>: {span.outputs}</p>
+                    <p><b>Attributes</b>: {span.attributes}</p>
                 </div>
             </div>
             """

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -1,4 +1,5 @@
 import colorsys
+import json
 import random
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -88,6 +89,10 @@ class DummyTraceClientWithHTMLDisplay(TraceClient):
             .expanded .metadata {
                 display: block;
             }
+
+            pre {
+                white-space: pre-wrap;
+            }
         </style>
         <script>
             function toggleExpand(event) {
@@ -96,6 +101,9 @@ class DummyTraceClientWithHTMLDisplay(TraceClient):
             }
         </script>
         """
+
+        def _pretty_print_dict(dict):
+            return f"<pre>{json.dumps(dict, default=str, indent=2)}</pre>"
 
         # Function to recursively generate HTML for each span event with depth-based indentation
         def _generate_span_html(node, depth=0):
@@ -112,9 +120,9 @@ class DummyTraceClientWithHTMLDisplay(TraceClient):
                 <div class="metadata">
                     <p><b>Trace ID</b>: {span.context.trace_id}</p>
                     <p><b>Span ID</b>: {span.context.span_id}</p>
-                    <p><b>Inputs</b>: {span.inputs}</p>
-                    <p><b>Outputs</b>: {span.outputs}</p>
-                    <p><b>Attributes</b>: {span.attributes}</p>
+                    <p><b>Inputs</b>: {_pretty_print_dict(span.inputs)}</p>
+                    <p><b>Outputs</b>: {_pretty_print_dict(span.outputs)}</p>
+                    <p><b>Attributes</b>: {_pretty_print_dict(span.attributes)}</p>
                 </div>
             </div>
             """

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -144,6 +144,40 @@ class TrackingServiceClient:
             run_name=run_name,
         )
 
+    def create_trace(self, experiment_id, start_time, end_time, status, attributes=None, tags=None):
+        """Create a :py:class:`mlflow.entities.Run` object that can be associated with
+        metrics, parameters, artifacts, etc.
+        Unlike :py:func:`mlflow.projects.run`, creates objects but does not run code.
+        Unlike :py:func:`mlflow.start_run`, does not change the "active run" used by
+        :py:func:`mlflow.log_param`.
+
+        Args:
+            experiment_id: The ID of the experiment to create a run in.
+            start_time: If not provided, use the current timestamp.
+            tags: A dictionary of key-value pairs that are converted into
+                :py:class:`mlflow.entities.RunTag` objects.
+            run_name: The name of this run.
+
+        Returns:
+            :py:class:`mlflow.entities.Run` that was created.
+
+        """
+
+        tags = tags if tags else {}
+
+        # Extract user from tags
+        # This logic is temporary; the user_id attribute of runs is deprecated and will be removed
+        # in a later release.
+        user_id = tags.get(MLFLOW_USER, "unknown")
+
+        return self.store.create_run(
+            experiment_id=experiment_id,
+            user_id=user_id,
+            start_time=start_time or get_current_time_millis(),
+            tags=[RunTag(key, value) for (key, value) in tags.items()],
+            run_name=run_name,
+        )
+
     def search_experiments(
         self,
         view_type=ViewType.ACTIVE_ONLY,

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -168,8 +168,8 @@ class TrackingServiceClient:
         Returns:
             The created Trace object.
         """
-        attributes = attributes if attributes else {}
-        tags = tags if tags else {}
+        attributes = attributes or {}
+        tags = tags or {}
 
         return self.store.create_trace(
             experiment_id=experiment_id,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -18,7 +18,17 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 import yaml
 
 import mlflow
-from mlflow.entities import DatasetInput, Experiment, FileInfo, Metric, Param, Run, RunTag, ViewType
+from mlflow.entities import (
+    DatasetInput,
+    Experiment,
+    FileInfo,
+    Metric,
+    Param,
+    Run,
+    RunTag,
+    TraceInfo,
+    ViewType,
+)
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
 from mlflow.exceptions import MlflowException
@@ -353,6 +363,54 @@ class MlflowClient:
             status: RUNNING
         """
         return self._tracking_client.create_run(experiment_id, start_time, tags, run_name)
+
+    def create_trace(
+        self,
+        experiment_id: str,
+        start_time: int,
+        end_time: int,
+        status: str,
+        attributes: Optional[Dict[str, Any]] = None,
+        tags: Optional[Dict[str, Any]] = None,
+    ) -> TraceInfo:
+        """
+        Create a :py:class:`mlflow.entities.TraceInfo` object.
+
+        Args:
+            experiment_id: String id of the experiment for this run.
+            start_time: start time of the trace.
+            end_time: end time of the trace.
+            status: status of the trace.
+            attributes: attributes of the trace.
+            tags: tags of the trace.
+
+        Returns:
+            :py:class:`mlflow.entities.TraceInfo` that was created.
+
+        .. code-block:: python
+            :caption: Example
+
+            from mlflow import MlflowClient
+
+            client = MlflowClient()
+            experiment_id = "12345678"
+            tags = {"engineering": "ML Platform"}
+            trace = client.create_trace(
+                experiment_id,
+                start_time=123,
+                end_time=567,
+                status="OK",
+                tags=tags,
+            )
+        """
+        return self._tracking_client.create_trace(
+            experiment_id,
+            start_time,
+            end_time,
+            status,
+            attributes=attributes,
+            tags=tags,
+        )
 
     def search_experiments(
         self,

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -22,6 +22,7 @@ from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.protos.service_pb2 import (
     CreateRun,
+    CreateTrace,
     DeleteExperiment,
     DeleteRun,
     DeleteTag,
@@ -200,6 +201,27 @@ def test_requestor():
                 actual_tags, key=lambda t: t["key"]
             )
             assert expected_kwargs == actual_kwargs
+
+    with mock_http_request() as mock_http:
+        store.create_trace(
+            experiment_id="447585625682310",
+            start_time=123,
+            end_time=456,
+            status="OK",
+            attributes=[],
+            tags=[],
+        )
+        body = message_to_json(
+            CreateTrace(
+                experiment_id="447585625682310",
+                start_time=123,
+                end_time=456,
+                status="OK",
+                attributes=[],
+                tags=[],
+            )
+        )
+        _verify_requests(mock_http, creds, "traces", "POST", body)
 
     with mock_http_request() as mock_http:
         store.log_param("some_uuid", Param("k1", "v1"))

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -4,7 +4,17 @@ from unittest import mock
 import pytest
 
 from mlflow import MlflowClient
-from mlflow.entities import ExperimentTag, Run, RunInfo, RunStatus, RunTag, SourceType, ViewType
+from mlflow.entities import (
+    ExperimentTag,
+    Run,
+    RunInfo,
+    RunStatus,
+    RunTag,
+    SourceType,
+    TraceAttribute,
+    TraceStatus,
+    ViewType,
+)
 from mlflow.entities.metric import Metric
 from mlflow.entities.model_registry import ModelVersion, ModelVersionTag
 from mlflow.entities.model_registry.model_version_status import ModelVersionStatus
@@ -118,6 +128,21 @@ def test_client_create_run_with_name(mock_store, mock_time):
         start_time=int(mock_time * 1000),
         tags=[],
         run_name="my name",
+    )
+
+
+def test_client_create_trace(mock_store, mock_time):
+    experiment_id = mock.Mock()
+
+    MlflowClient().create_trace(experiment_id, 123, 456, "OK", attributes={"key": "val"}, tags={})
+
+    mock_store.create_trace.assert_called_once_with(
+        experiment_id=experiment_id,
+        start_time=123,
+        end_time=456,
+        status=TraceStatus.from_string("OK"),
+        attributes=[TraceAttribute("key", "val")],
+        tags=[],
     )
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/11453?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11453/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11453
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add client API `client.create_trace()`. Also creating the associated MLflow entities. Testing is a bit tricky, basically the following code will work if connected to the right server:
```
import mlflow

mlflow.set_tracking_uri("databricks")
mlflow.set_experiment("/test-rest-client")

client = mlflow.MlflowClient()
client.create_trace("447585625682310", 199, 299, "OK")
```

I will discuss offline for the actual testing details, but the code should be pretty straightforward.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
