### PR TITLE
Move type check for input example to earlier

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -203,17 +203,6 @@ class _Example:
             elif np.isscalar(input_ex):
                 input_ex = pd.DataFrame([input_ex])
             elif not isinstance(input_ex, pd.DataFrame):
-                try:
-                    import pyspark.sql.dataframe
-
-                    if isinstance(input_example, pyspark.sql.dataframe.DataFrame):
-                        raise MlflowException(
-                            "Examples can not be provided as Spark Dataframe. "
-                            "Please make sure your example is of a small size and "
-                            "turn it into a pandas DataFrame."
-                        )
-                except ImportError:
-                    pass
                 input_ex = None
             return input_ex
 
@@ -225,6 +214,18 @@ class _Example:
                 # No need to write default column index out
                 del result["columns"]
             return result
+
+        try:
+            import pyspark.sql
+
+            if isinstance(input_example, pyspark.sql.DataFrame):
+                raise MlflowException(
+                    "Examples can not be provided as Spark Dataframe. "
+                    "Please make sure your example is of a small size and "
+                    "turn it into a pandas DataFrame."
+                )
+        except ImportError:
+            pass
 
         self.info = {
             INPUT_EXAMPLE_PATH: EXAMPLE_FILENAME,

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -8,7 +8,6 @@ from unittest import mock
 
 import numpy as np
 import pandas as pd
-from mlflow.exceptions import MlflowException
 import pyspark
 import pytest
 import yaml
@@ -25,6 +24,7 @@ import mlflow.utils.file_utils
 from mlflow import pyfunc
 from mlflow.entities.model_registry import ModelVersion
 from mlflow.environment_variables import MLFLOW_DFS_TMP
+from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelSignature
 from mlflow.models.utils import _read_example
 from mlflow.spark import _add_code_from_conf_to_system_path
@@ -276,9 +276,7 @@ def test_model_export_raise_when_example_is_spark_dataframe(spark, spark_model_i
     features_df = spark_model_iris.pandas_df.drop("label", axis=1)
     example = spark.createDataFrame(features_df.head(3))
     with pytest.raises(MlflowException, match="Examples can not be provided as Spark Dataframe."):
-        mlflow.spark.save_model(
-            spark_model_iris.model, path=model_path, input_example=example
-        )
+        mlflow.spark.save_model(spark_model_iris.model, path=model_path, input_example=example)
 
 
 def test_log_model_with_signature_and_examples(spark_model_iris, iris_signature):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11455?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11455/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11455
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

MLflow doesn't accept Spark DataFrame as an input example. This check is currently done when converting example to Pandas DataFrame. However, some earlier logic doesn't work when Spark DataFrame is passed, which hides the error message and confused users. We should check this earlier to fail first.

The failed line is where we create a deepcopy of input example to avoid inline modification. Python's deepcopy tries to copy the SparkContext as well, which is not allowed for an executor in distributed environment, and raise the following error.
```
File /usr/lib/python3.10/copy.py:161, in deepcopy(x, memo, _nil)
    159 reductor = getattr(x, "__reduce_ex__", None)
    160 if reductor is not None:
--> 161     rv = reductor(4)
    162 else:
    163     reductor = getattr(x, "__reduce__", None)

File /databricks/spark/python/pyspark/context.py:514, in SparkContext.__getnewargs__(self)
    512 def __getnewargs__(self) -> NoReturn:
    513     # This method is called when attempting to pickle SparkContext, which is always an error:
--> 514     raise PySparkRuntimeError(
    515         error_class="CONTEXT_ONLY_VALID_ON_DRIVER",
    516         message_parameters={},
    517     )

PySparkRuntimeError: [CONTEXT_ONLY_VALID_ON_DRIVER] It appears that you are attempting to reference SparkContext from a broadcast variable, action, or transformation. SparkContext can only be used on the driver, not in code that it run on workers. For more information, see SPARK-5063.
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
