### PR TITLE
Log table images

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1709,6 +1709,38 @@ class MlflowClient:
             # for data like {"inputs": "What is MLflow?"}
             except ValueError:
                 data = pd.DataFrame([data])
+
+        # Check if column is Image object and save filepath
+        if len(data.select_dtypes(include=["object"]).columns) > 0:
+            try:
+                import PIL
+            except ImportError as exc:
+                raise ImportError(
+                    "`log_table` requires Pillow to verify if column contains PIL Image. "
+                    "Please install it via: pip install Pillow"
+                ) from exc
+
+            def process_image(image: PIL.Image.Image):
+                # remove extension from artifact_file
+                table_name, _ = os.path.splitext(artifact_file)
+                # save image to path
+                filepath = posixpath.join("table_images", table_name, str(uuid.uuid4()) + ".png")
+                with self._log_artifact_helper(run_id, filepath) as artifact_path:
+                    image.save(artifact_path)
+                # store a dictionary object indicating its an image path
+                return {"type": "image", "path": filepath}
+
+            for column in data.columns:
+                isImage = data[column].map(lambda x: isinstance(x, (PIL.Image.Image)))
+                if any(isImage) and not all(isImage):
+                    raise ValueError(
+                        "The column contains a mix of images and non-images. "
+                        "Please ensure that all elements in the column are of the same type."
+                    )
+                elif all(isImage):
+                    # Save files to artifact storage
+                    data[column] = data[column].map(lambda x: process_image(x))
+
         norm_path = posixpath.normpath(artifact_file)
         artifact_dir = posixpath.dirname(norm_path)
         artifact_dir = None if artifact_dir == "" else artifact_dir

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1774,7 +1774,7 @@ class MlflowClient:
                 isImage = data[column].map(lambda x: isinstance(x, (PIL.Image.Image)))
                 if any(isImage) and not all(isImage):
                     raise ValueError(
-                        "The column contains a mix of images and non-images. "
+                        f"Column `{column}` contains a mix of images and non-images. "
                         "Please ensure that all elements in the column are of the same type."
                     )
                 elif all(isImage):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1729,6 +1729,38 @@ class MlflowClient:
             # for data like {"inputs": "What is MLflow?"}
             except ValueError:
                 data = pd.DataFrame([data])
+
+        # Check if column is Image object and save filepath
+        if len(data.select_dtypes(include=["object"]).columns) > 0:
+            try:
+                import PIL
+            except ImportError as exc:
+                raise ImportError(
+                    "`log_table` requires Pillow to verify if column contains PIL Image. "
+                    "Please install it via: pip install Pillow"
+                ) from exc
+
+            def process_image(image: PIL.Image.Image):
+                # remove extension from artifact_file
+                table_name, _ = os.path.splitext(artifact_file)
+                # save image to path
+                filepath = posixpath.join("table_images", table_name, str(uuid.uuid4()) + ".png")
+                with self._log_artifact_helper(run_id, filepath) as artifact_path:
+                    image.save(artifact_path)
+                # store a dictionary object indicating its an image path
+                return {"type": "image", "path": filepath}
+
+            for column in data.columns:
+                isImage = data[column].map(lambda x: isinstance(x, (PIL.Image.Image)))
+                if any(isImage) and not all(isImage):
+                    raise ValueError(
+                        "The column contains a mix of images and non-images. "
+                        "Please ensure that all elements in the column are of the same type."
+                    )
+                elif all(isImage):
+                    # Save files to artifact storage
+                    data[column] = data[column].map(lambda x: process_image(x))
+
         norm_path = posixpath.normpath(artifact_file)
         artifact_dir = posixpath.dirname(norm_path)
         artifact_dir = None if artifact_dir == "" else artifact_dir

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1754,7 +1754,7 @@ class MlflowClient:
                 isImage = data[column].map(lambda x: isinstance(x, (PIL.Image.Image)))
                 if any(isImage) and not all(isImage):
                     raise ValueError(
-                        "The column contains a mix of images and non-images. "
+                        f"Column `{column}` contains a mix of images and non-images. "
                         "Please ensure that all elements in the column are of the same type."
                     )
                 elif all(isImage):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1724,11 +1724,31 @@ class MlflowClient:
                 # remove extension from artifact_file
                 table_name, _ = os.path.splitext(artifact_file)
                 # save image to path
-                filepath = posixpath.join("table_images", table_name, str(uuid.uuid4()) + ".png")
-                with self._log_artifact_helper(run_id, filepath) as artifact_path:
+                filepath = posixpath.join("table_images", table_name, str(uuid.uuid4()))
+                image_filepath = filepath + ".png"
+                compressed_image_filepath = filepath + ".webp"
+                with self._log_artifact_helper(run_id, image_filepath) as artifact_path:
                     image.save(artifact_path)
+
+                # save compressed image to path
+                # TODO: when other PR is merged, use helper functions in multimedia module.
+                width, height = image.size
+                if width > height:
+                    new_width = 256
+                    new_height = int(height * (new_width / width))
+                else:
+                    new_height = 256
+                    new_width = int(width * (new_height / height))
+                compressed_image = image.resize((new_width, new_height))
+                with self._log_artifact_helper(run_id, compressed_image_filepath) as artifact_path:
+                    compressed_image.save(artifact_path)
+
                 # store a dictionary object indicating its an image path
-                return {"type": "image", "path": filepath}
+                return {
+                    "type": "image",
+                    "filepath": image_filepath,
+                    "compressed_filepath": compressed_image_filepath,
+                }
 
             for column in data.columns:
                 isImage = data[column].map(lambda x: isinstance(x, (PIL.Image.Image)))


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jessechancy/mlflow/pull/11464?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11464/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11464
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- Add log_table support for images

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
