### PR TITLE
Fix for `get_databricks_host_creds` in Model Serving Environment

### DIFF
--- a/mlflow/legacy_databricks_cli/configure/provider.py
+++ b/mlflow/legacy_databricks_cli/configure/provider.py
@@ -4,11 +4,15 @@
 # because the latest Databricks Runtime does not contain legacy databricks CLI
 # but MLflow still depends on it.
 
+import logging
 import os
+import time
 import sys
 from abc import ABCMeta, abstractmethod
 from configparser import ConfigParser
 from os.path import expanduser, join
+
+_logger = logging.getLogger(__name__)
 
 _home = expanduser("~")
 CONFIG_FILE_ENV_VAR = "DATABRICKS_CONFIG_FILE"
@@ -204,6 +208,7 @@ class DefaultConfigProvider(DatabricksConfigProvider):
             SparkTaskContextConfigProvider(),
             EnvironmentVariableConfigProvider(),
             ProfileConfigProvider(),
+            DatabricksModelServingConfigProvider()
         )
 
     def get_config(self):
@@ -287,6 +292,60 @@ class ProfileConfigProvider(DatabricksConfigProvider):
         if config.is_valid:
             return config
         return None
+
+
+class DatabricksModelServingConfigProvider(DatabricksConfigProvider):
+    """Loads from the databrickscfg file."""
+
+    def get_config(self):
+        from mlflow.utils.databricks_utils import should_fetch_model_serving_environment_oauth
+
+        try:
+            if should_fetch_model_serving_environment_oauth():
+                config = DatabricksModelServingConfigProvider._get_databricks_model_serving_config()
+                if config.is_valid:
+                    return config
+        except Exception as e:
+            _logger.warning("Unexpected error resolving Databricks Model Serving config: %s", e)
+
+    @staticmethod
+    def _get_databricks_model_serving_config():
+        from mlflow.utils.databricks_utils import get_model_dependency_oauth_token
+
+        # Since we do not record OAuth expiration time in OAuth file, perform periodic refresh
+        # of OAuth environment variable cache here. As currently configured (02/24) OAuth token
+        # in model serving environment is guaranteed to have at least 30 min remaining on TTL
+        # at any point in time but refresh at higher rate of every 5 min here to be safe
+        # and conform with refresh logic for Brickstore tables.
+        OAUTH_CACHE_REFRESH_DURATION_SEC = 5 * 60
+        OAUTH_CACHE_ENV_VAR = "DATABRICKS_DEPENDENCY_OAUTH_CACHE"
+        OAUTH_CACHE_EXPIRATION_ENV_VAR = "DATABRICKS_DEPENDENCY_OAUTH_CACHE_EXIRY_TS"
+        MODEL_SERVING_HOST_ENV_VAR = "DATABRICKS_MODEL_SERVING_HOST_URL"
+
+        # check if dependency is cached in env var before reading from file
+        oauth_token = ""
+        if (
+            OAUTH_CACHE_ENV_VAR in os.environ
+            and OAUTH_CACHE_EXPIRATION_ENV_VAR in os.environ
+            and float(os.environ[OAUTH_CACHE_EXPIRATION_ENV_VAR]) > time.time()
+        ):
+            oauth_token = os.environ[OAUTH_CACHE_ENV_VAR]
+        else:
+            oauth_token = get_model_dependency_oauth_token()
+            os.environ[OAUTH_CACHE_ENV_VAR] = oauth_token
+            os.environ[OAUTH_CACHE_EXPIRATION_ENV_VAR] = str(
+                time.time() + OAUTH_CACHE_REFRESH_DURATION_SEC
+            )
+
+        return DatabricksConfig(
+            host=os.environ[MODEL_SERVING_HOST_ENV_VAR],
+            token=oauth_token,
+            username=None,
+            password=None,
+            refresh_token=None,
+            insecure=None,
+            jobs_api_version=None,
+        )
 
 
 class DatabricksConfig:

--- a/mlflow/legacy_databricks_cli/configure/provider.py
+++ b/mlflow/legacy_databricks_cli/configure/provider.py
@@ -295,7 +295,7 @@ class ProfileConfigProvider(DatabricksConfigProvider):
 
 
 class DatabricksModelServingConfigProvider(DatabricksConfigProvider):
-    """Loads from the databrickscfg file."""
+    """Loads from OAuth credentials in the Databricks Model Serving environment."""
 
     def get_config(self):
         from mlflow.utils.databricks_utils import should_fetch_model_serving_environment_oauth

--- a/mlflow/legacy_databricks_cli/configure/provider.py
+++ b/mlflow/legacy_databricks_cli/configure/provider.py
@@ -6,8 +6,8 @@
 
 import logging
 import os
-import time
 import sys
+import time
 from abc import ABCMeta, abstractmethod
 from configparser import ConfigParser
 from os.path import expanduser, join

--- a/mlflow/legacy_databricks_cli/configure/provider.py
+++ b/mlflow/legacy_databricks_cli/configure/provider.py
@@ -305,6 +305,8 @@ class DatabricksModelServingConfigProvider(DatabricksConfigProvider):
                 config = DatabricksModelServingConfigProvider._get_databricks_model_serving_config()
                 if config.is_valid:
                     return config
+            else:
+                return None
         except Exception as e:
             _logger.warning("Unexpected error resolving Databricks Model Serving config: %s", e)
 

--- a/mlflow/legacy_databricks_cli/configure/provider.py
+++ b/mlflow/legacy_databricks_cli/configure/provider.py
@@ -204,6 +204,8 @@ class DefaultConfigProvider(DatabricksConfigProvider):
     """Look for credentials in a chain of default locations."""
 
     def __init__(self):
+        # The order of providers here will be used to determine
+        # the precedence order for the config provider used in `get_config`
         self._providers = (
             SparkTaskContextConfigProvider(),
             EnvironmentVariableConfigProvider(),

--- a/mlflow/legacy_databricks_cli/configure/provider.py
+++ b/mlflow/legacy_databricks_cli/configure/provider.py
@@ -208,7 +208,7 @@ class DefaultConfigProvider(DatabricksConfigProvider):
             SparkTaskContextConfigProvider(),
             EnvironmentVariableConfigProvider(),
             ProfileConfigProvider(),
-            DatabricksModelServingConfigProvider()
+            DatabricksModelServingConfigProvider(),
         )
 
     def get_config(self):

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -166,14 +166,15 @@ def is_in_databricks_job():
     except Exception:
         return False
 
-
 def is_in_databricks_model_serving_environment():
-    return (
-        "DATABRICKS_MODEL_SERVING_ENV" in os.environ
-        and os.path.exists(_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH)
-        and os.path.isfile(_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH)
-    )
+    return "DATABRICKS_MODEL_SERVING_ENV" in os.environ
 
+def should_fetch_model_serving_environment_oauth():
+    return (
+        is_in_databricks_model_serving_environment() and \
+            os.path.exists(_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH) \
+            and os.path.isfile(_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH) 
+    )
 
 def is_in_databricks_repo():
     try:
@@ -533,8 +534,9 @@ def get_databricks_host_creds(server_uri=None):
         MlflowHostCreds which includes the hostname and authentication information necessary to
         talk to the Databricks server.
     """
-    # if in model serving environment databricks attempt to fetch model dependency OAuth token
-    if is_in_databricks_model_serving_environment():
+    # if in model serving environment databricks and OAuth file exists, 
+    # attempt to fetch model dependency OAuth token
+    if should_fetch_model_serving_environment_oauth():
         return _model_serving_env_databricks_host_creds()
     # default host creds behavior if not fetching OAuth token for model serving dependency
     else:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -166,15 +166,18 @@ def is_in_databricks_job():
     except Exception:
         return False
 
+
 def is_in_databricks_model_serving_environment():
     return "DATABRICKS_MODEL_SERVING_ENV" in os.environ
 
+
 def should_fetch_model_serving_environment_oauth():
     return (
-        is_in_databricks_model_serving_environment() and \
-            os.path.exists(_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH) \
-            and os.path.isfile(_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH) 
+        is_in_databricks_model_serving_environment()
+        and os.path.exists(_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH)
+        and os.path.isfile(_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH)
     )
+
 
 def is_in_databricks_repo():
     try:
@@ -534,7 +537,7 @@ def get_databricks_host_creds(server_uri=None):
         MlflowHostCreds which includes the hostname and authentication information necessary to
         talk to the Databricks server.
     """
-    # if in model serving environment databricks and OAuth file exists, 
+    # if in model serving environment databricks and OAuth file exists,
     # attempt to fetch model dependency OAuth token
     if should_fetch_model_serving_environment_oauth():
         return _model_serving_env_databricks_host_creds()

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -170,7 +170,8 @@ def is_in_databricks_job():
 def is_in_databricks_model_serving_environment():
     return "DATABRICKS_MODEL_SERVING_ENV" in os.environ
 
-
+# this should only be the case when we are in model serving environment
+# and OAuth token file exists in specified path
 def should_fetch_model_serving_environment_oauth():
     return (
         is_in_databricks_model_serving_environment()

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -27,6 +27,7 @@ _logger = logging.getLogger(__name__)
 
 _MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH = "/var/credentials-secret/model-dependencies-oauth-token"
 
+
 def _use_repl_context_if_available(name):
     """Creates a decorator to insert a short circuit that returns the specified REPL context
     attribute if it's available.
@@ -167,9 +168,11 @@ def is_in_databricks_job():
 
 
 def is_in_databricks_model_serving_environment():
-    return "DATABRICKS_MODEL_SERVING_ENV" in os.environ and \
-        os.path.exists(_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH) \
+    return (
+        "DATABRICKS_MODEL_SERVING_ENV" in os.environ
+        and os.path.exists(_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH)
         and os.path.isfile(_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH)
+    )
 
 
 def is_in_databricks_repo():

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -168,7 +168,7 @@ def is_in_databricks_job():
 
 
 def is_in_databricks_model_serving_environment():
-    return "DATABRICKS_MODEL_SERVING_ENV" in os.environ
+    return "IS_IN_DATABRICKS_MODEL_SERVING_ENV" in os.environ
 
 
 # this should only be the case when we are in model serving environment

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -170,6 +170,7 @@ def is_in_databricks_job():
 def is_in_databricks_model_serving_environment():
     return "DATABRICKS_MODEL_SERVING_ENV" in os.environ
 
+
 # this should only be the case when we are in model serving environment
 # and OAuth token file exists in specified path
 def should_fetch_model_serving_environment_oauth():

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -440,7 +440,7 @@ def _fail_malformed_databricks_auth(profile):
 
 # Helper function to attempt to read OAuth Token from
 # mounted file in Databricks Model Serving environment
-def _get_model_dependency_oauth_token(should_retry=True):
+def get_model_dependency_oauth_token(should_retry=True):
     try:
         with open(_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH) as f:
             oauth_dict = json.load(f)
@@ -449,7 +449,7 @@ def _get_model_dependency_oauth_token(should_retry=True):
         # sleep and retry in case of any race conditions with OAuth refreshing
         if should_retry:
             time.sleep(0.5)
-            return _get_model_dependency_oauth_token(should_retry=False)
+            return get_model_dependency_oauth_token(should_retry=False)
         else:
             raise MlflowException(
                 "Unable to read Oauth credentials from file mount for Databricks "
@@ -457,10 +457,28 @@ def _get_model_dependency_oauth_token(should_retry=True):
             ) from e
 
 
-def _default_databricks_host_creds(server_uri):
+def get_databricks_host_creds(server_uri=None):
+    """
+    Reads in configuration necessary to make HTTP requests to a Databricks server. This
+    uses the Databricks CLI's ConfigProvider interface to load the DatabricksConfig object.
+    If no Databricks CLI profile is found corresponding to the server URI, this function
+    will attempt to retrieve these credentials from the Databricks Secret Manager. For that to work,
+    the server URI will need to be of the following format: "databricks://scope:prefix". In the
+    Databricks Secret Manager, we will query for a secret in the scope "<scope>" for secrets with
+    keys of the form "<prefix>-host" and "<prefix>-token". Note that this prefix *cannot* be empty
+    if trying to authenticate with this method. If found, those host credentials will be used. This
+    method will throw an exception if sufficient auth cannot be found.
+
+    Args:
+        server_uri: A URI that specifies the Databricks profile you want to use for making
+            requests.
+
+    Returns:
+        MlflowHostCreds which includes the hostname and authentication information necessary to
+        talk to the Databricks server.
+    """
     profile, path = get_db_info_from_uri(server_uri)
     config = ProfileConfigProvider(profile).get_config() if profile else get_config()
-    insecure = getattr(config, "insecure", False)
     # if a path is specified, that implies a Databricks tracking URI of the form:
     # databricks://profile-name/path-specifier
     if (not config or not config.host) and path:
@@ -474,6 +492,9 @@ def _default_databricks_host_creds(server_uri):
                 config = DatabricksConfig.from_token(host=host, token=token, insecure=False)
     if not config or not config.host:
         _fail_malformed_databricks_auth(profile)
+
+    insecure = hasattr(config, "insecure") and config.insecure
+
     if config.username is not None and config.password is not None:
         return MlflowHostCreds(
             config.host,
@@ -484,68 +505,6 @@ def _default_databricks_host_creds(server_uri):
     elif config.token:
         return MlflowHostCreds(config.host, token=config.token, ignore_tls_verification=insecure)
     _fail_malformed_databricks_auth(profile)
-
-
-def _model_serving_env_databricks_host_creds():
-    # Since we do not record OAuth expiration time in OAuth file, perform periodic refresh
-    # of OAuth environment variable cache here. As currently configured (02/24) OAuth token
-    # in model serving environment is guaranteed to have at least 30 min remaining on TTL
-    # at any point in time but refresh at higher rate of every 5 min here to be safe
-    # and conform with refresh logic for Brickstore tables.
-    OAUTH_CACHE_REFRESH_DURATION_SEC = 5 * 60
-    OAUTH_CACHE_ENV_VAR = "DATABRICKS_DEPENDENCY_OAUTH_CACHE"
-    OAUTH_CACHE_EXPIRATION_ENV_VAR = "DATABRICKS_DEPENDENCY_OAUTH_CACHE_EXIRY_TS"
-    MODEL_SERVING_HOST_ENV_VAR = "DATABRICKS_MODEL_SERVING_HOST_URL"
-
-    # check if dependency is cached in env var before reading from file
-    oauth_token = ""
-    if (
-        OAUTH_CACHE_ENV_VAR in os.environ
-        and OAUTH_CACHE_EXPIRATION_ENV_VAR in os.environ
-        and float(os.environ[OAUTH_CACHE_EXPIRATION_ENV_VAR]) > time.time()
-    ):
-        oauth_token = os.environ[OAUTH_CACHE_ENV_VAR]
-    else:
-        oauth_token = _get_model_dependency_oauth_token()
-        os.environ[OAUTH_CACHE_ENV_VAR] = oauth_token
-        os.environ[OAUTH_CACHE_EXPIRATION_ENV_VAR] = str(
-            time.time() + OAUTH_CACHE_REFRESH_DURATION_SEC
-        )
-
-    return MlflowHostCreds(
-        os.environ[MODEL_SERVING_HOST_ENV_VAR], token=oauth_token, ignore_tls_verification=True
-    )
-
-
-def get_databricks_host_creds(server_uri=None):
-    """
-    Reads in configuration necessary to make HTTP requests to a Databricks server. This
-    uses the Databricks CLI's ConfigProvider interface to load the DatabricksConfig object.
-    If no Databricks CLI profile is found corresponding to the server URI, this function
-    will attempt to retrieve these credentials from the Databricks Secret Manager. For that to work,
-    the server URI will need to be of the following format: "databricks://scope:prefix". In the
-    Databricks Secret Manager, we will query for a secret in the scope "<scope>" for secrets with
-    keys of the form "<prefix>-host" and "<prefix>-token". Note that this prefix *cannot* be empty
-    if trying to authenticate with this method. If found, those host credentials will be used. This
-    method will throw an exception if sufficient auth cannot be found. If called, within Databricks
-    Model Serving environment, this method will attempt to read the OAuth token from where it would
-    expect to find it in the serving environment.
-
-    Args:
-        server_uri: A URI that specifies the Databricks profile you want to use for making
-            requests.
-
-    Returns:
-        MlflowHostCreds which includes the hostname and authentication information necessary to
-        talk to the Databricks server.
-    """
-    # if in model serving environment databricks and OAuth file exists,
-    # attempt to fetch model dependency OAuth token
-    if should_fetch_model_serving_environment_oauth():
-        return _model_serving_env_databricks_host_creds()
-    # default host creds behavior if not fetching OAuth token for model serving dependency
-    else:
-        return _default_databricks_host_creds(server_uri)
 
 
 @_use_repl_context_if_available("mlflowGitRepoUrl")

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -25,6 +25,8 @@ from mlflow.utils.uri import get_db_info_from_uri, is_databricks_uri
 _logger = logging.getLogger(__name__)
 
 
+_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH = "/var/credentials-secret/model-dependencies-oauth-token"
+
 def _use_repl_context_if_available(name):
     """Creates a decorator to insert a short circuit that returns the specified REPL context
     attribute if it's available.
@@ -165,7 +167,9 @@ def is_in_databricks_job():
 
 
 def is_in_databricks_model_serving_environment():
-    return "DATABRICKS_MODEL_SERVING_ENV" in os.environ
+    return "DATABRICKS_MODEL_SERVING_ENV" in os.environ and \
+        os.path.exists(_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH) \
+        and os.path.isfile(_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH)
 
 
 def is_in_databricks_repo():
@@ -423,10 +427,6 @@ def _fail_malformed_databricks_auth(profile):
         "Databricks CLI is properly configured as described at "
         "https://github.com/databricks/databricks-cli." % profile
     )
-
-
-# constant defined outside function for testing override
-_MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH = "/var/credentials-secret/model-dependencies-oauth-token"
 
 
 # Helper function to attempt to read OAuth Token from

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -102,6 +102,8 @@ def test_databricks_single_slash_in_uri_scheme_throws(get_config):
         databricks_utils.get_databricks_host_creds("databricks:/profile:path")
 
     # if is_in_databricks_model_serving_environment is True, but reading from credentials fails
+
+
 @mock.patch("mlflow.utils.databricks_utils.is_in_databricks_model_serving_environment")
 def test_databricks_model_serving_throws(is_in_databricks_model_serving_environment):
     is_in_databricks_model_serving_environment.return_value = True
@@ -123,7 +125,6 @@ def test_databricks_params_model_serving_oauth_cache(monkeypatch, oauth_file):
         assert params.host == "host"
         # should use token from cache, rather than token from oauthfile
         assert params.token == "token"
-
 
 
 @pytest.fixture
@@ -163,6 +164,7 @@ def test_databricks_params_model_serving_read_oauth(monkeypatch, oauth_file):
         assert float(os.environ["DATABRICKS_DEPENDENCY_OAUTH_CACHE_EXIRY_TS"]) > time.time()
         assert params.host == "host"
         assert params.token == "token2"
+
 
 def test_get_workspace_info_from_databricks_secrets():
     mock_dbutils = mock.MagicMock()
@@ -295,11 +297,10 @@ def test_is_in_databricks_model_serving_environment(monkeypatch, oauth_file):
     # will return false if file mount is not configured even if env var set
     assert not databricks_utils.is_in_databricks_model_serving_environment()
 
-
     with mock.patch(
         "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
     ):
-        #both file mount and env var exist, should return true
+        # both file mount and env var exist, should return true
         assert databricks_utils.is_in_databricks_model_serving_environment
 
         # file mount without env var should return false

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -114,7 +114,8 @@ def test_databricks_params_model_serving_oauth_cache(monkeypatch, oauth_file):
     monkeypatch.setenv("DATABRICKS_MODEL_SERVING_HOST_URL", "host")
     monkeypatch.setenv("DATABRICKS_DEPENDENCY_OAUTH_CACHE", "token")
     monkeypatch.setenv("DATABRICKS_DEPENDENCY_OAUTH_CACHE_EXIRY_TS", str(time.time() + 5))
-    # oauth file still needs to be present for is_in_databricks_model_serving_environment() to evaluate true
+    # oauth file still needs to be present for is_in_databricks_model_serving_environment()
+    #  to evaluate true
     with mock.patch(
         "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
     ):
@@ -298,9 +299,9 @@ def test_is_in_databricks_model_serving_environment(monkeypatch, oauth_file):
     with mock.patch(
         "mlflow.utils.databricks_utils._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH", str(oauth_file)
     ):
-        #both file mount and env var exist, should return true 
+        #both file mount and env var exist, should return true
         assert databricks_utils.is_in_databricks_model_serving_environment
-        
+
         # file mount without env var should return false
         monkeypatch.delenv("DATABRICKS_MODEL_SERVING_ENV")
         assert not databricks_utils.is_in_databricks_model_serving_environment()

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -102,7 +102,7 @@ def test_databricks_single_slash_in_uri_scheme_throws(get_config):
         databricks_utils.get_databricks_host_creds("databricks:/profile:path")
 
 
- # if should_fetch_model_serving_environment_oauth is True, but reading from OAuth fails
+# if should_fetch_model_serving_environment_oauth is True, but reading from OAuth fails
 @mock.patch("mlflow.utils.databricks_utils.should_fetch_model_serving_environment_oauth")
 def test_databricks_model_serving_throws(should_fetch_model_serving_environment_oauth):
     should_fetch_model_serving_environment_oauth.return_value = True
@@ -291,7 +291,7 @@ def test_is_in_databricks_runtime(monkeypatch):
     assert not databricks_utils.is_in_databricks_runtime()
 
 
-# test both is_in_databricks_model_serving_environment and 
+# test both is_in_databricks_model_serving_environment and
 # should_fetch_model_serving_environment_oauth return apprropriate values
 def test_should_fetch_model_serving_environment_oauth(monkeypatch, oauth_file):
     monkeypatch.setenv("DATABRICKS_MODEL_SERVING_ENV", "true")

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -130,6 +130,7 @@ def test_databricks_params_model_serving_oauth_cache(monkeypatch, oauth_file):
         # should use token from cache, rather than token from oauthfile
         assert params.token == "token"
 
+
 def test_databricks_params_env_var_overrides_model_serving_oauth(monkeypatch, oauth_file):
     monkeypatch.setenv("IS_IN_DATABRICKS_MODEL_SERVING_ENV", "true")
     monkeypatch.setenv("DATABRICKS_MODEL_SERVING_HOST_URL", "host")

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -8,8 +8,10 @@ from unittest import mock
 import pytest
 
 from mlflow.exceptions import MlflowException
-from mlflow.legacy_databricks_cli.configure.provider import DatabricksConfig
-from mlflow.legacy_databricks_cli.configure.provider import DatabricksModelServingConfigProvider
+from mlflow.legacy_databricks_cli.configure.provider import (
+    DatabricksConfig,
+    DatabricksModelServingConfigProvider,
+)
 from mlflow.utils import databricks_utils
 from mlflow.utils.databricks_utils import (
     check_databricks_secret_scope_access,
@@ -139,7 +141,7 @@ def test_databricks_params_model_serving_oauth_cache(monkeypatch, oauth_file):
         assert params.host == "host"
         # should use token from cache, rather than token from oauthfile
         assert params.token == "token"
-    
+
 
 def test_databricks_params_model_serving_oauth_cache_expired(monkeypatch, oauth_file):
     monkeypatch.setenv("IS_IN_DATABRICKS_MODEL_SERVING_ENV", "true")
@@ -170,6 +172,7 @@ def test_databricks_params_model_serving_read_oauth(monkeypatch, oauth_file):
         assert params.host == "host"
         assert params.token == "token2"
 
+
 def test_databricks_params_env_var_overrides_model_serving_oauth(monkeypatch, oauth_file):
     monkeypatch.setenv("IS_IN_DATABRICKS_MODEL_SERVING_ENV", "true")
     monkeypatch.setenv("DATABRICKS_MODEL_SERVING_HOST_URL", "host")
@@ -185,10 +188,16 @@ def test_databricks_params_env_var_overrides_model_serving_oauth(monkeypatch, oa
         assert params.host == "host_envvar"
         assert params.token == "pat_token"
 
+
 def test_model_serving_config_provider_errors_caught():
     provider = DatabricksModelServingConfigProvider()
-    with mock.patch.object(provider, '_get_databricks_model_serving_config', side_effect=Exception("Failed to Read OAuth Creds")):
-        assert provider.get_config() == None
+    with mock.patch.object(
+        provider,
+        "_get_databricks_model_serving_config",
+        side_effect=Exception("Failed to Read OAuth Creds"),
+    ):
+        assert provider.get_config() is None
+
 
 def test_get_workspace_info_from_databricks_secrets():
     mock_dbutils = mock.MagicMock()
@@ -516,5 +525,3 @@ def test_get_dbr_major_minor_version_throws_on_invalid_version_key(monkeypatch):
     monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "12.x")
     with pytest.raises(MlflowException, match="Failed to parse databricks runtime version"):
         get_databricks_runtime_major_minor_version()
-
-


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/victorsun123/mlflow/pull/11468?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11468/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11468
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

We were previously seeing that customers who didn't have dependency parsing enabled were calling `get_databricks_host_creds` which was failing because the file mount was not setup at the appropriate location. Setting up an additional guard for `is_in_databricks_model_serving_env` where the code will only evaluate to true if the OAuth mount file also exists. 
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested models with 
1. Just env var passed in credentials works [model](https://e2-dogfood-feature-store.staging.cloud.databricks.com/ml/endpoints/dbdemos_endpoint_main_rag_chatbot_1?o=3583333072588378)
2. Passed in credentials with env var and file mount enabled, verified that passed in credentials trump (vector search logs showed usingOAuth=false) [model](https://e2-dogfood-feature-store.staging.cloud.databricks.com/ml/endpoints/dbdemos_endpoint_main_rag_chatbot_2?o=3583333072588378)
3. Just env var and file mount enabled no passed in credentials works (vector search logs showed usingOAuth=True) [model](https://e2-dogfood-feature-store.staging.cloud.databricks.com/ml/endpoints/rag-27?o=3583333072588378)

With 3, able to verify this actually works with older VS client, so we may not even need to make any changes there. This is because VS client already calls get_databricks_host_creds on initialization so we don't even need to add aditional logic to update creds on query. 


<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
