### PR TITLE
Fix pydantic-v2 model deprecation warning (#11469)

### DIFF
--- a/mlflow/gateway/schemas/embeddings.py
+++ b/mlflow/gateway/schemas/embeddings.py
@@ -31,6 +31,59 @@ class EmbeddingsUsage(ResponseModel):
     total_tokens: Optional[int] = None
 
 
+_RESPONSE_PAYLOAD_EXTRA_SCHEMA = {
+    "object": "list",
+    "data": [
+        {
+            "object": "embedding",
+            "index": 0,
+            "embedding": [
+                0.017291732,
+                -0.017291732,
+                0.014577783,
+                -0.02902633,
+                -0.037271563,
+                0.019333655,
+                -0.023055641,
+                -0.007359971,
+                -0.015818445,
+                -0.030654699,
+                0.008348623,
+                0.018312693,
+                -0.017149571,
+                -0.0044424757,
+                -0.011165961,
+                0.01018377,
+            ],
+        },
+        {
+            "object": "embedding",
+            "index": 1,
+            "embedding": [
+                0.0060126893,
+                -0.008691099,
+                -0.0040095365,
+                0.019889368,
+                0.036211833,
+                -0.0013270887,
+                0.013401738,
+                -0.0036735237,
+                -0.0049594184,
+                0.035229642,
+                -0.03435084,
+                0.019798903,
+                -0.0006110424,
+                0.0073793563,
+                0.005657291,
+                0.022487005,
+            ],
+        },
+    ],
+    "model": "text-embedding-ada-002-v2",
+    "usage": {"prompt_tokens": 400, "total_tokens": 400},
+}
+
+
 class ResponsePayload(ResponseModel):
     object: Literal["list"] = "list"
     data: List[EmbeddingObject]
@@ -38,54 +91,7 @@ class ResponsePayload(ResponseModel):
     usage: EmbeddingsUsage
 
     class Config:
-        schema_extra = {
-            "object": "list",
-            "data": [
-                {
-                    "object": "embedding",
-                    "index": 0,
-                    "embedding": [
-                        0.017291732,
-                        -0.017291732,
-                        0.014577783,
-                        -0.02902633,
-                        -0.037271563,
-                        0.019333655,
-                        -0.023055641,
-                        -0.007359971,
-                        -0.015818445,
-                        -0.030654699,
-                        0.008348623,
-                        0.018312693,
-                        -0.017149571,
-                        -0.0044424757,
-                        -0.011165961,
-                        0.01018377,
-                    ],
-                },
-                {
-                    "object": "embedding",
-                    "index": 1,
-                    "embedding": [
-                        0.0060126893,
-                        -0.008691099,
-                        -0.0040095365,
-                        0.019889368,
-                        0.036211833,
-                        -0.0013270887,
-                        0.013401738,
-                        -0.0036735237,
-                        -0.0049594184,
-                        0.035229642,
-                        -0.03435084,
-                        0.019798903,
-                        -0.0006110424,
-                        0.0073793563,
-                        0.005657291,
-                        0.022487005,
-                    ],
-                },
-            ],
-            "model": "text-embedding-ada-002-v2",
-            "usage": {"prompt_tokens": 400, "total_tokens": 400},
-        }
+        if IS_PYDANTIC_V2:
+            json_schema_extra = _RESPONSE_PAYLOAD_EXTRA_SCHEMA
+        else:
+            schema_extra = _RESPONSE_PAYLOAD_EXTRA_SCHEMA


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/clemenskol/mlflow/pull/11470?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11470/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11470
```

</p>
</details>

### Related Issues/PRs

Resolve #11469

### What changes are proposed in this pull request?

The pydantic v2 deprecation warning when importing `ResponsePayload` is removed. No functional change beyond that. The change follows the existing handling in other classes to handle pydantic v1/v2 differences.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
