### PR TITLE
Disallow % in model names

### DIFF
--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -39,6 +39,7 @@ from mlflow.store.model_registry import (
 from mlflow.store.model_registry.abstract_store import AbstractStore
 from mlflow.utils.file_utils import (
     contains_path_separator,
+    contains_percent,
     exists,
     find,
     is_directory,
@@ -78,6 +79,10 @@ def _validate_model_name(name):
         raise MlflowException(
             f"Invalid name: '{name}'. Registered model name cannot contain path separator",
             INVALID_PARAMETER_VALUE,
+        )
+    if contains_percent(name):
+        raise MlflowException(
+            f"Invalid name: '{name}'. Registered model name cannot contain '%' character",
         )
 
 

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -83,6 +83,7 @@ def _validate_model_name(name):
     if contains_percent(name):
         raise MlflowException(
             f"Invalid name: '{name}'. Registered model name cannot contain '%' character",
+            INVALID_PARAMETER_VALUE,
         )
 
 

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -986,6 +986,13 @@ def contains_path_separator(path):
     return any((sep in path) for sep in (os.path.sep, os.path.altsep) if sep is not None)
 
 
+def contains_percent(path):
+    """
+    Returns True if a path contains a percent character, False otherwise.
+    """
+    return "%" in path
+
+
 def read_chunk(path: os.PathLike, size: int, start_byte: int = 0) -> bytes:
     """Read a chunk of bytes from a file.
 

--- a/tests/store/model_registry/test_file_store.py
+++ b/tests/store/model_registry/test_file_store.py
@@ -71,6 +71,13 @@ def test_create_registered_model_with_name_that_looks_like_path(store, tmp_path)
         store.get_registered_model(name)
 
 
+def test_create_registered_model_with_percent_in_name(store, tmp_path):
+    with pytest.raises(
+        MlflowException, match=r"Registered model name cannot contain '%' character"
+    ):
+        store.get_registered_model("m%6fdel")
+
+
 def _verify_registered_model(fs, name, rm_data):
     rm = fs.get_registered_model(name)
     assert rm.name == name


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11474?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11474/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11474
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR disallows the use of the "%" char in registered model names. The reason for this is that model names are appended to the URL when visiting the models in the UI. This causes various problems like "m%6fdel-1" leading to "model-1", and also malformed URI errors for model names like "%asd"

https://github.com/mlflow/mlflow/assets/148037680/d3ae0216-3fbb-4392-8dcd-c0700d70a218

Another solution could be to escape the "%" char in the URLs, but the solution from this PR matches up with the behavior in Databricks (just disallowing %s)

**NOTE: this will cause the model registry page to fail to load if the user already has invalid model names. in order to resolve this, the user will have to delete any models containing "%" in the name before upgrading to the next minor version of MLflow.**

The reason for this is that the `_list_all_registered_models()` function eventually calls `validate_name()` on all model names (why?)

https://github.com/mlflow/mlflow/blob/2692f35ee18b6d06dee0de3d413d154af3c97576/mlflow/store/model_registry/file_store.py#L333-L338

<img width="1720" alt="Screenshot 2024-03-20 at 2 45 07 PM" src="https://github.com/mlflow/mlflow/assets/148037680/885fb5d4-0efb-4e2f-9d2e-d5399e2d4dcb">

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

https://github.com/mlflow/mlflow/assets/148037680/9b0fd40e-3745-4b75-82a6-aafbe76eb173



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Registered model names now cannot contain the '%' character. If you have any registered models with '%' in the name, you'll need to delete them before upgrading to this version of MLflow.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
