### PR TITLE
Fix databricks runtime checking issue in databricks DCS cluster

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -183,8 +183,22 @@ def is_in_databricks_repo_notebook():
         return False
 
 
+DATABRICKS_VERSION_FILE_PATH = "/databricks/DBR_VERSION"
+
+
+def get_databricks_runtime_version_string():
+    if ver := os.environ.get("DATABRICKS_RUNTIME_VERSION"):
+        return ver
+    if os.path.exists(DATABRICKS_VERSION_FILE_PATH):
+        # In Databricks DCS cluster, it doesn't have DATABRICKS_RUNTIME_VERSION
+        # environment variable, we have to read version from the version file.
+        with open(DATABRICKS_VERSION_FILE_PATH) as f:
+            return f.read().strip()
+    return None
+
+
 def is_in_databricks_runtime():
-    return "DATABRICKS_RUNTIME_VERSION" in os.environ
+    return get_databricks_runtime_version_string() is not None
 
 
 def is_dbfs_fuse_available():
@@ -805,7 +819,7 @@ class DatabricksRuntimeVersion(NamedTuple):
 
     @classmethod
     def parse(cls):
-        dbr_version = os.environ["DATABRICKS_RUNTIME_VERSION"]
+        dbr_version = get_databricks_runtime_version_string()
         try:
             dbr_version_splits = dbr_version.split(".", maxsplit=2)
             if dbr_version_splits[0] == "client":

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -183,22 +183,22 @@ def is_in_databricks_repo_notebook():
         return False
 
 
-DATABRICKS_VERSION_FILE_PATH = "/databricks/DBR_VERSION"
+_DATABRICKS_VERSION_FILE_PATH = "/databricks/DBR_VERSION"
 
 
-def get_databricks_runtime_version_string():
+def get_databricks_runtime_version():
     if ver := os.environ.get("DATABRICKS_RUNTIME_VERSION"):
         return ver
-    if os.path.exists(DATABRICKS_VERSION_FILE_PATH):
+    if os.path.exists(_DATABRICKS_VERSION_FILE_PATH):
         # In Databricks DCS cluster, it doesn't have DATABRICKS_RUNTIME_VERSION
         # environment variable, we have to read version from the version file.
-        with open(DATABRICKS_VERSION_FILE_PATH) as f:
+        with open(_DATABRICKS_VERSION_FILE_PATH) as f:
             return f.read().strip()
     return None
 
 
 def is_in_databricks_runtime():
-    return get_databricks_runtime_version_string() is not None
+    return get_databricks_runtime_version() is not None
 
 
 def is_dbfs_fuse_available():
@@ -819,7 +819,7 @@ class DatabricksRuntimeVersion(NamedTuple):
 
     @classmethod
     def parse(cls):
-        dbr_version = get_databricks_runtime_version_string()
+        dbr_version = get_databricks_runtime_version()
         try:
             dbr_version_splits = dbr_version.split(".", maxsplit=2)
             if dbr_version_splits[0] == "client":


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/11483?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11483/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11483
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fix databricks runtime checking issue in databricks DCS cluster (see https://docs.databricks.com/en/compute/custom-containers.html).

In DCS cluster, it doesn't have "DATABRICKS_RUNTIME_VERSION" environment variable.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
