### PR TITLE
Fix Tensorflow cross-version test

### DIFF
--- a/mlflow/catboost/__init__.py
+++ b/mlflow/catboost/__init__.py
@@ -64,7 +64,6 @@ _MODEL_BINARY_FILE_NAME = "model.cb"
 model_data_artifact_paths = [_MODEL_BINARY_FILE_NAME]
 
 _logger = logging.getLogger(__name__)
-_DUMMY = "hoge"
 
 
 def get_default_pip_requirements():

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -79,7 +79,7 @@ def _create_model_for_dict_mapping():
         "c": tf.keras.Input(shape=(1,), name="c"),
         "d": tf.keras.Input(shape=(1,), name="d"),
     }
-    concatenated = layers.Concatenate()(inputs.values())
+    concatenated = layers.Concatenate()(list(inputs.values()))
     x = layers.Dense(16, activation="relu", input_shape=(4,))(concatenated)
     outputs = layers.Dense(3, activation="softmax")(x)
     model = tf.keras.Model(inputs=inputs, outputs=outputs)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11489?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11489/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11489
```

</p>
</details>

### Related Issues/PRs

Fix https://github.com/mlflow-automation/mlflow/actions/runs/8343693820/job/22846704887

### What changes are proposed in this pull request?

The error ^ is just an failure in test model creation, nothing affects MLflow itself.

Keras had been using [dm-tree](https://pypi.org/project/dm-tree/) for flatting nested data structure but switched to [optree](https://pypi.org/project/optree/0.4.0/) very recently. These two libraries have slight different behavior when passed dictionary values. While `dm-tree` simply returns list of values, `optree` returns a list that contains dict_values - so it's nested.

```
>>> d = {"a": 1, "b": 2}
>>> import tree  # this is dm-tree
>>> tree.flatten(d.values())
[1, 2]
>>> import optree
>>> optree.tree_flatten(d.values())
([dict_values([1, 2])], PyTreeSpec(*))
```
This affects [one place](https://github.com/mlflow/mlflow/blob/a924d129e7e9bac7db32528fa0d8fc8d02cb624c/tests/tensorflow/test_tensorflow2_autolog.py#L82) in our Tensorflow test, where we pass input tensors to a layer as dictionary values.

```
    inputs = {
        "a": tf.keras.Input(shape=(1,), name="a"),
        "b": tf.keras.Input(shape=(1,), name="b"),
        "c": tf.keras.Input(shape=(1,), name="c"),
        "d": tf.keras.Input(shape=(1,), name="d"),
    }
    concatenated = layers.Concatenate()(inputs.values())
```

Previously, this was flattened to be a list of tensors, and passed the validation [here](https://github.com/keras-team/keras/blob/dc398f7b072a8d177af698370eca9bd9d0e30056/keras/layers/layer.py#L717C24-L726) in the Keras layer. However, now `optree` returns a nested list and this validation fails.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
