### PR TITLE
Deleting the global context for config path in langchain

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -18,6 +18,7 @@ import logging
 import os
 import warnings
 from typing import Any, Dict, List, Optional, Union
+from contextlib import contextmanager
 
 import cloudpickle
 import pandas as pd
@@ -800,10 +801,16 @@ def load_model(model_uri, dst_path=None):
     return _load_model_from_local_fs(local_model_path)
 
 
-def _load_code_model(code_path: Optional[str] = None):
+@contextmanager
+def _config_path_context(code_path: Optional[str] = None):
     _set_config_path(code_path)
+    yield
+    _set_config_path(None)
 
-    import chain  # noqa: F401
+
+def _load_code_model(code_path: Optional[str] = None):
+    with _config_path_context(code_path):
+        import chain  # noqa: F401
 
     return mlflow.langchain._rag_utils.__databricks_rag_chain__
 

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -804,8 +804,10 @@ def load_model(model_uri, dst_path=None):
 @contextmanager
 def _config_path_context(code_path: Optional[str] = None):
     _set_config_path(code_path)
-    yield
-    _set_config_path(None)
+    try:
+        yield
+    finally:
+        _set_config_path(None)
 
 
 def _load_code_model(code_path: Optional[str] = None):

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -17,8 +17,8 @@ import functools
 import logging
 import os
 import warnings
-from typing import Any, Dict, List, Optional, Union
 from contextlib import contextmanager
+from typing import Any, Dict, List, Optional, Union
 
 import cloudpickle
 import pandas as pd
@@ -814,9 +814,9 @@ def _load_code_model(code_path: Optional[str] = None):
     with _config_path_context(code_path):
         try:
             import chain  # noqa: F401
-        except Exception as e:
+        except ImportError as e:
             raise mlflow.MlflowException(
-                f"Failed to load LangChain model. More details: {e}"
+                f"Failed to import LangChain model."
             ) from e
 
     return mlflow.langchain._rag_utils.__databricks_rag_chain__

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -815,9 +815,7 @@ def _load_code_model(code_path: Optional[str] = None):
         try:
             import chain  # noqa: F401
         except ImportError as e:
-            raise mlflow.MlflowException(
-                f"Failed to import LangChain model."
-            ) from e
+            raise mlflow.MlflowException("Failed to import LangChain model.") from e
 
     return mlflow.langchain._rag_utils.__databricks_rag_chain__
 

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -810,7 +810,12 @@ def _config_path_context(code_path: Optional[str] = None):
 
 def _load_code_model(code_path: Optional[str] = None):
     with _config_path_context(code_path):
-        import chain  # noqa: F401
+        try:
+            import chain  # noqa: F401
+        except Exception as e:
+            raise mlflow.MlflowException(
+                f"Failed to load LangChain model. More details: {e}"
+            ) from e
 
     return mlflow.langchain._rag_utils.__databricks_rag_chain__
 

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2178,7 +2178,9 @@ def test_save_load_chain_as_code():
             code_paths=["tests/langchain/state_of_the_union.txt"],
         )
 
+    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ == None
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
+    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ == None
     answer = "Databricks"
     assert loaded_model.invoke(input_example) == answer
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
@@ -2367,7 +2369,9 @@ def test_save_load_chain_as_code_optional_code_path():
             code_paths=[],
         )
 
+    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ == None
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
+    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ == None
     answer = "Databricks"
     assert loaded_model.invoke(input_example) == answer
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
@@ -2393,3 +2397,13 @@ def test_save_load_chain_as_code_optional_code_path():
     assert langchain_flavor["databricks_dependency"] == {
         "databricks_chat_endpoint_name": ["fake-endpoint"]
     }
+
+
+def test_config_path_context():
+    with mlflow.langchain._config_path_context("tests/langchain/config.yml"):
+        assert (
+            mlflow.langchain._rag_utils.__databricks_rag_config_path__
+            == "tests/langchain/config.yml"
+        )
+
+    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ == None

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2178,9 +2178,9 @@ def test_save_load_chain_as_code():
             code_paths=["tests/langchain/state_of_the_union.txt"],
         )
 
-    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ == None
+    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ is None
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
-    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ == None
+    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ is None
     answer = "Databricks"
     assert loaded_model.invoke(input_example) == answer
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
@@ -2369,9 +2369,9 @@ def test_save_load_chain_as_code_optional_code_path():
             code_paths=[],
         )
 
-    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ == None
+    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ is None
     loaded_model = mlflow.langchain.load_model(model_info.model_uri)
-    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ == None
+    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ is None
     answer = "Databricks"
     assert loaded_model.invoke(input_example) == answer
     pyfunc_loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
@@ -2406,4 +2406,4 @@ def test_config_path_context():
             == "tests/langchain/config.yml"
         )
 
-    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ == None
+    assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ is None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sunishsheth2009/mlflow/pull/11494?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11494/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11494
```

</p>
</details>

### What changes are proposed in this pull request?
Deleting the global context for config path in langchain

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
