### PR TITLE
Fix `get_feature_cols` for dev version spark

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -363,7 +363,6 @@ spark:
       cd python
       pip install '.[connect]'
       pyspark --version
-      echo test
 
   models:
     minimum: "3.1.2"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -363,6 +363,7 @@ spark:
       cd python
       pip install '.[connect]'
       pyspark --version
+      echo test
 
   models:
     minimum: "3.1.2"

--- a/mlflow/pyspark/ml/_autolog.py
+++ b/mlflow/pyspark/ml/_autolog.py
@@ -89,7 +89,7 @@ def get_feature_cols(
         try:
             transformer.transform(df_subset.drop(column))
         except IllegalArgumentException as iae:
-            if re.search("does not exist", str(iae), re.IGNORECASE):
+            if re.search("does not exist|no such struct field", str(iae), re.IGNORECASE):
                 feature_cols.add(column)
                 continue
             raise


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11501?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11501/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11501
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fixes https://github.com/mlflow-automation/mlflow/actions/runs/8375610391/job/22965491033#step:12:1493

```
____________________________ test_get_feature_cols _____________________________

input_df_with_non_features = DataFrame[id: bigint, category: string, not_a_feature_1: string, not_a_feature_2: string]
pipeline_for_feature_cols = Pipeline_222e3bd1dec9

    def test_get_feature_cols(input_df_with_non_features, pipeline_for_feature_cols):
        pipeline_model = pipeline_for_feature_cols.fit(input_df_with_non_features)
>       assert get_feature_cols(input_df_with_non_features, pipeline_model) == {
            "id"
        }, "Wrong feature columns returned"

input_df_with_non_features = DataFrame[id: bigint, category: string, not_a_feature_1: string, not_a_feature_2: string]
pipeline_for_feature_cols = Pipeline_222e3bd1dec9
pipeline_model = PipelineModel_15439d05d115

...

    def deco(*a: Any, **kw: Any) -> Any:
        try:
            return f(*a, **kw)
        except Py4JJavaError as e:
            converted = convert_exception(e.java_exception)
            if not isinstance(converted, UnknownException):
                # Hide where the exception came from that shows a non-Pythonic
                # JVM exception message.
>               raise converted from None
E               pyspark.errors.exceptions.captured.IllegalArgumentException: [FIELD_NOT_FOUND] No such struct field `id` in `category`, `not_a_feature_1`, `not_a_feature_2`, `label`. SQLSTATE: 42704

a          = ('xro23556', <py4j.java_gateway.GatewayClient object at 0x7fda4158f400>, 'o23228', 'transform')
converted  = IllegalArgumentException()
f          = <function get_return_value at 0x7fda5064f670>
kw         = {}
```

Fix `get_feature_cols` for dev version spark.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
