### PR TITLE
Fix `test_disable_sklearn_autologging_does_not_revert_with_trainer`

### DIFF
--- a/tests/transformers/test_transformers_autolog.py
+++ b/tests/transformers/test_transformers_autolog.py
@@ -5,6 +5,7 @@ import optuna
 import pytest
 import sklearn
 import sklearn.cluster
+import sklearn.datasets
 import torch
 from datasets import load_dataset
 from sentence_transformers.losses import CosineSimilarityLoss
@@ -453,6 +454,7 @@ def test_disable_sklearn_autologging_does_not_revert_with_trainer(iris_data, tra
     exp = mlflow.set_experiment(experiment_name="trainer_with_sklearn")
 
     transformers_trainer.train()
+    mlflow.flush_async_logging()
 
     last_run = mlflow.last_active_run()
     assert last_run.data.metrics["epoch"] == 1.0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11509?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11509/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11509
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fixes https://github.com/mlflow-automation/mlflow/actions/runs/8409595819/job/23029881366#step:12:164

```
def test_disable_sklearn_autologging_does_not_revert_with_trainer(iris_data, transformers_trainer):
        mlflow.autolog()
        mlflow.sklearn.autolog(disable=True)
    
        exp = mlflow.set_experiment(experiment_name="trainer_with_sklearn")
    
        transformers_trainer.train()
    
        last_run = mlflow.last_active_run()
>       assert last_run.data.metrics["epoch"] == 1.0
E       KeyError: 'epoch'

exp        = <Experiment: artifact_location='/home/runner/work/mlflow/mlflow/mlruns/1', creation_time=17113007620[57](https://github.com/mlflow-automation/mlflow/actions/runs/8409595819/job/23029881366#step:12:58), experiment_id='1', last_update_time=1711300762057, lifecycle_stage='active', name='trainer_with_sklearn', tags={}>
iris_data  = (array([[5.1, 3.5],
       [4.9, 3. ],
       [4.7, 3.2],
       [4.6, 3.1],
       [5. , 3.6],
       [5.4, 3.9],
   ...2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
       2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]))
last_run   = <Run: data=<RunData: metrics={}, params={'_name_or_path': 'distilbert-base-uncased',
 'accelerator_config': "{'split_b...adc9c5e2cb85a6', start_time=17113007[62](https://github.com/mlflow-automation/mlflow/actions/runs/8409595819/job/23029881366#step:12:63)445, status='FINISHED', user_id='runner'>, inputs=<RunInputs: dataset_inputs=[]>>
transformers_trainer = <transformers.trainer.Trainer object at 0x7f0e54ca9d30>
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
