### PR TITLE
Fix Transformers task inference for local custom code with llm v1 task

### DIFF
--- a/mlflow/transformers/llm_inference_utils.py
+++ b/mlflow/transformers/llm_inference_utils.py
@@ -315,3 +315,16 @@ def _get_finish_reason(total_tokens: int, completion_tokens: int, model_config):
         finish_reason = "length"
 
     return finish_reason
+
+
+def _get_default_task_for_llm_inference_task(llm_inference_task: Optional[str]) -> Optional[str]:
+    """
+    Get corresponding original Transformers task for the given LLM inference task.
+
+    NB: This assumes there is only one original Transformers task for each LLM inference
+      task, which might not be true in the future.
+    """
+    for task, llm_tasks in _SUPPORTED_LLM_INFERENCE_TASK_TYPES_BY_PIPELINE_TASK.items():
+        if llm_inference_task in llm_tasks:
+            return task
+    return None

--- a/tests/transformers/test_transformers_llm_inference_utils.py
+++ b/tests/transformers/test_transformers_llm_inference_utils.py
@@ -9,6 +9,7 @@ import torch
 from mlflow.exceptions import MlflowException
 from mlflow.models import infer_signature
 from mlflow.transformers.llm_inference_utils import (
+    _get_default_task_for_llm_inference_task,
     _get_finish_reason,
     _get_output_and_usage_from_tensor,
     _get_stopping_criteria,
@@ -167,3 +168,15 @@ def test_finish_reason():
         _get_finish_reason(total_tokens=20, completion_tokens=10, model_config={"max_length": 15})
         == "length"
     )
+
+
+@pytest.mark.parametrize(
+    ("inference_task", "expected_task"),
+    [
+        ("llm/v1/completions", "text-generation"),
+        ("llm/v1/chat", "text-generation"),
+        (None, None),
+    ],
+)
+def test_default_task_for_llm_inference_task(inference_task, expected_task):
+    assert _get_default_task_for_llm_inference_task(inference_task) == expected_task

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3575,10 +3575,14 @@ def test_local_custom_model_save_and_load(text_generation_pipeline, model_path, 
     assert isinstance(inference[0], str)
     assert inference[0].startswith("How to save Transformer model?")
 
-    shutil.rmtree(model_path)
+    if Version(transformers.__version__) < Version("4.34.0"):
+        # Chat model is not supported for Transformers < 4.34.0
+        return
 
     # 3. Save local custom model with LLM v1 chat inference task -> saves successfully
     #    with the corresponding Transformers task
+    shutil.rmtree(model_path)
+
     mlflow.transformers.save_model(
         transformers_model=model_dict,
         path=model_path,

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3550,6 +3550,63 @@ def test_text_generation_task_completions_serve(text_generation_pipeline):
     assert output_dict["usage"]["prompt_tokens"] < 20
 
 
+def test_local_custom_model_save_and_load(text_generation_pipeline, model_path, tmp_path):
+    local_repo_path = tmp_path / "local_repo"
+    text_generation_pipeline.save_pretrained(local_repo_path)
+
+    locally_loaded_model = transformers.AutoModelWithLMHead.from_pretrained(local_repo_path)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(local_repo_path)
+    model_dict = {"model": locally_loaded_model, "tokenizer": tokenizer}
+
+    # 1. Save local custom model without specifying task -> raises MlflowException
+    with pytest.raises(MlflowException, match=r"The task could not be inferred"):
+        mlflow.transformers.save_model(transformers_model=model_dict, path=model_path)
+
+    # 2. Save local custom model with task -> saves successfully
+    mlflow.transformers.save_model(
+        transformers_model=model_dict,
+        path=model_path,
+        task="text-generation",
+    )
+
+    pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
+
+    inference = pyfunc_loaded.predict("How to save Transformer model?")
+    assert isinstance(inference[0], str)
+    assert inference[0].startswith("How to save Transformer model?")
+
+    shutil.rmtree(model_path)
+
+    # 3. Save local custom model with LLM v1 chat inference task -> saves successfully
+    #    with the corresponding Transformers task
+    mlflow.transformers.save_model(
+        transformers_model=model_dict,
+        path=model_path,
+        task="llm/v1/chat",
+    )
+
+    mlmodel = yaml.safe_load(model_path.joinpath("MLmodel").read_bytes())
+    flavor_config = mlmodel["flavors"]["transformers"]
+    assert flavor_config["task"] == "text-generation"
+    assert flavor_config["inference_task"] == "llm/v1/chat"
+    assert mlmodel["metadata"]["task"] == "llm/v1/chat"
+
+    pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
+
+    inference = pyfunc_loaded.predict(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "How to save Transformer model?",
+                }
+            ]
+        }
+    )
+    assert isinstance(inference[0], dict)
+    assert inference[0]["choices"][0]["message"]["role"] == "assistant"
+
+
 def test_model_config_is_not_mutated_after_prediction(text2text_generation_pipeline):
     # max_length and max_new_tokens cannot be used together in Transformers earlier than 4.27
     validate_max_new_tokens = Version(transformers.__version__) > Version("4.26.1")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11510?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11510/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11510
```

</p>
</details>

### Related Issues/PRs

Internal bug report

### What changes are proposed in this pull request?

#### Problem
There was an issue in saving a Transformers model loaded from local file (i.e. not loaded from HuggingFace hub), with `llm/v1/chat` task. 

```
local_model = transformers.AutoModelWithLMHead.from_pretrained("local_disk0/path/to/model")

mlflow.transformers.save_model(
    transformers_model={
        "model": local_model,
        "tokenizer": tokenizer,
    ),
    artifact_path="model",
    task="llm/v1/chat"
)

>> RuntimeError: Instantiating a pipeline without a task set raised an error: Repo
id must be in the form 'repo_name' or 'namespace/repo_name':
'/local_models/codellama/CodeLlama-7b-hf'. Use `repo_type` argument if needed.
```

#### Root Cause
The root cause is that MLflow tries to infer the Transformers task type using built-in `get_task` method [here](https://github.com/mlflow/mlflow/blob/master/mlflow/transformers/__init__.py#L1352), which doesn't work with local model path.

```
from transformers.pipelines import get_task

get_task("local_disk0/path/to/model")

>> RuntimeError: Instantiating a pipeline ....
```

#### Solution

Simply catch this exception and fallback to `text-generation`. Currently, only `text-generation` model is supported by LLM inference task (both `llm/v1/chat` and `llm/v1/completion`).

When there are multiple fallbacks available in the future, we should always ask customers to construct the pipeline on their end when passing LLM inference task, which is less convenient but at least not break UJ.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested in staging.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix local model saving issue in Transformers flavor provided `llm/v1/xxx` task.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
