### PR TITLE
Include MLflow Tracing modules in mlflow-skinny

### DIFF
--- a/mlflow/tracing/types/model.py
+++ b/mlflow/tracing/types/model.py
@@ -4,6 +4,8 @@ import json
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Union
 
+from opentelemetry import trace as trace_api
+
 
 @dataclass
 class Trace:
@@ -147,8 +149,6 @@ class Status:
 #     the OpenTelemetry Status class so users code doesn't have to import the OTel's
 #     StatusCode object, which makes future migration easier.
 class StatusCode:
-    from opentelemetry import trace as trace_api
-
     UNSET = trace_api.StatusCode.UNSET
     OK = trace_api.StatusCode.OK
     ERROR = trace_api.StatusCode.ERROR

--- a/pyproject.skinny.toml
+++ b/pyproject.skinny.toml
@@ -27,6 +27,8 @@ dependencies = [
   "entrypoints<1",
   "gitpython<4,>=3.1.9",
   "importlib_metadata<8,>=3.7.0,!=4.7.0",
+  "opentelemetry-api<3,>=1.0.0",
+  "opentelemetry-sdk<3,>=1.0.0",
   "packaging<24",
   "protobuf<5,>=3.12.0",
   "pytz<2025",

--- a/requirements/core-requirements.txt
+++ b/requirements/core-requirements.txt
@@ -19,5 +19,3 @@ Jinja2<4,>=2.11; platform_system != 'Windows'
 Jinja2<4,>=3.0; platform_system == 'Windows'
 matplotlib<4
 graphene<4
-opentelemetry-api<3,>=1.0.0
-opentelemetry-sdk<3,>=1.0.0

--- a/requirements/core-requirements.yaml
+++ b/requirements/core-requirements.yaml
@@ -85,14 +85,3 @@ matplotlib:
 graphene:
   pip_release: graphene
   max_major_version: 3
-
-# Required for tracing
-opentelemetry-api:
-  pip_release: opentelemetry-api
-  minimum: "1.0.0"
-  max_major_version: 2
-
-opentelemetry-sdk:
-  pip_release: opentelemetry-sdk
-  minimum: "1.0.0"
-  max_major_version: 2

--- a/requirements/skinny-requirements.txt
+++ b/requirements/skinny-requirements.txt
@@ -13,3 +13,5 @@ requests<3,>=2.17.3
 packaging<24
 importlib_metadata<8,>=3.7.0,!=4.7.0
 sqlparse<1,>=0.4.0
+opentelemetry-api<3,>=1.0.0
+opentelemetry-sdk<3,>=1.0.0

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -60,3 +60,14 @@ sqlparse:
   # Lower bound sqlparse for: https://github.com/andialbrecht/sqlparse/pull/567
   minimum: "0.4.0"
   max_major_version: 0
+
+# Required for tracing
+opentelemetry-api:
+  pip_release: opentelemetry-api
+  minimum: "1.0.0"
+  max_major_version: 2
+
+opentelemetry-sdk:
+  pip_release: opentelemetry-sdk
+  minimum: "1.0.0"
+  max_major_version: 2

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -105,7 +105,7 @@ def test_trace_ignore_exception_from_tracing_logic(mock_client):
     model = TestModel()
 
     # Exception during span creation: no-op span wrapper created and no trace is logged
-    with mock.patch("mlflow.tracing.fluent._get_tracer", side_effect=ValueError("Some error")):
+    with mock.patch("mlflow.tracing.fluent.get_tracer", side_effect=ValueError("Some error")):
         output = model.predict(2, 5)
 
     assert output == 7


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11512?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11512/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11512
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

We decided to include tracing features in mlflow-skinny, so now we can import tracing modules globally.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
