### PR TITLE
Improve langchain runnable save exception handling

### DIFF
--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -248,11 +248,8 @@ def _save_internal_runnables(runnable, path, loader_fn, persist_dir):
         # TODO: check if `dict` is enough to load it back
         elif hasattr(runnable, "dict"):
             runnable_dict = runnable.dict()
-            try:
-                with open(path, "w") as f:
-                    yaml.dump(runnable_dict, f, default_flow_style=False)
-            except Exception as e:
-                return e
+            with open(path, "w") as f:
+                yaml.dump(runnable_dict, f, default_flow_style=False)
         else:
             return Exception(f"Runnable {runnable} is not supported for saving.")
     return conf
@@ -312,11 +309,12 @@ def _save_runnable_with_steps(model, file_path: Union[Path, str], loader_fn=None
         # Save each step into a subfolder named by step
         save_runnable_path = steps_path / step
         save_runnable_path.mkdir()
-        result = _save_internal_runnables(runnable, save_runnable_path, loader_fn, persist_dir)
-        if isinstance(result, Exception):
-            unsaved_runnables[step] = f"{runnable} -- {result}"
-        else:
-            steps_conf[step] = result
+        try:
+            steps_conf[step] = _save_internal_runnables(
+                runnable, save_runnable_path, loader_fn, persist_dir
+            )
+        except Exception as e:
+            unsaved_runnables[step] = f"{runnable} -- {e}"
 
     if unsaved_runnables:
         raise MlflowException(f"Failed to save runnable sequence: {unsaved_runnables}.")
@@ -346,21 +344,22 @@ def _save_runnable_branch(model, file_path, loader_fn, persist_dir):
             save_runnable_path.mkdir(parents=True)
             branches_conf[f"{index}-{i}"] = {}
 
-            result = _save_internal_runnables(runnable, save_runnable_path, loader_fn, persist_dir)
-            if isinstance(result, Exception):
-                unsaved_runnables[f"{index}-{i}"] = f"{runnable} -- {result}"
-            else:
-                branches_conf[f"{index}-{i}"] = result
+            try:
+                branches_conf[f"{index}-{i}"] = _save_internal_runnables(
+                    runnable, save_runnable_path, loader_fn, persist_dir
+                )
+            except Exception as e:
+                unsaved_runnables[f"{index}-{i}"] = f"{runnable} -- {e}"
 
     # save default branch
     default_branch_path = branches_path / _DEFAULT_BRANCH_NAME
     default_branch_path.mkdir()
-    result = _save_internal_runnables(model.default, default_branch_path, loader_fn, persist_dir)
-    if isinstance(result, Exception):
-        unsaved_runnables[_DEFAULT_BRANCH_NAME] = f"{model.default} -- {result}"
-    else:
-        branches_conf[_DEFAULT_BRANCH_NAME] = result
-
+    try:
+        branches_conf[_DEFAULT_BRANCH_NAME] = _save_internal_runnables(
+            model.default, default_branch_path, loader_fn, persist_dir
+        )
+    except Exception as e:
+        unsaved_runnables[_DEFAULT_BRANCH_NAME] = f"{model.default} -- {e}"
     if unsaved_runnables:
         raise MlflowException(f"Failed to save runnable branch: {unsaved_runnables}.")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/11516?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11516/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11516
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Use try catch for collecting exceptions on internal runnables saving

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
