### PR TITLE
Minor updates to Transformers llm inference task doc

### DIFF
--- a/docs/source/llms/transformers/guide/index.rst
+++ b/docs/source/llms/transformers/guide/index.rst
@@ -139,11 +139,11 @@ loaded as a ``pyfunc`` and used to generate a response from a passed-in list of 
 
 
 Saving Transformer Pipelines with an OpenAI-Compatible Inference Interface
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------------------------------------------------------
 
 .. note::
 
-    This feature is only available in MLflow 2.11.0 and above.
+    This feature is only available in MLflow 2.11.0 and above. Also, the ``llm/v1/chat`` task type is only available for models saved with ``transformers >= 4.34.0``.
 
 
 MLflow's native transformers integration allows you to pass in the ``task`` param when saving a model 
@@ -152,11 +152,11 @@ accepts any of the `Transformers pipeline task types <https://huggingface.co/tas
 and above, we've added a few more MLflow-specific keys for ``text-generation`` pipelines.
 
 For ``text-generation`` pipelines, instead of specifying ``text-generation`` as the task type, you can provide 
-one of two string literals conforming to the `MLflow Deployments Server's endpoint_type specification <https://mlflow.org/docs/latest/llms/deployments/index.html#general-configuration-parameters>`_ 
-(``"llm/v1/embeddings"`` can be specified as a task on models saved with :py:func:`mlflow.sentence_transformers.save_model()`):
+one of two string literals conforming to the `MLflow Deployments Server's endpoint_type specification <https://mlflow.org/docs/latest/llms/deployments/index.html#general-configuration-parameters>`_:
 
 - ``"llm/v1/chat"`` for chat-style applications
 - ``"llm/v1/completions"`` for generic completions
+- (The last ``"llm/v1/embeddings"`` can be specified as a task on models saved with :py:func:`mlflow.sentence_transformers.save_model()`)
 
 For example:
 

--- a/docs/source/llms/transformers/index.rst
+++ b/docs/source/llms/transformers/index.rst
@@ -242,6 +242,8 @@ To learn more about the nuances of the `transformers` flavor in MLflow, delve in
 
 - `Transformers Model as a Python Function <guide/index.html#loading-a-transformers-model-as-a-python-function>`_ : Familiarize yourself with the various ``transformers`` pipeline types compatible with the pyfunc model flavor. Understand the standardization of input and output formats in the pyfunc model implementation for the flavor, ensuring seamless integration with JSON and Pandas DataFrames.
 
+- `Saving Transformer Models with an OpenAI-Compatible Interface <guide/index.html#saving-transformer-pipelines-with-an-openai-compatible-inference-interface>`_: Deploying Transformer models with an OpenAI-compatible chat or completion interface is streamlined: just set the ``task`` parameter to ``llm/v1/chat`` or ``llm/v1/completion``.
+
 - `Prompt Template <guide/index.html#saving-prompt-templates-with-transformer-pipelines>`_: Learn how to save a prompt template with transformers pipelines to optimize inference with less boilerplate.
 
 - `Model Config and Model Signature Params for Inference <guide/index.html#using-model-config-and-model-signature-params-for-inference>`_: Learn how to leverage ``model_config`` and ``ModelSignature`` for flexible and customized model loading and inference.

--- a/docs/source/llms/transformers/tutorials/conversational/pyfunc-chat-model.ipynb
+++ b/docs/source/llms/transformers/tutorials/conversational/pyfunc-chat-model.ipynb
@@ -21,6 +21,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install mlflow>=2.11.0 -q -U\n",
+    "# OpenAI-compatible chat model support is available for Transformers 4.34.0 and above\n",
+    "%pip install transformers>=4.34.0 -q -U"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Given a few recent queries about the `llm/v1/xxx` task support in Transformers, updating the related portion of the doc.
* Fix inconsistent section level so that the section becomes visible in the index.
* Add note that the `llm/v1/chat` is only supported for Transformers >= 4.34.0 (due to the dependency to their prompt templating feature)
* Add link from the index.html.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
