### PR TITLE
Add middle-of-name truncation to excessively long deployment names for Sagemaker image deployment

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -1355,16 +1355,38 @@ def _get_deployment_config(flavor_name, env_override=None):
     return deployment_config
 
 
+def _truncate_name(name, max_length):
+    # NB: Sagemaker prevents the registration of models and configurations whose names
+    # exceed 63 characters in length. For reference:
+    # https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Model.html
+    # https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_TransformJob.html
+    # https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ModelConfiguration.html
+    # This function middle-truncates the name provided to
+    # ensure that the least critical name information is not lost
+    if len(name) <= max_length:
+        return name
+    available_length = max_length - 3
+    start_len = available_length // 2
+    end_len = available_length - start_len
+    return f"{name[:start_len]}...{name[-end_len:]}"
+
+
+def _get_unique_name(base_name, unique_suffix, unique_id_length=20):
+    unique_resource_string = f"{unique_suffix}{get_unique_resource_id(unique_id_length)}"
+    max_length = 63 - len(unique_resource_string)
+    return _truncate_name(base_name, max_length) + unique_resource_string
+
+
 def _get_sagemaker_model_name(endpoint_name):
-    return f"{endpoint_name}-model-{get_unique_resource_id()}"
+    return _get_unique_name(endpoint_name, "-model-")
 
 
 def _get_sagemaker_transform_model_name(job_name):
-    return f"{job_name}-model-{get_unique_resource_id()}"
+    return _get_unique_name(job_name, "-transform-")
 
 
 def _get_sagemaker_config_name(endpoint_name):
-    return f"{endpoint_name}-config-{get_unique_resource_id()}"
+    return _get_unique_name(endpoint_name, "-config-")
 
 
 def _get_sagemaker_config_tags(endpoint_name):

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -1386,7 +1386,7 @@ def _get_sagemaker_model_name(endpoint_name):
 
 
 def _get_sagemaker_transform_model_name(job_name):
-    return _get_unique_name(job_name, "-transform-")
+    return _get_unique_name(job_name, "-model-")
 
 
 def _get_sagemaker_config_name(endpoint_name):

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -1368,7 +1368,11 @@ def _truncate_name(name, max_length):
     available_length = max_length - 3
     start_len = available_length // 2
     end_len = available_length - start_len
-    return f"{name[:start_len]}...{name[-end_len:]}"
+    truncated_name = f"{name[:start_len]}---{name[-end_len:]}"
+    _logger.warning(
+        f"Truncated name {name} to {truncated_name} to coerce total character counts to < 64"
+    )
+    return truncated_name
 
 
 def _get_unique_name(base_name, unique_suffix, unique_id_length=20):

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -1670,3 +1670,38 @@ def test_predict_with_array_input_output(sagemaker_deployment_client):
 
         assert isinstance(result, pd.DataFrame)
         assert list(result[0]) == [1, 2, 3]
+
+
+def test_truncate_name():
+    assert mfs._truncate_name("a" * 64, 63) == "a" * 30 + "..." + "a" * 30
+    assert mfs._truncate_name("a" * 10, 63) == "a" * 10
+    assert mfs._truncate_name("abcdefghijklmnopqrst", 10) == "abc...qrst"
+
+
+def test_get_sagemaker_model_name():
+    model_name = mfs._get_sagemaker_model_name("testEndpoint")
+    assert model_name.startswith("testEndpoint-model-")
+    assert len(model_name) <= 63
+
+
+def test_get_sagemaker_transform_model_name():
+    transform_name = mfs._get_sagemaker_transform_model_name("testJob")
+    assert transform_name.startswith("testJob-transform-")
+    assert len(transform_name) <= 63
+
+
+# Test unique name generation with the specified suffix for config names
+def test_get_sagemaker_config_name():
+    config_name = mfs._get_sagemaker_config_name("testConfig")
+    assert config_name.startswith("testConfig-config-")
+    assert len(config_name) <= 63
+
+
+# Test the behavior when the base name is too long and needs truncation
+def test_name_truncation_for_long_base_name():
+    long_base_name = "a" * 100  # 100 characters long
+    with mock.patch("mlflow.sagemaker.get_unique_resource_id", return_value="1234567890abcdef1234"):
+        model_name = mfs._get_sagemaker_model_name(long_base_name)
+    assert model_name.endswith("-model-1234567890abcdef1234")
+    assert "..." in model_name
+    assert len(model_name) == 63

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -1688,7 +1688,7 @@ def test_get_sagemaker_model_name():
 
 def test_get_sagemaker_transform_model_name():
     transform_name = mfs._get_sagemaker_transform_model_name("testJob")
-    assert transform_name.startswith("testJob-transform-")
+    assert transform_name.startswith("testJob-model-")
     assert len(transform_name) <= 63
 
 

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -413,7 +413,7 @@ def test_update_deployment_with_serverless_config_when_endpoint_exists(
     configs = sagemaker_client.list_endpoint_configs()
     target_config = None
     for config in configs["EndpointConfigs"]:
-        if app_name in config["EndpointConfigName"]:
+        if app_name[:8] in config["EndpointConfigName"]:
             target_config = config
     if target_config is None:
         raise Exception("Endpoint config not found")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/11523?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11523/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11523
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Updates the passed-in model names and configuration names for sagemaker deployment to truncate generated names that are in excess of 63 characters long to prevent build failures and rejections from AWS. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Updates the passed-in model names and configuration names for sagemaker deployment to truncate generated names that are in excess of 63 characters long to prevent build failures and rejections from AWS. 

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [X] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
