### PR TITLE
Fix dtype extraction logic for Transformers dev version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -387,6 +387,7 @@ nitpick_ignore = [
     ("py:class", "pytorch_lightning.trainer.trainer.Trainer"),
     ("py:class", "pytorch_lightning.core.module.LightningModule"),
     ("py:class", "pytorch_lightning.core.LightningModule"),
+    ("py:class", "torch.dtype"),
 ]
 
 

--- a/docs/source/llms/transformers/guide/index.rst
+++ b/docs/source/llms/transformers/guide/index.rst
@@ -602,13 +602,13 @@ Example:
             "t5-small", model_max_length=100
         ),
         framework="pt",
-        torch_dtype=torch.bfloat16,
     )
 
     with mlflow.start_run():
         model_info = mlflow.transformers.log_model(
             transformers_model=my_pipeline,
             artifact_path="my_pipeline",
+            torch_dtype=torch.bfloat16,
         )
 
     # Illustrate that the torch data type is recorded in the flavor configuration
@@ -651,13 +651,13 @@ Example:
             "t5-small", model_max_length=100
         ),
         framework="pt",
-        torch_dtype=torch.bfloat16,
     )
 
     with mlflow.start_run():
         model_info = mlflow.transformers.log_model(
             transformers_model=my_pipeline,
             artifact_path="my_pipeline",
+            torch_dtype=torch.bfloat16,
         )
 
     loaded_pipeline = mlflow.transformers.load_model(

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -124,6 +124,7 @@ from mlflow.utils.requirements_utils import _get_pinned_requirement
 
 # The following import is only used for type hinting
 if TYPE_CHECKING:
+    import torch
     from transformers import Pipeline
 
 # Transformers pipeline complains that PeftModel is not supported for any task type, even
@@ -265,6 +266,7 @@ def save_model(
     path: str,
     processor=None,
     task: Optional[str] = None,
+    torch_dtype: Optional[torch.dtype] = None,
     model_card=None,
     inference_config: Optional[Dict[str, Any]] = None,
     code_paths: Optional[List[str]] = None,
@@ -579,7 +581,7 @@ def save_model(
         save_pretrained = True
 
     # Create the flavor configuration
-    flavor_conf = build_flavor_config(built_pipeline, processor, save_pretrained)
+    flavor_conf = build_flavor_config(built_pipeline, processor, torch_dtype, save_pretrained)
 
     if llm_inference_task:
         flavor_conf.update({_LLM_INFERENCE_TASK_KEY: llm_inference_task})
@@ -717,6 +719,7 @@ def log_model(
     artifact_path: str,
     processor=None,
     task: Optional[str] = None,
+    torch_dtype: Optional[torch.dtype] = None,
     model_card=None,
     inference_config: Optional[Dict[str, Any]] = None,
     code_paths: Optional[List[str]] = None,
@@ -796,6 +799,10 @@ def log_model(
             pipeline utilities within the transformers library will be used to infer the
             correct task type. If the value specified is not a supported type within the
             version of transformers that is currently installed, an Exception will be thrown.
+        torch_dtype: The Pytorch dtype applied to the model when loading back. This is useful
+            when you want to save the model with a specific dtype that is different from the
+            dtype of the model when it was trained. If not specified, the current dtype of the
+            model instance will be used.
         model_card: An Optional `ModelCard` instance from `huggingface-hub`. If provided, the
             contents of the model card will be saved along with the provided
             `transformers_model`. If not provided, an attempt will be made to fetch
@@ -930,6 +937,7 @@ def log_model(
         transformers_model=transformers_model,
         processor=processor,
         task=task,
+        torch_dtype=torch_dtype,
         model_card=model_card,
         inference_config=inference_config,
         conda_env=conda_env,

--- a/tests/transformers/test_flavor_configs.py
+++ b/tests/transformers/test_flavor_configs.py
@@ -57,6 +57,7 @@ def test_flavor_config_pt_save_pretrained_false(small_qa_pipeline):
         "source_model_name": "csarron/mobilebert-uncased-squad-v2",
         # "source_model_revision": "SOME_COMMIT_SHA",
         "framework": "pt",
+        "torch_dtype": "torch.float32",
         "components": ["tokenizer"],
         "tokenizer_type": "MobileBertTokenizerFast",
         "tokenizer_name": "csarron/mobilebert-uncased-squad-v2",

--- a/tests/transformers/test_flavor_configs.py
+++ b/tests/transformers/test_flavor_configs.py
@@ -69,6 +69,13 @@ def test_flavor_config_pt_save_pretrained_false(small_qa_pipeline):
     assert conf == expected
 
 
+def test_flavor_config_torch_dtype_overridden_when_specified(small_qa_pipeline):
+    import torch
+
+    conf = build_flavor_config(small_qa_pipeline, torch_dtype=torch.float16, save_pretrained=False)
+    assert conf["torch_dtype"] == "torch.float16"
+
+
 def test_flavor_config_component_multi_modal(multi_modal_pipeline):
     pipeline, task, processor, expected_components = multi_modal_pipeline
 
@@ -90,7 +97,7 @@ def test_flavor_config_component_multi_modal(multi_modal_pipeline):
 def test_flavor_config_component_multi_modal_save_pretrained_false(multi_modal_pipeline):
     pipeline, task, processor, expected_components = multi_modal_pipeline
 
-    conf = build_flavor_config(pipeline, processor, False)
+    conf = build_flavor_config(pipeline, processor, save_pretrained=False)
 
     assert "model_binary" not in conf
     assert conf["pipeline_model_type"] == "ViltForQuestionAnswering"

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -59,8 +59,6 @@ from tests.helper_functions import (
 from tests.transformers.helper import IS_NEW_FEATURE_EXTRACTION_API, flaky
 from tests.transformers.test_transformers_peft_model import SKIP_IF_PEFT_NOT_AVAILABLE
 
-_IS_PIPELINE_DTYPE_SUPPORTED_VERSION = Version(transformers.__version__) >= Version("4.26.1")
-
 # NB: Some pipelines under test in this suite come very close or outright exceed the
 # default runner containers specs of 7GB RAM. Due to this inability to run the suite without
 # generating a SIGTERM Error (143), some tests are marked as local only.
@@ -402,6 +400,21 @@ def test_basic_save_model_and_load_text_pipeline(small_seq2seq_pipeline, model_p
     result = loaded("MLflow is a really neat tool!")
     assert result[0]["label"] == "happy"
     assert result[0]["score"] > 0.5
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float64])
+def test_basic_save_model_with_torch_dtype(text2text_generation_pipeline, model_path, dtype):
+    mlflow.transformers.save_model(
+        transformers_model=text2text_generation_pipeline,
+        path=model_path,
+        torch_dtype=dtype,
+    )
+
+    loaded = mlflow.transformers.load_model(model_path)
+    assert loaded.model.dtype == dtype
+
+    loaded = mlflow.transformers.load_model(model_path, torch_dtype=torch.float32)
+    assert loaded.model.dtype == torch.float32
 
 
 def test_basic_save_model_and_load_vision_pipeline(small_vision_model, model_path, image_for_test):
@@ -2453,71 +2466,6 @@ def test_instructional_pipeline_with_prompt_in_output(model_path):
 
     assert inference[0].startswith("What is MLflow?")
     assert "\n\n" in inference[0]
-
-
-@pytest.mark.skipif(not _IS_PIPELINE_DTYPE_SUPPORTED_VERSION, reason="Feature does not exist")
-def test_load_as_pipeline_preserves_framework_and_dtype(model_path):
-    task = "translation_en_to_fr"
-
-    # Many of the 'full configuration' arguments specified are not stored as instance arguments
-    # for a pipeline; rather, they are only used when acquiring the pipeline components from
-    # the huggingface hub at initial pipeline creation. If a pipeline is specified, it is
-    # irrelevant to store these.
-    full_config_pipeline = transformers.pipeline(
-        task=task,
-        model=transformers.T5ForConditionalGeneration.from_pretrained("t5-small"),
-        tokenizer=transformers.T5TokenizerFast.from_pretrained("t5-small", model_max_length=100),
-        framework="pt",
-        torch_dtype=torch.bfloat16,
-    )
-
-    mlflow.transformers.save_model(
-        transformers_model=full_config_pipeline,
-        path=model_path,
-    )
-
-    base_loaded = mlflow.transformers.load_model(model_path)
-    assert base_loaded.torch_dtype == torch.bfloat16
-    assert base_loaded.framework == "pt"
-    assert base_loaded.model.dtype == torch.bfloat16
-
-    loaded_pipeline = mlflow.transformers.load_model(model_path, torch_dtype=torch.float64)
-
-    assert loaded_pipeline.torch_dtype == torch.float64
-    assert loaded_pipeline.framework == "pt"
-    assert loaded_pipeline.model.dtype == torch.float64
-
-    prediction = loaded_pipeline.predict("Hello there. How are you today?")
-    assert prediction[0]["translation_text"].startswith("Bonjour")
-
-
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float64])
-@pytest.mark.skipif(not _IS_PIPELINE_DTYPE_SUPPORTED_VERSION, reason="Feature does not exist")
-@flaky()
-def test_load_pyfunc_mutate_torch_dtype(model_path, dtype):
-    task = "translation_en_to_fr"
-
-    full_config_pipeline = transformers.pipeline(
-        task=task,
-        model=transformers.T5ForConditionalGeneration.from_pretrained("t5-small"),
-        tokenizer=transformers.T5TokenizerFast.from_pretrained("t5-small", model_max_length=100),
-        framework="pt",
-        torch_dtype=dtype,
-    )
-
-    mlflow.transformers.save_model(
-        transformers_model=full_config_pipeline,
-        path=model_path,
-    )
-
-    # Since we can't directly access the underlying wrapped model instance, evaluate the
-    # ability to generate an inference with a specific dtype to ensure that there are no
-    # complications with setting different types within pyfunc.
-    loaded_pipeline = mlflow.pyfunc.load_model(model_path)
-
-    prediction = loaded_pipeline.predict("Hello there. How are you today?")
-
-    assert prediction[0].startswith("Bonjour")
 
 
 @pytest.mark.skipif(

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -2456,7 +2456,6 @@ def test_instructional_pipeline_with_prompt_in_output(model_path):
 
 
 @pytest.mark.skipif(not _IS_PIPELINE_DTYPE_SUPPORTED_VERSION, reason="Feature does not exist")
-@flaky()
 def test_load_as_pipeline_preserves_framework_and_dtype(model_path):
     task = "translation_en_to_fr"
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11527?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11527/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11527
```

</p>
</details>

### Related Issues/PRs

Resolve https://github.com/mlflow-automation/mlflow/actions/runs/8420708589/job/23067463853#step:12:2371

### What changes are proposed in this pull request?

A while ago, there was an issue that the Transformers pipeline's `torch_dtype` property does not reflect the underyling model dtype. So we added a workaround [here](https://github.com/mlflow/mlflow/blob/master/mlflow/transformers/torch_utils.py#L18-L39) to check model dtype as a fallback. Later, I've made [a change](https://github.com/huggingface/transformers/pull/28940) in Transformers side in order to remove this workaround, which was merged this week. Basically, I changed pipeline's `torch_dtype` property to pass the underlying model `dtype`, assuming only Pytorch-based model has `dtype` attribute.

However, this assumption was not correct.  Tensorflow-based models also have [dtype](https://github.com/keras-team/tf-keras/blob/9f64291e2db56f922917185ab8c1d5cd4e962021/tf_keras/engine/base_layer.py#L1173-L1180) property inherited from Keras layer. As a result, the `torch_dtype` field was incorrectly logged for TF models and failed to load back.

I've contacted to HF maintainers, so the issue should be fixed before releasing next version. However, probably we don't want to rely on pipeline's `torch_dtype` field anyway for a few reasons:
* For earlier version of Transformers, it still doesn't reflect the underlying model dtype. 
* It can be both string and torch.dtype object, so we need to do validation and deserialization before logging.

Therefore, this PR changes the extraction logic to directly look at model's `dtype` field, not relying on pipeline's `torch_dtype` field at all. The model's dtype is always more reliable than pipeline's field, and also it is guaranteed to have `torch.dtype` object if the model is Pytorch model ([ref](https://github.com/huggingface/transformers/blob/7eb3ba82241c927053689270a0751f4ff5d33c54/src/transformers/modeling_utils.py#L898)). 

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
