### PR TITLE
Log model source and class name in the `sentence-transformers` flavor

### DIFF
--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -60,8 +60,7 @@ _LLM_V1_EMBEDDING_INPUT_KEY = "input"
 # Patterns to extract HuggingFace model repository name from the local snapshot path.
 # The path format would be like /path/to/{username}_{modelname}, where user name can
 # only contain number, letters, and dashes.
-_HF_REPO_NAME_PATTERN = re.compile(r"[0-9a-zA-Z-]+/[^\/]+")
-_LOCAL_SNAPSHOT_PATH_PATTERN = re.compile(r"/[\w/-]+/([0-9a-zA-Z-]+)_([^\/]+)")
+_LOCAL_SNAPSHOT_PATH_PATTERN = re.compile(r"/([0-9a-zA-Z-]+)_([^\/]+)/$")
 
 model_data_artifact_paths = [SENTENCE_TRANSFORMERS_DATA_PATH]
 
@@ -289,10 +288,7 @@ def _get_transformers_model_name(model_name_or_path):
     download, so the name_or_path attribute points to the local filepath.
     https://github.com/UKPLab/sentence-transformers/commit/9db0f205adcf315d16961fea7e9e6906cb950d43
     """
-    # NB: We have to check the normal repo pattern xxx/yyy as it can match local path pattern too
-    if not _HF_REPO_NAME_PATTERN.match(model_name_or_path) and (
-        m := _LOCAL_SNAPSHOT_PATH_PATTERN.match(model_name_or_path)
-    ):
+    if m := _LOCAL_SNAPSHOT_PATH_PATTERN.search(model_name_or_path):
         return f"{m.group(1)}/{m.group(2)}"
     return model_name_or_path
 

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
+import re
 import yaml
 
 import mlflow
@@ -55,6 +56,12 @@ SENTENCE_TRANSFORMERS_DATA_PATH = "model.sentence_transformer"
 _INFERENCE_CONFIG_PATH = "inference_config"
 _LLM_INFERENCE_TASK_EMBEDDING = "llm/v1/embeddings"
 _LLM_V1_EMBEDDING_INPUT_KEY = "input"
+
+# Patterns to extract HuggingFace model repository name from the local snapshot path.
+# The path format would be like /path/to/{username}_{modelname}, where user name can
+# only contain number, letters, and dashes.
+_HF_REPO_NAME_PATTERN = re.compile(r"[0-9a-zA-Z-]+/[^\/]+")
+_LOCAL_SNAPSHOT_PATH_PATTERN = re.compile(r"/[\w/-]+/([0-9a-zA-Z-]+)_([^\/]+)")
 
 model_data_artifact_paths = [SENTENCE_TRANSFORMERS_DATA_PATH]
 
@@ -265,10 +272,24 @@ def _get_transformers_model_metadata(model) -> Dict[str, str]:
         if isinstance(module, Transformer):
             model_instance = module.auto_model
             return {
-                _TRANSFORMER_SOURCE_MODEL_NAME_KEY: model_instance.name_or_path,
+                _TRANSFORMER_SOURCE_MODEL_NAME_KEY: _get_transformers_model_name(model_instance.name_or_path),
                 _TRANSFORMER_MODEL_TYPE_KEY: model_instance.__class__.__name__,
             }
     return {}
+
+def _get_transformers_model_name(model_name_or_path):
+    """
+    Extract the Transformers model name from name_or_path attribute of a Transformer model.
+
+    Normally the name_or_path attribute just points to the model name, but in Sentence Transformers < 2.3.0,
+    the library loads the Transformers model after local snapshot download, so the name_or_path attribute
+    points to the local filepath.
+    https://github.com/UKPLab/sentence-transformers/commit/9db0f205adcf315d16961fea7e9e6906cb950d43
+    """
+    # NB: We have to check the normal repo pattern xxx/yyy because it can match local path pattern as well
+    if not _HF_REPO_NAME_PATTERN.match(model_name_or_path) and (m := _LOCAL_SNAPSHOT_PATH_PATTERN.match(model_name_or_path)):
+        return f"{m.group(1)}/{m.group(2)}"
+    return model_name_or_path
 
 
 @experimental

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -1,11 +1,11 @@
 import json
 import logging
 import pathlib
+import re
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
-import re
 import yaml
 
 import mlflow
@@ -272,22 +272,27 @@ def _get_transformers_model_metadata(model) -> Dict[str, str]:
         if isinstance(module, Transformer):
             model_instance = module.auto_model
             return {
-                _TRANSFORMER_SOURCE_MODEL_NAME_KEY: _get_transformers_model_name(model_instance.name_or_path),
+                _TRANSFORMER_SOURCE_MODEL_NAME_KEY: _get_transformers_model_name(
+                    model_instance.name_or_path
+                ),
                 _TRANSFORMER_MODEL_TYPE_KEY: model_instance.__class__.__name__,
             }
     return {}
+
 
 def _get_transformers_model_name(model_name_or_path):
     """
     Extract the Transformers model name from name_or_path attribute of a Transformer model.
 
-    Normally the name_or_path attribute just points to the model name, but in Sentence Transformers < 2.3.0,
-    the library loads the Transformers model after local snapshot download, so the name_or_path attribute
-    points to the local filepath.
+    Normally the name_or_path attribute just points to the model name, but in Sentence
+    Transformers < 2.3.0, the library loads the Transformers model after local snapshot
+    download, so the name_or_path attribute points to the local filepath.
     https://github.com/UKPLab/sentence-transformers/commit/9db0f205adcf315d16961fea7e9e6906cb950d43
     """
-    # NB: We have to check the normal repo pattern xxx/yyy because it can match local path pattern as well
-    if not _HF_REPO_NAME_PATTERN.match(model_name_or_path) and (m := _LOCAL_SNAPSHOT_PATH_PATTERN.match(model_name_or_path)):
+    # NB: We have to check the normal repo pattern xxx/yyy as it can match local path pattern too
+    if not _HF_REPO_NAME_PATTERN.match(model_name_or_path) and (
+        m := _LOCAL_SNAPSHOT_PATH_PATTERN.match(model_name_or_path)
+    ):
         return f"{m.group(1)}/{m.group(2)}"
     return model_name_or_path
 

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -91,11 +91,15 @@ def test_logged_data_structure(model_path, basic_model):
     ) == expected_requirements
 
     mlmodel = yaml.safe_load(model_path.joinpath("MLmodel").read_bytes())
-    assert mlmodel["flavors"]["python_function"]["loader_module"] == "mlflow.sentence_transformers"
-    assert (
-        mlmodel["flavors"]["python_function"]["data"]
-        == mlflow.sentence_transformers.SENTENCE_TRANSFORMERS_DATA_PATH
-    )
+    assert "model_size_bytes" in mlmodel
+
+    pyfunc_flavor = mlmodel["flavors"]["python_function"]
+    assert pyfunc_flavor["loader_module"] == "mlflow.sentence_transformers"
+    assert pyfunc_flavor["data"] == mlflow.sentence_transformers.SENTENCE_TRANSFORMERS_DATA_PATH
+
+    st_flavor = mlmodel["flavors"]["sentence_transformers"]
+    assert st_flavor["source_model_name"] == "sentence-transformers/all-MiniLM-L6-v2"
+    assert st_flavor["pipeline_model_type"] == "BertModel"
 
 
 def test_model_logging_and_inference(basic_model):

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -101,13 +101,28 @@ def test_logged_data_structure(model_path, basic_model):
 
     st_flavor = mlmodel["flavors"]["sentence_transformers"]
     assert st_flavor["pipeline_model_type"] == "BertModel"
-    if Version(sentence_transformers.__version__) >= Version("2.3.0"):
-        assert st_flavor["source_model_name"] == "sentence-transformers/all-MiniLM-L6-v2"
-    else:
-        # Before Transformers 2.3.0, the library loads the Transformers model after local snapshot
-        # download, so the name_or_path attribute points to the local filepath.
-        # https://github.com/UKPLab/sentence-transformers/commit/9db0f205adcf315d16961fea7e9e6906cb950d43
-        assert st_flavor["source_model_name"].endswith("sentence-transformers_all-MiniLM-L6-v2/")
+    assert st_flavor["source_model_name"] == "sentence-transformers/all-MiniLM-L6-v2"
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected"),
+    [
+        (
+            "sentence-transformers/all-MiniLM-L6-v2",
+            "sentence-transformers/all-MiniLM-L6-v2",
+        ),
+        (
+            "/path/to/local/path/sentence-transformers_all-MiniLM-L6-v2",
+            "sentence-transformers/all-MiniLM-L6-v2",
+        ),
+        (
+            "/path/to/local/path/custom-user-009_model_name_with_underscore",
+            "custom-user-009/model_name_with_underscore",
+        ),
+    ],
+)
+def test_get_transformers_model_name(model_name, expected):
+    assert mlflow.sentence_transformers._get_transformers_model_name(model_name) == expected
 
 
 def test_model_logging_and_inference(basic_model):

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -110,11 +110,11 @@ def test_logged_data_structure(model_path, basic_model):
             "sentence-transformers/all-MiniLM-L6-v2",
         ),
         (
-            "/path/to/local/path/sentence-transformers_all-MiniLM-L6-v2",
+            "/path./to_/local-/path?/sentence-transformers_all-MiniLM-L6-v2/",
             "sentence-transformers/all-MiniLM-L6-v2",
         ),
         (
-            "/path/to/local/path/custom-user-009_model_name_with_underscore",
+            "/path/to/local/path/custom-user-009_model_name_with_underscore/",
             "custom-user-009/model_name_with_underscore",
         ),
     ],

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -5,9 +5,7 @@ from unittest import mock
 import numpy as np
 import pandas as pd
 import pytest
-import sentence_transformers
 import yaml
-from packaging.version import Version
 from pyspark.sql import SparkSession
 from pyspark.sql.types import ArrayType, DoubleType
 from sentence_transformers import SentenceTransformer


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11529?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11529/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11529
```

</p>
</details>

### What changes are proposed in this pull request?

Log `source_model_name` and `pipeline_model_type` fields in the `sentence-transformers` flavor, similar to the `transformers` flavor. These fields are required for computing provisioned throughput in Databricks model serving.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
