### PR TITLE
Split cross version tests

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -57,8 +57,10 @@ jobs:
     permissions:
       issues: read # listLabelsOnIssue
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-      is_matrix_empty: ${{ steps.set-matrix.outputs.is_matrix_empty }}
+      matrix1: ${{ steps.set-matrix.outputs.matrix1 }}
+      matrix2: ${{ steps.set-matrix.outputs.matrix2 }}
+      is_matrix1_empty: ${{ steps.set-matrix.outputs.is_matrix1_empty }}
+      is_matrix2_empty: ${{ steps.set-matrix.outputs.is_matrix2_empty }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -117,14 +119,64 @@ jobs:
           else
             python dev/set_matrix.py
           fi
-  test:
+
+  test1:
     needs: set-matrix
-    if: ${{ needs.set-matrix.outputs.is_matrix_empty == 'false' }}
+    if: ${{ needs.set-matrix.outputs.is_matrix1_empty == 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.set-matrix.outputs.matrix1) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          repository: ${{ github.event_name == 'schedule' && 'mlflow/mlflow' || github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.ref }}
+      - uses: ./.github/actions/free-disk-space
+        if: matrix.free_disk_space
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: "adopt"
+      - name: Install mlflow & test dependencies
+        run: |
+          pip install wheel
+          pip install .[extras]
+          pip install -r requirements/test-requirements.txt
+      - name: Install ${{ matrix.package }} ${{ matrix.version }}
+        run: |
+          ${{ matrix.install }}
+      - name: Check package versions
+        run: |
+          python dev/show_package_release_dates.py
+      - name: Pre-test
+        if: matrix.pre_test
+        run: |
+          ${{ matrix.pre_test }}
+      - uses: ./.github/actions/pipdeptree
+      - name: Run tests
+        env:
+          MLFLOW_CONDA_HOME: /usr/share/miniconda
+          SPARK_LOCAL_IP: localhost
+          JOHNSNOWLABS_LICENSE_JSON: ${{ secrets.JOHNSNOWLABS_LICENSE_JSON }}
+          HF_HUB_ENABLE_HF_TRANSFER: 1
+        run: |
+          ${{ matrix.run }}
+
+  test2:
+    needs: set-matrix
+    if: ${{ needs.set-matrix.outputs.is_matrix2_empty == 'false' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.set-matrix.outputs.matrix2) }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -513,7 +513,7 @@ def set_action_output(name, value):
         f.write(f"{name}={value}\n")
 
 
-def find_split(matrix, n):
+def find_split_idx(matrix, n):
     prev = ""
     for idx, item in enumerate(matrix):
         if prev != item.name and idx > n:
@@ -534,7 +534,7 @@ def main(args):
     # Ensure we can split the matrix into two jobs
     assert len(matrix) <= MAX_JOBS * 2, f"Too many jobs: {len(matrix)} > {MAX_JOBS * 2}"
 
-    idx = find_split(matrix, len(matrix) // 2)
+    idx = find_split_idx(matrix, len(matrix) // 2)
     matrix1 = matrix[:idx]
     matrix2 = matrix[idx:]
     for idx, mat in enumerate((matrix1, matrix2), start=1):

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -552,7 +552,7 @@ def validate_action_config(num_jobs: int):
 def main(args):
     # https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits
     # > A job matrix can generate a maximum of 256 jobs per workflow run.
-    MAX_JOBS = 256
+    MAX_ITEMS = 256
     NUM_JOBS = 2
     validate_action_config(NUM_JOBS)
 
@@ -561,7 +561,7 @@ def main(args):
     matrix = generate_matrix(args)
     matrix = sorted(matrix, key=lambda x: (x.name, x.category, x.version))
     matrix = [x for x in matrix if x.flavor not in ("gluon", "mleap")]
-    assert len(matrix) <= MAX_JOBS * 2, f"Too many jobs: {len(matrix)} > {MAX_JOBS * NUM_JOBS}"
+    assert len(matrix) <= MAX_ITEMS * 2, f"Too many jobs: {len(matrix)} > {MAX_ITEMS * NUM_JOBS}"
     for idx, mat in enumerate(split(matrix, NUM_JOBS), start=1):
         mat = {"include": mat, "job_name": [x.job_name for x in mat]}
         print(divider(f"Matrix {idx}"))

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -543,7 +543,7 @@ def main(args):
         print(json.dumps(mat, indent=2, cls=CustomEncoder))
         if "GITHUB_ACTIONS" in os.environ:
             set_action_output(f"matrix{idx}", json.dumps(mat, cls=CustomEncoder))
-            set_action_output(f"is_matrix{idx}_empty", "true" if bool(mat) else "false")
+            set_action_output(f"is_matrix{idx}_empty", "true" if len(mat) == 0 else "false")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11539?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11539/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11539
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The number of jobs for cross version tests exceeds 256. We need to split them into two jobs.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
