### PR TITLE
Fix GraphQL enum fetching error

### DIFF
--- a/dev/proto_to_graphql/schema_autogeneration.py
+++ b/dev/proto_to_graphql/schema_autogeneration.py
@@ -90,8 +90,10 @@ def generate_schema(state):
     for enum in sorted(state.enums, key=lambda item: item.full_name):
         pascal_class_name = snake_to_pascal(get_descriptor_full_pascal_name(enum))
         schema_builder += f"\nclass {pascal_class_name}(graphene.Enum):"
-        for value in enum.values:
-            schema_builder += f'''\n{INDENT}{value.name} = "{value.name}"'''
+        for i in range(len(enum.values)):
+            value = enum.values[i]
+            # enum indices start from 1
+            schema_builder += f"""\n{INDENT}{value.name} = {i+1}"""
         schema_builder += "\n\n"
 
     for type in state.types:

--- a/mlflow/server/graphql/autogenerated_graphql_schema.py
+++ b/mlflow/server/graphql/autogenerated_graphql_schema.py
@@ -7,17 +7,17 @@ from mlflow.utils.proto_json_utils import parse_dict
 
 
 class MlflowModelVersionStatus(graphene.Enum):
-    PENDING_REGISTRATION = "PENDING_REGISTRATION"
-    FAILED_REGISTRATION = "FAILED_REGISTRATION"
-    READY = "READY"
+    PENDING_REGISTRATION = 1
+    FAILED_REGISTRATION = 2
+    READY = 3
 
 
 class MlflowRunStatus(graphene.Enum):
-    RUNNING = "RUNNING"
-    SCHEDULED = "SCHEDULED"
-    FINISHED = "FINISHED"
-    FAILED = "FAILED"
-    KILLED = "KILLED"
+    RUNNING = 1
+    SCHEDULED = 2
+    FINISHED = 3
+    FAILED = 4
+    KILLED = 5
 
 
 class MlflowModelVersionTag(graphene.ObjectType):

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -2033,7 +2033,7 @@ def test_get_run_and_experiment_graphql(mlflow_client):
     )
     assert response.status_code == 200
     json = response.json()
-    assert json["errors"] == None
+    assert json["errors"] is None
     assert (
         json["data"]["mlflowGetRun"]["run"]["info"]["status"] == created_run.info.status
     )

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -2034,8 +2034,6 @@ def test_get_run_and_experiment_graphql(mlflow_client):
     assert response.status_code == 200
     json = response.json()
     assert json["errors"] is None
-    assert (
-        json["data"]["mlflowGetRun"]["run"]["info"]["status"] == created_run.info.status
-    )
+    assert json["data"]["mlflowGetRun"]["run"]["info"]["status"] == created_run.info.status
     assert json["data"]["mlflowGetRun"]["run"]["experiment"]["name"] == name
     assert json["data"]["mlflowGetRun"]["run"]["modelVersions"][0]["name"] == name

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -2014,6 +2014,9 @@ def test_get_run_and_experiment_graphql(mlflow_client):
                 query testQuery {{
                     mlflowGetRun(input: {{runId: "{run_id}"}}) {{
                         run {{
+                            info {{
+                                status
+                            }}
                             experiment {{
                                 name
                             }}
@@ -2030,5 +2033,9 @@ def test_get_run_and_experiment_graphql(mlflow_client):
     )
     assert response.status_code == 200
     json = response.json()
+    assert json["errors"] == None
+    assert (
+        json["data"]["mlflowGetRun"]["run"]["info"]["status"] == created_run.info.status
+    )
     assert json["data"]["mlflowGetRun"]["run"]["experiment"]["name"] == name
     assert json["data"]["mlflowGetRun"]["run"]["modelVersions"][0]["name"] == name


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/edwardfeng-db/mlflow/pull/11542?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11542/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11542
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx
Resolves https://github.com/mlflow/mlflow/issues/11526

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
- Fixing the error when GraphQL fails to resolve enum values
- The enum values should be integers starting from 1 instead of just the string representation of the value. Updated the autogeneration code to address this issue
- Adding unit test case

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
