### PR TITLE
Fix for `upload_trace_data` and `download_trace_data`

### DIFF
--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -266,6 +266,24 @@ class ArtifactRepository:
         num_cpus = os.cpu_count() or _NUM_DEFAULT_CPUS
         return min(num_cpus * _NUM_MAX_THREADS_PER_CPU, _NUM_MAX_THREADS)
 
+    def download_trace_data(self) -> Dict[str, Any]:
+        """
+        Download the trace data.
+
+        Returns:
+            The trace data as a dictionary.
+        """
+        raise NotImplementedError
+
+    def upload_trace_data(self, trace_data: Dict[str, Any]) -> None:
+        """
+        Upload the trace data.
+
+        Args:
+            trace_data: The trace data to upload.
+        """
+        raise NotImplementedError
+
 
 class MultipartUploadMixin(ABC):
     @abstractmethod
@@ -323,24 +341,6 @@ class MultipartUploadMixin(ABC):
 
         """
         pass
-
-    def download_trace_data(self) -> Dict[str, Any]:
-        """
-        Download the trace data.
-
-        Returns:
-            The trace data as a dictionary.
-        """
-        raise NotImplementedError
-
-    def upload_trace_data(self, trace_data: Dict[str, Any]) -> None:
-        """
-        Upload the trace data.
-
-        Args:
-            trace_data: The trace data to upload.
-        """
-        raise NotImplementedError
 
 
 def verify_artifact_path(artifact_path):

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -579,10 +579,8 @@ class TrackingServiceClient:
 
     def _get_artifact_repo_for_trace(self, request_id):
         trace_info = self.get_trace_info(request_id)
-        artifact_uri_attr = next(t for t in trace_info.tags if t.key == "mlflow.artifactLocation")
-        artifact_uri = add_databricks_profile_info_to_artifact_uri(
-            artifact_uri_attr.value, self.tracking_uri
-        )
+        artifact_uri = next(v for k, v in trace_info.tags.items() if k == "mlflow.artifactLocation")
+        artifact_uri = add_databricks_profile_info_to_artifact_uri(artifact_uri, self.tracking_uri)
         return get_artifact_repository(artifact_uri)
 
     def _get_artifact_repo(self, run_id):

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -625,7 +625,7 @@ class TrackingServiceClient:
 
     def _upload_trace_data(self, request_id: str, trace_data: TraceData) -> None:
         artifact_repo = self._get_artifact_repo_for_trace(request_id)
-        return artifact_repo.upload_trace_data(trace_data.dict())
+        return artifact_repo.upload_trace_data(trace_data.to_dict())
 
     def log_artifacts(self, run_id, local_dir, artifact_path=None):
         """Write a directory of files to the remote ``artifact_uri``.

--- a/tests/tracking/_tracking_service/test_tracking_service_client.py
+++ b/tests/tracking/_tracking_service/test_tracking_service_client.py
@@ -114,7 +114,6 @@ def test_upload_trace_data(tmp_path):
         ),
     ) as mock_get_trace_info, mock.patch(
         "mlflow.store.artifact.artifact_repo.ArtifactRepository.upload_trace_data",
-        return_value={"spans": []},
     ) as mock_upload_trace_data:
         client = TrackingServiceClient(tmp_path.as_uri())
         client._upload_trace_data(request_id="test", trace_data=TraceData())


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11545?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11545/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11545
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for `upload_trace_data` and `download_trace_data`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

```python
import mlflow

mlflow.set_tracking_uri("databricks")
name = "/Users/harutaka.kawamura@databricks.com/test"
mlflow.set_experiment(name)
exp = mlflow.get_experiment_by_name(name)


@mlflow.trace
def f(x):
    return x

f(x=1)
trace = mlflow.get_traces()[0]

client = mlflow.MlflowClient()
trace_info = client.create_trace(
    experiment_id=exp.experiment_id,
    timestamp_ms=123,
    execution_time_ms=567,
    status="OK",
)

client._tracking_client._upload_trace_data(trace_info.request_id, trace.trace_data)
downloaded = client._tracking_client._download_trace_data(trace_info.request_id)
print(downloaded)

```

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
