### PR TITLE
[Bug-bash] Allow passing arbitral types for attributes/inputs/outputs

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -50,7 +50,7 @@ class Span(_MLflowObject):
     status: SpanStatus
     start_time: int
     end_time: int
-    span_type: str = field(default=SpanType.UNKNOWN)
+    span_type: str = SpanType.UNKNOWN
     inputs: Optional[Dict[str, Any]] = None
     outputs: Optional[Dict[str, Any]] = None
     attributes: Dict[str, Any] = field(default_factory=dict)

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -50,7 +50,7 @@ class Span(_MLflowObject):
     status: SpanStatus
     start_time: int
     end_time: int
-    span_type: Optional[str] = field(default=SpanType.UNKNOWN)
+    span_type: str = field(default=SpanType.UNKNOWN)
     inputs: Optional[Dict[str, Any]] = None
     outputs: Optional[Dict[str, Any]] = None
     attributes: Dict[str, Any] = field(default_factory=dict)

--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -91,11 +91,14 @@ class MLflowSpanExporter(SpanExporter):
         if not input_or_output:
             return ""
 
-        try:
-            serialized = json.dumps(input_or_output)
-        except TypeError:
-            # If not JSON-serializable, use string representation
-            serialized = str(input_or_output)
+        if type(input_or_output) is str:
+            serialized = input_or_output
+        else:
+            try:
+                serialized = json.dumps(input_or_output)
+            except TypeError:
+                # If not JSON-serializable, use string representation
+                serialized = str(input_or_output)
 
         if len(serialized) > MAX_CHARS_IN_TRACE_INFO_ATTRIBUTE:
             trunc_length = MAX_CHARS_IN_TRACE_INFO_ATTRIBUTE - len(TRUNCATION_SUFFIX)

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -67,7 +67,7 @@ def trace(
                 span.set_attribute("function_name", fn.__name__)
                 span.set_inputs(capture_function_input_args(fn, args, kwargs))
                 result = fn(*args, **kwargs)
-                span.set_outputs({"output": result})
+                span.set_outputs(result)
                 return result
 
         return wrapper

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from opentelemetry import trace as trace_api
 
+from mlflow.entities import SpanType
 from mlflow.tracing.provider import get_tracer
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.types.wrapper import MLflowSpanWrapper, NoOpMLflowSpanWrapper
@@ -18,7 +19,7 @@ _logger = logging.getLogger(__name__)
 def trace(
     func: Optional[Callable] = None,
     name: Optional[str] = None,
-    span_type: Optional[str] = None,
+    span_type: str = SpanType.UNKNOWN,
     attributes: Optional[Dict[str, Any]] = None,
 ):
     """
@@ -76,7 +77,9 @@ def trace(
 
 @contextlib.contextmanager
 def start_span(
-    name: str = "span", span_type: Optional[str] = None, attributes: Optional[Dict[str, Any]] = None
+    name: str = "span",
+    span_type: Optional[str] = SpanType.UNKNOWN,
+    attributes: Optional[Dict[str, Any]] = None,
 ):
     """
     Context manager to create a new span and start it as the current span in the context.
@@ -88,7 +91,7 @@ def start_span(
         with mlflow.start_span("my_span") as span:
             span.set_inputs({"x": 1, "y": 2})
             z = x + y
-            span.set_outputs({"z": z})
+            span.set_outputs(z)
             span.set_attribute("key", "value")
             # do something
 

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 from cachetools import TTLCache
 from opentelemetry import trace as trace_api
 
-from mlflow.entities import Trace, TraceData, TraceInfo, TraceStatus
+from mlflow.entities import SpanType, Trace, TraceData, TraceInfo, TraceStatus
 from mlflow.environment_variables import (
     MLFLOW_TRACE_BUFFER_MAX_SIZE,
     MLFLOW_TRACE_BUFFER_TTL_SECONDS,
@@ -57,7 +57,7 @@ class InMemoryTraceManager:
         name: str,
         request_id: Optional[str] = None,
         parent_span_id: Optional[str] = None,
-        span_type: Optional[str] = None,
+        span_type: str = SpanType.UNKNOWN,
     ) -> MLflowSpanWrapper:
         """
         Start a new OpenTelemetry span that is not part of the current trace context, but with the

--- a/mlflow/tracing/types/wrapper.py
+++ b/mlflow/tracing/types/wrapper.py
@@ -17,7 +17,7 @@ class MLflowSpanWrapper:
     Span object, so need to implement the same interfaces as the original Span.
     """
 
-    def __init__(self, span: trace_api.Span, span_type: SpanType = SpanType.UNKNOWN):
+    def __init__(self, span: trace_api.Span, span_type: str = SpanType.UNKNOWN):
         self._span = span
         self._span_type = span_type
         self._inputs = None
@@ -93,7 +93,7 @@ class MLflowSpanWrapper:
         if not isinstance(key, str):
             _logger.warning(f"Attribute key must be a string, but got {type(key)}. Skipping.")
             return
-        self.set_attributes({key: value})
+        self._attributes[key] = value
 
     def set_status(self, status: SpanStatus):
         # NB: We need to set the OpenTelemetry native StatusCode, because span's set_status

--- a/mlflow/tracing/types/wrapper.py
+++ b/mlflow/tracing/types/wrapper.py
@@ -4,8 +4,7 @@ from typing import Any, Dict, Optional
 
 from opentelemetry import trace as trace_api
 
-from mlflow.entities import Span, SpanContext, SpanEvent, SpanStatus, TraceStatus
-from mlflow.entities.span import SpanType
+from mlflow.entities import Span, SpanContext, SpanEvent, SpanStatus, SpanType, TraceStatus
 
 _logger = logging.getLogger(__name__)
 
@@ -18,13 +17,14 @@ class MLflowSpanWrapper:
     Span object, so need to implement the same interfaces as the original Span.
     """
 
-    def __init__(self, span: trace_api.Span, span_type: SpanType = None):
+    def __init__(self, span: trace_api.Span, span_type: SpanType = SpanType.UNKNOWN):
         self._span = span
-        # NB: Default to UNKNOWN type, but not use it as default in the constructor
-        #  cuz some upstream function want to pass None by default.
-        self._span_type = span_type or SpanType.UNKNOWN
+        self._span_type = span_type
         self._inputs = None
         self._outputs = None
+        # NB: We don't use the OpenTelemetry's attributes because it only accepts
+        #  a limited set of types as primitive values, but we want to allow any type.
+        self._attributes = {}
 
     @property
     def request_id(self) -> str:
@@ -75,20 +75,25 @@ class MLflowSpanWrapper:
     def outputs(self) -> Dict[str, Any]:
         return self._outputs
 
-    def set_inputs(self, inputs: Dict[str, Any]):
+    def set_inputs(self, inputs: Any):
         self._inputs = inputs
 
-    def set_outputs(self, outputs: Dict[str, Any]):
+    def set_outputs(self, outputs: Any):
         self._outputs = outputs
 
     def set_attributes(self, attributes: Dict[str, Any]):
-        try:
-            self._span.set_attributes(attributes)
-        except Exception as e:
-            _logger.warning(f"Failed to set attributes {attributes} on span {self.name}: {e}")
+        if not isinstance(attributes, dict):
+            _logger.warning(
+                f"Attributes must be a dictionary, but got {type(attributes)}. Skipping."
+            )
+            return
+        self._attributes.update(attributes)
 
     def set_attribute(self, key: str, value: Any):
-        self._span.set_attribute(key, value)
+        if not isinstance(key, str):
+            _logger.warning(f"Attribute key must be a string, but got {type(key)}. Skipping.")
+            return
+        self.set_attributes({key: value})
 
     def set_status(self, status: SpanStatus):
         # NB: We need to set the OpenTelemetry native StatusCode, because span's set_status
@@ -143,8 +148,8 @@ class MLflowSpanWrapper:
             end_time=self.end_time,
             inputs=self.inputs,
             outputs=self.outputs,
-            # Convert from MappingProxyType to dict for serialization
-            attributes=dict(self._span.attributes),
+            # NB: There may be some attributes set by OpenTelemetry automatically
+            attributes={**self._span.attributes, **self._attributes},
             events=[
                 SpanEvent(
                     name=event.name,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -27,13 +27,13 @@ from mlflow.entities import (
     Run,
     RunTag,
     SpanStatus,
+    SpanType,
     TraceInfo,
     TraceStatus,
     ViewType,
 )
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
-from mlflow.entities import SpanType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import (
     FEATURE_DISABLED,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -33,6 +33,7 @@ from mlflow.entities import (
 )
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
+from mlflow.entities import SpanType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import (
     FEATURE_DISABLED,
@@ -533,7 +534,7 @@ class MlflowClient:
         name: str,
         request_id: str,
         parent_span_id: str,
-        span_type: Optional[str] = None,
+        span_type: str = SpanType.UNKNOWN,
         inputs: Optional[Dict[str, Any]] = None,
         attributes: Optional[Dict[str, Any]] = None,
     ):
@@ -621,7 +622,7 @@ class MlflowClient:
         request_id: str,
         span_id: str,
         outputs: Optional[Dict[str, Any]] = None,
-        attributes: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Any] = None,
         status: SpanStatus = SpanStatus(TraceStatus.OK),
     ):
         """

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -27,6 +27,7 @@ def test_json_deserialization(mock_trace_client):
             name="add_one_with_custom_name",
             attributes={
                 "delta": 1,
+                "metadata": {"foo": "bar"},
                 # Test for non-json-serializable input
                 "datetime": datetime_now,
             },
@@ -90,6 +91,7 @@ def test_json_deserialization(mock_trace_client):
                     "attributes": {
                         "delta": 1,
                         "datetime": str(datetime_now),
+                        "metadata": '{"foo": "bar"}',
                         "function_name": "add_one",
                     },
                     "events": [],

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -1,5 +1,6 @@
 import importlib
 import json
+from datetime import datetime
 
 import pytest
 from packaging.version import Version
@@ -12,6 +13,8 @@ from tests.tracing.conftest import mock_client as mock_trace_client  # noqa: F40
 
 
 def test_json_deserialization(mock_trace_client):
+    datetime_now = datetime.now()
+
     class TestModel:
         @mlflow.trace()
         def predict(self, x, y):
@@ -20,7 +23,13 @@ def test_json_deserialization(mock_trace_client):
             return z  # noqa: RET504
 
         @mlflow.trace(
-            span_type=SpanType.LLM, name="add_one_with_custom_name", attributes={"delta": 1}
+            span_type=SpanType.LLM,
+            name="add_one_with_custom_name",
+            attributes={
+                "delta": 1,
+                # Test for non-json-serializable input
+                "datetime": datetime_now,
+            },
         )
         def add_one(self, z):
             return z + 1
@@ -43,7 +52,7 @@ def test_json_deserialization(mock_trace_client):
             "request_metadata": {
                 "name": "predict",
                 "inputs": '{"x": 2, "y": 5}',
-                "outputs": '{"output": 8}',
+                "outputs": "8",
             },
             "tags": {},
         },
@@ -61,7 +70,7 @@ def test_json_deserialization(mock_trace_client):
                     "end_time": trace.trace_data.spans[0].end_time,
                     "status": {"status_code": "OK", "description": ""},
                     "inputs": {"x": 2, "y": 5},
-                    "outputs": {"output": 8},
+                    "outputs": 8,
                     "attributes": {"function_name": "predict"},
                     "events": [],
                 },
@@ -77,8 +86,12 @@ def test_json_deserialization(mock_trace_client):
                     "end_time": trace.trace_data.spans[1].end_time,
                     "status": {"status_code": "OK", "description": ""},
                     "inputs": {"z": 7},
-                    "outputs": {"output": 8},
-                    "attributes": {"delta": 1, "function_name": "add_one"},
+                    "outputs": 8,
+                    "attributes": {
+                        "delta": 1,
+                        "datetime": str(datetime_now),
+                        "function_name": "add_one",
+                    },
                     "events": [],
                 },
             ],

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -91,7 +91,7 @@ def test_json_deserialization(mock_trace_client):
                     "attributes": {
                         "delta": 1,
                         "datetime": str(datetime_now),
-                        "metadata": '{"foo": "bar"}',
+                        "metadata": {"foo": "bar"},
                         "function_name": "add_one",
                     },
                     "events": [],

--- a/tests/tracing/export/test_mlflow_exporter.py
+++ b/tests/tracing/export/test_mlflow_exporter.py
@@ -85,7 +85,7 @@ def test_export():
     assert len(inputs) == MAX_CHARS_IN_TRACE_INFO_ATTRIBUTE
 
     outputs = trace_info.request_metadata[TraceMetadataKey.OUTPUTS]
-    assert outputs.startswith("very long output")
+    assert outputs.startswith('"very long output')
     assert outputs.endswith(TRUNCATION_SUFFIX)
     assert len(outputs) == MAX_CHARS_IN_TRACE_INFO_ATTRIBUTE
 
@@ -99,10 +99,11 @@ def test_export():
 def test_serialize_inputs_outputs():
     exporter = MLflowSpanExporter(MagicMock())
     assert exporter._serialize_inputs_outputs({"x": 1, "y": 2}) == '{"x": 1, "y": 2}'
+    assert exporter._serialize_inputs_outputs("string input") == '"string input"'
     # Truncate long inputs
     assert len(exporter._serialize_inputs_outputs({"x": "very long input" * 100})) == 300
     # non-JSON-serializable inputs
     assert (
         exporter._serialize_inputs_outputs({"input": pd.DataFrame({"x": [1], "y": [2]})})
-        == "{'input':    x  y\n0  1  2}"
+        == '{"input": "   x  y\\n0  1  2"}'
     )

--- a/tests/tracing/export/test_mlflow_exporter.py
+++ b/tests/tracing/export/test_mlflow_exporter.py
@@ -65,7 +65,7 @@ def test_export():
     # Export the root span -> client call
     root_span = MLflowSpanWrapper(otel_span_root)
     root_span.set_inputs({"input1": "very long input" * 100})
-    root_span.set_outputs({"output1": "very long output" * 100})
+    root_span.set_outputs("very long output" * 100)
     exporter.export([root_span])
 
     assert mock_client.log_trace.call_count == 1
@@ -85,7 +85,7 @@ def test_export():
     assert len(inputs) == MAX_CHARS_IN_TRACE_INFO_ATTRIBUTE
 
     outputs = trace_info.request_metadata[TraceMetadataKey.OUTPUTS]
-    assert outputs.startswith('{"output1": "very long output')
+    assert outputs.startswith("very long output")
     assert outputs.endswith(TRUNCATION_SUFFIX)
     assert len(outputs) == MAX_CHARS_IN_TRACE_INFO_ATTRIBUTE
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11547?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11547/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11547
```

</p>
</details>

### What changes are proposed in this pull request?

This PR addresses two gaps identified during the bug-bash.

1. The span's `attributes` field only accept values with type `['bool', 'str', 'bytes', 'int', 'float']`. This is due to the OpenTelemetry's specification, but not reasonable for our use cases. After this PR, any types can be specified as attribute values.
    * One caveat is that non Json-serializable values are stringified, so not rendered nicely on UI or inconvenient to loading back. However, this seems to be inevitable limitation as long as we use JSON as a way to transfer span data. Perhaps we may still be able to define custom encoder for common data types like data frame, but it's not the scope of this PR.
2. Similarly, `inputs` and `outputs` field were limited to dictionary (strictly to say it's not limited, as it was just type annotation, but UI doesn't work if it's not dictionary). This PR removes this requirement and simply accept any input/output to be passed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
