### PR TITLE
Conversational LangChain model support

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -272,7 +272,7 @@ def save_model(
     code_dir_subpath = _validate_and_copy_code_paths(formatted_code_path, path)
 
     if signature is None:
-        if input_example is not None:
+        if input_example is not None and not isinstance(lc_model, str):
             wrapped_model = _LangChainModelWrapper(lc_model)
             signature = _infer_signature_from_input_example(input_example, wrapped_model)
         else:

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -594,7 +594,8 @@ class _LangChainModelWrapper:
         """
         Args:
             data: Model input data.
-            params: Additional parameters to pass to the model for inference.
+            params: Additional parameters passed to model during inference so that
+            config={"configurable": params}.
 
                 .. Note:: Experimental: This parameter may change or be removed in a future
                     release without warning.

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -595,7 +595,7 @@ class _LangChainModelWrapper:
         Args:
             data: Model input data.
             params: Additional parameters passed to model during inference so that
-            config={"configurable": params}.
+                config={"configurable": params}.
 
                 .. Note:: Experimental: This parameter may change or be removed in a future
                     release without warning.
@@ -699,7 +699,8 @@ class _TestLangChainWrapper(_LangChainModelWrapper):
 
         Args:
             data: Model input data.
-            params: Additional parameters to pass to the model for inference.
+            params: Additional parameters passed to model during inference so that
+                config={"configurable": params}.
 
                 .. Note:: Experimental: This parameter may change or be removed in a future
                     release without warning.
@@ -733,7 +734,7 @@ class _TestLangChainWrapper(_LangChainModelWrapper):
             mockContent = TEST_CONTENT
 
         with _mock_async_request(mockContent):
-            result = super().predict(data)
+            result = super().predict(data, params)
         if (
             hasattr(self.lc_model, "return_source_documents")
             and self.lc_model.return_source_documents

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -605,7 +605,9 @@ class _LangChainModelWrapper:
         from mlflow.langchain.api_request_parallel_processor import process_api_requests
 
         messages, return_first_element = self._prepare_messages(data)
-        results = process_api_requests(lc_model=self.lc_model, requests=messages)
+        results = process_api_requests(
+            lc_model=self.lc_model, requests=messages, configurables=params
+        )
         return results[0] if return_first_element else results
 
     @experimental

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -179,8 +179,7 @@ class APIRequest:
         Calls the LangChain API and stores results.
         """
         from langchain.schema import BaseRetriever
-
-        from mlflow.langchain.utils import lc_runnables_types
+        from langchain_core.runnables import Runnable
 
         _logger.debug(f"Request #{self.index} started with payload: {self.request_json}")
 
@@ -191,7 +190,7 @@ class APIRequest:
                 response = [
                     {"page_content": doc.page_content, "metadata": doc.metadata} for doc in docs
                 ]
-            elif isinstance(self.lc_model, lc_runnables_types()):
+            elif isinstance(self.lc_model, Runnable):
                 if isinstance(self.request_json, dict):
                     # This is a temporary fix for the case when spark_udf converts
                     # input into pandas dataframe with column name, while the model

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, Set, Union
 
 import langchain.chains
+import langchain_core.runnables
 import pydantic
 from langchain.callbacks.base import BaseCallbackHandler
 from langchain.schema import AgentAction, AIMessage, HumanMessage, SystemMessage
@@ -129,7 +130,7 @@ class APIRequest:
     """
 
     index: int
-    lc_model: langchain.chains.base.Chain
+    lc_model: langchain.chains.base.Chain | langchain_core.runnables.Runnable
     request_json: dict
     results: list[tuple[int, str]]
     errors: dict
@@ -175,24 +176,47 @@ class APIRequest:
             ]
 
     def call_api(
-        self, status_tracker: StatusTracker, callback_handlers: Optional[List[BaseCallbackHandler]]
+        self,
+        status_tracker: StatusTracker,
+        callback_handlers: Optional[List[BaseCallbackHandler]],
     ):
         """
         Calls the LangChain API and stores results.
         """
         from langchain.schema import BaseRetriever
-        from langchain_core.runnables import Runnable
+
+        from mlflow.langchain.utils import base_lc_types
 
         _logger.debug(f"Request #{self.index} started with payload: {self.request_json}")
 
         try:
+            config = {
+                "callbacks": callback_handlers,
+                "configurable": self.configurables,
+            }
+
             if isinstance(self.lc_model, BaseRetriever):
                 # Retrievers are invoked differently than Chains
                 docs = self.lc_model.get_relevant_documents(**self.request_json)
                 response = [
                     {"page_content": doc.page_content, "metadata": doc.metadata} for doc in docs
                 ]
-            elif isinstance(self.lc_model, Runnable):
+            elif isinstance(self.lc_model, base_lc_types()):
+                response = self.lc_model.invoke(
+                    self.request_json,
+                    return_only_outputs=True,
+                    config=config,
+                )
+
+                if self.did_perform_chat_conversion or self.convert_chat_responses:
+                    response = APIRequest._try_transform_response_to_chat_format(response)
+                elif len(response) == 1:
+                    # to maintain existing code, single output chains will still return
+                    # only the result
+                    response = response.popitem()[1]
+                else:
+                    self._prepare_to_serialize(response)
+            else:
                 if isinstance(self.request_json, dict):
                     # This is a temporary fix for the case when spark_udf converts
                     # input into pandas dataframe with column name, while the model
@@ -201,10 +225,7 @@ class APIRequest:
                     try:
                         response = self.lc_model.invoke(
                             self.request_json,
-                            config={
-                                "callbacks": callback_handlers,
-                                "configurable": self.configurables,
-                            },
+                            config=config,
                         )
                     except TypeError as e:
                         _logger.warning(
@@ -223,41 +244,23 @@ class APIRequest:
 
                         response = self.lc_model.invoke(
                             prepared_request_json,
-                            config={
-                                "callbacks": callback_handlers,
-                                "configurable": self.configurables,
-                            },
+                            config=config,
                         )
                 else:
                     response = self.lc_model.invoke(
                         self.request_json,
-                        config={"callbacks": callback_handlers, "configurable": self.configurables},
+                        config=config,
                     )
                 if self.did_perform_chat_conversion or self.convert_chat_responses:
                     response = APIRequest._try_transform_response_to_chat_format(response)
-            else:
-                response = self.lc_model(
-                    self.request_json,
-                    return_only_outputs=True,
-                    callbacks=callback_handlers,
-                )
-
-                if self.did_perform_chat_conversion or self.convert_chat_responses:
-                    response = APIRequest._try_transform_response_to_chat_format(response)
-                elif len(response) == 1:
-                    # to maintain existing code, single output chains will still return
-                    # only the result
-                    response = response.popitem()[1]
-                else:
-                    self._prepare_to_serialize(response)
 
             _logger.debug(f"Request #{self.index} succeeded with response: {response}")
             self.results.append((self.index, response))
             status_tracker.complete_task(success=True)
         except Exception as e:
-            self.errors[self.index] = (
-                f"error: {e!r} {traceback.format_exc()}\n request payload: {self.request_json}"
-            )
+            self.errors[
+                self.index
+            ] = f"error: {e!r} {traceback.format_exc()}\n request payload: {self.request_json}"
             status_tracker.increment_num_api_errors()
             status_tracker.complete_task(success=False)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,10 @@ extend-exclude = [
   "tests/protos",
 ]
 
+[tool.ruff.format]
+docstring-code-format = true
+docstring-code-line-length = 88
+
 [tool.ruff.lint]
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,10 +162,6 @@ extend-exclude = [
   "tests/protos",
 ]
 
-[tool.ruff.format]
-docstring-code-format = true
-docstring-code-line-length = 88
-
 [tool.ruff.lint]
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 select = [

--- a/tests/langchain/runnable_with_message_history/chain.py
+++ b/tests/langchain/runnable_with_message_history/chain.py
@@ -1,0 +1,34 @@
+from langchain.chat_models import ChatOpenAI
+from langchain.memory import ChatMessageHistory
+from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain.schema import BaseChatMessageHistory
+from langchain.schema.output_parser import StrOutputParser
+from langchain_core.runnables.history import RunnableWithMessageHistory
+
+from mlflow.langchain._rag_utils import _set_chain
+
+store = {}
+
+
+def get_session_history(session_id: str) -> BaseChatMessageHistory:
+    if session_id not in store:
+        store[session_id] = ChatMessageHistory()
+    return store[session_id]
+
+
+model = ChatOpenAI()
+prompt = ChatPromptTemplate.from_messages(
+    [
+        MessagesPlaceholder(variable_name="history"),
+        ("human", "{input}"),
+    ]
+)
+runnable = prompt | model | StrOutputParser()
+history_runnable = RunnableWithMessageHistory(
+    runnable,
+    get_session_history,
+    input_messages_key="input",
+    history_messages_key="history",
+)
+
+_set_chain(history_runnable)

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -47,7 +47,18 @@ def test_parsing_dependency_from_databricks_llm(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setenv("DATABRICKS_HOST", "my-default-host")
     monkeypatch.setenv("DATABRICKS_TOKEN", "my-default-token")
 
-    llm = Databricks(endpoint_name="databricks-mixtral-8x7b-instruct")
+    try:
+        import langchain_community
+
+        if Version(langchain_community.__version__) >= Version("0.0.27"):
+            llm = Databricks(
+                endpoint_name="databricks-mixtral-8x7b-instruct",
+                allow_dangerous_deserialization=True,
+            )
+        else:
+            llm = Databricks(endpoint_name="databricks-mixtral-8x7b-instruct")
+    except ImportError:
+        llm = Databricks(endpoint_name="databricks-mixtral-8x7b-instruct")
     d = defaultdict(list)
     _extract_databricks_dependencies_from_llm(llm, d)
     assert d.get(_DATABRICKS_LLM_ENDPOINT_NAME_KEY) == ["databricks-mixtral-8x7b-instruct"]

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2544,3 +2544,27 @@ def test_config_path_context():
         )
 
     assert mlflow.langchain._rag_utils.__databricks_rag_config_path__ is None
+
+
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.0.337"),
+    reason="feature not existing",
+)
+def test_runnable_with_message_history_predict():
+    with mlflow.start_run():
+        input_example = {"input": "test"}
+        params_example = {"session_id": "000000"}
+        output_example = [TEST_CONTENT]
+        signature = mlflow.models.signature.infer_signature(
+            input_example, output_example, params_example
+        )
+        model_info = mlflow.langchain.log_model(
+            lc_model="tests/langchain/runnable_with_message_history/chain.py",
+            artifact_path="model_path",
+            signature=signature,
+            input_example=input_example,
+            code_paths=[],
+        )
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    result = loaded_model.predict([input_example], params_example)
+    assert result == [TEST_CONTENT]

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2566,5 +2566,9 @@ def test_runnable_with_message_history_predict():
             code_paths=[],
         )
     loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+
+    # functionally an assert that the params were passed, as RunnableWithMessageHistory throws
+    # an error if the expected configurable fields are not passed
     result = loaded_model.predict([input_example], params_example)
+
     assert result == [TEST_CONTENT]


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adds support for conversational LangChain models (such as `RunnableWithMessageHistory`) by passing configurables to model invocation and calling `invoke` instead `__call__` for all models.

Adds check to ensure signature is not inferred from `lc_model` passed as a `str`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added support for prediction with any LangChain model loaded as a `python_function` (`pyfunc`) instead of select types. Added support  for passing `configurable` fields to `Runnable` LangChain models loaded as a `python_function` (`pyfunc`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
