### PR TITLE
Enrich docs for tracing APIs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -360,7 +360,7 @@ nitpick_ignore = [
     ("py:class", "mlflow.types.schema.Object"),
     ("py:class", "mlflow.types.schema.ParamSchema"),
     ("py:class", "mlflow.types.schema.ParamSpec"),
-    ("py:class", "MLflowSpanWrapper"),
+    ("py:class", "opentelemetry.trace.span.Span"),
     ("py:class", "opentelemetry.trace.status.Status"),
     ("py:class", "opentelemetry.trace.status.StatusCode"),
     ("py:class", "ModelSignature"),
@@ -414,6 +414,7 @@ def _get_reference_map():
     """
     ref_map = {
         # < Invalid reference >: < valid reference >
+        "mlflow.tracing.MLflowSpanWrapper": "mlflow.tracing.types.wrapper.MLflowSpanWrapper",
         "mlflow.tracking.fluent.ActiveRun": "mlflow.ActiveRun",
         "mlflow.store.entities.paged_list.PagedList": "mlflow.store.entities.PagedList",
     }

--- a/docs/source/python_api/mlflow.tracing.rst
+++ b/docs/source/python_api/mlflow.tracing.rst
@@ -1,0 +1,67 @@
+mlflow.tracing
+==============
+
+.. attention::
+
+    This is a tentative documentation for the development period. The main objective is to serve as an up-to-date internal reference for API specifications and notable implementation details. The documentation must be updated and polished before the official release.
+
+MLflow Tracing SDKs provide Python APIs to instrument machine learning application, so that developers can easily debug and monitor their systems.
+
+.. contents:: Table of Contents
+  :local:
+  :depth: 2
+
+
+.. _tracing-automatic-instrumentation:
+
+Automatic instrumentation
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+*This will cover LangChain/OpenAI/etc auto-instrumentation once implemented.*
+
+
+.. _tracing-fluent-apis:
+
+Fluent APIs
+~~~~~~~~~~~
+
+Fluent APIs are high-level APIs that allows developers to instrument their code with minimal changes. The APIs are designed to be easy to use that manages the spans parent-child relationships and set some fields of the span automatically. When instrumenting Python code, it is generally recommended to use Fluent APIs over Mlflow Client APIs as they are more user-friendly and less error-prone.
+
+
+.. autofunction:: mlflow.trace
+    :noindex:
+
+
+.. autofunction:: mlflow.start_span
+    :noindex:
+
+
+.. autofunction:: mlflow.get_traces
+    :noindex:
+
+.. _tracing-client-apis:
+
+MLflow Client APIs
+~~~~~~~~~~~~~~~~~~
+
+:py:class:`MlflowClient <mlflow.client.MlflowClient>` exposes APIs to start and end traces, spans, and set fields of the spans, with more flexibility and control to the trace lifecycle and structure. They are useful when the Fluent APIs are not sufficient for the use case, such as multi-threaded applications, callbacks, etc.
+
+.. autofunction:: mlflow.client.MlflowClient.start_trace
+    :noindex:
+
+.. autofunction:: mlflow.client.MlflowClient.end_trace
+    :noindex:
+
+.. autofunction:: mlflow.client.MlflowClient.start_span
+    :noindex:
+
+.. autofunction:: mlflow.client.MlflowClient.end_span
+    :noindex:
+
+
+MLflowSpanWrapper
+~~~~~~~~~~~~~~~~~
+
+.. autoclass:: mlflow.tracing.types.wrapper.MLflowSpanWrapper
+    :members:
+

--- a/docs/source/python_api/mlflow.tracing.rst
+++ b/docs/source/python_api/mlflow.tracing.rst
@@ -25,7 +25,7 @@ Automatic instrumentation
 Fluent APIs
 ~~~~~~~~~~~
 
-Fluent APIs are high-level APIs that allows developers to instrument their code with minimal changes. The APIs are designed to be easy to use that manages the spans parent-child relationships and set some fields of the span automatically. When instrumenting Python code, it is generally recommended to use Fluent APIs over Mlflow Client APIs as they are more user-friendly and less error-prone.
+Fluent APIs are high-level APIs that allows developers to instrument their code with minimal changes. The APIs are designed to be easy to use that manages the spans parent-child relationships and set some fields of the span automatically. When instrumenting Python code, it is generally recommended to use Fluent APIs over MLflow Client APIs as they are more user-friendly and less error-prone.
 
 
 .. autofunction:: mlflow.trace

--- a/docs/source/python_api/mlflow.tracing.rst
+++ b/docs/source/python_api/mlflow.tracing.rst
@@ -5,7 +5,7 @@ mlflow.tracing
 
     This is a tentative documentation for the development period. The main objective is to serve as an up-to-date internal reference for API specifications and notable implementation details. The documentation must be updated and polished before the official release.
 
-MLflow Tracing SDKs provide Python APIs to instrument machine learning application, so that developers can easily debug and monitor their systems.
+MLflow Tracing Python APIs instrument machine learning application, so that developers can easily debug and monitor their systems.
 
 .. contents:: Table of Contents
   :local:
@@ -25,7 +25,7 @@ Automatic instrumentation
 Fluent APIs
 ~~~~~~~~~~~
 
-Fluent APIs are high-level APIs that allows developers to instrument their code with minimal changes. The APIs are designed to be easy to use that manages the spans parent-child relationships and set some fields of the span automatically. When instrumenting Python code, it is generally recommended to use Fluent APIs over MLflow Client APIs as they are more user-friendly and less error-prone.
+Fluent APIs are high-level APIs that allow developers to instrument their code with minimal changes. The APIs are designed to be easy to use that manages the spans parent-child relationships and set some fields of the span automatically. When instrumenting Python code, it is generally recommended to use Fluent APIs over MLflow Client APIs as they are more user-friendly and less error-prone.
 
 
 .. autofunction:: mlflow.trace

--- a/mlflow/entities/span_status.py
+++ b/mlflow/entities/span_status.py
@@ -53,7 +53,7 @@ class SpanStatus:
 
     def to_otel_status(self) -> trace_api.Status:
         """
-        Convert our status object to OpenTelemetry status object.
+        Convert :py:class:`mlflow.entities.SpanStatus` object to OpenTelemetry status object.
 
         :meta private:
         """

--- a/mlflow/entities/span_status.py
+++ b/mlflow/entities/span_status.py
@@ -52,7 +52,11 @@ class SpanStatus:
                 )
 
     def to_otel_status(self) -> trace_api.Status:
-        """Convert our status object to OpenTelemetry status object."""
+        """
+        Convert our status object to OpenTelemetry status object.
+
+        :meta private:
+        """
         if self.status_code not in SpanStatus._mlflow_status_code_to_otel:
             raise MlflowException(
                 f"Invalid status code: {self.status_code}", error_code=INVALID_PARAMETER_VALUE
@@ -63,7 +67,11 @@ class SpanStatus:
 
     @classmethod
     def from_otel_status(cls, otel_status: trace_api.Status) -> SpanStatus:
-        """Convert OpenTelemetry status object to our status object."""
+        """
+        Convert OpenTelemetry status object to our status object.
+
+        :meta private:
+        """
         if otel_status.status_code not in cls._otel_status_code_to_mlflow:
             raise MlflowException(
                 f"Got invalid status code from OpenTelemetry: {otel_status.status_code}",

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -24,7 +24,7 @@ def trace(
     attributes: Optional[Dict[str, Any]] = None,
 ) -> Callable:
     """
-    A decorator that create a new span for the decorated function.
+    A decorator that creates a new span for the decorated function.
 
     When you decorate a function with this :py:func:`@mlflow.trace() <trace>` decorator,
     a span will be created for the scope of the decorated function. The span will automatically
@@ -62,7 +62,7 @@ def trace(
         The @mlflow.trace decorator is useful when you want to trace a function defined by
         yourself. However, you may also want to trace a function in external libraries. In
         such case, you can use this ``mlflow.trace()`` function to directly wrap the function,
-        instead of using as the decorator. This will creates an exact same span as the
+        instead of using as the decorator. This will create the exact same span as the
         one created by the decorator i.e. captures information from the function call.
 
         .. code-block:: python
@@ -106,10 +106,10 @@ def start_span(
     Context manager to create a new span and start it as the current span in the context.
 
     This context manager automatically manages the span lifecycle and parent-child relationships.
-    The span will be ended when the context manager exists. Any exception raised within the
+    The span will be ended when the context manager exits. Any exception raised within the
     context manager will set the span status to ``ERROR``, and detailed information such as
     exception message and stacktrace will be recorded to the ``attributes`` field of the span.
-    New spans can be created within the context manager, then they will be assigned as children
+    New spans can be created within the context manager, then they will be assigned as child
     spans.
 
     .. code-block:: python

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -7,8 +7,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from opentelemetry import trace as trace_api
 
-from mlflow.entities import SpanType
-from mlflow.entities import Trace
+from mlflow.entities import SpanType, Trace
 from mlflow.tracing.provider import get_tracer
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.types.wrapper import MLflowSpanWrapper, NoOpMLflowSpanWrapper

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -555,7 +555,7 @@ class MlflowClient:
         This is an imperative API to manually create a new span under a specific trace id
         and parent span, unlike the higher-level APIs like
         :py:func:`@mlflow.trace <mlflow.trace>` decorator and
-        py:func:`with mlflow.start_span() <mlflow.start_span>` context manager, which
+        :py:func:`with mlflow.start_span() <mlflow.start_span>` context manager, which
         automatically manage the span lifecycle and parent-child relationship.
 
         This API is useful for the case where the automatic context management is not
@@ -615,7 +615,7 @@ class MlflowClient:
             request_id: The ID of the trace to attach the span to. This is synonym to
                 trace_id` in OpenTelemetry.
             span_type: The type of the span. Can be either a string or a
-                py:class:`SpanType <mlflow.entities.SpanType>` enum value.
+                :py:class:`SpanType <mlflow.entities.SpanType>` enum value.
             parent_span_id: The ID of the parent span. The parent span can be a span created by
                 both fluent APIs like `with mlflow.start_span()`, and imperative APIs like this.
             inputs: Inputs to set on the span.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -605,9 +605,9 @@ class MlflowClient:
 
             However, **the opposite does not work**. You cannot use the fluent APIs within
             the span created by this MlflowClient API. This is because the fluent APIs
-            fetches the current span from the managed context, which is not set by the Mlflow
-            Client APIs. Once you create a span with the Mlflow Client APIs, all children
-            spans must be created with the Mlflow Client APIs. Please be cautious when using
+            fetches the current span from the managed context, which is not set by the MLflow
+            Client APIs. Once you create a span with the MLflow Client APIs, all children
+            spans must be created with the MLflow Client APIs. Please be cautious when using
             this mixed approach, as it can lead to unexpected behavior if not used properly.
 
         Args:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11554?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11554/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11554
```

</p>
</details>

### What changes are proposed in this pull request?

Now that the high-level design and capabilities of trace APIs are ready for preview, enriching the docstring to describe more concrete usages and notable caveats. 

Also, creating a tentative `mlflow.tracing.html` page to provide holistic view, because fluent API / client API / data models are scattered across different modules i.e. different pages in Python API docs. This is just created for developer convenience so intended to be polished like a public doc.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
