### PR TITLE
Add a script to check patch PRs

### DIFF
--- a/dev/check_patch_prs.py
+++ b/dev/check_patch_prs.py
@@ -1,0 +1,66 @@
+import re
+import subprocess
+import sys
+
+import click
+import requests
+
+
+def get_release_branch(version):
+    major_minor_version = ".".join(version.split(".")[:2])
+    return f"branch-{major_minor_version}"
+
+
+def get_merged_prs(version):
+    """
+    Get the PRs merged into the release branch for the given version.
+    """
+    release_branch = get_release_branch(version)
+    commits = subprocess.check_output(
+        [
+            "git",
+            "log",
+            release_branch,
+            '--since="2 months ago"',
+            "--pretty=format:%s",
+        ],
+        text=True,
+    )
+    pr_rgx = re.compile(r"\s+\(#(\d+)\)$")
+    prs = set()
+    for commit in commits.splitlines():
+        if pr := pr_rgx.search(commit.rstrip()):
+            prs.add(int(pr.group(1)))
+
+    return prs
+
+
+def fetch_patch_prs(version):
+    """
+    Fetch PRs labeled with `patch-{version}` from the MLflow repository.
+    """
+    label = f"patch-{version}"
+    response = requests.get(
+        f'https://api.github.com/search/issues?q=is:pr+repo:mlflow/mlflow+label:"{label}"'
+    )
+    response.raise_for_status()
+    data = response.json()
+    return {pr["number"] for pr in data["items"]}
+
+
+@click.command()
+@click.option("--version", required=True, help="The version to release")
+def main(version):
+    prs = get_merged_prs(version)
+    patch_prs = fetch_patch_prs(version)
+    if not_cherry_picked := patch_prs - prs:
+        branch = get_release_branch(version)
+        click.echo(f"The following patch PRs are not cherry-picked to {branch}:")
+        for pr_num in sorted(not_cherry_picked):
+            url = f"https://github.com/mlflow/mlflow/pull/{pr_num}"
+            click.echo(f"  - {url}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11555?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11555/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11555
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Add a script to check patch PRs.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->


```
% python dev/check_patch_prs.py --version 2.11.2
The following patch PRs are not cherry-picked to branch-2.11:
  - https://github.com/mlflow/mlflow/pull/11555
```


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
