### PR TITLE
[Bug-bash] Handle serialization for pydantic models

### DIFF
--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -1,7 +1,12 @@
+import importlib
 import json
+
+import pytest
+from packaging.version import Version
 
 import mlflow
 from mlflow.entities import SpanType
+from mlflow.entities.trace import _TraceJSONEncoder
 
 from tests.tracing.conftest import mock_client as mock_trace_client  # noqa: F401
 
@@ -78,4 +83,69 @@ def test_json_deserialization(mock_trace_client):
                 },
             ],
         },
+    }
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("pydantic") is None, reason="Pydantic is not installed"
+)
+def test_trace_serialize_pydantic_model():
+    from pydantic import BaseModel
+
+    class MyModel(BaseModel):
+        x: int
+        y: str
+
+    data = MyModel(x=1, y="foo")
+    data_json = json.dumps(data, cls=_TraceJSONEncoder)
+    assert data_json == '{"x": 1, "y": "foo"}'
+    assert json.loads(data_json) == {"x": 1, "y": "foo"}
+
+
+def _is_langchain_v0_1():
+    try:
+        import langchain
+
+        return Version(langchain.__version__) >= Version("0.1")
+    except ImportError:
+        return None
+
+
+@pytest.mark.skipif(not _is_langchain_v0_1(), reason="langchain is not installed")
+def test_trace_serialize_langchain_base_message():
+    from langchain_core.messages import BaseMessage
+
+    message = BaseMessage(
+        content=[
+            {
+                "role": "system",
+                "content": "Hello, World!",
+            },
+            {
+                "role": "user",
+                "content": "Hi!",
+            },
+        ],
+        type="chat",
+    )
+
+    message_json = json.dumps(message, cls=_TraceJSONEncoder)
+    # "additional_kwargs" field is added by Langchain
+    assert message_json == (
+        '{"content": [{"role": "system", "content": "Hello, World!"}, '
+        '{"role": "user", "content": "Hi!"}], "additional_kwargs": {}, "type": "chat"}'
+    )
+    assert json.loads(message_json) == {
+        "content": [
+            {
+                "role": "system",
+                "content": "Hello, World!",
+            },
+            {
+                "role": "user",
+                "content": "Hi!",
+            },
+        ],
+        "type": "chat",
+        "additional_kwargs": {},
     }

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -130,12 +130,12 @@ def test_trace_serialize_langchain_base_message():
     )
 
     message_json = json.dumps(message, cls=_TraceJSONEncoder)
-    # "additional_kwargs" field is added by Langchain
-    assert message_json == (
-        '{"content": [{"role": "system", "content": "Hello, World!"}, '
-        '{"role": "user", "content": "Hi!"}], "additional_kwargs": {}, "type": "chat"}'
-    )
-    assert json.loads(message_json) == {
+    # LangChain message model contains a few more default fields actually. But we
+    # only check if the following subset of the expected dictionary is present in
+    # the loaded JSON rather than exact equality, because the LangChain BaseModel
+    # has been changing frequently and the additional default fields may differ
+    # across versions installed on developers' machines.
+    expected_dict_subset = {
         "content": [
             {
                 "role": "system",
@@ -147,5 +147,6 @@ def test_trace_serialize_langchain_base_message():
             },
         ],
         "type": "chat",
-        "additional_kwargs": {},
     }
+    loaded = json.loads(message_json)
+    assert expected_dict_subset.items() <= loaded.items()

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -111,7 +111,7 @@ def _is_langchain_v0_1():
         return None
 
 
-@pytest.mark.skipif(not _is_langchain_v0_1(), reason="langchain is not installed")
+@pytest.mark.skipif(not _is_langchain_v0_1(), reason="langchain>=0.1 is not installed")
 def test_trace_serialize_langchain_base_message():
     from langchain_core.messages import BaseMessage
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11556?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11556/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11556
```

</p>
</details>

### What changes are proposed in this pull request?

Currently Pydantic models stored in a span's field is serialized with `str(model)` as they cannot serialized with `json.dumps()`. This will cause a bad UX where they are shown as a single long string rather than proper json format. This is particularly important for LangChain tracing as they use pydantic BaseModel many places, such as [chat model input](https://github.com/langchain-ai/langchain/blob/f7c903e24acaa938c79060511738a40e6940fcc2/libs/core/langchain_core/messages/base.py#L15).

This PR resolves this issue by adding custom JSON encoder that uses pydantic's built-in serialization method.

**Note**: Deserializing back to pydantic model is not straight-forward, because once the model is serialized, it will look exactly like a normal dictionary. Users can still recover the base model using `.parse_dict()` method, but it is challenging for us to do that on behalf of the user. I think it's ok to keep it out-of-scope as long as we use JSON format for span data.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
