### PR TITLE
Togetherai provider

### DIFF
--- a/docs/source/llms/deployments/index.rst
+++ b/docs/source/llms/deployments/index.rst
@@ -262,6 +262,10 @@ below can be used as a helpful guide when configuring a given endpoint for any n
 | Mistral                  | - mistral-tiny           | N/A                      |  - mistral-embed         |
 |                          | - mistral-small          |                          |                          |
 +--------------------------+--------------------------+--------------------------+--------------------------+
++--------------------------+--------------------------+--------------------------+--------------------------+
+| TogetherAI               | - google/gemma-2b        | - dbrx-instruct          |  - BAAI/bge-large-en-v1.5|
+|                          | - microsoft/phi-2        |                          |                          |
++--------------------------+--------------------------+--------------------------+--------------------------+
 
 § For full compatibility references for ``OpenAI``, see the `OpenAI Model Compatibility Matrix <https://platform.openai.com/docs/models/model-endpoint-compatibility>`_.
 
@@ -308,6 +312,7 @@ As of now, the MLflow Deployments Server supports the following providers:
 * **ai21labs**: This is used for models offered by `AI21 Labs <https://studio.ai21.com/foundation-models>`_.
 * **bedrock**: This is used for models offered by `Amazon Bedrock <https://aws.amazon.com/bedrock/>`_.
 * **mistral**: This is used for models offered by `Mistral <https://docs.mistral.ai/>`_.
+* **togetherai**: This is used for models offered by `TogetherAI <https://docs.together.ai/docs/>`_.
 
 More providers are being added continually. Check the latest version of the MLflow Deployments Server Docs for the
 most up-to-date list of supported providers.
@@ -517,6 +522,7 @@ Each endpoint has the following configuration parameters:
     - "ai21labs"
     - "bedrock"
     - "mistral"
+    - "togetherai"
 
   - **name**: This is an optional field to specify the name of the model.
   - **config**: This contains provider-specific configuration details.
@@ -697,6 +703,15 @@ Mistral
 | **mistral_api_key**       | Yes      | N/A                      | This is the API key for the Mistral service.         |
 +--------------------------+----------+--------------------------+-------------------------------------------------------+
 
+
+TogetherAI
+++++++++++
+
++---------------------------------------------------------------------------------------------------+
+| Configuration Parameter  | Required | Default  | Description                                      |
++--------------------------+----------+----------+--------------------------------------------------+
+| **togetherai_api_key**   | Yes      | N/A      | This is the API key for the TogetherAI service.  |
++--------------------------+----------+----------+--------------------------------------------------+
 
 An example configuration for Azure OpenAI is:
 

--- a/docs/source/llms/gateway/index.rst
+++ b/docs/source/llms/gateway/index.rst
@@ -305,7 +305,9 @@ below can be used as a helpful guide when configuring a given route for any newl
 | Mistral                  | - mistral-tiny           | N/A                      |  - mistral-embed         |
 |                          | - mistral-small          |                          |                          |
 +--------------------------+--------------------------+--------------------------+--------------------------+
-
+| TogetherAI               | - google/gemma-2b        | - dbrx-instruct          |  - BAAI/bge-large-en-v1.5|
+|                          | - microsoft/phi-2        |                          |                          |
++--------------------------+--------------------------+--------------------------+--------------------------+
 
 † Llama 2 is licensed under the `LLAMA 2 Community License <https://ai.meta.com/llama/license/>`_, Copyright © Meta Platforms, Inc. All Rights Reserved.
 
@@ -347,6 +349,7 @@ As of now, the MLflow AI Gateway supports the following providers:
 * **ai21labs**: This is used for models offered by `AI21 Labs <https://studio.ai21.com/foundation-models>`_.
 * **bedrock**: This is used for models offered by `Amazon Bedrock <https://aws.amazon.com/bedrock/>`_.
 * **mistral**: This is used for models offered by `Mistral <https://docs.mistral.ai/>`_.
+* **togetherai**: This is used for models offered by `TogetherAI <https://docs.together.ai/docs/>`_.
 
 More providers are being added continually. Check the latest version of the MLflow AI Gateway Docs for the
 most up-to-date list of supported providers.
@@ -545,6 +548,7 @@ Each route has the following configuration parameters:
     - "ai21labs"
     - "bedrock"
     - "mistral"
+    - "togetherai"
 
   - **name**: This is an optional field to specify the name of the model.
   - **config**: This contains provider-specific configuration details.
@@ -652,6 +656,16 @@ Mistral
 +==========================+==========+==========================+=======================================================+
 | **mistral_api_key**       | Yes      | N/A                      | This is the API key for the Mistral service.         |
 +--------------------------+----------+--------------------------+-------------------------------------------------------+
+
+
+TogetherAI
+++++++++++
+
++---------------------------------------------------------------------------------------------------+
+| Configuration Parameter  | Required | Default  | Description                                      |
++--------------------------+----------+----------+--------------------------------------------------+
+| **togetherai_api_key**   | Yes      | N/A      | This is the API key for the TogetherAI service.  |
++--------------------------+----------+----------+--------------------------------------------------+
 
 
 To use key-based authentication, define an Amazon Bedrock route with the required fields below.

--- a/examples/deployments/deployments_server/README.md
+++ b/examples/deployments/deployments_server/README.md
@@ -48,6 +48,7 @@ For full examples of configurations and supported endpoint types, see:
 - [PaLM](palm/config.yaml)
 - [AzureOpenAI](azure_openai/config.yaml)
 - [Mistral](mistral/config.yaml)
+- [TogetherAI](togetherai/config.yaml)
 
 ## Step 3: Setting Access Keys
 

--- a/examples/deployments/deployments_server/togetherai/README.md
+++ b/examples/deployments/deployments_server/togetherai/README.md
@@ -1,0 +1,13 @@
+## Example endpoint configuration for TogetherAI
+
+To see an example of specifying both the completions and the embeddings endpoints for TogetherAI, see [the configuration](config.yaml) YAML file.
+
+This configuration file specifies two endpoints: 'completions' and 'embeddings', both using TogetherAI's provided models 'mistralai/Mixtral-8x7B-v0.1' and 'togethercomputer/m2-bert-80M-8k-retrieval', respectively.
+
+## Setting a Mistral API Key
+
+This example requires a [TogetherAI API key](https://docs.together.ai/docs/):
+
+```sh
+export TOGETHERAI_API_KEY=...
+```

--- a/examples/deployments/deployments_server/togetherai/config.yaml
+++ b/examples/deployments/deployments_server/togetherai/config.yaml
@@ -1,0 +1,24 @@
+endpoints:
+  - name: completions
+    endpoint_type: llm/v1/completions
+    model:
+      provider: togetherai
+      name: mistralai/Mixtral-8x7B-v0.1
+      config:
+        togetherai_api_key: $TOGETHERAI_API_KEY
+
+  - name: chat
+    endpoint_type: llm/v1/chat
+    model:
+      provider: togetherai
+      name: mistralai/Mixtral-8x7B-Instruct-v0.1
+      config:
+        togetherai_api_key: $TOGETHERAI_API_KEY
+
+  - name: embeddings
+    endpoint_type: llm/v1/embeddings
+    model:
+      provider: togetherai
+      name: togethercomputer/m2-bert-80M-8k-retrieval
+      config:
+        togetherai_api_key: $TOGETHERAI_API_KEY

--- a/examples/deployments/deployments_server/togetherai/example.py
+++ b/examples/deployments/deployments_server/togetherai/example.py
@@ -1,0 +1,43 @@
+from mlflow.deployments import get_deploy_client
+
+
+def main():
+    client = get_deploy_client("http://localhost:7000")
+
+    print(f"Togetherai endpoints: {client.list_endpoints()}\n")
+    print(f"Togetherai completions endpoint info: {client.get_endpoint(endpoint='completions')}\n")
+    print(f"Togetherai chat endpoint info: {client.get_endpoint(endpoint='chat')}\n")
+    print(f"Togetherai embeddings endpoint info: {client.get_endpoint(endpoint='embeddings')}\n")
+
+    response_completions = client.predict(
+        endpoint="completions",
+        inputs={
+            "prompt": "Who is the protagonist in Witcher 3 Wild Hunt?",
+            "max_tokens": 200,
+            "temperature": 0.1,
+        },
+    )
+
+    print(f"Togetherai response for completions: {response_completions}")
+
+    response_embeddings = client.predict(
+        endpoint="embeddings",
+        inputs={
+            "input": ["Who is Wes Montgomery?"],
+        },
+    )
+
+    print(f"Togetherai response for embeddings: {response_embeddings}")
+
+    response_chat = client.predict(
+        endpoint="chat",
+        inputs={
+            "messages": [{"role": "user", "content": "Get out of the sunlight's way Alexander!"}],
+        },
+    )
+
+    print(f"Togetherai response for chat: {response_chat}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -48,11 +48,18 @@ class Provider(str, Enum):
     DATABRICKS_MODEL_SERVING = "databricks-model-serving"
     DATABRICKS = "databricks"
     MISTRAL = "mistral"
+    TOGETHERAI = "togetherai"
 
     @classmethod
     def values(cls):
         return {p.value for p in cls}
 
+class TogetherAIConfig(ConfigModel):
+    togetherai_api_key: str
+
+    @validator("togetherai_api_key", pre=True)
+    def validate_togetherai_api_key(cls, value): 
+        return _resolve_api_key_from_input(value)
 
 class RouteType(str, Enum):
     LLM_V1_COMPLETIONS = "llm/v1/completions"
@@ -232,6 +239,7 @@ config_types = {
     Provider.PALM: PaLMConfig,
     Provider.HUGGINGFACE_TEXT_GENERATION_INFERENCE: HuggingFaceTextGenerationInferenceConfig,
     Provider.MISTRAL: MistralConfig,
+    Provider.TOGETHERAI: TogetherAIConfig,
 }
 
 
@@ -291,6 +299,7 @@ class Model(ConfigModel):
             HuggingFaceTextGenerationInferenceConfig,
             PaLMConfig,
             MistralConfig,
+            TogetherAIConfig,
         ]
     ] = None
 
@@ -520,3 +529,5 @@ def _validate_config(config_path: str) -> GatewayConfig:
         return _load_route_config(config_path)
     except ValidationError as e:
         raise MlflowException.invalid_parameter_value(f"Invalid gateway configuration: {e}") from e
+
+

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -58,7 +58,7 @@ class TogetherAIConfig(ConfigModel):
     togetherai_api_key: str
 
     @validator("togetherai_api_key", pre=True)
-    def validate_togetherai_api_key(cls, value): 
+    def validate_togetherai_api_key(cls, value):
         return _resolve_api_key_from_input(value)
 
 class RouteType(str, Enum):

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -54,12 +54,14 @@ class Provider(str, Enum):
     def values(cls):
         return {p.value for p in cls}
 
+
 class TogetherAIConfig(ConfigModel):
     togetherai_api_key: str
 
     @validator("togetherai_api_key", pre=True)
     def validate_togetherai_api_key(cls, value):
         return _resolve_api_key_from_input(value)
+
 
 class RouteType(str, Enum):
     LLM_V1_COMPLETIONS = "llm/v1/completions"
@@ -529,5 +531,3 @@ def _validate_config(config_path: str) -> GatewayConfig:
         return _load_route_config(config_path)
     except ValidationError as e:
         raise MlflowException.invalid_parameter_value(f"Invalid gateway configuration: {e}") from e
-
-

--- a/mlflow/gateway/providers/__init__.py
+++ b/mlflow/gateway/providers/__init__.py
@@ -16,6 +16,7 @@ def get_provider(provider: Provider) -> Type[BaseProvider]:
     from mlflow.gateway.providers.mosaicml import MosaicMLProvider
     from mlflow.gateway.providers.openai import OpenAIProvider
     from mlflow.gateway.providers.palm import PaLMProvider
+    from mlflow.gateway.providers.togetherai import TogetherAIProvider
 
     provider_to_class = {
         Provider.OPENAI: OpenAIProvider,
@@ -28,6 +29,7 @@ def get_provider(provider: Provider) -> Type[BaseProvider]:
         Provider.HUGGINGFACE_TEXT_GENERATION_INFERENCE: HFTextGenerationInferenceServerProvider,
         Provider.BEDROCK: AmazonBedrockProvider,
         Provider.MISTRAL: MistralProvider,
+        Provider.TOGETHERAI: TogetherAIProvider,
     }
     if prov := provider_to_class.get(provider):
         return prov

--- a/mlflow/gateway/providers/togetherai.py
+++ b/mlflow/gateway/providers/togetherai.py
@@ -355,6 +355,15 @@ class TogetherAIProvider(BaseProvider):
     ) -> AsyncIterable[completions_schema.StreamResponsePayload]:
         payload = jsonable_encoder(payload, exclude_none=True)
 
+        if not payload.get("max_tokens"):
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "max_tokens is not present in payload."
+                    "It is a required parameter for TogetherAI completions."
+                ),
+            )
+
         stream = await self._stream_request(
             path="completions",
             payload={
@@ -379,6 +388,15 @@ class TogetherAIProvider(BaseProvider):
         self, payload: completions_schema.RequestPayload
     ) -> completions_schema.ResponsePayload:
         payload = jsonable_encoder(payload, exclude_none=True)
+
+        if not payload.get("max_tokens"):
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "max_tokens is not present in payload."
+                    "It is a required parameter for TogetherAI completions."
+                ),
+            )
 
         resp = await self._request(
             path="completions",

--- a/mlflow/gateway/providers/togetherai.py
+++ b/mlflow/gateway/providers/togetherai.py
@@ -151,7 +151,7 @@ class TogetherAIAdapter(ProviderAdapter):
             raise HTTPException(
                 status_code=422,
                 detail=(
-                    "Wrong type for logprobs." 
+                    "Wrong type for logprobs."
                     "If logprobs is set it should be an 32bit integer."
                 ),
             )

--- a/mlflow/gateway/providers/togetherai.py
+++ b/mlflow/gateway/providers/togetherai.py
@@ -151,7 +151,8 @@ class TogetherAIAdapter(ProviderAdapter):
             raise HTTPException(
                 status_code=422,
                 detail=(
-                    "Wrong type for logprobs." "If logprobs is set it should be an 32bit integer."
+                    "Wrong type for logprobs." 
+                    "If logprobs is set it should be an 32bit integer."
                 ),
             )
 

--- a/mlflow/gateway/providers/togetherai.py
+++ b/mlflow/gateway/providers/togetherai.py
@@ -143,7 +143,7 @@ class TogetherAIAdapter(ProviderAdapter):
                     )
                 )
 
-                for idx, choice in enumerate(resp.get("choices"))
+                for idx, choice in enumerate(resp.get("choices", []))
             ],
             # usage is not included in OpenAI StreamResponsePayload
             #usage=completions.CompletionsUsage(
@@ -253,7 +253,37 @@ class TogetherAIAdapter(ProviderAdapter):
 
     @classmethod
     def model_to_chat_streaming(cls, resp, config):
-        raise NotImplementedError
+        #b'data: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051390,"choices":[{"index":0,"text":" According","logprobs":null,"finish_reason":null,"delta":{"token_id":6586,"content":" According"}}],"model":"mistralai/Mixtral-8x7B-v0.1","usage":null}\n\n'
+        #b'data: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051390,"choices":[{"index":0,"text":" to","logprobs":null,"finish_reason":null,"delta":{"token_id":298,"content":" to"}}],"model":"mistralai/Mixtral-8x7B-v0.1","usage":null}\n\ndata: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051390,"choices":[{"index":0,"text":" the","logprobs":null,"finish_reason":null,"delta":{"token_id":272,"content":" the"}}],"model":"mistralai/Mixtral-8x7B-v0.1","usage":null}\n\ndata: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051390,"choices":[{"index":0,"text":" Econom","logprobs":null,"finish_reason":null,"delta":{"token_id":11003,"content":" Econom"}}],"model":"mistralai/Mixtral-8x7B-v0.1","usage":null}\n\n'
+        #b'data: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051391,"choices":[{"index":0,"text":"ist","logprobs":null,"finish_reason":null,"delta":{"token_id":392,"content":"ist"}}],"model":"mistralai/Mixtral-8x7B-v0.1","usage":null}\n\ndata: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051391,"choices":[{"index":0,"text":" Intelligence","logprobs":null,"finish_reason":null,"delta":{"token_id":23091,"content":" Intelligence"}}],"model":"mistralai/Mixtral-8x7B-v0.1","usage":null}\n\ndata: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051391,"choices":[{"index":0,"text":" Unit","logprobs":null,"finish_reason":null,"delta":{"token_id":13332,"content":" Unit"}}],"model":"mistralai/Mixtral-8x7B-v0.1","usage":null}\n\ndata: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051391,"choices":[{"index":0,"text":" World","logprobs":null,"finish_reason":null,"delta":{"token_id":3304,"content":" World"}}],"model":"mistr'
+        #b'alai/Mixtral-8x7B-v0.1","usage":null}\n\n'
+        #b'data: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051391,"choices":[{"index":0,"text":"wide","logprobs":null,"finish_reason":null,"delta":{"token_id":5734,"content":"wide"}}],"model":"mistralai/Mixtral-8x7B-v0.1","usage":null}\n\n'
+        #b'data: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051391,"choices":[{"index":0,"text":" Cost","logprobs":null,"finish_reason":null,"delta":{"token_id":9319,"content":" Cost"}}],"model":"mistralai/Mixtral-8x7B-v0.1","usage":null}\n\n'
+        #b'data: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051391,"choices":[{"index":0,"text":" of","logprobs":null,"finish_reason":null,"delta":{"token_id":302,"content":" of"}}],"model":"mistralai/Mixtral-8x7B-v0.1","usage":null}\n\ndata: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051391,"choices":[{"index":0,"text":" Living","logprobs":null,"finish_reason":null,"delta":{"token_id":16303,"content":" Living"}}],"model":"mistralai/Mixtral-8x7B-v0.1","usage":null}\n\ndata: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051391,"choices":[{"index":0,"text":" Survey","logprobs":null,"finish_reason":null,"delta":{"token_id":24004,"content":" Survey"}}],"model":"mistralai/Mixtral-8x7B-v0.1","usage":null}\n\ndata: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051391,"choices":[{"index":0,"text":" in","logprobs":null,"finish_reason":null,"delta":{"token_id":297,"content":" in"}}],"model":"mistralai/Mixtral-8x'
+        #b'7B-v0.1","usage":null}\n\n'
+        #b'data: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051391,"choices":[{"index":0,"text":" ","logprobs":null,"finish_reason":null,"delta":{"token_id":28705,"content":" "}}],"model":"mistralai/Mixtral-8x7B-v0.1","usage":null}\n\ndata: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051391,"choices":[{"index":0,"text":"2","logprobs":null,"finish_reason":null,"delta":{"token_id":28750,"content":"2"}}],"model":"mistralai/Mixtral-8x7B-v0.1","usage":null}\n\ndata: {"id":"86dfe9397f84eed4-ATH","object":"chat.completion.chunk","created":1712051391,"choices":[{"index":0,"text":"0","logprobs":null,"finish_reason":"length","delta":{"token_id":28734,"content":"0"}}],"model":"mistralai/Mixtral-8x7B-v0.1","usage":{"prompt_tokens":93,"completion_tokens":200,"total_tokens":293}}\n\n'
+        #b'data: [DONE]\n\n'
+
+        return chat.StreamResponsePayload(
+            id=resp["id"],
+            model=config.model.name,
+            object="chat.completion.chunk",
+            created=resp["created"],
+            choices=[
+                chat.StreamChoice(
+                    index=idx, 
+                    # TODO: is this a good idea? This comes from the TogetherAI API
+                    finish_reason=choice.get("finish_reason"),
+                    delta=chat.StreamDelta(
+                        role=None,
+                        content=choice.get("text"),
+                    )
+                )
+                # Added enumerate and a default empty list
+                for idx, choice in enumerate(resp.get("choices", []))  
+            ],
+            usage=resp.get("usage")
+        )
 
     @classmethod
     def chat_to_model(cls, payload, config):
@@ -270,7 +300,8 @@ class TogetherAIAdapter(ProviderAdapter):
 
     @classmethod
     def chat_streaming_to_model(cls, payload, config):
-        raise NotImplementedError
+        # streaming and standard chat contain the same parameters
+        return TogetherAIAdapter.chat_to_model(payload, config)
 
     @classmethod
     def embeddings_to_model(cls, payload, config):
@@ -350,7 +381,10 @@ class TogetherAIProvider(BaseProvider):
 
     # WARNING CHANGING THE ORDER OF METHODS HERE FOR SOME REASON CAUSES AN ERROR
     # completions MODULE IS INTERPERTED AS THE completions function
-    async def completions_stream(self, payload: completions.RequestPayload) -> AsyncIterable[completions.StreamResponsePayload]:
+    async def completions_stream(
+        self, 
+        payload: completions.RequestPayload
+    ) -> AsyncIterable[completions.StreamResponsePayload]:
         from fastapi.encoders import jsonable_encoder
 
         payload = jsonable_encoder(payload, exclude_none=True)
@@ -391,6 +425,33 @@ class TogetherAIProvider(BaseProvider):
         )
 
         return TogetherAIAdapter.model_to_completions(resp, self.config)
+
+
+    async def chat_stream(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
+        payload = jsonable_encoder(payload, exclude_none=True)
+
+        stream = await self._stream_request(
+            path="chat/completions",
+            payload={
+                "model": self.config.model.name,
+                **TogetherAIAdapter.chat_streaming_to_model(payload, self.config)
+            }
+        )
+
+        async for chunk in stream:
+            chunk = chunk.strip()
+            if not chunk:
+                continue
+
+
+            chunk = strip_sse_prefix(chunk.decode("utf-8"))
+            if chunk == "[DONE]":
+                return
+
+            resp = json.loads(chunk)
+            yield TogetherAIAdapter.model_to_chat_streaming(resp, self.config)
 
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
         from fastapi.encoders import jsonable_encoder

--- a/mlflow/gateway/providers/togetherai.py
+++ b/mlflow/gateway/providers/togetherai.py
@@ -271,7 +271,7 @@ class TogetherAIAdapter(ProviderAdapter):
             created=resp["created"],
             choices=[
                 chat.StreamChoice(
-                    index=idx, 
+                    index=idx,
                     # TODO: is this a good idea? This comes from the TogetherAI API
                     finish_reason=choice.get("finish_reason"),
                     delta=chat.StreamDelta(
@@ -280,7 +280,7 @@ class TogetherAIAdapter(ProviderAdapter):
                     )
                 )
                 # Added enumerate and a default empty list
-                for idx, choice in enumerate(resp.get("choices", []))  
+                for idx, choice in enumerate(resp.get("choices", []))
             ],
             usage=resp.get("usage")
         )
@@ -382,7 +382,7 @@ class TogetherAIProvider(BaseProvider):
     # WARNING CHANGING THE ORDER OF METHODS HERE FOR SOME REASON CAUSES AN ERROR
     # completions MODULE IS INTERPERTED AS THE completions function
     async def completions_stream(
-        self, 
+        self,
         payload: completions.RequestPayload
     ) -> AsyncIterable[completions.StreamResponsePayload]:
         from fastapi.encoders import jsonable_encoder

--- a/mlflow/gateway/providers/togetherai.py
+++ b/mlflow/gateway/providers/togetherai.py
@@ -151,8 +151,7 @@ class TogetherAIAdapter(ProviderAdapter):
             raise HTTPException(
                 status_code=422,
                 detail=(
-                    "Wrong type for logprobs."
-                    "If logprobs is set it should be an 32bit integer."
+                    "Wrong type for logprobs.\n" "If logprobs is set it should be an 32bit integer."
                 ),
             )
 

--- a/mlflow/gateway/providers/togetherai.py
+++ b/mlflow/gateway/providers/togetherai.py
@@ -1,0 +1,267 @@
+
+from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
+from mlflow.gateway.config import TogetherAIConfig, RouteConfig
+from mlflow.gateway.providers.utils import rename_payload_keys, send_request, send_stream_request
+from mlflow.gateway.schemas import chat, completions, embeddings
+
+
+from typing import Dict, Any, AsyncGenerator, AsyncIterable
+
+class TogetherAIAdapter(ProviderAdapter): 
+
+
+    def _scale_repetition_penalty(openai_frequency_penalty: float, min_repetion_penalty=-3.402823669209385e+38, max_repetion_penalty=3.402823669209385e+38): 
+
+        # Normalize OpenAI penalty to a 0-1 range
+        normalized_penalty = (openai_penalty + 2) / 4  # Transforming [-2, 2] to [0, 1] = (repetition_penalty - 1)/(max_repetion_penalty - 1) 
+
+
+        scale_penalty = normalized_penalty * (max_repetion_penalty - min_repetion_penalty) + min_repetion_penalty
+
+
+        return scale_penalty
+    
+    @classmethod
+    def model_to_embeddings(cls, resp, config):
+        #Response example: (https://docs.together.ai/docs/embeddings-rest)
+        #```
+        #{
+        #  "object": "list",
+        #  "data": [
+        #    {
+        #      "object": "embedding",
+        #      "embedding": [
+        #        0.44990748,
+        #        -0.2521129,
+        #        ...
+        #        -0.43091708,
+        #        0.214978
+        #      ],
+        #      "index": 0
+        #    }
+        #  ],
+        #  "model": "togethercomputer/m2-bert-80M-8k-retrieval",
+        #  "request_id": "840fc1b5bb2830cb-SEA"
+        #}
+        #```
+        return embeddings.ResponsePayload(
+            data=[
+                embeddings.EmbeddingObject(
+                    embedding=item['embedding'],
+                    index=item['index'],
+                )
+                for item in resp['data']
+            ], 
+            model=config.model.name, 
+            usage=embeddings.EmbeddingsUsage(
+                prompt_tokens=None,  
+                total_tokens=None
+            )
+        )
+
+    @classmethod
+    def model_to_completions(cls, resp, config):
+        # Example response (https://docs.together.ai/reference/completions): 
+        #{
+        #  "id": "8447f286bbdb67b3-SJC",
+        #  "choices": [
+        #    {
+        #      "text": "The capital of France is Paris. It's located in the north-central part of the country and is one of the most famous cities in the world, known for its iconic landmarks such as the Eiffel Tower, Louvre Museum, Notre-Dame Cathedral, and more. Paris is also the cultural, political, and economic center of France."
+        #    }
+        #  ],
+        #  "usage": {
+        #    "prompt_tokens": 16,
+        #    "completion_tokens": 78,
+        #    "total_tokens": 94
+        #  },
+        #  "created": 1705089226,
+        #  "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+        #  "object": "text_completion"
+        #}
+
+
+        return completions.ResponsePayload(
+            id=resp["id"],
+            created=resp["created"],
+            model=config.model.name,
+            choices=[ 
+                completions.Choice(
+                    index=idx,
+                    text=c["text"],
+                    finish_reason=None,
+                )
+                for idx, c in enumerate(resp["choices"])
+            ],
+            usage=completions.CompletionsUsage(
+                prompt_tokens=resp["usage"]["prompt_tokens"],
+                completion_tokens=resp["usage"]["completion_tokens"],
+                total_tokens=resp["usage"]["total_tokens"]
+            )
+
+        )
+
+    @classmethod
+    def model_to_completions_streaming(cls, resp, config):
+        raise NotImplementedError
+
+    @classmethod
+    def completions_to_model(cls, payload, config):
+        key_mapping = {
+            # repetition_penalty (-3.402823669209385e+38, 3.402823669209385e+38)
+            # frequency_penalty (-2.0, 2.0)
+            # presence_penalty (-2.0, 2.0)
+            "frequency_penalty": "repetition_penalty",
+            # top_logprobs (0, 20)
+            # logprobs (-2147483648,2147483648) 
+            "top_logprobs": "logprobs"
+        }
+
+        payload = rename_payload_keys(payload, key_mapping)
+
+        if "logprobs" in payload and payload["logprobs"] and not "logprobs" in payload:
+            raise HTTPException(
+                status_code=422, 
+                detail="Missing paramater in payload. If flag logprobs parameter is set to True then logsprobs parameter must contain a value."
+            )
+
+        # TODO maybe let the api service handle these internally?
+
+        if "logitbias" in payload: 
+            raise HTTPException(
+                status_code=422, 
+                detail="Invalid parameter in payload. Parameter logitbias is not supported for togetherai."
+            )
+
+        if "seed" in payload: 
+            raise HTTPException(
+                status_code=422,
+                detail="Invalid parameter in payload. Parameter seed is not suuported of togetherai."
+            )
+
+        if "presence_penalty" in payload: 
+            raise HTTPException(
+                status_code=422,
+                detail="Invalid parameter in payload. Parameter presence_penalty is not supported for togetherai."
+            )
+
+
+        return payload
+
+    @classmethod
+    def completions_streaming_to_model(cls, payload, config):
+        raise NotImplementedError
+
+    @classmethod
+    def model_to_chat(cls, resp, config):
+        raise NotImplementedError
+
+    @classmethod
+    def model_to_chat_streaming(cls, resp, config):
+        raise NotImplementedError
+
+    @classmethod
+    def chat_to_model(cls, payload, config):
+        raise NotImplementedError
+
+    @classmethod
+    def chat_streaming_to_model(cls, payload, config):
+        raise NotImplementedError
+
+    @classmethod
+    def embeddings_to_model(cls, payload, config):
+        #Example request (https://docs.together.ai/reference/embeddings): 
+        #curl --request POST \
+        #   --url https://api.together.xyz/v1/embeddings \
+        #   --header 'accept: application/json' \
+        #   --header 'content-type: application/json' \
+        #   --data '
+        #   {
+        #     "model": "togethercomputer/m2-bert-80M-8k-retrieval",
+        #     "input": "Our solar system orbits the Milky Way galaxy at about 515,000 mph"
+        #   }
+
+        # This is just to keep the interface consistent the adapter
+        # class is not needed here as the togetherai request similar
+        # to the openAI one.
+
+        return payload
+
+class TogetherAIProvider(BaseProvider):
+    NAME = "TogetherAI"
+
+    def __init__(self, config: RouteConfig) -> None: 
+        super().__init__(config)
+        if config.model.config is None or not isinstance(config.model.config, TogetherAIConfig):
+            # Should be unreachable
+            raise MlflowException.invalid_parameter_value(
+                "Invalid config type {config.model.config}"
+            )
+        self.togetherai_config:  TogetherAIConfig = config.model.config
+
+    @property
+    def base_url(self): 
+        #togetherai seems to support only this url
+        return "https://api.together.xyz/v1"
+
+    @property
+    def auth_headers(self): 
+        return {"Authorization": f"Bearer {self.togetherai_config.togetherai_api_key}"} 
+
+
+    def _add_model_to_payload(self, payload: chat.RequestPayload):
+        return {"model":self.config.model.name, **payload}
+
+    async def _request(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return await send_request(
+            headers=self.auth_headers,
+            base_url=self.base_url,
+            path=path,
+            payload=payload,
+        )
+
+    async def _stream_request(self, path: str, payload: Dict[str, Any]) -> AsyncGenerator[bytes, None]:
+        return send_stream_request(
+            headers=self.auth_headers,
+            base_url=self.base_url,
+            path=path,
+            payload=payload,
+        )
+
+
+    def _add_model_to_payload(self, payload: chat.RequestPayload):
+        return {"model":self.config.model.name, **payload}
+
+    async def embeddings(self, payload: chat.RequestPayload):
+        from fastapi.encoders import jsonable_encoder
+
+        payload = jsonable_encoder(payload, exclude_none=True)
+        #self.check_for_model_field(payload)
+
+        resp = await self._request(
+            path="embeddings",
+            payload={
+                "model": self.config.model.name, 
+                **TogetherAIAdapter.embeddings_to_model(payload, self.config)
+            }
+        )
+
+        return TogetherAIAdapter.model_to_embeddings(resp, self.config)
+
+    async def completions(self, payload: chat.RequestPayload) -> completions.ResponsePayload:
+        from fastapi.encoders import jsonable_encoder
+
+        payload = jsonable_encoder(payload, exclude_none=True)
+
+        resp = await self._request(
+            path="completions",
+            payload={
+                "model": self.config.model.name, 
+                **TogetherAIAdapter.completions_to_model(payload, self.config)
+            }
+        )
+
+        return TogetherAIAdapter.model_to_completions(resp, self.config)
+
+    async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
+        raise NotImplementedError 
+

--- a/mlflow/gateway/providers/togetherai.py
+++ b/mlflow/gateway/providers/togetherai.py
@@ -150,9 +150,7 @@ class TogetherAIAdapter(ProviderAdapter):
         if logprobs_in_payload_condition:
             raise HTTPException(
                 status_code=422,
-                detail=(
-                    "Wrong type for logprobs.\n" "If logprobs is set it should be an 32bit integer."
-                ),
+                detail="Wrong type for logprobs. It should be an 32bit integer.",
             )
 
         openai_top_logprobs_in_payload_condition = "top_logprobs" in payload and not isinstance(
@@ -162,10 +160,7 @@ class TogetherAIAdapter(ProviderAdapter):
         if openai_top_logprobs_in_payload_condition:
             raise HTTPException(
                 status_code=422,
-                detail=(
-                    "Wrong type for top_logprobs."
-                    "If top_logprobs is set it should a 32bit integer."
-                ),
+                detail="Wrong type for top_logprobs. It should a 32bit integer.",
             )
 
         return rename_payload_keys(payload, key_mapping)

--- a/mlflow/gateway/providers/togetherai.py
+++ b/mlflow/gateway/providers/togetherai.py
@@ -326,7 +326,7 @@ class TogetherAIProvider(BaseProvider):
         if config.model.config is None or not isinstance(config.model.config, TogetherAIConfig):
             # Should be unreachable
             raise MlflowException.invalid_parameter_value(
-                "Invalid config type {config.model.config}"
+                f"Invalid config type {config.model.config}"
             )
         self.togetherai_config: TogetherAIConfig = config.model.config
 

--- a/tests/gateway/providers/test_togetherai.py
+++ b/tests/gateway/providers/test_togetherai.py
@@ -1,0 +1,134 @@
+import math
+from unittest import mock
+
+import pytest
+from aiohttp import ClientTimeout
+from fastapi import HTTPException
+from fastapi.encoders import jsonable_encoder
+from pydantic import ValidationError
+
+from mlflow.gateway.config import RouteConfig
+from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
+from mlflow.gateway.providers.togetherai import TogetherAIProvider
+from mlflow.gateway.schemas import chat, completions, embeddings
+
+from tests.gateway.tools import MockAsyncResponse
+
+import logging
+import os 
+
+def completions_config():
+    return {
+        "name": "completions",
+        "route_type": "llm/v1/completions",
+        "model": {
+            "provider": "togetherai",
+            "name": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+            "config": {
+                "togetherai_api_key": "key",
+            },
+        },
+    }
+
+
+def completions_response():
+    return {
+        "id": "8447f286bbdb67b3-SJC",
+        "choices": [
+          {
+            "index": 0,
+            "text": "The capital of France is Paris. It's located in the north-central part of the country and is one of the most famous cities in the world, known for its iconic landmarks such as the Eiffel Tower, Louvre Museum, Notre-Dame Cathedral, and more. Paris is also the cultural, political, and economic center of France.",
+            "finish_reason": None,
+          }
+        ],
+        "usage": {
+          "prompt_tokens": 16,
+          "completion_tokens": 78,
+          "total_tokens": 94
+        },
+        "created": 1705089226,
+        "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+        "object": "text_completion"
+    }
+
+
+@pytest.mark.asyncio
+async def test_completions():
+
+    config = completions_config()
+    resp = completions_response()
+
+    with mock.patch("time.time", return_value=1677858242), mock.patch(
+    "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+    ) as mock_post:
+        
+        provider = TogetherAIProvider(RouteConfig(**config))
+
+        payload = {
+            "prompt": "Whats the capital of France?",
+            "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+            "max_tokens": 200, 
+            "temperature": 1.0,
+            "n": 1,
+        }
+
+        response = await provider.completions(completions.RequestPayload(**payload))
+
+        assert jsonable_encoder(response) == {
+            "id": "8447f286bbdb67b3-SJC",
+            "choices": [
+              {
+                "index": 0,
+                "text": "The capital of France is Paris. It's located in the north-central part of the country and is one of the most famous cities in the world, known for its iconic landmarks such as the Eiffel Tower, Louvre Museum, Notre-Dame Cathedral, and more. Paris is also the cultural, political, and economic center of France.",
+                "finish_reason": None,
+              }
+            ],
+            "usage": {
+              "prompt_tokens": 16,
+              "completion_tokens": 78,
+              "total_tokens": 94
+            },
+            "created": 1705089226,
+            "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+            "object": "text_completion"
+        }
+
+        mock_post.assert_called_once_with(
+            "https://api.together.xyz/v1/completions",
+            json={
+                "prompt": "Whats the capital of France?",
+                "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+                "max_tokens": 200,
+                "temperature": 1,
+                "n": 1,
+            },
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
+        )
+
+def embeddings_config():
+    return {
+        "name": "embeddings",
+        "route_type": "llm/v1/embeddings",
+        "model": {
+            "provider": "togetherai",
+            "name": "togethercomputer/m2-bert-80M-8k-retrieval",
+            "config": {
+                "togetherai_key": "key",
+            },
+        },
+    }
+    
+
+def chat_config():
+    return {
+        "name": "chat",
+        "route_type": "llm/v1/completions/chat",
+        "model": {
+            "provider": "togetherai",
+            "name": "togethercomputer/m2-bert-80M-8k-retrieval",
+            "config": {
+                "togetherai_key": "key",
+            },
+        },
+    }
+

--- a/tests/gateway/providers/test_togetherai.py
+++ b/tests/gateway/providers/test_togetherai.py
@@ -30,33 +30,27 @@ def completions_response():
     return {
         "id": "8447f286bbdb67b3-SJC",
         "choices": [
-          {
-            "index": 0,
-            "text": "The capital of France is Paris. It's located in the north-central part of the country and is one of the most famous cities in the world, known for its iconic landmarks such as the Eiffel Tower, Louvre Museum, Notre-Dame Cathedral, and more. Paris is also the cultural, political, and economic center of France.",
-            "finish_reason": None,
-          }
+            {
+                "index": 0,
+                "text": "The capital of France is Paris. It's located in the north-central part of the country and is one of the most famous cities in the world, known for its iconic landmarks such as the Eiffel Tower, Louvre Museum, Notre-Dame Cathedral, and more. Paris is also the cultural, political, and economic center of France.",
+                "finish_reason": None,
+            }
         ],
-        "usage": {
-          "prompt_tokens": 16,
-          "completion_tokens": 78,
-          "total_tokens": 94
-        },
+        "usage": {"prompt_tokens": 16, "completion_tokens": 78, "total_tokens": 94},
         "created": 1705089226,
         "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
-        "object": "text_completion"
+        "object": "text_completion",
     }
 
 
 @pytest.mark.asyncio
 async def test_completions():
-
     config = completions_config()
     resp = completions_response()
 
     with mock.patch("time.time", return_value=1677858242), mock.patch(
-    "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
     ) as mock_post:
-
         provider = TogetherAIProvider(RouteConfig(**config))
 
         payload = {
@@ -72,20 +66,16 @@ async def test_completions():
         assert jsonable_encoder(response) == {
             "id": "8447f286bbdb67b3-SJC",
             "choices": [
-              {
-                "index": 0,
-                "text": "The capital of France is Paris. It's located in the north-central part of the country and is one of the most famous cities in the world, known for its iconic landmarks such as the Eiffel Tower, Louvre Museum, Notre-Dame Cathedral, and more. Paris is also the cultural, political, and economic center of France.",
-                "finish_reason": None,
-              }
+                {
+                    "index": 0,
+                    "text": "The capital of France is Paris. It's located in the north-central part of the country and is one of the most famous cities in the world, known for its iconic landmarks such as the Eiffel Tower, Louvre Museum, Notre-Dame Cathedral, and more. Paris is also the cultural, political, and economic center of France.",
+                    "finish_reason": None,
+                }
             ],
-            "usage": {
-              "prompt_tokens": 16,
-              "completion_tokens": 78,
-              "total_tokens": 94
-            },
+            "usage": {"prompt_tokens": 16, "completion_tokens": 78, "total_tokens": 94},
             "created": 1705089226,
             "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
-            "object": "text_completion"
+            "object": "text_completion",
         }
 
         mock_post.assert_called_once_with(
@@ -113,7 +103,7 @@ def completion_stream_response():
         b'"choices":[{"index":0,"text":"test","logprobs":null,"finish_reason":"length","delta":{"token_id":1345,"content":"test"}}],"model":"test","usage":{"prompt_tokens":17,"completion_tokens":200,"total_tokens":217}}\n',
         b"\n",
         b"data: [DONE]\n",
-        b"\n"
+        b"\n",
     ]
 
 
@@ -130,10 +120,13 @@ def completion_stream_response_incomplete():
         b'ed":1,"choices":[{"index":0,"text":"test","logprobs":null,"finish_reason":"length","delta":{"token_id":1345,"content":"test"}}],"model":"test","usage":{"prompt_tokens":17,"completion_tokens":200,"total_tokens":217}}\n',
         b"\n",
         b"data: [DONE]\n",
-        b"\n"
+        b"\n",
     ]
 
-@pytest.mark.parametrize("resp", [completion_stream_response(), completion_stream_response_incomplete()])
+
+@pytest.mark.parametrize(
+    "resp", [completion_stream_response(), completion_stream_response_incomplete()]
+)
 @pytest.mark.asyncio
 async def test_completions_stream(resp):
     config = completions_config()
@@ -143,7 +136,7 @@ async def test_completions_stream(resp):
     ) as mock_post:
         provider = TogetherAIProvider(RouteConfig(**config))
         payload = {
-            "model":"mistralai/Mixtral-8x7B-v0.1",
+            "model": "mistralai/Mixtral-8x7B-v0.1",
             "prompt": "This is a test",
             "temperature": 1,
             "n": 1,
@@ -155,7 +148,7 @@ async def test_completions_stream(resp):
             {
                 "choices": [
                     {
-                        "delta": {"role":None,"content":"test"},
+                        "delta": {"role": None, "content": "test"},
                         "finish_reason": None,
                         "index": 0,
                     }
@@ -167,11 +160,7 @@ async def test_completions_stream(resp):
             },
             {
                 "choices": [
-                    {
-                        "delta": {"role": None, "content": "test"},
-                        "finish_reason": None,
-                        "index": 0
-                    }
+                    {"delta": {"role": None, "content": "test"}, "finish_reason": None, "index": 0}
                 ],
                 "created": 1,
                 "id": "test-id",
@@ -199,7 +188,7 @@ async def test_completions_stream(resp):
                 "model": "mistralai/Mixtral-8x7B-v0.1",
                 "temperature": 1,
                 "n": 1,
-                "prompt": "This is a test"
+                "prompt": "This is a test",
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )
@@ -218,62 +207,51 @@ def embeddings_config():
         },
     }
 
+
 def embeddings_response():
     return {
         "object": "list",
         "data": [
-          {
-            "object": "embedding",
-            "embedding": [
-              0.44990748,
-              -0.2521129,
-              -0.43091708,
-              0.214978
-            ],
-            "index": 0
-          }
+            {
+                "object": "embedding",
+                "embedding": [0.44990748, -0.2521129, -0.43091708, 0.214978],
+                "index": 0,
+            }
         ],
         "model": "togethercomputer/m2-bert-80M-8k-retrieval",
-        "request_id": "840fc1b5bb2830cb-SEA"
+        "request_id": "840fc1b5bb2830cb-SEA",
     }
+
 
 @pytest.mark.asyncio
 async def test_embeddings():
-
     config = embeddings_config()
     resp = embeddings_response()
 
     with mock.patch("time.time", return_value=1677858242), mock.patch(
-    "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
     ) as mock_post:
-
         provider = TogetherAIProvider(RouteConfig(**config))
 
         payload = {
             "input": "Our solar system orbits the Milky Way galaxy at about 515,000 mph.",
-            "model": "togethercomputer/m2-bert-80M-8k-retrieval"
+            "model": "togethercomputer/m2-bert-80M-8k-retrieval",
         }
 
         response = await provider.embeddings(embeddings.RequestPayload(**payload))
 
         assert jsonable_encoder(response) == {
-              "object": "list",
-              "data": [
+            "object": "list",
+            "data": [
                 {
-                  "object": "embedding",
-                  "embedding": [
-                    0.44990748,
-                    -0.2521129,
-                    -0.43091708,
-                    0.214978
-                  ],
-                  "index": 0
+                    "object": "embedding",
+                    "embedding": [0.44990748, -0.2521129, -0.43091708, 0.214978],
+                    "index": 0,
                 }
-              ],
-              "model": "togethercomputer/m2-bert-80M-8k-retrieval",
-              "usage": {"prompt_tokens": None, "total_tokens": None},
+            ],
+            "model": "togethercomputer/m2-bert-80M-8k-retrieval",
+            "usage": {"prompt_tokens": None, "total_tokens": None},
         }
-
 
         mock_post.assert_called_once_with(
             "https://api.together.xyz/v1/embeddings",
@@ -283,6 +261,7 @@ async def test_embeddings():
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )
+
 
 def chat_config():
     return {
@@ -299,44 +278,28 @@ def chat_config():
 
 
 def chat_response():
-
     return {
-      "id": "8448080b880415ea-SJC",
-      "choices": [
-        {
-          "message": {
-            "role": "assistant",
-            "content": "Its Artyom!"
-          }
-        }
-      ],
-      "usage": {
-        "prompt_tokens": 13,
-        "completion_tokens": 7,
-        "total_tokens": 20
-      },
-      "created": 1705090115,
-      "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
-      "object": "chat.completion"
+        "id": "8448080b880415ea-SJC",
+        "choices": [{"message": {"role": "assistant", "content": "Its Artyom!"}}],
+        "usage": {"prompt_tokens": 13, "completion_tokens": 7, "total_tokens": 20},
+        "created": 1705090115,
+        "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+        "object": "chat.completion",
     }
 
 
 @pytest.mark.asyncio
 async def test_chat():
-
     config = chat_config()
     resp = chat_response()
 
     with mock.patch("time.time", return_value=1677858242), mock.patch(
-    "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
     ) as mock_post:
-
         provider = TogetherAIProvider(RouteConfig(**config))
 
         payload = {
-            "messages": [
-                {"role": "user", "content": "Who's the protagonist in Metro 2033?"}
-             ],
+            "messages": [{"role": "user", "content": "Who's the protagonist in Metro 2033?"}],
             "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
             "max_tokens": 200,
             "temperature": 1.0,
@@ -346,25 +309,22 @@ async def test_chat():
         response = await provider.chat(chat.RequestPayload(**payload))
 
         assert jsonable_encoder(response) == {
-              "id": "8448080b880415ea-SJC",
-              "object": "chat.completion",
-              "created": 1705090115,
-              "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
-              "choices": [{
-                "index": 0,
-                "message": {
-                  "role": "assistant",
-                  "content": "Its Artyom!",
-                },
-                "finish_reason": None
-              }],
-              "usage": {
-                "prompt_tokens": 13,
-                "completion_tokens": 7,
-                "total_tokens": 20
-              }
+            "id": "8448080b880415ea-SJC",
+            "object": "chat.completion",
+            "created": 1705090115,
+            "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Its Artyom!",
+                    },
+                    "finish_reason": None,
+                }
+            ],
+            "usage": {"prompt_tokens": 13, "completion_tokens": 7, "total_tokens": 20},
         }
-
 
         mock_post.assert_called_once_with(
             "https://api.together.xyz/v1/chat/completions",
@@ -378,6 +338,7 @@ async def test_chat():
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )
 
+
 def chat_stream_response():
     return [
         b'data: {"id":"test-id","object":"chat.completion.chunk","created":1,'
@@ -390,7 +351,7 @@ def chat_stream_response():
         b'"choices":[{"index":0,"text":"test","logprobs":null,"finish_reason":"length","delta":{"token_id":1345,"content":"test"}}],"model":"test","usage":{"prompt_tokens":17,"completion_tokens":200,"total_tokens":217}}\n',
         b"\n",
         b"data: [DONE]\n",
-        b"\n"
+        b"\n",
     ]
 
 
@@ -407,8 +368,9 @@ def chat_stream_response_incomplete():
         b'ed":1,"choices":[{"index":0,"text":"test","logprobs":null,"finish_reason":"length","delta":{"token_id":1345,"content":"test"}}],"model":"test","usage":{"prompt_tokens":17,"completion_tokens":200,"total_tokens":217}}\n',
         b"\n",
         b"data: [DONE]\n",
-        b"\n"
+        b"\n",
     ]
+
 
 @pytest.mark.parametrize("resp", [chat_stream_response(), chat_stream_response_incomplete()])
 @pytest.mark.asyncio
@@ -420,7 +382,7 @@ async def test_chat_stream(resp):
     ) as mock_post:
         provider = TogetherAIProvider(RouteConfig(**config))
         payload = {
-            "model":"mistralai/Mixtral-8x7B-v0.1",
+            "model": "mistralai/Mixtral-8x7B-v0.1",
             "messages": [
                 {"role": "system", "content": "This is a test"},
                 {"role": "user", "content": "This is a test"},
@@ -437,7 +399,7 @@ async def test_chat_stream(resp):
             {
                 "choices": [
                     {
-                        "delta": {"role":None,"content":"test"},
+                        "delta": {"role": None, "content": "test"},
                         "finish_reason": None,
                         "index": 0,
                     }
@@ -449,11 +411,7 @@ async def test_chat_stream(resp):
             },
             {
                 "choices": [
-                    {
-                        "delta": {"role": None, "content": "test"},
-                        "finish_reason": None,
-                        "index": 0
-                    }
+                    {"delta": {"role": None, "content": "test"}, "finish_reason": None, "index": 0}
                 ],
                 "created": 1,
                 "id": "test-id",

--- a/tests/gateway/providers/test_togetherai.py
+++ b/tests/gateway/providers/test_togetherai.py
@@ -277,7 +277,8 @@ async def test_wrong_logprobs_type_error():
             "logprobs": "invalid_type",
         }
         error_string = (
-            "Wrong type for logprobs." "If logprobs is set it should be an 32bit integer."
+            "Wrong type for logprobs." 
+            "If logprobs is set it should be an 32bit integer."
         )
         # Test whether HTTPException is raised when max_tokens is missing
         with pytest.raises(HTTPException, match=error_string) as exc_info:

--- a/tests/gateway/providers/test_togetherai.py
+++ b/tests/gateway/providers/test_togetherai.py
@@ -277,8 +277,7 @@ async def test_wrong_logprobs_type_error():
             "logprobs": "invalid_type",
         }
         error_string = (
-            "Wrong type for logprobs."
-            "If logprobs is set it should be an 32bit integer."
+            "Wrong type for logprobs." "If logprobs is set it should be an 32bit integer."
         )
         # Test whether HTTPException is raised when max_tokens is missing
         with pytest.raises(HTTPException, match=error_string) as exc_info:

--- a/tests/gateway/providers/test_togetherai.py
+++ b/tests/gateway/providers/test_togetherai.py
@@ -277,7 +277,7 @@ async def test_wrong_logprobs_type_error():
             "logprobs": "invalid_type",
         }
         error_string = (
-            "Wrong type for logprobs." 
+            "Wrong type for logprobs."
             "If logprobs is set it should be an 32bit integer."
         )
         # Test whether HTTPException is raised when max_tokens is missing

--- a/tests/gateway/providers/test_togetherai.py
+++ b/tests/gateway/providers/test_togetherai.py
@@ -1,20 +1,16 @@
-import math
 from unittest import mock
 
 import pytest
 from aiohttp import ClientTimeout
-from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
-from pydantic import ValidationError
 
 from mlflow.gateway.config import RouteConfig
 from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
 from mlflow.gateway.providers.togetherai import TogetherAIProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
-from mlflow.gateway.utils import handle_incomplete_chunks, strip_sse_prefix
+from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse
 
-from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse, mock_http_client
 
 def completions_config():
     return {
@@ -60,13 +56,13 @@ async def test_completions():
     with mock.patch("time.time", return_value=1677858242), mock.patch(
     "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
     ) as mock_post:
-        
+
         provider = TogetherAIProvider(RouteConfig(**config))
 
         payload = {
             "prompt": "Whats the capital of France?",
             "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
-            "max_tokens": 200, 
+            "max_tokens": 200,
             "temperature": 1.0,
             "n": 1,
         }
@@ -139,7 +135,7 @@ def completion_stream_response_incomplete():
 
 @pytest.mark.parametrize("resp", [completion_stream_response(), completion_stream_response_incomplete()])
 @pytest.mark.asyncio
-async def test_completions_stream(resp): 
+async def test_completions_stream(resp):
     config = completions_config()
 
     with mock.patch("time.time", return_value=1677858242), mock.patch(
@@ -148,7 +144,7 @@ async def test_completions_stream(resp):
         provider = TogetherAIProvider(RouteConfig(**config))
         payload = {
             "model":"mistralai/Mixtral-8x7B-v0.1",
-            "prompt": "This is a test", 
+            "prompt": "This is a test",
             "temperature": 1,
             "n": 1,
         }
@@ -172,8 +168,8 @@ async def test_completions_stream(resp):
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": "test"}, 
-                        "finish_reason": None, 
+                        "delta": {"role": None, "content": "test"},
+                        "finish_reason": None,
                         "index": 0
                     }
                 ],
@@ -195,7 +191,7 @@ async def test_completions_stream(resp):
                 "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
                 "object": "text_completion_chunk",
             },
-        ] 
+        ]
 
         mock_post.assert_called_once_with(
             "https://api.together.xyz/v1/completions",
@@ -221,7 +217,7 @@ def embeddings_config():
             },
         },
     }
-    
+
 def embeddings_response():
     return {
         "object": "list",
@@ -250,7 +246,7 @@ async def test_embeddings():
     with mock.patch("time.time", return_value=1677858242), mock.patch(
     "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
     ) as mock_post:
-        
+
         provider = TogetherAIProvider(RouteConfig(**config))
 
         payload = {
@@ -327,14 +323,14 @@ def chat_response():
 
 @pytest.mark.asyncio
 async def test_chat():
-    
+
     config = chat_config()
     resp = chat_response()
 
     with mock.patch("time.time", return_value=1677858242), mock.patch(
     "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
     ) as mock_post:
-        
+
         provider = TogetherAIProvider(RouteConfig(**config))
 
         payload = {
@@ -342,7 +338,7 @@ async def test_chat():
                 {"role": "user", "content": "Who's the protagonist in Metro 2033?"}
              ],
             "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
-            "max_tokens": 200, 
+            "max_tokens": 200,
             "temperature": 1.0,
             "n": 1,
         }
@@ -375,7 +371,7 @@ async def test_chat():
             json={
                 "messages": [{"role": "user", "content": "Who's the protagonist in Metro 2033?"}],
                 "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
-                "max_tokens": 200, 
+                "max_tokens": 200,
                 "temperature": 1.0,
                 "n": 1,
             },

--- a/tests/gateway/providers/test_togetherai.py
+++ b/tests/gateway/providers/test_togetherai.py
@@ -276,9 +276,7 @@ async def test_wrong_logprobs_type_error():
             "n": 1,
             "logprobs": "invalid_type",
         }
-        error_string = (
-            "Wrong type for logprobs." "If logprobs is set it should be an 32bit integer."
-        )
+        error_string = "Wrong type for logprobs. It should be an 32bit integer."
         # Test whether HTTPException is raised when max_tokens is missing
         with pytest.raises(HTTPException, match=error_string) as exc_info:
             await provider.completions(completions.RequestPayload(**payload))

--- a/tests/gateway/providers/test_togetherai.py
+++ b/tests/gateway/providers/test_togetherai.py
@@ -1,3 +1,4 @@
+import textwrap
 from unittest import mock
 
 import pytest
@@ -32,7 +33,16 @@ def completions_response():
         "choices": [
             {
                 "index": 0,
-                "text": "The capital of France is Paris. It's located in the north-central part of the country and is one of the most famous cities in the world, known for its iconic landmarks such as the Eiffel Tower, Louvre Museum, Notre-Dame Cathedral, and more. Paris is also the cultural, political, and economic center of France.",
+                "text": textwrap.dedent(
+                    """\
+                The capital of France is Paris.
+                It's located in the north-central part of the country
+                and is one of the most famous cities in the world,
+                known for its iconic landmarks such as the Eiffel Tower,
+                Louvre Museum, Notre-Dame Cathedral, and more.
+                Paris is also the cultural, political, and economic center of France.
+                """
+                ),
                 "finish_reason": None,
             }
         ],
@@ -68,7 +78,16 @@ async def test_completions():
             "choices": [
                 {
                     "index": 0,
-                    "text": "The capital of France is Paris. It's located in the north-central part of the country and is one of the most famous cities in the world, known for its iconic landmarks such as the Eiffel Tower, Louvre Museum, Notre-Dame Cathedral, and more. Paris is also the cultural, political, and economic center of France.",
+                    "text": textwrap.dedent(
+                        """\
+                    The capital of France is Paris.
+                    It's located in the north-central part of the country
+                    and is one of the most famous cities in the world,
+                    known for its iconic landmarks such as the Eiffel Tower,
+                    Louvre Museum, Notre-Dame Cathedral, and more.
+                    Paris is also the cultural, political, and economic center of France.
+                    """
+                    ),
                     "finish_reason": None,
                 }
             ],

--- a/tests/gateway/test_integration.py
+++ b/tests/gateway/test_integration.py
@@ -19,6 +19,7 @@ from mlflow.gateway.providers.mlflow import MlflowModelServingProvider
 from mlflow.gateway.providers.mosaicml import MosaicMLProvider
 from mlflow.gateway.providers.openai import OpenAIProvider
 from mlflow.gateway.providers.palm import PaLMProvider
+from mlflow.gateway.providers.togetherai import TogetherAIProvider
 from mlflow.utils.request_utils import _cached_get_request_session
 
 from tests.gateway.tools import (
@@ -242,6 +243,39 @@ def basic_config_dict():
                     },
                 },
             },
+            {
+                "name": "completions-togetherai",
+                "route_type": "llm/v1/completions",
+                "model": {
+                    "provider": "togetherai",
+                    "name": "mistralai/Mixtral-8x7B-v0.1",
+                    "config": {
+                        "togetherai_api_key": "$TOGETHERAI_API_KEY",
+                    },
+                },
+            },
+            {
+                "name": "chat-togetherai",
+                "route_type": "llm/v1/chat",
+                "model": {
+                    "provider": "togetherai",
+                    "name": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+                    "config": {
+                        "togetherai_api_key": "$TOGETHERAI_API_KEY",
+                    },
+                },
+            },
+            {
+                "name": "embeddings-togetherai",
+                "route_type": "llm/v1/embeddings",
+                "model": {
+                    "provider": "togetherai",
+                    "name": "togethercomputer/m2-bert-80M-8k-retrieval",
+                    "config": {
+                        "togetherai_api_key": "$TOGETHERAI_API_KEY",
+                    },
+                },
+            },
         ]
     }
 
@@ -268,6 +302,7 @@ def env_setup(monkeypatch):
     monkeypatch.setenv("MOSAICML_API_KEY", "test_mosaicml_key")
     monkeypatch.setenv("PALM_API_KEY", "test_palm_key")
     monkeypatch.setenv("MISTRAL_API_KEY", "test_mistral_key")
+    monkeypatch.setenv("TOGETHERAI_API_KEY", "test_togetherai_key")
 
 
 @pytest.fixture
@@ -291,7 +326,7 @@ def test_create_gateway_client_with_declared_url(gateway):
     assert gateway_client.gateway_uri == gateway.url
     assert isinstance(gateway_client.get_route("chat-openai"), Route)
     routes = gateway_client.search_routes()
-    assert len(routes) == 20
+    assert len(routes) == 23
     assert all(isinstance(route, Route) for route in routes)
 
 
@@ -1040,5 +1075,124 @@ def test_mistral_embeddings(gateway):
         return expected_output
 
     with patch.object(MistralProvider, "embeddings", mock_embeddings):
+        response = client.query(route=route.name, data=data)
+    assert response == expected_output
+
+
+def test_togetherai_completions(gateway):
+    client = MlflowGatewayClient(gateway_uri=gateway.url)
+    route = client.get_route("completions-togetherai")
+
+    expected_output = {
+        "id": "8782fbf478f2ee87-ATH",
+        "object": "text_completion",
+        "created": 1713761335,
+        "model": "mistralai/Mixtral-8x7B-v0.1",
+        "choices": [
+            {
+                "index": 0,
+                "text": (
+                    "\n\nGeralt of Rivia"
+                    "\nGeralt of Rivia is the protagonist of The Witcher 3: Wild Hunt.\n\n"
+                    "## Is Geralt a good guy?\n\nGeralt is a good guy, but he’s not a hero."
+                    "He’s a monster hunter, "
+                    "and he’s not afraid to kill."
+                    "He’s also not afraid to get his hands dirty. He’s not a hero, "
+                    "but he’s not a villain either.\n\n"
+                    "## Is Geralt a good person?\n\nGeralt is a good person. "
+                    "He’s a monster hunter, but he’s also "
+                    "a good person. He’s a good person because he’s a monster hunter. "
+                    "He’s a good person because he’s "
+                    "a good person.\n\n"
+                    "## Is Geralt a good person?\n\nGeralt is a good person. "
+                    "He’s a monster hunter, but he"
+                ),
+                "finish_reason": None,
+            }
+        ],
+        "usage": {"prompt_tokens": 15, "completion_tokens": 200, "total_tokens": 215},
+    }
+
+    data = {
+        "prompt": "Who's the protagonist in the Witcher 3 Wild Hunt?",
+        "temperature": 0.1,
+        "max_tokens": 200,
+    }
+
+    async def mock_completions(self, payload):
+        return expected_output
+
+    with patch.object(TogetherAIProvider, "completions", mock_completions):
+        response = client.query(route=route.name, data=data)
+    assert response == expected_output
+
+
+def test_togetherai_chat(gateway):
+    client = MlflowGatewayClient(gateway_uri=gateway.url)
+    route = client.get_route("chat-togetherai")
+    expected_output = {
+        "id": "8782fc033a48eea0-ATH",
+        "object": "chat.completion",
+        "created": 1713761337,
+        "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": (
+                        "I am not Alexander, but I can help you with your request. "
+                        "To tell someone to get out of the sunlight, you could say:\n\n"
+                        '* "Step out of the sun, please."\n'
+                        '* "Can you move to the shade? The sun is quite strong."\n'
+                        '* "The sun is too intense, do you mind finding some shade?"\n\n'
+                        "I hope this helps! If you have any other questions or need further "
+                        "clarification, just let me know."
+                    ),
+                },
+                "finish_reason": None,
+            }
+        ],
+        "usage": {"prompt_tokens": 19, "completion_tokens": 97, "total_tokens": 116},
+    }
+
+    data = {
+        "messages": [{"role": "user", "content": "Get out of the sunlight's way Alexander!"}],
+    }
+
+    async def mock_chat(self, payload):
+        return expected_output
+
+    with patch.object(TogetherAIProvider, "chat", mock_chat):
+        response = client.query(route=route.name, data=data)
+    assert response == expected_output
+
+
+def test_togetherai_embeddings(gateway):
+    client = MlflowGatewayClient(gateway_uri=gateway.url)
+    route = client.get_route("embeddings-togetherai")
+    expected_output = {
+        "object": "list",
+        "data": [
+            {
+                "object": "embedding",
+                "embedding": [
+                    0.1,
+                    0.2,
+                    0.3,
+                ],
+                "index": 0,
+            }
+        ],
+        "model": "togethercomputer/m2-bert-80M-8k-retrieval",
+        "usage": {"prompt_tokens": 7, "total_tokens": 20},
+    }
+
+    data = {"input": "Please I need embeddings!", "max_tokens": 50}
+
+    async def mock_embeddings(self, payload):
+        return expected_output
+
+    with patch.object(TogetherAIProvider, "embeddings", mock_embeddings):
         response = client.query(route=route.name, data=data)
     assert response == expected_output


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/FotiosBistas/mlflow/pull/11557?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11557/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11557
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #11530 

### What changes are proposed in this pull request?

- [ ] Add TogetherAI provider support in MLflow deployments server

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

https://github.com/FotiosBistas/mlflow/blob/togetherai_provider/tests/gateway/providers/test_togetherai.py

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [x] API references
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add TogetherAI provider support in the MLflow deployments server. This means that TogetherAI endpoints can be added in the ``config.yaml`` file and users can interact with these endpoints from within MLflow. 

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
