### PR TITLE
[Bug-bash] Refine validations for tracing imperative APIs

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -105,7 +105,7 @@ from mlflow.config import (
 from mlflow.exceptions import MlflowException
 from mlflow.models import evaluate
 from mlflow.projects import run
-from mlflow.tracing.fluent import get_traces, start_span, trace
+from mlflow.tracing.fluent import get_current_active_span, get_traces, start_span, trace
 from mlflow.tracking._model_registry.fluent import (
     register_model,
     search_model_versions,
@@ -212,6 +212,7 @@ __all__ = [
     "start_run",
     "Image",
     # Tracing Fluent APIs
+    "get_current_active_span",
     "get_traces",
     "start_span",
     "trace",

--- a/mlflow/tracing/clients/base.py
+++ b/mlflow/tracing/clients/base.py
@@ -5,7 +5,7 @@ from mlflow.entities import Trace
 
 class TraceClient(ABC):
     @abstractmethod
-    def get_trace(self, request_id: Trace):
+    def get_trace(self, request_id: str):
         """Get the trace with the given request_id."""
         pass
 

--- a/mlflow/tracing/clients/base.py
+++ b/mlflow/tracing/clients/base.py
@@ -5,10 +5,11 @@ from mlflow.entities import Trace
 
 class TraceClient(ABC):
     @abstractmethod
-    def log_trace(self, trace: Trace):
+    def get_trace(self, request_id: Trace):
+        """Get the trace with the given request_id."""
         pass
 
-
-class NoOpClient(TraceClient):
+    @abstractmethod
     def log_trace(self, trace: Trace):
+        """Log the given trace."""
         pass

--- a/mlflow/tracing/clients/local.py
+++ b/mlflow/tracing/clients/local.py
@@ -1,6 +1,6 @@
 from collections import deque
 from trace import Trace
-from typing import List
+from typing import List, Optional
 
 from mlflow.environment_variables import MLFLOW_TRACING_CLIENT_BUFFER_SIZE
 from mlflow.tracing.clients.base import TraceClient
@@ -73,6 +73,19 @@ class InMemoryTraceClient(TraceClient):
             A list of Trace objects.
         """
         return list(self.queue) if n is None else list(self.queue)[-n:]
+
+    def get_trace(self, request_id: str) -> Optional[Trace]:
+        """
+        Get the trace with the given request_id.
+
+        Args:
+            request_id: The request_id of the trace to return.
+        Returns:
+            A Trace object.
+        """
+        for trace in self.queue:
+            if trace.trace_info.request_id == request_id:
+                return trace
 
     def _flush(self):
         self.queue.clear()

--- a/mlflow/tracing/clients/local.py
+++ b/mlflow/tracing/clients/local.py
@@ -1,3 +1,4 @@
+import threading
 from collections import deque
 from trace import Trace
 from typing import List, Optional
@@ -26,6 +27,7 @@ class InMemoryTraceClient(TraceClient):
     def __init__(self):
         queue_size = MLFLOW_TRACING_CLIENT_BUFFER_SIZE.get()
         self.queue = deque(maxlen=queue_size)
+        self._lock = threading.Lock()  # Lock for accessing the queue
 
         # used for displaying traces in IPython notebooks
         self._prev_execution_count = -1
@@ -60,7 +62,8 @@ class InMemoryTraceClient(TraceClient):
             pass
 
     def log_trace(self, trace: Trace):
-        self.queue.append(trace)
+        with self._lock:
+            self.queue.append(trace)
         self._display_trace(trace)
 
     def get_traces(self, n: int = 10) -> List[Trace]:
@@ -72,7 +75,9 @@ class InMemoryTraceClient(TraceClient):
         Returns:
             A list of Trace objects.
         """
-        return list(self.queue) if n is None else list(self.queue)[-n:]
+        with self._lock:
+            trace_list = list(self.queue)
+        return trace_list if n is None else trace_list[-n:]
 
     def get_trace(self, request_id: str) -> Optional[Trace]:
         """
@@ -83,9 +88,10 @@ class InMemoryTraceClient(TraceClient):
         Returns:
             A Trace object.
         """
-        for trace in self.queue:
-            if trace.trace_info.request_id == request_id:
-                return trace
+        with self._lock:
+            for trace in self.queue:
+                if trace.trace_info.request_id == request_id:
+                    return trace
 
     def _flush(self):
         self.queue.clear()

--- a/mlflow/tracing/clients/local.py
+++ b/mlflow/tracing/clients/local.py
@@ -66,12 +66,12 @@ class InMemoryTraceClient(TraceClient):
             self.queue.append(trace)
         self._display_trace(trace)
 
-    def get_traces(self, n: int = 10) -> List[Trace]:
+    def get_traces(self, n: Optional[int] = 10) -> List[Trace]:
         """
         Get the last n traces from the buffer.
 
         Args:
-            n: The number of traces to return.
+            n: The number of traces to return. If None, return all traces.
         Returns:
             A list of Trace objects.
         """

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -198,3 +198,25 @@ def get_traces(n: int = 1) -> List[Trace]:
     from mlflow.tracing.clients import get_trace_client
 
     return get_trace_client().get_traces(n)
+
+
+def get_current_active_span() -> Optional[MLflowSpanWrapper]:
+    """
+    Get the current active span in the global context.
+
+    .. attention::
+
+        This only works when the span is created with fluent APIs like `@mlflow.trace` or
+        `with mlflow.start_span`. If a span is created with MlflowClient APIs, it won't be
+        attached to the global context so this function will not return it.
+
+    Returns:
+        The current active span if exists, otherwise None.
+    """
+    otel_span = trace_api.get_current_span()
+    if otel_span is None:
+        return None
+
+    span_context = otel_span.get_span_context()
+    trace_manager = InMemoryTraceManager.get_instance()
+    return trace_manager.get_span_from_id(span_context.trace_id, span_context.span_id)

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -200,7 +200,7 @@ def get_traces(n: int = 1) -> List[Trace]:
     return get_trace_client().get_traces(n)
 
 
-def get_current_active_span() -> Optional[MLflowSpanWrapper]:
+def get_current_active_span():
     """
     Get the current active span in the global context.
 

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -1,7 +1,6 @@
 import logging
 import threading
 from dataclasses import dataclass, field
-from functools import lru_cache
 from typing import Dict, Optional
 
 from cachetools import TTLCache
@@ -154,9 +153,6 @@ class InMemoryTraceManager:
 
         return trace.span_dict.get(span_id) if trace else None
 
-    # NB: Caching as this requires a linear search over all spans in the trace and
-    #   the return value should not change for the same request_id.
-    @lru_cache(maxsize=128)
     def get_root_span_id(self, request_id) -> Optional[str]:
         """
         Get the root span ID for the given trace ID.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -510,7 +510,7 @@ class MlflowClient:
                 "because it may lead to unexpected behavior. To resolve this issue, consider the "
                 "following options:\n"
                 " - If you want to create a child span under the active trace, use "
-                "`with mlflow.start_span()` or `MlflowClient.start_span()` instead."
+                "`with mlflow.start_span()` or `MlflowClient.start_span()` instead.\n"
                 " - If you want to start multiple traces in parallel, avoid using fluent APIs "
                 "and create all traces using `MlflowClient.start_trace()`.",
                 error_code=BAD_REQUEST,
@@ -733,7 +733,7 @@ class MlflowClient:
 
         if span is None:
             raise MlflowException(
-                f"Span with ID {span_id} not found in trace with ID {request_id}.",
+                f"Span with ID {span_id} is not found or already finished.",
                 error_code=RESOURCE_DOES_NOT_EXIST,
             )
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -713,8 +713,10 @@ class MlflowClient:
         span = trace_manager.get_span_from_id(request_id, span_id)
 
         if span is None:
-            _logger.warning(f"Span with ID {span_id} not found in trace with ID {request_id}.")
-            return
+            raise MlflowException(
+                f"Span with ID {span_id} not found in trace with ID {request_id}.",
+                error_code=RESOURCE_DOES_NOT_EXIST,
+            )
 
         if attributes:
             span.set_attributes(attributes or {})

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -509,9 +509,9 @@ class MlflowClient:
                 "to call MlflowClient.start_trace() under an active trace created by fluent APIs "
                 "because it may lead to unexpected behavior. To resolve this issue, consider the "
                 "following options:\n"
-                " - If you want to create a child span under the active trace, use "
+                " - To create a child span under the active trace, use "
                 "`with mlflow.start_span()` or `MlflowClient.start_span()` instead.\n"
-                " - If you want to start multiple traces in parallel, avoid using fluent APIs "
+                " - To start multiple traces in parallel, avoid using fluent APIs "
                 "and create all traces using `MlflowClient.start_trace()`.",
                 error_code=BAD_REQUEST,
             )

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -506,7 +506,7 @@ class MlflowClient:
                 f"Another trace is already set in the global context with ID {span.request_id}. "
                 "It appears that you have already started a trace using fluent APIs like "
                 "`@mlflow.trace()` or `with mlflow.start_span()`. However, it is not allowed "
-                "to call MlflowClient.start_trace() under an active trace created by fluent APIs, "
+                "to call MlflowClient.start_trace() under an active trace created by fluent APIs "
                 "because it may lead to unexpected behavior. To resolve this issue, consider the "
                 "following options:\n"
                 " - If you want to create a child span under the active trace, use "

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -329,20 +329,24 @@ def test_start_span_raise_error_when_parent_span_id_is_not_provided():
         )
 
 
+def test_end_span_raise_error_when_span_not_active():
+    with pytest.raises(MlflowException, match=r"Span with ID test_span not found in"):
+        mlflow.tracking.MlflowClient().end_span("test_trace", "test_span")
+
+
 @mock.patch("mlflow.tracking.client.get_trace_client")
 def test_end_trace_raise_error_when_trace_not_active(mock_get_trace_client):
     mock_trace_client = mock_get_trace_client.return_value
-    test_request_id = "test"
 
     # Case 1: the trace already ended
     mock_trace_client.get_trace.return_value = Trace(None, [])
     with pytest.raises(MlflowException, match=r"Trace with ID test already finished"):
-        mlflow.tracking.MlflowClient().end_trace(test_request_id)
+        mlflow.tracking.MlflowClient().end_trace("test")
 
     # Case 2: the trace does not exist
     mock_trace_client.get_trace.return_value = None
     with pytest.raises(MlflowException, match=r"Trace with ID test not found"):
-        mlflow.tracking.MlflowClient().end_trace(test_request_id)
+        mlflow.tracking.MlflowClient().end_trace("test")
 
 
 def test_client_create_experiment(mock_store):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -356,7 +356,7 @@ def test_start_span_raise_error_when_parent_span_id_is_not_provided():
 
 
 def test_end_span_raise_error_when_span_not_active():
-    with pytest.raises(MlflowException, match=r"Span with ID test_span not found in"):
+    with pytest.raises(MlflowException, match=r"Span with ID test_span is not found or"):
         mlflow.tracking.MlflowClient().end_span("test_trace", "test_span")
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11562?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11562/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11562
```

</p>
</details>

### What changes are proposed in this pull request?

This PR fixes a few papercuts about state validation and error messages for MLflow Client APIs for trace creation.

**1. Disallow calling `MlflowClient().start_trace()` when there is an active span created by fluent APIs.**
The `start_trace()` method tries to create a root span, however, if there is active span created by fluent API, the new span will be child span of it. We block doing that and instead recommend customers to avoid mixing two APIs.
```
with mlflow.start_span(xxx):
    MlflowClient().start_trace(yyy) <- This should raise error
```

**2. Raise exception when `MlflowClient().end_span()` is called for already ended span_id.**

This only emit warning currently, but should be an exception as it is invalid use of API not internal error.

**3. Fix error message when `MlflowClient().end_trace()` is called for already ended request_id.**
When `end_trace` is accidentally called twice, we raises an error.
```
root_span = MlflowClient().start_trace()
MlflowClient().end_trace(root_span.request_id)
MlflowClient().end_trace(root_span.request_id)
```
Current error message is `Trace with ID xxx not found`, which is not accurate for this case. This PR changes it to `Trace with ID xxx already finished` by adding validation to check if the trace is already recorded or not.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
