### PR TITLE
Add a lint rule to prevent using `MLflow` or `MLFlow` in a class name

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -77,7 +77,7 @@ LAZY_BUILTIN_IMPORT = Rule(
 MLFLOW_CLASS_NAME = Rule(
     "Z0003",
     "mlflow-class-name",
-    "Should use `Mlflow` in class name, not `MLflow`.",
+    "Should use `Mlflow` in class name, not `MLflow` or `MLFlow`.",
 )
 
 
@@ -114,7 +114,7 @@ class Linter(ast.NodeVisitor):
         return bool(self.stack)
 
     def _mlflow_class_name(self, node: ast.ClassDef) -> None:
-        if not node.name.startswith("_") and "MLflow" in node.name:
+        if not node.name.startswith("_") and ("MLflow" in node.name or "MLFlow" in node.name):
             self._check(node, MLFLOW_CLASS_NAME)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -74,6 +74,11 @@ LAZY_BUILTIN_IMPORT = Rule(
     "lazy-builtin-import",
     "Builtin modules must be imported at the top level.",
 )
+MLFLOW_CLASS_NAME = Rule(
+    "Z0003",
+    "mlflow-class-name",
+    "Should use `Mlflow` in class name, not `MLflow`.",
+)
 
 
 class Linter(ast.NodeVisitor):
@@ -108,9 +113,14 @@ class Linter(ast.NodeVisitor):
     def _is_in_function(self) -> bool:
         return bool(self.stack)
 
+    def _mlflow_class_name(self, node: ast.ClassDef) -> None:
+        if not node.name.startswith("_") and "MLflow" in node.name:
+            self._check(node, MLFLOW_CLASS_NAME)
+
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self.stack.append(node)
         self._no_rst(node)
+        self._mlflow_class_name(node)
         self.generic_visit(node)
         self.stack.pop()
 

--- a/docs/source/deep-learning/keras/quickstart/quickstart_keras.ipynb
+++ b/docs/source/deep-learning/keras/quickstart/quickstart_keras.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Get Started with Keras 3.0 + MLflow\n",
     "\n",
-    "This tutorial is an end-to-end tutorial on training a MINST classifier with **Keras 3.0** and logging results with **MLflow**. It will demonstrate the use of `mlflow.keras.MLflowCallback`, and how to subclass it to implement custom logging logic.\n",
+    "This tutorial is an end-to-end tutorial on training a MINST classifier with **Keras 3.0** and logging results with **MLflow**. It will demonstrate the use of `mlflow.keras.MlflowCallback`, and how to subclass it to implement custom logging logic.\n",
     "\n",
     "**Keras** is a high-level api that is designed to be simple, flexible, and powerful - allowing everyone from beginners to advanced users to quickly build, train, and evaluate models. **Keras 3.0**, or Keras Core, is a full rewrite of the Keras codebase that rebases it on top of a modular backend architecture. It makes it possible to run Keras workflows on top of arbitrary frameworks — starting with TensorFlow, JAX, and PyTorch."
    ]
@@ -260,7 +260,7 @@
    "metadata": {},
    "source": [
     "## Train Model (Default Callback)\n",
-    "We will fit the model on the dataset, using MLflow's `mlflow.keras_core.MLflowCallback` to log metrics during training."
+    "We will fit the model on the dataset, using MLflow's `mlflow.keras.MlflowCallback` to log metrics during training."
    ]
   },
   {
@@ -315,7 +315,7 @@
     "    batch_size=BATCH_SIZE,\n",
     "    epochs=EPOCHS,\n",
     "    validation_split=0.1,\n",
-    "    callbacks=[mlflow.keras_core.MLflowCallback(run)],\n",
+    "    callbacks=[mlflow.keras.MlflowCallback(run)],\n",
     ")\n",
     "mlflow.end_run()"
    ]
@@ -372,7 +372,7 @@
     "        batch_size=BATCH_SIZE,\n",
     "        epochs=EPOCHS,\n",
     "        validation_split=0.1,\n",
-    "        callbacks=[mlflow.keras.MLflowCallback(run, log_every_epoch=False, log_every_n_steps=5)],\n",
+    "        callbacks=[mlflow.keras.MlflowCallback(run, log_every_epoch=False, log_every_n_steps=5)],\n",
     "    )"
    ]
   },
@@ -423,7 +423,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class MlflowCallbackLogPerBatch(mlflow.keras_core.MLflowCallback):\n",
+    "class MlflowCallbackLogPerBatch(mlflow.keras.MlflowCallback):\n",
     "    def on_batch_end(self, batch, logs=None):\n",
     "        if self.log_every_n_steps is None or logs is None:\n",
     "            return\n",
@@ -504,7 +504,7 @@
    ],
    "source": [
     "with mlflow.start_run() as run:\n",
-    "    model.evaluate(x_test, y_test, callbacks=[mlflow.keras_core.MLflowCallback(run)])"
+    "    model.evaluate(x_test, y_test, callbacks=[mlflow.keras_core.MlflowCallback(run)])"
    ]
   }
  ],

--- a/docs/source/deep-learning/tensorflow/guide/index.rst
+++ b/docs/source/deep-learning/tensorflow/guide/index.rst
@@ -86,9 +86,9 @@ implementation via this default callback, you can write your own callback to log
 Using the Predefined Callback
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-MLflow offers a predefined callback :py:class:`mlflow.tensorflow.MLflowCallback` that you can use or
+MLflow offers a predefined callback :py:class:`mlflow.tensorflow.MlflowCallback` that you can use or
 extend to log information to MLflow. The callback function provides the same functionality as autologging
-and is suitable for users willing to have a better control of the experiment. Using ``mlflow.tensorflow.MLflowCallback``
+and is suitable for users willing to have a better control of the experiment. Using ``mlflow.tensorflow.MlflowCallback``
 is the same as other Keras callbacks:
 
 .. code-block:: python
@@ -99,10 +99,10 @@ is the same as other Keras callbacks:
             label,
             batch_size=5,
             epochs=2,
-            callbacks=[mlflow.tensorflow.MLflowCallback()],
+            callbacks=[mlflow.tensorflow.MlflowCallback()],
         )
 
-You can change the logging frequency in :py:class:`mlflow.tensorflow.MLflowCallback` by setting
+You can change the logging frequency in :py:class:`mlflow.tensorflow.MlflowCallback` by setting
 ``log_every_epoch`` and ``log_every_n_steps``, by default metrics are logged per epoch. Please refer to
 the API documentation for more details.
 
@@ -122,7 +122,7 @@ in log scale:
     import math
     import mlflow
 
-    class MLflowCallback(keras.callbacks.Callback):
+    class MlflowCallback(keras.callbacks.Callback):
         def on_epoch_end(self, epoch, logs=None):
             logs = logs or {}
             for k, v in logs.items():

--- a/docs/source/deep-learning/tensorflow/quickstart/quickstart_tensorflow.ipynb
+++ b/docs/source/deep-learning/tensorflow/quickstart/quickstart_tensorflow.ipynb
@@ -515,7 +515,7 @@
     }
    ],
    "source": [
-    "from mlflow.tensorflow import MllflowCallback\n",
+    "from mlflow.tensorflow import MlflowCallback\n",
     "\n",
     "# Turn off autologging.\n",
     "mlflow.tensorflow.autolog(disable=True)\n",
@@ -524,7 +524,7 @@
     "    model.fit(\n",
     "        x=train_ds,\n",
     "        epochs=2,\n",
-    "        callbacks=[MllflowCallback(run)],\n",
+    "        callbacks=[MlflowCallback(run)],\n",
     "    )"
    ]
   },
@@ -561,8 +561,8 @@
     "import math\n",
     "\n",
     "\n",
-    "# Create our own callback by subclassing `MllflowCallback`.\n",
-    "class MLflowCustomCallback(MllflowCallback):\n",
+    "# Create our own callback by subclassing `MlflowCallback`.\n",
+    "class MlflowCustomCallback(MlflowCallback):\n",
     "    def on_epoch_end(self, epoch, logs=None):\n",
     "        if not self.log_every_epoch:\n",
     "            return\n",
@@ -616,7 +616,7 @@
     "    model.fit(\n",
     "        x=train_ds,\n",
     "        epochs=2,\n",
-    "        callbacks=[MLflowCustomCallback(run)],\n",
+    "        callbacks=[MlflowCustomCallback(run)],\n",
     "    )"
    ]
   },

--- a/docs/source/deep-learning/tensorflow/quickstart/quickstart_tensorflow.ipynb
+++ b/docs/source/deep-learning/tensorflow/quickstart/quickstart_tensorflow.ipynb
@@ -487,7 +487,7 @@
    "source": [
     "### Log with MLflow Callback\n",
     "\n",
-    "Auto logging is powerful and convenient, but if you are looking for a more native way as Tensorflow pipelines, you can use `mlflow.tensorflow.MLflowCallback` inside `model.fit()`, it will log:\n",
+    "Auto logging is powerful and convenient, but if you are looking for a more native way as Tensorflow pipelines, you can use `mlflow.tensorflow.MllflowCallback` inside `model.fit()`, it will log:\n",
     "- Your model configuration, layers, hyperparameters and so on.\n",
     "- The training stats, including losses and metrics configured with `model.compile()`."
    ]
@@ -515,7 +515,7 @@
     }
    ],
    "source": [
-    "from mlflow.tensorflow import MLflowCallback\n",
+    "from mlflow.tensorflow import MllflowCallback\n",
     "\n",
     "# Turn off autologging.\n",
     "mlflow.tensorflow.autolog(disable=True)\n",
@@ -524,7 +524,7 @@
     "    model.fit(\n",
     "        x=train_ds,\n",
     "        epochs=2,\n",
-    "        callbacks=[MLflowCallback(run)],\n",
+    "        callbacks=[MllflowCallback(run)],\n",
     "    )"
    ]
   },
@@ -545,7 +545,7 @@
    "source": [
     "### Customize the MLflow Callback\n",
     "\n",
-    "If you want to add extra logging logic, you can customize the MLflow callback. You can either subclass from `keras.callbacks.Callback` and write everything from scratch or subclass from `mlflow.tensorflow.MLflowCallback` to add you custom logging logic.\n",
+    "If you want to add extra logging logic, you can customize the MLflow callback. You can either subclass from `keras.callbacks.Callback` and write everything from scratch or subclass from `mlflow.tensorflow.MllflowCallback` to add you custom logging logic.\n",
     "\n",
     "Let's look at an example that we want to replace the loss with its log value to log to MLflow."
    ]
@@ -561,8 +561,8 @@
     "import math\n",
     "\n",
     "\n",
-    "# Create our own callback by subclassing `MLflowCallback`.\n",
-    "class MLflowCustomCallback(MLflowCallback):\n",
+    "# Create our own callback by subclassing `MllflowCallback`.\n",
+    "class MLflowCustomCallback(MllflowCallback):\n",
     "    def on_epoch_end(self, epoch, logs=None):\n",
     "        if not self.log_every_epoch:\n",
     "            return\n",
@@ -606,7 +606,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023/11/15 01:57:50 WARNING mlflow.utils.autologging_utils: Encountered unexpected error during tensorflow autologging: MLflow autologging must be turned off if an `MLflowCallback` is explicitly added to the callback list. You are creating an `MLflowCallback` while having autologging enabled. Please either call `mlflow.tensorflow.autolog(disable=True)` to disable autologging or remove `MLflowCallback` from the callback list. \n"
+      "2023/11/15 01:57:50 WARNING mlflow.utils.autologging_utils: Encountered unexpected error during tensorflow autologging: MLflow autologging must be turned off if an `MllflowCallback` is explicitly added to the callback list. You are creating an `MllflowCallback` while having autologging enabled. Please either call `mlflow.tensorflow.autolog(disable=True)` to disable autologging or remove `MllflowCallback` from the callback list. \n"
      ]
     }
    ],

--- a/docs/source/python_api/mlflow.tensorflow.rst
+++ b/docs/source/python_api/mlflow.tensorflow.rst
@@ -6,6 +6,6 @@ mlflow.tensorflow
     :undoc-members:
     :show-inheritance:
 
-.. autoclass:: mlflow.tensorflow.MLflowCallback
+.. autoclass:: mlflow.tensorflow.MlflowCallback
     :members:
     :undoc-members:

--- a/examples/flower_classifier/train.py
+++ b/examples/flower_classifier/train.py
@@ -86,7 +86,7 @@ def run(training_data, test_ratio, epochs, batch_size, image_width, image_height
     )
 
 
-class MLflowLogger(Callback):
+class MlflowLogger(Callback):
     """
     Keras callback for logging metrics and final model with MLflow.
 
@@ -225,7 +225,7 @@ def train(
                     epochs=epochs,
                     batch_size=batch_size,
                     callbacks=[
-                        MLflowLogger(
+                        MlflowLogger(
                             model=model,
                             x_train=x_train,
                             y_train=y_train,

--- a/examples/hyperparam/train.py
+++ b/examples/hyperparam/train.py
@@ -36,7 +36,7 @@ def get_standardize_f(train):
     return lambda x: (x - mu) / std
 
 
-class MLflowCheckpoint(Callback):
+class MlflowCheckpoint(Callback):
     """
     Example of Keras MLflow logger.
     Logs training metrics and final model with MLflow.
@@ -133,7 +133,7 @@ def run(training_data, epochs, batch_size, learning_rate, momentum, seed):
             eval_and_log_metrics("val", valid_y, np.ones(len(valid_y)) * np.mean(valid_y), epoch=-1)
             eval_and_log_metrics("test", test_y, np.ones(len(test_y)) * np.mean(test_y), epoch=-1)
         else:
-            with MLflowCheckpoint(test_x, test_y) as mlflow_logger:
+            with MlflowCheckpoint(test_x, test_y) as mlflow_logger:
                 model = Sequential()
                 model.add(Lambda(get_standardize_f(train_x)))
                 model.add(

--- a/examples/rest_api/mlflow_tracking_rest_api.py
+++ b/examples/rest_api/mlflow_tracking_rest_api.py
@@ -20,7 +20,7 @@ from mlflow.utils.time import get_current_time_millis
 _DEFAULT_USER_ID = "unknown"
 
 
-class MLflowTrackingRestApi:
+class MlflowTrackingRestApi:
     def __init__(self, hostname, port, experiment_id):
         self.base_url = "http://" + hostname + ":" + str(port) + "/api/2.0/mlflow"
         self.experiment_id = experiment_id
@@ -113,7 +113,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    mlflow_rest = MLflowTrackingRestApi(args.hostname, args.port, args.experiment_id)
+    mlflow_rest = MlflowTrackingRestApi(args.hostname, args.port, args.experiment_id)
     # Parameter is a key/val pair (str types)
     param = {"key": "alpha", "value": "0.1980"}
     status_code = mlflow_rest.log_param(param)

--- a/mlflow/keras/__init__.py
+++ b/mlflow/keras/__init__.py
@@ -22,7 +22,7 @@ if Version(keras.__version__) < Version("3.0.0"):
     ]
 else:
     from mlflow.keras.autologging import autolog
-    from mlflow.keras.callback import MLflowCallback
+    from mlflow.keras.callback import MlflowCallback
     from mlflow.keras.load import _load_pyfunc, load_model
     from mlflow.keras.save import (
         get_default_conda_env,
@@ -34,8 +34,11 @@ else:
 
     FLAVOR_NAME = "keras"
 
+    MLflowCallback = MlflowCallback  # for backwards compatibility
+
     __all__ = [
         "_load_pyfunc",
+        "MlflowCallback",
         "MLflowCallback",
         "autolog",
         "load_model",

--- a/mlflow/keras/autologging.py
+++ b/mlflow/keras/autologging.py
@@ -10,7 +10,7 @@ from mlflow.data.code_dataset_source import CodeDatasetSource
 from mlflow.data.numpy_dataset import from_numpy
 from mlflow.data.tensorflow_dataset import from_tensorflow
 from mlflow.exceptions import MlflowException
-from mlflow.keras.callback import MLflowCallback
+from mlflow.keras.callback import MlflowCallback
 from mlflow.keras.save import log_model
 from mlflow.keras.utils import get_model_signature
 from mlflow.tracking.context import registry as context_registry
@@ -29,12 +29,12 @@ _logger = logging.getLogger(__name__)
 
 def _check_existing_mlflow_callback(callbacks):
     for callback in callbacks:
-        if isinstance(callback, MLflowCallback):
+        if isinstance(callback, MlflowCallback):
             raise MlflowException(
-                "MLflow autologging must be turned off if an `MLflowCallback` is explicitly added "
-                "to the callback list. You are creating an `MLflowCallback` while having "
+                "MLflow autologging must be turned off if an `MlflowCallback` is explicitly added "
+                "to the callback list. You are creating an `MlflowCallback` while having "
                 "autologging enabled. Please either call `mlflow.keras.autolog(disable=True)` "
-                "to disable autologging or remove `MLflowCallback` from the callback list. "
+                "to disable autologging or remove `MlflowCallback` from the callback list. "
             )
 
 
@@ -250,9 +250,9 @@ def autolog(
                 except Exception as e:
                     _logger.warning(f"Failed to log dataset information to MLflow. Reason: {e}")
 
-            # Add `MLflowCallback` to the callback list.
+            # Add `MlflowCallback` to the callback list.
             callbacks = args[5] if len(args) >= 6 else kwargs.get("callbacks", [])
-            mlflow_callback = MLflowCallback(
+            mlflow_callback = MlflowCallback(
                 log_every_epoch=log_every_epoch,
                 log_every_n_steps=log_every_n_steps,
             )

--- a/mlflow/keras/callback.py
+++ b/mlflow/keras/callback.py
@@ -8,7 +8,7 @@ from mlflow.utils.autologging_utils import ExceptionSafeClass
 
 
 @experimental
-class MLflowCallback(keras.callbacks.Callback, metaclass=ExceptionSafeClass):
+class MlflowCallback(keras.callbacks.Callback, metaclass=ExceptionSafeClass):
     """Callback for logging Keras metrics/params/model/... to MLflow.
 
     This callback logs model metadata at training begins, and logs training metrics every epoch or
@@ -48,7 +48,7 @@ class MLflowCallback(keras.callbacks.Callback, metaclass=ExceptionSafeClass):
                 label,
                 batch_size=4,
                 epochs=2,
-                callbacks=[mlflow.keras.MLflowCallback()],
+                callbacks=[mlflow.keras.MlflowCallback()],
             )
     """
 

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -938,16 +938,16 @@ def _setup_callbacks(callbacks, log_every_epoch, log_every_n_steps):
     input list, and returns the new list and appropriate log directory.
     """
     from mlflow.tensorflow.autologging import _TensorBoard
-    from mlflow.tensorflow.callback import MLflowCallback, MlflowModelCheckpointCallback
+    from mlflow.tensorflow.callback import MlflowCallback, MlflowModelCheckpointCallback
 
     tb = _get_tensorboard_callback(callbacks)
     for callback in callbacks:
-        if isinstance(callback, MLflowCallback):
+        if isinstance(callback, MlflowCallback):
             raise MlflowException(
-                "MLflow autologging must be turned off if an `MLflowCallback` is explicitly added "
-                "to the callback list. You are creating an `MLflowCallback` while having "
+                "MLflow autologging must be turned off if an `MlflowCallback` is explicitly added "
+                "to the callback list. You are creating an `MlflowCallback` while having "
                 "autologging enabled. Please either call `mlflow.tensorflow.autolog(disable=True)` "
-                "to disable autologging or remove `MLflowCallback` from the callback list. "
+                "to disable autologging or remove `MlflowCallback` from the callback list. "
             )
     if tb is None:
         log_dir = _TensorBoardLogDir(location=tempfile.mkdtemp(), is_temp=True)
@@ -956,7 +956,7 @@ def _setup_callbacks(callbacks, log_every_epoch, log_every_n_steps):
         log_dir = _TensorBoardLogDir(location=tb.log_dir, is_temp=False)
 
     callbacks.append(
-        MLflowCallback(
+        MlflowCallback(
             log_every_epoch=log_every_epoch,
             log_every_n_steps=log_every_n_steps,
         )
@@ -1053,8 +1053,8 @@ def autolog(
     <https://www.mlflow.org/docs/latest/tracking.html#tensorflow-and-keras-experimental>`_.
 
     Note that autologging cannot be used together with explicit MLflow callback, i.e.,
-    `mlflow.tensorflow.MLflowCallback`, because it will cause the same metrics to be logged twice.
-    If you want to include `mlflow.tensorflow.MLflowCallback` in the callback list, please turn off
+    `mlflow.tensorflow.MlflowCallback`, because it will cause the same metrics to be logged twice.
+    If you want to include `mlflow.tensorflow.MlflowCallback` in the callback list, please turn off
     autologging by calling `mlflow.tensorflow.autolog(disable=True)`.
 
     Args:

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -29,7 +29,7 @@ from mlflow.models import Model, ModelInputExample, ModelSignature, infer_signat
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import _infer_signature_from_input_example
 from mlflow.models.utils import _save_example
-from mlflow.tensorflow.callback import MLflowCallback, MlflowModelCheckpointCallback  # noqa: F401
+from mlflow.tensorflow.callback import MlflowCallback, MlflowModelCheckpointCallback  # noqa: F401
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.tracking.context import registry as context_registry
@@ -96,6 +96,9 @@ _KERAS_MODEL_DATA_PATH = "data"
 _TF2MODEL_SUBPATH = "tf2model"
 
 model_data_artifact_paths = [_KERAS_MODEL_DATA_PATH, _TF2MODEL_SUBPATH]
+
+
+MLflowCallback = MlflowCallback  # for backwards compatibility
 
 
 def get_default_pip_requirements(include_cloudpickle=False):

--- a/mlflow/tensorflow/callback.py
+++ b/mlflow/tensorflow/callback.py
@@ -6,7 +6,7 @@ from mlflow.utils.autologging_utils import ExceptionSafeClass
 from mlflow.utils.checkpoint_utils import MlflowModelCheckpointCallbackBase
 
 
-class MLflowCallback(keras.callbacks.Callback, metaclass=ExceptionSafeClass):
+class MlflowCallback(keras.callbacks.Callback, metaclass=ExceptionSafeClass):
     """Callback for logging Tensorflow training metrics to MLflow.
 
     This callback logs model information at training start, and logs training metrics every epoch or
@@ -49,7 +49,7 @@ class MLflowCallback(keras.callbacks.Callback, metaclass=ExceptionSafeClass):
                 label,
                 batch_size=4,
                 epochs=2,
-                callbacks=[MLflowCallback(run)],
+                callbacks=[mlflow.keras.MlflowCallback(run)],
             )
     """
 
@@ -231,3 +231,6 @@ class MlflowModelCheckpointCallback(Callback, MlflowModelCheckpointCallbackBase)
                 global_step=self.global_step,
                 metric_dict={k: float(v) for k, v in logs.items()},
             )
+
+
+MLflowCallback = MlflowCallback  # for backward compatibility

--- a/mlflow/tensorflow/callback.py
+++ b/mlflow/tensorflow/callback.py
@@ -231,6 +231,3 @@ class MlflowModelCheckpointCallback(Callback, MlflowModelCheckpointCallbackBase)
                 global_step=self.global_step,
                 metric_dict={k: float(v) for k, v in logs.items()},
             )
-
-
-MLflowCallback = MlflowCallback  # for backward compatibility

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,7 +251,6 @@ forced-separate = ["tests"]
 [tool.clint]
 exclude = [
   "docs",
-  "examples",
   "mlflow/protos",
   "mlflow/ml_package_versions.py",
   "mlflow/server/js",

--- a/tests/keras/test_callback.py
+++ b/tests/keras/test_callback.py
@@ -4,7 +4,7 @@ import keras
 import numpy as np
 
 import mlflow
-from mlflow.keras.callback import MLflowCallback
+from mlflow.keras.callback import MlflowCallback
 from mlflow.tracking.fluent import flush_async_logging
 
 
@@ -29,7 +29,7 @@ def test_keras_mlflow_callback_log_every_epoch():
 
     num_epochs = 2
     with mlflow.start_run() as run:
-        mlflow_callback = MLflowCallback(log_every_epoch=True)
+        mlflow_callback = MlflowCallback(log_every_epoch=True)
         model.fit(
             data,
             label,
@@ -82,7 +82,7 @@ def test_keras_mlflow_callback_log_every_n_steps():
     log_every_n_steps = 1
     num_epochs = 2
     with mlflow.start_run() as run:
-        mlflow_callback = MLflowCallback(log_every_epoch=False, log_every_n_steps=log_every_n_steps)
+        mlflow_callback = MlflowCallback(log_every_epoch=False, log_every_n_steps=log_every_n_steps)
         model.fit(
             data,
             label,

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -250,7 +250,7 @@ def fake_classifier_chat_model():
     from langchain.chat_models.base import SimpleChatModel
     from langchain.schema.messages import BaseMessage
 
-    class FakeMLflowClassifier(SimpleChatModel):
+    class FakeMlflowClassifier(SimpleChatModel):
         """Fake Chat Model wrapper for testing purposes."""
 
         def _call(
@@ -270,7 +270,7 @@ def fake_classifier_chat_model():
         def _llm_type(self) -> str:
             return "fake mlflow classifier"
 
-    return FakeMLflowClassifier()
+    return FakeMlflowClassifier()
 
 
 def test_langchain_native_save_and_load_model(model_path):

--- a/tests/tensorflow/test_mlflow_callback.py
+++ b/tests/tensorflow/test_mlflow_callback.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 from tensorflow import keras
 
 import mlflow
-from mlflow.tensorflow.callback import MLflowCallback
+from mlflow.tensorflow.callback import MlflowCallback
 
 
 @pytest.mark.parametrize(("log_every_epoch", "log_every_n_steps"), [(True, None), (False, 1)])
@@ -28,7 +28,7 @@ def test_tf_mlflow_callback(log_every_epoch, log_every_n_steps):
     )
 
     with mlflow.start_run() as run:
-        mlflow_callback = MLflowCallback(
+        mlflow_callback = MlflowCallback(
             run=run,
             log_every_epoch=log_every_epoch,
             log_every_n_steps=log_every_n_steps,

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -23,7 +23,7 @@ from mlflow.models import Model
 from mlflow.models.utils import _read_example
 from mlflow.tensorflow import load_checkpoint
 from mlflow.tensorflow.autologging import _TensorBoard
-from mlflow.tensorflow.callback import MLflowCallback
+from mlflow.tensorflow.callback import MlflowCallback
 from mlflow.types.utils import _infer_schema
 from mlflow.utils.autologging_utils import (
     AUTOLOGGING_INTEGRATIONS,
@@ -1066,7 +1066,7 @@ def test_fluent_autolog_with_tf_keras_logs_expected_content(
 
 
 def test_callback_is_picklable():
-    cb = MLflowCallback()
+    cb = MlflowCallback()
     pickle.dumps(cb)
 
     tb = _TensorBoard()
@@ -1318,7 +1318,7 @@ def test_autolog_throw_error_on_explicit_mlflow_callback(keras_data_gen_sequence
     model = create_tf_keras_model()
     with mlflow.start_run() as run:
         with pytest.raises(MlflowException, match="MLflow autologging must be turned off*"):
-            model.fit(keras_data_gen_sequence, callbacks=[MLflowCallback(run)])
+            model.fit(keras_data_gen_sequence, callbacks=[MlflowCallback(run)])
 
 
 def test_autolog_correct_logging_frequency(random_train_data, random_one_hot_labels):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11563?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11563/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11563
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

We've been using `Mlflow` (not `MLflow`) for class names. This PRs adds a lint rule to enforce that convention for consistency.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
