### PR TITLE
Rename MLflowSpanWrapper to MlflowSpanWrapper

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -414,7 +414,7 @@ def _get_reference_map():
     """
     ref_map = {
         # < Invalid reference >: < valid reference >
-        "mlflow.tracing.MLflowSpanWrapper": "mlflow.tracing.types.wrapper.MLflowSpanWrapper",
+        "mlflow.tracing.MlflowSpanWrapper": "mlflow.tracing.types.wrapper.MlflowSpanWrapper",
         "mlflow.tracking.fluent.ActiveRun": "mlflow.ActiveRun",
         "mlflow.store.entities.paged_list.PagedList": "mlflow.store.entities.PagedList",
     }

--- a/docs/source/python_api/mlflow.tracing.rst
+++ b/docs/source/python_api/mlflow.tracing.rst
@@ -59,9 +59,9 @@ MLflow Client APIs
     :noindex:
 
 
-MLflowSpanWrapper
+MlflowSpanWrapper
 ~~~~~~~~~~~~~~~~~
 
-.. autoclass:: mlflow.tracing.types.wrapper.MLflowSpanWrapper
+.. autoclass:: mlflow.tracing.types.wrapper.MlflowSpanWrapper
     :members:
 

--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -11,7 +11,7 @@ from mlflow.tracing.types.constant import (
     TRUNCATION_SUFFIX,
     TraceMetadataKey,
 )
-from mlflow.tracing.types.wrapper import MLflowSpanWrapper
+from mlflow.tracing.types.wrapper import MlflowSpanWrapper
 
 _logger = logging.getLogger(__name__)
 
@@ -34,20 +34,20 @@ class MLflowSpanExporter(SpanExporter):
         self._client = client
         self._trace_manager = InMemoryTraceManager.get_instance()
 
-    def export(self, spans: Sequence[MLflowSpanWrapper]):
+    def export(self, spans: Sequence[MlflowSpanWrapper]):
         """
         Export the spans to MLflow backend.
 
         Args:
-            spans: A sequence of MLflowSpanWrapper objects to be exported. The base
+            spans: A sequence of MlflowSpanWrapper objects to be exported. The base
                 OpenTelemetry (OTel) exporter should take OTel spans but this exporter
                 takes the wrapper object, so we can carry additional MLflow-specific
                 information such as inputs and outputs.
         """
         for span in spans:
-            if not isinstance(span, MLflowSpanWrapper):
+            if not isinstance(span, MlflowSpanWrapper):
                 _logger.warning(
-                    "Span exporter expected MLflowSpanWrapper, but got "
+                    "Span exporter expected MlflowSpanWrapper, but got "
                     f"{type(span)}. Skipping the span."
                 )
                 continue
@@ -61,7 +61,7 @@ class MLflowSpanExporter(SpanExporter):
             if span.parent_span_id is None:
                 self._export_trace(span)
 
-    def _export_trace(self, root_span: MLflowSpanWrapper):
+    def _export_trace(self, root_span: MlflowSpanWrapper):
         request_id = root_span.request_id
         trace = self._trace_manager.pop_trace(request_id)
         if trace is None:

--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -16,7 +16,7 @@ from mlflow.tracing.types.wrapper import MlflowSpanWrapper
 _logger = logging.getLogger(__name__)
 
 
-class MLflowSpanExporter(SpanExporter):
+class MlflowSpanExporter(SpanExporter):
     """
     An exporter implementation that logs the traces to MLflow.
 

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -10,7 +10,7 @@ from opentelemetry import trace as trace_api
 from mlflow.entities import SpanType, Trace
 from mlflow.tracing.provider import get_tracer
 from mlflow.tracing.trace_manager import InMemoryTraceManager
-from mlflow.tracing.types.wrapper import MLflowSpanWrapper, NoOpMLflowSpanWrapper
+from mlflow.tracing.types.wrapper import MlflowSpanWrapper, NoOpMlflowSpanWrapper
 from mlflow.tracing.utils import capture_function_input_args
 
 _logger = logging.getLogger(__name__)
@@ -156,7 +156,7 @@ def start_span(
         attributes: A dictionary of attributes to set on the span.
 
     Returns:
-        Yields an :py:class:`mlflow.tracing.MLflowSpanWrapper` that represents the created span.
+        Yields an :py:class:`mlflow.tracing.MlflowSpanWrapper` that represents the created span.
     """
     # TODO: refactor this logic
     try:
@@ -171,15 +171,15 @@ def start_span(
         if span is not None:
             trace_manager = InMemoryTraceManager.get_instance()
             # Setting end_on_exit = False to suppress the default span
-            # export and instead invoke MLflowSpanWrapper.end()
+            # export and instead invoke MlflowSpanWrapper.end()
             with trace_api.use_span(span, end_on_exit=False):
-                mlflow_span = MLflowSpanWrapper(span, span_type=span_type)
+                mlflow_span = MlflowSpanWrapper(span, span_type=span_type)
                 mlflow_span.set_attributes(attributes or {})
                 trace_manager.add_or_update_span(mlflow_span)
                 yield mlflow_span
         else:
             # Span creation should not raise an exception
-            mlflow_span = NoOpMLflowSpanWrapper()
+            mlflow_span = NoOpMlflowSpanWrapper()
             yield mlflow_span
     finally:
         mlflow_span.end()

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -6,7 +6,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.util._once import Once
 
 from mlflow.tracing.clients import TraceClient, get_trace_client
-from mlflow.tracing.export.mlflow import MLflowSpanExporter
+from mlflow.tracing.export.mlflow import MlflowSpanExporter
 
 # Once() object ensures a function is executed only once in a process.
 # Note that it doesn't work as expected in a distributed environment.
@@ -31,7 +31,7 @@ def _setup_tracer_provider(client: Optional[TraceClient] = None):
     client = client or get_trace_client()
 
     # TODO: Make factory method for exporters once we support more sink destinations
-    exporter = MLflowSpanExporter(client)
+    exporter = MlflowSpanExporter(client)
 
     tracer_provider = TracerProvider()
     tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))

--- a/mlflow/tracing/types/wrapper.py
+++ b/mlflow/tracing/types/wrapper.py
@@ -9,7 +9,7 @@ from mlflow.entities import Span, SpanContext, SpanEvent, SpanStatus, SpanType, 
 _logger = logging.getLogger(__name__)
 
 
-class MLflowSpanWrapper:
+class MlflowSpanWrapper:
     """
     A wrapper around OpenTelemetry's Span object to provide MLflow-specific functionality.
 
@@ -192,12 +192,12 @@ class MLflowSpanWrapper:
         )
 
 
-class NoOpMLflowSpanWrapper:
+class NoOpMlflowSpanWrapper:
     """
-    No-op implementation of all MLflowSpanWrapper.
+    No-op implementation of all MlflowSpanWrapper.
 
     This instance should be returned from the mlflow.start_span context manager when span
-    creation fails. This class should have exactly the same interface as MLflowSpanWrapper
+    creation fails. This class should have exactly the same interface as MlflowSpanWrapper
     so that user's setter calls do not raise runtime errors.
 
     E.g.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -51,7 +51,7 @@ from mlflow.store.model_registry import (
 )
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.tracing.trace_manager import InMemoryTraceManager
-from mlflow.tracing.types.wrapper import MLflowSpanWrapper
+from mlflow.tracing.types.wrapper import MlflowSpanWrapper
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking._model_registry import utils as registry_utils
 from mlflow.tracking._model_registry.client import ModelRegistryClient
@@ -450,7 +450,7 @@ class MlflowClient:
         inputs: Optional[Dict[str, Any]] = None,
         attributes: Optional[Dict[str, str]] = None,
         tags: Optional[Dict[str, str]] = None,
-    ) -> MLflowSpanWrapper:
+    ) -> MlflowSpanWrapper:
         """
         Create a new trace object and start a root span under it.
 
@@ -473,7 +473,7 @@ class MlflowClient:
             tags: A dictionary of tags to set on the trace.
 
         Returns:
-            An :py:class:`MLflowSpanWrapper <mlflow.tracing.MLflowSpanWrapper>` object
+            An :py:class:`MlflowSpanWrapper <mlflow.tracing.MlflowSpanWrapper>` object
             representing the root span of the trace.
 
         Example:
@@ -548,7 +548,7 @@ class MlflowClient:
         span_type: str = SpanType.UNKNOWN,
         inputs: Optional[Dict[str, Any]] = None,
         attributes: Optional[Dict[str, Any]] = None,
-    ) -> MLflowSpanWrapper:
+    ) -> MlflowSpanWrapper:
         """
         Create a new span and start it without attaching it to the global trace context.
 
@@ -622,7 +622,7 @@ class MlflowClient:
             attributes: A dictionary of attributes to set on the span.
 
         Returns:
-            An :py:class:`mlflow.tracing.MLflowSpanWrapper` object representing the span.
+            An :py:class:`mlflow.tracing.MlflowSpanWrapper` object representing the span.
 
         Example:
 

--- a/tests/tracing/export/test_mlflow_exporter.py
+++ b/tests/tracing/export/test_mlflow_exporter.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import pandas as pd
 from opentelemetry.sdk.trace import ReadableSpan
 
-from mlflow.tracing.export.mlflow import MLflowSpanExporter
+from mlflow.tracing.export.mlflow import MlflowSpanExporter
 from mlflow.tracing.types.constant import (
     MAX_CHARS_IN_TRACE_INFO_ATTRIBUTE,
     TRUNCATION_SUFFIX,
@@ -52,7 +52,7 @@ def test_export():
     )
 
     mock_client = MagicMock()
-    exporter = MLflowSpanExporter(mock_client)
+    exporter = MlflowSpanExporter(mock_client)
 
     # Export the first child span -> no client call
     exporter.export([MlflowSpanWrapper(otel_span_child_1)])
@@ -97,7 +97,7 @@ def test_export():
 
 
 def test_serialize_inputs_outputs():
-    exporter = MLflowSpanExporter(MagicMock())
+    exporter = MlflowSpanExporter(MagicMock())
     assert exporter._serialize_inputs_outputs({"x": 1, "y": 2}) == '{"x": 1, "y": 2}'
     assert exporter._serialize_inputs_outputs("string input") == '"string input"'
     # Truncate long inputs

--- a/tests/tracing/export/test_mlflow_exporter.py
+++ b/tests/tracing/export/test_mlflow_exporter.py
@@ -10,7 +10,7 @@ from mlflow.tracing.types.constant import (
     TRUNCATION_SUFFIX,
     TraceMetadataKey,
 )
-from mlflow.tracing.types.wrapper import MLflowSpanWrapper
+from mlflow.tracing.types.wrapper import MlflowSpanWrapper
 
 
 @dataclass
@@ -55,15 +55,15 @@ def test_export():
     exporter = MLflowSpanExporter(mock_client)
 
     # Export the first child span -> no client call
-    exporter.export([MLflowSpanWrapper(otel_span_child_1)])
+    exporter.export([MlflowSpanWrapper(otel_span_child_1)])
     assert mock_client.log_trace.call_count == 0
 
     # Export the second child span -> no client call
-    exporter.export([MLflowSpanWrapper(otel_span_child_2)])
+    exporter.export([MlflowSpanWrapper(otel_span_child_2)])
     assert mock_client.log_trace.call_count == 0
 
     # Export the root span -> client call
-    root_span = MLflowSpanWrapper(otel_span_root)
+    root_span = MlflowSpanWrapper(otel_span_root)
     root_span.set_inputs({"input1": "very long input" * 100})
     root_span.set_outputs("very long output" * 100)
     exporter.export([root_span])

--- a/tests/tracing/test_trace_manager.py
+++ b/tests/tracing/test_trace_manager.py
@@ -6,7 +6,7 @@ from opentelemetry import trace as trace_api
 
 from mlflow.entities import Trace
 from mlflow.tracing.trace_manager import InMemoryTraceManager
-from mlflow.tracing.types.wrapper import MLflowSpanWrapper
+from mlflow.tracing.types.wrapper import MlflowSpanWrapper
 
 
 def test_aggregator_singleton():
@@ -213,4 +213,4 @@ def _create_test_span(request_id_1, span_id, parent_span_id=None, start_time=Non
     mock_span.status.status_code = trace_api.StatusCode.OK
     mock_span.status.description = ""
 
-    return MLflowSpanWrapper(mock_span)
+    return MlflowSpanWrapper(mock_span)

--- a/tests/tracing/test_wrapper.py
+++ b/tests/tracing/test_wrapper.py
@@ -1,7 +1,7 @@
 import time
 from unittest import mock
 
-from mlflow.tracing.types.wrapper import MLflowSpanWrapper
+from mlflow.tracing.types.wrapper import MlflowSpanWrapper
 
 
 def test_wrapper_property():
@@ -15,7 +15,7 @@ def test_wrapper_property():
     mock_otel_span._end_time = end_time
     mock_otel_span.parent.span_id = "parent_span_id"
 
-    span = MLflowSpanWrapper(mock_otel_span)
+    span = MlflowSpanWrapper(mock_otel_span)
 
     assert span.request_id == "trace_id"
     assert span.span_id == "span_id"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11564?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11564/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11564
```

</p>
</details>

### What changes are proposed in this pull request?

https://github.com/mlflow/mlflow/pull/11554#discussion_r1546000873

Lowercase the 2nd `L` in M**L**flowSpanWrapper to comply with standard format.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
