### PR TITLE
Enable `mlflow-class-name` rule for private classes

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -114,7 +114,7 @@ class Linter(ast.NodeVisitor):
         return bool(self.stack)
 
     def _mlflow_class_name(self, node: ast.ClassDef) -> None:
-        if not node.name.startswith("_") and ("MLflow" in node.name or "MLFlow" in node.name):
+        if "MLflow" in node.name or "MLFlow" in node.name:
             self._check(node, MLFLOW_CLASS_NAME)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:

--- a/mlflow/entities/_mlflow_object.py
+++ b/mlflow/entities/_mlflow_object.py
@@ -2,7 +2,7 @@ import pprint
 from abc import abstractmethod
 
 
-class _MLflowObject:
+class _MlflowObject:
     def __iter__(self):
         # Iterate through list of properties and yield as key -> value
         for prop in self._properties():
@@ -31,20 +31,20 @@ class _MLflowObject:
 
 
 def to_string(obj):
-    return _MLflowObjectPrinter().to_string(obj)
+    return _MlflowObjectPrinter().to_string(obj)
 
 
 def get_classname(obj):
     return type(obj).__name__
 
 
-class _MLflowObjectPrinter:
+class _MlflowObjectPrinter:
     def __init__(self):
         super().__init__()
         self.printer = pprint.PrettyPrinter()
 
     def to_string(self, obj):
-        if isinstance(obj, _MLflowObject):
+        if isinstance(obj, _MlflowObject):
             return f"<{get_classname(obj)}: {self._entity_to_string(obj)}>"
         return self.printer.pformat(obj)
 

--- a/mlflow/entities/dataset.py
+++ b/mlflow/entities/dataset.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
-from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.protos.service_pb2 import Dataset as ProtoDataset
 
 
-class Dataset(_MLflowObject):
+class Dataset(_MlflowObject):
     """Dataset object associated with an experiment."""
 
     def __init__(
@@ -23,7 +23,7 @@ class Dataset(_MLflowObject):
         self._schema = schema
         self._profile = profile
 
-    def __eq__(self, other: _MLflowObject) -> bool:
+    def __eq__(self, other: _MlflowObject) -> bool:
         if type(other) is type(self):
             return self.__dict__ == other.__dict__
         return False

--- a/mlflow/entities/dataset_input.py
+++ b/mlflow/entities/dataset_input.py
@@ -1,19 +1,19 @@
 from typing import List, Optional
 
-from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.entities.dataset import Dataset
 from mlflow.entities.input_tag import InputTag
 from mlflow.protos.service_pb2 import DatasetInput as ProtoDatasetInput
 
 
-class DatasetInput(_MLflowObject):
+class DatasetInput(_MlflowObject):
     """DatasetInput object associated with an experiment."""
 
     def __init__(self, dataset: Dataset, tags: Optional[List[InputTag]] = None) -> None:
         self._dataset = dataset
         self._tags = tags or []
 
-    def __eq__(self, other: _MLflowObject) -> bool:
+    def __eq__(self, other: _MlflowObject) -> bool:
         if type(other) is type(self):
             return self.__dict__ == other.__dict__
         return False

--- a/mlflow/entities/experiment.py
+++ b/mlflow/entities/experiment.py
@@ -1,10 +1,10 @@
-from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.entities.experiment_tag import ExperimentTag
 from mlflow.protos.service_pb2 import Experiment as ProtoExperiment
 from mlflow.protos.service_pb2 import ExperimentTag as ProtoExperimentTag
 
 
-class Experiment(_MLflowObject):
+class Experiment(_MlflowObject):
     """
     Experiment object.
     """

--- a/mlflow/entities/experiment_tag.py
+++ b/mlflow/entities/experiment_tag.py
@@ -1,8 +1,8 @@
-from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.protos.service_pb2 import ExperimentTag as ProtoExperimentTag
 
 
-class ExperimentTag(_MLflowObject):
+class ExperimentTag(_MlflowObject):
     """Tag object associated with an experiment."""
 
     def __init__(self, key, value):

--- a/mlflow/entities/file_info.py
+++ b/mlflow/entities/file_info.py
@@ -1,8 +1,8 @@
-from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.protos.service_pb2 import FileInfo as ProtoFileInfo
 
 
-class FileInfo(_MLflowObject):
+class FileInfo(_MlflowObject):
     """
     Metadata about a file or directory.
     """

--- a/mlflow/entities/input_tag.py
+++ b/mlflow/entities/input_tag.py
@@ -1,15 +1,15 @@
-from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.protos.service_pb2 import InputTag as ProtoInputTag
 
 
-class InputTag(_MLflowObject):
+class InputTag(_MlflowObject):
     """Input tag object associated with a dataset."""
 
     def __init__(self, key: str, value: str) -> None:
         self._key = key
         self._value = value
 
-    def __eq__(self, other: _MLflowObject) -> bool:
+    def __eq__(self, other: _MlflowObject) -> bool:
         if type(other) is type(self):
             return self.__dict__ == other.__dict__
         return False

--- a/mlflow/entities/metric.py
+++ b/mlflow/entities/metric.py
@@ -1,9 +1,9 @@
-from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.protos.service_pb2 import Metric as ProtoMetric
 from mlflow.protos.service_pb2 import MetricWithRunId as ProtoMetricWithRunId
 
 
-class Metric(_MLflowObject):
+class Metric(_MlflowObject):
     """
     Metric object.
     """

--- a/mlflow/entities/model_registry/_model_registry_entity.py
+++ b/mlflow/entities/model_registry/_model_registry_entity.py
@@ -1,9 +1,9 @@
 from abc import abstractmethod
 
-from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities._mlflow_object import _MlflowObject
 
 
-class _ModelRegistryEntity(_MLflowObject):
+class _ModelRegistryEntity(_MlflowObject):
     @classmethod
     @abstractmethod
     def from_proto(cls, proto):

--- a/mlflow/entities/param.py
+++ b/mlflow/entities/param.py
@@ -1,10 +1,10 @@
 import sys
 
-from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.protos.service_pb2 import Param as ProtoParam
 
 
-class Param(_MLflowObject):
+class Param(_MlflowObject):
     """
     Parameter object.
     """

--- a/mlflow/entities/run.py
+++ b/mlflow/entities/run.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.entities.run_data import RunData
 from mlflow.entities.run_info import RunInfo
 from mlflow.entities.run_inputs import RunInputs
@@ -8,7 +8,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.service_pb2 import Run as ProtoRun
 
 
-class Run(_MLflowObject):
+class Run(_MlflowObject):
     """
     Run object.
     """

--- a/mlflow/entities/run_data.py
+++ b/mlflow/entities/run_data.py
@@ -1,4 +1,4 @@
-from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.entities.metric import Metric
 from mlflow.entities.param import Param
 from mlflow.entities.run_tag import RunTag
@@ -7,7 +7,7 @@ from mlflow.protos.service_pb2 import RunData as ProtoRunData
 from mlflow.protos.service_pb2 import RunTag as ProtoRunTag
 
 
-class RunData(_MLflowObject):
+class RunData(_MlflowObject):
     """
     Run data (metrics and parameters).
     """

--- a/mlflow/entities/run_info.py
+++ b/mlflow/entities/run_info.py
@@ -1,4 +1,4 @@
-from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.entities.run_status import RunStatus
 from mlflow.exceptions import MlflowException
@@ -26,7 +26,7 @@ class orderable_attribute(property):
     pass
 
 
-class RunInfo(_MLflowObject):
+class RunInfo(_MlflowObject):
     """
     Metadata about a run.
     """

--- a/mlflow/entities/run_inputs.py
+++ b/mlflow/entities/run_inputs.py
@@ -1,17 +1,17 @@
 from typing import Any, Dict, List
 
-from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.entities.dataset_input import DatasetInput
 from mlflow.protos.service_pb2 import RunInputs as ProtoRunInputs
 
 
-class RunInputs(_MLflowObject):
+class RunInputs(_MlflowObject):
     """RunInputs object."""
 
     def __init__(self, dataset_inputs: List[DatasetInput]) -> None:
         self._dataset_inputs = dataset_inputs
 
-    def __eq__(self, other: _MLflowObject) -> bool:
+    def __eq__(self, other: _MlflowObject) -> bool:
         if type(other) is type(self):
             return self.__dict__ == other.__dict__
         return False

--- a/mlflow/entities/run_tag.py
+++ b/mlflow/entities/run_tag.py
@@ -1,8 +1,8 @@
-from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.protos.service_pb2 import RunTag as ProtoRunTag
 
 
-class RunTag(_MLflowObject):
+class RunTag(_MlflowObject):
     """Tag object associated with a run."""
 
     def __init__(self, key, value):

--- a/mlflow/gluon/__init__.py
+++ b/mlflow/gluon/__init__.py
@@ -436,10 +436,10 @@ def autolog(
 
     from mxnet.gluon.contrib.estimator import Estimator
 
-    from mlflow.gluon._autolog import __MLflowGluonCallback
+    from mlflow.gluon._autolog import __MlflowGluonCallback
 
     def getGluonCallback(metrics_logger):
-        return __MLflowGluonCallback(log_models, metrics_logger)
+        return __MlflowGluonCallback(log_models, metrics_logger)
 
     def fit(original, self, *args, **kwargs):
         # Wrap `fit` execution within a batch metrics logger context.

--- a/mlflow/gluon/_autolog.py
+++ b/mlflow/gluon/_autolog.py
@@ -5,7 +5,7 @@ import mlflow
 from mlflow.utils.autologging_utils import ExceptionSafeClass, get_autologging_config
 
 
-class __MLflowGluonCallback(EpochEnd, TrainEnd, TrainBegin, metaclass=ExceptionSafeClass):
+class __MlflowGluonCallback(EpochEnd, TrainEnd, TrainBegin, metaclass=ExceptionSafeClass):
     def __init__(self, log_models, metrics_logger):
         self.log_models = log_models
         self._logger = metrics_logger

--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -196,7 +196,7 @@ def patched_inference(func_name, original, self, *args, **kwargs):
     import langchain
     from langchain_community.callbacks import MlflowCallbackHandler
 
-    class _MLflowLangchainCallback(MlflowCallbackHandler, metaclass=ExceptionSafeAbstractClass):
+    class _MlflowLangchainCallback(MlflowCallbackHandler, metaclass=ExceptionSafeAbstractClass):
         """
         Callback for auto-logging metrics and parameters.
         We need to inherit ExceptionSafeAbstractClass to avoid invalid new
@@ -235,7 +235,7 @@ def patched_inference(func_name, original, self, *args, **kwargs):
     # callback logs artifacts into, to avoid overriding artifacts
     session_id = getattr(self, "session_id", uuid.uuid4().hex)
     inference_id = getattr(self, "inference_id", 0)
-    mlflow_callback = _MLflowLangchainCallback(
+    mlflow_callback = _MlflowLangchainCallback(
         tracking_uri=mlflow.get_tracking_uri(),
         run_id=run_id,
         artifacts_dir=f"artifacts-{session_id}-{inference_id}",

--- a/mlflow/paddle/_paddle_autolog.py
+++ b/mlflow/paddle/_paddle_autolog.py
@@ -9,7 +9,7 @@ from mlflow.utils.autologging_utils import (
 )
 
 
-class __MLflowPaddleCallback(paddle.callbacks.Callback, metaclass=ExceptionSafeAbstractClass):
+class __MlflowPaddleCallback(paddle.callbacks.Callback, metaclass=ExceptionSafeAbstractClass):
     """Callback for auto-logging metrics and parameters."""
 
     def __init__(self, client, metrics_logger, run_id, log_models, log_every_n_epoch):
@@ -101,7 +101,7 @@ def patched_fit(original, self, *args, **kwargs):
     log_every_n_epoch = get_autologging_config(mlflow.paddle.FLAVOR_NAME, "log_every_n_epoch", 1)
 
     early_stop_callback = None
-    mlflow_callback = __MLflowPaddleCallback(
+    mlflow_callback = __MlflowPaddleCallback(
         client, metrics_logger, run_id, log_models, log_every_n_epoch
     )
     if "callbacks" in kwargs:

--- a/mlflow/pytorch/_lightning_autolog.py
+++ b/mlflow/pytorch/_lightning_autolog.py
@@ -66,7 +66,7 @@ def _get_optimizer_name(optimizer):
         )
 
 
-class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
+class __MlflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
     """
     Callback for auto-logging metrics and parameters.
     """
@@ -486,9 +486,9 @@ def patched_fit(original, self, *args, **kwargs):
                 early_stop_callback = callback
                 _log_early_stop_params(early_stop_callback, client, run_id)
 
-        if not any(isinstance(callbacks, __MLflowPLCallback) for callbacks in self.callbacks):
+        if not any(isinstance(callbacks, __MlflowPLCallback) for callbacks in self.callbacks):
             self.callbacks += [
-                __MLflowPLCallback(
+                __MlflowPLCallback(
                     client, metrics_logger, run_id, log_models, log_every_n_epoch, log_every_n_step
                 )
             ]

--- a/mlflow/utils/autologging_utils/logging_and_warnings.py
+++ b/mlflow/utils/autologging_utils/logging_and_warnings.py
@@ -230,13 +230,13 @@ def set_mlflow_events_and_warnings_behavior_globally(
 
     """
 
-    with _SetMLflowEventsAndWarningsBehaviorGlobally(
+    with _SetMlflowEventsAndWarningsBehaviorGlobally(
         disable_event_logs, disable_warnings, reroute_warnings
     ):
         yield
 
 
-class _SetMLflowEventsAndWarningsBehaviorGlobally:
+class _SetMlflowEventsAndWarningsBehaviorGlobally:
     _lock = RLock()
     _disable_event_logs_count = 0
     _disable_warnings_count = 0
@@ -249,45 +249,45 @@ class _SetMLflowEventsAndWarningsBehaviorGlobally:
 
     def __enter__(self):
         try:
-            with _SetMLflowEventsAndWarningsBehaviorGlobally._lock:
+            with _SetMlflowEventsAndWarningsBehaviorGlobally._lock:
                 if self._disable_event_logs:
-                    if _SetMLflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count <= 0:
+                    if _SetMlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count <= 0:
                         logging_utils.disable_logging()
-                    _SetMLflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count += 1
+                    _SetMlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count += 1
 
                 if self._disable_warnings:
-                    if _SetMLflowEventsAndWarningsBehaviorGlobally._disable_warnings_count <= 0:
+                    if _SetMlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count <= 0:
                         _WARNINGS_CONTROLLER.set_mlflow_warnings_disablement_state_globally(
                             disabled=True
                         )
-                    _SetMLflowEventsAndWarningsBehaviorGlobally._disable_warnings_count += 1
+                    _SetMlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count += 1
 
                 if self._reroute_warnings:
-                    if _SetMLflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count <= 0:
+                    if _SetMlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count <= 0:
                         _WARNINGS_CONTROLLER.set_mlflow_warnings_rerouting_state_globally(
                             rerouted=True
                         )
-                    _SetMLflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count += 1
+                    _SetMlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count += 1
         except Exception:
             pass
 
     def __exit__(self, *args, **kwargs):
         try:
-            with _SetMLflowEventsAndWarningsBehaviorGlobally._lock:
+            with _SetMlflowEventsAndWarningsBehaviorGlobally._lock:
                 if self._disable_event_logs:
-                    _SetMLflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count -= 1
+                    _SetMlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count -= 1
                 if self._disable_warnings:
-                    _SetMLflowEventsAndWarningsBehaviorGlobally._disable_warnings_count -= 1
+                    _SetMlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count -= 1
                 if self._reroute_warnings:
-                    _SetMLflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count -= 1
+                    _SetMlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count -= 1
 
-                if _SetMLflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count <= 0:
+                if _SetMlflowEventsAndWarningsBehaviorGlobally._disable_event_logs_count <= 0:
                     logging_utils.enable_logging()
-                if _SetMLflowEventsAndWarningsBehaviorGlobally._disable_warnings_count <= 0:
+                if _SetMlflowEventsAndWarningsBehaviorGlobally._disable_warnings_count <= 0:
                     _WARNINGS_CONTROLLER.set_mlflow_warnings_disablement_state_globally(
                         disabled=False
                     )
-                if _SetMLflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count <= 0:
+                if _SetMlflowEventsAndWarningsBehaviorGlobally._reroute_warnings_count <= 0:
                     _WARNINGS_CONTROLLER.set_mlflow_warnings_rerouting_state_globally(
                         rerouted=False
                     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11572?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11572/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11572
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Enable `mlflow-class-name` rule for private classes. Just for consistency.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
