### PR TITLE
Deprecate `mlflow.tensorflow.MLflowCallback` and `mlflow.keras.MLflowCallback`

### DIFF
--- a/mlflow/keras/__init__.py
+++ b/mlflow/keras/__init__.py
@@ -35,8 +35,8 @@ else:
 
     FLAVOR_NAME = "keras"
 
-    MLflowCallback = deprecated(
-        MlflowCallback, alternative="mlflow.keras.MlflowCallback"
+    MLflowCallback = deprecated(alternative="mlflow.keras.MlflowCallback")(
+        MlflowCallback
     )  # for backwards compatibility
 
     __all__ = [

--- a/mlflow/keras/__init__.py
+++ b/mlflow/keras/__init__.py
@@ -31,10 +31,13 @@ else:
         model_data_artifact_paths,
         save_model,
     )
+    from mlflow.utils.annotations import deprecated
 
     FLAVOR_NAME = "keras"
 
-    MLflowCallback = MlflowCallback  # for backwards compatibility
+    MLflowCallback = deprecated(
+        MlflowCallback, alternative="mlflow.keras.MlflowCallback"
+    )  # for backwards compatibility
 
     __all__ = [
         "_load_pyfunc",

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -35,6 +35,7 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.tracking.context import registry as context_registry
 from mlflow.types.schema import TensorSpec
 from mlflow.utils import is_iterator
+from mlflow.utils.annotations import deprecated
 from mlflow.utils.autologging_utils import (
     PatchFunction,
     autologging_integration,
@@ -98,7 +99,9 @@ _TF2MODEL_SUBPATH = "tf2model"
 model_data_artifact_paths = [_KERAS_MODEL_DATA_PATH, _TF2MODEL_SUBPATH]
 
 
-MLflowCallback = MlflowCallback  # for backwards compatibility
+MLflowCallback = deprecated(
+    MlflowCallback, alternative="mlflow.keras.MlflowCallback"
+)  # for backwards compatibility
 
 
 def get_default_pip_requirements(include_cloudpickle=False):

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -99,8 +99,8 @@ _TF2MODEL_SUBPATH = "tf2model"
 model_data_artifact_paths = [_KERAS_MODEL_DATA_PATH, _TF2MODEL_SUBPATH]
 
 
-MLflowCallback = deprecated(
-    MlflowCallback, alternative="mlflow.keras.MlflowCallback"
+MLflowCallback = deprecated(alternative="mlflow.keras.MlflowCallback")(
+    MlflowCallback
 )  # for backwards compatibility
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11573?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11573/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11573
```

</p>
</details>



### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Deprecate `mlflow.tensorflow.MLflowCallback` and `mlflow.keras.MLflowCallback`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
