### PR TITLE
Support custom prediction functions in `SklearnModelWrapper`

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -526,7 +526,8 @@ class _SklearnModelWrapper:
         # Patch the model with custom predict functions that can be specified
         # via `pyfunc_predict_fn` argument when saving or logging.
         for predict_fn in self._SUPPORTED_CUSTOM_PREDICT_FN:
-            setattr(self, predict_fn, getattr(self.sklearn_model, predict_fn))
+            if hasattr(self.sklearn_model, predict_fn):
+                setattr(self, predict_fn, getattr(self.sklearn_model, predict_fn))
 
     def predict(
         self,

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -526,8 +526,8 @@ class _SklearnModelWrapper:
         # Patch the model with custom predict functions that can be specified
         # via `pyfunc_predict_fn` argument when saving or logging.
         for predict_fn in self._SUPPORTED_CUSTOM_PREDICT_FN:
-            if hasattr(self.sklearn_model, predict_fn):
-                setattr(self, predict_fn, getattr(self.sklearn_model, predict_fn))
+            if fn := getattr(self.sklearn_model, predict_fn, None):
+                setattr(self, predict_fn, fn)
 
     def predict(
         self,

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -197,7 +197,9 @@ def save_model(
         pip_requirements: {{ pip_requirements }}
         extra_pip_requirements: {{ extra_pip_requirements }}
         pyfunc_predict_fn: The name of the prediction function to use for inference with the
-            pyfunc representation of the resulting MLflow Model; e.g. ``"predict_proba"``.
+            pyfunc representation of the resulting MLflow Model. Current supported functions
+            are: ``"predict"``, ``"predict_proba"``, ``"predict_log_proba"``,
+            ``"predict_joint_log_proba"``, and ``"score"``.
         metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
             .. Note:: Experimental: This parameter may change or be removed in a future
@@ -382,7 +384,9 @@ def log_model(
         pip_requirements: {{ pip_requirements }}
         extra_pip_requirements: {{ extra_pip_requirements }}
         pyfunc_predict_fn: The name of the prediction function to use for inference with the
-            pyfunc representation of the resulting MLflow Model; e.g. ``"predict_proba"``.
+            pyfunc representation of the resulting MLflow Model. Current supported functions
+            are: ``"predict"``, ``"predict_proba"``, ``"predict_log_proba"``,
+            ``"predict_joint_log_proba"``, and ``"score"``.
         metadata: Custom metadata dictionary passed to the model and stored in the MLmodel file.
 
             .. Note:: Experimental: This parameter may change or be removed in a future
@@ -509,8 +513,20 @@ def _load_pyfunc(path):
 
 
 class _SklearnModelWrapper:
+    _SUPPORTED_CUSTOM_PREDICT_FN = [
+        "predict_proba",
+        "predict_log_proba",
+        "predict_joint_log_proba",
+        "score",
+    ]
+
     def __init__(self, sklearn_model):
         self.sklearn_model = sklearn_model
+
+        # Patch the model with custom predict functions that can be specified
+        # via `pyfunc_predict_fn` argument when saving or logging.
+        for predict_fn in self._SUPPORTED_CUSTOM_PREDICT_FN:
+            setattr(self, predict_fn, getattr(self.sklearn_model, predict_fn))
 
     def predict(
         self,
@@ -529,18 +545,6 @@ class _SklearnModelWrapper:
             Model predictions.
         """
         return self.sklearn_model.predict(data)
-
-    def predict_proba(self, *args, **kwargs):
-        if hasattr(self.sklearn_model, "predict_proba"):
-            return self.sklearn_model.predict_proba(*args, **kwargs)
-
-    def predict_log_proba(self, *args, **kwargs):
-        if hasattr(self.sklearn_model, "predict_log_proba"):
-            return self.sklearn_model.predict_log_proba(*args, **kwargs)
-
-    def score(self, *args, **kwargs):
-        if hasattr(self.sklearn_model, "score"):
-            return self.sklearn_model.score(*args, **kwargs)
 
 
 class _SklearnCustomModelPicklingError(pickle.PicklingError):

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -534,6 +534,10 @@ class _SklearnModelWrapper:
         if hasattr(self.sklearn_model, "predict_proba"):
             return self.sklearn_model.predict_proba(*args, **kwargs)
 
+    def predict_log_proba(self, *args, **kwargs):
+        if hasattr(self.sklearn_model, "predict_log_proba"):
+            return self.sklearn_model.predict_log_proba(*args, **kwargs)
+
     def score(self, *args, **kwargs):
         if hasattr(self.sklearn_model, "score"):
             return self.sklearn_model.score(*args, **kwargs)

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -781,6 +781,19 @@ def test_log_predict_proba(sklearn_logreg_model):
     np.testing.assert_array_almost_equal(expected_scores, actual_scores)
 
 
+def test_log_predict_log_proba(sklearn_logreg_model):
+    model, inference_dataframe = sklearn_logreg_model
+    expected_scores = model.predict_log_proba(inference_dataframe)
+    artifact_path = "model"
+    with mlflow.start_run():
+        mlflow.sklearn.log_model(model, artifact_path, pyfunc_predict_fn="predict_log_proba")
+        model_uri = mlflow.get_artifact_uri(artifact_path)
+
+    loaded_model = pyfunc.load_model(model_uri)
+    actual_scores = loaded_model.predict(inference_dataframe)
+    np.testing.assert_array_almost_equal(expected_scores, actual_scores)
+
+
 def test_virtualenv_subfield_points_to_correct_path(sklearn_logreg_model, model_path):
     mlflow.sklearn.save_model(sklearn_logreg_model.model, path=model_path)
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -781,6 +781,9 @@ def test_log_model_with_code_paths(sklearn_knn_model):
     "predict_fn", ["predict", "predict_proba", "predict_log_proba", "predict_joint_log_proba"]
 )
 def test_log_model_with_custom_pyfunc_predict_fn(sklearn_gaussian_model, predict_fn):
+    if Version(sklearn.__version__) < Version("1.2.0") and predict_fn == "predict_joint_log_proba":
+        pytest.skip("predict_joint_log_proba is not available in scikit-learn < 1.2.0")
+
     model, inference_dataframe = sklearn_gaussian_model
     expected_scores = getattr(model, predict_fn)(inference_dataframe)
     artifact_path = "model"

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pytest
 import sklearn
 import sklearn.linear_model as glm
+import sklearn.naive_bayes as nb
 import sklearn.neighbors as knn
 import yaml
 from packaging.version import Version
@@ -96,6 +97,14 @@ def sklearn_logreg_model(iris_df):
     linear_lr = glm.LogisticRegression()
     linear_lr.fit(X, y)
     return ModelWithData(model=linear_lr, inference_data=X)
+
+
+@pytest.fixture(scope="module")
+def sklearn_gaussian_model(iris_df):
+    X, y = iris_df
+    gaussian_nb = nb.GaussianNB()
+    gaussian_nb.fit(X, y)
+    return ModelWithData(model=gaussian_nb, inference_data=X)
 
 
 @pytest.fixture(scope="module")
@@ -768,25 +777,15 @@ def test_log_model_with_code_paths(sklearn_knn_model):
         add_mock.assert_called()
 
 
-def test_log_predict_proba(sklearn_logreg_model):
-    model, inference_dataframe = sklearn_logreg_model
-    expected_scores = model.predict_proba(inference_dataframe)
+@pytest.mark.parametrize(
+    "predict_fn", ["predict", "predict_proba", "predict_log_proba", "predict_joint_log_proba"]
+)
+def test_log_model_with_custom_pyfunc_predict_fn(sklearn_gaussian_model, predict_fn):
+    model, inference_dataframe = sklearn_gaussian_model
+    expected_scores = getattr(model, predict_fn)(inference_dataframe)
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.sklearn.log_model(model, artifact_path, pyfunc_predict_fn="predict_proba")
-        model_uri = mlflow.get_artifact_uri(artifact_path)
-
-    loaded_model = pyfunc.load_model(model_uri)
-    actual_scores = loaded_model.predict(inference_dataframe)
-    np.testing.assert_array_almost_equal(expected_scores, actual_scores)
-
-
-def test_log_predict_log_proba(sklearn_logreg_model):
-    model, inference_dataframe = sklearn_logreg_model
-    expected_scores = model.predict_log_proba(inference_dataframe)
-    artifact_path = "model"
-    with mlflow.start_run():
-        mlflow.sklearn.log_model(model, artifact_path, pyfunc_predict_fn="predict_log_proba")
+        mlflow.sklearn.log_model(model, artifact_path, pyfunc_predict_fn=predict_fn)
         model_uri = mlflow.get_artifact_uri(artifact_path)
 
     loaded_model = pyfunc.load_model(model_uri)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11577?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11577/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11577
```

</p>
</details>

### Related Issues/PRs

#11559

### What changes are proposed in this pull request?

The `predict_log_proba` method is one of prediction methods of [LogisticRegression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html) model, but we accidentally dropped support for it when `_SklearnModelWrapper` was introduced in MLflow 2.6.0. It works with prior versions of MLflow.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


```
import mlflow 
from mlflow.models.signature import infer_signature
from sklearn.ensemble import RandomForestClassifier
from sklearn.datasets import load_iris 

# load the iris dataset
iris = load_iris(as_frame=True)
x = iris.data
y = iris.target

# infer signature
signature = infer_signature(model_input=x, model_output=y)
input_example = x.iloc[0:10]

with mlflow.start_run(run_name="logging_with_custom_predict_function") as run:

    rfc = RandomForestClassifier()
    rfc.fit(x, y)

    # Log the model
    mlflow.sklearn.log_model(
        sk_model=rfc,
        artifact_path = rfc.__class__.__name__,
        signature=signature,
        input_example=input_example,
        pyfunc_predict_fn = "predict_log_proba"
        )
    
# load model using pyfunc
model_uri = f"runs:/{run.info.run_id}/{rfc.__class__.__name__}"
model = mlflow.pyfunc.load_model(model_uri)

# predict
model.predict(x)
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix regression of scikit-learn model flavor, where the `predict_log_proba` and `predict_joint_log_probe` method couldn't be specified as pyfunc predict function via `pyfunc_predict_fn` parameter.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
