### PR TITLE
Span name deduplication on trace completion

### DIFF
--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -84,7 +84,7 @@ class MlflowSpanExporter(SpanExporter):
         )
 
         # Rename spans to have unique names
-        self._deduplicate_span_names_in_place(trace.trace_data)
+        MlflowSpanExporter._deduplicate_span_names_in_place(trace.trace_data)
 
         # TODO: Make this async
         self._client.log_trace(trace)

--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -1,9 +1,11 @@
 import json
 import logging
+from collections import Counter
 from typing import Any, Optional, Sequence
 
 from opentelemetry.sdk.trace.export import SpanExporter
 
+from mlflow.entities import TraceData
 from mlflow.tracing.clients import TraceClient
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.types.constant import (
@@ -81,6 +83,9 @@ class MlflowSpanExporter(SpanExporter):
             }
         )
 
+        # Rename spans to have unique names
+        self._deduplicate_span_names_in_place(trace.trace_data)
+
         # TODO: Make this async
         self._client.log_trace(trace)
 
@@ -104,3 +109,26 @@ class MlflowSpanExporter(SpanExporter):
             trunc_length = MAX_CHARS_IN_TRACE_INFO_ATTRIBUTE - len(TRUNCATION_SUFFIX)
             serialized = serialized[:trunc_length] + TRUNCATION_SUFFIX
         return serialized
+
+    def _deduplicate_span_names_in_place(self, trace_data: TraceData):
+        """
+        Deduplicate span names in the trace data by appending an index number to the span name.
+
+        This is only applied when there are more than one span with the same name. The span
+        names are modified in place to avoid unnecessary copying.
+
+        E.g.
+            ["red", "red"] -> ["red_1", "red_2"]
+            ["red", "red", "blue"] -> ["red_1", "red_2", "blue"]
+
+        Args:
+            trace_data: The trace data object to deduplicate span names.
+        """
+        span_name_counter = Counter(span.name for span in trace_data.spans)
+        # Filter to only duplicated spans
+        span_name_counter = {name: count for name, count in span_name_counter.items() if count > 1}
+        # Add index to the duplicated span names
+        for span in trace_data.spans[::-1]:
+            if count := span_name_counter.get(span.name):
+                span_name_counter[span.name] -= 1
+                span.name = f"{span.name}_{count}"

--- a/tests/tracing/export/test_mlflow_exporter.py
+++ b/tests/tracing/export/test_mlflow_exporter.py
@@ -114,18 +114,18 @@ def test_serialize_inputs_outputs():
 def test_deduplicate_span_names():
     span_names = ["red", "red", "blue", "red", "green", "blue"]
 
-    spans = []
-    for i, span_name in enumerate(span_names):
-        spans.append(
-            Span(
-                name=span_name,
-                context=SpanContext("trace_id", span_id=i),
-                parent_span_id=None,
-                status=SpanStatus(TraceStatus.OK),
-                start_time=0,
-                end_time=1,
-            )
+    spans = [
+        Span(
+            name=span_name,
+            context=SpanContext("trace_id", span_id=i),
+            parent_span_id=None,
+            status=SpanStatus(TraceStatus.OK),
+            start_time=0,
+            end_time=1,
         )
+        for i, span_name in enumerate(span_names)
+    ]
+
     trace_data = TraceData(spans=spans)
     exporter = MlflowSpanExporter(MagicMock())
     exporter._deduplicate_span_names_in_place(trace_data)

--- a/tests/tracing/export/test_mlflow_exporter.py
+++ b/tests/tracing/export/test_mlflow_exporter.py
@@ -127,8 +127,7 @@ def test_deduplicate_span_names():
     ]
 
     trace_data = TraceData(spans=spans)
-    exporter = MlflowSpanExporter(MagicMock())
-    exporter._deduplicate_span_names_in_place(trace_data)
+    MlflowSpanExporter._deduplicate_span_names_in_place(trace_data)
 
     assert [span.name for span in trace_data.spans] == [
         "red_1",
@@ -144,7 +143,5 @@ def test_deduplicate_span_names():
 
 def test_deduplicate_span_names_empty_spans():
     trace_data = TraceData(spans=[])
-    exporter = MlflowSpanExporter(MagicMock())
-    exporter._deduplicate_span_names_in_place(trace_data)
-
+    MlflowSpanExporter._deduplicate_span_names_in_place(trace_data)
     assert trace_data.spans == []

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -131,7 +131,7 @@ def test_start_span_context_manager(mock_client):
                 root_span.set_inputs({"x": x, "y": y})
                 z = x + y
 
-                with mlflow.start_span(name="child_span_1", span_type=SpanType.LLM) as child_span:
+                with mlflow.start_span(name="child_span", span_type=SpanType.LLM) as child_span:
                     child_span.set_inputs(z)
                     z = z + 2
                     child_span.set_outputs(z)
@@ -142,7 +142,7 @@ def test_start_span_context_manager(mock_client):
             return res
 
         def square(self, t):
-            with mlflow.start_span(name="child_span_2") as span:
+            with mlflow.start_span(name="child_span") as span:
                 span.set_inputs({"t": t})
                 res = t**2
                 time.sleep(0.1)
@@ -172,6 +172,7 @@ def test_start_span_context_manager(mock_client):
     assert root_span.inputs == {"x": 1, "y": 2}
     assert root_span.outputs == 25
 
+    # Span with duplicate name should be renamed to have an index number like "_1", "_2", ...
     child_span_1 = span_name_to_span["child_span_1"]
     assert child_span_1.parent_span_id == root_span.context.span_id
     assert child_span_1.span_type == SpanType.LLM


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11579?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11579/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11579
```

</p>
</details>

### Related Issues/PRs

ML-39923

### What changes are proposed in this pull request?

Add deduplication logic for span names within a single trace. It appends an index number like `_1`, `_2`, ... to a span name, only if it has other spans with the sama name.

For example, if a trace the following span names:
```
["red", "red", "blue", "green", "blue"]
```
Then they will be renamed to
```
["red_1", "red_2", "blue_1", "green", "blue_2"]
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
