### PR TITLE
Patch LangChain loading functions to handle pickle serialization issue

### DIFF
--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -21,6 +21,7 @@ from mlflow.langchain.utils import (
     _load_from_json,
     _load_from_pickle,
     _load_from_yaml,
+    _patch_loader,
     _save_base_lcs,
     _validate_and_wrap_lc_model,
     base_lc_types,
@@ -63,7 +64,7 @@ def _load_model_from_config(path, model_config):
     if _type in chains_type_to_loader_dict:
         from langchain.chains.loading import load_chain
 
-        return load_chain(config_path)
+        return _patch_loader(load_chain)(config_path)
     elif _type in prompts_types:
         from langchain.prompts.loading import load_prompt
 
@@ -71,7 +72,7 @@ def _load_model_from_config(path, model_config):
     elif _type in llms_get_type_to_cls_dict():
         from langchain.llms.loading import load_llm
 
-        return load_llm(config_path)
+        return _patch_loader(load_llm)(config_path)
     elif _type in custom_type_to_loader_dict():
         return custom_type_to_loader_dict()[_type](config)
     raise MlflowException(f"Unsupported type {_type} for loading.")

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -11,14 +11,17 @@ import types
 import warnings
 from functools import lru_cache
 from importlib.util import find_spec
-from typing import NamedTuple
+from typing import Callable, NamedTuple
 
 import cloudpickle
+import importlib_metadata
 import yaml
 from packaging import version
 from packaging.version import Version
 
 import mlflow
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INTERNAL_ERROR
 from mlflow.utils.class_utils import _get_class_from_string
 
 _AGENT_PRIMITIVES_FILE_NAME = "agent_primitive_args.json"
@@ -63,6 +66,13 @@ _UNSUPPORTED_LLM_WARNING_MESSAGE = (
 # will not work.
 _LC_MIN_VERSION_SUPPORT_CHAT_OPEN_AI = Version("0.0.307")
 _CHAT_MODELS_ERROR_MSG = re.compile("Loading (openai-chat|azure-openai-chat) LLM not supported")
+
+
+# Since langchain-community 0.0.27, saving or loading a module that relies on the pickle
+# deserialization requires passing `allow_dangerous_deserialization=True`.
+IS_PICKLE_SERIALIZATION_RESTRICTED = Version(
+    importlib_metadata.version("langchain-community")
+) >= Version("0.0.27")
 
 logger = logging.getLogger(__name__)
 
@@ -422,6 +432,55 @@ def _get_path_by_key(root_path, key, conf):
     return os.path.join(root_path, key_path) if key_path else None
 
 
+def _patch_loader(loader_func: Callable) -> Callable:
+    """
+    Patch LangChain loader function like load_chain() to handle the breaking change introduced in
+    LangChain 0.1.12.
+
+    Since langchain-community 0.0.27, loading a module that relies on the pickle deserialization
+    requires the `allow_dangerous_deserialization` flag to be set to True, for security reasons.
+    However, this flag could not be specified via the LangChain's loading API like load_chain(),
+    load_llm(), until LangChain 0.1.14. As a result, such module cannot be loaded with MLflow
+    with earlier version of LangChain and we have to tell the user to upgrade LangChain to 0.0.14
+    or above.
+
+    Args:
+        loader_func: The LangChain loader function to be patched e.g. load_chain().
+    Returns:
+        The patched loader function.
+    """
+    if not IS_PICKLE_SERIALIZATION_RESTRICTED:
+        return loader_func
+
+    import langchain
+
+    if Version(langchain.__version__) >= Version("0.1.14"):
+        # For LangChain 0.1.14 and above, we can pass `allow_dangerous_deserialization` flag
+        # via the loader APIs. Since the model is serialized by the user (or someone who has
+        # access to the tracking server), it is safe to set this flag to True.
+        def patched_loader(*args, **kwargs):
+            return loader_func(*args, **kwargs, allow_dangerous_deserialization=True)
+    else:
+
+        def patched_loader(*args, **kwargs):
+            try:
+                return loader_func(*args, **kwargs)
+            except ValueError as e:
+                if "This code relies on the pickle module" in str(e):
+                    raise MlflowException(
+                        "Since langchain-community 0.0.27, loading a module that relies on "
+                        "the pickle deserialization requires the `allow_dangerous_deserialization` "
+                        "flag to be set to True when loading. However, this flag is not supported "
+                        "by the installed version of LangChain. Please upgrade LangChain to 0.1.14 "
+                        "or above by running `pip install langchain>=0.1.14 -U`.",
+                        error_code=INTERNAL_ERROR,
+                    ) from e
+                else:
+                    raise
+
+    return patched_loader
+
+
 def _load_base_lcs(
     local_model_path,
     conf,
@@ -453,13 +512,13 @@ def _load_base_lcs(
         if model_type == _RetrieverChain.__name__:
             model = _RetrieverChain.load(lc_model_path, **kwargs).retriever
         else:
-            model = load_chain(lc_model_path, **kwargs)
+            model = _patch_loader(load_chain)(lc_model_path, **kwargs)
     elif agent_path is None and tools_path is None:
-        model = load_chain(lc_model_path)
+        model = _patch_loader(load_chain)(lc_model_path)
     else:
         from langchain.agents import initialize_agent
 
-        llm = load_chain(lc_model_path)
+        llm = _patch_loader(load_chain)(lc_model_path)
         tools = []
         kwargs = {}
 

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -14,7 +14,6 @@ from importlib.util import find_spec
 from typing import Callable, NamedTuple
 
 import cloudpickle
-import importlib_metadata
 import yaml
 from packaging import version
 from packaging.version import Version
@@ -68,11 +67,16 @@ _LC_MIN_VERSION_SUPPORT_CHAT_OPEN_AI = Version("0.0.307")
 _CHAT_MODELS_ERROR_MSG = re.compile("Loading (openai-chat|azure-openai-chat) LLM not supported")
 
 
-# Since langchain-community 0.0.27, saving or loading a module that relies on the pickle
-# deserialization requires passing `allow_dangerous_deserialization=True`.
-IS_PICKLE_SERIALIZATION_RESTRICTED = Version(
-    importlib_metadata.version("langchain-community")
-) >= Version("0.0.27")
+try:
+    import langchain_community
+
+    # Since langchain-community 0.0.27, saving or loading a module that relies on the pickle
+    # deserialization requires passing `allow_dangerous_deserialization=True`.
+    IS_PICKLE_SERIALIZATION_RESTRICTED = Version(langchain_community.__version__) >= Version(
+        "0.0.27"
+    )
+except ImportError:
+    IS_PICKLE_SERIALIZATION_RESTRICTED = False
 
 logger = logging.getLogger(__name__)
 
@@ -446,6 +450,7 @@ def _patch_loader(loader_func: Callable) -> Callable:
 
     Args:
         loader_func: The LangChain loader function to be patched e.g. load_chain().
+
     Returns:
         The patched loader function.
     """

--- a/mlflow/langchain/utils.py
+++ b/mlflow/langchain/utils.py
@@ -477,7 +477,7 @@ def _patch_loader(loader_func: Callable) -> Callable:
                         "the pickle deserialization requires the `allow_dangerous_deserialization` "
                         "flag to be set to True when loading. However, this flag is not supported "
                         "by the installed version of LangChain. Please upgrade LangChain to 0.1.14 "
-                        "or above by running `pip install langchain>=0.1.14 -U`.",
+                        "or above by running `pip install langchain>=0.1.14`.",
                         error_code=INTERNAL_ERROR,
                     ) from e
                 else:

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -827,6 +827,10 @@ def load_db(persist_dir):
     version.parse(langchain.__version__) < version.parse("0.0.297"),
     reason="Saving SQLDatabaseChain chains requires langchain>=0.0.297",
 )
+@pytest.mark.skipif(
+    version.parse(langchain.__version__) in (version.parse("0.1.14"), version.parse("0.1.15")),
+    reason="LangChain 0.1.14 and 0.1.15 has a bug in loading SQLDatabaseChain",
+)
 def test_log_and_load_sql_database_chain(tmp_path):
     # Create the SQLDatabaseChain
     db_file_path = tmp_path / "my_database.db"

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -51,8 +51,10 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.deployments import PredictionsResponse
 from mlflow.exceptions import MlflowException
 from mlflow.langchain.api_request_parallel_processor import APIRequest
-from mlflow.langchain.utils import _LC_MIN_VERSION_SUPPORT_CHAT_OPEN_AI
-from mlflow.langchain.utils import IS_PICKLE_SERIALIZATION_RESTRICTED
+from mlflow.langchain.utils import (
+    _LC_MIN_VERSION_SUPPORT_CHAT_OPEN_AI,
+    IS_PICKLE_SERIALIZATION_RESTRICTED,
+)
 from mlflow.models.signature import ModelSignature, Schema, infer_signature
 from mlflow.types.schema import Array, ColSpec, DataType, Object, Property
 from mlflow.utils.openai_utils import (

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2244,6 +2244,9 @@ def test_pyfunc_builtin_chat_response_conversion_fails_gracefully():
         ]
 
 
+@pytest.mark.skipif(
+    Version(langchain.__version__) < Version("0.0.311"), reason="feature not existing"
+)
 def test_save_load_chain_that_relies_on_pickle_serialization(monkeypatch, model_path):
     from langchain_community.llms.databricks import Databricks
     from langchain_core.output_parsers import StrOutputParser

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -2275,8 +2275,7 @@ def test_save_load_chain_that_relies_on_pickle_serialization(monkeypatch, model_
         with pytest.raises(MlflowException, match=r"Since langchain-community 0.0.27, loading a"):
             mlflow.langchain.load_model(model_path)
         return
-    else:
-        loaded_model = mlflow.langchain.load_model(model_path)
+    loaded_model = mlflow.langchain.load_model(model_path)
 
     # Check if the deserialized model has the same endpoint and temperature
     loaded_databricks_llm = loaded_model.middle[0]

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -52,6 +52,7 @@ from mlflow.deployments import PredictionsResponse
 from mlflow.exceptions import MlflowException
 from mlflow.langchain.api_request_parallel_processor import APIRequest
 from mlflow.langchain.utils import _LC_MIN_VERSION_SUPPORT_CHAT_OPEN_AI
+from mlflow.langchain.utils import IS_PICKLE_SERIALIZATION_RESTRICTED
 from mlflow.models.signature import ModelSignature, Schema, infer_signature
 from mlflow.types.schema import Array, ColSpec, DataType, Object, Property
 from mlflow.utils.openai_utils import (
@@ -65,18 +66,11 @@ from mlflow.utils.openai_utils import (
 
 from tests.helper_functions import pyfunc_serve_and_score_model
 
-try:
-    import langchain_community
-
-    # this kwarg was added in langchain_community 0.0.27, and
-    # prevents the use of pickled objects if not provided.
-    VECTORSTORE_KWARGS = (
-        {"allow_dangerous_deserialization": True}
-        if Version(langchain_community.__version__) >= Version("0.0.27")
-        else {}
-    )
-except ImportError:
-    VECTORSTORE_KWARGS = {}
+# this kwarg was added in langchain_community 0.0.27, and
+# prevents the use of pickled objects if not provided.
+VECTORSTORE_KWARGS = (
+    {"allow_dangerous_deserialization": True} if IS_PICKLE_SERIALIZATION_RESTRICTED else {}
+)
 
 
 @contextmanager
@@ -2242,6 +2236,43 @@ def test_pyfunc_builtin_chat_response_conversion_fails_gracefully():
                 "text": TEST_CONTENT,
             }
         ]
+
+
+def test_save_load_chain_that_relies_on_pickle_serialization(monkeypatch, model_path):
+    from langchain_community.llms.databricks import Databricks
+    from langchain_core.output_parsers import StrOutputParser
+
+    monkeypatch.setattr(
+        "langchain_community.llms.databricks._DatabricksServingEndpointClient",
+        mock.MagicMock(),
+    )
+    monkeypatch.setenv("DATABRICKS_HOST", "test-host")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "test-token")
+
+    llm_kwargs = {"endpoint_name": "test-endpoint", "temperature": 0.9}
+    if IS_PICKLE_SERIALIZATION_RESTRICTED:
+        llm_kwargs["allow_dangerous_deserialization"] = True
+
+    llm = Databricks(**llm_kwargs)
+    prompt = PromptTemplate(input_variables=["question"], template="I have a question: {question}")
+    chain = prompt | llm | StrOutputParser()
+
+    # Not passing an input_example to avoid triggering prediction
+    mlflow.langchain.save_model(chain, model_path)
+
+    if IS_PICKLE_SERIALIZATION_RESTRICTED and Version(langchain.__version__) < Version("0.1.14"):
+        # For LangChain between 0.1.12 and 0.1.14, MLflow cannot load a model that relies on pickle
+        # serialization, instead, raises an MlflowException with a message that explains the issue.
+        with pytest.raises(MlflowException, match=r"Since langchain-community 0.0.27, loading a"):
+            mlflow.langchain.load_model(model_path)
+        return
+    else:
+        loaded_model = mlflow.langchain.load_model(model_path)
+
+    # Check if the deserialized model has the same endpoint and temperature
+    loaded_databricks_llm = loaded_model.middle[0]
+    assert loaded_databricks_llm.endpoint_name == "test-endpoint"
+    assert loaded_databricks_llm.temperature == 0.9
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11582?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11582/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11582
```

</p>
</details>

### What changes are proposed in this pull request?

Since `langchain-community` >= 0.0.27, saving or loading a module that relies on pickle serialization requires `allow_dangerous_deserialization` flag set to `True`. This broke the model loading in the LangChain flavor.

This was not solvable on MLflow side until [this PR](https://github.com/langchain-ai/langchain/pull/18894)was merged to LangChain on `0.1.14`. Before this patch, the `allow_dangerous_deserialization` argument cannot be passed via higher-level loading function like `load_chain()`, `load_llm()`, which we are using inside the LangChain flavor.

**Note**: The patching logic can be improved to be consistent with how we've done in #11644, but it requires good amount of refactoring. To avoid complicating the diff and risking the release schedule, this PR implements the minimum change to make the feature work, and refactoring is done in a separate draft PR here: #11677 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?
TODO
- [ ] No. You can skip the rest of this section. 
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
