### PR TITLE
Accept string value in Span status setter

### DIFF
--- a/mlflow/entities/span_status.py
+++ b/mlflow/entities/span_status.py
@@ -46,7 +46,7 @@ class SpanStatus:
                 self.status_code = TraceStatus(self.status_code)
             except ValueError:
                 raise MlflowException(
-                    f"{self.status_code} is not a valid TraceStatus value."
+                    f"{self.status_code} is not a valid TraceStatus value. "
                     f"Please use one of {[status.value for status in TraceStatus]}",
                     error_code=INVALID_PARAMETER_VALUE,
                 )

--- a/mlflow/tracing/types/wrapper.py
+++ b/mlflow/tracing/types/wrapper.py
@@ -118,9 +118,9 @@ class MlflowSpanWrapper:
         Set the status of the span.
 
         Args:
-            status: The status of the span. This can be a :py:class:`SpanStatus` object or
-                a string representing of the status code defined in :py:class:`TraceStatus`
-                e.g. ``"OK"``, ``"ERROR"``.
+            status: The status of the span. This can be a :py:class:`SpanStatus <mlflow.entities.SpanStatus>`
+                object or a string representing of the status code defined in
+                :py:class:`TraceStatus <mlflow.entities.TraceStatus>` e.g. ``"OK"``, ``"ERROR"``.
         """
         if isinstance(status, str):
             status = SpanStatus(status)

--- a/mlflow/tracing/types/wrapper.py
+++ b/mlflow/tracing/types/wrapper.py
@@ -1,6 +1,6 @@
 import logging
 from time import time_ns
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from opentelemetry import trace as trace_api
 
@@ -113,8 +113,18 @@ class MlflowSpanWrapper:
             return
         self._attributes[key] = value
 
-    def set_status(self, status: SpanStatus):
-        """Set the status of the span."""
+    def set_status(self, status: Union[SpanStatus, str]):
+        """
+        Set the status of the span.
+
+        Args:
+            status: The status of the span. This can be a :py:class:`SpanStatus` object or
+                a string representing of the status code defined in :py:class:`TraceStatus`
+                e.g. ``"OK"``, ``"ERROR"``.
+        """
+        if isinstance(status, str):
+            status = SpanStatus(status)
+
         # NB: We need to set the OpenTelemetry native StatusCode, because span's set_status
         #     method only accepts a StatusCode enum in their definition.
         #     https://github.com/open-telemetry/opentelemetry-python/blob/8ed71b15fb8fc9534529da8ce4a21e686248a8f3/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py#L949

--- a/mlflow/tracing/types/wrapper.py
+++ b/mlflow/tracing/types/wrapper.py
@@ -118,9 +118,10 @@ class MlflowSpanWrapper:
         Set the status of the span.
 
         Args:
-            status: The status of the span. This can be a :py:class:`SpanStatus <mlflow.entities.SpanStatus>`
-                object or a string representing of the status code defined in
-                :py:class:`TraceStatus <mlflow.entities.TraceStatus>` e.g. ``"OK"``, ``"ERROR"``.
+            status: The status of the span. This can be a
+                :py:class:`SpanStatus <mlflow.entities.SpanStatus>` object or a string representing
+                of the status code defined in :py:class:`TraceStatus <mlflow.entities.TraceStatus>`
+                e.g. ``"OK"``, ``"ERROR"``.
         """
         if isinstance(status, str):
             status = SpanStatus(status)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -30,7 +30,6 @@ from mlflow.entities import (
     SpanStatus,
     SpanType,
     TraceInfo,
-    TraceStatus,
     ViewType,
 )
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
@@ -534,7 +533,7 @@ class MlflowClient:
         request_id: str,
         outputs: Optional[Dict[str, Any]] = None,
         attributes: Optional[Dict[str, Any]] = None,
-        status: SpanStatus = SpanStatus(TraceStatus.OK),
+        status: SpanStatus = "OK",
     ):
         """
         End the trace with the given trace ID. This will end the root span of the trace and
@@ -550,7 +549,10 @@ class MlflowClient:
             attributes: A dictionary of attributes to set on the trace. If the trace already
                 has attributes, the new attributes will be merged with the existing ones.
                 If the same key already exists, the new value will overwrite the old one.
-            status: The status of the trace. The default status is OK.
+            status: The status of the trace. This can be a
+                :py:class:`SpanStatus <mlflow.entities.SpanStatus>` object or a string representing
+                of the status code defined in :py:class:`TraceStatus <mlflow.entities.TraceStatus>`
+                e.g. ``"OK"``, ``"ERROR"``. The default status is OK.
         """
         trace_manager = InMemoryTraceManager.get_instance()
         root_span_id = trace_manager.get_root_span_id(request_id)
@@ -714,7 +716,7 @@ class MlflowClient:
         span_id: str,
         outputs: Optional[Dict[str, Any]] = None,
         attributes: Optional[Any] = None,
-        status: SpanStatus = SpanStatus(TraceStatus.OK),
+        status: Union[SpanStatus, str] = "OK",
     ):
         """
         End the span with the given trace ID and span ID.
@@ -726,7 +728,10 @@ class MlflowClient:
             attributes: A dictionary of attributes to set on the span. If the span already has
                 attributes, the new attributes will be merged with the existing ones. If the same
                 key already exists, the new value will overwrite the old one.
-            status: The status of the span. The default status is OK.
+            status: The status of the span. This can be a
+                :py:class:`SpanStatus <mlflow.entities.SpanStatus>` object or a string representing
+                of the status code defined in :py:class:`TraceStatus <mlflow.entities.TraceStatus>`
+                e.g. ``"OK"``, ``"ERROR"``. The default status is OK.
         """
         trace_manager = InMemoryTraceManager.get_instance()
         span = trace_manager.get_span_from_id(request_id, span_id)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -533,7 +533,7 @@ class MlflowClient:
         request_id: str,
         outputs: Optional[Dict[str, Any]] = None,
         attributes: Optional[Dict[str, Any]] = None,
-        status: SpanStatus = "OK",
+        status: Union[SpanStatus, str] = "OK",
     ):
         """
         End the trace with the given trace ID. This will end the root span of the trace and
@@ -551,7 +551,7 @@ class MlflowClient:
                 If the same key already exists, the new value will overwrite the old one.
             status: The status of the trace. This can be a
                 :py:class:`SpanStatus <mlflow.entities.SpanStatus>` object or a string representing
-                of the status code defined in :py:class:`TraceStatus <mlflow.entities.TraceStatus>`
+                the status code defined in :py:class:`TraceStatus <mlflow.entities.TraceStatus>`
                 e.g. ``"OK"``, ``"ERROR"``. The default status is OK.
         """
         trace_manager = InMemoryTraceManager.get_instance()
@@ -730,7 +730,7 @@ class MlflowClient:
                 key already exists, the new value will overwrite the old one.
             status: The status of the span. This can be a
                 :py:class:`SpanStatus <mlflow.entities.SpanStatus>` object or a string representing
-                of the status code defined in :py:class:`TraceStatus <mlflow.entities.TraceStatus>`
+                the status code defined in :py:class:`TraceStatus <mlflow.entities.TraceStatus>`
                 e.g. ``"OK"``, ``"ERROR"``. The default status is OK.
         """
         trace_manager = InMemoryTraceManager.get_instance()

--- a/tests/tracing/test_wrapper.py
+++ b/tests/tracing/test_wrapper.py
@@ -1,6 +1,11 @@
 import time
 from unittest import mock
 
+import pytest
+
+import mlflow
+from mlflow.entities import SpanStatus, TraceStatus
+from mlflow.exceptions import MlflowException
 from mlflow.tracing.types.wrapper import MlflowSpanWrapper
 
 
@@ -22,3 +27,20 @@ def test_wrapper_property():
     assert span.start_time == start_time // 1_000
     assert span.end_time == end_time // 1_000
     assert span.parent_span_id == "parent_span_id"
+
+
+@pytest.mark.parametrize(
+    "status",
+    [SpanStatus("OK"), SpanStatus(TraceStatus.ERROR, "Error!"), "OK", "ERROR"],
+)
+def test_set_status(status):
+    with mlflow.start_span("test_span") as span:
+        span.set_status(status)
+
+    assert isinstance(span.status, SpanStatus)
+
+
+def test_set_status_raise_for_invalid_value():
+    with mlflow.start_span("test_span") as span:
+        with pytest.raises(MlflowException, match=r"INVALID is not a valid TraceStatus value."):
+            span.set_status("INVALID")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11585?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11585/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11585
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Allow passing string value for `set_status` method for convenience.

```
with mlflow.start_span("test") as span:
    span.set_status("OK")
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
