### PR TITLE
Refactor os validation checks

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ import click
 import pytest
 
 from mlflow.environment_variables import _MLFLOW_TESTING, MLFLOW_TRACKING_URI
+from mlflow.utils.os import is_windows
 from mlflow.version import VERSION
 
 from tests.helper_functions import get_safe_port
@@ -274,7 +275,7 @@ def clean_up_envs():
         from mlflow.utils.virtualenv import _get_mlflow_virtualenv_root
 
         shutil.rmtree(_get_mlflow_virtualenv_root(), ignore_errors=True)
-        if os.name != "nt":
+        if not is_windows():
             conda_info = json.loads(subprocess.check_output(["conda", "info", "--json"], text=True))
             root_prefix = conda_info["root_prefix"]
             regex = re.compile(r"mlflow-\w{32,}")

--- a/mlflow/mleap/__init__.py
+++ b/mlflow/mleap/__init__.py
@@ -26,6 +26,7 @@ from mlflow.models.utils import _save_example
 from mlflow.utils import reraise
 from mlflow.utils.annotations import deprecated, keyword_only
 from mlflow.utils.file_utils import path_to_local_file_uri
+from mlflow.utils.os import is_windows
 
 FLAVOR_NAME = "mleap"
 
@@ -246,7 +247,7 @@ def add_to_model(mlflow_model, path, spark_model, sample_input):
     os.makedirs(mleap_path_full)
 
     dataset = spark_model.transform(sample_input)
-    if os.name == "nt":
+    if is_windows():
         # NB: On Windows, MLeap requires the "file://" prefix in order to correctly
         # parse the model data path, even though the result is not a correct URI.
         # None of "file:", "file:/", or "file:///", which would be canonically correct,

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -44,6 +44,7 @@ from mlflow.utils.databricks_utils import get_databricks_env_vars, is_in_databri
 from mlflow.utils.environment import _PythonEnv
 from mlflow.utils.file_utils import get_or_create_nfs_tmp_dir
 from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV
+from mlflow.utils.os import is_windows
 from mlflow.utils.virtualenv import (
     _PYENV_ROOT_DIR,
     _VIRTUALENV_ENVS_DIR,
@@ -272,7 +273,7 @@ def _run_entry_point(command, work_dir, experiment_id, run_id):
     _logger.info("=== Running command '%s' in run with ID '%s' === ", command, run_id)
     # in case os name is not 'nt', we are not running on windows. It introduces
     # bash command otherwise.
-    if os.name != "nt":
+    if not is_windows():
         process = subprocess.Popen(["bash", "-c", command], close_fds=True, cwd=work_dir, env=env)
     else:
         # process = subprocess.Popen(command, close_fds=True, cwd=work_dir, env=env)

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -34,6 +34,7 @@ from mlflow.utils.file_utils import (
 )
 from mlflow.utils.model_utils import _get_all_flavor_configurations
 from mlflow.utils.nfs_on_spark import get_nfs_cache_root_dir
+from mlflow.utils.os import is_windows
 from mlflow.utils.process import ShellCommandException, cache_return_value_per_process
 from mlflow.utils.virtualenv import (
     _get_or_create_virtualenv,
@@ -43,7 +44,6 @@ from mlflow.version import VERSION
 
 _logger = logging.getLogger(__name__)
 
-_IS_UNIX = os.name != "nt"
 _STDIN_SERVER_SCRIPT = Path(__file__).parent.joinpath("stdin_server.py")
 
 # Flavors that require Java to be installed in the environment
@@ -260,7 +260,7 @@ class PyFuncBackend(FlavorBackend):
         else:
             setup_sigterm_on_parent_death = None
 
-        if _IS_UNIX:
+        if not is_windows():
             # Add "exec" before the starting scoring server command, so that the scoring server
             # process replaces the bash process, otherwise the scoring server process is created
             # as a child process of the bash process.
@@ -284,7 +284,7 @@ class PyFuncBackend(FlavorBackend):
         else:
             _logger.info("=== Running command '%s'", command)
 
-            if os.name != "nt":
+            if not is_windows():
                 command = ["bash", "-c", command]
 
             child_proc = subprocess.Popen(

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -38,6 +38,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_DATASET_CONTEXT,
     MLFLOW_PARENT_RUN_ID,
 )
+from mlflow.utils.os import is_windows
 from mlflow.utils.rest_utils import (
     MlflowHostCreds,
     augmented_raise_for_status,
@@ -69,7 +70,7 @@ def _read_log_model_allowlist_from_file(allowlist_file):
     url_parsed = urlparse(allowlist_file)
     scheme = url_parsed.scheme
     path = url_parsed.path
-    if os.name == "nt" and not url_parsed.hostname:
+    if is_windows() and not url_parsed.hostname:
         path = scheme + "://" + path
         scheme = ""
     if scheme in ("file", ""):

--- a/mlflow/recipes/utils/step.py
+++ b/mlflow/recipes/utils/step.py
@@ -14,6 +14,7 @@ from mlflow.utils.databricks_utils import (
     is_in_databricks_runtime,
     is_running_in_ipython_environment,
 )
+from mlflow.utils.os import is_windows
 
 _logger = logging.getLogger(__name__)
 
@@ -127,7 +128,7 @@ def display_html(html_data: Optional[str] = None, html_file_path: Optional[str] 
 # multiprocessing and pytest don't play well together on Windows.
 # Relevant code: https://github.com/ydataai/pandas-profiling/blob/f8bad5dde27e3f87f11ac74fb8966c034bc22db8/src/pandas_profiling/model/pandas/summary_pandas.py#L76-L97
 def _get_pool_size():
-    return 1 if "PYTEST_CURRENT_TEST" in os.environ and os.name == "nt" else 0
+    return 1 if "PYTEST_CURRENT_TEST" in os.environ and is_windows() else 0
 
 
 def get_pandas_data_profiles(inputs: Iterable[Tuple[str, pd.DataFrame]]) -> str:

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -15,6 +15,7 @@ from mlflow.store.artifact.dbfs_artifact_repo import DbfsRestArtifactRepository
 from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.tracking._tracking_service.utils import _get_store
 from mlflow.utils.file_utils import path_to_local_file_uri
+from mlflow.utils.os import is_windows
 from mlflow.utils.uri import add_databricks_profile_info_to_artifact_uri, append_to_uri_path
 
 
@@ -65,7 +66,7 @@ def _get_root_uri_and_artifact_path(artifact_uri):
         artifact_uri: The *absolute* URI of the artifact.
     """
     if os.path.exists(artifact_uri):
-        if os.name != "nt":
+        if not is_windows():
             # If we're dealing with local files, just reference the direct pathing.
             # non-nt-based file systems can directly reference path information, while nt-based
             # systems need to url-encode special characters in directory listings to be able to

--- a/mlflow/transformers/signature.py
+++ b/mlflow/transformers/signature.py
@@ -7,7 +7,7 @@ from mlflow.environment_variables import MLFLOW_INPUT_EXAMPLE_INFERENCE_TIMEOUT
 from mlflow.models.signature import ModelSignature, infer_signature
 from mlflow.models.utils import _contains_params
 from mlflow.types.schema import ColSpec, DataType, Schema, TensorSpec
-from mlflow.utils.process import _IS_UNIX
+from mlflow.utils.os import is_windows
 from mlflow.utils.timeout import MlflowTimeoutError, run_with_timeout
 
 _logger = logging.getLogger(__name__)
@@ -91,7 +91,7 @@ def infer_or_get_default_signature(
     if example:
         try:
             timeout = MLFLOW_INPUT_EXAMPLE_INFERENCE_TIMEOUT.get()
-            if timeout and not _IS_UNIX:
+            if timeout and is_windows():
                 timeout = None
                 _logger.warning(
                     "On Windows, timeout is not supported for model signature inference. "

--- a/mlflow/utils/conda.py
+++ b/mlflow/utils/conda.py
@@ -8,6 +8,7 @@ from mlflow.environment_variables import MLFLOW_CONDA_CREATE_ENV_CMD, MLFLOW_CON
 from mlflow.exceptions import ExecutionException
 from mlflow.utils import insecure_hash, process
 from mlflow.utils.environment import Environment
+from mlflow.utils.os import is_windows
 
 _logger = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ CONDA_EXE = "CONDA_EXE"
 
 def get_conda_command(conda_env_name):
     #  Checking for newer conda versions
-    if os.name != "nt" and (CONDA_EXE in os.environ or MLFLOW_CONDA_HOME.defined):
+    if not is_windows() and (CONDA_EXE in os.environ or MLFLOW_CONDA_HOME.defined):
         conda_path = get_conda_bin_executable("conda")
         activate_conda_env = [f"source {os.path.dirname(conda_path)}/../etc/profile.d/conda.sh"]
         activate_conda_env += [f"conda activate {conda_env_name} 1>&2"]
@@ -24,7 +25,7 @@ def get_conda_command(conda_env_name):
         activate_path = get_conda_bin_executable("activate")
         # in case os name is not 'nt', we are not running on windows. It introduces
         # bash command otherwise.
-        if os.name != "nt":
+        if not is_windows():
             return [f"source {activate_path} {conda_env_name} 1>&2"]
         else:
             return [f"conda activate {conda_env_name}"]

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -843,7 +843,7 @@ def _handle_readonly_on_windows(func, path, exc_info):
     """
     exc_type, exc_value = exc_info[:2]
     should_reattempt = (
-        os.name == "nt"
+        is_windows()
         and func in (os.unlink, os.rmdir)
         and issubclass(exc_type, PermissionError)
         and exc_value.winerror == 5

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import sys
 
-_IS_UNIX = os.name != "nt"
+from mlflow.utils.os import is_windows
 
 
 class ShellCommandException(Exception):
@@ -122,8 +122,8 @@ def _exec_cmd(
 
 
 def _join_commands(*commands):
-    entry_point = ["bash", "-c"] if _IS_UNIX else ["cmd", "/c"]
-    sep = " && " if _IS_UNIX else " & "
+    entry_point = ["bash", "-c"] if not is_windows() else ["cmd", "/c"]
+    sep = " && " if not is_windows() else " & "
     return [*entry_point, sep.join(map(str, commands))]
 
 

--- a/mlflow/utils/string_utils.py
+++ b/mlflow/utils/string_utils.py
@@ -1,7 +1,8 @@
-import os
 import re
 import shlex
 from typing import List
+
+from mlflow.utils.os import is_windows
 
 
 def strip_prefix(original, prefix):
@@ -128,4 +129,4 @@ def mslex_quote(s, for_cmd=True):
 
 
 def quote(s):
-    return mslex_quote(s) if os.name == "nt" else shlex.quote(s)
+    return mslex_quote(s) if is_windows() else shlex.quote(s)

--- a/mlflow/utils/timeout.py
+++ b/mlflow/utils/timeout.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import NOT_IMPLEMENTED
-from mlflow.utils.process import _IS_UNIX
+from mlflow.utils.os import is_windows
 
 
 class MlflowTimeoutError(Exception):
@@ -24,7 +24,7 @@ def run_with_timeout(seconds):
             model.predict(data)
         ```
     """
-    if not _IS_UNIX:
+    if is_windows():
         raise MlflowException(
             "Timeouts are not implemented yet for non-Unix platforms",
             error_code=NOT_IMPLEMENTED,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,7 +106,7 @@ def clean_up_mlruns_directory(request):
         try:
             shutil.rmtree(mlruns_dir)
         except OSError:
-            if os.name == "nt":
+            if is_windows():
                 raise
             # `shutil.rmtree` can't remove files owned by root in a docker container.
             subprocess.run(["sudo", "rm", "-rf", mlruns_dir], check=True)

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -29,6 +29,7 @@ from mlflow.utils.environment import (
     _get_pip_deps,
 )
 from mlflow.utils.file_utils import read_yaml, write_yaml
+from mlflow.utils.os import is_windows
 
 AWS_METADATA_IP = "169.254.169.254"  # Used to fetch AWS Instance and User metadata.
 LOCALHOST = "127.0.0.1"
@@ -252,7 +253,7 @@ def _get_mlflow_home():
 
 
 def _start_scoring_proc(cmd, env, stdout=sys.stdout, stderr=sys.stderr):
-    if os.name != "nt":
+    if not is_windows():
         return subprocess.Popen(
             cmd,
             stdout=stdout,
@@ -312,7 +313,7 @@ class RestEndpoint:
         if self._proc.poll() is None:
             # Terminate the process group containing the scoring process.
             # This will terminate all child processes of the scoring process
-            if os.name != "nt":
+            if not is_windows():
                 pgrp = os.getpgid(self._proc.pid)
                 os.killpg(pgrp, signal.SIGTERM)
             else:

--- a/tests/recipes/test_train_step.py
+++ b/tests/recipes/test_train_step.py
@@ -26,6 +26,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_RECIPE_TEMPLATE_NAME,
     MLFLOW_SOURCE_TYPE,
 )
+from mlflow.utils.os import is_windows
 
 
 # Sets up the train step output dir
@@ -838,7 +839,7 @@ def test_train_step_with_label_encoding(tmp_recipe_root_path: Path, tmp_recipe_e
 
 
 @pytest.mark.skipif(
-    os.name == "nt",
+    is_windows(),
     reason="Flaky on windows, sometimes fails with `(sqlite3.OperationalError) database is locked`",
 )
 def test_train_step_with_probability_calibration(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.server import handlers
 from mlflow.store.tracking.file_store import FileStore
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+from mlflow.utils.os import is_windows
 from mlflow.utils.rest_utils import augmented_raise_for_status
 from mlflow.utils.time import get_current_time_millis
 
@@ -390,9 +391,7 @@ def test_mlflow_gc_experiments(get_store_details, request):
         # https://github.com/SeldonIO/MLServer/issues/361
         pytest.param(
             True,
-            marks=pytest.mark.skipif(
-                os.name == "nt", reason="MLServer is not supported in Windows"
-            ),
+            marks=pytest.mark.skipif(is_windows(), reason="MLServer is not supported in Windows"),
         ),
         False,
     ],

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -6,8 +6,10 @@ import uuid
 
 import pytest
 
+from mlflow.utils.os import is_windows
 
-@pytest.mark.skipif(os.name == "nt", reason="This test fails on Windows")
+
+@pytest.mark.skipif(is_windows(), reason="This test fails on Windows")
 @pytest.mark.skipif(shutil.which("docker") is None, reason="docker is required to run this test")
 def test_import_mlflow(tmp_path):
     tmp_script = tmp_path.joinpath("test.sh")

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -11,13 +11,10 @@ import requests
 import mlflow
 from mlflow import MlflowClient
 from mlflow.artifacts import download_artifacts
+from mlflow.utils.os import is_windows
 
 from tests.helper_functions import LOCALHOST, get_safe_port
 from tests.tracking.integration_test_utils import _await_server_up_or_die
-
-
-def is_windows():
-    return os.name == "nt"
 
 
 def _launch_server(host, port, backend_store_uri, default_artifact_root, artifacts_destination):

--- a/tests/utils/test_process_utils.py
+++ b/tests/utils/test_process_utils.py
@@ -3,6 +3,7 @@ import uuid
 
 import pytest
 
+from mlflow.utils.os import is_windows
 from mlflow.utils.process import cache_return_value_per_process
 
 
@@ -47,7 +48,7 @@ def test_cache_return_value_per_process():
     assert len({path1, path3, f2_path1, f2_path2}) == 4
 
     # Skip the following block on Windows which doesn't support `os.fork`
-    if os.name != "nt":
+    if not is_windows():
         # Use `os.fork()` to make parent and child processes share the same global variable
         # `_per_process_value_cache_map`.
         pid = os.fork()

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -10,6 +10,7 @@ import pytest
 import mlflow
 import mlflow.utils.requirements_utils
 from mlflow.utils.environment import infer_pip_requirements
+from mlflow.utils.os import is_windows
 from mlflow.utils.requirements_utils import (
     _capture_imported_modules,
     _get_installed_version,
@@ -141,8 +142,8 @@ line-cont-eof\
     # pip's requirements parser collapses an absolute requirements file path:
     # https://github.com/pypa/pip/issues/10121
     # As a workaround, use a relative path on Windows.
-    absolute_req = abs_req.name if os.name == "nt" else str(abs_req)
-    absolute_con = abs_con.name if os.name == "nt" else str(abs_con)
+    absolute_req = abs_req.name if is_windows() else str(abs_req)
+    absolute_con = abs_con.name if is_windows() else str(abs_con)
     root_req.write_text(
         root_req_src.format(
             relative_req=rel_req.name,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/tlm365/mlflow/pull/11589?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11589/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11589
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #10044

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Remove all references of `os.name != 'nt'` or `os.name == 'nt'`, replace with `mlflow.utils.os.is_windows()`
### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
