### PR TITLE
Introduce private environment variables for overriding http retries

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -118,6 +118,19 @@ MLFLOW_HTTP_RESPECT_RETRY_AFTER_HEADER = _BooleanEnvironmentVariable(
     "MLFLOW_HTTP_RESPECT_RETRY_AFTER_HEADER", True
 )
 
+#: Internal-only configuration that sets an upper bound to the allowable maximum
+#: retries for HTTP requests
+#: (default: ``10``)
+_MLFLOW_HTTP_REQUEST_MAX_RETRIES_LIMIT = _EnvironmentVariable(
+    "_MLFLOW_HTTP_REQUEST_MAX_RETRIES_LIMIT", int, 10
+)
+
+#: Internal-only configuration that sets the upper bound for an HTTP backoff_factor
+#: (default: ``120``)
+_MLFLOW_HTTP_REQUEST_MAX_BACKOFF_FACTOR_LIMIT = _EnvironmentVariable(
+    "_MLFLOW_HTTP_REQUEST_MAX_BACKOFF_FACTOR_LIMIT", int, 120
+)
+
 #: Specifies whether MLflow HTTP requests should be signed using AWS signature V4. It will overwrite
 #: (default: ``False``). When set, it will overwrite the "Authorization" HTTP header.
 #: See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html for more information.

--- a/mlflow/utils/request_utils.py
+++ b/mlflow/utils/request_utils.py
@@ -114,8 +114,6 @@ def _cached_get_request_session(
     """
     This function should not be called directly. Instead, use `_get_request_session` below.
     """
-    assert 0 <= max_retries < 10
-    assert 0 <= backoff_factor < 120
 
     retry_kwargs = {
         "total": max_retries,

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -12,7 +12,13 @@ from mlflow.environment_variables import (
     MLFLOW_HTTP_REQUEST_TIMEOUT,
     MLFLOW_HTTP_RESPECT_RETRY_AFTER_HEADER,
 )
-from mlflow.exceptions import InvalidUrlException, MlflowException, RestException, get_error_code
+from mlflow.exceptions import (
+    INVALID_PARAMETER_VALUE,
+    InvalidUrlException,
+    MlflowException,
+    RestException,
+    get_error_code,
+)
 from mlflow.protos import databricks_pb2
 from mlflow.protos.databricks_pb2 import ENDPOINT_NOT_FOUND, INVALID_PARAMETER_VALUE, ErrorCode
 from mlflow.utils.proto_json_utils import parse_dict
@@ -74,7 +80,8 @@ def http_request(
     backoff_factor = (
         MLFLOW_HTTP_REQUEST_BACKOFF_FACTOR.get() if backoff_factor is None else backoff_factor
     )
-    _validate_retries_and_backoff_values(max_retries, backoff_factor)
+    _validate_max_retries(max_retries)
+    _validate_backoff_factor(backoff_factor)
     respect_retry_after_header = (
         MLFLOW_HTTP_RESPECT_RETRY_AFTER_HEADER.get()
         if respect_retry_after_header is None
@@ -186,38 +193,52 @@ def verify_rest_response(response, endpoint):
     return response
 
 
-def _validate_retries_and_backoff_values(max_retries, backoff_factor):
+def _validate_max_retries(max_retries):
     max_retry_limit = _MLFLOW_HTTP_REQUEST_MAX_RETRIES_LIMIT.get()
+
+    if max_retry_limit < 0:
+        raise MlflowException(
+            message=f"The current maximum retry limit is invalid ({max_retry_limit}). "
+            "Cannot be negative.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+    if max_retries >= max_retry_limit:
+        raise MlflowException(
+            message=f"The configured max_retries value ({max_retries}) is "
+            f"in excess of the maximum allowable retries ({max_retry_limit})",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+    if max_retries < 0:
+        raise MlflowException(
+            message=f"The max_retries value must be either 0 a positive integer. Got {max_retries}",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+
+def _validate_backoff_factor(backoff_factor):
     max_backoff_factor_limit = _MLFLOW_HTTP_REQUEST_MAX_BACKOFF_FACTOR_LIMIT.get()
 
     if max_backoff_factor_limit < 0:
         raise MlflowException(
-            "The current maximum backoff factor limit is invalid "
-            f"({max_backoff_factor_limit}). Cannot be negative."
+            message="The current maximum backoff factor limit is invalid "
+            f"({max_backoff_factor_limit}). Cannot be negative.",
+            error_code=INVALID_PARAMETER_VALUE,
         )
-    if max_retry_limit < 0:
-        raise MlflowException(
-            f"The current maximum retry limit is invalid ({max_retry_limit}). "
-            "Cannot be negative."
-        )
-    if max_retries >= max_retry_limit:
-        raise MlflowException(
-            f"The configured max_retries ({max_retries}) are "
-            f"in excess of the maximum allowable retries ({max_retry_limit})"
-        )
+
     if backoff_factor >= max_backoff_factor_limit:
         raise MlflowException(
-            f"The configured backoff_factor ({backoff_factor}) are in excess "
+            message=f"The configured backoff_factor value ({backoff_factor}) is in excess "
             "of the maximum allowable backoff_factor limit "
-            f"({max_backoff_factor_limit})"
+            f"({max_backoff_factor_limit})",
+            error_code=INVALID_PARAMETER_VALUE,
         )
-    if max_retries < 0:
-        raise MlflowException(
-            f"The max_retries value must be either 0 a positive integer. Got {max_retries}"
-        )
+
     if backoff_factor < 0:
         raise MlflowException(
-            f"The backoff_factor value must be either 0 a positive integer. Got {backoff_factor}"
+            message="The backoff_factor value must be either 0 a positive integer. "
+            f"Got {backoff_factor}",
+            error_code=INVALID_PARAMETER_VALUE,
         )
 
 

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -602,3 +602,45 @@ def test_provide_redirect_kwarg():
             verify=mock.ANY,
             timeout=120,
         )
+
+
+def test_http_request_max_retries(monkeypatch):
+    monkeypatch.setenv("_MLFLOW_HTTP_REQUEST_MAX_RETRIES_LIMIT", "15")
+    host_creds = MlflowHostCreds("http://example.com")
+
+    with mock.patch("requests.Session.request") as mock_request:
+        with pytest.raises(MlflowException, match="The configured max_retries"):
+            http_request(host_creds, "/endpoint", "GET", max_retries=16)
+        mock_request.assert_not_called()
+        http_request(host_creds, "/endpoint", "GET", max_retries=3)
+        mock_request.assert_called()
+
+
+def test_http_request_backoff_factor(monkeypatch):
+    monkeypatch.setenv("_MLFLOW_HTTP_REQUEST_MAX_BACKOFF_FACTOR_LIMIT", "200")
+    host_creds = MlflowHostCreds("http://example.com")
+
+    with mock.patch("requests.Session.request") as mock_request:
+        with pytest.raises(MlflowException, match="The configured backoff_factor"):
+            http_request(host_creds, "/endpoint", "GET", backoff_factor=250)
+        mock_request.assert_not_called()
+        http_request(host_creds, "/endpoint", "GET", backoff_factor=10)
+        mock_request.assert_called()
+
+
+def test_http_request_negative_max_retries():
+    host_creds = MlflowHostCreds("http://example.com")
+
+    with mock.patch("requests.Session.request") as mock_request:
+        with pytest.raises(MlflowException, match="The max_retries value must be either"):
+            http_request(host_creds, "/endpoint", "GET", max_retries=-1)
+        mock_request.assert_not_called()
+
+
+def test_http_request_negative_backoff_factor():
+    host_creds = MlflowHostCreds("http://example.com")
+
+    with mock.patch("requests.Session.request") as mock_request:
+        with pytest.raises(MlflowException, match="The backoff_factor value must be"):
+            http_request(host_creds, "/endpoint", "GET", backoff_factor=-1)
+        mock_request.assert_not_called()

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -613,7 +613,7 @@ def test_http_request_max_retries(monkeypatch):
             http_request(host_creds, "/endpoint", "GET", max_retries=16)
         mock_request.assert_not_called()
         http_request(host_creds, "/endpoint", "GET", max_retries=3)
-        mock_request.assert_called()
+        mock_request.assert_called_once()
 
 
 def test_http_request_backoff_factor(monkeypatch):
@@ -625,7 +625,7 @@ def test_http_request_backoff_factor(monkeypatch):
             http_request(host_creds, "/endpoint", "GET", backoff_factor=250)
         mock_request.assert_not_called()
         http_request(host_creds, "/endpoint", "GET", backoff_factor=10)
-        mock_request.assert_called()
+        mock_request.assert_called_once()
 
 
 def test_http_request_negative_max_retries():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/11590?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11590/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11590
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
