### PR TITLE
Fix comments in proto

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
@@ -71011,7 +71011,7 @@ public final class Service {
      * <pre>
      * A filter expression over trace attributes and tags that allows returning a subset of
      * traces. The syntax is a subset of SQL that supports ANDing together binary operations
-     * Example: ``trace.status = 'OK' and trace.start_time &gt; 1711089570679``.
+     * Example: ``trace.status = 'OK' and trace.timestamp_ms &gt; 1711089570679``.
      * </pre>
      *
      * <code>optional string filter = 2;</code>
@@ -71022,7 +71022,7 @@ public final class Service {
      * <pre>
      * A filter expression over trace attributes and tags that allows returning a subset of
      * traces. The syntax is a subset of SQL that supports ANDing together binary operations
-     * Example: ``trace.status = 'OK' and trace.start_time &gt; 1711089570679``.
+     * Example: ``trace.status = 'OK' and trace.timestamp_ms &gt; 1711089570679``.
      * </pre>
      *
      * <code>optional string filter = 2;</code>
@@ -71033,7 +71033,7 @@ public final class Service {
      * <pre>
      * A filter expression over trace attributes and tags that allows returning a subset of
      * traces. The syntax is a subset of SQL that supports ANDing together binary operations
-     * Example: ``trace.status = 'OK' and trace.start_time &gt; 1711089570679``.
+     * Example: ``trace.status = 'OK' and trace.timestamp_ms &gt; 1711089570679``.
      * </pre>
      *
      * <code>optional string filter = 2;</code>
@@ -71063,7 +71063,7 @@ public final class Service {
 
     /**
      * <pre>
-     * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+     * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
      * </pre>
      *
      * <code>repeated string order_by = 4;</code>
@@ -71073,7 +71073,7 @@ public final class Service {
         getOrderByList();
     /**
      * <pre>
-     * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+     * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
      * </pre>
      *
      * <code>repeated string order_by = 4;</code>
@@ -71082,7 +71082,7 @@ public final class Service {
     int getOrderByCount();
     /**
      * <pre>
-     * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+     * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
      * </pre>
      *
      * <code>repeated string order_by = 4;</code>
@@ -71092,7 +71092,7 @@ public final class Service {
     java.lang.String getOrderBy(int index);
     /**
      * <pre>
-     * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+     * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
      * </pre>
      *
      * <code>repeated string order_by = 4;</code>
@@ -72403,7 +72403,7 @@ public final class Service {
      * <pre>
      * A filter expression over trace attributes and tags that allows returning a subset of
      * traces. The syntax is a subset of SQL that supports ANDing together binary operations
-     * Example: ``trace.status = 'OK' and trace.start_time &gt; 1711089570679``.
+     * Example: ``trace.status = 'OK' and trace.timestamp_ms &gt; 1711089570679``.
      * </pre>
      *
      * <code>optional string filter = 2;</code>
@@ -72417,7 +72417,7 @@ public final class Service {
      * <pre>
      * A filter expression over trace attributes and tags that allows returning a subset of
      * traces. The syntax is a subset of SQL that supports ANDing together binary operations
-     * Example: ``trace.status = 'OK' and trace.start_time &gt; 1711089570679``.
+     * Example: ``trace.status = 'OK' and trace.timestamp_ms &gt; 1711089570679``.
      * </pre>
      *
      * <code>optional string filter = 2;</code>
@@ -72442,7 +72442,7 @@ public final class Service {
      * <pre>
      * A filter expression over trace attributes and tags that allows returning a subset of
      * traces. The syntax is a subset of SQL that supports ANDing together binary operations
-     * Example: ``trace.status = 'OK' and trace.start_time &gt; 1711089570679``.
+     * Example: ``trace.status = 'OK' and trace.timestamp_ms &gt; 1711089570679``.
      * </pre>
      *
      * <code>optional string filter = 2;</code>
@@ -72494,7 +72494,7 @@ public final class Service {
     private com.google.protobuf.LazyStringList orderBy_;
     /**
      * <pre>
-     * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+     * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
      * </pre>
      *
      * <code>repeated string order_by = 4;</code>
@@ -72506,7 +72506,7 @@ public final class Service {
     }
     /**
      * <pre>
-     * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+     * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
      * </pre>
      *
      * <code>repeated string order_by = 4;</code>
@@ -72517,7 +72517,7 @@ public final class Service {
     }
     /**
      * <pre>
-     * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+     * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
      * </pre>
      *
      * <code>repeated string order_by = 4;</code>
@@ -72529,7 +72529,7 @@ public final class Service {
     }
     /**
      * <pre>
-     * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+     * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
      * </pre>
      *
      * <code>repeated string order_by = 4;</code>
@@ -73185,7 +73185,7 @@ public final class Service {
        * <pre>
        * A filter expression over trace attributes and tags that allows returning a subset of
        * traces. The syntax is a subset of SQL that supports ANDing together binary operations
-       * Example: ``trace.status = 'OK' and trace.start_time &gt; 1711089570679``.
+       * Example: ``trace.status = 'OK' and trace.timestamp_ms &gt; 1711089570679``.
        * </pre>
        *
        * <code>optional string filter = 2;</code>
@@ -73198,7 +73198,7 @@ public final class Service {
        * <pre>
        * A filter expression over trace attributes and tags that allows returning a subset of
        * traces. The syntax is a subset of SQL that supports ANDing together binary operations
-       * Example: ``trace.status = 'OK' and trace.start_time &gt; 1711089570679``.
+       * Example: ``trace.status = 'OK' and trace.timestamp_ms &gt; 1711089570679``.
        * </pre>
        *
        * <code>optional string filter = 2;</code>
@@ -73222,7 +73222,7 @@ public final class Service {
        * <pre>
        * A filter expression over trace attributes and tags that allows returning a subset of
        * traces. The syntax is a subset of SQL that supports ANDing together binary operations
-       * Example: ``trace.status = 'OK' and trace.start_time &gt; 1711089570679``.
+       * Example: ``trace.status = 'OK' and trace.timestamp_ms &gt; 1711089570679``.
        * </pre>
        *
        * <code>optional string filter = 2;</code>
@@ -73245,7 +73245,7 @@ public final class Service {
        * <pre>
        * A filter expression over trace attributes and tags that allows returning a subset of
        * traces. The syntax is a subset of SQL that supports ANDing together binary operations
-       * Example: ``trace.status = 'OK' and trace.start_time &gt; 1711089570679``.
+       * Example: ``trace.status = 'OK' and trace.timestamp_ms &gt; 1711089570679``.
        * </pre>
        *
        * <code>optional string filter = 2;</code>
@@ -73266,7 +73266,7 @@ public final class Service {
        * <pre>
        * A filter expression over trace attributes and tags that allows returning a subset of
        * traces. The syntax is a subset of SQL that supports ANDing together binary operations
-       * Example: ``trace.status = 'OK' and trace.start_time &gt; 1711089570679``.
+       * Example: ``trace.status = 'OK' and trace.timestamp_ms &gt; 1711089570679``.
        * </pre>
        *
        * <code>optional string filter = 2;</code>
@@ -73282,7 +73282,7 @@ public final class Service {
        * <pre>
        * A filter expression over trace attributes and tags that allows returning a subset of
        * traces. The syntax is a subset of SQL that supports ANDing together binary operations
-       * Example: ``trace.status = 'OK' and trace.start_time &gt; 1711089570679``.
+       * Example: ``trace.status = 'OK' and trace.timestamp_ms &gt; 1711089570679``.
        * </pre>
        *
        * <code>optional string filter = 2;</code>
@@ -73364,7 +73364,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+       * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
        * </pre>
        *
        * <code>repeated string order_by = 4;</code>
@@ -73376,7 +73376,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+       * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
        * </pre>
        *
        * <code>repeated string order_by = 4;</code>
@@ -73387,7 +73387,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+       * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
        * </pre>
        *
        * <code>repeated string order_by = 4;</code>
@@ -73399,7 +73399,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+       * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
        * </pre>
        *
        * <code>repeated string order_by = 4;</code>
@@ -73412,7 +73412,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+       * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
        * </pre>
        *
        * <code>repeated string order_by = 4;</code>
@@ -73432,7 +73432,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+       * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
        * </pre>
        *
        * <code>repeated string order_by = 4;</code>
@@ -73451,7 +73451,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+       * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
        * </pre>
        *
        * <code>repeated string order_by = 4;</code>
@@ -73468,7 +73468,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+       * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
        * </pre>
        *
        * <code>repeated string order_by = 4;</code>
@@ -73482,7 +73482,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+       * List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
        * </pre>
        *
        * <code>repeated string order_by = 4;</code>

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -456,8 +456,8 @@ service MlflowService {
   }
 
   // Search for traces that satisfy specified filters
-  // (e.g. ``trace.status = 'OK' and trace.start_time > 1711089570679``), and retrieve the traces
-  // in a specified ordering (e.g. ``["start_time DESC"]``).
+  // (e.g. ``trace.status = 'OK' and trace.timestamp_ms > 1711089570679``), and retrieve the traces
+  // in a specified ordering (e.g. ``["timestamp_ms DESC"]``).
   rpc searchTraces (SearchTraces) returns (SearchTraces.Response) {
     option (rpc) = {
       endpoints: [{
@@ -1330,13 +1330,13 @@ message SearchTraces {
 
   // A filter expression over trace attributes and tags that allows returning a subset of
   // traces. The syntax is a subset of SQL that supports ANDing together binary operations
-  // Example: ``trace.status = 'OK' and trace.start_time > 1711089570679``.
+  // Example: ``trace.status = 'OK' and trace.timestamp_ms > 1711089570679``.
   optional string filter = 2;
 
   // Maximum number of traces desired. Max threshold is 500.
   optional int32 max_results = 3 [default = 100];
 
-  // List of columns for ordering the results, e.g. ``["start_time DESC"]``.
+  // List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.
   repeated string order_by = 4;
 
   // Token indicating the page of traces to fetch.


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix comments in proto (`start_time` -> `timestamp_ms`).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
