### PR TITLE
Add type hint and code example for parent_span arg

### DIFF
--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -29,9 +29,24 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
     Callback for auto-logging traces.
     We need to inherit ExceptionSafeAbstractClass to avoid invalid new
     input arguments added to original function call.
+    Args:
+        parent_span: Optional parent span for the trace. If provided, the trace
+                     will be created as child of this span. Otherwise, a single trace
+                     will be created. Example usage:
+
+                     .. code-block:: python
+                        from mlflow.langchain.langchain_tracer import MlflowLangchainTracer
+                        from langchain_community.chat_models import ChatDatabricks
+
+                        chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat")
+                        with mlflow.start_span("Custom root span") as root_span:
+                            chat_model.invoke(
+                                "What is MLflow",
+                                config={"callbacks": [MlflowLangchainTracer(root_span)]},
+                            )
     """
 
-    def __init__(self, parent_span=None):
+    def __init__(self, parent_span: MlflowSpanWrapper = None):
         super().__init__()
         self._mlflow_client = MlflowClient()
         self._parent_span = parent_span

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -29,24 +29,26 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
     Callback for auto-logging traces.
     We need to inherit ExceptionSafeAbstractClass to avoid invalid new
     input arguments added to original function call.
+
     Args:
-        parent_span: Optional parent span for the trace. If provided, the trace
-                     will be created as child of this span. Otherwise, a single trace
-                     will be created. Example usage:
+        parent_span: Optional parent span for the trace. If provided, spans will be
+            created under the given parent span. Otherwise, a single trace will be
+            created. Example usage:
 
-                     .. code-block:: python
-                        from mlflow.langchain.langchain_tracer import MlflowLangchainTracer
-                        from langchain_community.chat_models import ChatDatabricks
+            .. code-block:: python
 
-                        chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat")
-                        with mlflow.start_span("Custom root span") as root_span:
-                            chat_model.invoke(
-                                "What is MLflow",
-                                config={"callbacks": [MlflowLangchainTracer(root_span)]},
-                            )
+                from mlflow.langchain.langchain_tracer import MlflowLangchainTracer
+                from langchain_community.chat_models import ChatDatabricks
+
+                chat_model = ChatDatabricks(endpoint="databricks-llama-2-70b-chat")
+                with mlflow.start_span("Custom root span") as root_span:
+                    chat_model.invoke(
+                        "What is MLflow?",
+                        config={"callbacks": [MlflowLangchainTracer(root_span)]},
+                    )
     """
 
-    def __init__(self, parent_span: MlflowSpanWrapper = None):
+    def __init__(self, parent_span: Optional[MlflowSpanWrapper] = None):
         super().__init__()
         self._mlflow_client = MlflowClient()
         self._parent_span = parent_span


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/11599?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11599/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11599
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
