### PR TITLE
Delete registered model permission upon model deletion

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -502,6 +502,21 @@ def set_can_manage_registered_model_permission(resp: Response):
     store.create_registered_model_permission(name, username, MANAGE.name)
 
 
+def delete_can_manage_registered_model_permission(resp: Response):
+    """
+    Delete registered model permission when the model is deleted.
+
+    We need to do this because the primary key of the registered model is the name,
+    unlike the experiment where the primary key is experiment_id (UUID). Therefore,
+    we have to delete the permission record when the model is deleted otherwise it
+    conflicts with the new model registered with the same name.
+    """
+    # Get model name from request context because it's not available in the response
+    name = request.get_json(force=True, silent=True)["name"]
+    username = authenticate_request().username
+    store.delete_registered_model_permission(name, username)
+
+
 def filter_search_experiments(resp: Response):
     if sender_is_admin():
         return
@@ -610,6 +625,7 @@ def filter_search_registered_models(resp: Response):
 AFTER_REQUEST_PATH_HANDLERS = {
     CreateExperiment: set_can_manage_experiment_permission,
     CreateRegisteredModel: set_can_manage_registered_model_permission,
+    DeleteRegisteredModel: delete_can_manage_registered_model_permission,
     SearchExperiments: filter_search_experiments,
     SearchRegisteredModels: filter_search_registered_models,
 }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11601?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11601/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11601
```

</p>
</details>

### Related Issues/PRs

Fix #11591

### What changes are proposed in this pull request?

When a model is registered via an auth-enabled tracking server, it will create a permission record in the auth table `(model_name (pk), user, permission)`. However, this record is not deleted even when a model is deleted. As a result, if we try to create a model with the same name, it will fail due to breaking uniqueness constraint. Please see the linked issue for repro example.

This PR adds an after-request hook to delete the permission record upon model deletion.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested with a local auth-enabled tracking server:

<img width="1210" alt="Screenshot 2024-04-03 at 14 40 24" src="https://github.com/mlflow/mlflow/assets/31463517/8b5b4ae6-49a3-4cbd-9a28-c4bb54cbd702">



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Update the model registry to delete model permission record upon model deletion. This will unblock re-creating a new model with the same name after deletion.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
