### PR TITLE
Implement `delete_traces`

### DIFF
--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -270,7 +270,7 @@ class AbstractStore:
         max_timestamp_millis: Optional[int] = None,
         max_traces: Optional[int] = None,
         request_ids: Optional[List[str]] = None,
-    ):
+    ) -> None:
         """
         Delete traces based on the specified criteria.
 

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -264,6 +264,25 @@ class AbstractStore:
         """
         raise NotImplementedError
 
+    def delete_traces(
+        self,
+        experiment_id: str,
+        max_timestamp_millis: Optional[int] = None,
+        max_traces: Optional[int] = None,
+        request_ids: Optional[List[str]] = None,
+    ):
+        """
+        Delete traces based on the specified criteria.
+
+        Args:
+            experiment_id: ID of the associated experiment.
+            max_timestamp_millis: The maximum timestamp in milliseconds since the UNIX epoch for
+                deleting traces.
+            max_traces: The maximum number of traces to delete.
+            request_ids: A set of request IDs to delete.
+        """
+        raise NotImplementedError
+
     def get_trace_info(self, request_id: str) -> TraceInfo:
         """
         Get the trace matching the `request_id`.

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -274,6 +274,9 @@ class AbstractStore:
         """
         Delete traces based on the specified criteria.
 
+        - Either `max_timestamp_millis` or `request_ids` must be specified, but not both.
+        - `max_traces` can't be specified if `request_ids` is specified.
+
         Args:
             experiment_id: ID of the associated experiment.
             max_timestamp_millis: The maximum timestamp in milliseconds since the UNIX epoch for

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -257,7 +257,7 @@ class RestStore(AbstractStore):
         max_timestamp_millis: Optional[int] = None,
         max_traces: Optional[int] = None,
         request_ids: Optional[List[str]] = None,
-    ):
+    ) -> None:
         req_body = message_to_json(
             DeleteTraces(
                 experiment_id=experiment_id,

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -10,6 +10,7 @@ from mlflow.protos.service_pb2 import (
     DeleteExperiment,
     DeleteRun,
     DeleteTag,
+    DeleteTraces,
     GetExperiment,
     GetExperimentByName,
     GetMetricHistory,
@@ -249,6 +250,23 @@ class RestStore(AbstractStore):
         )
         response_proto = self._call_endpoint(CreateTrace, req_body)
         return TraceInfo.from_proto(response_proto.trace_info)
+
+    def delete_traces(
+        self,
+        experiment_id: str,
+        max_timestamp_millis: Optional[int] = None,
+        max_traces: Optional[int] = None,
+        request_ids: Optional[List[str]] = None,
+    ):
+        req_body = message_to_json(
+            DeleteTraces(
+                experiment_id=experiment_id,
+                max_timestamp_millis=max_timestamp_millis,
+                max_traces=max_traces,
+                request_ids=request_ids,
+            )
+        )
+        self._call_endpoint(DeleteTraces, req_body)
 
     def get_trace_info(self, request_id):
         """

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -193,6 +193,20 @@ class TrackingServiceClient:
             tags=tags or {},
         )
 
+    def delete_traces(
+        self,
+        experiment_id: str,
+        max_timestamp_millis: Optional[int] = None,
+        max_traces: Optional[int] = None,
+        request_ids: Optional[List[str]] = None,
+    ):
+        return self.store.delete_traces(
+            experiment_id=experiment_id,
+            max_timestamp_millis=max_timestamp_millis,
+            max_traces=max_traces,
+            request_ids=request_ids,
+        )
+
     def get_trace_info(self, request_id):
         """
         Get the trace matching the `request_id`.

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -199,7 +199,7 @@ class TrackingServiceClient:
         max_timestamp_millis: Optional[int] = None,
         max_traces: Optional[int] = None,
         request_ids: Optional[List[str]] = None,
-    ):
+    ) -> None:
         return self.store.delete_traces(
             experiment_id=experiment_id,
             max_timestamp_millis=max_timestamp_millis,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -435,6 +435,7 @@ class MlflowClient:
     ):
         """
         Delete traces based on the specified criteria.
+
         Args:
             experiment_id: ID of the associated experiment.
             max_timestamp_millis: The maximum timestamp in milliseconds since the UNIX epoch for

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -432,7 +432,7 @@ class MlflowClient:
         max_timestamp_millis: Optional[int] = None,
         max_traces: Optional[int] = None,
         request_ids: Optional[List[str]] = None,
-    ):
+    ) -> None:
         """
         Delete traces based on the specified criteria.
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -433,6 +433,15 @@ class MlflowClient:
         max_traces: Optional[int] = None,
         request_ids: Optional[List[str]] = None,
     ):
+        """
+        Delete traces based on the specified criteria.
+        Args:
+            experiment_id: ID of the associated experiment.
+            max_timestamp_millis: The maximum timestamp in milliseconds since the UNIX epoch for
+                deleting traces.
+            max_traces: The maximum number of traces to delete.
+            request_ids: A set of request IDs to delete.
+        """
         return self._tracking_client.delete_traces(
             experiment_id=experiment_id,
             max_timestamp_millis=max_timestamp_millis,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -436,6 +436,9 @@ class MlflowClient:
         """
         Delete traces based on the specified criteria.
 
+        - Either `max_timestamp_millis` or `request_ids` must be specified, but not both.
+        - `max_traces` can't be specified if `request_ids` is specified.
+
         Args:
             experiment_id: ID of the associated experiment.
             max_timestamp_millis: The maximum timestamp in milliseconds since the UNIX epoch for

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -426,6 +426,20 @@ class MlflowClient:
             tags=tags,
         )
 
+    def delete_traces(
+        self,
+        experiment_id: str,
+        max_timestamp_millis: Optional[int] = None,
+        max_traces: Optional[int] = None,
+        request_ids: Optional[List[str]] = None,
+    ):
+        return self._tracking_client.delete_traces(
+            experiment_id=experiment_id,
+            max_timestamp_millis=max_timestamp_millis,
+            max_traces=max_traces,
+            request_ids=request_ids,
+        )
+
     def get_trace_info(self, request_id: str) -> TraceInfo:
         """
         Get the trace matching the `request_id`.

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -27,6 +27,7 @@ from mlflow.protos.service_pb2 import (
     DeleteExperiment,
     DeleteRun,
     DeleteTag,
+    DeleteTraces,
     GetExperimentByName,
     LogBatch,
     LogInputs,
@@ -570,3 +571,26 @@ def test_search_traces():
             )
         ]
         assert token == "token"
+
+
+def test_delete_traces():
+    creds = MlflowHostCreds("https://hello")
+    store = RestStore(lambda: creds)
+    response = mock.MagicMock()
+    response.status_code = 200
+    request = DeleteTraces(
+        experiment_id="0",
+        max_timestamp_millis=1,
+        max_traces=2,
+        request_ids=["tr-1234"],
+    )
+    response.text = "{}"
+    with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
+        res = store.delete_traces(
+            experiment_id=request.experiment_id,
+            max_timestamp_millis=request.max_timestamp_millis,
+            max_traces=request.max_traces,
+            request_ids=request.request_ids,
+        )
+        _verify_requests(mock_http, creds, "traces/delete-traces", "POST", message_to_json(request))
+        assert res is None

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -194,6 +194,21 @@ def test_client_search_traces():
         )
 
 
+def test_client_delete_traces(mock_store):
+    MlflowClient().delete_traces(
+        experiment_id="0",
+        max_timestamp_millis=1,
+        max_traces=2,
+        request_ids=["tr-1234"],
+    )
+    mock_store.delete_traces.assert_called_once_with(
+        experiment_id="0",
+        max_timestamp_millis=1,
+        max_traces=2,
+        request_ids=["tr-1234"],
+    )
+
+
 def test_start_and_end_trace(clear_singleton, mock_trace_client):
     class TestModel:
         def __init__(self):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11602?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11602/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11602
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Implement `delete_traces`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```python
import mlflow
from mlflow.entities.trace_data import TraceData

mlflow.set_tracking_uri("databricks")
name = "/Users/harutaka.kawamura@databricks.com/test2"
mlflow.set_experiment(name)
exp = mlflow.get_experiment_by_name(name)

client = mlflow.MlflowClient()
trace_info = client.create_trace(
    experiment_id=exp.experiment_id,
    timestamp_ms=5,
    execution_time_ms=5,
    status="OK",
)
print(trace_info)
client._tracking_client._upload_trace_data(
    trace_info.request_id,
    trace_data=TraceData(spans=[]),
)

print("deleting")
client.delete_traces(
    experiment_id=exp.experiment_id,
    request_ids=[trace_info.request_id],
)

try:
    client.get_trace_info(trace_info.request_id)
except Exception as e:
    print(e)
else:
    assert False, "Expected exception"


trace_info = client.create_trace(
    experiment_id=exp.experiment_id,
    timestamp_ms=5,
    execution_time_ms=5,
    status="OK",
)
print(trace_info)
client._tracking_client._upload_trace_data(
    trace_info.request_id,
    trace_data=TraceData(spans=[]),
)

print("deleting")
client.delete_traces(
    experiment_id=exp.experiment_id,
    max_timestamp_millis=3,
)

client.get_trace_info(trace_info.request_id)

```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
