### PR TITLE
Mixedbread provider

### DIFF
--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -68,6 +68,7 @@ class MixedBreadConfig(ConfigModel):
     def validate_mixedbread_api_key(cls, value):
         return _resolve_api_key_from_input(value)
 
+
 class CohereConfig(ConfigModel):
     cohere_api_key: str
 
@@ -240,7 +241,7 @@ config_types = {
     Provider.PALM: PaLMConfig,
     Provider.HUGGINGFACE_TEXT_GENERATION_INFERENCE: HuggingFaceTextGenerationInferenceConfig,
     Provider.MISTRAL: MistralConfig,
-    Provider.MIXEDBREAD: MixedBreadConfig
+    Provider.MIXEDBREAD: MixedBreadConfig,
 }
 
 

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -48,6 +48,7 @@ class Provider(str, Enum):
     DATABRICKS_MODEL_SERVING = "databricks-model-serving"
     DATABRICKS = "databricks"
     MISTRAL = "mistral"
+    MIXEDBREAD = "mixedbread"
 
     @classmethod
     def values(cls):
@@ -59,6 +60,13 @@ class RouteType(str, Enum):
     LLM_V1_CHAT = "llm/v1/chat"
     LLM_V1_EMBEDDINGS = "llm/v1/embeddings"
 
+
+class MixedBreadConfig(ConfigModel):
+    mixedbread_api_key: str
+
+    @validator("mixedbread_api_key", pre=True)
+    def validate_mixedbread_api_key(cls, value):
+        return _resolve_api_key_from_input(value)
 
 class CohereConfig(ConfigModel):
     cohere_api_key: str
@@ -232,6 +240,7 @@ config_types = {
     Provider.PALM: PaLMConfig,
     Provider.HUGGINGFACE_TEXT_GENERATION_INFERENCE: HuggingFaceTextGenerationInferenceConfig,
     Provider.MISTRAL: MistralConfig,
+    Provider.MIXEDBREAD: MixedBreadConfig
 }
 
 
@@ -291,6 +300,7 @@ class Model(ConfigModel):
             HuggingFaceTextGenerationInferenceConfig,
             PaLMConfig,
             MistralConfig,
+            MixedBreadConfig,
         ]
     ] = None
 

--- a/mlflow/gateway/providers/__init__.py
+++ b/mlflow/gateway/providers/__init__.py
@@ -16,6 +16,7 @@ def get_provider(provider: Provider) -> Type[BaseProvider]:
     from mlflow.gateway.providers.mosaicml import MosaicMLProvider
     from mlflow.gateway.providers.openai import OpenAIProvider
     from mlflow.gateway.providers.palm import PaLMProvider
+    from mlflow.gateway.providers.mixedbread import MixedBreadProvider
 
     provider_to_class = {
         Provider.OPENAI: OpenAIProvider,
@@ -28,6 +29,7 @@ def get_provider(provider: Provider) -> Type[BaseProvider]:
         Provider.HUGGINGFACE_TEXT_GENERATION_INFERENCE: HFTextGenerationInferenceServerProvider,
         Provider.BEDROCK: AmazonBedrockProvider,
         Provider.MISTRAL: MistralProvider,
+        Provider.MIXEDBREAD: MixedBreadProvider
     }
     if prov := provider_to_class.get(provider):
         return prov

--- a/mlflow/gateway/providers/__init__.py
+++ b/mlflow/gateway/providers/__init__.py
@@ -12,11 +12,11 @@ def get_provider(provider: Provider) -> Type[BaseProvider]:
     from mlflow.gateway.providers.cohere import CohereProvider
     from mlflow.gateway.providers.huggingface import HFTextGenerationInferenceServerProvider
     from mlflow.gateway.providers.mistral import MistralProvider
+    from mlflow.gateway.providers.mixedbread import MixedBreadProvider
     from mlflow.gateway.providers.mlflow import MlflowModelServingProvider
     from mlflow.gateway.providers.mosaicml import MosaicMLProvider
     from mlflow.gateway.providers.openai import OpenAIProvider
     from mlflow.gateway.providers.palm import PaLMProvider
-    from mlflow.gateway.providers.mixedbread import MixedBreadProvider
 
     provider_to_class = {
         Provider.OPENAI: OpenAIProvider,
@@ -29,7 +29,7 @@ def get_provider(provider: Provider) -> Type[BaseProvider]:
         Provider.HUGGINGFACE_TEXT_GENERATION_INFERENCE: HFTextGenerationInferenceServerProvider,
         Provider.BEDROCK: AmazonBedrockProvider,
         Provider.MISTRAL: MistralProvider,
-        Provider.MIXEDBREAD: MixedBreadProvider
+        Provider.MIXEDBREAD: MixedBreadProvider,
     }
     if prov := provider_to_class.get(provider):
         return prov

--- a/mlflow/gateway/providers/mixedbread.py
+++ b/mlflow/gateway/providers/mixedbread.py
@@ -4,9 +4,9 @@ from typing import Any, Dict
 from fastapi import HTTPException
 
 from mlflow.exceptions import MlflowException
-from mlflow.gateway.config import RouteConfig, MixedBreadConfig
+from mlflow.gateway.config import MixedBreadConfig, RouteConfig
 from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
-from mlflow.gateway.providers.utils import rename_payload_keys, send_request
+from mlflow.gateway.providers.utils import send_request
 from mlflow.gateway.schemas import embeddings
 
 
@@ -43,11 +43,11 @@ class MixedBreadAdapter(ProviderAdapter):
         #   "normalized": true
         #}
 
-        usage = resp.get("usage") 
+        usage = resp.get("usage")
         prompt_tokens = None
         total_tokens = None
         # if usage is not None
-        if usage: 
+        if usage:
             prompt_tokens = usage.get("prompt_tokens")
             total_tokens = usage.get("total_tokens")
 
@@ -72,14 +72,14 @@ class MixedBreadAdapter(ProviderAdapter):
 
         #TODO maybe let the end API handle these?
 
-        if "encoding_format" in payload: 
+        if "encoding_format" in payload:
             raise HTTPException(
-                status_code=422, 
+                status_code=422,
                 detail=("Parameter encoding_format in payload."
                 "Mixedbread does not support encoding_format.")
             )
 
-        if "dimensions" in payload: 
+        if "dimensions" in payload:
             raise HTTPException(
                 "Invalid parameter dimensions in payload."
                 "The parameter is not supported in mixedbread."
@@ -90,11 +90,11 @@ class MixedBreadAdapter(ProviderAdapter):
                 "Invalid parameter user in payload."
                 "The parameter is not supported in mixedbread."
             )
-       
+
         return payload
 
 class MixedBreadProvider(BaseProvider):
-    
+
     NAME = "MixedBread"
 
     @property
@@ -102,21 +102,21 @@ class MixedBreadProvider(BaseProvider):
         return "https://api.mixedbread.ai/v1/"
 
     @property
-    def auth_headers(self): 
+    def auth_headers(self):
 
         return {"Authorization": f"Bearer {self.mixedbread_config.mixedbread_api_key}"}
 
     async def _request(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
 
         return await send_request(
-            headers=self.auth_headers, 
-            base_url=self.base_url, 
+            headers=self.auth_headers,
+            base_url=self.base_url,
             path=path,
             payload=payload
         )
 
     def __init__(self, config: RouteConfig) -> None:
-        
+
         super().__init__(config)
 
         if config.model.config is None or not isinstance(config.model.config,MixedBreadConfig):
@@ -126,10 +126,10 @@ class MixedBreadProvider(BaseProvider):
 
         self.mixedbread_config: MixedBreadConfig = config.model.config
 
-        
+
 
     async def embeddings(
-        self, 
+        self,
         payload: embeddings.RequestPayload
     ) -> embeddings.ResponsePayload:
 

--- a/mlflow/gateway/providers/mixedbread.py
+++ b/mlflow/gateway/providers/mixedbread.py
@@ -1,0 +1,149 @@
+
+from typing import Any, Dict
+
+from fastapi import HTTPException
+
+from mlflow.exceptions import MlflowException
+from mlflow.gateway.config import RouteConfig, MixedBreadConfig
+from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
+from mlflow.gateway.providers.utils import rename_payload_keys, send_request
+from mlflow.gateway.schemas import embeddings
+
+
+class MixedBreadAdapter(ProviderAdapter):
+
+    @classmethod
+    def embeddings_to_model(cls, resp, config):
+        # Example from API reference(https://www.mixedbread.ai/api-reference/endpoints/embeddings#create-embeddings):
+        #{
+        #   "model": "UAE-Large-V1",
+        #   "data": [
+        #      {
+        #          "embedding": [
+        #             0.1,
+        #             0.06069,
+        #             ...
+        #          ],
+        #          "index": 0
+        #      },
+        #      {
+        #          "embedding": [
+        #              -0.1,
+        #              0.3,
+        #              ...
+        #          ],
+        #          "index": 1,
+        #          "truncated": true
+        #      }
+        #   ],
+        #   "usage":{
+        #      "prompt_tokens": 420,
+        #      "total_tokens": 420
+        #   },
+        #   "normalized": true
+        #}
+
+        usage = resp.get("usage") 
+        prompt_tokens = None
+        total_tokens = None
+        # if usage is not None
+        if usage: 
+            prompt_tokens = usage.get("prompt_tokens")
+            total_tokens = usage.get("total_tokens")
+
+        return embeddings.ResponsePayload(
+            model=config.model.name,
+            data=[
+                embeddings.EmbeddingObject(
+                    index=idx,
+                    embedding=embedding_item['embedding'],
+                )
+                for idx, embedding_item in enumerate(resp.get("data", []))
+                if 'embedding' in embedding_item
+            ],
+            usage=embeddings.EmbeddingsUsage(
+                prompt_tokens=prompt_tokens,
+                total_tokens=total_tokens
+            ),
+        )
+
+    @classmethod
+    def model_to_embeddings(cls, payload, config):
+
+        #TODO maybe let the end API handle these?
+
+        if "encoding_format" in payload: 
+            raise HTTPException(
+                status_code=422, 
+                detail=("Parameter encoding_format in payload."
+                "Mixedbread does not support encoding_format.")
+            )
+
+        if "dimensions" in payload: 
+            raise HTTPException(
+                "Invalid parameter dimensions in payload."
+                "The parameter is not supported in mixedbread."
+            )
+
+        if "user" in payload:
+            raise HTTPException(
+                "Invalid parameter user in payload."
+                "The parameter is not supported in mixedbread."
+            )
+       
+        return payload
+
+class MixedBreadProvider(BaseProvider):
+    
+    NAME = "MixedBread"
+
+    @property
+    def base_url(self):
+        return "https://api.mixedbread.ai/v1/"
+
+    @property
+    def auth_headers(self): 
+
+        return {"Authorization": f"Bearer {self.mixedbread_config.mixedbread_api_key}"}
+
+    async def _request(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+
+        return await send_request(
+            headers=self.auth_headers, 
+            base_url=self.base_url, 
+            path=path,
+            payload=payload
+        )
+
+    def __init__(self, config: RouteConfig) -> None:
+        
+        super().__init__(config)
+
+        if config.model.config is None or not isinstance(config.model.config,MixedBreadConfig):
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid config type {config.model.config}"
+            )
+
+        self.mixedbread_config: MixedBreadConfig = config.model.config
+
+        
+
+    async def embeddings(
+        self, 
+        payload: embeddings.RequestPayload
+    ) -> embeddings.ResponsePayload:
+
+        from fastapi.encoders import jsonable_encoder
+
+
+        payload = jsonable_encoder(payload, exclude_none=True)
+
+        resp = await self._request(
+            path="embeddings",
+            payload={
+                "model": self.config.model.name,
+                **MixedBreadAdapter.model_to_embeddings(payload, self.config)
+            }
+        )
+
+        return MixedBreadAdapter.embeddings_to_model(resp, self.config)

--- a/tests/gateway/providers/test_mixedbread.py
+++ b/tests/gateway/providers/test_mixedbread.py
@@ -25,6 +25,7 @@ def embeddings_config():
         },
     }
 
+
 def embeddings_response():
     return {
         "id": "bc57846a-3e56-4327-8acc-588ca1a37b8a",
@@ -49,6 +50,7 @@ def embeddings_response():
         "normalized": True,  # Corrected from 'true' to 'True'
     }
 
+
 @pytest.mark.asyncio
 async def test_embeddings():
     resp = embeddings_response()
@@ -56,14 +58,10 @@ async def test_embeddings():
     with mock.patch("time.time", return_value=1677858242), mock.patch(
         "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
     ) as mock_post:
-
         provider = MixedBreadProvider(RouteConfig(**config))
         payload = {
-            "input": [
-                'Who is german and likes bread?',
-                'Everybody in Germany.'
-            ],
-            "model": 'UAE-Large-V1',
+            "input": ["Who is german and likes bread?", "Everybody in Germany."],
+            "model": "UAE-Large-V1",
         }
         response = await provider.embeddings(embeddings.RequestPayload(**payload))
 
@@ -92,11 +90,8 @@ async def test_embeddings():
         mock_post.assert_called_once_with(
             "https://api.mixedbread.ai/v1/embeddings",
             json={
-                "input": [
-                    'Who is german and likes bread?',
-                    'Everybody in Germany.'
-                ],
-                "model": "UAE-Large-V1"
+                "input": ["Who is german and likes bread?", "Everybody in Germany."],
+                "model": "UAE-Large-V1",
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )

--- a/tests/gateway/providers/test_mixedbread.py
+++ b/tests/gateway/providers/test_mixedbread.py
@@ -1,0 +1,103 @@
+from unittest import mock
+
+import pytest
+from aiohttp import ClientTimeout
+from fastapi import HTTPException
+from fastapi.encoders import jsonable_encoder
+from pydantic import ValidationError
+
+from mlflow.gateway.config import RouteConfig
+from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
+from mlflow.gateway.providers.mixedbread import MixedBreadProvider
+from mlflow.gateway.schemas import embeddings
+
+from tests.gateway.tools import MockAsyncResponse
+
+def embeddings_config():
+    return {
+        "name": "embeddings",
+        "route_type": "llm/v1/embeddings",
+        "model": {
+            "provider": "mixedbread",
+            "name": "UAE-Large-V1",
+            "config": {
+                "mixedbread_api_key": "key",
+            },
+        },
+    }
+
+def embeddings_response():
+    return {
+        "id": "bc57846a-3e56-4327-8acc-588ca1a37b8a",
+        "object": "list",
+        "data": [
+            {
+                "object": "embedding",
+                "embedding": [
+                    3.25,
+                    0.7685547,
+                    2.65625,
+                    -0.30126953,
+                    -2.3554688,
+                    1.2597656,
+                ],
+                "index": 0,
+                "truncated": True,  # Corrected from 'true' to 'True'
+            }
+        ],
+        "model": "UAE-Large-V1",
+        "usage": {"prompt_tokens": 420, "total_tokens": 420},
+        "normalized": True,  # Corrected from 'true' to 'True'
+    }
+
+@pytest.mark.asyncio
+async def test_embeddings():
+    resp = embeddings_response()
+    config = embeddings_config()
+    with mock.patch("time.time", return_value=1677858242), mock.patch(
+        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+    ) as mock_post:
+
+        provider = MixedBreadProvider(RouteConfig(**config))
+        payload = {
+            "input": [
+                'Who is german and likes bread?',
+                'Everybody in Germany.'
+            ],
+            "model": 'UAE-Large-V1',
+        }
+        response = await provider.embeddings(embeddings.RequestPayload(**payload))
+
+        expected_response = {
+            "object": "list",  # Corrected to "list" from list
+            "data": [
+                {
+                    "object": "embedding",
+                    "embedding": [
+                        3.25,
+                        0.7685547,
+                        2.65625,
+                        -0.30126953,
+                        -2.3554688,
+                        1.2597656,
+                    ],
+                    "index": 0,
+                }
+            ],
+            "model": "UAE-Large-V1",
+            "usage": {"prompt_tokens": 420, "total_tokens": 420},
+        }
+
+        assert jsonable_encoder(response) == expected_response
+
+        mock_post.assert_called_once_with(
+            "https://api.mixedbread.ai/v1/embeddings",
+            json={
+                "input": [
+                    'Who is german and likes bread?',
+                    'Everybody in Germany.'
+                ],
+                "model": "UAE-Large-V1"
+            },
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
+        )

--- a/tests/gateway/providers/test_mixedbread.py
+++ b/tests/gateway/providers/test_mixedbread.py
@@ -2,9 +2,7 @@ from unittest import mock
 
 import pytest
 from aiohttp import ClientTimeout
-from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
-from pydantic import ValidationError
 
 from mlflow.gateway.config import RouteConfig
 from mlflow.gateway.constants import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
@@ -12,6 +10,7 @@ from mlflow.gateway.providers.mixedbread import MixedBreadProvider
 from mlflow.gateway.schemas import embeddings
 
 from tests.gateway.tools import MockAsyncResponse
+
 
 def embeddings_config():
     return {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/FotiosBistas/mlflow/pull/11606?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11606/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11606
```

</p>
</details>

### Related Issues/PRs

#11530 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests


https://github.com/FotiosBistas/mlflow/blob/mixedbread_provider/tests/gateway/providers/test_mixedbread.py

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add MixedBread provider support in the MLflow deployments server. This means that MixedBread endpoints can be added in the config.yaml file and users can interact with these endpoints from within MLflow. Also done for TogetherAI at #11557 

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
