### PR TITLE
Rename create_trace() client API and make it private

### DIFF
--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -239,7 +239,7 @@ class AbstractStore:
         """
         pass
 
-    def create_trace(
+    def create_trace_info(
         self,
         experiment_id: str,
         timestamp_ms: int,
@@ -249,7 +249,7 @@ class AbstractStore:
         tags: Dict[str, str],
     ) -> TraceInfo:
         """
-        Create a trace under the specified experiment ID.
+        Create a TraceInfo object under the specified experiment ID.
 
         Args:
             experiment_id: String id of the experiment for this run.
@@ -260,7 +260,7 @@ class AbstractStore:
             tags: tags of the trace.
 
         Returns:
-            The created Trace object
+            The created TraceInfo object
         """
         raise NotImplementedError
 

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -201,7 +201,7 @@ class RestStore(AbstractStore):
         response_proto = self._call_endpoint(CreateRun, req_body)
         return Run.from_proto(response_proto.run)
 
-    def create_trace(
+    def create_trace_info(
         self,
         experiment_id,
         timestamp_ms,
@@ -211,7 +211,7 @@ class RestStore(AbstractStore):
         tags,
     ):
         """
-        Create a trace under the specified experiment ID.
+        Create a TraceInfo object under the specified experiment ID.
 
         Args:
             experiment_id: String id of the experiment for this run.
@@ -222,7 +222,7 @@ class RestStore(AbstractStore):
             tags: tags of the trace.
 
         Returns:
-            The created Trace object
+            The created TraceInfo object
         """
         request_metadata_proto = []
         for key, value in request_metadata.items():

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -159,7 +159,7 @@ class TrackingServiceClient:
             run_name=run_name,
         )
 
-    def create_trace(
+    def create_trace_info(
         self,
         experiment_id,
         timestamp_ms,
@@ -168,7 +168,7 @@ class TrackingServiceClient:
         request_metadata=None,
         tags=None,
     ):
-        """Create a trace object and log in the backend store.
+        """Create a TraceInfo object and log in the backend store.
 
         Args:
             experiment_id: String id of the experiment for this run.
@@ -179,9 +179,9 @@ class TrackingServiceClient:
             tags: dict, tags of the trace.
 
         Returns:
-            The created Trace object.
+            The created TraceInfo object.
         """
-        return self.store.create_trace(
+        return self.store.create_trace_info(
             experiment_id=experiment_id,
             timestamp_ms=timestamp_ms,
             execution_time_ms=execution_time_ms,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -379,7 +379,7 @@ class MlflowClient:
         """
         return self._tracking_client.create_run(experiment_id, start_time, tags, run_name)
 
-    def create_trace(
+    def _create_trace_info(
         self,
         experiment_id,
         timestamp_ms,
@@ -388,7 +388,7 @@ class MlflowClient:
         request_metadata=None,
         tags=None,
     ):
-        """Create a trace object and log in the backend store.
+        """Create a TraceInfo object and log in the backend store.
 
         Args:
             experiment_id: String id of the experiment for this run.
@@ -400,24 +400,8 @@ class MlflowClient:
 
         Returns:
             :py:class:`mlflow.entities.TraceInfo` that was created.
-
-        .. code-block:: python
-            :caption: Example
-
-            from mlflow import MlflowClient
-
-            client = MlflowClient()
-            experiment_id = "12345678"
-            tags = {"engineering": "ML Platform"}
-            trace = client.create_trace(
-                experiment_id,
-                start_time=123,
-                end_time=567,
-                status="OK",
-                tags=tags,
-            )
         """
-        return self._tracking_client.create_trace(
+        return self._tracking_client.create_trace_info(
             experiment_id,
             timestamp_ms,
             execution_time_ms,

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -208,7 +208,7 @@ def test_requestor():
             assert expected_kwargs == actual_kwargs
 
     with mock_http_request() as mock_http:
-        store.create_trace(
+        store.create_trace_info(
             experiment_id="447585625682310",
             timestamp_ms=123,
             execution_time_ms=456,

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -138,10 +138,10 @@ def test_client_create_run_with_name(mock_store, mock_time):
     )
 
 
-def test_client_create_trace(mock_store, mock_time):
+def test_client_create_trace_info(mock_store, mock_time):
     experiment_id = mock.Mock()
 
-    MlflowClient().create_trace(
+    MlflowClient()._create_trace_info(
         experiment_id,
         123,
         456,
@@ -150,7 +150,7 @@ def test_client_create_trace(mock_store, mock_time):
         tags={},
     )
 
-    mock_store.create_trace.assert_called_once_with(
+    mock_store.create_trace_info.assert_called_once_with(
         experiment_id=experiment_id,
         timestamp_ms=123,
         execution_time_ms=456,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11612?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11612/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11612
```

</p>
</details>

### What changes are proposed in this pull request?

The `create_trace` API is not designed to be called by users, and the name is confusing with the public `start_trace` API.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
