### PR TITLE
Add `InMemoryTraceClientWithTracking` to log traces

### DIFF
--- a/mlflow/tracing/clients/__init__.py
+++ b/mlflow/tracing/clients/__init__.py
@@ -1,8 +1,13 @@
 from mlflow.tracing.clients.base import TraceClient
-from mlflow.tracing.clients.local import InMemoryTraceClient
+from mlflow.tracing.clients.local import InMemoryTraceClient, InMemoryTraceClientWithTracking
 
-__all__ = ["InMemoryTraceClient", "TraceClient", "get_trace_client"]
+__all__ = [
+    "InMemoryTraceClient",
+    "InMemoryTraceClientWithTracking",
+    "TraceClient",
+    "get_trace_client",
+]
 
 
 def get_trace_client() -> TraceClient:
-    return InMemoryTraceClient.get_instance()
+    return InMemoryTraceClientWithTracking.get_instance()

--- a/mlflow/tracing/clients/__init__.py
+++ b/mlflow/tracing/clients/__init__.py
@@ -1,5 +1,6 @@
 from mlflow.tracing.clients.base import TraceClient
-from mlflow.tracing.clients.local import InMemoryTraceClient, InMemoryTraceClientWithTracking
+from mlflow.tracing.clients.local import InMemoryTraceClient
+from mlflow.tracing.clients.tracking import InMemoryTraceClientWithTracking
 
 __all__ = [
     "InMemoryTraceClient",

--- a/mlflow/tracing/clients/local.py
+++ b/mlflow/tracing/clients/local.py
@@ -71,7 +71,7 @@ class InMemoryTraceClient(TraceClient):
 
 class InMemoryTraceClientWithTracking(InMemoryTraceClient):
     """
-    InMemoryTraceClient with tracking capabilities.
+    `InMemoryTraceClient` with tracking capabilities.
     """
 
     def log_trace(self, trace: Trace):

--- a/mlflow/tracing/clients/local.py
+++ b/mlflow/tracing/clients/local.py
@@ -6,6 +6,7 @@ from mlflow.entities import Trace
 from mlflow.environment_variables import MLFLOW_TRACING_CLIENT_BUFFER_SIZE
 from mlflow.tracing.clients.base import TraceClient
 from mlflow.tracing.display import get_display_handler
+from mlflow.tracking.client import MlflowClient
 
 
 class InMemoryTraceClient(TraceClient):
@@ -66,3 +67,16 @@ class InMemoryTraceClient(TraceClient):
 
     def _flush(self):
         self.queue.clear()
+
+
+class InMemoryTraceClientWithTracking(InMemoryTraceClient):
+    """
+    TODO: Add docstring
+    """
+
+    def log_trace(self, trace: Trace):
+        super().log_trace(trace)
+
+        client = MlflowClient()
+        client._create_trace_info(trace.trace_info)
+        client._upload_trace_data(trace.trace_info.request_id, trace.trace_data)

--- a/mlflow/tracing/clients/local.py
+++ b/mlflow/tracing/clients/local.py
@@ -79,11 +79,11 @@ class InMemoryTraceClientWithTracking(InMemoryTraceClient):
         super().log_trace(trace)
         client = MlflowClient()
         created_info = client._create_trace_info(
-            experiment_id=trace.trace_info.experiment_id,
-            timestamp_ms=trace.trace_info.timestamp_ms,
-            execution_time_ms=trace.trace_info.execution_time_ms,
-            status=trace.trace_info.status,
-            request_metadata=trace.trace_info.request_metadata,
-            tags=trace.trace_info.tags,
+            experiment_id=trace.info.experiment_id,
+            timestamp_ms=trace.info.timestamp_ms,
+            execution_time_ms=trace.info.execution_time_ms,
+            status=trace.info.status,
+            request_metadata=trace.info.request_metadata,
+            tags=trace.info.tags,
         )
-        client._upload_trace_data(created_info, trace.trace_data)
+        client._upload_trace_data(created_info, trace.data)

--- a/mlflow/tracing/clients/local.py
+++ b/mlflow/tracing/clients/local.py
@@ -73,12 +73,15 @@ class InMemoryTraceClientWithTracking(InMemoryTraceClient):
     `InMemoryTraceClient` with tracking capabilities.
     """
 
-    def log_trace(self, trace: Trace):
+    def __init__(self):
         from mlflow.tracking.client import MlflowClient  # avoid circular import
 
+        super().__init__()
+        self._client = MlflowClient()
+
+    def log_trace(self, trace: Trace):
         super().log_trace(trace)
-        client = MlflowClient()
-        created_info = client._create_trace_info(
+        created_info = self._client._create_trace_info(
             experiment_id=trace.info.experiment_id,
             timestamp_ms=trace.info.timestamp_ms,
             execution_time_ms=trace.info.execution_time_ms,
@@ -86,4 +89,4 @@ class InMemoryTraceClientWithTracking(InMemoryTraceClient):
             request_metadata=trace.info.request_metadata,
             tags=trace.info.tags,
         )
-        client._upload_trace_data(created_info, trace.data)
+        self._client._upload_trace_data(created_info, trace.data)

--- a/mlflow/tracing/clients/local.py
+++ b/mlflow/tracing/clients/local.py
@@ -66,27 +66,3 @@ class InMemoryTraceClient(TraceClient):
 
     def _flush(self):
         self.queue.clear()
-
-
-class InMemoryTraceClientWithTracking(InMemoryTraceClient):
-    """
-    `InMemoryTraceClient` with tracking capabilities.
-    """
-
-    def __init__(self):
-        from mlflow.tracking.client import MlflowClient  # avoid circular import
-
-        super().__init__()
-        self._client = MlflowClient()
-
-    def log_trace(self, trace: Trace):
-        super().log_trace(trace)
-        created_info = self._client._create_trace_info(
-            experiment_id=trace.info.experiment_id,
-            timestamp_ms=trace.info.timestamp_ms,
-            execution_time_ms=trace.info.execution_time_ms,
-            status=trace.info.status,
-            request_metadata=trace.info.request_metadata,
-            tags=trace.info.tags,
-        )
-        self._client._upload_trace_data(created_info, trace.data)

--- a/mlflow/tracing/clients/local.py
+++ b/mlflow/tracing/clients/local.py
@@ -6,7 +6,6 @@ from mlflow.entities import Trace
 from mlflow.environment_variables import MLFLOW_TRACING_CLIENT_BUFFER_SIZE
 from mlflow.tracing.clients.base import TraceClient
 from mlflow.tracing.display import get_display_handler
-from mlflow.tracking.client import MlflowClient
 
 
 class InMemoryTraceClient(TraceClient):

--- a/mlflow/tracing/clients/local.py
+++ b/mlflow/tracing/clients/local.py
@@ -75,6 +75,8 @@ class InMemoryTraceClientWithTracking(InMemoryTraceClient):
     """
 
     def log_trace(self, trace: Trace):
+        from mlflow.tracking.client import MlflowClient  # avoid circular import
+
         super().log_trace(trace)
         client = MlflowClient()
         client._create_trace_info(trace.trace_info)

--- a/mlflow/tracing/clients/local.py
+++ b/mlflow/tracing/clients/local.py
@@ -23,7 +23,7 @@ class InMemoryTraceClient(TraceClient):
         # NB: Only implement the minimal singleton functionality but not thread-safety.
         #     as this is intended to be used in a demonstration and testing purpose.
         if cls._instance is None:
-            cls._instance = InMemoryTraceClient()
+            cls._instance = cls()
         return cls._instance
 
     def __init__(self):
@@ -79,5 +79,12 @@ class InMemoryTraceClientWithTracking(InMemoryTraceClient):
 
         super().log_trace(trace)
         client = MlflowClient()
-        client._create_trace_info(trace.trace_info)
+        client._create_trace_info(
+            experiment_id=trace.trace_info.experiment_id,
+            timestamp_ms=trace.trace_info.timestamp_ms,
+            execution_time_ms=trace.trace_info.execution_time_ms,
+            status=trace.trace_info.status,
+            request_metadata=trace.trace_info.request_metadata,
+            tags=trace.trace_info.tags,
+        )
         client._upload_trace_data(trace.trace_info, trace.trace_data)

--- a/mlflow/tracing/clients/local.py
+++ b/mlflow/tracing/clients/local.py
@@ -79,7 +79,7 @@ class InMemoryTraceClientWithTracking(InMemoryTraceClient):
 
         super().log_trace(trace)
         client = MlflowClient()
-        client._create_trace_info(
+        created_info = client._create_trace_info(
             experiment_id=trace.trace_info.experiment_id,
             timestamp_ms=trace.trace_info.timestamp_ms,
             execution_time_ms=trace.trace_info.execution_time_ms,
@@ -87,4 +87,4 @@ class InMemoryTraceClientWithTracking(InMemoryTraceClient):
             request_metadata=trace.trace_info.request_metadata,
             tags=trace.trace_info.tags,
         )
-        client._upload_trace_data(trace.trace_info, trace.trace_data)
+        client._upload_trace_data(created_info, trace.trace_data)

--- a/mlflow/tracing/clients/local.py
+++ b/mlflow/tracing/clients/local.py
@@ -71,12 +71,11 @@ class InMemoryTraceClient(TraceClient):
 
 class InMemoryTraceClientWithTracking(InMemoryTraceClient):
     """
-    TODO: Add docstring
+    InMemoryTraceClient with tracking capabilities.
     """
 
     def log_trace(self, trace: Trace):
         super().log_trace(trace)
-
         client = MlflowClient()
         client._create_trace_info(trace.trace_info)
-        client._upload_trace_data(trace.trace_info.request_id, trace.trace_data)
+        client._upload_trace_data(trace.trace_info, trace.trace_data)

--- a/mlflow/tracing/clients/tracking.py
+++ b/mlflow/tracing/clients/tracking.py
@@ -1,0 +1,26 @@
+from mlflow.entities import Trace
+from mlflow.tracing.clients.local import InMemoryTraceClient
+
+
+class InMemoryTraceClientWithTracking(InMemoryTraceClient):
+    """
+    `InMemoryTraceClient` with tracking capabilities.
+    """
+
+    def __init__(self):
+        from mlflow.tracking.client import MlflowClient  # avoid circular import
+
+        super().__init__()
+        self._client = MlflowClient()
+
+    def log_trace(self, trace: Trace):
+        super().log_trace(trace)
+        created_info = self._client._create_trace_info(
+            experiment_id=trace.info.experiment_id,
+            timestamp_ms=trace.info.timestamp_ms,
+            execution_time_ms=trace.info.execution_time_ms,
+            status=trace.info.status,
+            request_metadata=trace.info.request_metadata,
+            tags=trace.info.tags,
+        )
+        self._client._upload_trace_data(created_info, trace.data)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -34,6 +34,8 @@ from mlflow.entities import (
 )
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
+from mlflow.entities.trace_data import TraceData
+from mlflow.entities.trace_info import TraceInfo
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import (
     BAD_REQUEST,
@@ -410,6 +412,9 @@ class MlflowClient:
             request_metadata=request_metadata,
             tags=tags,
         )
+
+    def _upload_trace_data(self, trace_info: TraceInfo, trace_data: TraceData) -> None:
+        return self._tracking_client.upload_trace_data(trace_info, trace_data)
 
     def delete_traces(
         self,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -414,7 +414,7 @@ class MlflowClient:
         )
 
     def _upload_trace_data(self, trace_info: TraceInfo, trace_data: TraceData) -> None:
-        return self._tracking_client.upload_trace_data(trace_info, trace_data)
+        return self._tracking_client._upload_trace_data(trace_info, trace_data)
 
     def delete_traces(
         self,

--- a/tests/tracing/clients/test_ipython.py
+++ b/tests/tracing/clients/test_ipython.py
@@ -1,13 +1,7 @@
 import json
-from unittest import mock
 from unittest.mock import Mock
 
-import pytest
-
 import mlflow
-from mlflow.entities.span_status import SpanStatus
-from mlflow.entities.trace_info import TraceInfo
-from mlflow.entities.trace_status import TraceStatus
 from mlflow.tracing.clients import get_trace_client
 
 
@@ -17,29 +11,6 @@ class MockIPython:
 
     def mock_run_cell(self):
         self.execution_count += 1
-
-
-@pytest.fixture
-def mock_tracking_serving_client():
-    with mock.patch(
-        "mlflow.tracking._tracking_service.client.TrackingServiceClient.create_trace_info",
-        return_value=TraceInfo(
-            request_id="tr-1234",
-            experiment_id="0",
-            timestamp_ms=0,
-            execution_time_ms=0,
-            status=SpanStatus(TraceStatus.OK),
-            request_metadata={},
-            tags={"mlflow.artifactLocation": "test"},
-        ),
-    ) as mock_create_trace_info, mock.patch(
-        "mlflow.tracking._tracking_service.client.TrackingServiceClient._upload_trace_data",
-        return_value=None,
-    ) as mock_upload_trace_data:
-        yield
-
-        mock_create_trace_info.assert_called()
-        mock_upload_trace_data.assert_called()
 
 
 def test_display_is_not_called_without_ipython(

--- a/tests/tracing/clients/test_ipython.py
+++ b/tests/tracing/clients/test_ipython.py
@@ -34,6 +34,7 @@ def mock_tracking_serving_client():
         ),
     ), mock.patch(
         "mlflow.tracking._tracking_service.client.TrackingServiceClient._upload_trace_data",
+        return_value=None,
     ):
         yield
 

--- a/tests/tracing/clients/test_ipython.py
+++ b/tests/tracing/clients/test_ipython.py
@@ -1,7 +1,13 @@
 import json
+from unittest import mock
 from unittest.mock import Mock
 
+import pytest
+
 import mlflow
+from mlflow.entities.span_status import SpanStatus
+from mlflow.entities.trace_info import TraceInfo
+from mlflow.entities.trace_status import TraceStatus
 from mlflow.tracing.clients import get_trace_client
 
 
@@ -11,6 +17,25 @@ class MockIPython:
 
     def mock_run_cell(self):
         self.execution_count += 1
+
+
+@pytest.fixture(autouse=True)
+def mock_tracking_serving_client():
+    with mock.patch(
+        "mlflow.tracking._tracking_service.client.TrackingServiceClient.create_trace_info",
+        return_value=TraceInfo(
+            request_id="tr-1234",
+            experiment_id="0",
+            timestamp_ms=0,
+            execution_time_ms=0,
+            status=SpanStatus(TraceStatus.OK),
+            request_metadata={},
+            tags={"mlflow.artifactLocation": "test"},
+        ),
+    ), mock.patch(
+        "mlflow.tracking._tracking_service.client.TrackingServiceClient._upload_trace_data",
+    ):
+        yield
 
 
 def test_display_is_not_called_without_ipython(monkeypatch, create_trace):

--- a/tests/tracing/clients/test_ipython.py
+++ b/tests/tracing/clients/test_ipython.py
@@ -14,7 +14,7 @@ class MockIPython:
 
 
 def test_display_is_not_called_without_ipython(
-    monkeypatch, create_trace, mock_tracking_serving_client
+    monkeypatch, create_trace, mock_tracking_service_client
 ):
     # in an IPython environment, the interactive shell will
     # be returned. however, for test purposes, just mock that
@@ -32,7 +32,7 @@ def test_display_is_not_called_without_ipython(
 
 
 def test_ipython_client_only_logs_once_per_execution(
-    monkeypatch, create_trace, mock_tracking_serving_client
+    monkeypatch, create_trace, mock_tracking_service_client
 ):
     mock_ipython = MockIPython()
     monkeypatch.setattr("IPython.get_ipython", lambda: mock_ipython)
@@ -57,7 +57,7 @@ def test_ipython_client_only_logs_once_per_execution(
 
 
 def test_display_is_called_in_correct_functions(
-    monkeypatch, create_trace, mock_tracking_serving_client
+    monkeypatch, create_trace, mock_tracking_service_client
 ):
     mock_ipython = MockIPython()
     monkeypatch.setattr("IPython.get_ipython", lambda: mock_ipython)
@@ -84,7 +84,7 @@ def test_display_is_called_in_correct_functions(
     assert mock_display.call_count == 3
 
 
-def test_display_deduplicates_traces(monkeypatch, create_trace, mock_tracking_serving_client):
+def test_display_deduplicates_traces(monkeypatch, create_trace, mock_tracking_service_client):
     mock_ipython = MockIPython()
     monkeypatch.setattr("IPython.get_ipython", lambda: mock_ipython)
     client = get_trace_client()

--- a/tests/tracing/clients/test_local.py
+++ b/tests/tracing/clients/test_local.py
@@ -21,6 +21,7 @@ def mock_tracking_serving_client():
         ),
     ), mock.patch(
         "mlflow.tracking._tracking_service.client.TrackingServiceClient._upload_trace_data",
+        return_value=None,
     ):
         yield
 

--- a/tests/tracing/clients/test_local.py
+++ b/tests/tracing/clients/test_local.py
@@ -2,7 +2,7 @@ from mlflow.entities import SpanStatus, Trace, TraceData, TraceInfo, TraceStatus
 from mlflow.tracing.clients import InMemoryTraceClientWithTracking
 
 
-def test_log_and_get_trace(monkeypatch, create_trace, mock_tracking_serving_client):
+def test_log_and_get_trace(monkeypatch, create_trace, mock_tracking_service_client):
     monkeypatch.setenv("MLFLOW_TRACING_CLIENT_BUFFER_SIZE", "3")
 
     def _create_trace(request_id: str):

--- a/tests/tracing/clients/test_local.py
+++ b/tests/tracing/clients/test_local.py
@@ -1,32 +1,5 @@
-from unittest import mock
-
-import pytest
-
 from mlflow.entities import SpanStatus, Trace, TraceData, TraceInfo, TraceStatus
 from mlflow.tracing.clients import InMemoryTraceClientWithTracking
-
-
-@pytest.fixture
-def mock_tracking_serving_client():
-    with mock.patch(
-        "mlflow.tracking._tracking_service.client.TrackingServiceClient.create_trace_info",
-        return_value=TraceInfo(
-            request_id="tr-1234",
-            experiment_id="0",
-            timestamp_ms=0,
-            execution_time_ms=0,
-            status=SpanStatus(TraceStatus.OK),
-            request_metadata={},
-            tags={"mlflow.artifactLocation": "test"},
-        ),
-    ) as mock_create_trace_info, mock.patch(
-        "mlflow.tracking._tracking_service.client.TrackingServiceClient._upload_trace_data",
-        return_value=None,
-    ) as mock_upload_trace_data:
-        yield
-
-        mock_create_trace_info.assert_called()
-        mock_upload_trace_data.assert_called()
 
 
 def test_log_and_get_trace(monkeypatch, create_trace, mock_tracking_serving_client):

--- a/tests/tracing/clients/test_tracking.py
+++ b/tests/tracing/clients/test_tracking.py
@@ -1,10 +1,10 @@
-from mlflow.tracing.clients import InMemoryTraceClient
+from mlflow.tracing.clients import InMemoryTraceClientWithTracking
 
 
-def test_log_and_get_trace(monkeypatch, create_trace):
+def test_log_and_get_trace(monkeypatch, create_trace, mock_tracking_service_client):
     monkeypatch.setenv("MLFLOW_TRACING_CLIENT_BUFFER_SIZE", "3")
 
-    client = InMemoryTraceClient.get_instance()
+    client = InMemoryTraceClientWithTracking.get_instance()
     traces = client.get_traces()
     assert len(traces) == 0
 

--- a/tests/tracing/conftest.py
+++ b/tests/tracing/conftest.py
@@ -6,7 +6,7 @@ from opentelemetry.trace import _TRACER_PROVIDER_SET_ONCE
 import mlflow
 from mlflow.entities import Trace, TraceData, TraceInfo, TraceStatus
 from mlflow.entities.span_status import SpanStatus
-from mlflow.tracing.clients.local import InMemoryTraceClientWithTracking
+from mlflow.tracing.clients import InMemoryTraceClient, InMemoryTraceClientWithTracking
 from mlflow.tracing.display import IPythonTraceDisplayHandler
 from mlflow.tracing.provider import _TRACER_PROVIDER_INITIALIZED, _setup_tracer_provider
 from mlflow.tracing.trace_manager import InMemoryTraceManager
@@ -18,6 +18,7 @@ def clear_singleton():
     Clear the singleton instances after each tests to avoid side effects.
     """
     InMemoryTraceManager._instance = None
+    InMemoryTraceClient._instance = None
     InMemoryTraceClientWithTracking._instance = None
     IPythonTraceDisplayHandler._instance = None
 

--- a/tests/tracing/conftest.py
+++ b/tests/tracing/conftest.py
@@ -3,7 +3,7 @@ from opentelemetry.trace import _TRACER_PROVIDER_SET_ONCE
 
 import mlflow
 from mlflow.entities import Trace, TraceData, TraceInfo, TraceStatus
-from mlflow.tracing.clients.local import InMemoryTraceClient
+from mlflow.tracing.clients.local import InMemoryTraceClientWithTracking
 from mlflow.tracing.display import IPythonTraceDisplayHandler
 from mlflow.tracing.provider import _TRACER_PROVIDER_INITIALIZED, _setup_tracer_provider
 from mlflow.tracing.trace_manager import InMemoryTraceManager
@@ -15,7 +15,7 @@ def clear_singleton():
     Clear the singleton instances after each tests to avoid side effects.
     """
     InMemoryTraceManager._instance = None
-    InMemoryTraceClient._instance = None
+    InMemoryTraceClientWithTracking._instance = None
     IPythonTraceDisplayHandler._instance = None
 
     # Tracer provider also needs to be reset as it may hold reference to the singleton
@@ -35,7 +35,7 @@ def mock_client():
     with _TRACER_PROVIDER_SET_ONCE._lock:
         _TRACER_PROVIDER_SET_ONCE._done = False
 
-    mock_client = InMemoryTraceClient.get_instance()
+    mock_client = InMemoryTraceClientWithTracking.get_instance()
 
     _setup_tracer_provider(mock_client)
 

--- a/tests/tracing/conftest.py
+++ b/tests/tracing/conftest.py
@@ -1,8 +1,11 @@
+from unittest import mock
+
 import pytest
 from opentelemetry.trace import _TRACER_PROVIDER_SET_ONCE
 
 import mlflow
 from mlflow.entities import Trace, TraceData, TraceInfo, TraceStatus
+from mlflow.entities.span_status import SpanStatus
 from mlflow.tracing.clients.local import InMemoryTraceClientWithTracking
 from mlflow.tracing.display import IPythonTraceDisplayHandler
 from mlflow.tracing.provider import _TRACER_PROVIDER_INITIALIZED, _setup_tracer_provider
@@ -65,3 +68,26 @@ def create_trace():
 def reset_active_experiment():
     yield
     mlflow.tracking.fluent._active_experiment_id = None
+
+
+@pytest.fixture
+def mock_tracking_serving_client():
+    with mock.patch(
+        "mlflow.tracking._tracking_service.client.TrackingServiceClient.create_trace_info",
+        return_value=TraceInfo(
+            request_id="tr-1234",
+            experiment_id="0",
+            timestamp_ms=0,
+            execution_time_ms=0,
+            status=SpanStatus(TraceStatus.OK),
+            request_metadata={},
+            tags={"mlflow.artifactLocation": "test"},
+        ),
+    ) as mock_create_trace_info, mock.patch(
+        "mlflow.tracking._tracking_service.client.TrackingServiceClient._upload_trace_data",
+        return_value=None,
+    ) as mock_upload_trace_data:
+        yield
+
+        mock_create_trace_info.assert_called()
+        mock_upload_trace_data.assert_called()

--- a/tests/tracing/conftest.py
+++ b/tests/tracing/conftest.py
@@ -71,7 +71,7 @@ def reset_active_experiment():
 
 
 @pytest.fixture
-def mock_tracking_serving_client():
+def mock_tracking_service_client():
     with mock.patch(
         "mlflow.tracking._tracking_service.client.TrackingServiceClient.create_trace_info",
         return_value=TraceInfo(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11618?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11618/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11618
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Run the following code with the databricks backend:

```python
import time
import uuid

import mlflow
from mlflow.entities.trace import Trace
from mlflow.entities.trace_data import TraceData
from mlflow.entities.trace_info import TraceInfo
from mlflow.entities.trace_status import TraceStatus
from mlflow.tracing.clients import get_trace_client

mlflow.set_tracking_uri("databricks")
name = "/Users/harutaka.kawamura@databricks.com/log-traces"
mlflow.set_experiment(name)
exp = mlflow.get_experiment_by_name(name)

tag = str(uuid.uuid4())

trace = Trace(
    info=TraceInfo(
        request_id="a",
        experiment_id=exp.experiment_id,
        timestamp_ms=int(time.time() * 1000),
        execution_time_ms=1000,
        status=TraceStatus.OK,
        tags={"test": tag},
    ),
    data=TraceData(),
)
trace_client = get_trace_client()
trace_client.log_trace(trace)

client = mlflow.MlflowClient()

traces = client.search_traces(experiment_ids=[exp.experiment_id], max_results=1)
print(traces)
assert "test" in traces[0].info.tags
assert traces[0].info.tags["test"] == tag

trace = client.get_trace(traces[0].info.request_id)
print(trace)


@mlflow.trace
def f():
    pass


@mlflow.trace
def g(x, y):
    return x + y


t = int(time.time() * 1000)
f()
g(3, 4)


with mlflow.start_span(name="test"):
    pass

traces = client.search_traces(
    experiment_ids=[exp.experiment_id],
    filter_string=f"timestamp_ms >= {t}",
    max_results=10,
)
assert len(traces) == 3
print(traces)
```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
