### PR TITLE
Fix LangChain tracer not to start span for Agent action.

### DIFF
--- a/mlflow/entities/span_event.py
+++ b/mlflow/entities/span_event.py
@@ -2,10 +2,12 @@ import sys
 import time
 import traceback
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence, Union
 
 from mlflow.entities._mlflow_object import _MlflowObject
 
+
+_AttrValueType = Union[str, int, float, bool, bytes]
 
 @dataclass
 class SpanEvent(_MlflowObject):
@@ -18,12 +20,14 @@ class SpanEvent(_MlflowObject):
         timestamp:  The exact time the event occurred, measured in microseconds.
         attributes: A collection of key-value pairs representing detailed
             attributes of the event, such as the exception stack trace.
+            Attributes value must be one of ``[str, int, float, bool, bytes]``
+            or a sequence of these types.
     """
 
     name: str
     # Use current time if not provided.
     timestamp: Optional[int] = field(default=int(time.time() * 1e6))
-    attributes: Dict[str, Any] = field(default_factory=dict)
+    attributes: Dict[str, Union[_AttrValueType, Sequence[_AttrValueType]]] = field(default_factory=dict)
 
     @classmethod
     def from_exception(cls, exception: Exception):

--- a/mlflow/entities/span_event.py
+++ b/mlflow/entities/span_event.py
@@ -2,7 +2,7 @@ import sys
 import time
 import traceback
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Sequence, Union
+from typing import Dict, Sequence, Union
 
 from mlflow.entities._mlflow_object import _MlflowObject
 
@@ -28,7 +28,7 @@ class SpanEvent(_MlflowObject):
     name: str
     # Use current time if not provided. We need to use default factory otherwise
     # the default value will be fixed to the build time of the class.
-    timestamp: Optional[int] = field(default_factory=lambda: int(time.time() * 1e6))
+    timestamp: int = field(default_factory=lambda: int(time.time() * 1e6))
     attributes: Dict[str, Union[_AttrValueType, Sequence[_AttrValueType]]] = field(
         default_factory=dict
     )

--- a/mlflow/entities/span_event.py
+++ b/mlflow/entities/span_event.py
@@ -2,12 +2,12 @@ import sys
 import time
 import traceback
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import Dict, Optional, Sequence, Union
 
 from mlflow.entities._mlflow_object import _MlflowObject
 
-
 _AttrValueType = Union[str, int, float, bool, bytes]
+
 
 @dataclass
 class SpanEvent(_MlflowObject):
@@ -27,7 +27,9 @@ class SpanEvent(_MlflowObject):
     name: str
     # Use current time if not provided.
     timestamp: Optional[int] = field(default=int(time.time() * 1e6))
-    attributes: Dict[str, Union[_AttrValueType, Sequence[_AttrValueType]]] = field(default_factory=dict)
+    attributes: Dict[str, Union[_AttrValueType, Sequence[_AttrValueType]]] = field(
+        default_factory=dict
+    )
 
     @classmethod
     def from_exception(cls, exception: Exception):

--- a/mlflow/entities/span_event.py
+++ b/mlflow/entities/span_event.py
@@ -18,6 +18,7 @@ class SpanEvent(_MlflowObject):
     Args:
         name: Name of the event.
         timestamp:  The exact time the event occurred, measured in microseconds.
+            If not provided, the current time will be used.
         attributes: A collection of key-value pairs representing detailed
             attributes of the event, such as the exception stack trace.
             Attributes value must be one of ``[str, int, float, bool, bytes]``
@@ -25,8 +26,9 @@ class SpanEvent(_MlflowObject):
     """
 
     name: str
-    # Use current time if not provided.
-    timestamp: Optional[int] = field(default=int(time.time() * 1e6))
+    # Use current time if not provided. We need to use default factory otherwise
+    # the default value will be fixed to the build time of the class.
+    timestamp: Optional[int] = field(default_factory=lambda: int(time.time() * 1e6))
     attributes: Dict[str, Union[_AttrValueType, Sequence[_AttrValueType]]] = field(
         default_factory=dict
     )

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -97,16 +97,13 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         status=SpanStatus(TraceStatus.OK),
     ):
         """Close MLflow Span (or Trace if it is root component)"""
-        # NB: Some chain
-        if str(span.run_id) in self._run_span_mapping:
-            self._mlflow_client.end_span(
-                request_id=span.request_id,
-                span_id=span.span_id,
-                outputs=outputs,
-                attributes=attributes,
-                status=status,
-            )
-        self._run_span_mapping.pop(str(span.run_id))
+        self._mlflow_client.end_span(
+            request_id=span.request_id,
+            span_id=span.span_id,
+            outputs=outputs,
+            attributes=attributes,
+            status=status,
+        )
 
     def _reset(self):
         self._run_span_mapping = {}
@@ -395,8 +392,8 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         """
         Run on agent action.
 
-        NB: Agent actiond doesn't create a new LangChain Run, so instead of creating a new span, an action
-           will be recorded as an event of the existing span created by a parent chain.
+        NB: Agent action doesn't create a new LangChain Run, so instead of creating a new span,
+        an action will be recorded as an event of the existing span created by a parent chain.
         """
         span = self._get_span_by_run_id(run_id)
         span.add_event(
@@ -406,7 +403,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
                     "tool": action.tool,
                     "tool_input": dumps(action.tool_input),
                     "log": action.log,
-                }
+                },
             )
         )
 
@@ -423,10 +420,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         span.add_event(
             SpanEvent(
                 name="agent_finish",
-                attributes={
-                    "return_values": dumps(finish.return_values),
-                    "log": finish.log
-                }
+                attributes={"return_values": dumps(finish.return_values), "log": finish.log},
             )
         )
 

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -97,13 +97,16 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         status=SpanStatus(TraceStatus.OK),
     ):
         """Close MLflow Span (or Trace if it is root component)"""
-        self._mlflow_client.end_span(
-            request_id=span.request_id,
-            span_id=span.span_id,
-            outputs=outputs,
-            attributes=attributes,
-            status=status,
-        )
+        # NB: Some chain
+        if str(span.run_id) in self._run_span_mapping:
+            self._mlflow_client.end_span(
+                request_id=span.request_id,
+                span_id=span.span_id,
+                outputs=outputs,
+                attributes=attributes,
+                status=status,
+            )
+        self._run_span_mapping.pop(str(span.run_id))
 
     def _reset(self):
         self._run_span_mapping = {}
@@ -387,18 +390,24 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         action: AgentAction,
         *,
         run_id: UUID,
-        parent_run_id: Optional[UUID] = None,
         **kwargs: Any,
     ) -> Any:
-        """Run on agent action."""
-        kwargs.update({"log": action.log})
-        self._start_span(
-            span_name=action.tool,
-            parent_run_id=parent_run_id,
-            span_type=SpanType.AGENT,
-            run_id=run_id,
-            inputs={"tool_input": action.tool_input},
-            attributes=kwargs,
+        """
+        Run on agent action.
+
+        NB: Agent actiond doesn't create a new LangChain Run, so instead of creating a new span, an action
+           will be recorded as an event of the existing span created by a parent chain.
+        """
+        span = self._get_span_by_run_id(run_id)
+        span.add_event(
+            SpanEvent(
+                name="agent_action",
+                attributes={
+                    "tool": action.tool,
+                    "tool_input": dumps(action.tool_input),
+                    "log": action.log,
+                }
+            )
         )
 
     @override
@@ -407,13 +416,19 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         finish: AgentFinish,
         *,
         run_id: UUID,
-        parent_run_id: Optional[UUID] = None,
         **kwargs: Any,
     ) -> Any:
         """Run on agent end."""
-        agent_span = self._get_span_by_run_id(run_id)
-        kwargs.update({"log": finish.log})
-        self._end_span(agent_span, outputs=finish.return_values, attributes=kwargs)
+        span = self._get_span_by_run_id(run_id)
+        span.add_event(
+            SpanEvent(
+                name="agent_finish",
+                attributes={
+                    "return_values": dumps(finish.return_values),
+                    "log": finish.log
+                }
+            )
+        )
 
     @override
     def on_text(

--- a/mlflow/tracing/clients/local.py
+++ b/mlflow/tracing/clients/local.py
@@ -1,8 +1,8 @@
 import threading
 from collections import deque
-from trace import Trace
 from typing import List, Optional
 
+from mlflow.entities import Trace
 from mlflow.environment_variables import MLFLOW_TRACING_CLIENT_BUFFER_SIZE
 from mlflow.tracing.clients.base import TraceClient
 

--- a/mlflow/tracing/types/wrapper.py
+++ b/mlflow/tracing/types/wrapper.py
@@ -137,7 +137,13 @@ class MlflowSpanWrapper:
         self._span.set_status(status.to_otel_status())
 
     def add_event(self, event: SpanEvent):
-        """Add an event to the span."""
+        """
+        Add an event to the span.
+
+        Args:
+            event: The event to add to the span. This should be a
+                :py:class:`SpanEvent <mlflow.entities.SpanEvent>` object.
+        """
         self._span.add_event(event.name, event.attributes, event.timestamp)
 
     def end(self):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -740,7 +740,7 @@ class MlflowClient:
         if not parent_span_id:
             raise MlflowException(
                 "start_span() must be called with an explicit parent_span_id."
-                "If you haven't start any span yet, use MLflowClient().start_trace() "
+                "If you haven't started any span yet, use MLflowClient().start_trace() "
                 "to start a new trace and root span.",
                 error_code=INVALID_PARAMETER_VALUE,
             )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11621?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11621/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11621
```

</p>
</details>

### What changes are proposed in this pull request?

When running a LangChain agent with the tracer, we faced the following warning:
```
2024/04/04 01:58:58 WARNING mlflow.utils.autologging_utils: Encountered unexpected error during autologging: Span with ID 14019314524353424371 is not found or already finished.
```

It turned out that both `on_agent_finish` and `on_chain_end` is called for the same LangChain run ID and tried to end the same Span. This is because LangChain doesn't create a Run for agent action, instead the same run is reused from the AgentExecutor chain. Therefore, we should not start/end a span in `on_agent_action` and `on_agent_finish` handlers, instead just log them as events.

Also fixes a few bugs / typo related to SpanEvents.

### How is this PR tested?

Note: will add tests for LangChain tracer as a follow-up, for now just did manual test on notebook.

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
