### PR TITLE
Tracing: Define client.get_trace() and optimize search

### DIFF
--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -204,7 +204,21 @@ class TrackingServiceClient:
             request_ids=request_ids,
         )
 
-    def get_trace_info(self, request_id):
+    def get_trace(self, request_id) -> Trace:
+        """
+        Get the trace matching the ``request_id``.
+
+        Args:
+            request_id: String id of the trace to fetch.
+
+        Returns:
+            The fetched Trace object, of type ``mlflow.entities.Trace``.
+        """
+        trace_info = self._get_trace_info(request_id)
+        trace_data = self._download_trace_data(request_id)
+        return Trace(trace_info, trace_data)
+
+    def _get_trace_info(self, request_id):
         """
         Get the trace matching the `request_id`.
 
@@ -632,7 +646,7 @@ class TrackingServiceClient:
         self.store.record_logged_model(run_id, mlflow_model)
 
     def _get_artifact_repo_for_trace(self, request_id):
-        trace_info = self.get_trace_info(request_id)
+        trace_info = self._get_trace_info(request_id)
         artifact_uri = next(v for k, v in trace_info.tags.items() if k == "mlflow.artifactLocation")
         artifact_uri = add_databricks_profile_info_to_artifact_uri(artifact_uri, self.tracking_uri)
         return get_artifact_repository(artifact_uri)

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -215,21 +215,9 @@ class TrackingServiceClient:
         Returns:
             The fetched Trace object, of type ``mlflow.entities.Trace``.
         """
-        trace_info = self._get_trace_info(request_id)
+        trace_info = self.store.get_trace_info(request_id)
         trace_data = self._download_trace_data(trace_info)
         return Trace(trace_info, trace_data)
-
-    def _get_trace_info(self, request_id):
-        """
-        Get the trace matching the `request_id`.
-
-        Args:
-            request_id: String id of the trace to fetch.
-
-        Returns:
-            The fetched Trace object, of type ``mlflow.entities.TraceInfo``.
-        """
-        return self.store.get_trace_info(request_id)
 
     def search_traces(
         self,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -29,6 +29,7 @@ from mlflow.entities import (
     RunTag,
     SpanStatus,
     SpanType,
+    Trace,
     TraceInfo,
     ViewType,
 )
@@ -452,7 +453,7 @@ class MlflowClient:
             request_ids=request_ids,
         )
 
-    def get_trace_info(self, request_id: str) -> TraceInfo:
+    def get_trace(self, request_id: str) -> Trace:
         """
         Get the trace matching the `request_id`.
 
@@ -460,7 +461,7 @@ class MlflowClient:
             request_id: String id of the trace to fetch.
 
         Returns:
-            The fetched Trace object, of type ``mlflow.entities.TraceInfo``.
+            The retrieved :py:class:`Trace`.
 
         .. code-block:: python
             :caption: Example
@@ -469,9 +470,9 @@ class MlflowClient:
 
             client = MlflowClient()
             request_id = "12345678"
-            trace = client.get_trace_info(request_id)
+            trace = client.get_trace(request_id)
         """
-        return self._tracking_client.get_trace_info(request_id)
+        return self._tracking_client.get_trace(request_id)
 
     def search_traces(
         self,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -30,7 +30,6 @@ from mlflow.entities import (
     SpanStatus,
     SpanType,
     Trace,
-    TraceInfo,
     ViewType,
 )
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -460,7 +460,7 @@ class MlflowClient:
             request_id: String ID of the trace to fetch.
 
         Returns:
-            The retrieved :py:class:`Trace`.
+            The retrieved :py:class:`Trace <mlflow.entities.Trace>`.
 
         .. code-block:: python
             :caption: Example

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -455,10 +455,10 @@ class MlflowClient:
 
     def get_trace(self, request_id: str) -> Trace:
         """
-        Get the trace matching the `request_id`.
+        Get the trace matching the specified ``request_id``.
 
         Args:
-            request_id: String id of the trace to fetch.
+            request_id: String ID of the trace to fetch.
 
         Returns:
             The retrieved :py:class:`Trace`.

--- a/tests/tracking/_tracking_service/test_tracking_service_client.py
+++ b/tests/tracking/_tracking_service/test_tracking_service_client.py
@@ -88,7 +88,7 @@ def test_download_trace_data(tmp_path):
     )
     with mock.patch(
         "mlflow.tracking._tracking_service.client.TrackingServiceClient._get_trace_info",
-        return_value=trace_info
+        return_value=trace_info,
     ) as mock_get_trace_info, mock.patch(
         "mlflow.store.artifact.artifact_repo.ArtifactRepository.download_trace_data",
         return_value={"spans": []},
@@ -115,7 +115,7 @@ def test_upload_trace_data(tmp_path):
     )
     with mock.patch(
         "mlflow.tracking._tracking_service.client.TrackingServiceClient._get_trace_info",
-        return_value=trace_info
+        return_value=trace_info,
     ) as mock_get_trace_info, mock.patch(
         "mlflow.store.artifact.artifact_repo.ArtifactRepository.upload_trace_data",
     ) as mock_upload_trace_data:

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -177,7 +177,7 @@ def test_client_get_trace(mock_store, mock_artifact_repo):
         tags={"mlflow.artifactLocation": "dbfs:/path/to/artifacts"},
     )
     MlflowClient().get_trace("1234567")
-    mock_store.get_trace_info.assert_called_with("1234567")
+    mock_store.get_trace_info.assert_called_once_with("1234567")
     mock_artifact_repo.download_trace_data.assert_called_once()
 
 def test_client_search_traces(mock_store, mock_artifact_repo):
@@ -211,6 +211,9 @@ def test_client_search_traces(mock_store, mock_artifact_repo):
         page_token=None,
     )
     mock_artifact_repo.download_trace_data.assert_called()
+    # The TraceInfo is already fetched prior to the upload_trace_data call,
+    # so we should not call _get_trace_info again
+    mock_store.get_trace_info.assert_not_called()
 
 
 def test_client_delete_traces(mock_store):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -64,7 +64,9 @@ def mock_store():
 
 @pytest.fixture
 def mock_artifact_repo():
-    with mock.patch("mlflow.tracking._tracking_service.client.get_artifact_repository") as mock_get_repo:
+    with mock.patch(
+        "mlflow.tracking._tracking_service.client.get_artifact_repository"
+    ) as mock_get_repo:
         yield mock_get_repo.return_value
 
 
@@ -179,6 +181,7 @@ def test_client_get_trace(mock_store, mock_artifact_repo):
     MlflowClient().get_trace("1234567")
     mock_store.get_trace_info.assert_called_once_with("1234567")
     mock_artifact_repo.download_trace_data.assert_called_once()
+
 
 def test_client_search_traces(mock_store, mock_artifact_repo):
     mock_traces = [


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/11622?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11622/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11622
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Define `client.get_trace()` and optimize search

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
