### PR TITLE
mark _model_impl as dev_stable

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -451,7 +451,7 @@ from mlflow.utils import (
 )
 from mlflow.utils import env_manager as _EnvManager
 from mlflow.utils._spark_utils import modified_environ
-from mlflow.utils.annotations import deprecated, experimental
+from mlflow.utils.annotations import deprecated, developer_stable, experimental
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
@@ -634,7 +634,7 @@ class PyFuncModel:
         if not model_meta:
             raise MlflowException("Model is missing metadata.")
         self._model_meta = model_meta
-        self._model_impl = model_impl
+        self.__model_impl = model_impl
         self._predict_fn = getattr(model_impl, predict_fn)
         if predict_stream_fn:
             if not hasattr(model_impl, predict_stream_fn):
@@ -644,6 +644,14 @@ class PyFuncModel:
             self._predict_stream_fn = getattr(model_impl, predict_stream_fn)
         else:
             self._predict_stream_fn = None
+
+    @property
+    @developer_stable
+    def _model_impl(self) -> Any:
+        """
+        The underlying model implementation object.
+        """
+        return self.__model_impl
 
     def _validate_prediction_input(
         self, data: PyFuncInput, params: Optional[Dict[str, Any]] = None

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -634,6 +634,9 @@ class PyFuncModel:
         if not model_meta:
             raise MlflowException("Model is missing metadata.")
         self._model_meta = model_meta
+        # Set as a fully private internal-only instance variable in favor of marking _model_impl
+        # safe for developer use as an instance property, requiring a deprecation notice prior to
+        # changing or removing `_model_impl` due to external integration reliance on that attribute.
         self.__model_impl = model_impl
         self._predict_fn = getattr(model_impl, predict_fn)
         if predict_stream_fn:
@@ -650,6 +653,8 @@ class PyFuncModel:
     def _model_impl(self) -> Any:
         """
         The underlying model implementation object.
+
+        NOTE: This is a stable developer API.
         """
         return self.__model_impl
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -634,9 +634,6 @@ class PyFuncModel:
         if not model_meta:
             raise MlflowException("Model is missing metadata.")
         self._model_meta = model_meta
-        # Set as a fully private internal-only instance variable in favor of marking _model_impl
-        # safe for developer use as an instance property, requiring a deprecation notice prior to
-        # changing or removing `_model_impl` due to external integration reliance on that attribute.
         self.__model_impl = model_impl
         self._predict_fn = getattr(model_impl, predict_fn)
         if predict_stream_fn:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/11626?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11626/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11626
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Mark pyfunc._model_init as developer stable

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
