### PR TITLE
Add `build.sh` for building a wheel

### DIFF
--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -39,14 +39,6 @@ jobs:
           submodules: recursive
       - uses: ./.github/actions/untracked
       - uses: ./.github/actions/setup-python
-      - name: Set environment variable for skinny client build
-        if: ${{ matrix.type == 'skinny' }}
-        run: |
-          cat pyproject.skinny.toml > pyproject.toml
-          echo "" >> README_SKINNY.rst
-          cat README.rst >> README_SKINNY.rst
-          cat README_SKINNY.rst > README.rst
-
       - name: Create dummy MLflow UI
         run: |
           mkdir -p mlflow/server/js/build
@@ -75,8 +67,11 @@ jobs:
       - name: Build distribution files
         id: build-dist
         run: |
-          # Build distribution files
-          python -m build .
+          if [ "${{ matrix.type }}" == "skinny" ]; then
+            ./dev/build.sh --skinny
+          else
+            ./dev/build.sh
+          fi
 
           # List distribution files and check their file sizes
           ls -lh dist

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+
+SKINNY=0
+
+for arg in "$@"
+do
+  if [ "$arg" == "--skinny" ]; then
+    SKINNY=1
+    break
+  fi
+done
+
+if [ $SKINNY -eq 1 ]; then
+  cat pyproject.skinny.toml > pyproject.toml
+  echo "" >> README_SKINNY.rst
+  cat README.rst >> README_SKINNY.rst
+  cat README_SKINNY.rst > README.rst
+  python -m build
+  git restore .
+else
+  python -m build
+fi


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Add `build.sh` for building a wheel. We can run this script in our internal repo. This prevents us from breaking our internal jobs (like we did when we migrated to `pyprojec.toml`). We're safe as long as `build.sh` works fine.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
