### PR TITLE
Turn off LangChain autolog artifact logging in favor of the tracer

### DIFF
--- a/mlflow/entities/span_event.py
+++ b/mlflow/entities/span_event.py
@@ -37,7 +37,7 @@ class SpanEvent(_MlflowObject):
     def from_exception(cls, exception: Exception):
         "Create a span event from an exception."
 
-        stack_trace = cls._get_stacktrace(exception)
+        stack_trace = _get_stacktrace(exception)
         return cls(
             name="exception",
             attributes={
@@ -47,14 +47,15 @@ class SpanEvent(_MlflowObject):
             },
         )
 
-    def _get_stacktrace(self, error: BaseException) -> str:
-        """Get the stacktrace of the parent error."""
-        msg = repr(error)
-        try:
-            if sys.version_info < (3, 10):
-                tb = traceback.format_exception(error.__class__, error, error.__traceback__)
-            else:
-                tb = traceback.format_exception(error)
-            return (msg + "\n\n".join(tb)).strip()
-        except Exception:
-            return msg
+
+def _get_stacktrace(error: BaseException) -> str:
+    """Get the stacktrace of the parent error."""
+    msg = repr(error)
+    try:
+        if sys.version_info < (3, 10):
+            tb = traceback.format_exception(error.__class__, error, error.__traceback__)
+        else:
+            tb = traceback.format_exception(error)
+        return (msg + "\n\n".join(tb)).strip()
+    except Exception:
+        return msg

--- a/mlflow/entities/span_event.py
+++ b/mlflow/entities/span_event.py
@@ -37,7 +37,7 @@ class SpanEvent(_MlflowObject):
     def from_exception(cls, exception: Exception):
         "Create a span event from an exception."
 
-        stack_trace = _get_stacktrace(exception)
+        stack_trace = cls._get_stacktrace(exception)
         return cls(
             name="exception",
             attributes={
@@ -47,15 +47,15 @@ class SpanEvent(_MlflowObject):
             },
         )
 
-
-def _get_stacktrace(error: BaseException) -> str:
-    """Get the stacktrace of the parent error."""
-    msg = repr(error)
-    try:
-        if sys.version_info < (3, 10):
-            tb = traceback.format_exception(error.__class__, error, error.__traceback__)
-        else:
-            tb = traceback.format_exception(error)
-        return (msg + "\n\n".join(tb)).strip()
-    except Exception:
-        return msg
+    @staticmethod
+    def _get_stacktrace(error: BaseException) -> str:
+        """Get the stacktrace of the parent error."""
+        msg = repr(error)
+        try:
+            if sys.version_info < (3, 10):
+                tb = traceback.format_exception(error.__class__, error, error.__traceback__)
+            else:
+                tb = traceback.format_exception(error)
+            return (msg + "\n\n".join(tb)).strip()
+        except Exception:
+            return msg

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -862,7 +862,7 @@ def autolog(
     log_model_signatures=False,
     log_models=False,
     log_datasets=False,
-    log_inputs_outputs=True,
+    log_inputs_outputs=False,
     disable=False,
     exclusive=False,
     disable_for_unsupported_versions=True,
@@ -895,7 +895,7 @@ def autolog(
         log_inputs_outputs: If ``True``, inference data and results are combined into a single
             pandas DataFrame and logged to MLflow Tracking as an artifact.
             If ``False``, inference data and results are not logged.
-            Default to ``True``.
+            Default to ``False``.
         disable: If ``True``, disables the Langchain autologging integration. If ``False``,
             enables the Langchain autologging integration.
         exclusive: If ``True``, autologged content is not logged to user-created fluent runs.

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -862,6 +862,10 @@ def autolog(
     log_model_signatures=False,
     log_models=False,
     log_datasets=False,
+    # TODO: log_inputs_outputs was originally defaulted to True in the production version of
+    # the LangChain autologging, as it is a common use case to log input/output table for
+    # evaluation. Once tracing is fully launched, this should be supported by the tracer
+    # but we should design it to be compatible with the existing UJ.
     log_inputs_outputs=False,
     disable=False,
     exclusive=False,

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -462,6 +462,9 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
             )
 
     def flush_tracker(self):
-        # Make sure the trace renders in the notebook
-        mlflow.get_traces()
-        self._reset()
+        try:
+            # Make sure the trace renders in the notebook
+            mlflow.get_traces()
+            self._reset()
+        except Exception as e:
+            _logger.debug(f"Failed to flush MLflow tracer due to error {e}.")

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -630,7 +630,7 @@ langchain:
       pip install git+https://github.com/hwchase17/langchain#subdirectory=libs/langchain
   models:
     minimum: "0.0.244"
-    maximum: "0.1.9"
+    maximum: "0.1.14"
     requirements:
       ">= 0.0.0": [
           "pyspark",
@@ -657,7 +657,7 @@ langchain:
       fi
   autologging:
     minimum: "0.1.4"
-    maximum: "0.1.9"
+    maximum: "0.1.14"
     requirements:
       ">= 0.0.0": [
           "pyspark",

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -630,7 +630,7 @@ langchain:
       pip install git+https://github.com/hwchase17/langchain#subdirectory=libs/langchain
   models:
     minimum: "0.0.244"
-    maximum: "0.1.14"
+    maximum: "0.1.15"
     requirements:
       ">= 0.0.0": [
           "pyspark",
@@ -657,7 +657,7 @@ langchain:
       fi
   autologging:
     minimum: "0.1.4"
-    maximum: "0.1.14"
+    maximum: "0.1.15"
     requirements:
       ">= 0.0.0": [
           "pyspark",

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -259,11 +259,11 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "0.0.244",
-            "maximum": "0.1.9"
+            "maximum": "0.1.14"
         },
         "autologging": {
             "minimum": "0.1.4",
-            "maximum": "0.1.9"
+            "maximum": "0.1.14"
         }
     },
     "sentence_transformers": {

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -259,11 +259,11 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "0.0.244",
-            "maximum": "0.1.14"
+            "maximum": "0.1.15"
         },
         "autologging": {
             "minimum": "0.1.4",
-            "maximum": "0.1.14"
+            "maximum": "0.1.15"
         }
     },
     "sentence_transformers": {

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -493,8 +493,10 @@ def disable_autologging():
     """
     global _AUTOLOGGING_GLOBALLY_DISABLED
     _AUTOLOGGING_GLOBALLY_DISABLED = True
-    yield None
-    _AUTOLOGGING_GLOBALLY_DISABLED = False
+    try:
+        yield None
+    finally:
+        _AUTOLOGGING_GLOBALLY_DISABLED = False
 
 
 @contextlib.contextmanager

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -77,12 +77,6 @@ MLFLOW_EXPERIMENT_PRIMARY_METRIC_GREATER_IS_BETTER = (
 # For automatic model checkpointing
 LATEST_CHECKPOINT_ARTIFACT_TAG_KEY = "mlflow.latest_checkpoint_artifact"
 
-# These tags are immutable once logged for a run
-IMMUTABLE_TAGS = {
-    MLFLOW_USER,
-    MLFLOW_LOGGED_MODELS,
-}
-
 
 def _get_run_name_from_tags(tags):
     for tag in tags:

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -77,6 +77,12 @@ MLFLOW_EXPERIMENT_PRIMARY_METRIC_GREATER_IS_BETTER = (
 # For automatic model checkpointing
 LATEST_CHECKPOINT_ARTIFACT_TAG_KEY = "mlflow.latest_checkpoint_artifact"
 
+# These tags are immutable once logged for a run
+IMMUTABLE_TAGS = {
+    MLFLOW_USER,
+    MLFLOW_LOGGED_MODELS,
+}
+
 
 def _get_run_name_from_tags(tags):
     for tag in tags:

--- a/tests/entities/test_span_event.py
+++ b/tests/entities/test_span_event.py
@@ -1,4 +1,4 @@
-from mlflow.entities import SpanEvent, TraceStatus
+from mlflow.entities import SpanEvent
 from mlflow.exceptions import MlflowException
 
 

--- a/tests/entities/test_span_event.py
+++ b/tests/entities/test_span_event.py
@@ -1,0 +1,11 @@
+from mlflow.entities import SpanEvent, TraceStatus
+from mlflow.exceptions import MlflowException
+
+
+def test_from_exception():
+    exception = MlflowException("test")
+    span_event = SpanEvent.from_exception(exception)
+    assert span_event.name == "exception"
+    assert span_event.attributes["exception.message"] == "test"
+    assert span_event.attributes["exception.type"] == "MlflowException"
+    assert span_event.attributes["exception.stacktrace"] is not None

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -230,11 +230,9 @@ def test_resolve_tags():
     with mlflow.start_run() as run:
         actual_tags = set(_resolve_tags(extra_tags, run).keys())
 
-    # The immutable tags user/runName should not be overridden in the active run
+    # The immutable tags starts with 'mlflow.' in the run should not be overridden
     assert actual_tags == {
         "mlflow.autologging",
-        "mlflow.source.name",
-        "mlflow.source.type",
         "test_tag",
     }
 

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -458,13 +458,13 @@ def test_runnable_sequence_autolog(clear_trace_singleton):
         matched = False
         for parallel_spans_order in [parallel_spans, parallel_spans[::-1]]:
             matched |= spans == [
-                ("RunnableSequence", "CHAIN"),
+                ("RunnableSequence_1", "CHAIN"),
                 ("RunnableParallel<question,chat_history>", "CHAIN"),
-                ("RunnableSequence", "CHAIN"),
-                ("RunnableLambda", "CHAIN"),
+                ("RunnableSequence_2", "CHAIN"),
+                ("RunnableLambda_1", "CHAIN"),
                 (parallel_spans_order[0], "CHAIN"),
-                ("RunnableSequence", "CHAIN"),
-                ("RunnableLambda", "CHAIN"),
+                ("RunnableSequence_3", "CHAIN"),
+                ("RunnableLambda_2", "CHAIN"),
                 (parallel_spans_order[1], "CHAIN"),
                 ("PromptTemplate", "CHAIN"),
                 ("FakeChatModel", "LLM"),

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -470,7 +470,7 @@ def test_runnable_sequence_autolog(clear_trace_singleton):
                 ("FakeChatModel", "LLM"),
                 ("StrOutputParser", "CHAIN"),
             ]
-        assert matched
+        assert matched, f"Spans do not match with the expected order: {spans}"
 
 
 # TODO: remove skip mark before merging the tracing feature branch to master

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -241,6 +241,7 @@ def test_resolve_tags():
 
 def test_autolog_record_exception(clear_trace_singleton):
     from langchain.schema.runnable import RunnableLambda
+
     def always_fail(input):
         raise Exception("Error!")
 

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -1,5 +1,4 @@
 import os
-import re
 from operator import itemgetter
 from typing import Any, List, Optional
 from unittest import mock
@@ -30,6 +29,9 @@ from mlflow.utils.openai_utils import (
     _MockResponse,
 )
 
+# TODO: This test helper is used outside the tracing module, we should move it to a common utils
+from tests.tracing.conftest import clear_singleton as clear_trace_singleton  # noqa: F401
+
 MODEL_DIR = "model"
 TEST_CONTENT = "test"
 
@@ -42,69 +44,9 @@ MLFLOW_CALLBACK_METRICS = mlflow_callback_metrics()
 TEXT_COMPLEXITY_METRICS = get_text_complexity_metrics()
 
 
-def get_mlflow_callback_artifacts(
-    contains_llm=True,
-    contains_on_text_action=True,
-    llm_new_token=False,
-    contains_chain=False,
-    contains_tool=False,
-    contains_agent=False,
-    contains_agent_action=False,
-    contains_retriever=False,
-):
-    artifacts = [
-        "table_action_records.html",
-    ]
-    if contains_llm:
-        artifacts += [
-            "chat_html.html",
-            "table_session_analysis.html",
-            re.compile(r"llm_start_\d+_prompt_\d+\.json"),
-            re.compile(r"llm_end_\d+_generation_\d+\.json"),
-        ]
-    if llm_new_token:
-        artifacts += [re.compile(r"llm_new_tokens_\d+\.json")]
-    if contains_chain:
-        artifacts += [
-            re.compile(r"chain_start_\d+\.json"),
-            re.compile(r"chain_end_\d+\.json"),
-        ]
-    if contains_tool:
-        artifacts += [
-            re.compile(r"tool_start_\d+\.json"),
-            re.compile(r"tool_end_\d+\.json"),
-        ]
-    if contains_agent:
-        artifacts += [
-            re.compile(r"agent_finish_\d+\.json"),
-        ]
-    if contains_agent_action:
-        artifacts += [
-            re.compile(r"agent_action_\d+\.json"),
-        ]
-    if contains_on_text_action:
-        artifacts += [
-            re.compile(r"on_text_\d+\.json"),
-        ]
-    if contains_retriever:
-        artifacts += [
-            re.compile(r"retriever_start_\d+\.json"),
-            re.compile(r"retriever_end_\d+\.json"),
-        ]
-    return artifacts
-
-
 def get_mlflow_model(artifact_uri, model_subpath=MODEL_DIR):
     model_conf_path = os.path.join(artifact_uri, model_subpath, "MLmodel")
     return Model.load(model_conf_path)
-
-
-def get_artifacts(run_id):
-    client = MlflowClient()
-    artifacts = client.list_artifacts(run_id)
-    artifacts_folder = [x for x in artifacts if x.path.split("/")[-1].startswith("artifacts-")][0]
-    artifacts = client.list_artifacts(run_id, artifacts_folder.path)
-    return [x.path.split("/")[-1] for x in artifacts]
 
 
 def create_openai_llmchain():
@@ -226,7 +168,6 @@ def test_autolog_manage_run():
         model = create_openai_llmchain()
         model.invoke("MLflow")
     assert mlflow.active_run() is not None
-    assert MlflowClient().get_run(run.info.run_id).data.metrics != {}
     assert MlflowClient().get_run(run.info.run_id).data.tags["test_tag"] == "test"
     assert MlflowClient().get_run(run.info.run_id).data.tags["mlflow.autologging"] == "langchain"
     mlflow.end_run()
@@ -245,12 +186,11 @@ def test_autolog_manage_run_no_active_run():
         model.invoke("MLflow")
     assert mlflow.active_run() is None
     run = MlflowClient().get_run(model.run_id)
-    assert run.data.metrics != {}
     assert run.data.tags["test_tag"] == "test"
     assert run.data.tags["mlflow.autologging"] == "langchain"
 
 
-def test_llmchain_autolog():
+def test_llmchain_autolog(clear_trace_singleton):
     mlflow.langchain.autolog(log_models=True)
     question = "MLflow"
     answer = {"product": "MLflow", "text": TEST_CONTENT}
@@ -261,6 +201,39 @@ def test_llmchain_autolog():
             # Call twice to test that the model is only logged once
             assert model.invoke(question) == answer
             log_model_mock.assert_called_once()
+
+    traces = mlflow.get_traces(None)
+    assert len(traces) == 2
+    for trace in traces:
+        spans = trace.trace_data.spans
+        assert len(spans) == 2  # chain + llm
+        assert spans[0].span_type == "CHAIN"
+        assert spans[0].name == "LLMChain"
+        assert spans[0].inputs == {"product": "MLflow"}
+        assert spans[0].outputs == {"text": TEST_CONTENT}
+        assert spans[1].span_type == "LLM"
+        assert spans[1].name == "OpenAI"
+        assert spans[1].parent_span_id == spans[0].context.span_id
+        assert spans[1].inputs == ["What is a good name for a company that makes MLflow?"]
+        assert spans[1].outputs["generations"][0][0]["text"] == "test"
+        assert spans[1].attributes["invocation_params"]["model_name"] == "gpt-3.5-turbo-instruct"
+        assert spans[1].attributes["invocation_params"]["temperature"] == 0.9
+
+
+def test_llmchain_autolog_no_optional_artifacts_by_default(clear_trace_singleton):
+    mlflow.langchain.autolog()
+    question = "MLflow"
+    answer = {"product": "MLflow", "text": TEST_CONTENT}
+    with _mock_request(return_value=_mock_chat_completion_response()):
+        model = create_openai_llmchain()
+        with mock.patch("mlflow.MlflowClient.create_run") as create_run_mock:
+            assert model.invoke(question) == answer
+            create_run_mock.assert_not_called()
+
+    traces = mlflow.get_traces(None)
+    assert len(traces) == 1
+    spans = traces[0].trace_data.spans
+    assert len(spans) == 2
 
 
 def test_llmchain_autolog_with_registered_model_name():
@@ -273,6 +246,8 @@ def test_llmchain_autolog_with_registered_model_name():
         assert registered_model.name == registered_model_name
 
 
+# TODO: remove skip mark before merging the tracing feature branch to master
+@pytest.mark.skip(reason="Metrics autologging is disabled in the tracing feature branch.")
 def test_llmchain_autolog_metrics():
     mlflow.langchain.autolog()
     with _mock_request(return_value=_mock_chat_completion_response()):
@@ -284,20 +259,6 @@ def test_llmchain_autolog_metrics():
         for metric_key in MLFLOW_CALLBACK_METRICS + TEXT_COMPLEXITY_METRICS:
             assert metric_key in metrics
     assert mlflow.active_run() is None
-
-
-def test_llmchain_autolog_artifacts():
-    mlflow.langchain.autolog()
-    with _mock_request(return_value=_mock_chat_completion_response()):
-        model = create_openai_llmchain()
-        with mlflow.start_run() as run:
-            model.invoke("MLflow")
-        artifacts = get_artifacts(run.info.run_id)
-        for artifact_name in get_mlflow_callback_artifacts():
-            if isinstance(artifact_name, str):
-                assert artifact_name in artifacts
-            else:
-                assert any(artifact_name.match(artifact) for artifact in artifacts)
 
 
 def test_loaded_llmchain_autolog():
@@ -373,7 +334,7 @@ def test_llmchain_autolog_log_inputs_outputs():
         assert new_session_id != session_id
 
 
-def test_agent_autolog():
+def test_agent_autolog(clear_trace_singleton):
     mlflow.langchain.autolog(log_models=True)
     model, input, mock_response = create_openai_llmagent()
     with _mock_request(return_value=_MockResponse(200, mock_response)), mock.patch(
@@ -393,14 +354,22 @@ def test_agent_autolog():
         assert model.invoke(input, return_only_outputs=True) == {"output": TEST_CONTENT}
         log_model_mock.assert_called_once()
 
-    trace = mlflow.get_traces()[0]
-    span = trace.trace_data.spans[0]
-    assert span.span_type == "CHAIN"
-    assert span.inputs == input
-    assert span.outputs == {"output": TEST_CONTENT}
+    traces = mlflow.get_traces(None)
+    assert len(traces) == 4
+    for trace in traces:
+        spans = [(s.name, s.span_type) for s in trace.trace_data.spans]
+        assert spans == [
+            ("AgentExecutor", "CHAIN"),
+            ("LLMChain", "CHAIN"),
+            ("OpenAI", "LLM"),
+        ]
+        assert trace.trace_data.spans[0].inputs == input
+        assert trace.trace_data.spans[0].outputs == {"output": TEST_CONTENT}
 
 
-def test_agent_autolog_metrics_and_artifacts():
+# TODO: remove skip mark before merging the tracing feature branch to master
+@pytest.mark.skip(reason="Metrics autologging is disabled in the tracing feature branch.")
+def test_agent_autolog_metrics():
     mlflow.langchain.autolog()
     model, input, mock_response = create_openai_llmagent()
     with _mock_request(return_value=_MockResponse(200, mock_response)):
@@ -411,14 +380,6 @@ def test_agent_autolog_metrics_and_artifacts():
         for metric_key in MLFLOW_CALLBACK_METRICS + TEXT_COMPLEXITY_METRICS:
             assert metric_key in metrics
 
-        artifacts = get_artifacts(run.info.run_id)
-        for artifact_name in get_mlflow_callback_artifacts(
-            contains_agent=True, contains_chain=True
-        ):
-            if isinstance(artifact_name, str):
-                assert artifact_name in artifacts
-            else:
-                assert any(artifact_name.match(artifact) for artifact in artifacts)
     assert mlflow.active_run() is None
 
 
@@ -477,21 +438,44 @@ def test_agent_autolog_log_inputs_outputs():
         )
 
 
-def test_runnable_sequence_autolog():
+def test_runnable_sequence_autolog(clear_trace_singleton):
     mlflow.langchain.autolog(log_models=True)
     chain, input_example = create_runnable_sequence()
     with mock.patch("mlflow.langchain.log_model") as log_model_mock:
         assert chain.invoke(input_example) == TEST_CONTENT
         assert chain.invoke(input_example) == TEST_CONTENT
         log_model_mock.assert_called_once()
-    trace = mlflow.get_traces()[0]
-    span = trace.trace_data.spans[0]
-    assert span.span_type == "CHAIN"
-    assert span.inputs == input_example
-    assert span.outputs == TEST_CONTENT
+
+    traces = mlflow.get_traces(None)
+    assert len(traces) == 2
+    for trace in traces:
+        spans = [(s.name, s.span_type) for s in trace.trace_data.spans]
+
+        # "extract_questions" and "extract_history" are executed in RunnableParallel
+        # so the order of these two spans is not deterministic. To avoid flakiness,
+        # we have to check both possible orders.
+        parallel_spans = ["extract_question", "extract_history"]
+        matched = False
+        for parallel_spans_order in [parallel_spans, parallel_spans[::-1]]:
+            matched |= spans == [
+                ("RunnableSequence", "CHAIN"),
+                ("RunnableParallel<question,chat_history>", "CHAIN"),
+                ("RunnableSequence", "CHAIN"),
+                ("RunnableLambda", "CHAIN"),
+                (parallel_spans_order[0], "CHAIN"),
+                ("RunnableSequence", "CHAIN"),
+                ("RunnableLambda", "CHAIN"),
+                (parallel_spans_order[1], "CHAIN"),
+                ("PromptTemplate", "CHAIN"),
+                ("FakeChatModel", "LLM"),
+                ("StrOutputParser", "CHAIN"),
+            ]
+        assert matched
 
 
-def test_runnable_sequence_autolog_metrics_and_artifacts():
+# TODO: remove skip mark before merging the tracing feature branch to master
+@pytest.mark.skip(reason="Metrics autologging is disabled in the tracing feature branch.")
+def test_runnable_sequence_autolog_metrics():
     mlflow.langchain.autolog()
     chain, input_example = create_runnable_sequence()
     with mlflow.start_run() as run:
@@ -500,13 +484,6 @@ def test_runnable_sequence_autolog_metrics_and_artifacts():
     metrics = client.get_run(run.info.run_id).data.metrics
     for metric_key in MLFLOW_CALLBACK_METRICS + TEXT_COMPLEXITY_METRICS:
         assert metric_key in metrics
-
-    artifacts = get_artifacts(run.info.run_id)
-    for artifact_name in get_mlflow_callback_artifacts(contains_on_text_action=False):
-        if isinstance(artifact_name, str):
-            assert artifact_name in artifacts
-        else:
-            assert any(artifact_name.match(artifact) for artifact in artifacts)
     assert mlflow.active_run() is None
 
 
@@ -563,7 +540,7 @@ def test_runnable_sequence_autolog_log_inputs_outputs():
     )
 
 
-def test_retriever_autolog(tmp_path):
+def test_retriever_autolog(tmp_path, clear_trace_singleton):
     mlflow.langchain.autolog(log_models=True)
     model, query = create_retriever(tmp_path)
     with mock.patch("mlflow.langchain.log_model") as log_model_mock, mock.patch(
@@ -572,13 +549,19 @@ def test_retriever_autolog(tmp_path):
         model.get_relevant_documents(query)
         log_model_mock.assert_not_called()
         logger_mock.assert_called_once_with(UNSUPPORT_LOG_MODEL_MESSAGE)
-    trace = mlflow.get_traces()[0]
-    span = trace.trace_data.spans[0]
-    assert span.span_type == "RETRIEVER"
-    assert span.inputs == query
-    assert span.outputs[0].metadata == {"source": "tests/langchain/state_of_the_union.txt"}
+
+    traces = mlflow.get_traces(None)
+    assert len(traces) == 1
+    spans = traces[0].trace_data.spans
+    assert len(spans) == 1
+    assert spans[0].span_type == "RETRIEVER"
+    assert spans[0].name == "VectorStoreRetriever"
+    assert spans[0].inputs == query
+    assert spans[0].outputs[0].metadata == {"source": "tests/langchain/state_of_the_union.txt"}
 
 
+# TODO: remove skip mark before merging the tracing feature branch to master
+@pytest.mark.skip(reason="Metrics autologging is disabled in the tracing feature branch.")
 def test_retriever_metrics_and_artifacts(tmp_path):
     mlflow.langchain.autolog()
     model, query = create_retriever(tmp_path)
@@ -589,16 +572,6 @@ def test_retriever_metrics_and_artifacts(tmp_path):
     for metric_key in MLFLOW_CALLBACK_METRICS:
         assert metric_key in metrics
 
-    artifacts = get_artifacts(run.info.run_id)
-    for artifact_name in get_mlflow_callback_artifacts(
-        contains_llm=False,
-        contains_on_text_action=False,
-        contains_retriever=True,
-    ):
-        if isinstance(artifact_name, str):
-            assert artifact_name in artifacts
-        else:
-            assert any(artifact_name.match(artifact) for artifact in artifacts)
     assert mlflow.active_run() is None
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11634?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11634/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11634
```

</p>
</details>

### What changes are proposed in this pull request?

The current production LangChain autologging does followings:
1. Logging intermediate steps like LLM input/output using [MlflowLangchainCallbackHandler](https://github.com/langchain-ai/langchain/blob/38fb1429fe5a955a863fb91b626c2c9f85efb703/libs/community/langchain_community/callbacks/mlflow_callback.py#L256).
2. Logging final artifacts such as model, signature, input example, etc, at the completion of the prediction. These are optional and only logged when corresponding configuration is enabled e.g. `mlflow.langchain.autolog(log_model_signatures=True)`.

However, (1) largely overlaps with the traces. Most of metrics/jsons logged at each intermediate steps are subset of the information available in traces. The duplication itself is not the main issue, but its side effect is. The legacy callback logs metrics/json at each step synchronously, so it adds certain latency (~1 sec) to the each step execution. This latency is not captured by the tracer because callbacks are executed independently, results in weird blanks in the span timeline.

Therefore, we decided to turn off the legacy callback in the feature branch. This PR removes (1) while keep (2) to be functioning, with some refactoring.

**Note**: There is one feature in the legacy callback that is covered by the new tracer - [complex text metrics](https://github.com/langchain-ai/langchain/blob/38fb1429fe5a955a863fb91b626c2c9f85efb703/libs/community/langchain_community/callbacks/mlflow_callback.py#L62-L81). These metrics are computed against LLM output inside the legacy callback, but we don't have corresponding implementation in the tracer. This should not be a blocker for feature branch, but we should add this back before the public release, probably as a separate callback.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
