### PR TITLE
Handle custom model in sentence-transformers flavor

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -694,7 +694,14 @@ sentence_transformers:
     minimum: "2.2.2"
     maximum: "2.4.0"
     requirements:
-      ">= 0.0.0": ["pyspark", "torch>1.6", "transformers>4.25", "hf_transfer"]
+      ">= 0.0.0": [
+          "pyspark",
+          "torch>1.6",
+          "transformers>4.25",
+          "hf_transfer",
+          # Required by a test model (nomic-ai/nomic-embed-text-v1.5)
+          "einops",
+        ]
     run: |
       pytest tests/sentence_transformers/test_sentence_transformers_model_export.py
 

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -5,10 +5,9 @@ import re
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
-from packaging.version import Version
 import pandas as pd
-import sentence_transformers
 import yaml
+from packaging.version import Version
 
 import mlflow
 from mlflow import pyfunc
@@ -63,8 +62,6 @@ _LLM_V1_EMBEDDING_INPUT_KEY = "input"
 # The path format would be like /path/to/{username}_{modelname}, where user name can
 # only contain number, letters, and dashes.
 _LOCAL_SNAPSHOT_PATH_PATTERN = re.compile(r"/([0-9a-zA-Z-]+)_([^\/]+)/$")
-
-_IS_REMOTE_CODE_SUPPORTED = Version(sentence_transformers.__version__) >= Version("2.3.0")
 
 model_data_artifact_paths = [SENTENCE_TRANSFORMERS_DATA_PATH]
 
@@ -465,7 +462,8 @@ def load_model(model_uri: str, dst_path: Optional[str] = None):
     _add_code_from_conf_to_system_path(local_model_path, flavor_config)
 
     load_kwargs = {}
-    if _IS_REMOTE_CODE_SUPPORTED:
+    # The trust_remote_code is supported since Sentence Transformers 2.3.0
+    if Version(sentence_transformers.__version__) >= Version("2.3.0"):
         # Always set trust_remote_code=True because we save the entire repository files in
         # the model artifacts, so there is no risk of running untrusted code unless the logged
         # artifact is modified by a malicious actor, which is much more broader security

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -130,6 +130,12 @@ def save_model(
     metadata: Optional[Dict[str, Any]] = None,
 ) -> None:
     """
+    .. note::
+
+        Saving Sentence Transformers models with custom code (i.e. models that require
+        ``trust_remote_code=True``) is supported in MLflow 2.12.0 and above.
+
+
     Save a trained ``sentence-transformers`` model to a path on the local file system.
 
     Args:
@@ -312,8 +318,12 @@ def log_model(
     metadata: Optional[Dict[str, Any]] = None,
 ):
     """
-    Log a ``sentence_transformers`` model as an MLflow artifact for the current run.
+    .. note::
 
+        Logging Sentence Transformers models with custom code (i.e. models that require
+        ``trust_remote_code=True``) is supported in MLflow 2.12.0 and above.
+
+    Log a ``sentence_transformers`` model as an MLflow artifact for the current run.
 
     .. code-block:: python
 
@@ -450,7 +460,11 @@ def load_model(model_uri: str, dst_path: Optional[str] = None):
 
     _add_code_from_conf_to_system_path(local_model_path, flavor_config)
 
-    return sentence_transformers.SentenceTransformer.load(str(local_model_dir))
+    # Always set trust_remote_code=True because we save the entire repository files in the model
+    # artifacts, so there is no risk of running untrusted code unless the logged artifact is
+    # modified by a malicious actor, which is much more broader security concern that even cannot
+    # be prevented by setting trust_remote_code=False.
+    return sentence_transformers.SentenceTransformer(str(local_model_dir), trust_remote_code=True)
 
 
 def _get_default_signature():

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -3,10 +3,11 @@ import os
 from unittest import mock
 
 import numpy as np
-from packaging.version import Version
 import pandas as pd
 import pytest
+import sentence_transformers
 import yaml
+from packaging.version import Version
 from pyspark.sql import SparkSession
 from pyspark.sql.types import ArrayType, DoubleType
 from sentence_transformers import SentenceTransformer
@@ -18,7 +19,6 @@ from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, infer_signature
 from mlflow.models.utils import _read_example
-from mlflow.sentence_transformers import _IS_REMOTE_CODE_SUPPORTED
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.utils.environment import _mlflow_conda_env
 
@@ -68,8 +68,8 @@ def test_model_save_and_load(model_path, basic_model):
 
 
 @pytest.mark.skipif(
-    not _IS_REMOTE_CODE_SUPPORTED,
-    reason="`trust_remote_code` is not supported in Sentence Transformers < 2.3.0"
+    Version(sentence_transformers.__version__) < Version("2.3.0"),
+    reason="`trust_remote_code` is not supported in Sentence Transformers < 2.3.0",
 )
 def test_model_save_and_load_with_custom_code(model_path, model_with_remote_code):
     mlflow.sentence_transformers.save_model(model=model_with_remote_code, path=model_path)

--- a/tests/sentence_transformers/test_sentence_transformers_model_export.py
+++ b/tests/sentence_transformers/test_sentence_transformers_model_export.py
@@ -3,6 +3,7 @@ import os
 from unittest import mock
 
 import numpy as np
+from packaging.version import Version
 import pandas as pd
 import pytest
 import yaml
@@ -17,6 +18,7 @@ from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, infer_signature
 from mlflow.models.utils import _read_example
+from mlflow.sentence_transformers import _IS_REMOTE_CODE_SUPPORTED
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.utils.environment import _mlflow_conda_env
 
@@ -65,6 +67,10 @@ def test_model_save_and_load(model_path, basic_model):
     assert all(len(x) == 384 for x in encoded_multi)
 
 
+@pytest.mark.skipif(
+    not _IS_REMOTE_CODE_SUPPORTED,
+    reason="`trust_remote_code` is not supported in Sentence Transformers < 2.3.0"
+)
 def test_model_save_and_load_with_custom_code(model_path, model_with_remote_code):
     mlflow.sentence_transformers.save_model(model=model_with_remote_code, path=model_path)
     loaded_model = mlflow.sentence_transformers.load_model(model_path)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11635?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11635/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11635
```

</p>
</details>

### What changes are proposed in this pull request?

Allow saving and loading SentenceTransformers model that relies on custom code.

The problem this PR addresses is same as the one fixed in the Transformers flavor by #11412. However, it's much easier in SentenceTransformer, because MLflow saves the entire HuggingFace repository and load back from it. Therefore, loading a custom model requires nothing but setting `trust_remote_code` flag to `True`, just like how we load the model initially from the hub.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested in staging notebook:
```
import mlflow
from sentence_transformers import SentenceTransformer

nomic_model_name = "nomic-ai/nomic-embed-text-v1.5"
nomic_model = SentenceTransformer(nomic_model_name, trust_remote_code=True)
nomic_query = "search query: what is the definition of an active business"

with mlflow.start_run():
    model_info = mlflow.sentence_transformers.log_model(
        model=nomic_model,
        artifact_path="nomic",
        input_example=nomic_query,
        signature = mlflow.models.infer_signature(
            model_input=nomic_query,
            model_output=nomic_model.encode(nomic_query),
        ),
        pip_requirements=["einops", "sentence_transformers"],
    )

loaded_model = mlflow.sentence_transformers.load_model(model_info.model_uri)
```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add support for models rely on custom code in Sentence Transformers flavor.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
