### PR TITLE
style: Improved Documentation Navigation in MLflow

### DIFF
--- a/docs/theme/mlflow/static/css/custom.css
+++ b/docs/theme/mlflow/static/css/custom.css
@@ -494,7 +494,6 @@ table > colgroup:first-child {
 .wy-menu-vertical li.current a,
 .wy-menu-vertical li.current > a {
   color: #000;
-  font-weight: normal !important;
   padding: 6px 30px !important;
   font-size: 1em;
   line-height: 1.25em;


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/minkj1992/mlflow/pull/11639?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11639/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11639
```

</p>
</details>

### Related Issues/PRs

Currently, navigating through the MLflow documentation, especially when going through multiple depths, can be confusing to determine the current page's location. This is because the left panel isn't effectively displaying the current reference; it doesn't seem intentional but rather a result of the !important normal directive in custom.css interfering with theme.css.

By removing the !important normal directive from custom.css, I resolved the problem of the left panel improperly displaying the current reference, restoring the original intent of properly rendering bold formatting



https://github.com/mlflow/mlflow/commit/80db2a7ffe73498df6bded5f50b1cf4fa124976b (cc @mateiz )
```css
.wy-menu-vertical li.current > a {
  color: #000;
  font-weight: normal !important;
  ...
}
```

#### AS-IS
<img width="1728" alt="Screen Shot 2024-04-06 at 8 22 47 PM" src="https://github.com/mlflow/mlflow/assets/37536298/41846766-162a-4729-be86-d42e39949465">

#### TO-BE
<img width="1727" alt="Screen Shot 2024-04-06 at 8 23 01 PM" src="https://github.com/mlflow/mlflow/assets/37536298/57f51424-685d-4363-992e-c36d3ec75dd9">


### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
