### PR TITLE
[Bug-Bash] Rename info and data

### DIFF
--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -15,12 +15,12 @@ class Trace(_MlflowObject):
     """A trace object. (TODO: Add conceptual guide for tracing.)
 
     Args:
-        trace_info: A lightweight object that contains the metadata of a trace.
-        trace_data: A container object that holds the spans data of a trace.
+        info: A lightweight object that contains the metadata of a trace.
+        data: A container object that holds the spans data of a trace.
     """
 
-    trace_info: TraceInfo
-    trace_data: TraceData
+    info: TraceInfo
+    data: TraceData
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), cls=_TraceJSONEncoder)

--- a/mlflow/tracing/clients/local.py
+++ b/mlflow/tracing/clients/local.py
@@ -61,7 +61,7 @@ class InMemoryTraceClient(TraceClient):
         """
         with self._lock:
             for trace in self.queue:
-                if trace.trace_info.request_id == request_id:
+                if trace.info.request_id == request_id:
                     return trace
 
     def _flush(self):

--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -52,7 +52,7 @@ class IPythonTraceDisplayHandler:
                 return
 
             traces = traces[:MAX_TRACES_TO_DISPLAY]
-            traces_dict = {trace.trace_info.request_id: trace for trace in traces}
+            traces_dict = {trace.info.request_id: trace for trace in traces}
 
             # if the current ipython exec count has changed, then
             # we're in a different cell (or rerendering the current

--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -72,11 +72,10 @@ class MlflowSpanExporter(SpanExporter):
             return
 
         # Update a TraceInfo object with the root span information
-        info = trace.trace_info
-        info.timestamp_ms = root_span.start_time // 1_000  # microsecond to millisecond
-        info.execution_time_ms = (root_span.end_time - root_span.start_time) // 1_000
-        info.status = root_span.status.status_code
-        info.request_metadata.update(
+        trace.info.timestamp_ms = root_span.start_time // 1_000  # microsecond to millisecond
+        trace.info.execution_time_ms = (root_span.end_time - root_span.start_time) // 1_000
+        trace.info.status = root_span.status.status_code
+        trace.info.request_metadata.update(
             {
                 TraceMetadataKey.INPUTS: self._serialize_inputs_outputs(root_span.inputs),
                 TraceMetadataKey.OUTPUTS: self._serialize_inputs_outputs(root_span.outputs),
@@ -90,7 +89,7 @@ class MlflowSpanExporter(SpanExporter):
         )
 
         # Rename spans to have unique names
-        MlflowSpanExporter._deduplicate_span_names_in_place(trace.trace_data)
+        MlflowSpanExporter._deduplicate_span_names_in_place(trace.data)
 
         # TODO: Make this async
         self._client.log_trace(trace)

--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -82,7 +82,7 @@ class MlflowSpanExporter(SpanExporter):
             }
         )
         # Mutable info like trace name should be recorded in tags
-        info.tags.update(
+        trace.info.tags.update(
             {
                 TraceTagKey.TRACE_NAME: root_span.name,
             }

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -22,7 +22,7 @@ _logger = logging.getLogger(__name__)
 # Dict[str, Span] is used instead of TraceData to allow access by span_id.
 @dataclass
 class _Trace:
-    trace_info: TraceInfo
+    info: TraceInfo
     span_dict: Dict[str, MlflowSpanWrapper] = field(default_factory=dict)
 
     def to_mlflow_trace(self) -> Trace:
@@ -32,7 +32,7 @@ class _Trace:
             if span.parent_span_id is None:
                 trace_data.request = span.inputs
                 trace_data.response = span.outputs
-        return Trace(self.trace_info, trace_data)
+        return Trace(self.info, trace_data)
 
 
 class InMemoryTraceManager:
@@ -149,7 +149,7 @@ class InMemoryTraceManager:
         """Set a tag on the trace with the given request_id."""
         with self._lock:
             if trace := self._traces.get(request_id):
-                trace.trace_info.tags[key] = str(value)
+                trace.info.tags[key] = str(value)
                 return
 
         raise MlflowException(
@@ -161,7 +161,7 @@ class InMemoryTraceManager:
         Get the trace info for the given request_id.
         """
         trace = self._traces.get(request_id)
-        return trace.trace_info if trace else None
+        return trace.info if trace else None
 
     def get_span_from_id(self, request_id: str, span_id: str) -> Optional[MlflowSpanWrapper]:
         """

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -262,10 +262,7 @@ class TrackingServiceClient:
                 )
                 return None
             else:
-                return Trace(
-                    trace_info=trace_info,
-                    trace_data=trace_data,
-                )
+                return Trace(trace_info, trace_data)
 
         traces = []
         next_max_results = max_results

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -44,11 +44,11 @@ def test_json_deserialization(mock_trace_client):
     trace_json_as_dict = json.loads(trace_json)
 
     assert trace_json_as_dict == {
-        "trace_info": {
-            "request_id": trace.trace_info.request_id,
+        "info": {
+            "request_id": trace.info.request_id,
             "experiment_id": "0",
-            "timestamp_ms": trace.trace_info.timestamp_ms,
-            "execution_time_ms": trace.trace_info.execution_time_ms,
+            "timestamp_ms": trace.info.timestamp_ms,
+            "execution_time_ms": trace.info.execution_time_ms,
             "status": "OK",
             "request_metadata": {
                 "mlflow.traceInputs": '{"x": 2, "y": 5}',
@@ -58,20 +58,20 @@ def test_json_deserialization(mock_trace_client):
                 "mlflow.traceName": "predict",
             },
         },
-        "trace_data": {
+        "data": {
             "request": {"x": 2, "y": 5},
             "response": 8,
             "spans": [
                 {
                     "name": "predict",
                     "context": {
-                        "request_id": trace.trace_data.spans[0].context.request_id,
-                        "span_id": trace.trace_data.spans[0].context.span_id,
+                        "request_id": trace.data.spans[0].context.request_id,
+                        "span_id": trace.data.spans[0].context.span_id,
                     },
                     "span_type": "UNKNOWN",
                     "parent_span_id": None,
-                    "start_time": trace.trace_data.spans[0].start_time,
-                    "end_time": trace.trace_data.spans[0].end_time,
+                    "start_time": trace.data.spans[0].start_time,
+                    "end_time": trace.data.spans[0].end_time,
                     "status": {"status_code": "OK", "description": ""},
                     "inputs": {"x": 2, "y": 5},
                     "outputs": 8,
@@ -81,13 +81,13 @@ def test_json_deserialization(mock_trace_client):
                 {
                     "name": "add_one_with_custom_name",
                     "context": {
-                        "request_id": trace.trace_data.spans[1].context.request_id,
-                        "span_id": trace.trace_data.spans[1].context.span_id,
+                        "request_id": trace.data.spans[1].context.request_id,
+                        "span_id": trace.data.spans[1].context.span_id,
                     },
                     "span_type": "LLM",
-                    "parent_span_id": trace.trace_data.spans[0].context.span_id,
-                    "start_time": trace.trace_data.spans[1].start_time,
-                    "end_time": trace.trace_data.spans[1].end_time,
+                    "parent_span_id": trace.data.spans[0].context.span_id,
+                    "start_time": trace.data.spans[1].start_time,
+                    "end_time": trace.data.spans[1].end_time,
                     "status": {"status_code": "OK", "description": ""},
                     "inputs": {"z": 7},
                     "outputs": 8,

--- a/tests/entities/test_trace_data.py
+++ b/tests/entities/test_trace_data.py
@@ -29,7 +29,7 @@ def test_json_deserialization(mock_trace_client):
     with pytest.raises(Exception, match="Error!"):
         model.predict(2, 5)
 
-    trace_data = mlflow.get_traces()[0].trace_data
+    trace_data = mlflow.get_traces()[0].data
     trace_data_dict = trace_data.to_dict()
 
     # Compare events separately as it includes exception stacktrace which is hard to hardcode

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -253,9 +253,9 @@ def test_autolog_record_exception(clear_trace_singleton):
     traces = mlflow.get_traces(None)
     assert len(traces) == 1
     trace = traces[0]
-    assert trace.trace_info.status == "ERROR"
-    assert len(trace.trace_data.spans) == 1
-    assert trace.trace_data.spans[0].name == "always_fail"
+    assert trace.info.status == "ERROR"
+    assert len(trace.data.spans) == 1
+    assert trace.data.spans[0].name == "always_fail"
 
 
 def test_llmchain_autolog(clear_trace_singleton):
@@ -273,7 +273,7 @@ def test_llmchain_autolog(clear_trace_singleton):
     traces = mlflow.get_traces(None)
     assert len(traces) == 2
     for trace in traces:
-        spans = trace.trace_data.spans
+        spans = trace.data.spans
         assert len(spans) == 2  # chain + llm
         assert spans[0].span_type == "CHAIN"
         assert spans[0].name == "LLMChain"
@@ -300,7 +300,7 @@ def test_llmchain_autolog_no_optional_artifacts_by_default(clear_trace_singleton
 
     traces = mlflow.get_traces(None)
     assert len(traces) == 1
-    spans = traces[0].trace_data.spans
+    spans = traces[0].data.spans
     assert len(spans) == 2
 
 

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -186,7 +186,7 @@ def test_autolog_manage_run():
     traces = mlflow.get_traces(None)
     assert len(traces) == 2
     for trace in traces:
-        span = trace.trace_data.spans[0]
+        span = trace.data.spans[0]
         assert span.span_type == "CHAIN"
         assert span.inputs == {"product": "MLflow"}
         assert span.outputs == {"text": TEST_CONTENT}
@@ -425,14 +425,14 @@ def test_agent_autolog(clear_trace_singleton):
     traces = mlflow.get_traces(None)
     assert len(traces) == 4
     for trace in traces:
-        spans = [(s.name, s.span_type) for s in trace.trace_data.spans]
+        spans = [(s.name, s.span_type) for s in trace.data.spans]
         assert spans == [
             ("AgentExecutor", "CHAIN"),
             ("LLMChain", "CHAIN"),
             ("OpenAI", "LLM"),
         ]
-        assert trace.trace_data.spans[0].inputs == input
-        assert trace.trace_data.spans[0].outputs == {"output": TEST_CONTENT}
+        assert trace.data.spans[0].inputs == input
+        assert trace.data.spans[0].outputs == {"output": TEST_CONTENT}
 
 
 # TODO: remove skip mark before merging the tracing feature branch to master
@@ -517,7 +517,7 @@ def test_runnable_sequence_autolog(clear_trace_singleton):
     traces = mlflow.get_traces(None)
     assert len(traces) == 2
     for trace in traces:
-        spans = {(s.name, s.span_type) for s in trace.trace_data.spans}
+        spans = {(s.name, s.span_type) for s in trace.data.spans}
         # Since the chain includes parallel execution, the order of some
         # spans is not deterministic.
         assert spans == {
@@ -614,7 +614,7 @@ def test_retriever_autolog(tmp_path, clear_trace_singleton):
 
     traces = mlflow.get_traces(None)
     assert len(traces) == 1
-    spans = traces[0].trace_data.spans
+    spans = traces[0].data.spans
     assert len(spans) == 1
     assert spans[0].span_type == "RETRIEVER"
     assert spans[0].name == "VectorStoreRetriever"

--- a/tests/tracing/clients/test_local.py
+++ b/tests/tracing/clients/test_local.py
@@ -7,7 +7,7 @@ def test_log_and_get_trace(monkeypatch, create_trace):
 
     def _create_trace(request_id: str):
         return Trace(
-            trace_info=TraceInfo(
+            info=TraceInfo(
                 request_id=request_id,
                 experiment_id="test",
                 timestamp_ms=0,
@@ -16,7 +16,7 @@ def test_log_and_get_trace(monkeypatch, create_trace):
                 request_metadata={},
                 tags={},
             ),
-            trace_data=TraceData(),
+            data=TraceData(),
         )
 
     client = InMemoryTraceClient.get_instance()
@@ -29,13 +29,13 @@ def test_log_and_get_trace(monkeypatch, create_trace):
 
     traces = client.get_traces()
     assert len(traces) == 3
-    assert traces[0].trace_info.request_id == "a"
+    assert traces[0].info.request_id == "a"
 
     traces = client.get_traces(1)
     assert len(traces) == 1
-    assert traces[0].trace_info.request_id == "c"
+    assert traces[0].info.request_id == "c"
 
     client.log_trace(create_trace("d"))
     traces = client.get_traces()
     assert len(traces) == 3
-    assert traces[0].trace_info.request_id == "b"
+    assert traces[0].info.request_id == "b"

--- a/tests/tracing/conftest.py
+++ b/tests/tracing/conftest.py
@@ -48,7 +48,7 @@ def mock_client():
 @pytest.fixture
 def create_trace():
     return lambda id: Trace(
-        trace_info=TraceInfo(
+        info=TraceInfo(
             request_id=id,
             experiment_id="test",
             timestamp_ms=0,
@@ -57,7 +57,7 @@ def create_trace():
             request_metadata={},
             tags={},
         ),
-        trace_data=TraceData(),
+        data=TraceData(),
     )
 
 

--- a/tests/tracing/export/test_mlflow_exporter.py
+++ b/tests/tracing/export/test_mlflow_exporter.py
@@ -75,7 +75,7 @@ def test_export():
     client_call_args = mock_client.log_trace.call_args[0][0]
 
     # Trace info should inherit fields from the root span
-    trace_info = client_call_args.trace_info
+    trace_info = client_call_args.info
     assert trace_info.request_id == f"tr-{trace_id}"
     assert trace_info.timestamp_ms == 0
     assert trace_info.execution_time_ms == 4
@@ -93,7 +93,7 @@ def test_export():
     assert len(outputs) == MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS
 
     # All 3 spans should be in the logged trace data
-    assert len(client_call_args.trace_data.spans) == 3
+    assert len(client_call_args.data.spans) == 3
 
     # Spans should be cleared from the aggregator
     assert len(exporter._trace_manager._traces) == 0

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -41,17 +41,11 @@ def test_trace(mock_client):
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 2, "y": 5}'
     assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == "64"
 
-<<<<<<< HEAD
-    trace_data = trace.trace_data
-    assert trace_data.request == {"x": 2, "y": 5}
-    assert trace_data.response == 64
-    assert len(trace_data.spans) == 3
-=======
-    spans = trace.data.spans
-    assert len(spans) == 3
->>>>>>> 1f9c6fe62 (Rename trace_info and trace_data attirbutes to info and data)
+    assert trace.data.request == {"x": 2, "y": 5}
+    assert trace.data.response == 64
+    assert len(trace.data.spans) == 3
 
-    span_name_to_span = {span.name: span for span in trace_data.spans}
+    span_name_to_span = {span.name: span for span in trace.data.spans}
     root_span = span_name_to_span["predict"]
     assert root_span.start_time // 1e3 == trace.info.timestamp_ms
     assert root_span.parent_span_id is None
@@ -92,24 +86,14 @@ def test_trace_handle_exception_during_prediction(mock_client):
 
     # Trace should be logged even if the function fails, with status code ERROR
     trace = mlflow.get_traces()[0]
-<<<<<<< HEAD
-    trace_info = trace.trace_info
-    assert trace_info.request_id is not None
-    assert trace_info.status == TraceStatus.ERROR
-    assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 2, "y": 5}'
-    assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == ""
-
-    trace_data = trace.trace_data
-    assert trace_data.request == {"x": 2, "y": 5}
-    assert trace_data.response is None
-    assert len(trace_data.spans) == 2
-=======
     assert trace.info.request_id is not None
     assert trace.info.status == TraceStatus.ERROR
     assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 2, "y": 5}'
     assert trace.info.request_metadata[TraceMetadataKey.OUTPUTS] == ""
+
+    assert trace.data.request == {"x": 2, "y": 5}
+    assert trace.data.response is None
     assert len(trace.data.spans) == 2
->>>>>>> 1f9c6fe62 (Rename trace_info and trace_data attirbutes to info and data)
 
 
 def test_trace_ignore_exception_from_tracing_logic(mock_client):
@@ -177,17 +161,11 @@ def test_start_span_context_manager(mock_client):
     assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
     assert trace.info.request_metadata[TraceMetadataKey.OUTPUTS] == "25"
 
-<<<<<<< HEAD
-    trace_data = trace.trace_data
-    assert trace_data.request == {"x": 1, "y": 2}
-    assert trace_data.response == 25
-    assert len(trace_data.spans) == 3
-=======
-    spans = trace.data.spans
-    assert len(spans) == 3
->>>>>>> 1f9c6fe62 (Rename trace_info and trace_data attirbutes to info and data)
+    assert trace.data.request == {"x": 1, "y": 2}
+    assert trace.data.response == 25
+    assert len(trace.data.spans) == 3
 
-    span_name_to_span = {span.name: span for span in trace_data.spans}
+    span_name_to_span = {span.name: span for span in trace.data.spans}
     root_span = span_name_to_span["root_span"]
     assert root_span.start_time // 1e3 == trace.info.timestamp_ms
     assert (root_span.end_time - root_span.start_time) // 1e3 == trace.info.execution_time_ms

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -33,7 +33,7 @@ def test_trace(mock_client):
     model.predict(2, 5)
 
     trace = mlflow.get_traces()[0]
-    trace_info = trace.trace_info
+    trace_info = trace.info
     assert trace_info.request_id is not None
     assert trace_info.experiment_id == "0"  # default experiment
     assert trace_info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
@@ -41,14 +41,19 @@ def test_trace(mock_client):
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 2, "y": 5}'
     assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == "64"
 
+<<<<<<< HEAD
     trace_data = trace.trace_data
     assert trace_data.request == {"x": 2, "y": 5}
     assert trace_data.response == 64
     assert len(trace_data.spans) == 3
+=======
+    spans = trace.data.spans
+    assert len(spans) == 3
+>>>>>>> 1f9c6fe62 (Rename trace_info and trace_data attirbutes to info and data)
 
     span_name_to_span = {span.name: span for span in trace_data.spans}
     root_span = span_name_to_span["predict"]
-    assert root_span.start_time // 1e3 == trace_info.timestamp_ms
+    assert root_span.start_time // 1e3 == trace.info.timestamp_ms
     assert root_span.parent_span_id is None
     assert root_span.inputs == {"x": 2, "y": 5}
     assert root_span.outputs == 64
@@ -87,6 +92,7 @@ def test_trace_handle_exception_during_prediction(mock_client):
 
     # Trace should be logged even if the function fails, with status code ERROR
     trace = mlflow.get_traces()[0]
+<<<<<<< HEAD
     trace_info = trace.trace_info
     assert trace_info.request_id is not None
     assert trace_info.status == TraceStatus.ERROR
@@ -97,6 +103,13 @@ def test_trace_handle_exception_during_prediction(mock_client):
     assert trace_data.request == {"x": 2, "y": 5}
     assert trace_data.response is None
     assert len(trace_data.spans) == 2
+=======
+    assert trace.info.request_id is not None
+    assert trace.info.status == TraceStatus.ERROR
+    assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 2, "y": 5}'
+    assert trace.info.request_metadata[TraceMetadataKey.OUTPUTS] == ""
+    assert len(trace.data.spans) == 2
+>>>>>>> 1f9c6fe62 (Rename trace_info and trace_data attirbutes to info and data)
 
 
 def test_trace_ignore_exception_from_tracing_logic(mock_client):
@@ -122,9 +135,8 @@ def test_trace_ignore_exception_from_tracing_logic(mock_client):
 
     assert output == 7
     trace = mlflow.get_traces()[0]
-    trace_info = trace.trace_info
-    assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == ""
-    assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == "7"
+    assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == ""
+    assert trace.info.request_metadata[TraceMetadataKey.OUTPUTS] == "7"
 
 
 def test_start_span_context_manager(mock_client):
@@ -158,23 +170,27 @@ def test_start_span_context_manager(mock_client):
     model.predict(1, 2)
 
     trace = mlflow.get_traces()[0]
-    trace_info = trace.trace_info
-    assert trace_info.request_id is not None
-    assert trace_info.experiment_id == "0"  # default experiment
-    assert trace_info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
-    assert trace_info.status == TraceStatus.OK
-    assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
-    assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == "25"
+    assert trace.info.request_id is not None
+    assert trace.info.experiment_id == "0"  # default experiment
+    assert trace.info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
+    assert trace.info.status == TraceStatus.OK
+    assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
+    assert trace.info.request_metadata[TraceMetadataKey.OUTPUTS] == "25"
 
+<<<<<<< HEAD
     trace_data = trace.trace_data
     assert trace_data.request == {"x": 1, "y": 2}
     assert trace_data.response == 25
     assert len(trace_data.spans) == 3
+=======
+    spans = trace.data.spans
+    assert len(spans) == 3
+>>>>>>> 1f9c6fe62 (Rename trace_info and trace_data attirbutes to info and data)
 
     span_name_to_span = {span.name: span for span in trace_data.spans}
     root_span = span_name_to_span["root_span"]
-    assert root_span.start_time // 1e3 == trace_info.timestamp_ms
-    assert (root_span.end_time - root_span.start_time) // 1e3 == trace_info.execution_time_ms
+    assert root_span.start_time // 1e3 == trace.info.timestamp_ms
+    assert (root_span.end_time - root_span.start_time) // 1e3 == trace.info.execution_time_ms
     assert root_span.parent_span_id is None
     assert root_span.span_type == SpanType.UNKNOWN
     assert root_span.inputs == {"x": 1, "y": 2}
@@ -232,23 +248,21 @@ def test_start_span_context_manager_with_imperative_apis(mock_client):
     model.predict(1, 2)
 
     trace = mlflow.get_traces()[0]
-    trace_info = trace.trace_info
-    assert trace_info.request_id is not None
-    assert trace_info.experiment_id == "0"  # default experiment
-    assert trace_info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
-    assert trace_info.status == TraceStatus.OK
-    assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
-    assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == "5"
+    assert trace.info.request_id is not None
+    assert trace.info.experiment_id == "0"  # default experiment
+    assert trace.info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
+    assert trace.info.status == TraceStatus.OK
+    assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
+    assert trace.info.request_metadata[TraceMetadataKey.OUTPUTS] == "5"
 
-    trace_data = trace.trace_data
-    assert trace_data.request == {"x": 1, "y": 2}
-    assert trace_data.response == 5
-    assert len(trace_data.spans) == 2
+    assert trace.data.request == {"x": 1, "y": 2}
+    assert trace.data.response == 5
+    assert len(trace.data.spans) == 2
 
-    span_name_to_span = {span.name: span for span in trace_data.spans}
+    span_name_to_span = {span.name: span for span in trace.data.spans}
     root_span = span_name_to_span["root_span"]
-    assert root_span.start_time // 1e3 == trace_info.timestamp_ms
-    assert (root_span.end_time - root_span.start_time) // 1e3 == trace_info.execution_time_ms
+    assert root_span.start_time // 1e3 == trace.info.timestamp_ms
+    assert (root_span.end_time - root_span.start_time) // 1e3 == trace.info.execution_time_ms
     assert root_span.parent_span_id is None
     assert root_span.span_type == SpanType.UNKNOWN
     assert root_span.inputs == {"x": 1, "y": 2}

--- a/tests/tracing/test_trace_manager.py
+++ b/tests/tracing/test_trace_manager.py
@@ -54,16 +54,16 @@ def test_add_spans():
     # Pop the trace data
     trace = trace_manager.pop_trace(request_id_1)
     assert isinstance(trace, Trace)
-    assert trace.trace_info.request_id == request_id_1
-    assert trace.trace_info.experiment_id == exp_id_1
-    assert len(trace.trace_data.spans) == 3
+    assert trace.info.request_id == request_id_1
+    assert trace.info.experiment_id == exp_id_1
+    assert len(trace.data.spans) == 3
     assert request_id_1 not in trace_manager._traces
 
     trace = trace_manager.pop_trace(request_id_2)
     assert isinstance(trace, Trace)
-    assert trace.trace_info.request_id == request_id_2
-    assert trace.trace_info.experiment_id == exp_id_2
-    assert len(trace.trace_data.spans) == 2
+    assert trace.info.request_id == request_id_2
+    assert trace.info.experiment_id == exp_id_2
+    assert len(trace.data.spans) == 2
     assert request_id_2 not in trace_manager._traces
 
     # Pop a trace that does not exist
@@ -109,8 +109,8 @@ def test_add_and_pop_span_thread_safety():
     for request_id in request_ids:
         trace = trace_manager.pop_trace(request_id)
         assert trace is not None
-        assert trace.trace_info.request_id == request_id
-        assert len(trace.trace_data.spans) == num_threads
+        assert trace.info.request_id == request_id
+        assert len(trace.data.spans) == num_threads
 
 
 def test_traces_buffer_expires_after_ttl(monkeypatch):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -304,15 +304,10 @@ def test_start_and_end_trace(clear_singleton, mock_trace_client):
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
     assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == '{"output": 25}'
 
-<<<<<<< HEAD
-    trace_data = traces[0].trace_data
+    trace_data = traces[0].data
     assert trace_data.request == {"x": 1, "y": 2}
     assert trace_data.response == {"output": 25}
     assert len(trace_data.spans) == 3
-=======
-    spans = traces[0].data.spans
-    assert len(spans) == 3
->>>>>>> 1f9c6fe62 (Rename trace_info and trace_data attirbutes to info and data)
 
     span_name_to_span = {span.name: span for span in trace_data.spans}
     root_span = span_name_to_span["predict"]
@@ -383,15 +378,10 @@ def test_start_and_end_trace_before_all_span_end(clear_singleton, mock_trace_cli
     assert trace_info.execution_time_ms is not None
     assert trace_info.status == TraceStatus.OK
 
-<<<<<<< HEAD
-    trace_data = traces[0].trace_data
+    trace_data = traces[0].data
     assert trace_data.request is None
     assert trace_data.response is None
     assert len(trace_data.spans) == 3  # The non-ended span should be also included in the trace
-=======
-    spans = traces[0].data.spans
-    assert len(spans) == 3  # The non-ended span should be also included in the trace
->>>>>>> 1f9c6fe62 (Rename trace_info and trace_data attirbutes to info and data)
 
     span_name_to_span = {span.name: span for span in trace_data.spans}
     root_span = span_name_to_span["predict"]

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -296,7 +296,7 @@ def test_start_and_end_trace(clear_singleton, mock_trace_client):
 
     traces = mlflow.get_traces()
     assert len(traces) == 1
-    trace_info = traces[0].trace_info
+    trace_info = traces[0].info
     assert trace_info.request_id is not None
     assert trace_info.experiment_id == "test_experiment"
     assert trace_info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
@@ -304,10 +304,15 @@ def test_start_and_end_trace(clear_singleton, mock_trace_client):
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
     assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == '{"output": 25}'
 
+<<<<<<< HEAD
     trace_data = traces[0].trace_data
     assert trace_data.request == {"x": 1, "y": 2}
     assert trace_data.response == {"output": 25}
     assert len(trace_data.spans) == 3
+=======
+    spans = traces[0].data.spans
+    assert len(spans) == 3
+>>>>>>> 1f9c6fe62 (Rename trace_info and trace_data attirbutes to info and data)
 
     span_name_to_span = {span.name: span for span in trace_data.spans}
     root_span = span_name_to_span["predict"]
@@ -371,17 +376,22 @@ def test_start_and_end_trace_before_all_span_end(clear_singleton, mock_trace_cli
     traces = mlflow.get_traces()
     assert len(traces) == 1
 
-    trace_info = traces[0].trace_info
+    trace_info = traces[0].info
     assert trace_info.request_id is not None
     assert trace_info.experiment_id == exp_id
     assert trace_info.timestamp_ms is not None
     assert trace_info.execution_time_ms is not None
     assert trace_info.status == TraceStatus.OK
 
+<<<<<<< HEAD
     trace_data = traces[0].trace_data
     assert trace_data.request is None
     assert trace_data.response is None
     assert len(trace_data.spans) == 3  # The non-ended span should be also included in the trace
+=======
+    spans = traces[0].data.spans
+    assert len(spans) == 3  # The non-ended span should be also included in the trace
+>>>>>>> 1f9c6fe62 (Rename trace_info and trace_data attirbutes to info and data)
 
     span_name_to_span = {span.name: span for span in trace_data.spans}
     root_span = span_name_to_span["predict"]
@@ -421,7 +431,7 @@ def test_end_trace_raise_error_when_trace_finished_twice(clear_singleton):
     client.end_trace(root_span.request_id)
 
     trace = mlflow.get_traces()[-1]
-    assert trace.trace_info.request_id == root_span.request_id
+    assert trace.info.request_id == root_span.request_id
 
     with pytest.raises(
         MlflowException, match=f"Trace with ID {root_span.request_id} already finished"
@@ -445,7 +455,7 @@ def test_set_trace_tag_on_active_trace(clear_singleton, mock_trace_client):
     client.end_trace(request_id)
 
     trace = mlflow.get_traces()[-1]
-    assert trace.trace_info.tags == {"mlflow.traceName": "test", "foo": "bar"}
+    assert trace.info.tags == {"mlflow.traceName": "test", "foo": "bar"}
 
 
 def test_set_trace_tag_on_logged_trace(mock_store, mock_trace_client):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11646?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11646/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11646
```

</p>
</details>

### What changes are proposed in this pull request?

To make the attribute access less verbose.  ~~**DO NOT MERGE UNTIL UI CHANGE IS DONE**~~

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
