### PR TITLE
[Bug-Bash] Log actual experiment_id in TraceInfo

### DIFF
--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -120,13 +120,14 @@ class InMemoryTraceManager:
         self,
         request_id: str,
         start_time_ns: int,
-        experiment_id: Optional[str] = None,
         request_metadata: Optional[Dict[str, str]] = None,
         tags: Optional[Dict[str, str]] = None,
     ):
+        from mlflow.tracking.fluent import _get_experiment_id
+
         trace_info = TraceInfo(
             request_id=request_id,
-            experiment_id=experiment_id or "EXPERIMENT",  # TODO: Fetch this from global state
+            experiment_id=_get_experiment_id(),
             timestamp_ms=start_time_ns // 1_000_000,
             execution_time_ms=None,
             status=TraceStatus.UNSPECIFIED,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -499,6 +499,7 @@ class MlflowClient:
         inputs: Optional[Dict[str, Any]] = None,
         attributes: Optional[Dict[str, str]] = None,
         tags: Optional[Dict[str, str]] = None,
+        experiment_id: Optional[str] = None,
     ) -> MlflowSpanWrapper:
         """
         Create a new trace object and start a root span under it.
@@ -521,6 +522,11 @@ class MlflowClient:
             inputs: Inputs to set on the root span of the trace.
             attributes: A dictionary of attributes to set on the root span of the trace.
             tags: A dictionary of tags to set on the trace.
+            experiment_id: The ID of the experiment to create the trace in. If not provided,
+                MLflow will look for valid experiment in the following order: activated using
+                :py:func:`mlflow.set_experiment() <mlflow.set_experiment>`,
+                ``MLFLOW_EXPERIMENT_NAME`` environment variable, ``MLFLOW_EXPERIMENT_ID``
+                environment variable, or the default experiment as defined by the tracking server.
 
         Returns:
             An :py:class:`MlflowSpanWrapper <mlflow.tracing.MlflowSpanWrapper>` object
@@ -575,6 +581,9 @@ class MlflowClient:
         trace_info = trace_manager.get_trace_info(root_span.request_id)
         if tags:
             trace_info.tags.update({k: str(v) for k, v in tags.items()})
+
+        if experiment_id:
+            trace_info.experiment_id = experiment_id
 
         return root_span
 

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -46,7 +46,7 @@ def test_json_deserialization(mock_trace_client):
     assert trace_json_as_dict == {
         "trace_info": {
             "request_id": trace.trace_info.request_id,
-            "experiment_id": "EXPERIMENT",
+            "experiment_id": "0",
             "timestamp_ms": trace.trace_info.timestamp_ms,
             "execution_time_ms": trace.trace_info.execution_time_ms,
             "status": "OK",

--- a/tests/tracing/conftest.py
+++ b/tests/tracing/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from opentelemetry.trace import _TRACER_PROVIDER_SET_ONCE
 
+import mlflow
 from mlflow.entities import Trace, TraceData, TraceInfo, TraceStatus
 from mlflow.tracing.clients.local import InMemoryTraceClient
 from mlflow.tracing.provider import _TRACER_PROVIDER_INITIALIZED, _setup_tracer_provider
@@ -56,3 +57,9 @@ def create_trace():
         ),
         trace_data=TraceData(),
     )
+
+
+@pytest.fixture(autouse=True)
+def reset_active_experiment():
+    yield
+    mlflow.tracking.fluent._active_experiment_id = None

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -35,6 +35,7 @@ def test_trace(mock_client):
     trace = mlflow.get_traces()[0]
     trace_info = trace.trace_info
     assert trace_info.request_id is not None
+    assert trace_info.experiment_id == "0"  # default experiment
     assert trace_info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
     assert trace_info.status == TraceStatus.OK
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 2, "y": 5}'
@@ -155,6 +156,7 @@ def test_start_span_context_manager(mock_client):
     trace = mlflow.get_traces()[0]
     trace_info = trace.trace_info
     assert trace_info.request_id is not None
+    assert trace_info.experiment_id == "0"  # default experiment
     assert trace_info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
     assert trace_info.status == TraceStatus.OK
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
@@ -226,6 +228,7 @@ def test_start_span_context_manager_with_imperative_apis(mock_client):
     trace = mlflow.get_traces()[0]
     trace_info = trace.trace_info
     assert trace_info.request_id is not None
+    assert trace_info.experiment_id == "0"  # default experiment
     assert trace_info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
     assert trace_info.status == TraceStatus.OK
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -234,7 +234,10 @@ def test_client_delete_traces(mock_store):
     )
 
 
+@pytest.mark.usefixtures("reset_active_experiment")
 def test_start_and_end_trace(clear_singleton, mock_trace_client):
+    exp_id = mlflow.set_experiment("test_experiment_1").experiment_id
+
     class TestModel:
         def __init__(self):
             self._client = MlflowClient()
@@ -295,6 +298,7 @@ def test_start_and_end_trace(clear_singleton, mock_trace_client):
     assert len(traces) == 1
     trace_info = traces[0].trace_info
     assert trace_info.request_id is not None
+    assert trace_info.experiment_id == exp_id
     assert trace_info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
     assert trace_info.status == TraceStatus.OK
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
@@ -327,8 +331,11 @@ def test_start_and_end_trace(clear_singleton, mock_trace_client):
     assert child_span_2.start_time <= child_span_2.end_time - 0.1 * 1e6
 
 
+@pytest.mark.usefixtures("reset_active_experiment")
 def test_start_and_end_trace_before_all_span_end(clear_singleton, mock_trace_client):
     # This test is to verify that the trace is still exported even if some spans are not ended
+    exp_id = mlflow.set_experiment("test_experiment_1").experiment_id
+
     class TestModel:
         def __init__(self):
             self._client = MlflowClient()
@@ -364,6 +371,7 @@ def test_start_and_end_trace_before_all_span_end(clear_singleton, mock_trace_cli
 
     trace_info = traces[0].trace_info
     assert trace_info.request_id is not None
+    assert trace_info.experiment_id == exp_id
     assert trace_info.timestamp_ms is not None
     assert trace_info.execution_time_ms is not None
     assert trace_info.status == TraceStatus.OK

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -234,17 +234,17 @@ def test_client_delete_traces(mock_store):
     )
 
 
-@pytest.mark.usefixtures("reset_active_experiment")
 def test_start_and_end_trace(clear_singleton, mock_trace_client):
-    exp_id = mlflow.set_experiment("test_experiment_1").experiment_id
-
     class TestModel:
         def __init__(self):
             self._client = MlflowClient()
 
         def predict(self, x, y):
             root_span = self._client.start_trace(
-                name="predict", inputs={"x": x, "y": y}, tags={"tag": "tag_value"}
+                name="predict",
+                inputs={"x": x, "y": y},
+                tags={"tag": "tag_value"},
+                experiment_id="test_experiment",
             )
             request_id = root_span.request_id
 
@@ -298,7 +298,7 @@ def test_start_and_end_trace(clear_singleton, mock_trace_client):
     assert len(traces) == 1
     trace_info = traces[0].trace_info
     assert trace_info.request_id is not None
-    assert trace_info.experiment_id == exp_id
+    assert trace_info.experiment_id == "test_experiment"
     assert trace_info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
     assert trace_info.status == TraceStatus.OK
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11648?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11648/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11648
```

</p>
</details>

### What changes are proposed in this pull request?

Replace the placeholder experiment_id to the actual one.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
