### PR TITLE
Fix `upload_trace_data` for Azure Blob Storage

### DIFF
--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -268,6 +268,9 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
                     credentials=cred,
                     local_file=temp_file,
                     artifact_file_path=None,
+                    get_credentials=lambda artifact_paths: [
+                        self._get_upload_trace_data_cred_info()
+                    ],
                 )
             elif cred.type == ArtifactCredentialType.AZURE_SAS_URI:
                 self._azure_upload_file(

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -275,9 +275,17 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
                 )
             elif cred.credential_info.type == ArtifactCredentialType.AZURE_SAS_URI:
                 block_id = base64.b64encode(uuid.uuid4().hex.encode()).decode("utf-8")
-                chunk = temp_file.read_bytes()
-                put_block(signed_uri, block_id, chunk, headers=headers)
-                put_block_list(signed_uri, [block_id], headers=headers)
+                put_block(
+                    sas_url=signed_uri,
+                    block_id=block_id,
+                    data=temp_file.read_bytes(),
+                    headers=headers,
+                )
+                put_block_list(
+                    sas_url=signed_uri,
+                    block_list=[block_id],
+                    headers=headers,
+                )
             elif (
                 cred.credential_info.type == ArtifactCredentialType.AZURE_SAS_URI
                 or cred.credential_info.type == ArtifactCredentialType.AWS_PRESIGNED_URL

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -271,7 +271,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
                 )
             elif cred.type == ArtifactCredentialType.AZURE_SAS_URI:
                 self._azure_upload_file(
-                    credentials=cred.credential_info,
+                    credentials=cred,
                     local_file=temp_file,
                     artifact_file_path=None,
                     get_credentials=lambda artifact_paths: [
@@ -282,7 +282,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
                 cred.type == ArtifactCredentialType.AWS_PRESIGNED_URL
                 or cred.type == ArtifactCredentialType.GCP_SIGNED_URL
             ):
-                self._signed_url_upload_file(cred.credential_info, temp_file)
+                self._signed_url_upload_file(cred, temp_file)
 
     def _get_read_credential_infos(self, remote_file_paths):
         """

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -473,6 +473,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
                     self._retryable_adls_function,
                     func=patch_adls_file_upload,
                     artifact_file_path=artifact_file_path,
+                    get_credentials=get_credentials,
                     sas_url=credentials.signed_uri,
                     local_file=local_file,
                     start_byte=start_byte,

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -542,7 +542,10 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
             )
         elif cloud_credential_info.type == ArtifactCredentialType.AZURE_ADLS_GEN2_SAS_URI:
             self._azure_adls_gen2_upload_file(
-                cloud_credential_info, src_file_path, artifact_file_path
+                cloud_credential_info,
+                src_file_path,
+                artifact_file_path,
+                self._get_write_credential_infos,
             )
         elif cloud_credential_info.type == ArtifactCredentialType.AWS_PRESIGNED_URL:
             if os.path.getsize(src_file_path) > MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE.get():

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -220,7 +220,12 @@ def test_log_artifact_azure(databricks_artifact_repo, test_file, artifact_path, 
         get_credential_infos_mock.assert_called_with(
             GetCredentialsForWrite, MOCK_RUN_ID, [expected_location]
         )
-        azure_upload_mock.assert_called_with(mock_credential_info, test_file, expected_location)
+        azure_upload_mock.assert_called_with(
+            mock_credential_info,
+            test_file,
+            expected_location,
+            get_credentials=mock.ANY,
+        )
 
 
 @pytest.mark.parametrize(("artifact_path", "expected_location"), [(None, "test.txt")])

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -309,7 +309,7 @@ def test_log_artifact_adls_gen2(
             GetCredentialsForWrite, MOCK_RUN_ID, [expected_location]
         )
         azure_adls_gen2_upload_mock.assert_called_with(
-            mock_credential_info, test_file, expected_location
+            mock_credential_info, test_file, expected_location, mock.ANY
         )
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11655?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11655/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11655
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Title

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```python
import mlflow
from mlflow.entities.trace_data import TraceData

mlflow.set_tracking_uri("databricks")
name = "/Users/harutaka.kawamura@databricks.com/test"
mlflow.set_experiment(name)
exp = mlflow.get_experiment_by_name(name)


client = mlflow.MlflowClient()
trace_info = client._create_trace_info(
    experiment_id=exp.experiment_id,
    timestamp_ms=123,
    execution_time_ms=567,
    status="OK",
)
print(trace_info)

data = TraceData(spans=[])
client._tracking_client._upload_trace_data(trace_info, data)
downloaded_data = client._tracking_client._download_trace_data(trace_info)
print(downloaded_data)

```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
