### PR TITLE
Fix `delete_traces` to return the number of traces deleted

### DIFF
--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -270,7 +270,7 @@ class AbstractStore:
         max_timestamp_millis: Optional[int] = None,
         max_traces: Optional[int] = None,
         request_ids: Optional[List[str]] = None,
-    ) -> None:
+    ) -> int:
         """
         Delete traces based on the specified criteria.
 
@@ -283,6 +283,9 @@ class AbstractStore:
                 deleting traces.
             max_traces: The maximum number of traces to delete.
             request_ids: A set of request IDs to delete.
+
+        Returns:
+            The number of traces deleted.
         """
         raise NotImplementedError
 

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -258,7 +258,7 @@ class RestStore(AbstractStore):
         max_timestamp_millis: Optional[int] = None,
         max_traces: Optional[int] = None,
         request_ids: Optional[List[str]] = None,
-    ) -> None:
+    ) -> int:
         req_body = message_to_json(
             DeleteTraces(
                 experiment_id=experiment_id,
@@ -267,7 +267,8 @@ class RestStore(AbstractStore):
                 request_ids=request_ids,
             )
         )
-        self._call_endpoint(DeleteTraces, req_body)
+        res = self._call_endpoint(DeleteTraces, req_body)
+        return res.traces_deleted
 
     def get_trace_info(self, request_id):
         """

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -201,7 +201,7 @@ class TrackingServiceClient:
         max_timestamp_millis: Optional[int] = None,
         max_traces: Optional[int] = None,
         request_ids: Optional[List[str]] = None,
-    ) -> None:
+    ) -> int:
         return self.store.delete_traces(
             experiment_id=experiment_id,
             max_timestamp_millis=max_timestamp_millis,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -415,7 +415,7 @@ class MlflowClient:
         max_timestamp_millis: Optional[int] = None,
         max_traces: Optional[int] = None,
         request_ids: Optional[List[str]] = None,
-    ) -> None:
+    ) -> int:
         """
         Delete traces based on the specified criteria.
 
@@ -428,6 +428,9 @@ class MlflowClient:
                 deleting traces.
             max_traces: The maximum number of traces to delete.
             request_ids: A set of request IDs to delete.
+
+        Returns:
+            The number of traces deleted.
         """
         return self._tracking_client.delete_traces(
             experiment_id=experiment_id,

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -585,7 +585,7 @@ def test_delete_traces():
         max_traces=2,
         request_ids=["tr-1234"],
     )
-    response.text = "{}"
+    response.text = json.dumps({"traces_deleted": 1})
     with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
         res = store.delete_traces(
             experiment_id=request.experiment_id,
@@ -594,7 +594,7 @@ def test_delete_traces():
             request_ids=request.request_ids,
         )
         _verify_requests(mock_http, creds, "traces/delete-traces", "POST", message_to_json(request))
-        assert res is None
+        assert res == 1
 
 
 def test_set_trace_tag():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11656?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11656/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11656
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix `delete_traces` to return the number of traces deleted.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
