### PR TITLE
[Bug-bash] Add 'tr-' prefix to trace request IDs

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -256,6 +256,6 @@ def get_current_active_span():
     if otel_span is None:
         return None
 
-    span_context = otel_span.get_span_context()
+    span = MlflowSpanWrapper(otel_span)
     trace_manager = InMemoryTraceManager.get_instance()
-    return trace_manager.get_span_from_id(span_context.trace_id, span_context.span_id)
+    return trace_manager.get_span_from_id(span.request_id, span.span_id)

--- a/mlflow/tracing/types/constant.py
+++ b/mlflow/tracing/types/constant.py
@@ -9,3 +9,6 @@ class TraceMetadataKey:
 # All storage backends are guaranteed to support key values up to 250 characters
 MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS = 250
 TRUNCATION_SUFFIX = "..."
+
+# Trace request ID must have the prefix "tr-" appended to the OpenTelemetry trace ID
+TRACE_REQUEST_ID_PREFIX = "tr-"

--- a/mlflow/tracing/types/wrapper.py
+++ b/mlflow/tracing/types/wrapper.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional, Union
 from opentelemetry import trace as trace_api
 
 from mlflow.entities import Span, SpanContext, SpanEvent, SpanStatus, SpanType, TraceStatus
+from mlflow.tracing.types.constant import TRACE_REQUEST_ID_PREFIX
 
 _logger = logging.getLogger(__name__)
 
@@ -33,9 +34,10 @@ class MlflowSpanWrapper:
     def request_id(self) -> str:
         """
         The request ID of the span, a unique identifier for the trace it belongs to.
-        Request ID is equivalent to the trace ID in OpenTelemetry.
+        Request ID is equivalent to the trace ID in OpenTelemetry, but prefixed with
+        "tr-" for backend compatibility.
         """
-        return self._span.get_span_context().trace_id
+        return TRACE_REQUEST_ID_PREFIX + str(self._span.get_span_context().trace_id)
 
     @property
     def span_id(self) -> str:

--- a/tests/tracing/export/test_mlflow_exporter.py
+++ b/tests/tracing/export/test_mlflow_exporter.py
@@ -75,7 +75,7 @@ def test_export():
 
     # Trace info should inherit fields from the root span
     trace_info = client_call_args.trace_info
-    assert trace_info.request_id == trace_id
+    assert trace_info.request_id == f"tr-{trace_id}"
     assert trace_info.timestamp_ms == 0
     assert trace_info.execution_time_ms == 4
     assert trace_info.request_metadata[TraceMetadataKey.NAME] == "test_span"

--- a/tests/tracing/test_wrapper.py
+++ b/tests/tracing/test_wrapper.py
@@ -14,7 +14,7 @@ def test_wrapper_property():
     end_time = start_time + 1_000_000
 
     mock_otel_span = mock.MagicMock()
-    mock_otel_span.get_span_context().trace_id = "trace_id"
+    mock_otel_span.get_span_context().trace_id = "12345"
     mock_otel_span.get_span_context().span_id = "span_id"
     mock_otel_span._start_time = start_time
     mock_otel_span._end_time = end_time
@@ -22,7 +22,7 @@ def test_wrapper_property():
 
     span = MlflowSpanWrapper(mock_otel_span)
 
-    assert span.request_id == "trace_id"
+    assert span.request_id == "tr-12345"
     assert span.span_id == "span_id"
     assert span.start_time == start_time // 1_000
     assert span.end_time == end_time // 1_000


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11658?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11658/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11658
```

</p>
</details>

### What changes are proposed in this pull request?

Append `"tr-"` prefix to the trace request ID as it is required by Databricks backend. The request ID will be `tr-` + `[OpenTelemetry's trace ID]`. We should do this prefixing in the property of `MlflowSpanWrapper` as it must be the only place we interact with OpenTelemetry span. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested in staging:
```
with mlflow.start_span() as span:
    print(span.request_id)

>> tr-266479432666298168740865197363700257094
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
