### PR TITLE
Add kwargs to `pytorch.load_checkpiont` method.

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -1133,7 +1133,7 @@ if autolog.__doc__ is not None:
     )
 
 
-def load_checkpoint(model_class, run_id=None, epoch=None, global_step=None, **kwargs):
+def load_checkpoint(model_class, run_id=None, epoch=None, global_step=None, kwargs=None):
     """
     If you enable "checkpoint" in autologging, during pytorch-lightning model
     training execution, checkpointed models are logged as MLflow artifacts.
@@ -1187,7 +1187,7 @@ def load_checkpoint(model_class, run_id=None, epoch=None, global_step=None, **kw
         downloaded_checkpoint_filepath = download_checkpoint_artifact(
             run_id=run_id, epoch=epoch, global_step=global_step, dst_path=tmp_dir.path()
         )
-        return model_class.load_from_checkpoint(downloaded_checkpoint_filepath, **kwargs)
+        return model_class.load_from_checkpoint(downloaded_checkpoint_filepath, **(kwargs or {}))
 
 
 __all__ = [

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -1133,7 +1133,7 @@ if autolog.__doc__ is not None:
     )
 
 
-def load_checkpoint(model_class, run_id=None, epoch=None, global_step=None):
+def load_checkpoint(model_class, run_id=None, epoch=None, global_step=None, **kwargs):
     """
     If you enable "checkpoint" in autologging, during pytorch-lightning model
     training execution, checkpointed models are logged as MLflow artifacts.
@@ -1156,6 +1156,7 @@ def load_checkpoint(model_class, run_id=None, epoch=None, global_step=None):
             "checkpoint_save_freq" to "epoch".
         global_step: The global step of the checkpoint to be loaded, if
             you set "checkpoint_save_freq" to an integer.
+        kwargs: Any extra kwargs needed to init the model.
 
     Returns:
         The instance of a pytorch-lightning model restored from the specified checkpoint.
@@ -1186,7 +1187,7 @@ def load_checkpoint(model_class, run_id=None, epoch=None, global_step=None):
         downloaded_checkpoint_filepath = download_checkpoint_artifact(
             run_id=run_id, epoch=epoch, global_step=global_step, dst_path=tmp_dir.path()
         )
-        return model_class.load_from_checkpoint(downloaded_checkpoint_filepath)
+        return model_class.load_from_checkpoint(downloaded_checkpoint_filepath, **kwargs)
 
 
 __all__ = [


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jmjeon94/mlflow/pull/11661?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11661/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11661
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #11638 

### What changes are proposed in this pull request?
Add **kwargs arguments in `pytorch.load_checkpoint` method.
It is needed to load LightningModule class model with extra arguments.
Also I added docstring of kwargs in method.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
