### PR TITLE
Add check to ensure patch section is filled in

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -83,3 +83,10 @@ Note that GitHub prefixes anchor names in markdown with "user-content-".
 - [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
 - [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
 - [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
+
+#### Should this PR be included in the next patch release?
+
+<!-- patch -->
+
+- [ ] Yes
+- [ ] No

--- a/.github/workflows/patch.js
+++ b/.github/workflows/patch.js
@@ -18,11 +18,15 @@ module.exports = async ({ context, github, core }) => {
   const no = noMatch ? noMatch[0].toLowerCase() === "x" : false;
 
   if (yes && no) {
-    core.setFailed("Both yes and no are selected. Please select only one.");
+    core.setFailed(
+      "Both yes and no are selected. Please select only one in the `Should this PR be included in the next patch release?` section"
+    );
   }
 
   if (!yes && !no) {
-    core.setFailed("Please select either yes or no.");
+    core.setFailed(
+      "Please fill in the `Should this PR be included in the next patch release?` section"
+    );
   }
 
   if (no) {

--- a/.github/workflows/patch.js
+++ b/.github/workflows/patch.js
@@ -16,6 +16,7 @@ module.exports = async ({ context, github, core }) => {
   const yes = yesMatch ? yesMatch[0].toLowerCase() === "x" : false;
   const noMatch = patchSection.match(/- \[( |x)\] no/gi);
   const no = noMatch ? noMatch[0].toLowerCase() === "x" : false;
+  console.log({ yes, no });
 
   if (yes && no) {
     core.setFailed(

--- a/.github/workflows/patch.js
+++ b/.github/workflows/patch.js
@@ -12,9 +12,11 @@ module.exports = async ({ context, github, core }) => {
   }
 
   const patchSection = body.split(marker)[1];
-  const yesMatch = patchSection.match(/- \[( |x)\] yes/gi);
+  const yesRegex = /- \[( |x)\] yes/gi;
+  const yesMatch = yesRegex.exec(patchSection);
   const yes = yesMatch ? yesMatch[1].toLowerCase() === "x" : false;
-  const noMatch = patchSection.match(/- \[( |x)\] no/gi);
+  const noRegex = /- \[( |x)\] no/gi;
+  const noMatch = noRegex.exec(patchSection);
   const no = noMatch ? noMatch[1].toLowerCase() === "x" : false;
   console.log({ yes, no, yesMatch, noMatch });
 

--- a/.github/workflows/patch.js
+++ b/.github/workflows/patch.js
@@ -19,13 +19,13 @@ module.exports = async ({ context, github, core }) => {
 
   if (yes && no) {
     core.setFailed(
-      "Both yes and no are selected. Please select only one in the `Should this PR be included in the next patch release?` section"
+      "Both yes and no are selected. Please select only one in the `Should this PR be included in the next patch release?` section."
     );
   }
 
   if (!yes && !no) {
     core.setFailed(
-      "Please fill in the `Should this PR be included in the next patch release?` section"
+      "Please fill in the `Should this PR be included in the next patch release?` section."
     );
   }
 

--- a/.github/workflows/patch.js
+++ b/.github/workflows/patch.js
@@ -16,7 +16,7 @@ module.exports = async ({ context, github, core }) => {
   const yes = yesMatch ? yesMatch[0].toLowerCase() === "x" : false;
   const noMatch = patchSection.match(/- \[( |x)\] no/gi);
   const no = noMatch ? noMatch[0].toLowerCase() === "x" : false;
-  console.log({ yes, no });
+  console.log({ yes, no, yesMatch, noMatch });
 
   if (yes && no) {
     core.setFailed(

--- a/.github/workflows/patch.js
+++ b/.github/workflows/patch.js
@@ -13,9 +13,9 @@ module.exports = async ({ context, github, core }) => {
 
   const patchSection = body.split(marker)[1];
   const yesMatch = patchSection.match(/- \[( |x)\] yes/gi);
-  const yes = yesMatch ? yesSelected[0].toLowerCase() === "x" : false;
+  const yes = yesMatch ? yesMatch[0].toLowerCase() === "x" : false;
   const noMatch = patchSection.match(/- \[( |x)\] no/gi);
-  const no = noMatch ? noSelected[0].toLowerCase() === "x" : false;
+  const no = noMatch ? noMatch[0].toLowerCase() === "x" : false;
 
   if (yes && no) {
     core.setFailed("Both yes and no are selected. Please select only one.");

--- a/.github/workflows/patch.js
+++ b/.github/workflows/patch.js
@@ -1,0 +1,45 @@
+module.exports = async ({ context, github, core }) => {
+  const { body, base } = context.payload.pull_request;
+  const { owner, repo } = context.repo;
+
+  if (base.ref.match(/^branch-\d+\.\d+$/)) {
+    return;
+  }
+
+  const marker = "<!-- patch -->";
+  if (!body.includes(marker)) {
+    return;
+  }
+
+  const patchSection = body.split(marker)[1];
+  const yesMatch = patchSection.match(/- \[( |x)\] yes/gi);
+  const yes = yesMatch ? yesSelected[0].toLowerCase() === "x" : false;
+  const noMatch = patchSection.match(/- \[( |x)\] no/gi);
+  const no = noMatch ? noSelected[0].toLowerCase() === "x" : false;
+
+  if (yes && no) {
+    core.setFailed("Both yes and no are selected. Please select only one.");
+  }
+
+  if (!yes && !no) {
+    core.setFailed("Please select either yes or no.");
+  }
+
+  if (no) {
+    return;
+  }
+
+  const latestRelease = await github.rest.repos.getLatestRelease({
+    owner,
+    repo,
+  });
+  const version = latestRelease.data.tag_name.replace("v", "");
+  const [major, minor, micro] = version.split(".");
+  const label = `patch-${major}.${minor}.${parseInt(micro) + 1}`;
+  await github.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: context.payload.pull_request.number,
+    labels: [label],
+  });
+};

--- a/.github/workflows/patch.js
+++ b/.github/workflows/patch.js
@@ -13,9 +13,9 @@ module.exports = async ({ context, github, core }) => {
 
   const patchSection = body.split(marker)[1];
   const yesMatch = patchSection.match(/- \[( |x)\] yes/gi);
-  const yes = yesMatch ? yesMatch[0].toLowerCase() === "x" : false;
+  const yes = yesMatch ? yesMatch[1].toLowerCase() === "x" : false;
   const noMatch = patchSection.match(/- \[( |x)\] no/gi);
-  const no = noMatch ? noMatch[0].toLowerCase() === "x" : false;
+  const no = noMatch ? noMatch[1].toLowerCase() === "x" : false;
   console.log({ yes, no, yesMatch, noMatch });
 
   if (yes && no) {

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -1,0 +1,30 @@
+name: Patch
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -exo pipefail {0}
+
+jobs:
+  labeling:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const script = require('./.github/workflows/patch.js');
+            await script({ github, context, core });

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - edited
+      - synchronize
 
 permissions:
   contents: read

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -14,7 +14,7 @@ defaults:
     shell: bash --noprofile --norc -exo pipefail {0}
 
 jobs:
-  labeling:
+  patch:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11662?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11662/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11662
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [x] Yes
- [ ] No

test