### PR TITLE
Fix exception handling in disable_autologging() context manager

### DIFF
--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -493,8 +493,10 @@ def disable_autologging():
     """
     global _AUTOLOGGING_GLOBALLY_DISABLED
     _AUTOLOGGING_GLOBALLY_DISABLED = True
-    yield None
-    _AUTOLOGGING_GLOBALLY_DISABLED = False
+    try:
+        yield None
+    finally:
+        _AUTOLOGGING_GLOBALLY_DISABLED = False
 
 
 @contextlib.contextmanager

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -598,7 +598,7 @@ def test_autologging_disable_restores_behavior():
     assert is_autolog_on()
 
     # The context manager should exit correctly even if an exception is raised
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="test"):  # noqa: PT012
         with mlflow.utils.autologging_utils.disable_autologging():
             assert not is_autolog_on()
             raise Exception("test")

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -572,8 +572,6 @@ def test_autologging_disable_restores_behavior():
     from sklearn.datasets import load_diabetes
     from sklearn.linear_model import LinearRegression
 
-    mlflow.sklearn.autolog()
-
     X, y = load_diabetes(return_X_y=True, as_frame=True)
     X = X.iloc[:50, :4]
     y = y.iloc[:50]
@@ -581,27 +579,32 @@ def test_autologging_disable_restores_behavior():
     # train a model
     model = LinearRegression()
 
-    run = mlflow.start_run()
-    model.fit(X, y)
-    mlflow.end_run()
-    run = MlflowClient().get_run(run.info.run_id)
-    assert run.data.metrics
-    assert run.data.params
-
-    run = mlflow.start_run()
-    with mlflow.utils.autologging_utils.disable_autologging():
+    def is_autolog_on():
+        run = mlflow.start_run()
         model.fit(X, y)
-    mlflow.end_run()
-    run = MlflowClient().get_run(run.info.run_id)
-    assert not run.data.metrics
-    assert not run.data.params
+        mlflow.end_run()
+        run = MlflowClient().get_run(run.info.run_id)
+        return run.data.metrics and run.data.params
 
-    run = mlflow.start_run()
-    model.fit(X, y)
-    mlflow.end_run()
-    run = MlflowClient().get_run(run.info.run_id)
-    assert run.data.metrics
-    assert run.data.params
+    # Turn on autologging
+    mlflow.sklearn.autolog()
+    assert is_autolog_on()
+
+    # Turn off autologging within a context manager
+    with mlflow.utils.autologging_utils.disable_autologging():
+        assert not is_autolog_on()
+
+    # Autologging should be turned back on
+    assert is_autolog_on()
+
+    # The context manager should exit correctly even if an exception is raised
+    with pytest.raises(Exception):
+        with mlflow.utils.autologging_utils.disable_autologging():
+            assert not is_autolog_on()
+            raise Exception("test")
+
+    # Autologging should be turned back on after the exception
+    assert is_autolog_on()
 
 
 def test_autologging_event_logger_default_implementation_does_not_throw_for_valid_inputs():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11663?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11663/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11663
```

</p>
</details>

### What changes are proposed in this pull request?

[disable_autologging](https://github.com/mlflow/mlflow/blob/1829741b28de16fbd1f208e128860b4128f65f23/mlflow/utils/autologging_utils/__init__.py#L489) is a context manager that is used in a few places like LangChain autologging ([code](https://github.com/mlflow/mlflow/blob/master/mlflow/langchain/_langchain_autolog.py#L245-L246)). Within the context manager, autologging is temporary turned off, and it should be turned back on when exiting.

However, the last line to revert the flag is not executed when an exception occurs inside the context, results in autologging to be disabled permanently. This caused a weird bug in tracing as well, where no trace is generated once any chain raises an exception.

```
import mlflow

mlflow.langchain.autolog()

with mlflow.utils.autologging_utils.disable_autologging():
    chain.invoke(input) # auto-logging is disabled here as expected
    raise Exception("error!")

# auto-logging is still disabled here after exiting the context manager
```



### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
