### PR TITLE
Dep doc string

### DIFF
--- a/mlflow/deployments/base.py
+++ b/mlflow/deployments/base.py
@@ -96,7 +96,8 @@ class BaseDeploymentClient(abc.ABC):
         deployment completes (i.e. until it's possible to perform inference with the deployment).
         In the case of conflicts (e.g. if it's not possible to create the specified deployment
         without due to conflict with an existing deployment), raises a
-        :py:class:`mlflow.exceptions.MlflowException`. See target-specific plugin documentation
+        :py:class:`mlflow.exceptions.MlflowException` or an `HTTPError` for remote
+        deployments. See target-specific plugin documentation
         for additional detail on support for asynchronous deployment and other configuration.
 
         Args:
@@ -187,9 +188,9 @@ class BaseDeploymentClient(abc.ABC):
     @abc.abstractmethod
     def get_deployment(self, name, endpoint=None):
         """
-        Returns a dictionary describing the specified deployment, throwing a
-        :py:class:`mlflow.exceptions.MlflowException` if no deployment exists with the provided
-        ID.
+        Returns a dictionary describing the specified deployment, throwing either a
+        :py:class:`mlflow.exceptions.MlflowException` or an HTTPError for remote
+        deployments if no deployment exists with the provided ID.
         The dict is guaranteed to contain an 'name' key containing the deployment name.
         The other fields of the returned dictionary and their types may vary across
         deployment targets.
@@ -264,7 +265,8 @@ class BaseDeploymentClient(abc.ABC):
         creation completes (i.e. until it's possible to create a deployment within the endpoint).
         In the case of conflicts (e.g. if it's not possible to create the specified endpoint
         due to conflict with an existing endpoint), raises a
-        :py:class:`mlflow.exceptions.MlflowException`. See target-specific plugin documentation
+        :py:class:`mlflow.exceptions.MlflowException` or an HTTPError for remote
+        deployments. See target-specific plugin documentation
         for additional detail on support for asynchronous creation and other configuration.
 
         Args:
@@ -342,7 +344,8 @@ class BaseDeploymentClient(abc.ABC):
     def get_endpoint(self, endpoint):
         """
         Returns a dictionary describing the specified endpoint, throwing a
-        py:class:`mlflow.exception.MlflowException` if no endpoint exists with the provided
+        py:class:`mlflow.exception.MlflowException` or an HTTPError for remote
+        deployments if no endpoint exists with the provided
         name.
         The dict is guaranteed to contain an 'name' key containing the endpoint name.
         The other fields of the returned dictionary and their types may vary across targets.

--- a/mlflow/deployments/base.py
+++ b/mlflow/deployments/base.py
@@ -189,7 +189,7 @@ class BaseDeploymentClient(abc.ABC):
     def get_deployment(self, name, endpoint=None):
         """
         Returns a dictionary describing the specified deployment, throwing either a
-        :py:class:`mlflow.exceptions.MlflowException` or an HTTPError for remote
+        :py:class:`mlflow.exceptions.MlflowException` or an `HTTPError` for remote
         deployments if no deployment exists with the provided ID.
         The dict is guaranteed to contain an 'name' key containing the deployment name.
         The other fields of the returned dictionary and their types may vary across
@@ -265,7 +265,7 @@ class BaseDeploymentClient(abc.ABC):
         creation completes (i.e. until it's possible to create a deployment within the endpoint).
         In the case of conflicts (e.g. if it's not possible to create the specified endpoint
         due to conflict with an existing endpoint), raises a
-        :py:class:`mlflow.exceptions.MlflowException` or an HTTPError for remote
+        :py:class:`mlflow.exceptions.MlflowException` or an `HTTPError` for remote
         deployments. See target-specific plugin documentation
         for additional detail on support for asynchronous creation and other configuration.
 
@@ -344,7 +344,7 @@ class BaseDeploymentClient(abc.ABC):
     def get_endpoint(self, endpoint):
         """
         Returns a dictionary describing the specified endpoint, throwing a
-        py:class:`mlflow.exception.MlflowException` or an HTTPError for remote
+        py:class:`mlflow.exception.MlflowException` or an `HTTPError` for remote
         deployments if no endpoint exists with the provided
         name.
         The dict is guaranteed to contain an 'name' key containing the endpoint name.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/11665?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11665/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11665
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adds specificity to the potential errors from concrete implementations of the deployment client

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
