### PR TITLE
Update code_paths docstrings

### DIFF
--- a/docs/source/model/dependencies.rst
+++ b/docs/source/model/dependencies.rst
@@ -181,7 +181,7 @@ Saving Extra Code with an MLflow Model
 --------------------------------------
 MLflow also supports saving your custom Python code as dependencies to the model. This is particularly useful
 when you want to deploy your custom modules that are required for prediction with the model.
-To do so, specify **code_path** when logging the model. For example, if you have the following file structure in your project:
+To do so, specify **code_paths** when logging the model. For example, if you have the following file structure in your project:
 
 ::
 
@@ -224,12 +224,12 @@ Then MLflow will save ``utils.py`` under ``code/`` directory in the model direct
         └── utils.py
 
 When MLflow loads the model for serving, the ``code`` directory will be added to the system path so that you can use the module in your model
-code like ``from utils import my_func``. You can also specify a directory path as ``code_path`` to save multiple files under the directory:
+code like ``from utils import my_func``. You can also specify a directory path as ``code_paths`` to save multiple files under the directory:
 
-Caveats of ``code_path`` Option
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Caveats of ``code_paths`` Option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When using the ``code_path`` option, please be aware of the limitation that the specified file or directory **must be in the same directory as your model script**.
+When using the ``code_paths`` option, please be aware of the limitation that the specified file or directory **must be in the same directory as your model script**.
 If the specified file or directory is in a parent or child directory like ``my_project/src/utils.py``, model serving will fail with ``ModuleNotFoundError``.
 For example, let's say that you have the following file structure in your project
 
@@ -269,7 +269,7 @@ it does **not** preserve the relative paths that they were originally residing w
 ``code/src/utils.py``. As a result, it has to be imported as ``from utils import my_func``, instead of ``from src.utils import my_func``.
 However, this may not be pleasant, as the import path is different from the original training script.
 
-To workaround this issue, the ``code_path`` should specify the parent directory, which is ``code_path=["src"]`` in this example.
+To workaround this issue, the ``code_paths`` should specify the parent directory, which is ``code_paths=["src"]`` in this example.
 This way, MLflow will copy the entire ``src/`` directory under ``code/`` and your model code will be able to import ``src.utils``.
 
 .. code-block:: python
@@ -292,11 +292,11 @@ This way, MLflow will copy the entire ``src/`` directory under ``code/`` and you
 
 .. warning::
 
-    By the same reason, ``code_path`` option doesn't handle the relative import like ``code_path=["../src"]``.
+    By the same reason, the ``code_paths`` option doesn't handle the relative import of ``code_path=["../src"]``.
 
 Recommended Project Structure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-With this limitation for ``code_path`` in mind, the recommended project structure looks like the following:
+With this limitation for ``code_paths`` in mind, the recommended project structure looks like the following:
 
 ::
 
@@ -310,7 +310,7 @@ With this limitation for ``code_path`` in mind, the recommended project structur
         |── evaluation.py
         └── ...
 
-Then you can log the model with ``code_paths=["core"]`` to include the required modules for prediction, while excluding the helper modules
+This way you can log the model with ``code_paths=["core"]`` to include the required modules for prediction, while excluding the helper modules
 that are only used for development.
 
 .. _validating-environment-for-prediction:

--- a/mlflow/diviner/__init__.py
+++ b/mlflow/diviner/__init__.py
@@ -113,9 +113,7 @@ def save_model(
             ``DataFrame``.
         path: Local path destination for the serialized model is to be saved.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` the flavor that this model is being added to.
         signature: :py:class:`Model Signature <mlflow.models.ModelSignature>` describes model
             input and output :py:class:`Schema <mlflow.types.Schema>`. The model
@@ -374,9 +372,7 @@ def log_model(
         diviner_model: ``Diviner`` model that has been ``fit`` on a grouped temporal ``DataFrame``.
         artifact_path: Run-relative artifact path to save the model instance to.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: This argument may change or be removed in a
             future release without warning. If given, create a model
             version under ``registered_model_name``, also creating a

--- a/mlflow/gluon/__init__.py
+++ b/mlflow/gluon/__init__.py
@@ -186,9 +186,7 @@ def save_model(
         path: Local path where the model is to be saved.
         mlflow_model: MLflow model config this flavor is being added to.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         signature: {{ signature }}
         input_example: {{ input_example }}
         pip_requirements: {{ pip_requirements }}
@@ -335,9 +333,7 @@ def log_model(
         gluon_model: Gluon model to be saved. Must be already hybridized.
         artifact_path: Run-relative artifact path.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: If given, create a model version under
             ``registered_model_name``, also creating a registered model if one
             with the given name does not exist.

--- a/mlflow/h2o/__init__.py
+++ b/mlflow/h2o/__init__.py
@@ -92,9 +92,7 @@ def save_model(
         h2o_model: H2O model to be saved.
         path: Local path where the model is to be saved.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
         signature: {{ signature }}
         input_example: {{ input_example }}
@@ -220,9 +218,7 @@ def log_model(
         h2o_model: H2O model to be saved.
         artifact_path: Run-relative artifact path.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: If given, create a model version under
             ``registered_model_name``, also creating a registered model if one
             with the given name does not exist.

--- a/mlflow/johnsnowlabs/__init__.py
+++ b/mlflow/johnsnowlabs/__init__.py
@@ -241,6 +241,7 @@ def log_model(
                         'johnsnowlabs'
                     ]
                 }
+        code_paths: {{ code_paths }}
         dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
             filesystem if running in local mode. The model is written in this
             destination and then copied into the model's artifact directory. This is
@@ -536,6 +537,7 @@ def save_model(
                         'johnsnowlabs'
                     ]
                 }
+        code_paths: {{ code_paths }}
         dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
             filesystem if running in local mode. The model is be written in this
             destination and then copied to the requested local path. This is necessary

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -153,9 +153,7 @@ def save_model(
             or `RunnableSequence <https://python.langchain.com/docs/modules/chains/foundational/sequential_chains#using-lcel>`_.
         path: Local path where the serialized model (as YAML) is to be saved.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
         signature: :py:class:`ModelSignature <mlflow.models.ModelSignature>`
             describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
@@ -426,9 +424,7 @@ def log_model(
             `retriever <https://python.langchain.com/docs/modules/data_connection/retrievers/>`_.
         artifact_path: Run-relative artifact path.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: This argument may change or be removed in a
             future release without warning. If given, create a model
             version under ``registered_model_name``, also creating a

--- a/mlflow/lightgbm/__init__.py
+++ b/mlflow/lightgbm/__init__.py
@@ -132,9 +132,7 @@ def save_model(
             models that implement the `scikit-learn API`_  to be saved.
         path: Local path where the model is to be saved.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
         signature: {{ signature }}
         input_example: {{ input_example }}
@@ -298,9 +296,7 @@ def log_model(
             models that implement the `scikit-learn API`_  to be saved.
         artifact_path: Run-relative artifact path.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: If given, create a model version under
             ``registered_model_name``, also creating a registered model if one
             with the given name does not exist.

--- a/mlflow/onnx/__init__.py
+++ b/mlflow/onnx/__init__.py
@@ -111,9 +111,7 @@ def save_model(
         onnx_model: ONNX model to be saved.
         path: Local path where the model is to be saved.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
         signature: :py:class:`ModelSignature <mlflow.models.ModelSignature>`
             describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
@@ -472,9 +470,7 @@ def log_model(
         onnx_model: ONNX model to be saved.
         artifact_path: Run-relative artifact path.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: If given, create a model version under
             ``registered_model_name``, also creating a registered model if one
             with the given name does not exist.

--- a/mlflow/openai/__init__.py
+++ b/mlflow/openai/__init__.py
@@ -273,9 +273,7 @@ def save_model(
             ``'chat.completions'``.
         path: Local path where the model is to be saved.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
         signature: :py:class:`ModelSignature <mlflow.models.ModelSignature>`
             describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
@@ -473,9 +471,7 @@ def log_model(
             ``'chat.completions'``.
         artifact_path: Run-relative artifact path.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: If given, create a model version under
             ``registered_model_name``, also creating a registered model if one
             with the given name does not exist.

--- a/mlflow/paddle/__init__.py
+++ b/mlflow/paddle/__init__.py
@@ -103,9 +103,7 @@ def save_model(
             If set to True, the saved model supports both re-training and
             inference. If set to False, it only supports inference.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
         signature: {{ signature }}
         input_example: {{ input_example }}
@@ -359,9 +357,7 @@ def log_model(
             If set to True, the saved model supports both re-training and
             inference. If set to False, it only supports inference.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: If given, create a model version under
             ``registered_model_name``, also creating a registered model if one
             with the given name does not exist.

--- a/mlflow/pmdarima/__init__.py
+++ b/mlflow/pmdarima/__init__.py
@@ -150,9 +150,7 @@ def save_model(
             temporal series.
         path: Local path destination for the serialized model (in pickle format) is to be saved.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
         signature: an instance of the :py:class:`ModelSignature <mlflow.models.ModelSignature>`
             class that describes the model's inputs and outputs. If not specified but an
@@ -308,9 +306,7 @@ def log_model(
             temporal series.
         artifact_path: Run-relative artifact path to save the model instance to.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: This argument may change or be removed in a
             future release without warning. If given, create a model
             version under ``registered_model_name``, also creating a

--- a/mlflow/promptflow/__init__.py
+++ b/mlflow/promptflow/__init__.py
@@ -116,9 +116,7 @@ def log_model(
         model: A promptflow model loaded by `promptflow.load_flow()`.
         artifact_path: Run-relative artifact path.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: If given, create a model version under
             ``registered_model_name``, also creating a registered model if one
             with the given name does not exist.
@@ -219,9 +217,7 @@ def save_model(
         model: A promptflow model loaded by `promptflow.load_flow()`.
         path: Local path where the serialized model (as YAML) is to be saved.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
         signature: {{ signature }}
         input_example: {{ input_example }}

--- a/mlflow/prophet/__init__.py
+++ b/mlflow/prophet/__init__.py
@@ -101,9 +101,7 @@ def save_model(
             on a temporal series.
         path: Local path where the serialized model (as JSON) is to be saved.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
         signature: an instance of the :py:class:`ModelSignature <mlflow.models.ModelSignature>`
             class that describes the model's inputs and outputs. If not specified but an
@@ -232,9 +230,7 @@ def log_model(
         pr_model: Prophet model to be saved.
         artifact_path: Run-relative artifact path.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: This argument may change or be removed in a
             future release without warning. If given, create a model
             version under ``registered_model_name``, also creating a

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -180,9 +180,7 @@ def log_model(
 
         artifact_path: Run-relative artifact path.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system path when the
-            model is loaded.
+        code_paths: {{ code_paths }}
         pickle_module: The module that PyTorch should use to serialize ("pickle") the specified
             ``pytorch_model``. This is passed as the ``pickle_module`` parameter to
             ``torch.save()``.  By default, this module is also used to deserialize ("unpickle") the
@@ -353,9 +351,7 @@ def save_model(
         path: Local path where the model is to be saved.
         conda_env: {{ conda_env }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system path when the
-            model is loaded.
+        code_paths: {{ code_paths }}
         pickle_module: The module that PyTorch should use to serialize ("pickle") the specified
             ``pytorch_model``. This is passed as the ``pickle_module`` parameter to
             ``torch.save()``. By default, this module is also used to deserialize ("unpickle") the

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -151,9 +151,7 @@ def save_model(
             Model or for use in Spark.
             These values are not applied to a returned model from a call to
             ``mlflow.sentence_transformers.load_model()``
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: An MLflow model object that specifies the flavor that this model is being
             added to.
         signature: an instance of the :py:class:`ModelSignature <mlflow.models.ModelSignature>`
@@ -362,9 +360,7 @@ def log_model(
             Model or for use in Spark.
             These values are not applied to a returned model from a call to
             ``mlflow.sentence_transformers.load_model()``
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: This argument may change or be removed in a
             future release without warning. If given, create a model
             version under ``registered_model_name``, also creating a

--- a/mlflow/shap/__init__.py
+++ b/mlflow/shap/__init__.py
@@ -317,9 +317,7 @@ def log_explainer(
             Defaults to True. Currently MLflow serialization is only supported for models of
             'sklearn' or 'pytorch' flavors.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system path when the
-            model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: If given, create a model version under ``registered_model_name``,
             also creating a registered model if one with the given name does not exist.
         signature: :py:class:`ModelSignature <mlflow.models.ModelSignature>` describes model input
@@ -393,9 +391,7 @@ def save_explainer(
             Defaults to True. Currently MLflow serialization is only supported for models of
             'sklearn' or 'pytorch' flavors.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system path when the
-            model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
         signature: :py:class:`ModelSignature <mlflow.models.ModelSignature>` describes model input
             and output :py:class:`Schema <mlflow.types.Schema>`. The model signature can be

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -181,9 +181,7 @@ def save_model(
         sk_model: scikit-learn model to be saved.
         path: Local path where the model is to be saved.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
         serialization_format: The format in which to serialize the model. This should be one of
             the formats listed in
@@ -364,9 +362,7 @@ def log_model(
         sk_model: scikit-learn model to be saved.
         artifact_path: Run-relative artifact path.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         serialization_format: The format in which to serialize the model. This should be one of
             the formats listed in
             ``mlflow.sklearn.SUPPORTED_SERIALIZATION_FORMATS``. The Cloudpickle

--- a/mlflow/spacy/__init__.py
+++ b/mlflow/spacy/__init__.py
@@ -90,9 +90,7 @@ def save_model(
         spacy_model: spaCy model to be saved.
         path: Local path where the model is to be saved.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                    containing file dependencies). These files are *prepended* to the system
-                    path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
 
         signature: :py:class:`ModelSignature <mlflow.models.ModelSignature>`
@@ -223,9 +221,7 @@ def log_model(
         spacy_model: spaCy model to be saved.
         artifact_path: Run-relative artifact path.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-                    containing file dependencies). These files are *prepended* to the system
-                    path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: If given, create a model version under
                                ``registered_model_name``, also creating a registered model if one
                                with the given name does not exist.

--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -170,6 +170,7 @@ def log_model(
             MLReadable and MLWritable.
         artifact_path: Run relative artifact path.
         conda_env: {{ conda_env }}
+        code_paths: {{ code_paths }}
         dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
                         filesystem if running in local mode. The model is written in this
                         destination and then copied into the model's artifact directory. This is
@@ -657,6 +658,7 @@ def save_model(
         path: Local path where the model is to be saved.
         mlflow_model: MLflow model config this flavor is being added to.
         conda_env: {{ conda_env }}
+        code_paths: {{ code_paths }}
         dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
             filesystem if running in local mode. The model is be written in this
             destination and then copied to the requested local path. This is necessary

--- a/mlflow/statsmodels/__init__.py
+++ b/mlflow/statsmodels/__init__.py
@@ -112,9 +112,7 @@ def save_model(
             be saved.
         path: Local path where the model is to be saved.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system path when the
-            model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
         remove_data: bool. If False (default), then the instance is pickled without changes. If
             True, then all arrays with length nobs are set to None before pickling. See the
@@ -243,9 +241,7 @@ def log_model(
             be saved.
         artifact_path: Run-relative artifact path.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system path when the
-            model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: If given, create a model version under ``registered_model_name``,
             also creating a registered model if one with the given name does not exist.
         remove_data: bool. If False (default), then the instance is pickled without changes. If

--- a/mlflow/tensorflow/__init__.py
+++ b/mlflow/tensorflow/__init__.py
@@ -194,9 +194,7 @@ def log_model(
             when the model is loaded with :py:func:`mlflow.tensorflow.load_model` and
             :py:func:`mlflow.pyfunc.load_model`.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: If given, create a model version under
             ``registered_model_name``, also creating a registered model if one
             with the given name does not exist.
@@ -317,9 +315,7 @@ def save_model(
         model: The Keras model or Tensorflow module to be saved.
         path: Local path where the MLflow model is to be saved.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: MLflow model configuration to which to add the ``tensorflow`` flavor.
         custom_objects: A Keras ``custom_objects`` dictionary mapping names (strings) to
             custom classes or functions associated with the Keras model. MLflow saves

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -412,9 +412,7 @@ def save_model(
                     model_config=model_config,
                 )
 
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: An MLflow model object that specifies the flavor that this model is being
             added to.
         signature: A Model Signature object that describes the input and output Schema of the
@@ -868,9 +866,7 @@ def log_model(
                         model_config=model_config,
                     )
 
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: This argument may change or be removed in a
             future release without warning. If given, create a model
             version under ``registered_model_name``, also creating a

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -282,9 +282,10 @@ is loaded. Files declared as dependencies for a given model should have relative
 imports declared from a common root path if multiple files are defined with import dependencies
 between them to avoid import errors when loading the model.
 
-For a detailed explanation of ``code_paths`` functionality, recommended usage patterns and limitations, see the
+For a detailed explanation of ``code_paths`` functionality, recommended usage patterns and
+limitations, see the
 `code_paths usage guide <https://mlflow.org/docs/latest/model/dependencies.html?highlight=code_paths#saving-extra-code-with-an-mlflow-model>`_.
-"""    
+"""
         ),
         "save_pretrained": (
             """If set to ``False``, MLflow will not save the Transformer model weight files,

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -275,6 +275,17 @@ Currently, only the following pipeline types are supported:
 - `text-generation <https://huggingface.co/transformers/main_classes/pipelines.html#transformers.TextGenerationPipeline>`_
 """
         ),
+        "code_paths": (
+            """A list of local filesystem paths to Python file dependencies (or directories
+containing file dependencies). These files are *prepended* to the system path when the model
+is loaded. Files declared as dependencies for a given model should have relative
+imports declared from a common root path if multiple files are defined with import dependencies
+between them to avoid import errors when loading the model.
+
+For a detailed explanation of ``code_paths`` functionality, recommended usage patterns and limitations, see the
+`code_paths usage guide <https://mlflow.org/docs/latest/model/dependencies.html?highlight=code_paths#saving-extra-code-with-an-mlflow-model>`_.
+"""    
+        ),
         "save_pretrained": (
             """If set to ``False``, MLflow will not save the Transformer model weight files,
 instead only saving the reference to the HuggingFace Hub model repository and its commit hash.

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -129,9 +129,7 @@ def save_model(
             `scikit-learn API`_) to be saved.
         path: Local path where the model is to be saved.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
         signature: {{ signature }}
         input_example: {{ input_example }}
@@ -248,9 +246,7 @@ def log_model(
             `scikit-learn API`_) to be saved.
         artifact_path: Run-relative artifact path.
         conda_env: {{ conda_env }}
-        code_paths: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path when the model is loaded.
+        code_paths: {{ code_paths }}
         registered_model_name: If given, create a model version under
             ``registered_model_name``, also creating a registered model if one
             with the given name does not exist.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/11675?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11675/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11675
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Provide additional guidance on how to find the guide for `code_paths` and correct some missing docstring entries for the argument.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes
- [X] No
