### PR TITLE
Fix langchain dependency detection during model logging

### DIFF
--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -669,8 +669,14 @@ class _LangChainModelWrapper:
         and `return_first_element` means if True, we should return the first element
         of inference result, otherwise we should return the whole inference result.
         """
+        # This handels spark_udf inputs and input_example inputs
         if isinstance(data, pd.DataFrame):
-            data = data.to_dict(orient="records")
+            # if the data only contains a single key as 0, we assume the input
+            # is either a string or list of strings
+            if list(data.columns) == [0]:
+                data = data.to_dict("list")[0]
+            else:
+                data = data.to_dict(orient="records")
 
         data = _convert_ndarray_to_list(data)
         if not isinstance(data, list):

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -215,6 +215,8 @@ class APIRequest:
                 return self.lc_model.invoke(single_input, config={"callbacks": callback_handlers})
 
             if isinstance(self.request_json, dict):
+                # TODO: check if this try catch is still needed now that
+                # we've updated pandas dataframe input parsing in predict
                 # This is a temporary fix for the case when spark_udf converts
                 # input into pandas dataframe with column name, while the model
                 # does not accept dictionaries as input, it leads to errors like

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -215,8 +215,6 @@ class APIRequest:
                 return self.lc_model.invoke(single_input, config={"callbacks": callback_handlers})
 
             if isinstance(self.request_json, dict):
-                # TODO: check if this try catch is still needed now that
-                # we've updated pandas dataframe input parsing in predict
                 # This is a temporary fix for the case when spark_udf converts
                 # input into pandas dataframe with column name, while the model
                 # does not accept dictionaries as input, it leads to errors like

--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -150,7 +150,7 @@ def store_imported_modules(cap_cm, model_path, flavor, output_file, error_file):
                         write_to(
                             error_file,
                             "Failed to run predict on input_example, dependencies "
-                            "introduced in predict is not captured.\n" + stack_trace,
+                            "introduced in predict are not captured.\n" + stack_trace,
                         )
                 return model
 

--- a/mlflow/utils/_capture_modules.py
+++ b/mlflow/utils/_capture_modules.py
@@ -142,8 +142,6 @@ def store_imported_modules(cap_cm, model_path, flavor, output_file, error_file):
         def _load_pyfunc_patch(*args, **kwargs):
             with cap_cm:
                 model = original(*args, **kwargs)
-                # TODO: fix
-                # even if this fails we should include already captured
                 if input_example is not None:
                     try:
                         model.predict(input_example, params=params)

--- a/mlflow/utils/exception_utils.py
+++ b/mlflow/utils/exception_utils.py
@@ -1,0 +1,14 @@
+import sys
+import traceback
+
+
+def get_stacktrace(error):
+    msg = repr(error)
+    try:
+        if sys.version_info < (3, 10):
+            tb = traceback.format_exception(error.__class__, error, error.__traceback__)
+        else:
+            tb = traceback.format_exception(error)
+        return (msg + "\n\n".join(tb)).strip()
+    except Exception:
+        return msg

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -345,7 +345,7 @@ def _capture_imported_modules(model_uri, flavor):
 
         if os.path.exists(error_file):
             with open(error_file) as f:
-                errors = f.read().splitlines()
+                errors = f.read()
             if errors:
                 _logger.warning(errors)
 

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -26,7 +26,10 @@ from mlflow.environment_variables import MLFLOW_REQUIREMENTS_INFERENCE_TIMEOUT
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.autologging_utils.versioning import _strip_dev_version_suffix
-from mlflow.utils.databricks_utils import is_in_databricks_runtime
+from mlflow.utils.databricks_utils import (
+    get_databricks_env_vars,
+    is_in_databricks_runtime,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -275,6 +278,9 @@ def _capture_imported_modules(model_uri, flavor):
         # See: ``https://github.com/mlflow/mlflow/issues/6905`` for context on minio configuration
         # resolution in a subprocess based on PATH entries.
         main_env["PATH"] = "/usr/sbin:/sbin:" + main_env["PATH"]
+        # Add databricks env, for langchain models loading we might need CLI configurations
+        if is_in_databricks_runtime():
+            main_env.update(get_databricks_env_vars(mlflow.get_tracking_uri()))
 
         if flavor == mlflow.transformers.FLAVOR_NAME:
             # Lazily import `_capture_transformers_module` here to avoid circular imports.
@@ -566,7 +572,9 @@ def _check_requirement_satisfied(requirement_str):
             from mlflow import gateway  # noqa: F401
         except ModuleNotFoundError:
             return _MismatchedPackageInfo(
-                package_name="mlflow[gateway]", installed_version=None, requirement=requirement_str
+                package_name="mlflow[gateway]",
+                installed_version=None,
+                requirement=requirement_str,
             )
 
     if (

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -323,6 +323,7 @@ def _capture_imported_modules(model_uri, flavor):
         # Lazily import `_capture_module` here to avoid circular imports.
         from mlflow.utils import _capture_modules
 
+        error_file = os.path.join(tmpdir, "error.txt")
         _run_command(
             [
                 sys.executable,
@@ -333,12 +334,19 @@ def _capture_imported_modules(model_uri, flavor):
                 flavor,
                 "--output-file",
                 output_file,
+                "--error-file",
+                error_file,
                 "--sys-path",
                 json.dumps(sys.path),
             ],
             timeout_seconds=process_timeout,
             env=main_env,
         )
+
+        with open(error_file) as f:
+            errors = f.read().splitlines()
+        if errors:
+            _logger.warning(errors)
 
         with open(output_file) as f:
             return f.read().splitlines()

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -343,10 +343,11 @@ def _capture_imported_modules(model_uri, flavor):
             env=main_env,
         )
 
-        with open(error_file) as f:
-            errors = f.read().splitlines()
-        if errors:
-            _logger.warning(errors)
+        if os.path.exists(error_file):
+            with open(error_file) as f:
+                errors = f.read().splitlines()
+            if errors:
+                _logger.warning(errors)
 
         with open(output_file) as f:
             return f.read().splitlines()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/11679?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11679/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11679
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> 
This PR solves below problems:

1. Missing env vars when capturing imports, if it's databricks runtime we should pass in those configs to make sure the predict works fine
2. For some non-native langchain models, when passing dataframe inputs to the langchain model, it reaches `_predict_single_input` and the exception is not TypeError, so it directly fails. This PR solves this problem by checking the input dataframe columns, if it's only one column with key 0 then we assume the input is either a string or list of strings. It's not common user wants to specify the model input as dictionary with key 0, so this change should be safe.
3. Add error_file to collect any exceptions happens when running predict on model input_example during capturing import modules. We should still capture whatever modules already captured, and emit the exception as a warning instead. This way we could make sure more modules are captured instead of using the simple fallback modules.

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

E2-dogfood test: NBA Rule Book answering - ML-40193; Capture errors in predict in infer_pip_requirements - ML-40193; FAISS dependency - ML-40193.

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes
- [x] No
