### PR TITLE
Fix langchain callback injection

### DIFF
--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -121,8 +121,7 @@ def _inject_mlflow_callback(func_name, mlflow_callback, args, kwargs):
             config = RunnableConfig(callbacks=callbacks)
         else:
             callbacks = config.get("callbacks") or []
-            callbacks.append(mlflow_callback)
-            config["callbacks"] = callbacks
+            config["callbacks"] = [*callbacks, mlflow_callback]
         if in_args:
             args = (args[0], config) + args[2:]
         else:
@@ -134,19 +133,16 @@ def _inject_mlflow_callback(func_name, mlflow_callback, args, kwargs):
         # https://github.com/langchain-ai/langchain/blob/7d444724d7582386de347fb928619c2243bd0e55/libs/langchain/langchain/chains/base.py#L320
         if len(args) >= 3:
             callbacks = args[2] or []
-            callbacks.append(mlflow_callback)
-            args = args[:2] + (callbacks,) + args[3:]
+            args = args[:2] + ([*callbacks, mlflow_callback],) + args[3:]
         else:
             callbacks = kwargs.get("callbacks") or []
-            callbacks.append(mlflow_callback)
-            kwargs["callbacks"] = callbacks
+            kwargs["callbacks"] = [*callbacks, mlflow_callback]
         return args, kwargs
 
     # https://github.com/langchain-ai/langchain/blob/7d444724d7582386de347fb928619c2243bd0e55/libs/core/langchain_core/retrievers.py#L173
     if func_name == "get_relevant_documents":
         callbacks = kwargs.get("callbacks") or []
-        callbacks.append(mlflow_callback)
-        kwargs["callbacks"] = callbacks
+        kwargs["callbacks"] = [*callbacks, mlflow_callback]
         return args, kwargs
 
 
@@ -230,7 +226,6 @@ def patched_inference(func_name, original, self, *args, **kwargs):
             )
     else:
         tags = None
-    # TODO: test adding callbacks works
     # Use session_id-inference_id as artifact directory where mlflow
     # callback logs artifacts into, to avoid overriding artifacts
     session_id = getattr(self, "session_id", uuid.uuid4().hex)

--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -121,6 +121,8 @@ def _inject_mlflow_callback(func_name, mlflow_callback, args, kwargs):
             config = RunnableConfig(callbacks=callbacks)
         else:
             callbacks = config.get("callbacks") or []
+            if not isinstance(callbacks, list):
+                callbacks = [callbacks]
             config["callbacks"] = [*callbacks, mlflow_callback]
         if in_args:
             args = (args[0], config) + args[2:]
@@ -133,15 +135,21 @@ def _inject_mlflow_callback(func_name, mlflow_callback, args, kwargs):
         # https://github.com/langchain-ai/langchain/blob/7d444724d7582386de347fb928619c2243bd0e55/libs/langchain/langchain/chains/base.py#L320
         if len(args) >= 3:
             callbacks = args[2] or []
+            if not isinstance(callbacks, list):
+                callbacks = [callbacks]
             args = args[:2] + ([*callbacks, mlflow_callback],) + args[3:]
         else:
             callbacks = kwargs.get("callbacks") or []
+            if not isinstance(callbacks, list):
+                callbacks = [callbacks]
             kwargs["callbacks"] = [*callbacks, mlflow_callback]
         return args, kwargs
 
     # https://github.com/langchain-ai/langchain/blob/7d444724d7582386de347fb928619c2243bd0e55/libs/core/langchain_core/retrievers.py#L173
     if func_name == "get_relevant_documents":
         callbacks = kwargs.get("callbacks") or []
+        if not isinstance(callbacks, list):
+            callbacks = [callbacks]
         kwargs["callbacks"] = [*callbacks, mlflow_callback]
         return args, kwargs
 

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -222,15 +222,13 @@ def create_runnable_sequence():
 
 def test_autolog_manage_run():
     mlflow.langchain.autolog(log_models=True, extra_tags={"test_tag": "test"})
-    run = mlflow.start_run()
-    with _mock_request(return_value=_mock_chat_completion_response()):
+    with mlflow.start_run() as run, _mock_request(return_value=_mock_chat_completion_response()):
         model = create_openai_llmchain()
         model.invoke("MLflow")
-    assert mlflow.active_run() is not None
+        assert mlflow.active_run() is not None
     assert MlflowClient().get_run(run.info.run_id).data.metrics != {}
     assert MlflowClient().get_run(run.info.run_id).data.tags["test_tag"] == "test"
     assert MlflowClient().get_run(run.info.run_id).data.tags["mlflow.autologging"] == "langchain"
-    mlflow.end_run()
 
 
 def test_autolog_manage_run_no_active_run():
@@ -691,15 +689,13 @@ def test_combine_input_and_output(input, output, expected):
 @pytest.mark.parametrize("callbacks", [StdOutCallbackHandler(), [StdOutCallbackHandler()]])
 def test_langchain_autolog_callback_injection(callbacks):
     mlflow.langchain.autolog(log_models=True, extra_tags={"test_tag": "test"})
-    run = mlflow.start_run()
-    with _mock_request(return_value=_mock_chat_completion_response()):
+    with mlflow.start_run() as run, _mock_request(return_value=_mock_chat_completion_response()):
         model = create_openai_llmchain()
         model.invoke("MLflow", callbacks=callbacks)
-    assert mlflow.active_run() is not None
+        assert mlflow.active_run() is not None
     assert MlflowClient().get_run(run.info.run_id).data.metrics != {}
     assert MlflowClient().get_run(run.info.run_id).data.tags["test_tag"] == "test"
     assert MlflowClient().get_run(run.info.run_id).data.tags["mlflow.autologging"] == "langchain"
-    mlflow.end_run()
     artifacts = get_artifacts(run.info.run_id)
     for artifact_name in get_mlflow_callback_artifacts():
         if isinstance(artifact_name, str):

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -11,6 +11,7 @@ from langchain.document_loaders import TextLoader
 from langchain.llms import OpenAI
 from langchain.prompts import PromptTemplate
 from langchain.text_splitter import CharacterTextSplitter
+from langchain_core.callbacks import StdOutCallbackHandler
 from test_langchain_model_export import FAISS, DeterministicDummyEmbeddings
 
 import mlflow
@@ -685,3 +686,23 @@ def test_combine_input_and_output(input, output, expected):
     loaded_table = mlflow.load_table(INFERENCE_FILE_NAME, run_ids=[run.info.run_id])
     pdf = pd.DataFrame(expected)
     pd.testing.assert_frame_equal(loaded_table, pdf)
+
+
+@pytest.mark.parametrize("callbacks", [StdOutCallbackHandler(), [StdOutCallbackHandler()]])
+def test_langchain_autolog_callback_injection(callbacks):
+    mlflow.langchain.autolog(log_models=True, extra_tags={"test_tag": "test"})
+    run = mlflow.start_run()
+    with _mock_request(return_value=_mock_chat_completion_response()):
+        model = create_openai_llmchain()
+        model.invoke("MLflow", callbacks=callbacks)
+    assert mlflow.active_run() is not None
+    assert MlflowClient().get_run(run.info.run_id).data.metrics != {}
+    assert MlflowClient().get_run(run.info.run_id).data.tags["test_tag"] == "test"
+    assert MlflowClient().get_run(run.info.run_id).data.tags["mlflow.autologging"] == "langchain"
+    mlflow.end_run()
+    artifacts = get_artifacts(run.info.run_id)
+    for artifact_name in get_mlflow_callback_artifacts():
+        if isinstance(artifact_name, str):
+            assert artifact_name in artifacts
+        else:
+            assert any(artifact_name.match(artifact) for artifact in artifacts)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/11685?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11685/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11685
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #11637

### What changes are proposed in this pull request?
langchain runnable config callbacks field can be a CallbackManager.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes
- [x] No
