### PR TITLE
fix: add libomp and commented out tensorflow-macos lines in req files

### DIFF
--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -160,7 +160,7 @@ if [ -z "$pyenv_exist" ]; then
       echo "Installing pyenv..."
       echo "Note: this will probably take a considerable amount of time."
       brew install pyenv
-      brew install openssl readline sqlite3 xz zlib
+      brew install openssl readline sqlite3 xz zlib libomp
     elif [[ "$machine" == linux ]]; then
       sudo apt-get update -y
       sudo apt-get install -y make build-essential libssl-dev zlib1g-dev \
@@ -211,13 +211,13 @@ fi
 echo "The top-level dependencies that will be installed are: "
 
 if [[ -n "$full" ]]; then
-  files=("$rd/extra-ml-requirements.txt" "$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-requirements.txt")
+  files=("$rd/extra-ml-requirements.txt" "$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-min-requirements.txt")
   echo "Files:"
   echo "MLflow test plugin: $MLFLOW_HOME/tests/resources/mlflow-test-plugin"
   echo "The local development branch of MLflow installed in editable mode with 'extras' requirements"
   echo "The following packages: "
 else
-  files=("$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-requirements.txt")
+  files=("$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-min-requirements.txt")
 fi
 tail -n +1 "${files[@]}" | grep "^[^#= ]" | sort | cat
 
@@ -267,7 +267,7 @@ if [[ -n "$full" ]]; then
   pip install $(quiet_command) -e "$MLFLOW_HOME/tests/resources//mlflow-test-plugin"
   echo "Finished installing pip dependencies."
 else
-  files=("$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-requirements.txt")
+  files=("$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-min-requirements.txt")
   for r in "${files[@]}";
   do
     pip install $(quiet_command) -r "$r"

--- a/dev/dev-env-setup.sh
+++ b/dev/dev-env-setup.sh
@@ -211,13 +211,13 @@ fi
 echo "The top-level dependencies that will be installed are: "
 
 if [[ -n "$full" ]]; then
-  files=("$rd/extra-ml-requirements.txt" "$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-min-requirements.txt")
+  files=("$rd/extra-ml-requirements.txt" "$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-requirements.txt")
   echo "Files:"
   echo "MLflow test plugin: $MLFLOW_HOME/tests/resources/mlflow-test-plugin"
   echo "The local development branch of MLflow installed in editable mode with 'extras' requirements"
   echo "The following packages: "
 else
-  files=("$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-min-requirements.txt")
+  files=("$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-requirements.txt")
 fi
 tail -n +1 "${files[@]}" | grep "^[^#= ]" | sort | cat
 
@@ -267,7 +267,7 @@ if [[ -n "$full" ]]; then
   pip install $(quiet_command) -e "$MLFLOW_HOME/tests/resources//mlflow-test-plugin"
   echo "Finished installing pip dependencies."
 else
-  files=("$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-min-requirements.txt")
+  files=("$rd/test-requirements.txt" "$rd/lint-requirements.txt" "$rd/doc-requirements.txt")
   for r in "${files[@]}";
   do
     pip install $(quiet_command) -r "$r"

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,4 +1,4 @@
 -r extra-ml-requirements.txt
 -r test-requirements.txt
 -r lint-requirements.txt
--r doc-requirements.txt
+-r doc-min-requirements.txt

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,4 +1,4 @@
 -r extra-ml-requirements.txt
 -r test-requirements.txt
 -r lint-requirements.txt
--r doc-min-requirements.txt
+-r doc-requirements.txt

--- a/requirements/doc-requirements.txt
+++ b/requirements/doc-requirements.txt
@@ -1,5 +1,6 @@
 -r doc-min-requirements.txt
 tensorflow-cpu<=2.12.0
+# tensorflow-macos<=2.12.0  # comment out the line above and uncomment this line if setting up dev environment on local ARM macOS
 pyspark
 datasets
 # nbsphinx and ipython are required for jupyter notebook rendering

--- a/requirements/doc-requirements.txt
+++ b/requirements/doc-requirements.txt
@@ -1,6 +1,9 @@
 -r doc-min-requirements.txt
 tensorflow-cpu<=2.12.0
-# tensorflow-macos<=2.12.0  # comment out the line above and uncomment this line if setting up dev environment on local ARM macOS
+# tensorflow-macos<=2.12.0  # Comment out the line above and uncomment this line if setting up dev
+                            # environment on local ARM macOS.
+                            # Only do this for the purpose of setting up the dev environment, do not
+                            # commit this change to the repo.
 pyspark
 datasets
 # nbsphinx and ipython are required for jupyter notebook rendering

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -10,7 +10,10 @@ fastai>=2.4.1
 spacy>=3.3.0
 # Required by mlflow.tensorflow
 tensorflow>=2.10.0
-# tensorflow-macos<=2.12.0  # comment out the line above and uncomment this line if setting up dev environment on local ARM macOS
+# tensorflow-macos<=2.12.0  # Comment out the line above and uncomment this line if setting up dev
+                            # environment on local ARM macOS.
+                            # Only do this for the purpose of setting up the dev environment, do not
+                            # commit this change to the repo.
 # Required by mlflow.pytorch
 torch>=1.11.0
 torchvision>=0.12.0

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -10,6 +10,7 @@ fastai>=2.4.1
 spacy>=3.3.0
 # Required by mlflow.tensorflow
 tensorflow>=2.10.0
+# tensorflow-macos<=2.12.0  # comment out the line above and uncomment this line if setting up dev environment on local ARM macOS
 # Required by mlflow.pytorch
 torch>=1.11.0
 torchvision>=0.12.0


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #11686

### What changes are proposed in this pull request?

* Install `libomp` with brew as part of the `pyenv` setup process on Mac
* Add commented out `tensorflow-macos` lines to `requirements/extra-ml-requirements.txt` and `requirements/doc-requirements.txt` and note that these should be used at dev environment set up time for ARM macs

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [X] Yes
- [ ] No
