### PR TITLE
Deprecate and add alias for `code_path` in `pyfunc`

### DIFF
--- a/docs/source/model/dependencies.rst
+++ b/docs/source/model/dependencies.rst
@@ -292,7 +292,7 @@ This way, MLflow will copy the entire ``src/`` directory under ``code/`` and you
 
 .. warning::
 
-    By the same reason, the ``code_paths`` option doesn't handle the relative import of ``code_path=["../src"]``.
+    By the same reason, the ``code_paths`` option doesn't handle the relative import of ``code_paths=["../src"]``.
 
 Recommended Project Structure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/flower_classifier/image_pyfunc.py
+++ b/examples/flower_classifier/image_pyfunc.py
@@ -154,7 +154,7 @@ def log_model(keras_model, signature, artifact_path, image_dims, domain):
             artifact_path=artifact_path,
             signature=signature,
             loader_module=__name__,
-            code_path=[__file__],
+            code_paths=[__file__],
             data_path=data_path,
             conda_env=conda_env,
         )

--- a/examples/pyfunc/train.py
+++ b/examples/pyfunc/train.py
@@ -38,7 +38,7 @@ with mlflow.start_run(run_name="test_pyfunc") as run:
         # log a custom model
         mlflow.pyfunc.log_model(
             artifact_path="artifacts",
-            code_path=[os.getcwd()],
+            code_paths=[os.getcwd()],
             artifacts={"custom_model": model_info.model_uri},
             python_model=CustomPredict(),
             signature=signature,

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -386,6 +386,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import warnings
 from copy import deepcopy
 from functools import lru_cache
 from typing import Any, Dict, Iterator, Optional, Tuple, Union
@@ -2047,7 +2048,8 @@ def save_model(
     path,
     loader_module=None,
     data_path=None,
-    code_path=None,
+    code_path=None,  # deprecated
+    code_paths=None,
     conda_env=None,
     mlflow_model=None,
     python_model=None,
@@ -2088,9 +2090,9 @@ def save_model(
             - One or more of the files specified by the ``code_path`` parameter.
 
         data_path: Path to a file or directory containing model data.
-        code_path: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path before the model is loaded.
+        code_path: **Deprecated** The legacy argument for defining dependent code. This argument is
+            replaced by ``code_paths`` and will be removed in a future version of MLflow.
+        code_paths: {{ code_paths }}
         conda_env: {{ conda_env }}
         mlflow_model: :py:mod:`mlflow.models.Model` configuration to which to add the
             **python_function** flavor.
@@ -2219,9 +2221,23 @@ def save_model(
     mlflow_model = kwargs.pop("model", mlflow_model)
     if len(kwargs) > 0:
         raise TypeError(f"save_model() got unexpected keyword arguments: {kwargs}")
+
+    if code_path is not None and code_paths is not None:
+        raise MlflowException(
+            "Both `code_path` and `code_paths` have been specified, which is " "not permitted."
+        )
     if code_path is not None:
-        if not isinstance(code_path, list):
-            raise TypeError(f"Argument code_path should be a list, not {type(code_path)}")
+        # Alias for `code_path` deprecation
+        code_paths = code_path
+        warnings.warn(
+            "The `code_path` argument is replaced by `code_paths` and is deprecated "
+            "as of MLflow version 2.12.0. This argument will be removed in a future "
+            "release of MLflow."
+        )
+
+    if code_paths is not None:
+        if not isinstance(code_paths, list):
+            raise TypeError(f"Argument code_path should be a list, not {type(code_paths)}")
 
     first_argument_set = {
         "loader_module": loader_module,
@@ -2327,7 +2343,7 @@ def save_model(
             path=path,
             loader_module=loader_module,
             data_path=data_path,
-            code_paths=code_path,
+            code_paths=code_paths,
             conda_env=conda_env,
             mlflow_model=mlflow_model,
             pip_requirements=pip_requirements,
@@ -2342,7 +2358,7 @@ def save_model(
             python_model=python_model,
             artifacts=artifacts,
             conda_env=conda_env,
-            code_paths=code_path,
+            code_paths=code_paths,
             mlflow_model=mlflow_model,
             pip_requirements=pip_requirements,
             extra_pip_requirements=extra_pip_requirements,
@@ -2355,7 +2371,8 @@ def log_model(
     artifact_path,
     loader_module=None,
     data_path=None,
-    code_path=None,
+    code_path=None,  # deprecated
+    code_paths=None,
     conda_env=None,
     python_model=None,
     artifacts=None,
@@ -2392,9 +2409,9 @@ def log_model(
             - One or more of the files specified by the ``code_path`` parameter.
 
         data_path: Path to a file or directory containing model data.
-        code_path: A list of local filesystem paths to Python file dependencies (or directories
-            containing file dependencies). These files are *prepended* to the system
-            path before the model is loaded.
+        code_path: **Deprecated** The legacy argument for defining dependent code. This argument is
+            replaced by ``code_paths`` and will be removed in a future version of MLflow.
+        code_paths: {{ code_paths }}
         conda_env: {{ conda_env }}
         python_model:
             An instance of a subclass of :class:`~PythonModel` or a callable object with a single
@@ -2531,7 +2548,8 @@ def log_model(
         flavor=mlflow.pyfunc,
         loader_module=loader_module,
         data_path=data_path,
-        code_path=code_path,
+        code_path=code_path,  # deprecated
+        code_paths=code_paths,
         python_model=python_model,
         artifacts=artifacts,
         conda_env=conda_env,

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2224,7 +2224,7 @@ def save_model(
 
     if code_path is not None and code_paths is not None:
         raise MlflowException(
-            "Both `code_path` and `code_paths` have been specified, which is " "not permitted."
+            "Both `code_path` and `code_paths` have been specified, which is not permitted."
         )
     if code_path is not None:
         # Alias for `code_path` deprecation

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -86,7 +86,7 @@ def test_model_save_load(sklearn_knn_model, iris_data, tmp_path, model_path):
         path=model_path,
         data_path=sk_model_path,
         loader_module=__name__,
-        code_path=[__file__],
+        code_paths=[__file__],
         mlflow_model=model_config,
     )
 
@@ -114,7 +114,7 @@ def test_signature_and_examples_are_saved_correctly(sklearn_knn_model, iris_data
                     path=path,
                     data_path=tmp.path("skmodel"),
                     loader_module=__name__,
-                    code_path=[__file__],
+                    code_paths=[__file__],
                     signature=signature,
                     input_example=example,
                 )
@@ -137,7 +137,7 @@ def test_model_log_load(sklearn_knn_model, iris_data, tmp_path):
             artifact_path=pyfunc_artifact_path,
             data_path=sk_model_path,
             loader_module=__name__,
-            code_path=[__file__],
+            code_paths=[__file__],
         )
         pyfunc_model_path = _download_artifact_from_uri(
             f"runs:/{mlflow.active_run().info.run_id}/{pyfunc_artifact_path}"
@@ -164,7 +164,7 @@ def test_model_log_load_no_active_run(sklearn_knn_model, iris_data, tmp_path):
         artifact_path=pyfunc_artifact_path,
         data_path=sk_model_path,
         loader_module=__name__,
-        code_path=[__file__],
+        code_paths=[__file__],
     )
     pyfunc_model_path = _download_artifact_from_uri(
         f"runs:/{mlflow.active_run().info.run_id}/{pyfunc_artifact_path}"
@@ -207,7 +207,7 @@ def test_log_model_persists_specified_conda_env_file_in_mlflow_model_directory(
             artifact_path=pyfunc_artifact_path,
             data_path=sk_model_path,
             loader_module=__name__,
-            code_path=[__file__],
+            code_paths=[__file__],
             conda_env=pyfunc_custom_env_file,
         )
         run_id = mlflow.active_run().info.run_id
@@ -241,7 +241,7 @@ def test_log_model_persists_specified_conda_env_dict_in_mlflow_model_directory(
             artifact_path=pyfunc_artifact_path,
             data_path=sk_model_path,
             loader_module=__name__,
-            code_path=[__file__],
+            code_paths=[__file__],
             conda_env=pyfunc_custom_env_dict,
         )
         run_id = mlflow.active_run().info.run_id
@@ -272,7 +272,7 @@ def test_log_model_persists_requirements_in_mlflow_model_directory(
             artifact_path=pyfunc_artifact_path,
             data_path=sk_model_path,
             loader_module=__name__,
-            code_path=[__file__],
+            code_paths=[__file__],
             conda_env=pyfunc_custom_env_dict,
         )
         run_id = mlflow.active_run().info.run_id
@@ -301,7 +301,7 @@ def test_log_model_without_specified_conda_env_uses_default_env_with_expected_de
             artifact_path=pyfunc_artifact_path,
             data_path=sk_model_path,
             loader_module=__name__,
-            code_path=[__file__],
+            code_paths=[__file__],
         )
         model_uri = mlflow.get_artifact_uri(pyfunc_artifact_path)
     _assert_pip_requirements(model_uri, mlflow.pyfunc.get_default_pip_requirements())

--- a/tests/pyfunc/test_pyfunc_model_config.py
+++ b/tests/pyfunc/test_pyfunc_model_config.py
@@ -83,7 +83,7 @@ def test_pyfunc_loader_without_model_config(model_path):
         path=model_path,
         data_path=".",
         loader_module=__name__,
-        code_path=[__file__],
+        code_paths=[__file__],
         mlflow_model=Model(run_id="test", artifact_path="testtest"),
     )
 

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -159,7 +159,7 @@ def test_spark_udf(spark, model_path):
     mlflow.pyfunc.save_model(
         path=model_path,
         loader_module=__name__,
-        code_path=[os.path.dirname(tests.__file__)],
+        code_paths=[os.path.dirname(tests.__file__)],
     )
 
     with mock.patch("mlflow.pyfunc.warn_dependency_requirement_mismatches") as mock_check_fn:
@@ -759,7 +759,7 @@ def test_model_cache(spark, model_path):
     mlflow.pyfunc.save_model(
         path=model_path,
         loader_module=__name__,
-        code_path=[os.path.dirname(tests.__file__)],
+        code_paths=[os.path.dirname(tests.__file__)],
     )
 
     archive_path = SparkModelCache.add_local_model(spark, model_path)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/11688?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11688/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11688
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Unifies the `code_paths` argument name and marks `code_path` as deprecated.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [X] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

The argument `code_path` within `pyfunc.save_model` and `pyfunc.log_model` is deprecated in favor of `code_paths`, similar to all other model flavors.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes
- [X] No
