### PR TITLE
Fix doc of start_run

### DIFF
--- a/docs/source/tracking/tracking-api.rst
+++ b/docs/source/tracking/tracking-api.rst
@@ -75,9 +75,10 @@ specify an experiment in :py:func:`mlflow.start_run`, new runs are launched unde
     must be an absolute path, e.g. ``"/Users/<username>/my-experiment"``.
 
 
-:py:func:`mlflow.start_run` returns the currently active run (if one exists), or starts a new run
-and returns a :py:class:`mlflow.ActiveRun` object usable as a context manager for the
-current run. You do not need to call ``start_run`` explicitly: calling one of the logging functions
+:py:func:`mlflow.start_run` starts a new run and returns a :py:class:`mlflow.ActiveRun` object 
+usable as a context manager for the current run. If an active run is already in progress, you 
+should either end the current run or nest the new run within the current run using ``nested=True``.
+You do not need to call ``start_run`` explicitly: calling one of the logging functions
 with no active run automatically starts a new one.
 
 .. note::

--- a/docs/source/tracking/tracking-api.rst
+++ b/docs/source/tracking/tracking-api.rst
@@ -77,7 +77,7 @@ specify an experiment in :py:func:`mlflow.start_run`, new runs are launched unde
 
 :py:func:`mlflow.start_run` starts a new run and returns a :py:class:`mlflow.ActiveRun` object 
 usable as a context manager for the current run. If an active run is already in progress, you 
-should either end the current run or nest the new run within the current run using ``nested=True``.
+should either end the current run before starting the new run or nest the new run within the current run using ``nested=True``.
 You do not need to call ``start_run`` explicitly: calling one of the logging functions
 with no active run automatically starts a new one.
 


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
start_run doesn't return the existing run if there's an active run

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes
- [x] No
