### PR TITLE
Fix generate_dockerfile env_manager

### DIFF
--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -170,7 +170,7 @@ def prepare_env(
     default="mlflow-dockerfile",
     help="Output directory where the generated Dockerfile is stored.",
 )
-@cli_args.ENV_MANAGER
+@cli_args.ENV_MANAGER_DOCKERFILE
 @cli_args.MLFLOW_HOME
 @cli_args.INSTALL_JAVA
 @cli_args.INSTALL_MLFLOW

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -79,6 +79,9 @@ class PyFuncBackend(FlavorBackend):
     ):
         """
         Args:
+            env_manager: Environment manager to use for preparing the environment. If None,
+                MLflow will automatically pick the env manager based on the model's flavor
+                configuration for generate_dockerfile. It can't be None for other methods.
             env_root_dir: Root path for conda env. If None, use Conda's default environments
                 directory. Note if this is set, conda package cache path becomes
                 "{env_root_dir}/conda_cache_pkgs" instead of the global package cache

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -57,6 +57,9 @@ FLAVOR_SPECIFIC_APT_PACKAGES = {
 
 # Directory to store loaded model inside the Docker context directory
 _MODEL_DIR_NAME = "model_dir"
+LOCAL_ENV_MANAGER_ERROR_MESSAGE = "We cannot use 'LOCAL' environment manager "
+"for your model configuration. Please specify a virtualenv or conda environment "
+"manager instead with `--env-manager` argument."
 
 
 class PyFuncBackend(FlavorBackend):
@@ -67,8 +70,8 @@ class PyFuncBackend(FlavorBackend):
     def __init__(
         self,
         config,
+        env_manager,
         workers=1,
-        env_manager=None,
         install_mlflow=False,
         create_env_root_dir=False,
         env_root_dir=None,
@@ -392,7 +395,7 @@ class PyFuncBackend(FlavorBackend):
                 # installing python on ubuntu image is problematic and not recommended officially
                 # so we recommend using conda or virtualenv instead on ubuntu image
                 if env_manager == _EnvManager.LOCAL:
-                    raise MlflowException("Please specify a virtualenv or conda environment!")
+                    raise MlflowException.invalid_parameter_value(LOCAL_ENV_MANAGER_ERROR_MESSAGE)
             # shouldn't reach here but add this so we can validate base_image value above
             else:
                 raise MlflowException(f"Unexpected base image value '{base_image}'")
@@ -407,7 +410,7 @@ class PyFuncBackend(FlavorBackend):
             base_image = UBUNTU_BASE_IMAGE
             env_manager = self._env_manager or _EnvManager.VIRTUALENV
             if env_manager == _EnvManager.LOCAL:
-                raise MlflowException("Please specify a virtualenv or conda environment!")
+                raise MlflowException.invalid_parameter_value(LOCAL_ENV_MANAGER_ERROR_MESSAGE)
 
             model_install_steps = ""
             # If model_uri is not specified, dependencies are installed at runtime

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -136,7 +136,11 @@ environment manager. The following values are supported:
 - virtualenv: use virtualenv (and pyenv for Python version management)
 - conda: use conda
 
-If unspecified, default to None.
+If unspecified, default to None, then MLflow will automatically pick the env manager
+based on the model's flavor configuration.
+If model-uri is specified: if python version is specified in the flavor configuration
+and no java installation is required, then we use local environment. Otherwise we use virtualenv.
+If no model-uri is provided, we use virtualenv.
 """,
 )
 

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -91,7 +91,7 @@ def _create_env_manager_option(help_string, default=None):
 
 
 ENV_MANAGER = _create_env_manager_option(
-    default=_EnvManager.VIRTUALENV,
+    default=None,
     # '\b' prevents rewrapping text:
     # https://click.palletsprojects.com/en/8.1.x/documentation/#preventing-rewrapping
     help_string="""

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -91,7 +91,7 @@ def _create_env_manager_option(help_string, default=None):
 
 
 ENV_MANAGER = _create_env_manager_option(
-    default=None,
+    default=_EnvManager.VIRTUALENV,
     # '\b' prevents rewrapping text:
     # https://click.palletsprojects.com/en/8.1.x/documentation/#preventing-rewrapping
     help_string="""
@@ -120,6 +120,23 @@ environment manager. The following values are supported:
 If unspecified, the appropriate environment manager is automatically selected based on
 the project configuration. For example, if `MLproject.yaml` contains a `python_env` key,
 virtualenv is used.
+""",
+)
+
+ENV_MANAGER_DOCKERFILE = _create_env_manager_option(
+    default=None,
+    # '\b' prevents rewrapping text:
+    # https://click.palletsprojects.com/en/8.1.x/documentation/#preventing-rewrapping
+    help_string="""
+If specified, create an environment for MLmodel using the specified
+environment manager. The following values are supported:
+
+\b
+- local: use the local environment
+- virtualenv: use virtualenv (and pyenv for Python version management)
+- conda: use conda
+
+If unspecified, default to None.
 """,
 )
 

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -759,7 +759,10 @@ def test_host_invalid_value():
             python_model=MyModel(), artifact_path="test_model", registered_model_name="model"
         )
 
-    with mock.patch("mlflow.models.cli.get_flavor_backend", return_value=PyFuncBackend({})):
+    with mock.patch(
+        "mlflow.models.cli.get_flavor_backend",
+        return_value=PyFuncBackend({}, env_manager=_EnvManager.VIRTUALENV),
+    ):
         with pytest.raises(ShellCommandException, match=r"Non-zero exit code: 1"):
             CliRunner().invoke(
                 models_cli.serve,

--- a/tests/pyfunc/docker/test_docker.py
+++ b/tests/pyfunc/docker/test_docker.py
@@ -121,7 +121,7 @@ def test_generate_dockerfile_for_java_flavor(tmp_path):
     model_path = save_model(tmp_path)
     add_spark_flavor_to_model(model_path)
 
-    backend = get_flavor_backend(model_path, docker_build=True)
+    backend = get_flavor_backend(model_path, docker_build=True, env_manager=None)
 
     backend.generate_dockerfile(
         model_uri=model_path,

--- a/tests/pyfunc/docker/test_docker.py
+++ b/tests/pyfunc/docker/test_docker.py
@@ -15,7 +15,7 @@ from mlflow.models import Model
 from mlflow.models.docker_utils import build_image_from_context
 from mlflow.models.flavor_backend_registry import get_flavor_backend
 from mlflow.utils import PYTHON_VERSION
-from mlflow.utils.env_manager import VIRTUALENV
+from mlflow.utils.env_manager import CONDA, LOCAL, VIRTUALENV
 from mlflow.version import VERSION
 
 from tests.pyfunc.docker.conftest import RESOURCE_DIR, get_released_mlflow_version
@@ -62,7 +62,7 @@ def add_spark_flavor_to_model(model_path):
 @dataclass
 class Param:
     expected_dockerfile: str
-    env_manager: str = VIRTUALENV
+    env_manager: Optional[str] = None
     mlflow_home: Optional[str] = None
     install_mlflow: bool = False
     enable_mlserver: bool = False
@@ -74,6 +74,9 @@ class Param:
     "params",
     [
         Param(expected_dockerfile="Dockerfile_default"),
+        Param(expected_dockerfile="Dockerfile_default", env_manager=LOCAL),
+        Param(expected_dockerfile="Dockerfile_java_flavor", env_manager=VIRTUALENV),
+        Param(expected_dockerfile="Dockerfile_conda", env_manager=CONDA),
         Param(install_mlflow=True, expected_dockerfile="Dockerfile_install_mlflow"),
         Param(enable_mlserver=True, expected_dockerfile="Dockerfile_enable_mlserver"),
         Param(mlflow_home=".", expected_dockerfile="Dockerfile_with_mlflow_home"),

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -114,7 +114,7 @@ def test_build_image_and_serve(flavor, request):
     flavor = flavor.split("_")[0]  # Remove _pt or _tf from the flavor name
 
     # Build an image
-    backend = get_flavor_backend(model_uri=model_path, docker_build=True)
+    backend = get_flavor_backend(model_uri=model_path, docker_build=True, env_manager=None)
     backend.build_image(
         model_uri=model_path,
         image_name=TEST_IMAGE_NAME,

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -761,7 +761,7 @@ def test_scoring_server_client(sklearn_model, model_path):
     server_proc = None
     try:
         server_proc = get_flavor_backend(
-            model_path, eng_manager=_EnvManager.CONDA, workers=1, install_mlflow=False
+            model_path, env_manager=_EnvManager.CONDA, workers=1, install_mlflow=False
         ).serve(
             model_uri=model_path,
             port=port,

--- a/tests/resources/dockerfile/Dockerfile_conda
+++ b/tests/resources/dockerfile/Dockerfile_conda
@@ -1,0 +1,44 @@
+# Build an image that can serve mlflow models.
+FROM ubuntu:20.04
+
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
+
+# Setup miniconda
+RUN curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh >> miniconda.sh
+RUN bash ./miniconda.sh -b -p /miniconda && rm ./miniconda.sh
+ENV PATH="/miniconda/bin:$PATH"
+
+
+# Setup Java
+RUN apt-get install -y --no-install-recommends openjdk-11-jdk maven
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+WORKDIR /opt/mlflow
+
+# Install MLflow
+RUN pip install mlflow==${{ MLFLOW_VERSION }}
+
+# Install Java mlflow-scoring from Maven Central
+RUN mvn --batch-mode dependency:copy -Dartifact=org.mlflow:mlflow-scoring:${{ MLFLOW_VERSION }}:pom -DoutputDirectory=/opt/java 
+RUN mvn --batch-mode dependency:copy -Dartifact=org.mlflow:mlflow-scoring:${{ MLFLOW_VERSION }}:jar -DoutputDirectory=/opt/java/jars 
+RUN cp /opt/java/mlflow-scoring-${{ MLFLOW_VERSION }}.pom /opt/java/pom.xml
+RUN cd /opt/java && mvn --batch-mode dependency:copy-dependencies -DoutputDirectory=/opt/java/jars 
+
+
+# Copy model to image and install dependencies
+COPY model_dir/model /opt/ml/model
+RUN python -c "from mlflow.models import container as C; C._install_pyfunc_deps('/opt/ml/model', install_mlflow=False, enable_mlserver=False, env_manager='conda');"
+
+ENV MLFLOW_DISABLE_ENV_CREATION=True
+ENV ENABLE_MLSERVER=False
+ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent"
+
+# granting read/write access and conditional execution authority to all child directories
+# and files to allow for deployment to AWS Sagemaker Serverless Endpoints
+# (see https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+RUN chmod o+rwX /opt/mlflow/
+
+# clean up apt cache to reduce image size
+RUN rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["python", "-c", "from mlflow.models import container as C; C._serve('conda')"]

--- a/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
@@ -1,0 +1,55 @@
+# Build an image that can serve mlflow models.
+FROM ubuntu:20.04
+
+RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
+
+# Setup pyenv
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
+    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+    libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+RUN git clone \
+    --depth 1 \
+    --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
+    https://github.com/pyenv/pyenv.git /root/.pyenv
+ENV PYENV_ROOT="/root/.pyenv"
+ENV PATH="$PYENV_ROOT/bin:$PATH"
+RUN apt install -y python3.8 python3.8-distutils \
+    && ln -s -f $(which python3.8) /usr/bin/python \
+    && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
+    && python /tmp/get-pip.py
+RUN pip install virtualenv
+
+
+# Setup Java
+RUN apt-get install -y --no-install-recommends openjdk-11-jdk maven
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+WORKDIR /opt/mlflow
+
+# Install MLflow
+RUN pip install mlflow==${{ MLFLOW_VERSION }}
+
+# Install Java mlflow-scoring from Maven Central
+RUN mvn --batch-mode dependency:copy -Dartifact=org.mlflow:mlflow-scoring:${{ MLFLOW_VERSION }}:pom -DoutputDirectory=/opt/java 
+RUN mvn --batch-mode dependency:copy -Dartifact=org.mlflow:mlflow-scoring:${{ MLFLOW_VERSION }}:jar -DoutputDirectory=/opt/java/jars 
+RUN cp /opt/java/mlflow-scoring-${{ MLFLOW_VERSION }}.pom /opt/java/pom.xml
+RUN cd /opt/java && mvn --batch-mode dependency:copy-dependencies -DoutputDirectory=/opt/java/jars 
+
+
+# Copy model to image and install dependencies
+COPY model_dir/model /opt/ml/model
+RUN python -c "from mlflow.models import container as C; C._install_pyfunc_deps('/opt/ml/model', install_mlflow=False, enable_mlserver=False, env_manager='virtualenv');"
+
+ENV MLFLOW_DISABLE_ENV_CREATION=True
+ENV ENABLE_MLSERVER=False
+ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent"
+
+# granting read/write access and conditional execution authority to all child directories
+# and files to allow for deployment to AWS Sagemaker Serverless Endpoints
+# (see https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+RUN chmod o+rwX /opt/mlflow/
+
+# clean up apt cache to reduce image size
+RUN rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["python", "-c", "from mlflow.models import container as C; C._serve('virtualenv')"]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/11690?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11690/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11690
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #11681

### What changes are proposed in this pull request?
Allow user's input take precedence over other env_manager settings.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes
- [x] No
