### PR TITLE
fix: cascade experiment id fk deletion in datasets table

### DIFF
--- a/mlflow/store/db_migrations/versions/93bd306463bd_add_cascading_delete_on_experiments_fk_in_datasets_table.py
+++ b/mlflow/store/db_migrations/versions/93bd306463bd_add_cascading_delete_on_experiments_fk_in_datasets_table.py
@@ -1,0 +1,67 @@
+"""add cascading delete on experiments fk in datasets table
+
+Revision ID: 93bd306463bd
+Revises: acf3f17fdcc7
+Create Date: 2024-04-12 10:13:01.319032
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "93bd306463bd"
+down_revision = "acf3f17fdcc7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    dialect_name = op.get_context().dialect.name
+    if dialect_name == "sqlite":
+        # Only way to drop unnamed fk constraint in sqllite
+        # See https://alembic.sqlalchemy.org/en/latest/batch.html#dropping-unnamed-or-named-foreign-key-constraints
+        with op.batch_alter_table(
+            "datasets",
+            schema=None,
+            naming_convention={
+                "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+            },
+        ) as batch_op:
+            batch_op.drop_constraint(
+                "fk_datasets_experiment_id_experiments", type_="foreignkey"
+            )
+            # Need to explicitly name the fk constraint with batch alter table
+            batch_op.create_foreign_key(
+                "fk_datasets_experiment_id_experiments",
+                "experiments",
+                ["experiment_id"],
+                ["experiment_id"],
+                ondelete="CASCADE",
+            )
+    else:
+        if dialect_name == "postgresql":
+            fk_constraint_name = "datasets_experiment_id_fkey"
+        elif dialect_name == "mysql":
+            fk_constraint_name = "datasets_ibfk_1"
+        elif dialect_name == "mssql":
+            # mssql fk constraint name at acf3f17fdcc7
+            fk_constraint_name = "FK__datasets__experi__6477ECF3"
+
+        # don't use batch alter table here so `create_foreign_key()` can be
+        # called with `None` as the `constraint_name` and have it set
+        # automatically based on the conventions of the sql flavor
+        op.drop_constraint(fk_constraint_name, "datasets", type_="foreignkey")
+        op.create_foreign_key(
+            None,
+            "datasets",
+            "experiments",
+            ["experiment_id"],
+            ["experiment_id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade():
+    pass

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -491,7 +491,7 @@ class SqlDataset(Base):
     Dataset UUID: `String` (limit 36 characters). Defined as *Non-null* in schema.
     Part of *Primary Key* for ``datasets`` table.
     """
-    experiment_id = Column(Integer, ForeignKey("experiments.experiment_id"))
+    experiment_id = Column(Integer, ForeignKey("experiments.experiment_id", ondelete="CASCADE"))
     """
     Experiment ID to which this dataset belongs: *Foreign Key* into ``experiments`` table.
     """
@@ -555,7 +555,11 @@ class SqlInput(Base):
     __tablename__ = "inputs"
     __table_args__ = (
         PrimaryKeyConstraint(
-            "source_type", "source_id", "destination_type", "destination_id", name="inputs_pk"
+            "source_type",
+            "source_id",
+            "destination_type",
+            "destination_id",
+            name="inputs_pk",
         ),
         Index(f"index_{__tablename__}_input_uuid", "input_uuid"),
         Index(

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -53,7 +53,7 @@ CREATE TABLE datasets (
 	dataset_schema VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	dataset_profile VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
-	CONSTRAINT "FK__datasets__experi__6477ECF3" FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT "FK__datasets__experi__693CA210" FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -54,7 +54,7 @@ CREATE TABLE datasets (
 	dataset_schema TEXT,
 	dataset_profile MEDIUMTEXT,
 	PRIMARY KEY (experiment_id, name, digest),
-	CONSTRAINT datasets_ibfk_1 FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT datasets_ibfk_1 FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -55,7 +55,7 @@ CREATE TABLE datasets (
 	dataset_schema TEXT,
 	dataset_profile TEXT,
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
-	CONSTRAINT datasets_experiment_id_fkey FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT datasets_experiment_id_fkey FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -56,7 +56,7 @@ CREATE TABLE datasets (
 	dataset_schema TEXT,
 	dataset_profile TEXT,
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
-	FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -56,7 +56,7 @@ CREATE TABLE datasets (
 	dataset_schema TEXT,
 	dataset_profile TEXT,
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
-	FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -411,7 +411,7 @@ def test_mlflow_gc_experiments(get_store_details, request):
     exp_id_6 = store.create_experiment("6")
     run_id_2 = store.create_run(exp_id_6, user_id="user", start_time=1, tags=[], run_name="2")
     run_id_2_datasets = [DatasetInput(dataset=numpy_dataset.from_numpy(np.array([1, 2, 3])))]
-    store.log_inputs(run_id_2, datasets=run_id_2_datasets)
+    store.log_inputs(run_id_2.info.run_id, datasets=run_id_2_datasets)
     store.delete_experiment(exp_id_6)
     invoke_gc("--backend-store-uri", uri, "--experiment-ids", exp_id_6)
     assert sorted([e.experiment_id for e in experiments]) == sorted(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -410,7 +410,9 @@ def test_mlflow_gc_experiments(get_store_details, request):
 
     exp_id_6 = store.create_experiment("6")
     run_id_2 = store.create_run(exp_id_6, user_id="user", start_time=1, tags=[], run_name="2")
-    run_id_2_datasets = [DatasetInput(dataset=numpy_dataset.from_numpy(np.array([1, 2, 3])))]
+    run_id_2_datasets = [
+        DatasetInput(dataset=numpy_dataset.from_numpy(np.array([1, 2, 3]))._to_mlflow_entity())
+    ]
     store.log_inputs(run_id_2.info.run_id, datasets=run_id_2_datasets)
     store.delete_experiment(exp_id_6)
     invoke_gc("--backend-store-uri", uri, "--experiment-ids", exp_id_6)


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #10699

### What changes are proposed in this pull request?

Apply cascading deletion to the `experiment_id` foreign key in the datasets table.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

I followed the README in the `tests/db` folder and everything seemed to be passing for every sql flavor

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes a bug where `mlflow gc` will fail attempting to permanently delete an experiment if existing datasets are associated with the experiment.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [X] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [X] Yes
- [ ] No
