### PR TITLE
Allow running cross-version tests without making a dummy change

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -118,7 +118,6 @@ jobs:
             ONLY_LATEST="${{ fromJson(steps.get-options.outputs.result).only_latest }}"
             ONLY_LATEST_FLAG=$([ "$ONLY_LATEST" == "true" ] && echo "--only-latest" || echo "")
             FLAVORS="${{ fromJson(steps.get-options.outputs.result).flavors }}"
-            FLAVORS="sklearn,xgboost"
             python dev/set_matrix.py --ref-versions-yaml $REF_VERSIONS_YAML \
               --changed-files "$CHANGED_FILES" $NO_DEV_FLAG $ONLY_LATEST_FLAG \
               --flavors "$FLAVORS"

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -113,7 +113,10 @@ jobs:
             NO_DEV_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--no-dev")
             ONLY_LATEST="${{ fromJson(steps.check-labels.outputs.result).only_latest }}"
             ONLY_LATEST_FLAG=$([ "$ONLY_LATEST" == "true" ] && echo "--only-latest" || echo "")
-            python dev/set_matrix.py --ref-versions-yaml $REF_VERSIONS_YAML --changed-files "$CHANGED_FILES" $NO_DEV_FLAG $ONLY_LATEST_FLAG
+            FLAVORS="sklearn,xgboost"
+            python dev/set_matrix.py --ref-versions-yaml $REF_VERSIONS_YAML \
+              --changed-files "$CHANGED_FILES" $NO_DEV_FLAG $ONLY_LATEST_FLAG \
+              --flavors "$FLAVORS"
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             python dev/set_matrix.py --flavors "${{ github.event.inputs.flavors }}" --versions "${{ github.event.inputs.versions }}"
           else

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           pip install -r dev/requirements.txt
           pip install pytest pytest-cov
-      - name: Check labels
+      - name: Get options
         uses: actions/github-script@v7
         id: get-options
         with:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -75,13 +75,14 @@ jobs:
           pip install pytest pytest-cov
       - name: Check labels
         uses: actions/github-script@v7
-        id: check-labels
+        id: get-options
         with:
           script: |
             if (context.eventName !== "pull_request") {
               return {
                 enable_dev_tests: true,
                 only_latest: false,
+                flavors: "",
               };
             }
             const labels = await github.rest.issues.listLabelsOnIssue({
@@ -90,9 +91,12 @@ jobs:
               issue_number: context.issue.number,
             });
             const labelNames = labels.data.map(({ name }) => name);
+            const { body } = context.payload.pull_request;
+            const flavorsMatch = body.match(/\/flavors\s+([^\n]+)/);
             return {
               enable_dev_tests: labelNames.includes("enable-dev-tests"),
               only_latest: labelNames.includes("only-latest"),
+              flavors: flavorsMatch ? flavorsMatch[1] : "",
             };
       - name: Test set_matrix.py
         run: |
@@ -109,10 +113,11 @@ jobs:
             BASE_REF="${{ github.base_ref }}"
             REF_VERSIONS_YAML="https://raw.githubusercontent.com/$REPO/$BASE_REF/mlflow/ml-package-versions.yml"
             CHANGED_FILES="$(python dev/list_changed_files.py --repository $REPO --pr-num $PR_NUMBER)"
-            ENABLE_DEV_TESTS="${{ fromJson(steps.check-labels.outputs.result).enable_dev_tests }}"
+            ENABLE_DEV_TESTS="${{ fromJson(steps.get-options.outputs.result).enable_dev_tests }}"
             NO_DEV_FLAG=$([ "$ENABLE_DEV_TESTS" == "true" ] && echo "" || echo "--no-dev")
-            ONLY_LATEST="${{ fromJson(steps.check-labels.outputs.result).only_latest }}"
+            ONLY_LATEST="${{ fromJson(steps.get-options.outputs.result).only_latest }}"
             ONLY_LATEST_FLAG=$([ "$ONLY_LATEST" == "true" ] && echo "--only-latest" || echo "")
+            FLAVORS="${{ fromJson(steps.get-options.outputs.result).flavors }}"
             FLAVORS="sklearn,xgboost"
             python dev/set_matrix.py --ref-versions-yaml $REF_VERSIONS_YAML \
               --changed-files "$CHANGED_FILES" $NO_DEV_FLAG $ONLY_LATEST_FLAG \

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -477,15 +477,15 @@ def generate_matrix(args):
             ref_matrix = expand_config(ref_config)
             matrix.update(mat.difference(ref_matrix))
 
+        if args.flavors:
+            matrix.update({x for x in mat if x.flavor in args.flavors})
+
         if args.changed_files:
             matrix.update(apply_changed_files(args.changed_files, mat))
 
     # Apply the filtering arguments
     if args.no_dev:
         matrix = filter(lambda x: x.version != Version.create_dev(), matrix)
-
-    if args.flavors:
-        matrix = filter(lambda x: x.flavor in args.flavors, matrix)
 
     if args.versions:
         matrix = filter(lambda x: x.version in map(Version, args.versions), matrix)

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -467,10 +467,10 @@ def apply_changed_files(changed_files, matrix):
 def generate_matrix(args):
     args = parse_args(args)
     config = read_yaml(args.versions_yaml)
-    if (args.ref_versions_yaml, args.changed_files).count(None) == 2:
+    if args.ref_versions_yaml is None and args.changed_files is None:
         matrix = expand_config(config)
         if args.flavors:
-            matrix = {x for x in matrix if x.flavor in args.flavors}
+            matrix = {x for x in matrix if x.flavor in args.flavors or "ALL" in args.flavors}
     else:
         matrix = set()
         mat = expand_config(config)
@@ -481,7 +481,7 @@ def generate_matrix(args):
             matrix.update(mat.difference(ref_matrix))
 
         if args.flavors:
-            matrix.update({x for x in mat if x.flavor in args.flavors})
+            matrix.update({x for x in mat if x.flavor in args.flavors or "ALL" in args.flavors})
 
         if args.changed_files:
             matrix.update(apply_changed_files(args.changed_files, mat))

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -457,7 +457,8 @@ def apply_changed_files(changed_files, matrix):
     changed_flavors = (
         # If this file has been changed, re-run all tests
         all_flavors
-        if (__file__ in changed_files)
+        if False
+        # if (__file__ in changed_files)
         else get_changed_flavors(changed_files, all_flavors)
     )
     return set(filter(lambda x: x.flavor in changed_flavors, matrix))

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -468,6 +468,8 @@ def generate_matrix(args):
     config = read_yaml(args.versions_yaml)
     if (args.ref_versions_yaml, args.changed_files).count(None) == 2:
         matrix = expand_config(config)
+        if args.flavors:
+            matrix = {x for x in matrix if x.flavor in args.flavors}
     else:
         matrix = set()
         mat = expand_config(config)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11705?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11705/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11705
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

It's painful to run cross-version tests by making a dummy change. This PR updates `set_matrix.py` to read the flavors to test from the PR description.

```
/flavors sklearn,xgboost
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes
- [x] No
