### PR TITLE
Use pre-commit to format files in autoformat workflow

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -75,15 +75,11 @@ jobs:
         run: |
           changed_files="$(gh pr view --repo ${{ github.repository }} ${{ needs.check-comment.outputs.pull_number }} --json files --jq '.files.[].path')"
           protos=$([[ -z $(echo "$changed_files" | grep '^\(mlflow/protos\|tests/protos\)') ]] && echo "false" || echo "true")
-          python=$([[ -z $(echo "$changed_files" | grep '\.py$\|^pyproject\.toml$') ]] && echo "false" || echo "true")
           js=$([[ -z $(echo "$changed_files" | grep '^mlflow/server/js') ]] && echo "false" || echo "true")
           r=$([[ -z $(echo "$changed_files" | grep '^mlflow/R/mlflow') ]] && echo "false" || echo "true")
-          requirements=$([[ -z $(echo "$changed_files" | grep '^requirements/.*\.txt$') ]] && echo "false" || echo "true")
           echo "protos=$protos" >> $GITHUB_OUTPUT
-          echo "python=$python" >> $GITHUB_OUTPUT
           echo "js=$js" >> $GITHUB_OUTPUT
           echo "r=$r" >> $GITHUB_OUTPUT
-          echo "requirements=$requirements" >> $GITHUB_OUTPUT
       # Merge the base branch (which is usually master) to apply formatting using the latest configurations.
       - name: Merge base branch
         run: |
@@ -93,16 +89,15 @@ jobs:
           git fetch base ${{ needs.check-comment.outputs.base_ref }}
           git merge base/${{ needs.check-comment.outputs.base_ref }}
       - uses: ./.github/actions/setup-python
+      # ************************************************************************
+      # pre-commit
+      # ************************************************************************
       - run: |
           pip install -r requirements/lint-requirements.txt
           # TODO: Use a precompiled binary once it's available: https://github.com/tamasfe/taplo/issues/542
           cargo install taplo-cli@0.9.0 --locked
           pre-commit install
-      # ************************************************************************
-      # Prettier
-      # ************************************************************************
-      - run: |
-          pre-commit run prettier --all-files --color=always || true
+          pre-commit run --all-files --color=always || true
       # ************************************************************************
       # protos
       # ************************************************************************
@@ -119,15 +114,6 @@ jobs:
       - if: steps.diff.outputs.protos == 'true'
         run: |
           ./dev/generate-protos.sh
-      # ************************************************************************
-      # python
-      # ************************************************************************
-      - if: steps.diff.outputs.python == 'true'
-        run: |
-          ruff check --fix .
-          ruff format .
-          taplo format $(git ls-files '*.toml')
-          blacken-docs $(git ls-files '*.rst' '*.md') || true
       # ************************************************************************
       # js
       # ************************************************************************
@@ -155,12 +141,6 @@ jobs:
         working-directory: docs
         run: |
           ./build-rdoc.sh
-      # ************************************************************************
-      # pyproject
-      # ************************************************************************
-      - if: steps.diff.outputs.requirements == 'true'
-        run: |
-          python ./dev/pyproject.py
       # ************************************************************************
       # Upload patch
       # ************************************************************************

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,6 +58,7 @@ jobs:
         id: pre-commit
         env:
           IS_MAINTAINER: ${{ contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association )}}
+          NO_FIX: "true"
         run: |
           source .venv/bin/activate
           pre-commit run --all-files

--- a/dev/format.py
+++ b/dev/format.py
@@ -26,7 +26,7 @@ def transform(stdout: str, is_maintainer: bool) -> str:
 
 
 def main():
-    if "GITHUB_ACTIONS" in os.environ:
+    if "NO_FIX" in os.environ:
         with subprocess.Popen(
             [
                 *RUFF_FORMAT,

--- a/dev/ruff.py
+++ b/dev/ruff.py
@@ -28,7 +28,7 @@ def transform(stdout: str, is_maintainer: bool) -> str:
 
 
 def main():
-    if "GITHUB_ACTIONS" in os.environ:
+    if "NO_FIX" in os.environ:
         with subprocess.Popen(
             [
                 *RUFF,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11718?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11718/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11718
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Use pre-commit to format files in autoformat workflow.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes
- [x] No
