### PR TITLE
Upgrades gunicorn dependency to 22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "entrypoints<1",
   "gitpython<4,>=3.1.9",
   "graphene<4",
-  "gunicorn<22; platform_system != 'Windows'",
+  "gunicorn<23; platform_system != 'Windows'",
   "importlib_metadata<8,>=3.7.0,!=4.7.0",
   "markdown<4,>=3.3",
   "matplotlib<4",

--- a/requirements/core-requirements.txt
+++ b/requirements/core-requirements.txt
@@ -10,7 +10,7 @@ scipy<2
 pandas<3
 querystring_parser<2
 sqlalchemy<3,>=1.4.0
-gunicorn<22; platform_system != 'Windows'
+gunicorn<23; platform_system != 'Windows'
 waitress<4; platform_system == 'Windows'
 scikit-learn<2
 pyarrow<16,>=4.0.0

--- a/requirements/core-requirements.yaml
+++ b/requirements/core-requirements.yaml
@@ -42,7 +42,7 @@ sqlalchemy:
 
 gunicorn:
   pip_release: gunicorn
-  max_major_version: 21
+  max_major_version: 22
   markers: "platform_system != 'Windows'"
 
 waitress:


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #11741 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

We update the version constraint for the `gunicorn` depdendency to be `<23` so that we can use the latest 22 version of `gunicorn` which fixes a security vulnerability.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Upgrades `gunicorn` to v22.0.0 to resolve a vulnerability

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [x] Yes
- [ ] No
