### PR TITLE
Include GPU power in system metrics

### DIFF
--- a/docs/source/system-metrics/index.rst
+++ b/docs/source/system-metrics/index.rst
@@ -150,6 +150,8 @@ By default, MLflow logs the following system metrics:
 * gpu_utilization_percentage
 * gpu_memory_usage_megabytes
 * gpu_memory_usage_percentage
+* gpu_power_usage_watts
+* gpu_power_usage_percentage
 * network_receive_megabytes
 * network_transmit_megabytes
 * disk_usage_megabytes

--- a/mlflow/system_metrics/metrics/gpu_monitor.py
+++ b/mlflow/system_metrics/metrics/gpu_monitor.py
@@ -47,5 +47,12 @@ class GPUMonitor(BaseMetricsMonitor):
             device_utilization = pynvml.nvmlDeviceGetUtilizationRates(handle)
             self._metrics[f"gpu_{i}_utilization_percentage"].append(device_utilization.gpu)
 
+            power_watts = pynvml.nvmlDeviceGetPowerUsage(handle)
+            power_capacity_watts = pynvml.nvmlDeviceGetEnforcedPowerLimit(handle)
+            self._metrics[f"gpu_{i}_power_usage_watts"].append(power_watts / 1000)
+            self._metrics[f"gpu_{i}_power_usage_percentage"].append(
+                (power_watts / power_capacity_watts) * 100
+            )
+
     def aggregate_metrics(self):
         return {k: round(sum(v) / len(v), 1) for k, v in self._metrics.items()}

--- a/mlflow/system_metrics/metrics/gpu_monitor.py
+++ b/mlflow/system_metrics/metrics/gpu_monitor.py
@@ -47,11 +47,11 @@ class GPUMonitor(BaseMetricsMonitor):
             device_utilization = pynvml.nvmlDeviceGetUtilizationRates(handle)
             self._metrics[f"gpu_{i}_utilization_percentage"].append(device_utilization.gpu)
 
-            power_watts = pynvml.nvmlDeviceGetPowerUsage(handle)
-            power_capacity_watts = pynvml.nvmlDeviceGetEnforcedPowerLimit(handle)
-            self._metrics[f"gpu_{i}_power_usage_watts"].append(power_watts / 1000)
+            power_milliwatts = pynvml.nvmlDeviceGetPowerUsage(handle)
+            power_capacity_milliwatts = pynvml.nvmlDeviceGetEnforcedPowerLimit(handle)
+            self._metrics[f"gpu_{i}_power_usage_watts"].append(power_milliwatts / 1000)
             self._metrics[f"gpu_{i}_power_usage_percentage"].append(
-                (power_watts / power_capacity_watts) * 100
+                (power_milliwatts / power_capacity_milliwatts) * 100
             )
 
     def aggregate_metrics(self):

--- a/tests/system_metrics/test_collect_metrics.py
+++ b/tests/system_metrics/test_collect_metrics.py
@@ -33,12 +33,16 @@ def test_gpu_monitor():
     assert isinstance(gpu_monitor.metrics["gpu_0_memory_usage_percentage"], list)
     assert isinstance(gpu_monitor.metrics["gpu_0_memory_usage_megabytes"], list)
     assert isinstance(gpu_monitor.metrics["gpu_0_utilization_percentage"], list)
+    assert isinstance(gpu_monitor.metrics["gpu_0_power_usage_watts"], list)
+    assert isinstance(gpu_monitor.metrics["gpu_0_power_usage_percentage"], list)
 
     gpu_monitor.collect_metrics()
     aggregated_metrics = gpu_monitor.aggregate_metrics()
     assert isinstance(aggregated_metrics["gpu_0_memory_usage_percentage"], float)
     assert isinstance(aggregated_metrics["gpu_0_memory_usage_megabytes"], float)
     assert isinstance(aggregated_metrics["gpu_0_utilization_percentage"], float)
+    assert isinstance(aggregated_metrics["gpu_0_power_usage_watts"], float)
+    assert isinstance(aggregated_metrics["gpu_0_power_usage_percentage"], float)
 
     gpu_monitor.clear_metrics()
     assert len(gpu_monitor.metrics.keys) == 0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/11747?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11747/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11747
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Include GPU power in system metrics:
- gpu_{i}_power_usage_watts
- gpu_{i}_power_usage_percentage

The UI looks like:
<img width="1048" alt="image" src="https://github.com/mlflow/mlflow/assets/22925031/35fea4a6-3cc2-45d0-86d6-00293f4d0728">


### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [x] Yes
- [ ] No
