### PR TITLE
Separate trace and span status enum

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -363,6 +363,7 @@ nitpick_ignore = [
     ("py:class", "opentelemetry.trace.span.Span"),
     ("py:class", "opentelemetry.trace.status.Status"),
     ("py:class", "opentelemetry.trace.status.StatusCode"),
+    ("py:class", "mlflow.entities.trace_status.TraceStatus"),
     ("py:class", "ModelSignature"),
     ("py:class", "ModelInputExample"),
     ("py:class", "Model"),

--- a/mlflow/entities/__init__.py
+++ b/mlflow/entities/__init__.py
@@ -23,11 +23,10 @@ from mlflow.entities.source_type import SourceType
 from mlflow.entities.span import Span, SpanType
 from mlflow.entities.span_context import SpanContext
 from mlflow.entities.span_event import SpanEvent
-from mlflow.entities.span_status import SpanStatus
+from mlflow.entities.span_status import SpanStatus, SpanStatusCode
 from mlflow.entities.trace import Trace
 from mlflow.entities.trace_data import TraceData
 from mlflow.entities.trace_info import TraceInfo
-from mlflow.entities.trace_status import TraceStatus
 from mlflow.entities.view_type import ViewType
 
 __all__ = [
@@ -56,6 +55,6 @@ __all__ = [
     "Trace",
     "TraceData",
     "TraceInfo",
-    "TraceStatus",
+    "SpanStatusCode",
     "_DatasetSummary",
 ]

--- a/mlflow/entities/span_status.py
+++ b/mlflow/entities/span_status.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar
+from enum import Enum
 
 from opentelemetry import trace as trace_api
 
-from mlflow.entities.trace_status import TraceStatus
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+
+
+class SpanStatusCode(str, Enum):
+    """Enum for status code of a span"""
+
+    # Uses the same set of status codes as OpenTelemetry
+    UNSET = "UNSET"
+    OK = "OK"
+    ERROR = "ERROR"
 
 
 @dataclass
@@ -17,26 +25,14 @@ class SpanStatus:
 
     Args:
         status_code: The status code of the span or the trace. This must be one of the
-            values of the :py:class:`mlflow.entities.TraceStatus` enum or a string
+            values of the :py:class:`mlflow.entities.SpanStatusCode` enum or a string
             representation of it like "OK", "ERROR".
         description: Description of the status. This should be only set when the status
             is ERROR, otherwise it will be ignored.
     """
 
-    # TODO: TraceStatus includes IN_PROGRESS, which is not supported as a span status.
-    #  We should split two enums.
-    status_code: TraceStatus
+    status_code: SpanStatusCode
     description: str = ""
-
-    # These class variables will not be serialized.
-    _otel_status_code_to_mlflow: ClassVar = {
-        trace_api.StatusCode.OK: TraceStatus.OK,
-        trace_api.StatusCode.ERROR: TraceStatus.ERROR,
-        trace_api.StatusCode.UNSET: TraceStatus.UNSPECIFIED,
-    }
-    _mlflow_status_code_to_otel: ClassVar = {
-        value: key for key, value in _otel_status_code_to_mlflow.items()
-    }
 
     def __post_init__(self):
         """
@@ -45,11 +41,11 @@ class SpanStatus:
         """
         if isinstance(self.status_code, str):
             try:
-                self.status_code = TraceStatus(self.status_code)
+                self.status_code = SpanStatusCode(self.status_code)
             except ValueError:
                 raise MlflowException(
-                    f"{self.status_code} is not a valid TraceStatus value. "
-                    f"Please use one of {[status.value for status in TraceStatus]}",
+                    f"{self.status_code} is not a valid SpanStatusCode value. "
+                    f"Please use one of {[status_code.value for status_code in SpanStatusCode]}",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
 
@@ -59,12 +55,12 @@ class SpanStatus:
 
         :meta private:
         """
-        if self.status_code not in SpanStatus._mlflow_status_code_to_otel:
+        try:
+            status_code = getattr(trace_api.StatusCode, self.status_code.name)
+        except AttributeError:
             raise MlflowException(
                 f"Invalid status code: {self.status_code}", error_code=INVALID_PARAMETER_VALUE
             )
-
-        status_code = SpanStatus._mlflow_status_code_to_otel[self.status_code]
         return trace_api.Status(status_code, self.description)
 
     @classmethod
@@ -74,11 +70,11 @@ class SpanStatus:
 
         :meta private:
         """
-        if otel_status.status_code not in cls._otel_status_code_to_mlflow:
+        try:
+            status_code = SpanStatusCode(otel_status.status_code.name)
+        except ValueError:
             raise MlflowException(
                 f"Got invalid status code from OpenTelemetry: {otel_status.status_code}",
                 error_code=INVALID_PARAMETER_VALUE,
             )
-
-        mlflow_status_code = cls._otel_status_code_to_mlflow[otel_status.status_code]
-        return cls(mlflow_status_code, otel_status.description)
+        return cls(status_code, otel_status.description)

--- a/mlflow/entities/trace_status.py
+++ b/mlflow/entities/trace_status.py
@@ -20,9 +20,6 @@ class TraceStatus(str, Enum):
     def from_proto(proto_status):
         return ProtoTraceStatus.Name(proto_status)
 
-    def to_otel_status(self) -> trace_api.Status:
-        return trace_api.Status(_MLFLOW_STATUS_CODE_TO_OTEL[self])
-
     @staticmethod
     def from_otel_status(otel_status: trace_api.Status):
         return _OTEL_STATUS_CODE_TO_MLFLOW[otel_status.status_code]
@@ -33,5 +30,3 @@ _OTEL_STATUS_CODE_TO_MLFLOW = {
     trace_api.StatusCode.ERROR: TraceStatus.ERROR,
     trace_api.StatusCode.UNSET: TraceStatus.UNSPECIFIED,
 }
-
-_MLFLOW_STATUS_CODE_TO_OTEL = {value: key for key, value in _OTEL_STATUS_CODE_TO_MLFLOW.items()}

--- a/mlflow/entities/trace_status.py
+++ b/mlflow/entities/trace_status.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+from opentelemetry import trace as trace_api
+
 from mlflow.protos.service_pb2 import TraceStatus as ProtoTraceStatus
 
 
@@ -17,3 +19,19 @@ class TraceStatus(str, Enum):
     @staticmethod
     def from_proto(proto_status):
         return ProtoTraceStatus.Name(proto_status)
+
+    def to_otel_status(self) -> trace_api.Status:
+        return trace_api.Status(_MLFLOW_STATUS_CODE_TO_OTEL[self])
+
+    @staticmethod
+    def from_otel_status(otel_status: trace_api.Status):
+        return _OTEL_STATUS_CODE_TO_MLFLOW[otel_status.status_code]
+
+
+_OTEL_STATUS_CODE_TO_MLFLOW = {
+    trace_api.StatusCode.OK: TraceStatus.OK,
+    trace_api.StatusCode.ERROR: TraceStatus.ERROR,
+    trace_api.StatusCode.UNSET: TraceStatus.UNSPECIFIED,
+}
+
+_MLFLOW_STATUS_CODE_TO_OTEL = {value: key for key, value in _OTEL_STATUS_CODE_TO_MLFLOW.items()}

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -17,7 +17,7 @@ from typing_extensions import override
 
 import mlflow
 from mlflow import MlflowClient
-from mlflow.entities import SpanEvent, SpanStatus, SpanType, TraceStatus
+from mlflow.entities import SpanEvent, SpanStatus, SpanStatusCode, SpanType
 from mlflow.exceptions import MlflowException
 from mlflow.tracing.types.wrapper import MlflowSpanWrapper
 from mlflow.utils.autologging_utils import ExceptionSafeAbstractClass
@@ -109,7 +109,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         span: MlflowSpanWrapper,
         outputs=None,
         attributes=None,
-        status=SpanStatus(TraceStatus.OK),
+        status=SpanStatus(SpanStatusCode.OK),
     ):
         """Close MLflow Span (or Trace if it is root component)"""
         self._mlflow_client.end_span(
@@ -247,7 +247,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         """Handle an error for an LLM run."""
         llm_span = self._get_span_by_run_id(run_id)
         llm_span.add_event(SpanEvent.from_exception(error))
-        self._end_span(llm_span, status=SpanStatus(TraceStatus.ERROR, str(error)))
+        self._end_span(llm_span, status=SpanStatus(SpanStatusCode.ERROR, str(error)))
 
     @override
     def on_chain_start(
@@ -305,7 +305,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         if inputs:
             chain_span.set_inputs(inputs)
         chain_span.add_event(SpanEvent.from_exception(error))
-        self._end_span(chain_span, status=SpanStatus(TraceStatus.ERROR, str(error)))
+        self._end_span(chain_span, status=SpanStatus(SpanStatusCode.ERROR, str(error)))
 
     @override
     def on_tool_start(
@@ -350,7 +350,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         """Run when tool errors."""
         tool_span = self._get_span_by_run_id(run_id)
         tool_span.add_event(SpanEvent.from_exception(error))
-        self._end_span(tool_span, status=SpanStatus(TraceStatus.ERROR, str(error)))
+        self._end_span(tool_span, status=SpanStatus(SpanStatusCode.ERROR, str(error)))
 
     @override
     def on_retriever_start(
@@ -394,7 +394,7 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         """Run when Retriever errors."""
         retriever_span = self._get_span_by_run_id(run_id)
         retriever_span.add_event(SpanEvent.from_exception(error))
-        self._end_span(retriever_span, status=SpanStatus(TraceStatus.ERROR, str(error)))
+        self._end_span(retriever_span, status=SpanStatus(SpanStatusCode.ERROR, str(error)))
 
     @override
     def on_agent_action(

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -4,10 +4,10 @@ from typing import Dict, List, Optional
 from mlflow.entities import (
     DatasetInput,
     TraceInfo,
-    TraceStatus,
     ViewType,
 )
 from mlflow.entities.metric import MetricWithRunId
+from mlflow.entities.trace_status import TraceStatus
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT, SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.utils.annotations import developer_stable

--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -7,7 +7,7 @@ from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter
 
 from mlflow.entities import TraceData
-from mlflow.entities.span_status import SpanStatus
+from mlflow.entities.trace_status import TraceStatus
 from mlflow.tracing.clients import TraceClient
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.types.constant import (
@@ -63,7 +63,7 @@ class MlflowSpanExporter(SpanExporter):
         # Update a TraceInfo object with the root span information
         trace.info.timestamp_ms = root_span.start_time // 1_000_000  # nanosecond to millisecond
         trace.info.execution_time_ms = (root_span.end_time - root_span.start_time) // 1_000_000
-        trace.info.status = SpanStatus.from_otel_status(root_span.status).status_code
+        trace.info.status = TraceStatus.from_otel_status(root_span.status)
         trace.info.request_metadata.update(
             {
                 TraceMetadataKey.INPUTS: self._truncate_metadata(

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -6,7 +6,8 @@ from typing import Dict, Optional
 from cachetools import TTLCache
 from opentelemetry import trace as trace_api
 
-from mlflow.entities import SpanType, Trace, TraceData, TraceInfo, TraceStatus
+from mlflow.entities import SpanType, Trace, TraceData, TraceInfo
+from mlflow.entities.trace_status import TraceStatus
 from mlflow.environment_variables import (
     MLFLOW_TRACE_BUFFER_MAX_SIZE,
     MLFLOW_TRACE_BUFFER_TTL_SECONDS,

--- a/mlflow/tracing/types/wrapper.py
+++ b/mlflow/tracing/types/wrapper.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Union
 
 from opentelemetry import trace as trace_api
 
-from mlflow.entities import Span, SpanContext, SpanEvent, SpanStatus, SpanType, TraceStatus
+from mlflow.entities import Span, SpanContext, SpanEvent, SpanStatus, SpanStatusCode, SpanType
 from mlflow.tracing.types.constant import SpanAttributeKey
 from mlflow.tracing.utils import TraceJSONEncoder, format_span_id, format_trace_id
 
@@ -135,14 +135,15 @@ class MlflowSpanWrapper:
         serialized_value = self._span.attributes.get(key)
         return json.loads(serialized_value) if serialized_value else None
 
-    def set_status(self, status: Union[SpanStatus, str]):
+    def set_status(self, status: Union[SpanStatusCode, str]):
         """
         Set the status of the span.
 
         Args:
             status: The status of the span. This can be a
                 :py:class:`SpanStatus <mlflow.entities.SpanStatus>` object or a string representing
-                of the status code defined in :py:class:`TraceStatus <mlflow.entities.TraceStatus>`
+                of the status code defined in
+                :py:class:`SpanStatusCode <mlflow.entities.SpanStatusCode>`
                 e.g. ``"OK"``, ``"ERROR"``.
         """
         if isinstance(status, str):
@@ -182,8 +183,8 @@ class MlflowSpanWrapper:
         # by the user. However, there is not way to set the status when using
         # @mlflow.trace decorator. Therefore, we just automatically set the status
         # to OK if it is not ERROR.
-        if self.status.status_code != TraceStatus.ERROR:
-            self.set_status(SpanStatus(TraceStatus.OK))
+        if self.status.status_code != SpanStatusCode.ERROR:
+            self.set_status(SpanStatus(SpanStatusCode.OK))
 
         self._span.end()
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -28,15 +28,15 @@ from mlflow.entities import (
     Run,
     RunTag,
     SpanStatus,
+    SpanStatusCode,
     SpanType,
     Trace,
+    TraceData,
+    TraceInfo,
     ViewType,
 )
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
-from mlflow.entities.trace_data import TraceData
-from mlflow.entities.trace_info import TraceInfo
-from mlflow.entities.trace_status import TraceStatus
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import (
     BAD_REQUEST,
@@ -594,8 +594,9 @@ class MlflowClient:
                 has attributes, the new attributes will be merged with the existing ones.
                 If the same key already exists, the new value will overwrite the old one.
             status: The status of the trace. This can be a
-                :py:class:`SpanStatus <mlflow.entities.SpanStatus>` object or a string representing
-                the status code defined in :py:class:`TraceStatus <mlflow.entities.TraceStatus>`
+                :py:class:`SpanStatus <mlflow.entities.SpanStatus>` object or a string
+                representing the status code defined in
+                :py:class:`SpanStatusCode <mlflow.entities.SpanStatusCode>`
                 e.g. ``"OK"``, ``"ERROR"``. The default status is OK.
         """
         trace_manager = InMemoryTraceManager.get_instance()
@@ -773,8 +774,9 @@ class MlflowClient:
                 attributes, the new attributes will be merged with the existing ones. If the same
                 key already exists, the new value will overwrite the old one.
             status: The status of the span. This can be a
-                :py:class:`SpanStatus <mlflow.entities.SpanStatus>` object or a string representing
-                the status code defined in :py:class:`TraceStatus <mlflow.entities.TraceStatus>`
+                :py:class:`SpanStatus <mlflow.entities.SpanStatus>` object or a string
+                representing the status code defined in
+                :py:class:`SpanStatusCode <mlflow.entities.SpanStatusCode>`
                 e.g. ``"OK"``, ``"ERROR"``. The default status is OK.
         """
         trace_manager = InMemoryTraceManager.get_instance()
@@ -798,7 +800,7 @@ class MlflowClient:
         self,
         request_id: str,
         timestamp_ms: int,
-        status: TraceStatus,
+        status: SpanStatusCode,
         request_metadata: Optional[Dict[str, str]] = None,
         tags: Optional[Dict[str, str]] = None,
     ) -> TraceInfo:
@@ -809,7 +811,7 @@ class MlflowClient:
             request_id: Unique string identifier of the trace.
             timestamp_ms: int, end time of the trace, in milliseconds. The execution time field
                 in the TraceInfo will be calculated by subtracting the start time from this.
-            status: TraceStatus, status of the trace.
+            status: SpanStatusCode, status of the trace.
             request_metadata: dict, metadata of the trace. This will be merged with the existing
                 metadata logged during the start_trace call.
             tags: dict, tags of the trace. This will be merged with the existing tags logged

--- a/tests/entities/test_span_status.py
+++ b/tests/entities/test_span_status.py
@@ -1,27 +1,27 @@
 import pytest
 from opentelemetry import trace as trace_api
 
-from mlflow.entities import SpanStatus, TraceStatus
+from mlflow.entities import SpanStatus, SpanStatusCode
 from mlflow.exceptions import MlflowException
 
 
-@pytest.mark.parametrize("status_code", [TraceStatus.OK, "OK"])
+@pytest.mark.parametrize("status_code", [SpanStatusCode.OK, "OK"])
 def test_span_status_init(status_code):
     span_status = SpanStatus(status_code)
-    assert span_status.status_code == TraceStatus.OK
+    assert span_status.status_code == SpanStatusCode.OK
 
 
 def test_span_status_raise_invalid_status_code():
-    with pytest.raises(MlflowException, match=r"INVALID is not a valid TraceStatus value."):
+    with pytest.raises(MlflowException, match=r"INVALID is not a valid SpanStatusCode value."):
         SpanStatus("INVALID", description="test")
 
 
 @pytest.mark.parametrize(
     ("status_code", "otel_status_code"),
     [
-        (TraceStatus.OK, trace_api.StatusCode.OK),
-        (TraceStatus.ERROR, trace_api.StatusCode.ERROR),
-        (TraceStatus.UNSPECIFIED, trace_api.StatusCode.UNSET),
+        (SpanStatusCode.OK, trace_api.StatusCode.OK),
+        (SpanStatusCode.ERROR, trace_api.StatusCode.ERROR),
+        (SpanStatusCode.UNSET, trace_api.StatusCode.UNSET),
     ],
 )
 def test_otel_status_conversion(status_code, otel_status_code):
@@ -30,7 +30,7 @@ def test_otel_status_conversion(status_code, otel_status_code):
 
     # OpenTelemetry only allows specify description when status is ERROR
     # Otherwise it will be ignored with warning message.
-    expected_description = "test" if status_code == TraceStatus.ERROR else None
+    expected_description = "test" if status_code == SpanStatusCode.ERROR else None
 
     assert otel_status.status_code == otel_status_code
     assert otel_status.description == expected_description

--- a/tests/entities/test_trace_info.py
+++ b/tests/entities/test_trace_info.py
@@ -1,4 +1,5 @@
-from mlflow.entities import TraceInfo, TraceStatus
+from mlflow.entities import TraceInfo
+from mlflow.entities.trace_status import TraceStatus
 from mlflow.protos.service_pb2 import TraceRequestMetadata as ProtoTraceRequestMetadata
 from mlflow.protos.service_pb2 import TraceTag as ProtoTraceTag
 

--- a/tests/tracing/conftest.py
+++ b/tests/tracing/conftest.py
@@ -4,8 +4,8 @@ import pytest
 from opentelemetry.trace import _TRACER_PROVIDER_SET_ONCE
 
 import mlflow
-from mlflow.entities import Trace, TraceData, TraceInfo, TraceStatus
-from mlflow.entities.span_status import SpanStatus
+from mlflow.entities import Trace, TraceData, TraceInfo
+from mlflow.entities.trace_status import TraceStatus
 from mlflow.tracing.clients import InMemoryTraceClient, InMemoryTraceClientWithTracking
 from mlflow.tracing.display import IPythonTraceDisplayHandler
 from mlflow.tracing.provider import _TRACER_PROVIDER_INITIALIZED, _setup_tracer_provider
@@ -80,7 +80,7 @@ def mock_tracking_service_client():
             experiment_id="0",
             timestamp_ms=0,
             execution_time_ms=0,
-            status=SpanStatus(TraceStatus.OK),
+            status=TraceStatus.OK,
             request_metadata={},
             tags={"mlflow.artifactLocation": "test"},
         ),

--- a/tests/tracing/export/test_mlflow_exporter.py
+++ b/tests/tracing/export/test_mlflow_exporter.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from mlflow.entities import Span, TraceStatus
+from mlflow.entities import Span, SpanStatusCode
 from mlflow.entities.span_context import SpanContext
 from mlflow.entities.trace_data import TraceData
 from mlflow.tracing.export.mlflow import MlflowSpanExporter
@@ -104,7 +104,7 @@ def test_deduplicate_span_names():
             name=span_name,
             context=SpanContext("trace_id", span_id=i),
             parent_id=None,
-            status_code=TraceStatus.OK.value,
+            status_code=SpanStatusCode.OK.value,
             status_message="",
             start_time=0,
             end_time=1,

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 
 import mlflow
-from mlflow.entities import SpanType, TraceStatus
+from mlflow.entities import SpanStatusCode, SpanType
 from mlflow.tracing.types.constant import TraceMetadataKey
 
 from tests.tracing.helper import deser_attributes
@@ -39,7 +39,7 @@ def test_trace(mock_client):
     assert trace_info.request_id is not None
     assert trace_info.experiment_id == "0"  # default experiment
     assert trace_info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
-    assert trace_info.status == TraceStatus.OK
+    assert trace_info.status == SpanStatusCode.OK
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 2, "y": 5}'
     assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == "64"
 
@@ -102,7 +102,7 @@ def test_trace_handle_exception_during_prediction(mock_client):
     # Trace should be logged even if the function fails, with status code ERROR
     trace = mlflow.get_traces()[0]
     assert trace.info.request_id is not None
-    assert trace.info.status == TraceStatus.ERROR
+    assert trace.info.status == SpanStatusCode.ERROR
     assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 2, "y": 5}'
     assert trace.info.request_metadata[TraceMetadataKey.OUTPUTS] == ""
 
@@ -172,7 +172,7 @@ def test_start_span_context_manager(mock_client):
     assert trace.info.request_id is not None
     assert trace.info.experiment_id == "0"  # default experiment
     assert trace.info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
-    assert trace.info.status == TraceStatus.OK
+    assert trace.info.status == SpanStatusCode.OK
     assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
     assert trace.info.request_metadata[TraceMetadataKey.OUTPUTS] == "25"
 
@@ -254,7 +254,7 @@ def test_start_span_context_manager_with_imperative_apis(mock_client):
     assert trace.info.request_id is not None
     assert trace.info.experiment_id == "0"  # default experiment
     assert trace.info.execution_time_ms >= 0.1 * 1e3  # at least 0.1 sec
-    assert trace.info.status == TraceStatus.OK
+    assert trace.info.status == SpanStatusCode.OK
     assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
     assert trace.info.request_metadata[TraceMetadataKey.OUTPUTS] == "5"
 

--- a/tests/tracing/test_wrapper.py
+++ b/tests/tracing/test_wrapper.py
@@ -4,7 +4,7 @@ import time
 import pytest
 
 import mlflow
-from mlflow.entities import SpanStatus, SpanType, TraceStatus
+from mlflow.entities import SpanStatus, SpanStatusCode, SpanType
 from mlflow.exceptions import MlflowException
 from mlflow.tracing.types.wrapper import MlflowSpanWrapper
 
@@ -48,7 +48,7 @@ def test_wrapper_property():
 
 @pytest.mark.parametrize(
     "status",
-    [SpanStatus("OK"), SpanStatus(TraceStatus.ERROR, "Error!"), "OK", "ERROR"],
+    [SpanStatus("OK"), SpanStatus(SpanStatusCode.ERROR, "Error!"), "OK", "ERROR"],
 )
 def test_set_status(status):
     with mlflow.start_span("test_span") as span:
@@ -59,5 +59,5 @@ def test_set_status(status):
 
 def test_set_status_raise_for_invalid_value():
     with mlflow.start_span("test_span") as span:
-        with pytest.raises(MlflowException, match=r"INVALID is not a valid TraceStatus value."):
+        with pytest.raises(MlflowException, match=r"INVALID is not a valid SpanStatusCode value."):
             span.set_status("INVALID")

--- a/tests/tracking/_tracking_service/test_tracking_service_client.py
+++ b/tests/tracking/_tracking_service/test_tracking_service_client.py
@@ -3,7 +3,6 @@ from unittest import mock
 import pytest
 
 from mlflow.entities import Run, RunInfo
-from mlflow.entities.span_status import SpanStatus
 from mlflow.entities.trace_data import TraceData
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
@@ -83,7 +82,7 @@ def test_download_trace_data(tmp_path, mock_store):
         experiment_id="test",
         timestamp_ms=0,
         execution_time_ms=1,
-        status=SpanStatus(TraceStatus.OK),
+        status=TraceStatus.OK,
         request_metadata={},
         tags={"mlflow.artifactLocation": "test"},
     )
@@ -107,7 +106,7 @@ def test_upload_trace_data(tmp_path, mock_store):
         experiment_id="test",
         timestamp_ms=0,
         execution_time_ms=1,
-        status=SpanStatus(TraceStatus.OK),
+        status=TraceStatus.OK,
         request_metadata={},
         tags={"mlflow.artifactLocation": "test"},
     )
@@ -136,7 +135,7 @@ def test_search_traces(tmp_path):
                         experiment_id="test",
                         timestamp_ms=0,
                         execution_time_ms=0,
-                        status=SpanStatus(TraceStatus.OK),
+                        status=TraceStatus.OK,
                         request_metadata={},
                         tags={"mlflow.artifactLocation": "test"},
                     ),
@@ -145,7 +144,7 @@ def test_search_traces(tmp_path):
                         experiment_id="test",
                         timestamp_ms=0,
                         execution_time_ms=0,
-                        status=SpanStatus(TraceStatus.OK),
+                        status=TraceStatus.OK,
                         request_metadata={},
                         tags={"mlflow.artifactLocation": "test"},
                     ),
@@ -160,7 +159,7 @@ def test_search_traces(tmp_path):
                         experiment_id="test",
                         timestamp_ms=1,
                         execution_time_ms=1,
-                        status=SpanStatus(TraceStatus.OK),
+                        status=TraceStatus.OK,
                         request_metadata={},
                         tags={"mlflow.artifactLocation": "test"},
                     ),
@@ -169,7 +168,7 @@ def test_search_traces(tmp_path):
                         experiment_id="test",
                         timestamp_ms=1,
                         execution_time_ms=1,
-                        status=SpanStatus(TraceStatus.OK),
+                        status=TraceStatus.OK,
                         request_metadata={},
                         tags={"mlflow.artifactLocation": "test"},
                     ),
@@ -215,7 +214,7 @@ def test_search_traces_download_failures(tmp_path):
                         experiment_id="test",
                         timestamp_ms=0,
                         execution_time_ms=0,
-                        status=SpanStatus(TraceStatus.OK),
+                        status=TraceStatus.OK,
                         request_metadata={},
                         tags={"mlflow.artifactLocation": "test"},
                     ),
@@ -224,7 +223,7 @@ def test_search_traces_download_failures(tmp_path):
                         experiment_id="test",
                         timestamp_ms=0,
                         execution_time_ms=0,
-                        status=SpanStatus(TraceStatus.OK),
+                        status=TraceStatus.OK,
                         request_metadata={},
                         tags={"mlflow.artifactLocation": "test"},
                     ),
@@ -239,7 +238,7 @@ def test_search_traces_download_failures(tmp_path):
                         experiment_id="test",
                         timestamp_ms=1,
                         execution_time_ms=1,
-                        status=SpanStatus(TraceStatus.OK),
+                        status=TraceStatus.OK,
                         request_metadata={},
                         tags={"mlflow.artifactLocation": "test"},
                     )
@@ -254,7 +253,7 @@ def test_search_traces_download_failures(tmp_path):
                         experiment_id="test",
                         timestamp_ms=1,
                         execution_time_ms=1,
-                        status=SpanStatus(TraceStatus.OK),
+                        status=TraceStatus.OK,
                         request_metadata={},
                         tags={"mlflow.artifactLocation": "test"},
                     )
@@ -295,7 +294,7 @@ def test_search_traces_download_failures(tmp_path):
                         experiment_id="test",
                         timestamp_ms=0,
                         execution_time_ms=0,
-                        status=SpanStatus(TraceStatus.OK),
+                        status=TraceStatus.OK,
                         request_metadata={},
                         tags={"mlflow.artifactLocation": "test"},
                     ),
@@ -304,7 +303,7 @@ def test_search_traces_download_failures(tmp_path):
                         experiment_id="test",
                         timestamp_ms=0,
                         execution_time_ms=0,
-                        status=SpanStatus(TraceStatus.OK),
+                        status=TraceStatus.OK,
                         request_metadata={},
                         tags={"mlflow.artifactLocation": "test"},
                     ),
@@ -319,7 +318,7 @@ def test_search_traces_download_failures(tmp_path):
                         experiment_id="test",
                         timestamp_ms=1,
                         execution_time_ms=1,
-                        status=SpanStatus(TraceStatus.OK),
+                        status=TraceStatus.OK,
                         request_metadata={},
                         tags={"mlflow.artifactLocation": "test"},
                     )
@@ -358,7 +357,7 @@ def test_search_traces_does_not_swallow_unexpected_exceptions(tmp_path):
                         experiment_id="test",
                         timestamp_ms=0,
                         execution_time_ms=0,
-                        status=SpanStatus(TraceStatus.OK),
+                        status=TraceStatus.OK,
                         request_metadata={},
                         tags={"mlflow.artifactLocation": "test"},
                     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11754?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11754/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11754
```

</p>
</details>

### Related Issues/PRs

Follow-up of https://github.com/mlflow/mlflow/pull/11734#discussion_r1569740014

### What changes are proposed in this pull request?

Currently, both trace and span shares the same set of status code defined in the `TraceStatus` enum. However, the new `IN_PROGRESS` status was added to trace status, which is not a valid (otel-compatible) status for the span. Hence, this PR creates separate set of status code for spans.

Note that users still only interact with a single enum, which is `SpanStatusCode`.  The other enum `TraceStatus` should always be managed by us and won't be surfaced in users code.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
