### PR TITLE
Check if it is in serverless mode when invoking `get_nfs_cache_root_dir`

### DIFF
--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -16,7 +16,6 @@ from mlflow.utils._spark_utils import _get_active_spark_session
 from mlflow.utils.credentials import get_default_host_creds
 from mlflow.utils.databricks_utils import (
     get_databricks_host_creds,
-    get_databricks_runtime_version,
     is_in_databricks_serverless,
     warn_on_deprecated_cross_workspace_registry_uri,
 )

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -17,6 +17,7 @@ from mlflow.utils.credentials import get_default_host_creds
 from mlflow.utils.databricks_utils import (
     get_databricks_host_creds,
     get_databricks_runtime_version,
+    is_in_databricks_serverless,
     warn_on_deprecated_cross_workspace_registry_uri,
 )
 from mlflow.utils.uri import _DATABRICKS_UNITY_CATALOG_SCHEME
@@ -83,8 +84,7 @@ def _get_registry_uri_from_spark_session():
     if session is None:
         return None
 
-    dbr_version = get_databricks_runtime_version()
-    if dbr_version and dbr_version.startswith("client."):
+    if is_in_databricks_serverless():
         # Connected to Serverless
         return "databricks-uc"
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -214,6 +214,11 @@ def is_in_databricks_runtime():
     return get_databricks_runtime_version() is not None
 
 
+def is_in_databricks_serverless():
+    dbr_version = get_databricks_runtime_version()
+    return dbr_version and dbr_version.startswith("client.")
+
+
 def is_dbfs_fuse_available():
     with open(os.devnull, "w") as devnull_stderr, open(os.devnull, "w") as devnull_stdout:
         try:

--- a/mlflow/utils/nfs_on_spark.py
+++ b/mlflow/utils/nfs_on_spark.py
@@ -31,8 +31,7 @@ def get_nfs_cache_root_dir():
             nfs_enabled = True
         else:
             nfs_enabled = spark_sess and (
-                spark_sess.conf.get("spark.databricks.mlflow.nfs.enabled", "true").lower()
-                == "true"
+                spark_sess.conf.get("spark.databricks.mlflow.nfs.enabled", "true").lower() == "true"
             )
         if nfs_enabled:
             try:

--- a/mlflow/utils/nfs_on_spark.py
+++ b/mlflow/utils/nfs_on_spark.py
@@ -3,7 +3,11 @@ import shutil
 import uuid
 
 from mlflow.utils._spark_utils import _get_active_spark_session
-from mlflow.utils.databricks_utils import _get_dbutils, is_in_databricks_runtime
+from mlflow.utils.databricks_utils import (
+    _get_dbutils,
+    is_in_databricks_runtime,
+    is_in_databricks_serverless,
+)
 
 # Set spark config "spark.mlflow.nfs.rootDir" to specify a NFS (network file system) directory
 # which is shared with all spark cluster nodes.
@@ -23,9 +27,13 @@ _NFS_CACHE_ROOT_DIR = None
 def get_nfs_cache_root_dir():
     if is_in_databricks_runtime():
         spark_sess = _get_active_spark_session()
-        nfs_enabled = spark_sess and (
-            spark_sess.conf.get("spark.databricks.mlflow.nfs.enabled", "true").lower() == "true"
-        )
+        if is_in_databricks_serverless():
+            nfs_enabled = True
+        else:
+            nfs_enabled = spark_sess and (
+                spark_sess.conf.get("spark.databricks.mlflow.nfs.enabled", "true").lower()
+                == "true"
+            )
         if nfs_enabled:
             try:
                 # The directory `getReplNFSTempDir` returns has read/write permissions.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/11757?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11757/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11757
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Check if it is in serverless mode when invoking `get_nfs_cache_root_dir`. If it is in serverless mode, skip reading spark config: `spark.databricks.mlflow.nfs.enabled`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
