### PR TITLE
Fix `get_databricks_runtime` in serverless

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -21,7 +21,7 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking._tracking_service.utils import _resolve_tracking_uri
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri, _upload_artifact_to_uri
 from mlflow.utils.annotations import experimental
-from mlflow.utils.databricks_utils import get_databricks_runtime
+from mlflow.utils.databricks_utils import get_databricks_runtime_version
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
@@ -490,7 +490,7 @@ class Model:
     def to_dict(self):
         """Serialize the model to a dictionary."""
         res = {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
-        databricks_runtime = get_databricks_runtime()
+        databricks_runtime = get_databricks_runtime_version()
         if databricks_runtime:
             res["databricks_runtime"] = databricks_runtime
         if self.signature is not None:

--- a/mlflow/recipes/utils/step.py
+++ b/mlflow/recipes/utils/step.py
@@ -10,7 +10,7 @@ import pandas as pd
 from mlflow.exceptions import BAD_REQUEST, INVALID_PARAMETER_VALUE, MlflowException
 from mlflow.recipes.cards import pandas_renderer
 from mlflow.utils.databricks_utils import (
-    get_databricks_runtime,
+    get_databricks_runtime_version,
     is_in_databricks_runtime,
     is_running_in_ipython_environment,
 )
@@ -80,8 +80,7 @@ def display_html(html_data: Optional[str] = None, html_file_path: Optional[str] 
         html_file_path = html_file_path if html_data is None else None
 
         if is_in_databricks_runtime():
-            dbr_version_image_key = get_databricks_runtime()
-            dbr_version = dbr_version_image_key.split("-")[0]
+            dbr_version = get_databricks_runtime_version()
             if int(dbr_version.split(".")[0]) < 11:
                 raise MlflowException(
                     f"Use Databricks Runtime 11 or newer with MLflow Recipes. "

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -264,17 +264,6 @@ def get_notebook_path():
         return _get_extra_context("notebook_path")
 
 
-@_use_repl_context_if_available("runtimeVersion")
-def get_databricks_runtime():
-    if is_in_databricks_runtime():
-        spark_session = _get_active_spark_session()
-        if spark_session is not None:
-            return spark_session.conf.get(
-                "spark.databricks.clusterUsageTags.sparkVersion", default=None
-            )
-    return None
-
-
 @_use_repl_context_if_available("clusterId")
 def get_cluster_id():
     spark_session = _get_active_spark_session()

--- a/mlflow/utils/doctor.py
+++ b/mlflow/utils/doctor.py
@@ -7,7 +7,7 @@ import yaml
 from packaging.requirements import Requirement
 
 import mlflow
-from mlflow.utils.databricks_utils import get_databricks_runtime
+from mlflow.utils.databricks_utils import get_databricks_runtime_version
 
 
 def doctor(mask_envs=False):
@@ -80,7 +80,7 @@ def doctor(mask_envs=False):
         ("Registry URI", mlflow.get_registry_uri()),
     ]
 
-    if (runtime := get_databricks_runtime()) is not None:
+    if (runtime := get_databricks_runtime_version()) is not None:
         items.append(("Databricks runtime version", runtime))
 
     active_run = mlflow.active_run()

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -261,7 +261,7 @@ def test_model_log_with_databricks_runtime():
         path = os.path.join(local_path, loaded_model.saved_input_example_info["artifact_path"])
         x = dataframe_from_raw_json(path)
         assert x.to_dict(orient="records")[0] == input_example
-        assert loaded_model.databricks_runtime == dbr
+        assert loaded_model.databricks_runtime == dbr_version
 
 
 def test_model_log_with_input_example_succeeds():

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -239,9 +239,9 @@ def test_load_model_without_mlflow_version():
 
 
 def test_model_log_with_databricks_runtime():
-    dbr = "8.3.x-snapshot-gpu-ml-scala2.12"
+    dbr_version = "8.3.x"
     with TempDir(chdr=True) as tmp, mock.patch(
-        "mlflow.models.model.get_databricks_runtime", return_value=dbr
+        "mlflow.models.model.get_databricks_runtime_version", return_value=dbr_version
     ):
         sig = ModelSignature(
             inputs=Schema([ColSpec("integer", "x"), ColSpec("integer", "y")]),

--- a/tests/recipes/test_step_utils.py
+++ b/tests/recipes/test_step_utils.py
@@ -48,8 +48,8 @@ def test_display_html_throws_error_on_old_dbr():
     ), mock.patch(
         "mlflow.recipes.utils.step.is_in_databricks_runtime", return_value=True
     ), mock.patch(
-        "mlflow.recipes.utils.step.get_databricks_runtime",
-        return_value="10.4.x-snapshot-cpu-ml-scala2.12",
+        "mlflow.recipes.utils.step.get_databricks_runtime_version",
+        return_value="10.4.x",
     ), pytest.raises(
         MlflowException, match="Use Databricks Runtime 11 or newer with MLflow Recipes"
     ):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -21,7 +21,7 @@ from mlflow.tracking._model_registry.utils import (
     _get_store_registry as _get_model_registry_store_registry,
 )
 from mlflow.tracking._tracking_service.utils import _register
-from mlflow.utils.databricks_utils import _construct_databricks_run_url, get_databricks_runtime
+from mlflow.utils.databricks_utils import _construct_databricks_run_url
 from mlflow.utils.mlflow_tags import (
     MLFLOW_GIT_COMMIT,
     MLFLOW_PARENT_RUN_ID,
@@ -618,20 +618,6 @@ def test_create_model_version_copy_not_called_to_nondb(mock_registry_store):
 
 def _default_model_version():
     return ModelVersion("model name", 1, creation_timestamp=123, status="READY")
-
-
-def test_get_databricks_runtime_no_spark_session():
-    with mock.patch(
-        "mlflow.utils.databricks_utils._get_active_spark_session", return_value=None
-    ), mock.patch("mlflow.utils.databricks_utils.is_in_databricks_notebook", return_value=True):
-        runtime = get_databricks_runtime()
-        assert runtime is None
-
-
-def test_get_databricks_runtime_nondb(mock_spark_session):
-    runtime = get_databricks_runtime()
-    assert runtime is None
-    mock_spark_session.conf.get.assert_not_called()
 
 
 def test_client_can_be_serialized_with_pickle(tmp_path):

--- a/tests/utils/test_doctor.py
+++ b/tests/utils/test_doctor.py
@@ -17,9 +17,9 @@ def test_doctor_active_run(capsys):
 
 
 def test_doctor_databricks_runtime(capsys):
-    mock_version = "12.0-cpu-ml-scala2.12"
+    mock_version = "12.0"
     with mock.patch(
-        "mlflow.utils.doctor.get_databricks_runtime", return_value=mock_version
+        "mlflow.utils.doctor.get_databricks_runtime_version", return_value=mock_version
     ) as mock_runtime:
         mlflow.doctor()
         mock_runtime.assert_called_once()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/11758?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11758/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11758
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fix `get_databricks_runtime` in serverless:

`get_databricks_runtime` function reads spark config `spark.databricks.clusterUsageTags.sparkVersion` , but in serverless it is not allowed.
But `get_databricks_runtime_version` always works and it can replace this function.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
