### PR TITLE
Run cross-version tests by comment

### DIFF
--- a/.github/workflows/cross-version-test-runner.js
+++ b/.github/workflows/cross-version-test-runner.js
@@ -1,0 +1,83 @@
+async function main({ context, github }) {
+  const { comment } = context.payload;
+  const { owner, repo } = context.repo;
+  const pull_number = context.issue.number;
+
+  const pr = await github.rest.pulls.get({ owner, repo, pull_number });
+  const flavorsMatch = comment.body.match(/\/(?:cross-version-test|crt)\s+([^\n]+)\n?/);
+  if (!flavorsMatch) {
+    return;
+  }
+
+  // Reject non-maintainers
+  if (!["OWNER", "MEMBER", "COLLABORATOR"].includes(comment.author_association)) {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: pull_number,
+      body: "Only maintainers are allowed to use this command.",
+    });
+    return;
+  }
+
+  // Run the workflow
+  const flavors = flavorsMatch[1];
+  const uuid = Array.from({ length: 16 }, () => Math.floor(Math.random() * 16).toString(16)).join(
+    ""
+  );
+  const workflow_id = "cross-version-tests.yml";
+  await github.rest.actions.createWorkflowDispatch({
+    owner,
+    repo,
+    workflow_id,
+    ref: pr.data.base.ref,
+    inputs: {
+      repository: `${owner}/${repo}`,
+      ref: pr.merge_commit_sha,
+      flavors,
+      // The response of this request doesn't contain the ID of the triggered workflow run.
+      // As a workaround, generate a UUID and include it in the workflow input.
+      // See https://github.com/orgs/community/discussions/9752 for more details.
+      uuid,
+    },
+  });
+
+  // Find the triggered workflow run
+  let run;
+  const maxAttempts = 5;
+  for (let i = 0; i < maxAttempts; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+      owner,
+      repo,
+      workflow_id,
+      event: "workflow_dispatch",
+    });
+    run = runs.workflow_runs.find((run) => run.name.includes(uuid));
+    if (run) {
+      break;
+    }
+  }
+
+  if (!run) {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: pull_number,
+      body: "Failed to find the triggered workflow run.",
+    });
+    return;
+  }
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: pull_number,
+    body: `Cross-version test run started: ${run.html_url}`,
+  });
+}
+
+module.exports = {
+  main,
+};

--- a/.github/workflows/cross-version-test-runner.js
+++ b/.github/workflows/cross-version-test-runner.js
@@ -35,9 +35,9 @@ async function main({ context, github }) {
       repository: `${owner}/${repo}`,
       ref: pr.merge_commit_sha,
       flavors,
-      // The response of this request doesn't contain the ID of the triggered workflow run.
-      // As a workaround, generate a UUID and include it in the workflow input.
-      // See https://github.com/orgs/community/discussions/9752 for more details.
+      // The response of create-workflow-dispatch request doesn't contain the ID of the triggered
+      // workflow run. We need to pass a unique identifier to the workflow run and find the run by
+      // the identifier. See https://github.com/orgs/community/discussions/9752 for more details.
       uuid,
     },
   });

--- a/.github/workflows/cross-version-test-runner.yml
+++ b/.github/workflows/cross-version-test-runner.yml
@@ -1,0 +1,30 @@
+name: Cross version test runner
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -exo pipefail {0}
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.event.issue.pull_request && github.event.comment.body }}
+    permissions:
+      pull-requests: write
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        id: get-ref
+        with:
+          result-encoding: string
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runner = require('./.github/workflows/cross-version-test-runner.js');
+            await runner.main({ context, github });

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -1,4 +1,5 @@
 name: Cross version tests
+run-name: ${{ inputs.uuid }}
 
 on:
   pull_request:
@@ -28,6 +29,10 @@ on:
         default: ""
       versions:
         description: "[Optional] Comma-separated string specifying which versions to test (e.g. '1.2.3, 4.5.6'). If unspecified, all versions are tested."
+        required: false
+        default: ""
+      uuid:
+        description: "[Optional] A unique identifier for this run."
         required: false
         default: ""
   schedule:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11765?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11765/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11765
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Add a github action workflow that allows us to run cross-version tests by a `/cross-version-test` comment.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Tested on https://github.com/harupy/mlflow/pull/88

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
