### PR TITLE
Address breaking change in LangChain RunnableSequence

### DIFF
--- a/mlflow/langchain/_langchain_autolog.py
+++ b/mlflow/langchain/_langchain_autolog.py
@@ -10,6 +10,7 @@ from packaging.version import Version
 import mlflow
 from mlflow.entities import RunTag
 from mlflow.exceptions import MlflowException
+from mlflow.langchain.runnables import get_runnable_steps
 from mlflow.ml_package_versions import _ML_PACKAGE_VERSIONS
 from mlflow.tracking.context import registry as context_registry
 from mlflow.utils.autologging_utils import (
@@ -165,10 +166,13 @@ def _runnable_with_retriever(model):
             return any(_runnable_with_retriever(runnable) for _, runnable in model.branches)
 
         if isinstance(model, RunnableParallel):
-            return any(_runnable_with_retriever(runnable) for runnable in model.steps.values())
+            return any(
+                _runnable_with_retriever(runnable)
+                for runnable in get_runnable_steps(model).values()
+            )
 
         if isinstance(model, RunnableSequence):
-            return any(_runnable_with_retriever(runnable) for runnable in model.steps)
+            return any(_runnable_with_retriever(runnable) for runnable in get_runnable_steps(model))
 
         if isinstance(model, RunnableAssign):
             return _runnable_with_retriever(model.mapper)

--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -36,7 +36,7 @@ from mlflow.langchain.utils import (
 )
 
 if TYPE_CHECKING:
-    from langchain.schema.runnable import RunnableSequence
+    from langchain.schema.runnable import Runnable
 
 _STEPS_FOLDER_NAME = "steps"
 _RUNNABLE_STEPS_FILE_NAME = "steps.yaml"
@@ -441,10 +441,11 @@ def _load_runnables(path, conf):
     )
 
 
-def get_runnable_steps(model: RunnableSequence):
-    # RunnableSequence stores steps as `steps__` attribute since version 0.16.0. However, it was
-    # stored as `steps` attribute before that.
+def get_runnable_steps(model: Runnable):
     try:
-        return model.steps__
-    except AttributeError:
         return model.steps
+    except AttributeError:
+        # RunnableParallel stores steps as `steps__` attribute since version 0.16.0, while it was
+        # stored as `steps` attribute before that and other runnables like RunnableSequence still
+        # has `steps` property.
+        return model.steps__

--- a/mlflow/langchain/runnables.py
+++ b/mlflow/langchain/runnables.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import cloudpickle
 import yaml
@@ -32,6 +34,9 @@ from mlflow.langchain.utils import (
     lc_runnables_types,
     picklable_runnable_types,
 )
+
+if TYPE_CHECKING:
+    from langchain.schema.runnable import RunnableSequence
 
 _STEPS_FOLDER_NAME = "steps"
 _RUNNABLE_STEPS_FILE_NAME = "steps.yaml"
@@ -293,7 +298,7 @@ def _save_runnable_with_steps(model, file_path: Union[Path, str], loader_fn=None
     steps_path = save_path / _STEPS_FOLDER_NAME
     steps_path.mkdir()
 
-    steps = model.steps
+    steps = get_runnable_steps(model)
     if isinstance(steps, list):
         generator = enumerate(steps)
     elif isinstance(steps, dict):
@@ -434,3 +439,12 @@ def _load_runnables(path, conf):
     raise MlflowException.invalid_parameter_value(
         _UNSUPPORTED_MODEL_ERROR_MESSAGE.format(instance_type=model_type)
     )
+
+
+def get_runnable_steps(model: RunnableSequence):
+    # RunnableSequence stores steps as `steps__` attribute since version 0.16.0. However, it was
+    # stored as `steps` attribute before that.
+    try:
+        return model.steps__
+    except AttributeError:
+        return model.steps

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -651,6 +651,7 @@ langchain:
         ]
     run: |
       pytest tests/langchain/test_langchain_model_export.py
+      pytest tests/langchain/test_langchain_databricks_dependency_extraction.py
       # test both pydantic v1 and v2
       PYDANTIC_VERSION=$(python -c "import pydantic; print(pydantic.__version__)")
       LANGCHAIN_NEW=$(python -c "from packaging.version import Version;import langchain;print(Version(langchain.__version__) >= Version('0.0.267'))")
@@ -658,6 +659,7 @@ langchain:
         pip install 'pydantic>2'
         echo "Testing langchain model export with pydantic v2"
         pytest tests/langchain/test_langchain_model_export.py
+        pytest tests/langchain/test_langchain_databricks_dependency_extraction.py
       fi
   autologging:
     minimum: "0.1.4"

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from unittest.mock import MagicMock
 
 import langchain
+from mlflow.langchain.utils import IS_PICKLE_SERIALIZATION_RESTRICTED
 import pytest
 from packaging.version import Version
 
@@ -47,7 +48,11 @@ def test_parsing_dependency_from_databricks_llm(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setenv("DATABRICKS_HOST", "my-default-host")
     monkeypatch.setenv("DATABRICKS_TOKEN", "my-default-token")
 
-    llm = Databricks(endpoint_name="databricks-mixtral-8x7b-instruct")
+    llm_kwargs = {"endpoint_name": "databricks-mixtral-8x7b-instruct"}
+    if IS_PICKLE_SERIALIZATION_RESTRICTED:
+        llm_kwargs["allow_dangerous_deserialization"] = True
+
+    llm = Databricks(**llm_kwargs)
     d = defaultdict(list)
     _extract_databricks_dependencies_from_llm(llm, d)
     assert d.get(_DATABRICKS_LLM_ENDPOINT_NAME_KEY) == ["databricks-mixtral-8x7b-instruct"]

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from unittest.mock import MagicMock
 
 import langchain
-from mlflow.langchain.utils import IS_PICKLE_SERIALIZATION_RESTRICTED
 import pytest
 from packaging.version import Version
 
@@ -17,6 +16,7 @@ from mlflow.langchain.databricks_dependencies import (
     _extract_databricks_dependencies_from_llm,
     _extract_databricks_dependencies_from_retriever,
 )
+from mlflow.langchain.utils import IS_PICKLE_SERIALIZATION_RESTRICTED
 
 
 class MockDatabricksServingEndpointClient:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11774?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11774/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11774
```

</p>
</details>

### Related Issues/PRs

Fix https://github.com/mlflow-automation/mlflow/actions/runs/8772962129/job/24075307910#step:12:3062

### What changes are proposed in this pull request?

LangChain 0.16.0 introduced a breaking change in `RunnableSequence`, which replaces `steps` attribute with `steps__` (langchain/pull/20631). There is no detailed information why it was renamed, but we have to replace our references.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
