### PR TITLE
Make Mlflow client's logging function controlled by global async logging config

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -755,11 +755,12 @@ class MlflowClient:
             step: Integer training step (iteration) at which was the metric calculated.
                 Defaults to 0.
             synchronous: *Experimental* If True, blocks until the metric is logged successfully.
-                If False, logs the metric asynchronously and returns a future
-                representing the logging operation.
+                If False, logs the metric asynchronously and returns a future representing the
+                logging operation. If None, read from environment variable
+                `MLFLOW_ENABLE_ASYNC_LOGGING`, which defaults to False if not set.
 
         Returns:
-            When `synchronous=True`, returns None. When `synchronous=False`, returns an
+            When `synchronous=True` or None, returns None. When `synchronous=False`, returns an
             :py:class:`mlflow.utils.async_logging.run_operations.RunOperations` instance that
             represents future for logging operation.
 
@@ -828,12 +829,13 @@ class MlflowClient:
             value: Parameter value, but will be string-ified if not.
                 All built-in backend stores support values up to length 6000, but some
                 may support larger values.
-            synchronous: *Experimental* If True, blocks until the parameter is logged
-                successfully. If False, logs the parameter asynchronously and
-                returns a future representing the logging operation.
+            synchronous: *Experimental* If True, blocks until the metric is logged successfully.
+                If False, logs the metric asynchronously and returns a future representing the
+                logging operation. If None, read from environment variable
+                `MLFLOW_ENABLE_ASYNC_LOGGING`, which defaults to False if not set.
 
         Returns:
-            When `synchronous=True`, returns parameter value. When `synchronous=False`,
+            When `synchronous=True` or None, returns parameter value. When `synchronous=False`,
             returns an :py:class:`mlflow.utils.async_logging.run_operations.RunOperations`
             instance that represents future for logging operation.
 
@@ -930,12 +932,13 @@ class MlflowClient:
                 length 250, but some may support larger keys.
             value: Tag value, but will be string-ified if not. All backend stores will support
                 values up to length 5000, but some may support larger values.
-            synchronous: *Experimental* If True, blocks until the tag is logged successfully. If
-                False, logs the tag asynchronously and returns a future representing the logging
-                operation.
+           synchronous: *Experimental* If True, blocks until the metric is logged successfully.
+                If False, logs the metric asynchronously and returns a future representing the
+                logging operation. If None, read from environment variable
+                `MLFLOW_ENABLE_ASYNC_LOGGING`, which defaults to False if not set.
 
         Returns:
-            When `synchronous=True`, returns None. When `synchronous=False`, returns an
+            When `synchronous=True` or None, returns None. When `synchronous=False`, returns an
             `mlflow.utils.async_logging.run_operations.RunOperations` instance that represents
             future for logging operation.
 
@@ -1084,15 +1087,16 @@ class MlflowClient:
             metrics: If provided, List of Metric(key, value, timestamp) instances.
             params: If provided, List of Param(key, value) instances.
             tags: If provided, List of RunTag(key, value) instances.
-            synchronous: *Experimental* If True, blocks until the metrics/tags/params are logged
-                successfully. If False, logs the metrics/tags/params asynchronously
-                and returns a future representing the logging operation.
+            synchronous: *Experimental* If True, blocks until the metric is logged successfully.
+                If False, logs the metric asynchronously and returns a future representing the
+                logging operation. If None, read from environment variable
+                `MLFLOW_ENABLE_ASYNC_LOGGING`, which defaults to False if not set.
 
         Raises:
             mlflow.MlflowException: If any errors occur.
 
         Returns:
-            When `synchronous=True`, returns None. When `synchronous=False`, returns an
+            When `synchronous=True` or None, returns None. When `synchronous=False`, returns an
             :py:class:`mlflow.utils.async_logging.run_operations.RunOperations` instance that
             represents future for logging operation.
 
@@ -1171,9 +1175,10 @@ class MlflowClient:
         Args:
             local_path: Path to the file or directory to write.
             artifact_path: If provided, the directory in ``artifact_uri`` to write to.
-            synchronous: *Experimental* If True, blocks until the artifact is logged
-                successfully. If False, logs the artifacts asynchronously
-                and returns a future representing the logging operation.
+            synchronous: *Experimental* If True, blocks until the metric is logged successfully.
+                If False, logs the metric asynchronously and returns a future representing the
+                logging operation. If None, read from environment variable
+                `MLFLOW_ENABLE_ASYNC_LOGGING`, which defaults to False if not set.
 
         .. code-block:: python
             :caption: Example

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -94,6 +94,13 @@ def mock_time():
         yield time
 
 
+@pytest.fixture
+def setup_async_logging():
+    enable_async_logging(True)
+    yield
+    enable_async_logging(False)
+
+
 def test_client_create_run(mock_store, mock_time):
     experiment_id = mock.Mock()
 
@@ -797,12 +804,9 @@ def test_client_log_metric_params_tags_overrides(mock_store):
     )
 
 
-def test_enable_async_logging(mock_store):
-    enable_async_logging(True)
+def test_enable_async_logging(mock_store, setup_async_logging):
     MlflowClient().log_param(run_id="run_id", key="key", value="val")
     mock_store.log_param_async.assert_called_once_with("run_id", Param("key", "val"))
 
     MlflowClient().log_metric(run_id="run_id", key="key", value="val", step=1, timestamp=1)
     mock_store.log_metric_async.assert_called_once_with("run_id", Metric("key", "val", 1, 1))
-    # Clean up the setup.
-    enable_async_logging(False)

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from mlflow import MlflowClient
+from mlflow import MlflowClient, flush_async_logging
 from mlflow.config import enable_async_logging
 from mlflow.entities import ExperimentTag, Run, RunInfo, RunStatus, RunTag, SourceType, ViewType
 from mlflow.entities.metric import Metric
@@ -98,6 +98,7 @@ def mock_time():
 def setup_async_logging():
     enable_async_logging(True)
     yield
+    flush_async_logging()
     enable_async_logging(False)
 
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 
 from mlflow import MlflowClient
+from mlflow.config import enable_async_logging
 from mlflow.entities import ExperimentTag, Run, RunInfo, RunStatus, RunTag, SourceType, ViewType
 from mlflow.entities.metric import Metric
 from mlflow.entities.model_registry import ModelVersion, ModelVersionTag
@@ -794,3 +795,14 @@ def test_client_log_metric_params_tags_overrides(mock_store):
     mock_store.log_batch_async.assert_called_once_with(
         run_id=run_id, metrics=metrics, params=params, tags=tags
     )
+
+
+def test_enable_async_logging(mock_store):
+    enable_async_logging(True)
+    MlflowClient().log_param(run_id="run_id", key="key", value="val")
+    mock_store.log_param_async.assert_called_once_with("run_id", Param("key", "val"))
+
+    MlflowClient().log_metric(run_id="run_id", key="key", value="val", step=1, timestamp=1)
+    mock_store.log_metric_async.assert_called_once_with("run_id", Metric("key", "val", 1, 1))
+    # Clean up the setup.
+    enable_async_logging(False)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/11778?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11778/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11778
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Currently `mlflow.config.enable_async_logging()` only affects fluent API, and it makes sense to have client APIs under control as well. This PR does the work.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
