### PR TITLE
Make it possible to set the threadpool size of async logging

### DIFF
--- a/mlflow/config/__init__.py
+++ b/mlflow/config/__init__.py
@@ -1,6 +1,5 @@
 from mlflow.environment_variables import (
     MLFLOW_ENABLE_ASYNC_LOGGING,
-    MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE,
 )
 from mlflow.system_metrics import (
     disable_system_metrics_logging,
@@ -44,15 +43,6 @@ def enable_async_logging(enable=True):
     """
 
     MLFLOW_ENABLE_ASYNC_LOGGING.set(enable)
-
-
-def set_async_logging_threadpool_size(num_workers):
-    """Set the number of workers in the thread pool for async logging.
-
-    Args:
-        num_workers: int, the number of workers in the thread pool for async logging.
-    """
-    MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE.set(num_workers)
 
 
 __all__ = [

--- a/mlflow/config/__init__.py
+++ b/mlflow/config/__init__.py
@@ -1,4 +1,7 @@
-from mlflow.environment_variables import MLFLOW_ENABLE_ASYNC_LOGGING
+from mlflow.environment_variables import (
+    MLFLOW_ENABLE_ASYNC_LOGGING,
+    MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE,
+)
 from mlflow.system_metrics import (
     disable_system_metrics_logging,
     enable_system_metrics_logging,
@@ -41,6 +44,15 @@ def enable_async_logging(enable=True):
     """
 
     MLFLOW_ENABLE_ASYNC_LOGGING.set(enable)
+
+
+def set_async_logging_threadpool_size(num_workers):
+    """Set the number of workers in the thread pool for async logging.
+
+    Args:
+        num_workers: int, the number of workers in the thread pool for async logging.
+    """
+    MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE.set(num_workers)
 
 
 __all__ = [

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -535,6 +535,11 @@ MLFLOW_GATEWAY_RATE_LIMITS_STORAGE_URI = _EnvironmentVariable(
 #: If True, MLflow fluent logging APIs, e.g., `mlflow.log_metric` will log asynchronously.
 MLFLOW_ENABLE_ASYNC_LOGGING = _BooleanEnvironmentVariable("MLFLOW_ENABLE_ASYNC_LOGGING", False)
 
+#: Number of workers in the thread pool used for asynchronous logging.
+MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE = _EnvironmentVariable(
+    "MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE", int, 10
+)
+
 #: Specifies whether or not to have mlflow configure logging on import.
 #: If set to True, mlflow will configure ``mlflow.<module_name>`` loggers with
 #: logging handlers and formatters.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -535,7 +535,7 @@ MLFLOW_GATEWAY_RATE_LIMITS_STORAGE_URI = _EnvironmentVariable(
 #: If True, MLflow fluent logging APIs, e.g., `mlflow.log_metric` will log asynchronously.
 MLFLOW_ENABLE_ASYNC_LOGGING = _BooleanEnvironmentVariable("MLFLOW_ENABLE_ASYNC_LOGGING", False)
 
-#: Number of workers in the thread pool used for asynchronous logging.
+#: Number of workers in the thread pool used for asynchronous logging, defaults to 10.
 MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE = _EnvironmentVariable(
     "MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE", int, 10
 )

--- a/mlflow/utils/async_logging/async_logging_queue.py
+++ b/mlflow/utils/async_logging/async_logging_queue.py
@@ -12,9 +12,9 @@ from queue import Empty, Queue
 from mlflow.entities.metric import Metric
 from mlflow.entities.param import Param
 from mlflow.entities.run_tag import RunTag
+from mlflow.environment_variables import MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE
 from mlflow.utils.async_logging.run_batch import RunBatch
 from mlflow.utils.async_logging.run_operations import RunOperations
-from mlflow.environment_variables import MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/utils/async_logging/async_logging_queue.py
+++ b/mlflow/utils/async_logging/async_logging_queue.py
@@ -14,6 +14,7 @@ from mlflow.entities.param import Param
 from mlflow.entities.run_tag import RunTag
 from mlflow.utils.async_logging.run_batch import RunBatch
 from mlflow.utils.async_logging.run_operations import RunOperations
+from mlflow.environment_variables import MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE
 
 _logger = logging.getLogger(__name__)
 
@@ -233,12 +234,12 @@ class AsyncLoggingQueue:
                 daemon=True,
             )
             self._batch_logging_worker_threadpool = ThreadPoolExecutor(
-                max_workers=10,
+                max_workers=MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE.get() or 10,
                 thread_name_prefix="MLflowBatchLoggingWorkerPool",
             )
 
             self._batch_status_check_threadpool = ThreadPoolExecutor(
-                max_workers=10,
+                max_workers=MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE.get() or 10,
                 thread_name_prefix="MLflowAsyncLoggingStatusCheck",
             )
             self._batch_logging_thread.start()

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -15,7 +15,7 @@ import yaml
 import mlflow
 from mlflow import MlflowClient, tracking
 from mlflow.entities import LifecycleStage, Metric, Param, RunStatus, RunTag, ViewType
-from mlflow.environment_variables import MLFLOW_RUN_ID
+from mlflow.environment_variables import MLFLOW_RUN_ID, MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST, ErrorCode
 from mlflow.store.tracking.file_store import FileStore
@@ -1209,3 +1209,17 @@ def test_log_table_with_valid_image_columns():
     with mlflow.start_run():
         # Log the dictionary as a table
         mlflow.log_table(data=table_dict, artifact_file=artifact_file)
+
+
+def test_set_async_logging_threadpool_size():
+    mlflow.config.set_async_logging_threadpool_size(6)
+    assert MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE.get() == 6
+
+    with mlflow.start_run():
+        mlflow.log_param("key", "val", synchronous=False)
+
+    store = mlflow.tracking._get_store()
+    async_queue = store._async_logging_queue
+    assert async_queue._batch_logging_worker_threadpool._max_workers == 6
+    mlflow.config.set_async_logging_threadpool_size(6)
+    MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE.unset()

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -15,7 +15,7 @@ import yaml
 import mlflow
 from mlflow import MlflowClient, tracking
 from mlflow.entities import LifecycleStage, Metric, Param, RunStatus, RunTag, ViewType
-from mlflow.environment_variables import MLFLOW_RUN_ID, MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE
+from mlflow.environment_variables import MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE, MLFLOW_RUN_ID
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST, ErrorCode
 from mlflow.store.tracking.file_store import FileStore
@@ -1212,7 +1212,7 @@ def test_log_table_with_valid_image_columns():
 
 
 def test_set_async_logging_threadpool_size():
-    mlflow.config.set_async_logging_threadpool_size(6)
+    MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE.set(6)
     assert MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE.get() == 6
 
     with mlflow.start_run():
@@ -1221,5 +1221,4 @@ def test_set_async_logging_threadpool_size():
     store = mlflow.tracking._get_store()
     async_queue = store._async_logging_queue
     assert async_queue._batch_logging_worker_threadpool._max_workers == 6
-    mlflow.config.set_async_logging_threadpool_size(6)
     MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE.unset()

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -1221,4 +1221,5 @@ def test_set_async_logging_threadpool_size():
     store = mlflow.tracking._get_store()
     async_queue = store._async_logging_queue
     assert async_queue._batch_logging_worker_threadpool._max_workers == 6
+    mlflow.flush_async_logging()
     MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE.unset()

--- a/tests/utils/test_async_logging_queue.py
+++ b/tests/utils/test_async_logging_queue.py
@@ -6,6 +6,7 @@ import time
 import uuid
 
 import pytest
+import mlflow
 
 from mlflow import MlflowException
 from mlflow.entities.metric import Metric

--- a/tests/utils/test_async_logging_queue.py
+++ b/tests/utils/test_async_logging_queue.py
@@ -6,7 +6,6 @@ import time
 import uuid
 
 import pytest
-import mlflow
 
 from mlflow import MlflowException
 from mlflow.entities.metric import Metric


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/11780?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11780/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11780
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Sometimes people are doing heavy async logging, in which case it makes sense to let user control the size of threadpool. Only for a few advanced user, but super useful for this group.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Use `mlflow.config.set_async_logging_threadpool_size` to change the threadpool size for async logging.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
