### PR TITLE
Support llm/v1/embeddings task in Transformers flavor

### DIFF
--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -522,5 +522,7 @@ class _SentenceTransformerModelWrapper:
             output_data = self.model.encode(sentences)
 
         if convert_output_to_llm_v1_format:
-            output_data = postprocess_output_for_llm_v1_embedding_task(sentences, output_data)
+            output_data = postprocess_output_for_llm_v1_embedding_task(
+                sentences, output_data, self.model.tokenizer
+            )
         return output_data

--- a/mlflow/sentence_transformers/__init__.py
+++ b/mlflow/sentence_transformers/__init__.py
@@ -17,6 +17,11 @@ from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import _infer_signature_from_input_example
 from mlflow.models.utils import _save_example
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+from mlflow.transformers.llm_inference_utils import (
+    _LLM_INFERENCE_TASK_EMBEDDING,
+    _LLM_V1_EMBEDDING_INPUT_KEY,
+    postprocess_output_for_llm_v1_embedding_task,
+)
 from mlflow.types.llm import (
     EMBEDDING_MODEL_INPUT_SCHEMA,
     EMBEDDING_MODEL_OUTPUT_SCHEMA,
@@ -55,8 +60,6 @@ _TRANSFORMER_MODEL_TYPE_KEY = "pipeline_model_type"
 
 SENTENCE_TRANSFORMERS_DATA_PATH = "model.sentence_transformer"
 _INFERENCE_CONFIG_PATH = "inference_config"
-_LLM_INFERENCE_TASK_EMBEDDING = "llm/v1/embeddings"
-_LLM_V1_EMBEDDING_INPUT_KEY = "input"
 
 # Patterns to extract HuggingFace model repository name from the local snapshot path.
 # The path format would be like /path/to/{username}_{modelname}, where user name can
@@ -519,56 +522,5 @@ class _SentenceTransformerModelWrapper:
             output_data = self.model.encode(sentences)
 
         if convert_output_to_llm_v1_format:
-            output_data = self.postprocess_output_for_llm_v1_embedding_task(sentences, output_data)
+            output_data = postprocess_output_for_llm_v1_embedding_task(sentences, output_data)
         return output_data
-
-    def postprocess_output_for_llm_v1_embedding_task(
-        self, input_prompts: Union[str, List[str]], output_tensers: List[List[int]]
-    ):
-        """
-        Wrap output data with usage information.
-
-        Examples:
-            .. code-block:: python
-                input_prompt = ["hello world and hello mlflow"]
-                output_embedding = [0.47137904, 0.4669448, ..., 0.69726706]
-                output_dicts = postprocess_output_for_llm_v1_embedding_task(
-                    input_prompt, output_embedding
-                )
-                assert output_dicts == [
-                    {
-                        "object": "list",
-                        "data": [
-                            {
-                                "object": "embedding",
-                                "index": 0,
-                                "embedding": [0.47137904, 0.4669448, ..., 0.69726706],
-                            }
-                        ],
-                        "usage": {"prompt_tokens": 8, "total_tokens": 8},
-                    }
-                ]
-
-        Args:
-            input_prompts: text input prompts
-            output_tensers: List of output tensors that contain the generated embeddings
-
-        Returns:
-             Dictionaries containing the output embedding and usage information for each
-             input prompt.
-        """
-        prompt_tokens = sum(
-            [len(self.model.tokenizer(prompt)["input_ids"]) for prompt in input_prompts]
-        )
-        return {
-            "object": "list",
-            "data": [
-                {
-                    "object": "embedding",
-                    "index": i,
-                    "embedding": tensor,
-                }
-                for i, tensor in enumerate(output_tensers)
-            ],
-            "usage": {"prompt_tokens": prompt_tokens, "total_tokens": prompt_tokens},
-        }

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -57,6 +57,8 @@ from mlflow.transformers.flavor_config import (
 from mlflow.transformers.hub_utils import is_valid_hf_repo_id
 from mlflow.transformers.llm_inference_utils import (
     _LLM_INFERENCE_TASK_CHAT,
+    _LLM_INFERENCE_TASK_COMPLETIONS,
+    _LLM_INFERENCE_TASK_EMBEDDING,
     _LLM_INFERENCE_TASK_KEY,
     _LLM_INFERENCE_TASK_PREFIX,
     _METADATA_LLM_INFERENCE_TASK_KEY,
@@ -65,6 +67,8 @@ from mlflow.transformers.llm_inference_utils import (
     convert_data_messages_with_chat_template,
     infer_signature_from_llm_inference_task,
     postprocess_output_for_llm_inference_task,
+    postprocess_output_for_llm_v1_embedding_task,
+    preprocess_llm_embedding_params,
     preprocess_llm_inference_params,
 )
 from mlflow.transformers.model_io import (
@@ -1648,9 +1652,11 @@ class _TransformersWrapper:
         """
         if self.llm_inference_task == _LLM_INFERENCE_TASK_CHAT:
             convert_data_messages_with_chat_template(data, self.pipeline.tokenizer)
-
-        if self.llm_inference_task:
             data, params = preprocess_llm_inference_params(data, self.flavor_config)
+        elif self.llm_inference_task == _LLM_INFERENCE_TASK_COMPLETIONS:
+            data, params = preprocess_llm_inference_params(data, self.flavor_config)
+        elif self.llm_inference_task == _LLM_INFERENCE_TASK_EMBEDDING:
+            data, params = preprocess_llm_embedding_params(data)
 
         # NB: This `predict` method updates the model_config several times. To make the predict
         # call idempotent, we keep the original self.model_config immutable and creates a deep
@@ -1809,7 +1815,13 @@ class _TransformersWrapper:
                 )
 
         elif isinstance(self.pipeline, transformers.FeatureExtractionPipeline):
-            return self._parse_feature_extraction_output(raw_output)
+            if self.llm_inference_task:
+                output = [np.array(tensor[0][0]) for tensor in raw_output]
+                output = postprocess_output_for_llm_v1_embedding_task(
+                    data, output, self.pipeline.tokenizer
+                )
+            else:
+                return self._parse_feature_extraction_output(raw_output)
         elif isinstance(self.pipeline, transformers.FillMaskPipeline):
             output = self._parse_list_of_multiple_dicts(raw_output, output_key)
         elif isinstance(self.pipeline, transformers.ZeroShotClassificationPipeline):

--- a/mlflow/transformers/llm_inference_utils.py
+++ b/mlflow/transformers/llm_inference_utils.py
@@ -13,6 +13,8 @@ from mlflow.types.llm import (
     CHAT_MODEL_OUTPUT_SCHEMA,
     COMPLETIONS_MODEL_INPUT_SCHEMA,
     COMPLETIONS_MODEL_OUTPUT_SCHEMA,
+    EMBEDDING_MODEL_INPUT_SCHEMA,
+    EMBEDDING_MODEL_OUTPUT_SCHEMA,
 )
 
 if TYPE_CHECKING:
@@ -26,6 +28,9 @@ _METADATA_LLM_INFERENCE_TASK_KEY = "task"
 _LLM_INFERENCE_TASK_PREFIX = "llm/v1"
 _LLM_INFERENCE_TASK_COMPLETIONS = f"{_LLM_INFERENCE_TASK_PREFIX}/completions"
 _LLM_INFERENCE_TASK_CHAT = f"{_LLM_INFERENCE_TASK_PREFIX}/chat"
+_LLM_INFERENCE_TASK_EMBEDDING = f"{_LLM_INFERENCE_TASK_PREFIX}/embeddings"
+
+_LLM_V1_EMBEDDING_INPUT_KEY = "input"
 
 
 _LLM_INFERENCE_OBJECT_NAME = {
@@ -35,6 +40,7 @@ _LLM_INFERENCE_OBJECT_NAME = {
 
 _SUPPORTED_LLM_INFERENCE_TASK_TYPES_BY_PIPELINE_TASK = {
     "text-generation": [_LLM_INFERENCE_TASK_COMPLETIONS, _LLM_INFERENCE_TASK_CHAT],
+    "feature-extraction": [_LLM_INFERENCE_TASK_EMBEDDING],
 }
 
 _SIGNATURE_FOR_LLM_INFERENCE_TASK = {
@@ -43,6 +49,9 @@ _SIGNATURE_FOR_LLM_INFERENCE_TASK = {
     ),
     _LLM_INFERENCE_TASK_COMPLETIONS: ModelSignature(
         inputs=COMPLETIONS_MODEL_INPUT_SCHEMA, outputs=COMPLETIONS_MODEL_OUTPUT_SCHEMA
+    ),
+    _LLM_INFERENCE_TASK_EMBEDDING: ModelSignature(
+        inputs=EMBEDDING_MODEL_INPUT_SCHEMA, outputs=EMBEDDING_MODEL_OUTPUT_SCHEMA
     ),
 }
 
@@ -61,7 +70,6 @@ def infer_signature_from_llm_inference_task(
             f"When `task` is specified as `{inference_task}`, the signature would "
             "be set by MLflow. Please do not set the signature."
         )
-
     return inferred_signature
 
 
@@ -328,3 +336,98 @@ def _get_default_task_for_llm_inference_task(llm_inference_task: Optional[str]) 
         if llm_inference_task in llm_tasks:
             return task
     return None
+
+
+def preprocess_llm_embedding_params(
+    data: Union[pd.DataFrame, Dict[str, Any]],
+) -> Tuple[List[str], Dict[str, Any]]:
+    """
+    When `llm/v1/embeddings` task is given, extract the input data (with "input" key) and
+    parameters, and format the input data into the unified format for easier downstream handling.
+
+    The handling is more complicated than other LLM inference tasks because the embedding endpoint
+    accepts heterogeneous input - both string and list of strings as input. Also we don't enforce
+    the input schema always, so there are 4 possible input types:
+      (1)  Pandas DataFrame with string column
+      (2)  Pandas DataFrame with list of strings column
+      (3)  Dictionary with string value
+      (4)  Dictionary with list of strings value
+    In all cases, the returned input data will be a list of strings.
+
+    Args:
+        data: Input data for the embedding task.
+
+    Returns:
+        Tuple of input data and parameters dictionary.
+    """
+    if isinstance(data, pd.DataFrame):
+        params = {}
+        for col in data.columns:
+            if col == _LLM_V1_EMBEDDING_INPUT_KEY:
+                input_data = data[col].to_list()
+                if isinstance(input_data[0], list):
+                    input_data = input_data[0]
+            else:
+                params[col] = data[col].tolist()[0]
+    else:
+        # NB: Input schema is not enforced for the embedding task because of the heterogeneous
+        # input type, so we have to cast the input data into unified format here.
+        input_data = data.get(_LLM_V1_EMBEDDING_INPUT_KEY)
+        if isinstance(input, str):
+            input_data = [input_data]
+        params = {k: v for k, v in data.items() if k != _LLM_V1_EMBEDDING_INPUT_KEY}
+
+    return input_data, params
+
+
+def postprocess_output_for_llm_v1_embedding_task(
+    input_prompts: List[str],
+    output_tensors: List[List[float]],
+    tokenizer,
+):
+    """
+    Wrap output data with usage information.
+
+    Examples:
+        .. code-block:: python
+            input_prompt = ["hello world and hello mlflow"]
+            output_embedding = [0.47137904, 0.4669448, ..., 0.69726706]
+            output_dicts = postprocess_output_for_llm_v1_embedding_task(
+                input_prompt, output_embedding
+            )
+            assert output_dicts == [
+                {
+                    "object": "list",
+                    "data": [
+                        {
+                            "object": "embedding",
+                            "index": 0,
+                            "embedding": [0.47137904, 0.4669448, ..., 0.69726706],
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 8, "total_tokens": 8},
+                }
+            ]
+
+    Args:
+        input_prompts: text input prompts
+        output_tensers: List of output tensors that contain the generated embeddings
+        tokenizer: The tokenizer object used for inference.
+
+    Returns:
+            Dictionaries containing the output embedding and usage information for each
+            input prompt.
+    """
+    prompt_tokens = sum(len(tokenizer(prompt)["input_ids"]) for prompt in input_prompts)
+    return {
+        "object": "list",
+        "data": [
+            {
+                "object": "embedding",
+                "index": i,
+                "embedding": tensor,
+            }
+            for i, tensor in enumerate(output_tensors)
+        ],
+        "usage": {"prompt_tokens": prompt_tokens, "total_tokens": prompt_tokens},
+    }

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3461,7 +3461,6 @@ def test_text_generation_task_completions_predict_with_stop(text_generation_pipe
     )
 
     pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
-
     inference = pyfunc_loaded.predict(
         {"prompt": "How to learn Python in 3 weeks?", "stop": ["Python"]},
     )
@@ -3496,6 +3495,72 @@ def test_text_generation_task_completions_serve(text_generation_pipeline):
     assert output_dict["choices"][0]["text"] is not None
     assert output_dict["choices"][0]["finish_reason"] == "stop"
     assert output_dict["usage"]["prompt_tokens"] < 20
+
+
+def test_llm_v1_task_embeddings_predict(feature_extraction_pipeline, model_path):
+    mlflow.transformers.save_model(
+        transformers_model=feature_extraction_pipeline,
+        path=model_path,
+        input_examples=["Football", "Soccer"],
+        task="llm/v1/embeddings",
+    )
+
+    mlmodel = yaml.safe_load(model_path.joinpath("MLmodel").read_bytes())
+
+    flavor_config = mlmodel["flavors"]["transformers"]
+    assert flavor_config["inference_task"] == "llm/v1/embeddings"
+    assert mlmodel["metadata"]["task"] == "llm/v1/embeddings"
+
+    pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
+
+    # Predict with single string input
+    prediction = pyfunc_loaded.predict({"input": "A great day"})
+    assert prediction["object"] == "list"
+    assert len(prediction["data"]) == 1
+    assert prediction["data"][0]["object"] == "embedding"
+    assert prediction["usage"]["prompt_tokens"] == 5
+    assert len(prediction["data"][0]["embedding"]) == 384
+
+    # Predict with list of string input
+    prediction = pyfunc_loaded.predict({"input": ["A great day", "A bad day"]})
+    assert prediction["object"] == "list"
+    assert len(prediction["data"]) == 2
+    assert prediction["data"][0]["object"] == "embedding"
+    assert prediction["usage"]["prompt_tokens"] == 10
+    assert len(prediction["data"][0]["embedding"]) == 384
+
+
+@pytest.mark.parametrize(
+    "request_payload",
+    [
+        {"input": "A single string"},
+        {
+            "inputs": {"input": ["A list of strings"]},
+        },
+    ],
+)
+def test_llm_v1_task_embeddings_serve(feature_extraction_pipeline, request_payload):
+    with mlflow.start_run():
+        model_info = mlflow.transformers.log_model(
+            transformers_model=feature_extraction_pipeline,
+            artifact_path="model",
+            input_examples=["Football", "Soccer"],
+            task="llm/v1/embeddings",
+        )
+
+    response = pyfunc_serve_and_score_model(
+        model_info.model_uri,
+        data=json.dumps(request_payload),
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
+        extra_args=["--env-manager", "local"],
+    )
+    response = json.loads(response.content.decode("utf-8"))
+    prediction = response["predictions"] if "inputs" in request_payload else response
+
+    assert prediction["object"] == "list"
+    assert len(prediction["data"]) == 1
+    assert prediction["data"][0]["object"] == "embedding"
+    assert len(prediction["data"][0]["embedding"]) == 384
 
 
 def test_local_custom_model_save_and_load(text_generation_pipeline, model_path, tmp_path):

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3529,6 +3529,15 @@ def test_llm_v1_task_embeddings_predict(feature_extraction_pipeline, model_path)
     assert prediction["usage"]["prompt_tokens"] == 10
     assert len(prediction["data"][0]["embedding"]) == 384
 
+    # Predict with pandas dataframe input
+    df = pd.DataFrame({"input": ["A great day", "A bad day", "A good day"]})
+    prediction = pyfunc_loaded.predict(df)
+    assert prediction["object"] == "list"
+    assert len(prediction["data"]) == 3
+    assert prediction["data"][0]["object"] == "embedding"
+    assert prediction["usage"]["prompt_tokens"] == 15
+    assert len(prediction["data"][0]["embedding"]) == 384
+
 
 @pytest.mark.parametrize(
     "request_payload",


### PR DESCRIPTION
### What changes are proposed in this pull request?

The `llm/v1/embeddings` task name has been used inside `metadata` field to deploy an Databricks model serving endpoint with provisioned throughput ([ref](https://docs.databricks.com/en/machine-learning/foundation-models/deploy-prov-throughput-foundation-model-apis.html#provisioned-throughput-foundation-model-apis)) like this:

```
model = AutoModel.from_pretrained("BAAI/bge-small-en-v1.5")
tokenizer = AutoTokenizer.from_pretrained("BAAI/bge-small-en-v1.5")
with mlflow.start_run():
    mlflow.transformers.log_model(
        transformers_model={"model": model, "tokenizer": tokenizer},
        artifact_path="bge-small-transformers",
        task="feature-extraction",
        metadata={"task": "llm/v1/embeddings"},
        registered_model_name=registered_model_name)'
```

In MLflow 2.12.1, we adds a validation that checks if the `task` argument and `metadata["task"]` value is consistent or not. This makes the above example fail with this validation.

```
> MlflowException: LLM v1 task type 'llm/v1/embeddings' is specified in metadata, but it doesn't match the task type provided in the `task` argument: 'feature-extraction'. The mismatched task type may cause incorrect model inference behavior. Please provide the correct LLM v1 task type in the `task` argument. E.g. `mlflow.transformers.save_model(task="llm/v1/embeddings", ...)`
```

However,  the user cannot specify `llm/v1/embeddings` to `task` argument because Transformers flavor [does **not** support it](https://github.com/mlflow/mlflow/blob/master/mlflow/transformers/llm_inference_utils.py#L36-L38). This blocks users to deploy an embedding model with provisioned throughput capability.

```
> MlflowException: The task could not be inferred from the model. If you are saving a custom local model that is not available in the Hugging Face hub, please provide the `task` argument to the `log_model` or `save_model` function.
```

Therefore, this PR adds support for `llm/v1/embeddings` task in the Transformers flavor. Indeed, the task is already supported in the SentenceTransformers flavors and so as the Databricks model serving.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Followed the [provision throughput documentation](https://docs.databricks.com/en/machine-learning/foundation-models/deploy-prov-throughput-foundation-model-apis.html#provisioned-throughput-foundation-model-apis) and successfully deployed the BGE embedding model with `llm/v1/embeddings` task.

```
mlflow.set_registry_uri('databricks-uc')
registered_model_name = f"{CATALOG}.{SCHEMA}.{MODEL_NAME}"

with mlflow.start_run():
    mlflow.transformers.log_model(
        transformers_model={"model": model, "tokenizer": tokenizer},
        artifact_path="bge-small-transformers",
        task="llm/v1/embeddings"
        registered_model_name=registered_model_name
   )
```
![Screenshot 2024-04-23 at 17 11 08](https://github.com/mlflow/mlflow/assets/31463517/0d632fd0-b511-4f61-8aba-e2de0d167f74)

![Screenshot 2024-04-23 at 17 12 34](https://github.com/mlflow/mlflow/assets/31463517/bccacdfe-2096-494c-9e5b-7710696a0ecb)

The response format is same as the one shown in [the documentation](https://docs.databricks.com/en/_extras/notebooks/source/machine-learning/large-language-models/provisioned-throughput-bge-serving.html).

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

We have to update the Databricks documentation, which is tracked in a separate PR.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The `llm/v1/embeddings` task is supported in Transformers flavors. Now the Transformers models can be deployed with OpenAI-compatible inference interface.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
