### PR TITLE
[MLflow] Adding resources class to define resources required to serve a model

### DIFF
--- a/mlflow/models/resources.py
+++ b/mlflow/models/resources.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List
 
+DEFAULT_API_VERSION = "1"
+
 
 class ResourceType(Enum):
     """
@@ -83,10 +85,14 @@ class _ResourceBuilder:
     """
 
     @staticmethod
-    def from_resources(resources: List[Resource]) -> Dict[str, Dict[ResourceType, List[str]]]:
+    def from_resources(
+        resources: List[Resource], api_version: str = DEFAULT_API_VERSION
+    ) -> Dict[str, Dict[ResourceType, List[str]]]:
         resource_dict = defaultdict(lambda: defaultdict(list))
         for resource in resources:
             resource_data = resource.to_dict()
             for resource_type, values in resource_data.items():
                 resource_dict[resource.target_uri][resource_type].extend(values)
+
+        resource_dict["api_version"] = api_version
         return dict(resource_dict)

--- a/mlflow/models/resources.py
+++ b/mlflow/models/resources.py
@@ -1,0 +1,145 @@
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from dataclasses import dataclass
+from enum import Enum
+from typing import List
+
+
+class ResourceType(Enum):
+    DATABRICKS_VECTOR_SEARCH_INDEX_NAME = "databricks_vector_search_index_name"
+    DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME = "databricks_vector_search_endpoint_name"
+    DATABRICKS_EMBEDDINGS_ENDPOINT_NAME = "databricks_embeddings_endpoint_name"
+    DATABRICKS_LLM_ENDPOINT_NAME = "databricks_llm_endpoint_name"
+    DATABRICKS_CHAT_ENDPOINT_NAME = "databricks_chat_endpoint_name"
+
+
+class Providers(Enum):
+    DATABRICKS = "databricks"
+
+
+@dataclass
+class Resource(ABC):
+    """
+    Base class for all resources to define the resources needed to serve a model.
+
+    Args:
+        type (ResourceType): The resource type.
+        target_uri (str): The target URI where these resources are hosted.
+    """
+
+    type: ResourceType
+    target_uri: Providers
+
+    @abstractmethod
+    def to_dict(self):
+        """
+        Convert the resource to a dictionary.
+        Subclasses must implement this method.
+        """
+
+
+@dataclass
+class DatabricksResource(Resource, ABC):
+    """
+    Base class to define all the Databricks resources to serve a model.
+    """
+
+    target_uri: Providers = Providers.DATABRICKS.value
+
+
+@dataclass
+class DatabricksLLMEndpoint(DatabricksResource):
+    """
+    Define Databricks LLM endpoint resource to serve a model.
+
+    Args:
+        endpoint_name (str): The name of all the databricks endpoints used by the model.
+    """
+
+    type: ResourceType = ResourceType.DATABRICKS_LLM_ENDPOINT_NAME
+    endpoint_name: str = None
+
+    def to_dict(self):
+        return {self.type.value: [self.endpoint_name]} if self.endpoint_name else {}
+
+
+@dataclass
+class DatabricksChatEndpoint(DatabricksResource):
+    """
+    Define Databricks LLM endpoint resource to serve a model.
+
+    Args:
+        endpoint_name (str): The name of all the databricks chat endpoints
+        used by the model.
+    """
+
+    type: ResourceType = ResourceType.DATABRICKS_CHAT_ENDPOINT_NAME
+    endpoint_name: str = None
+
+    def to_dict(self):
+        return {self.type.value: [self.endpoint_name]} if self.endpoint_name else {}
+
+
+@dataclass
+class DatabricksEmbeddingEndpoint(DatabricksResource):
+    """
+    Define Databricks embedding endpoint resource to serve a model.
+
+    Args:
+        endpoint_name (str): The name of all the databricks embedding endpoints
+        used by the model.
+    """
+
+    type: ResourceType = ResourceType.DATABRICKS_EMBEDDINGS_ENDPOINT_NAME
+    endpoint_name: str = None
+
+    def to_dict(self):
+        return {self.type.value: [self.endpoint_name]} if self.endpoint_name else {}
+
+
+@dataclass
+class DatabricksVectorSearchEndpoint(DatabricksResource):
+    """
+    Define Databricks vector search endpoint resource to serve a model.
+
+    Args:
+        endpoint_name (str): The name of all the databricks vector search endpoints
+        used by the model.
+    """
+
+    type: ResourceType = ResourceType.DATABRICKS_VECTOR_SEARCH_ENDPOINT_NAME
+    endpoint_name: str = None
+
+    def to_dict(self):
+        return {self.type.value: [self.endpoint_name]} if self.endpoint_name else {}
+
+
+@dataclass
+class DatabricksVectorSearchIndexName(DatabricksResource):
+    """
+    Define Databricks vector search index name resource to serve a model.
+
+    Args:
+        index_name (str): The name of all the databricks vector search index names
+        used by the model.
+    """
+
+    type: ResourceType = ResourceType.DATABRICKS_VECTOR_SEARCH_INDEX_NAME
+    index_name: str = None
+
+    def to_dict(self):
+        return {self.type.value: [self.index_name]} if self.index_name else {}
+
+
+class _ResourceBuilder:
+    """
+    Private builder class to build the resources dictionary.
+    """
+
+    @staticmethod
+    def from_resources(resources: List[Resource]) -> dict:
+        resource_dict = defaultdict(list)
+        for resource in resources:
+            for resource_type, values in resource.to_dict().items():
+                resource_dict[resource_type].extend(values)
+        return dict(resource_dict)

--- a/tests/models/test_resources.py
+++ b/tests/models/test_resources.py
@@ -1,0 +1,101 @@
+from mlflow.models.resources import (
+    DatabricksChatEndpoint,
+    DatabricksEmbeddingEndpoint,
+    DatabricksLLMEndpoint,
+    DatabricksVectorSearchEndpoint,
+    DatabricksVectorSearchIndexName,
+    _ResourceBuilder,
+)
+
+
+def test_llm_endpoint():
+    endpoint = DatabricksLLMEndpoint(endpoint_name="llm_server")
+    expected = {"databricks_llm_endpoint_name": ["llm_server"]}
+    assert endpoint.to_dict() == expected
+    assert _ResourceBuilder.from_resources([endpoint]) == expected
+
+    resources = [
+        DatabricksLLMEndpoint(endpoint_name="llm_server"),
+        DatabricksLLMEndpoint(endpoint_name="llm_server2"),
+    ]
+    expected = {"databricks_llm_endpoint_name": ["llm_server", "llm_server2"]}
+    assert _ResourceBuilder.from_resources(resources) == expected
+
+
+def test_chat_endpoint():
+    endpoint = DatabricksChatEndpoint(endpoint_name="chat_server")
+    expected = {"databricks_chat_endpoint_name": ["chat_server"]}
+    assert endpoint.to_dict() == expected
+    assert _ResourceBuilder.from_resources([endpoint]) == expected
+
+    resources = [
+        DatabricksChatEndpoint(endpoint_name="chat_server"),
+        DatabricksChatEndpoint(endpoint_name="chat_server2"),
+    ]
+    expected = {"databricks_chat_endpoint_name": ["chat_server", "chat_server2"]}
+    assert _ResourceBuilder.from_resources(resources) == expected
+
+
+def test_embedding_endpoint():
+    endpoint = DatabricksEmbeddingEndpoint(endpoint_name="embedding_server")
+    expected = {"databricks_embeddings_endpoint_name": ["embedding_server"]}
+    assert endpoint.to_dict() == expected
+    assert _ResourceBuilder.from_resources([endpoint]) == expected
+
+    resources = [
+        DatabricksEmbeddingEndpoint(endpoint_name="embedding_server"),
+        DatabricksEmbeddingEndpoint(endpoint_name="embedding_server2"),
+    ]
+    expected = {"databricks_embeddings_endpoint_name": ["embedding_server", "embedding_server2"]}
+    assert _ResourceBuilder.from_resources(resources) == expected
+
+
+def test_vector_search_endpoint():
+    endpoint = DatabricksVectorSearchEndpoint(endpoint_name="search_server")
+    expected = {"databricks_vector_search_endpoint_name": ["search_server"]}
+    assert endpoint.to_dict() == expected
+    assert _ResourceBuilder.from_resources([endpoint]) == expected
+
+    resources = [
+        DatabricksVectorSearchEndpoint(endpoint_name="search_server"),
+        DatabricksVectorSearchEndpoint(endpoint_name="search_server2"),
+    ]
+    expected = {"databricks_vector_search_endpoint_name": ["search_server", "search_server2"]}
+    assert _ResourceBuilder.from_resources(resources) == expected
+
+
+def test_index_name():
+    index = DatabricksVectorSearchIndexName(index_name="index1")
+    expected = {"databricks_vector_search_index_name": ["index1"]}
+    assert index.to_dict() == expected
+    assert _ResourceBuilder.from_resources([index]) == expected
+
+    resources = [
+        DatabricksVectorSearchIndexName(index_name="index1"),
+        DatabricksVectorSearchIndexName(index_name="index2"),
+    ]
+    expected = {"databricks_vector_search_index_name": ["index1", "index2"]}
+    assert _ResourceBuilder.from_resources(resources) == expected
+
+
+def test_resources():
+    resources = [
+        DatabricksVectorSearchIndexName(index_name="rag.studio_bugbash.databricks_docs_index"),
+        DatabricksVectorSearchEndpoint(endpoint_name="azure-eastus-model-serving-2_vs_endpoint"),
+        DatabricksEmbeddingEndpoint(endpoint_name="databricks-bge-large-en"),
+        DatabricksLLMEndpoint(endpoint_name="llm-endpoint"),
+        DatabricksChatEndpoint(endpoint_name="databricks-mixtral-8x7b-instruct"),
+        DatabricksChatEndpoint(endpoint_name="databricks-llama-8x7b-instruct"),
+    ]
+    expected = {
+        "databricks_vector_search_index_name": ["rag.studio_bugbash.databricks_docs_index"],
+        "databricks_vector_search_endpoint_name": ["azure-eastus-model-serving-2_vs_endpoint"],
+        "databricks_embeddings_endpoint_name": ["databricks-bge-large-en"],
+        "databricks_llm_endpoint_name": ["llm-endpoint"],
+        "databricks_chat_endpoint_name": [
+            "databricks-mixtral-8x7b-instruct",
+            "databricks-llama-8x7b-instruct",
+        ],
+    }
+
+    assert _ResourceBuilder.from_resources(resources) == expected

--- a/tests/models/test_resources.py
+++ b/tests/models/test_resources.py
@@ -1,4 +1,5 @@
 from mlflow.models.resources import (
+    DEFAULT_API_VERSION,
     DatabricksServingEndpoint,
     DatabricksVectorSearchIndex,
     _ResourceBuilder,
@@ -9,14 +10,20 @@ def test_serving_endpoint():
     endpoint = DatabricksServingEndpoint(endpoint_name="llm_server")
     expected = {"serving_endpoint": [{"name": "llm_server"}]}
     assert endpoint.to_dict() == expected
-    assert _ResourceBuilder.from_resources([endpoint]) == {"databricks": expected}
+    assert _ResourceBuilder.from_resources([endpoint]) == {
+        "api_version": DEFAULT_API_VERSION,
+        "databricks": expected,
+    }
 
 
 def test_index_name():
     index = DatabricksVectorSearchIndex(index_name="index1")
     expected = {"vector_search_index": [{"name": "index1"}]}
     assert index.to_dict() == expected
-    assert _ResourceBuilder.from_resources([index]) == {"databricks": expected}
+    assert _ResourceBuilder.from_resources([index]) == {
+        "api_version": DEFAULT_API_VERSION,
+        "databricks": expected,
+    }
 
 
 def test_resources():
@@ -26,13 +33,14 @@ def test_resources():
         DatabricksServingEndpoint(endpoint_name="databricks-llama-8x7b-instruct"),
     ]
     expected = {
+        "api_version": DEFAULT_API_VERSION,
         "databricks": {
             "vector_search_index": [{"name": "rag.studio_bugbash.databricks_docs_index"}],
             "serving_endpoint": [
                 {"name": "databricks-mixtral-8x7b-instruct"},
                 {"name": "databricks-llama-8x7b-instruct"},
             ],
-        }
+        },
     }
 
     assert _ResourceBuilder.from_resources(resources) == expected

--- a/tests/models/test_resources.py
+++ b/tests/models/test_resources.py
@@ -1,101 +1,38 @@
 from mlflow.models.resources import (
-    DatabricksChatEndpoint,
-    DatabricksEmbeddingEndpoint,
-    DatabricksLLMEndpoint,
-    DatabricksVectorSearchEndpoint,
-    DatabricksVectorSearchIndexName,
+    DatabricksServingEndpoint,
+    DatabricksVectorSearchIndex,
     _ResourceBuilder,
 )
 
 
-def test_llm_endpoint():
-    endpoint = DatabricksLLMEndpoint(endpoint_name="llm_server")
-    expected = {"databricks_llm_endpoint_name": ["llm_server"]}
+def test_serving_endpoint():
+    endpoint = DatabricksServingEndpoint(endpoint_name="llm_server")
+    expected = {"serving_endpoint": [{"name": "llm_server"}]}
     assert endpoint.to_dict() == expected
-    assert _ResourceBuilder.from_resources([endpoint]) == expected
-
-    resources = [
-        DatabricksLLMEndpoint(endpoint_name="llm_server"),
-        DatabricksLLMEndpoint(endpoint_name="llm_server2"),
-    ]
-    expected = {"databricks_llm_endpoint_name": ["llm_server", "llm_server2"]}
-    assert _ResourceBuilder.from_resources(resources) == expected
-
-
-def test_chat_endpoint():
-    endpoint = DatabricksChatEndpoint(endpoint_name="chat_server")
-    expected = {"databricks_chat_endpoint_name": ["chat_server"]}
-    assert endpoint.to_dict() == expected
-    assert _ResourceBuilder.from_resources([endpoint]) == expected
-
-    resources = [
-        DatabricksChatEndpoint(endpoint_name="chat_server"),
-        DatabricksChatEndpoint(endpoint_name="chat_server2"),
-    ]
-    expected = {"databricks_chat_endpoint_name": ["chat_server", "chat_server2"]}
-    assert _ResourceBuilder.from_resources(resources) == expected
-
-
-def test_embedding_endpoint():
-    endpoint = DatabricksEmbeddingEndpoint(endpoint_name="embedding_server")
-    expected = {"databricks_embeddings_endpoint_name": ["embedding_server"]}
-    assert endpoint.to_dict() == expected
-    assert _ResourceBuilder.from_resources([endpoint]) == expected
-
-    resources = [
-        DatabricksEmbeddingEndpoint(endpoint_name="embedding_server"),
-        DatabricksEmbeddingEndpoint(endpoint_name="embedding_server2"),
-    ]
-    expected = {"databricks_embeddings_endpoint_name": ["embedding_server", "embedding_server2"]}
-    assert _ResourceBuilder.from_resources(resources) == expected
-
-
-def test_vector_search_endpoint():
-    endpoint = DatabricksVectorSearchEndpoint(endpoint_name="search_server")
-    expected = {"databricks_vector_search_endpoint_name": ["search_server"]}
-    assert endpoint.to_dict() == expected
-    assert _ResourceBuilder.from_resources([endpoint]) == expected
-
-    resources = [
-        DatabricksVectorSearchEndpoint(endpoint_name="search_server"),
-        DatabricksVectorSearchEndpoint(endpoint_name="search_server2"),
-    ]
-    expected = {"databricks_vector_search_endpoint_name": ["search_server", "search_server2"]}
-    assert _ResourceBuilder.from_resources(resources) == expected
+    assert _ResourceBuilder.from_resources([endpoint]) == {"databricks": expected}
 
 
 def test_index_name():
-    index = DatabricksVectorSearchIndexName(index_name="index1")
-    expected = {"databricks_vector_search_index_name": ["index1"]}
+    index = DatabricksVectorSearchIndex(index_name="index1")
+    expected = {"vector_search_index": [{"name": "index1"}]}
     assert index.to_dict() == expected
-    assert _ResourceBuilder.from_resources([index]) == expected
-
-    resources = [
-        DatabricksVectorSearchIndexName(index_name="index1"),
-        DatabricksVectorSearchIndexName(index_name="index2"),
-    ]
-    expected = {"databricks_vector_search_index_name": ["index1", "index2"]}
-    assert _ResourceBuilder.from_resources(resources) == expected
+    assert _ResourceBuilder.from_resources([index]) == {"databricks": expected}
 
 
 def test_resources():
     resources = [
-        DatabricksVectorSearchIndexName(index_name="rag.studio_bugbash.databricks_docs_index"),
-        DatabricksVectorSearchEndpoint(endpoint_name="azure-eastus-model-serving-2_vs_endpoint"),
-        DatabricksEmbeddingEndpoint(endpoint_name="databricks-bge-large-en"),
-        DatabricksLLMEndpoint(endpoint_name="llm-endpoint"),
-        DatabricksChatEndpoint(endpoint_name="databricks-mixtral-8x7b-instruct"),
-        DatabricksChatEndpoint(endpoint_name="databricks-llama-8x7b-instruct"),
+        DatabricksVectorSearchIndex(index_name="rag.studio_bugbash.databricks_docs_index"),
+        DatabricksServingEndpoint(endpoint_name="databricks-mixtral-8x7b-instruct"),
+        DatabricksServingEndpoint(endpoint_name="databricks-llama-8x7b-instruct"),
     ]
     expected = {
-        "databricks_vector_search_index_name": ["rag.studio_bugbash.databricks_docs_index"],
-        "databricks_vector_search_endpoint_name": ["azure-eastus-model-serving-2_vs_endpoint"],
-        "databricks_embeddings_endpoint_name": ["databricks-bge-large-en"],
-        "databricks_llm_endpoint_name": ["llm-endpoint"],
-        "databricks_chat_endpoint_name": [
-            "databricks-mixtral-8x7b-instruct",
-            "databricks-llama-8x7b-instruct",
-        ],
+        "databricks": {
+            "vector_search_index": [{"name": "rag.studio_bugbash.databricks_docs_index"}],
+            "serving_endpoint": [
+                {"name": "databricks-mixtral-8x7b-instruct"},
+                {"name": "databricks-llama-8x7b-instruct"},
+            ],
+        }
     }
 
     assert _ResourceBuilder.from_resources(resources) == expected


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sunishsheth2009/mlflow/pull/11804?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11804/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11804
```

</p>
</details>

### What changes are proposed in this pull request?
[MLflow] Adding resources class to define resources required to serve a model
Pending work:
- [ ] Add a simple function to take a yaml file and return a list of resources
- [ ] Add support to define resources for a pyfunc model
- [ ] Update langchain to reuse resources class
- [ ] Update langchain to not add resources in the flavor, rather add it as a top level entity

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
