### PR TITLE
Fix protobuf requirement

### DIFF
--- a/pyproject.skinny.toml
+++ b/pyproject.skinny.toml
@@ -28,7 +28,7 @@ dependencies = [
   "gitpython<4,>=3.1.9",
   "importlib_metadata<8,>=3.7.0,!=4.7.0",
   "packaging<25",
-  "protobuf<6,>=3.12.0",
+  "protobuf<5,>=3.12.0",
   "pytz<2025",
   "pyyaml<7,>=5.1",
   "requests<3,>=2.17.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "numpy<2",
   "packaging<25",
   "pandas<3",
-  "protobuf<6,>=3.12.0",
+  "protobuf<5,>=3.12.0",
   "pyarrow<16,>=4.0.0",
   "pytz<2025",
   "pyyaml<7,>=5.1",

--- a/requirements/skinny-requirements.txt
+++ b/requirements/skinny-requirements.txt
@@ -7,7 +7,7 @@ cloudpickle<4
 entrypoints<1
 gitpython<4,>=3.1.9
 pyyaml<7,>=5.1
-protobuf<6,>=3.12.0
+protobuf<5,>=3.12.0
 pytz<2025
 requests<3,>=2.17.3
 packaging<25

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -30,7 +30,7 @@ pyyaml:
 protobuf:
   pip_release: protobuf
   minimum: "3.12.0"
-  max_major_version: 5
+  max_major_version: 4
 
 pytz:
   pip_release: pytz


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/11816?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11816/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11816
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #11811

I confirmed that this is indeed a problem when using protobuf without C descriptors:

```
$ export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
$ pip install protobuf==5.26.1
$ python

>>> import mlflow

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/daniel.lok/anaconda3/envs/fresh-env/lib/python3.9/site-packages/mlflow/__init__.py", line 34, in <module>
    from mlflow import (
  File "/Users/daniel.lok/anaconda3/envs/fresh-env/lib/python3.9/site-packages/mlflow/artifacts/__init__.py", line 9, in <module>
    from mlflow.exceptions import MlflowException
  File "/Users/daniel.lok/anaconda3/envs/fresh-env/lib/python3.9/site-packages/mlflow/exceptions.py", line 4, in <module>
    from mlflow.protos.databricks_pb2 import (
  File "/Users/daniel.lok/anaconda3/envs/fresh-env/lib/python3.9/site-packages/mlflow/protos/databricks_pb2.py", line 17, in <module>
    from .scalapb import scalapb_pb2 as scalapb_dot_scalapb__pb2
  File "/Users/daniel.lok/anaconda3/envs/fresh-env/lib/python3.9/site-packages/mlflow/protos/scalapb/scalapb_pb2.py", line 53, in <module>
    google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(options)
AttributeError: type object 'FileOptions' has no attribute 'RegisterExtension'
```

It looks like protobuf 5.x only got released last month: https://pypi.org/project/protobuf/#history

This might be why we didn't catch it earlier.

### What changes are proposed in this pull request?

Change protobuf requirement to <5

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Confirmed that it doesn't throw with `protobuf==4.25.3`

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
