### PR TITLE
[Langchain autologging improvement - 2] Patch stream method

### DIFF
--- a/docs/source/llms/langchain/index.rst
+++ b/docs/source/llms/langchain/index.rst
@@ -218,3 +218,17 @@ I can't load the model logged by mlflow langchain autologging
     For certain models that LangChain does not support native saving or loading, we will pickle the object when saving it. Due to this functionality, your cloudpickle version must be 
     consistent between the saving and loading environments to ensure that object references resolve properly. For further guarantees of correct object representation, you should ensure that your
     environment has `pydantic` installed with at least version 2. 
+
+MLflow langchain autologging callback support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **Model inference without callbacks**:
+
+    If you invoke your model with `invoke`, `__call__`, `batch`, `stream` or `get_relevant_documents`(for BaseRetriever) functions, MLflow autologging will inject
+    mlflow callback into the inference call to collect metrics and artifacts that can be generated from the call chain.
+
+- **Model inference with user-specified callbacks**:
+
+    If your inference call already include callbacks in the config, e.g. `model.invoke(input, config=RunnableConfig(callbacks=customer_callbacks))`, then MLflow autologging
+    still preserves your callbacks and injects mlflow callback after them. `RunnableConfig callbacks parameter <https://github.com/langchain-ai/langchain/blob/6ccecf23639ef5cbebcbc4eaeda99eb1f7b84deb/libs/core/langchain_core/callbacks/base.py#L636>`_ 
+    supports both `BaseCallbackManager` or `List[BaseCallbackHandler]`, in either case MLflow autologging can inject mlflow callback into existing callbacks.

--- a/docs/source/llms/langchain/index.rst
+++ b/docs/source/llms/langchain/index.rst
@@ -225,10 +225,10 @@ MLflow langchain autologging callback support
 - **Model inference without callbacks**:
 
     If you invoke your model with `invoke`, `__call__`, `batch`, `stream` or `get_relevant_documents` (for BaseRetriever) functions, MLflow autologging will inject
-    mlflow callback into the inference call to collect metrics and artifacts that can be generated from the call chain.
+    a callback into the inference call to collect metrics and artifacts that can be generated from the call chain.
 
 - **Model inference with user-specified callbacks**:
 
-    If your inference call already include callbacks in the config, e.g. `model.invoke(input, config=RunnableConfig(callbacks=customer_callbacks))`, then MLflow autologging
-    still preserves your callbacks and injects mlflow callback after them. `RunnableConfig callbacks parameter <https://github.com/langchain-ai/langchain/blob/6ccecf23639ef5cbebcbc4eaeda99eb1f7b84deb/libs/core/langchain_core/callbacks/base.py#L636>`_ 
-    supports both `BaseCallbackManager` or `List[BaseCallbackHandler]`, in either case MLflow autologging can inject mlflow callback into existing callbacks.
+    If your inference call already includes callbacks in the config, e.g. `model.invoke(input, config=RunnableConfig(callbacks=customer_callbacks))`, then MLflow autologging
+    still preserves your callbacks and appends a callback after them. `RunnableConfig callbacks parameter <https://github.com/langchain-ai/langchain/blob/6ccecf23639ef5cbebcbc4eaeda99eb1f7b84deb/libs/core/langchain_core/callbacks/base.py#L636>`_ 
+    supports both `BaseCallbackManager` or `List[BaseCallbackHandler]`, in either case MLflow autologging appends a callback to collect metrics and artifacts.

--- a/docs/source/llms/langchain/index.rst
+++ b/docs/source/llms/langchain/index.rst
@@ -219,16 +219,16 @@ I can't load the model logged by mlflow langchain autologging
     consistent between the saving and loading environments to ensure that object references resolve properly. For further guarantees of correct object representation, you should ensure that your
     environment has `pydantic` installed with at least version 2. 
 
-MLflow langchain autologging callback support
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+How does MLflow langchain autologging interact with callbacks?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- **Model inference without callbacks**:
+- **Model inference with default callbacks**:
 
-    If you invoke your model with `invoke`, `__call__`, `batch`, `stream` or `get_relevant_documents` (for BaseRetriever) functions, MLflow autologging will inject
+    If you invoke a langchain model with `invoke`, `__call__`, `batch`, `stream` or `get_relevant_documents` (for BaseRetriever) functions directly, MLflow autologging will inject
     a callback into the inference call to collect metrics and artifacts that can be generated from the call chain.
 
 - **Model inference with user-specified callbacks**:
 
     If your inference call already includes callbacks in the config, e.g. `model.invoke(input, config=RunnableConfig(callbacks=customer_callbacks))`, then MLflow autologging
-    still preserves your callbacks and appends a callback after them. `RunnableConfig callbacks parameter <https://github.com/langchain-ai/langchain/blob/6ccecf23639ef5cbebcbc4eaeda99eb1f7b84deb/libs/core/langchain_core/callbacks/base.py#L636>`_ 
+    still preserves your callbacks and appends a callback after them. `RunnableConfig callbacks parameter <https://api.python.langchain.com/en/latest/runnables/langchain_core.runnables.config.RunnableConfig.html#langchain_core.runnables.config.RunnableConfig>`_ 
     supports both `BaseCallbackManager` or `List[BaseCallbackHandler]`, in either case MLflow autologging appends a callback to collect metrics and artifacts.

--- a/docs/source/llms/langchain/index.rst
+++ b/docs/source/llms/langchain/index.rst
@@ -224,7 +224,7 @@ MLflow langchain autologging callback support
 
 - **Model inference without callbacks**:
 
-    If you invoke your model with `invoke`, `__call__`, `batch`, `stream` or `get_relevant_documents`(for BaseRetriever) functions, MLflow autologging will inject
+    If you invoke your model with `invoke`, `__call__`, `batch`, `stream` or `get_relevant_documents` (for BaseRetriever) functions, MLflow autologging will inject
     mlflow callback into the inference call to collect metrics and artifacts that can be generated from the call chain.
 
 - **Model inference with user-specified callbacks**:

--- a/mlflow/langchain/__init__.py
+++ b/mlflow/langchain/__init__.py
@@ -998,6 +998,13 @@ def autolog(
                 functools.partial(patched_inference, "batch"),
             )
 
+            safe_patch(
+                FLAVOR_NAME,
+                cls,
+                "stream",
+                functools.partial(patched_inference, "stream"),
+            )
+
         for cls in [AgentExecutor, Chain]:
             safe_patch(
                 FLAVOR_NAME,

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pandas as pd
 import pytest
-from langchain.chains import LLMChain
+from langchain.chains.llm import LLMChain
 from langchain.document_loaders import TextLoader
 from langchain.llms import OpenAI
 from langchain.prompts import PromptTemplate
@@ -786,3 +786,37 @@ def test_langchain_autolog_callback_injection_in_batch(invoke_arg, generate_conf
         assert sorted(callbacks.handlers[0].logs) == expected_logs
     else:
         assert sorted(callbacks[0].logs) == expected_logs
+
+
+@pytest.mark.parametrize("invoke_arg", ["args", "kwargs"])
+@pytest.mark.parametrize(
+    "generate_config",
+    [
+        lambda: RunnableConfig(callbacks=[CustomCallbackHandler()]),
+        lambda: RunnableConfig(callbacks=BaseCallbackManager([CustomCallbackHandler()])),
+    ],
+)
+def test_langchain_autolog_callback_injection_in_stream(invoke_arg, generate_config):
+    mlflow.langchain.autolog(log_models=True, extra_tags={"test_tag": "test"})
+    config = generate_config()
+    with mlflow.start_run() as run, _mock_request(return_value=_mock_chat_completion_response()):
+        model = create_openai_llmchain()
+        # convert iterator to list to materialize the stream compute
+        if invoke_arg == "args":
+            list(model.stream("MLflow", config))
+        elif invoke_arg == "kwargs":
+            list(model.stream("MLflow", config=config))
+    run_data = MlflowClient().get_run(run.info.run_id).data
+    assert run_data.metrics["chain_starts"] == 1
+    assert run_data.metrics["chain_ends"] == 1
+    assert run_data.tags["test_tag"] == "test"
+    assert run_data.tags["mlflow.autologging"] == "langchain"
+    artifacts = get_artifacts(run.info.run_id)
+    for artifact_name in ["chain_start_1.json", "chain_end_1.json"]:
+        assert artifact_name in artifacts
+    callbacks = config["callbacks"]
+    expected_logs = ["chain_start", "chain_end"]
+    if isinstance(callbacks, BaseCallbackManager):
+        assert callbacks.handlers[0].logs == expected_logs
+    else:
+        assert callbacks[0].logs == expected_logs

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -803,9 +803,9 @@ def test_langchain_autolog_callback_injection_in_stream(invoke_arg, generate_con
         model = create_openai_llmchain()
         # convert iterator to list to materialize the stream compute
         if invoke_arg == "args":
-            list(model.stream("MLflow", config))
+            next(model.stream("MLflow", config))
         elif invoke_arg == "kwargs":
-            list(model.stream("MLflow", config=config))
+            next(model.stream("MLflow", config=config))
     run_data = MlflowClient().get_run(run.info.run_id).data
     assert run_data.metrics["chain_starts"] == 1
     assert run_data.metrics["chain_ends"] == 1


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/11820?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11820/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11820
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Patch `stream` method and inject mlflow callbacks.
Output of stream function is a generator, we skip logging inputs&outputs for this because once we switch to tracing the log_inputs_outputs function can be replaced. Supporting generator output logging is more effort, and the inner type within generator is not known for different models, tracing can handle it more accurately and correctly.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
