### PR TITLE
Add active run ID as trace `mlflow.sourceRun`  tag

### DIFF
--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -27,6 +27,3 @@ TRUNCATION_SUFFIX = "..."
 
 # Trace request ID must have the prefix "tr-" appended to the OpenTelemetry trace ID
 TRACE_REQUEST_ID_PREFIX = "tr-"
-
-# A set of trace tags that cannot be updated by the user
-IMMUTABLE_TRACE_TAGS = {"mlflow.user", "mlflow.artifactLocation"}

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -8,6 +8,7 @@ class TraceMetadataKey:
 
 class TraceTagKey:
     TRACE_NAME = "mlflow.traceName"
+    SOURCE_RUN = "mlflow.sourceRun"
 
 
 # A set of reserved attribute keys
@@ -26,3 +27,6 @@ TRUNCATION_SUFFIX = "..."
 
 # Trace request ID must have the prefix "tr-" appended to the OpenTelemetry trace ID
 TRACE_REQUEST_ID_PREFIX = "tr-"
+
+# A set of trace tags that cannot be updated by the user
+IMMUTABLE_TRACE_TAGS = {"mlflow.user", "mlflow.artifactLocation"}

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -66,8 +66,8 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         tags = {}
 
         # If the span is started within an active MLflow run, we should record it as a trace tag
-        if mlflow.active_run():
-            tags[TraceTagKey.SOURCE_RUN] = mlflow.active_run().info.run_id
+        if run := mlflow.active_run():
+            tags[TraceTagKey.SOURCE_RUN] = run.info.run_id
 
         try:
             return self._client._start_tracked_trace(

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -7,6 +7,7 @@ from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
 from opentelemetry.sdk.trace import Span as OTelSpan
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter
 
+import mlflow
 from mlflow.entities.trace import Trace
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
@@ -59,13 +60,20 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         span.set_attribute(SpanAttributeKey.REQUEST_ID, json.dumps(request_id))
 
     def _create_trace_info(self, span: OTelSpan) -> TraceInfo:
+        experiment_id = (
+            get_otel_attribute(span, SpanAttributeKey.EXPERIMENT_ID) or _get_experiment_id()
+        )
+        tags = {}
+
+        # If the span is started within an active MLflow run, we should record it as a trace tag
+        if mlflow.active_run():
+            tags[TraceTagKey.SOURCE_RUN] = mlflow.active_run().info.run_id
+
         try:
-            experiment_id = (
-                get_otel_attribute(span, SpanAttributeKey.EXPERIMENT_ID) or _get_experiment_id()
-            )
             return self._client._start_tracked_trace(
                 experiment_id=experiment_id,
-                timestamp_ms=span.start_time // 1_000_000,  # nanosecond to millisecond
+                timestamp_ms=span.start_time // 1_000_000,  # nanosecond to millisecond,
+                tags=tags,
             )
 
         # TODO: This catches all exceptions from the tracking server so the in-memory tracing still
@@ -84,6 +92,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
             timestamp_ms=span.start_time // 1_000_000,  # nanosecond to millisecond
             execution_time_ms=None,
             status=TraceStatus.IN_PROGRESS,
+            tags=tags,
         )
 
     def on_end(self, span: OTelReadableSpan) -> None:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -55,7 +55,7 @@ from mlflow.store.model_registry import (
     SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
 )
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT, SEARCH_TRACES_DEFAULT_MAX_RESULTS
-from mlflow.tracing.constant import IMMUTABLE_TRACE_TAGS, TRACE_REQUEST_ID_PREFIX, SpanAttributeKey
+from mlflow.tracing.constant import TRACE_REQUEST_ID_PREFIX, SpanAttributeKey
 from mlflow.tracing.display import get_display_handler
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import get_otel_attribute
@@ -72,6 +72,7 @@ from mlflow.utils.async_logging.run_operations import RunOperations
 from mlflow.utils.databricks_utils import get_databricks_run_url
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.mlflow_tags import (
+    IMMUTABLE_TAGS,
     MLFLOW_LOGGED_ARTIFACTS,
     MLFLOW_LOGGED_IMAGES,
     MLFLOW_PARENT_RUN_ID,
@@ -875,7 +876,7 @@ class MlflowClient:
 
     def _exclude_immutable_tags(self, tags: Dict[str, str]) -> Dict[str, str]:
         """Exclude immutable tags e.g. "mlflow.user" from the given tags."""
-        return {k: v for k, v in tags.items() if k not in IMMUTABLE_TRACE_TAGS}
+        return {k: v for k, v in tags.items() if k not in IMMUTABLE_TAGS}
 
     def set_trace_tag(self, request_id: str, key: str, value: str):
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -55,7 +55,7 @@ from mlflow.store.model_registry import (
     SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
 )
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT, SEARCH_TRACES_DEFAULT_MAX_RESULTS
-from mlflow.tracing.constant import TRACE_REQUEST_ID_PREFIX, SpanAttributeKey
+from mlflow.tracing.constant import IMMUTABLE_TRACE_TAGS, TRACE_REQUEST_ID_PREFIX, SpanAttributeKey
 from mlflow.tracing.display import get_display_handler
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import get_otel_attribute
@@ -875,7 +875,7 @@ class MlflowClient:
 
     def _exclude_immutable_tags(self, tags: Dict[str, str]) -> Dict[str, str]:
         """Exclude immutable tags e.g. "mlflow.user" from the given tags."""
-        return {k: v for k, v in tags.items() if not k.startswith("mlflow.")}
+        return {k: v for k, v in tags.items() if k not in IMMUTABLE_TRACE_TAGS}
 
     def set_trace_tag(self, request_id: str, key: str, value: str):
         """

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -10,6 +10,7 @@ MLFLOW_EXPERIMENT_SOURCE_TYPE = "mlflow.experiment.sourceType"
 MLFLOW_RUN_NAME = "mlflow.runName"
 MLFLOW_RUN_NOTE = "mlflow.note.content"
 MLFLOW_PARENT_RUN_ID = "mlflow.parentRunId"
+MLFLOW_ARTIFACT_LOCATION = "mlflow.artifactLocation"
 MLFLOW_USER = "mlflow.user"
 MLFLOW_SOURCE_TYPE = "mlflow.source.type"
 MLFLOW_RECIPE_TEMPLATE_NAME = "mlflow.pipeline.template.name"
@@ -77,6 +78,9 @@ MLFLOW_EXPERIMENT_PRIMARY_METRIC_GREATER_IS_BETTER = (
 
 # For automatic model checkpointing
 LATEST_CHECKPOINT_ARTIFACT_TAG_KEY = "mlflow.latest_checkpoint_artifact"
+
+# A set of tags that cannot be updated by the user
+IMMUTABLE_TAGS = {MLFLOW_USER, MLFLOW_ARTIFACT_LOCATION}
 
 
 def _get_run_name_from_tags(tags):

--- a/tests/tracing/processor/test_mlflow_processor.py
+++ b/tests/tracing/processor/test_mlflow_processor.py
@@ -27,7 +27,9 @@ def test_on_start(clear_singleton):
 
     processor.on_start(span)
 
-    mock_client._start_tracked_trace.assert_called_once_with(experiment_id="0", timestamp_ms=5)
+    mock_client._start_tracked_trace.assert_called_once_with(
+        experiment_id="0", timestamp_ms=5, tags={}
+    )
     assert span.attributes.get(SpanAttributeKey.REQUEST_ID) == json.dumps(_REQUEST_ID)
     assert _REQUEST_ID in InMemoryTraceManager.get_instance()._traces
 
@@ -59,6 +61,7 @@ def test_on_start_with_experiment_id(clear_singleton):
     mock_client._start_tracked_trace.assert_called_once_with(
         experiment_id=experiment_id,
         timestamp_ms=5,
+        tags={},
     )
     assert span.attributes.get(SpanAttributeKey.REQUEST_ID) == json.dumps(_REQUEST_ID)
     assert _REQUEST_ID in InMemoryTraceManager.get_instance()._traces
@@ -75,7 +78,9 @@ def test_on_start_fallback_to_client_side_request_id(clear_singleton):
 
     processor.on_start(span)
 
-    mock_client._start_tracked_trace.assert_called_once_with(experiment_id="0", timestamp_ms=5)
+    mock_client._start_tracked_trace.assert_called_once_with(
+        experiment_id="0", timestamp_ms=5, tags={}
+    )
     # When the backend returns an error, the request_id is generated at client side from trace_id
     expected_request_id = encode_trace_id(_TRACE_ID)
     assert span.attributes.get(SpanAttributeKey.REQUEST_ID) == json.dumps(expected_request_id)

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -47,7 +47,8 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_USER,
 )
 
-from tests.tracing.conftest import _mock_end_trace, _mock_start_trace, clear_singleton  # noqa: F401
+from tests.tracing.conftest import clear_singleton  # noqa: F401
+from tests.tracing.conftest import mock_store as mock_store_for_tracing  # noqa: F401
 from tests.tracing.helper import create_test_trace_info
 
 
@@ -281,7 +282,8 @@ def test_client_delete_traces(mock_store):
     )
 
 
-def test_start_and_end_trace(clear_singleton):
+@pytest.mark.parametrize("with_active_run", [True, False])
+def test_start_and_end_trace(clear_singleton, with_active_run):
     class TestModel:
         def __init__(self):
             self._client = MlflowClient()
@@ -337,7 +339,12 @@ def test_start_and_end_trace(clear_singleton):
             return res
 
     model = TestModel()
-    model.predict(1, 2)
+    if with_active_run:
+        with mlflow.start_run() as run:
+            model.predict(1, 2)
+            run_id = run.info.run_id
+    else:
+        model.predict(1, 2)
 
     traces = mlflow.get_traces()
     assert len(traces) == 1
@@ -348,6 +355,8 @@ def test_start_and_end_trace(clear_singleton):
     assert trace_info.status == TraceStatus.OK
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
     assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == '{"output": 25}'
+    if with_active_run:
+        assert trace_info.tags["mlflow.sourceRun"] == run_id
 
     trace_data = traces[0].data
     assert trace_data.request == '{"x": 1, "y": 2}'
@@ -457,12 +466,17 @@ def test_start_and_end_trace_before_all_span_end(clear_singleton):
 
 
 @mock.patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
-def test_log_trace_with_databricks_tracking_uri(clear_singleton, mock_store, monkeypatch):
+def test_log_trace_with_databricks_tracking_uri(
+    clear_singleton, mock_store_for_tracing, monkeypatch
+):
     monkeypatch.setenv("MLFLOW_EXPERIMENT_NAME", "test")
-    mock_store.get_experiment_by_name().experiment_id = "test_experiment_id"
-
-    mock_store.start_trace.side_effect = _mock_start_trace
-    mock_store.end_trace.side_effect = _mock_end_trace
+    mock_experiment = mock.MagicMock()
+    mock_experiment.experiment_id = "test_experiment_id"
+    monkeypatch.setattr(
+        mock_store_for_tracing,
+        "get_experiment_by_name",
+        mock.MagicMock(return_value=mock_experiment),
+    )
 
     class TestModel:
         def __init__(self):
@@ -525,8 +539,8 @@ def test_log_trace_with_databricks_tracking_uri(clear_singleton, mock_store, mon
     assert trace_data.response == "5"
     assert len(trace_data.spans) == 2
 
-    mock_store.start_trace.assert_called_once()
-    mock_store.end_trace.assert_called_once()
+    mock_store_for_tracing.start_trace.assert_called_once()
+    mock_store_for_tracing.end_trace.assert_called_once()
     mock_upload_trace_data.assert_called_once()
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11821?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11821/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11821
```

</p>
</details>

### What changes are proposed in this pull request?

Record the active run ID in `mlflow.sourceRun` tag if the trace is created within the context of a run.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```
import mlflow
from mlflow.tracking.client import MlflowClient
from mlflow.tracking.fluent import _get_experiment_id

with mlflow.start_run(run_name="run_with_span") as run:
    with mlflow.start_span(name="span") as span:
        span.set_inputs({"x": 1})
        span.set_outputs(10)
    print(f"Run ID: {run.info.run_id}")

> Run ID: d88960eb19c6495c9975b0e149bea699

mlflow.get_traces()[-1].info.tags

> {'mlflow.sourceRun': 'd88960eb19c6495c9975b0e149bea699', ... }
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
