### PR TITLE
Improve `dev/check_patch_prs.py`

### DIFF
--- a/dev/check_patch_prs.py
+++ b/dev/check_patch_prs.py
@@ -66,7 +66,7 @@ def fetch_patch_prs(version):
             break
         page += 1
 
-    return {pr["number"]: pr["pull_request"].get("merged_at") is not None for pr in data["items"]}
+    return {pr["number"]: pr["pull_request"].get("merged_at") is not None for pr in pulls}
 
 
 @click.command()

--- a/dev/check_patch_prs.py
+++ b/dev/check_patch_prs.py
@@ -1,6 +1,7 @@
 import re
 import subprocess
 import sys
+from dataclasses import dataclass
 
 import click
 import requests
@@ -11,28 +12,39 @@ def get_release_branch(version):
     return f"branch-{major_minor_version}"
 
 
-def get_merged_prs(version):
+@dataclass(frozen=True)
+class Commit:
+    sha: str
+    pr_num: int
+
+
+def get_commits(branch: str):
     """
-    Get the PRs merged into the release branch for the given version.
+    Get the commits in the release branch.
     """
-    release_branch = get_release_branch(version)
-    commits = subprocess.check_output(
+    log_stdout = subprocess.check_output(
         [
             "git",
             "log",
-            release_branch,
-            '--since="2 months ago"',
-            "--pretty=format:%s",
+            branch,
+            '--since="3 months ago"',
+            "--pretty=format:%H %s",
         ],
         text=True,
     )
-    pr_rgx = re.compile(r"\s+\(#(\d+)\)$")
-    prs = set()
-    for commit in commits.splitlines():
-        if pr := pr_rgx.search(commit.rstrip()):
-            prs.add(int(pr.group(1)))
+    pr_rgx = re.compile(r"([a-z0-9]+) .+\s+\(#(\d+)\)$")
+    commits = []
+    for commit in log_stdout.splitlines():
+        if m := pr_rgx.search(commit.rstrip()):
+            commits.append(Commit(sha=m.group(1), pr_num=int(m.group(2))))
 
-    return prs
+    return commits
+
+
+@dataclass(frozen=True)
+class PR:
+    pr_num: int
+    merged: bool
 
 
 def fetch_patch_prs(version):
@@ -40,25 +52,40 @@ def fetch_patch_prs(version):
     Fetch PRs labeled with `patch-{version}` from the MLflow repository.
     """
     label = f"patch-{version}"
-    response = requests.get(
-        f'https://api.github.com/search/issues?q=is:pr+repo:mlflow/mlflow+label:"{label}"'
-    )
-    response.raise_for_status()
-    data = response.json()
-    return {pr["number"] for pr in data["items"]}
+    per_page = 100
+    page = 1
+    pulls = []
+    while True:
+        response = requests.get(
+            f'https://api.github.com/search/issues?q=is:pr+repo:mlflow/mlflow+label:"{label}"&per_page={per_page}&page={page}',
+        )
+        response.raise_for_status()
+        data = response.json()
+        pulls.extend(data["items"])
+        if len(data) < per_page:
+            break
+        page += 1
+
+    return {pr["number"]: pr["pull_request"].get("merged_at") is not None for pr in data["items"]}
 
 
 @click.command()
 @click.option("--version", required=True, help="The version to release")
 def main(version):
-    prs = get_merged_prs(version)
+    release_branch = get_release_branch(version)
+    commits = get_commits(release_branch)
     patch_prs = fetch_patch_prs(version)
-    if not_cherry_picked := patch_prs - prs:
-        branch = get_release_branch(version)
-        click.echo(f"The following patch PRs are not cherry-picked to {branch}:")
-        for pr_num in sorted(not_cherry_picked):
-            url = f"https://github.com/mlflow/mlflow/pull/{pr_num}"
-            click.echo(f"  - {url}")
+    if not_cherry_picked := set(patch_prs) - {c.pr_num for c in commits}:
+        click.echo(f"The following patch PRs are not cherry-picked to {release_branch}:")
+        for idx, pr_num in enumerate(sorted(not_cherry_picked)):
+            url = f"https://github.com/mlflow/mlflow/pull/{pr_num} (merged: {patch_prs[pr_num]})"
+            click.echo(f"  {idx + 1}. {url}")
+
+        master_commits = get_commits("master")
+        cherry_picks = [c.sha for c in master_commits if c.pr_num in not_cherry_picked]
+        # reverse the order of cherry-picks to maintain the order of PRs
+        print("\nTo cherry-pick the above commits, run:")
+        print("git cherry-pick " + " ".join(cherry_picks[::-1]))
         sys.exit(1)
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/11826?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11826/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11826
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Makes the following updates:

- Print out the command for cherry-pick.
- Use pagination to fetch PRs.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
