### PR TITLE
MLflow evaluate: don't require the user to specify predictions or model in order to use custom evaluators

### DIFF
--- a/mlflow/data/spark_dataset.py
+++ b/mlflow/data/spark_dataset.py
@@ -211,6 +211,7 @@ class SparkDataset(Dataset, PyFuncConvertibleDatasetMixin):
             targets=self._targets,
             path=path,
             feature_names=feature_names,
+            predictions=self._predictions,
         )
 
 

--- a/mlflow/data/spark_dataset.py
+++ b/mlflow/data/spark_dataset.py
@@ -46,7 +46,7 @@ class SparkDataset(Dataset, PyFuncConvertibleDatasetMixin):
             )
         if predictions is not None and predictions not in df.columns:
             raise MlflowException(
-                f"The specified Spark DataFrame does not contain the specified predictions column"
+                f"The specified Spark dataset does not contain the specified predictions column"
                 f" '{predictions}'.",
                 INVALID_PARAMETER_VALUE,
             )
@@ -108,6 +108,13 @@ class SparkDataset(Dataset, PyFuncConvertibleDatasetMixin):
             The string name of the Spark DataFrame column containing targets.
         """
         return self._targets
+
+    @property
+    def predictions(self) -> Optional[str]:
+        """
+        The name of the predictions column. May be ``None`` if no predictions column is available.
+        """
+        return self._predictions
 
     @property
     def source(self) -> Union[SparkDatasetSource, DeltaDatasetSource]:

--- a/mlflow/data/spark_dataset.py
+++ b/mlflow/data/spark_dataset.py
@@ -112,7 +112,8 @@ class SparkDataset(Dataset, PyFuncConvertibleDatasetMixin):
     @property
     def predictions(self) -> Optional[str]:
         """
-        The name of the predictions column. May be ``None`` if no predictions column is available.
+        The name of the predictions column. May be ``None`` if no predictions column
+        was specified when the dataset was created.
         """
         return self._predictions
 

--- a/mlflow/data/spark_dataset.py
+++ b/mlflow/data/spark_dataset.py
@@ -36,6 +36,7 @@ class SparkDataset(Dataset, PyFuncConvertibleDatasetMixin):
         targets: Optional[str] = None,
         name: Optional[str] = None,
         digest: Optional[str] = None,
+        predictions: Optional[str] = None,
     ):
         if targets is not None and targets not in df.columns:
             raise MlflowException(
@@ -43,9 +44,16 @@ class SparkDataset(Dataset, PyFuncConvertibleDatasetMixin):
                 f" '{targets}'.",
                 INVALID_PARAMETER_VALUE,
             )
+        if predictions is not None and predictions not in df.columns:
+            raise MlflowException(
+                f"The specified Spark DataFrame does not contain the specified predictions column"
+                f" '{predictions}'.",
+                INVALID_PARAMETER_VALUE,
+            )
 
         self._df = df
         self._targets = targets
+        self._predictions = predictions
         super().__init__(source=source, name=name, digest=digest)
 
     def _compute_digest(self) -> str:
@@ -274,6 +282,7 @@ def from_spark(
     targets: Optional[str] = None,
     name: Optional[str] = None,
     digest: Optional[str] = None,
+    predictions: Optional[str] = None,
 ) -> SparkDataset:
     """
     Given a Spark DataFrame, constructs a
@@ -314,6 +323,9 @@ def from_spark(
             generated.
         digest: The digest (hash, fingerprint) of the dataset. If unspecified, a digest is
             automatically computed.
+        predictions: Optional. The name of the column containing model predictions,
+            if the dataset contains model predictions. If specified, this column
+            must be present in the dataframe (``df``).
 
     Returns:
         An instance of :py:class:`SparkDataset <mlflow.data.spark_dataset.SparkDataset>`.
@@ -379,4 +391,5 @@ def from_spark(
         targets=targets,
         name=name,
         digest=digest,
+        predictions=predictions,
     )

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1679,11 +1679,11 @@ def evaluate(
 
         predictions: Optional. The name of the column that contains model outputs.
 
-            - When ``model`` is specified and outputs multiple columns. The
-              ``predictions`` should be the name of the column that is used for
+            - When ``model`` is specified and outputs multiple columns, ``predictions`` can be used
+              to specify the name of the column that will be used to store model outputs for
               evaluation.
-            - When ``model`` is not specified and ``data`` is a pandas dataframe. The
-              ``predictions`` should be the name of the column in ``data`` that
+            - When ``model`` is not specified and ``data`` is a pandas dataframe,
+              ``predictions`` can be used to specify the name of the column in ``data`` that
               contains model outputs.
 
             .. code-block:: python

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1206,7 +1206,7 @@ def _convert_data_to_mlflow_dataset(data, targets=None, predictions=None):
     elif isinstance(data, pd.DataFrame):
         return mlflow.data.from_pandas(df=data, targets=targets, predictions=predictions)
     elif "pyspark" in sys.modules and isinstance(data, SparkDataFrame):
-        return mlflow.data.from_spark(df=data, targets=targets, predictions=predictions)
+        return mlflow.data.from_spark(df=data, targets=targets)
     else:
         # Cannot convert to mlflow dataset, return original data.
         _logger.info(

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1206,7 +1206,7 @@ def _convert_data_to_mlflow_dataset(data, targets=None, predictions=None):
     elif isinstance(data, pd.DataFrame):
         return mlflow.data.from_pandas(df=data, targets=targets, predictions=predictions)
     elif "pyspark" in sys.modules and isinstance(data, SparkDataFrame):
-        return mlflow.data.from_spark(df=data, targets=targets)
+        return mlflow.data.from_spark(df=data, targets=targets, predictions=predictions)
     else:
         # Cannot convert to mlflow dataset, return original data.
         _logger.info(

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1650,8 +1650,7 @@ def evaluate(
             ``data`` is a :py:class:`mlflow.data.dataset.Dataset` that defines targets,
             then ``targets`` is optional.
 
-        predictions: Optional. The name of the column that contains model outputs. There are two
-            cases where this argument is required:
+        predictions: Optional. The name of the column that contains model outputs.
 
             - When ``model`` is specified and outputs multiple columns. The
               ``predictions`` should be the name of the column that is used for
@@ -1991,36 +1990,9 @@ def evaluate(
                 "the desired configuration there.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
-    elif model is None:
-        # Evaluating a static dataset
-        if isinstance(data, pd.DataFrame):
-            # If data is a pandas dataframe, predictions must be specified
-            if predictions is None:
-                raise MlflowException(
-                    message="The model output must be specified in the predictions "
-                    "parameter when model=None.",
-                    error_code=INVALID_PARAMETER_VALUE,
-                )
-        elif isinstance(data, mlflow.data.pandas_dataset.PandasDataset):
-            # If data is a mlflow PandasDataset, data.predictions must be specified
-            if data.predictions is None:
-                raise MlflowException(
-                    message="The predictions parameter must be specified with the provided "
-                    "PandasDataset when model=None. For example: "
-                    "`data = mlflow.data.from_pandas(df=X.assign(y=y), predictions='y')`",
-                    error_code=INVALID_PARAMETER_VALUE,
-                )
-        else:
-            # Other data formats are not supported
-            raise MlflowException(
-                message="The data must be a pandas dataframe or mlflow.data.pandas_dataset."
-                "PandasDataset when model=None.",
-                error_code=INVALID_PARAMETER_VALUE,
-            )
-
     elif callable(model):
         model = _get_model_from_function(model)
-    else:
+    elif model is not None:
         raise MlflowException(
             message="The model argument must be a string URI referring to an MLflow model, "
             "an MLflow Deployments endpoint URI, an instance of `mlflow.pyfunc.PyFuncModel`, "

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1877,6 +1877,16 @@ class DefaultEvaluator(ModelEvaluator):
         predictions=None,
         **kwargs,
     ):
+        if model is None and predictions is None:
+            raise MlflowException(
+                message=(
+                    "Either a model or set of predictions must be specified. Please either specify"
+                    " the `model` parameter, the `predictions` parameter, or an MLflow dataset"
+                    " containing the `predictions` column name."
+                ),
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+
         self.dataset = dataset
         self.run_id = run_id
         self.model_type = model_type

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1877,7 +1877,7 @@ class DefaultEvaluator(ModelEvaluator):
         predictions=None,
         **kwargs,
     ):
-        if model is None and predictions is None:
+        if model is None and predictions is None and dataset.predictions_data is None:
             raise MlflowException(
                 message=(
                     "Either a model or set of predictions must be specified in order to use the"

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1880,9 +1880,11 @@ class DefaultEvaluator(ModelEvaluator):
         if model is None and predictions is None:
             raise MlflowException(
                 message=(
-                    "Either a model or set of predictions must be specified. Please either specify"
-                    " the `model` parameter, the `predictions` parameter, or an MLflow dataset"
-                    " containing the `predictions` column name."
+                    "Either a model or set of predictions must be specified in order to use the"
+                    " default evaluator. Either specify the `model` parameter, the `predictions`"
+                    " parameter, an MLflow dataset containing the `predictions` column name"
+                    " (via the `data` parameter), or a different evaluator (via the `evaluators`"
+                    " parameter)."
                 ),
                 error_code=INVALID_PARAMETER_VALUE,
             )

--- a/tests/data/test_spark_dataset.py
+++ b/tests/data/test_spark_dataset.py
@@ -349,8 +349,10 @@ def test_to_evaluation_dataset(spark_session, tmp_path, df):
         source=source,
         targets="c",
         name="testname",
+        predictions="b",
     )
     evaluation_dataset = dataset.to_evaluation_dataset()
     assert isinstance(evaluation_dataset, EvaluationDataset)
-    assert evaluation_dataset.features_data.equals(df_spark.toPandas().drop(columns=["c"]))
+    assert evaluation_dataset.features_data.equals(df_spark.toPandas()[["a"]])
     assert np.array_equal(evaluation_dataset.labels_data, df_spark.toPandas()["c"].values)
+    assert np.array_equal(evaluation_dataset.predictions_data, df_spark.toPandas()["b"].values)

--- a/tests/data/test_spark_dataset.py
+++ b/tests/data/test_spark_dataset.py
@@ -166,6 +166,49 @@ def test_targets_property(spark_session, tmp_path, df):
     )
     assert dataset_with_targets.targets == "c"
 
+    with pytest.raises(
+        MlflowException,
+        match="The specified Spark dataset does not contain the specified targets column",
+    ):
+        SparkDataset(
+            df=df_spark,
+            source=source,
+            targets="nonexistent",
+            name="testname",
+        )
+
+
+def test_predictions_property(spark_session, tmp_path, df):
+    df_spark = spark_session.createDataFrame(df)
+    path = str(tmp_path / "temp.parquet")
+    df_spark.write.parquet(path)
+
+    source = SparkDatasetSource(path=path)
+    dataset_no_predictions = SparkDataset(
+        df=df_spark,
+        source=source,
+        name="testname",
+    )
+    assert dataset_no_predictions.predictions is None
+    dataset_with_predictions = SparkDataset(
+        df=df_spark,
+        source=source,
+        predictions="b",
+        name="testname",
+    )
+    assert dataset_with_predictions.predictions == "b"
+
+    with pytest.raises(
+        MlflowException,
+        match="The specified Spark dataset does not contain the specified predictions column",
+    ):
+        SparkDataset(
+            df=df_spark,
+            source=source,
+            predictions="nonexistent",
+            name="testname",
+        )
+
 
 def test_from_spark_no_source_specified(spark_session, df):
     df_spark = spark_session.createDataFrame(df)

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -610,8 +610,6 @@ def test_spark_regressor_model_evaluation_disable_logging_metrics_and_artifacts(
         logged_metrics=logged_metrics,
     )
 
-    assert "mlflow.datasets" not in tags
-
     check_artifacts_are_not_generated_for_baseline_model_evaluation(
         logged_artifacts=artifacts,
         result_artifacts=result.artifacts,

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2834,6 +2834,45 @@ def test_constructing_eval_df_for_custom_metrics():
     ]
 
 
+def test_evaluate_no_model_or_predictions_specified():
+    data = pd.DataFrame(
+        {
+            "question": ["words random", "This is a sentence."],
+            "truth": ["words random", "This is a sentence."],
+        }
+    )
+
+    with pytest.raises(
+        MlflowException,
+        match=(
+            "Either a model or set of predictions must be specified in order to use the"
+            " default evaluator"
+        ),
+    ):
+        mlflow.evaluate(
+            data=data,
+            targets="truth",
+            model_type="regressor",
+        )
+
+
+def test_evaluate_no_model_and_predictions_specified_with_unsupported_data_type():
+    X = np.random.random((5, 5))
+    y = np.random.random(5)
+
+    with pytest.raises(
+        MlflowException,
+        match="If predictions is specified, data must be one of the following types",
+    ):
+        mlflow.evaluate(
+            data=X,
+            targets=y,
+            predictions="model_output",
+            model_type="regressor",
+            evaluators="default",
+        )
+
+
 def test_evaluate_no_model_type():
     with mlflow.start_run():
         model_info = mlflow.pyfunc.log_model(

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2853,6 +2853,7 @@ def test_evaluate_no_model_or_predictions_specified():
             data=data,
             targets="truth",
             model_type="regressor",
+            evaluators="default",
         )
 
 

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1468,30 +1468,6 @@ def test_evaluate_with_static_mlflow_dataset_input():
     assert "root_mean_squared_error" in run.data.metrics
 
 
-def test_evaluate_with_static_spark_dataset_unsupported():
-    data = sklearn.datasets.load_diabetes()
-    spark = SparkSession.builder.master("local[*]").getOrCreate()
-    rows = [
-        (Vectors.dense(features), float(label), float(label))
-        for features, label in zip(data.data, data.target)
-    ]
-    spark_dataframe = spark.createDataFrame(
-        spark.sparkContext.parallelize(rows, 1), ["features", "label", "model_output"]
-    )
-    with mlflow.start_run():
-        with pytest.raises(
-            MlflowException,
-            match="The data must be a pandas dataframe or mlflow.data."
-            "pandas_dataset.PandasDataset when model=None.",
-        ):
-            mlflow.evaluate(
-                data=spark_dataframe,
-                targets="label",
-                predictions="model_output",
-                model_type="regressor",
-            )
-
-
 def test_evaluate_with_static_dataset_error_handling_pandas_dataframe():
     X, y = sklearn.datasets.load_diabetes(return_X_y=True, as_frame=True)
     X = X[::5]

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1497,29 +1497,6 @@ def test_evaluate_with_static_dataset_error_handling_pandas_dataframe():
     X = X[::5]
     y = y[::5]
     with mlflow.start_run():
-        with pytest.raises(
-            MlflowException,
-            match="The model output must be specified in the "
-            "predictions parameter when model=None.",
-        ):
-            mlflow.evaluate(
-                data=X.assign(y=y, model_output=y),
-                targets="y",
-                model_type="regressor",
-            )
-
-        with pytest.raises(
-            MlflowException,
-            match="The data must be a pandas dataframe or "
-            "mlflow.data.pandas_dataset.PandasDataset when model=None.",
-        ):
-            mlflow.evaluate(
-                data=X.assign(y=y, model_output=y).to_numpy(),
-                targets="y",
-                predictions="model_output",
-                model_type="regressor",
-            )
-
         with pytest.raises(MlflowException, match="The data argument cannot be None."):
             mlflow.evaluate(
                 data=None,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/11831?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11831/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11831
```

</p>
</details>

### What changes are proposed in this pull request?

Don't require the user to specify predictions or model in order to use custom evaluators. Custom evaluators may be able to infer the predictions column based on the provided data.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
