### PR TITLE
[MINOR] Move run name from tag to metadata

### DIFF
--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -2,13 +2,11 @@
 class TraceMetadataKey:
     INPUTS = "mlflow.traceInputs"
     OUTPUTS = "mlflow.traceOutputs"
-    SOURCE_NAME = "mlflow.source.name"
-    SOURCE_TYPE = "mlflow.source.type"
+    SOURCE_RUN = "mlflow.sourceRun"
 
 
 class TraceTagKey:
     TRACE_NAME = "mlflow.traceName"
-    SOURCE_RUN = "mlflow.sourceRun"
 
 
 # A set of reserved attribute keys

--- a/tests/tracing/processor/test_mlflow_processor.py
+++ b/tests/tracing/processor/test_mlflow_processor.py
@@ -29,7 +29,7 @@ def test_on_start(clear_singleton):
     processor.on_start(span)
 
     mock_client._start_tracked_trace.assert_called_once_with(
-        experiment_id="0", timestamp_ms=5, tags={}
+        experiment_id="0", timestamp_ms=5, request_metadata={}
     )
     assert span.attributes.get(SpanAttributeKey.REQUEST_ID) == json.dumps(_REQUEST_ID)
     assert _REQUEST_ID in InMemoryTraceManager.get_instance()._traces
@@ -83,7 +83,7 @@ def test_on_start_with_experiment_id(clear_singleton):
     mock_client._start_tracked_trace.assert_called_once_with(
         experiment_id=experiment_id,
         timestamp_ms=5,
-        tags={},
+        request_metadata={},
     )
     assert span.attributes.get(SpanAttributeKey.REQUEST_ID) == json.dumps(_REQUEST_ID)
     assert _REQUEST_ID in InMemoryTraceManager.get_instance()._traces
@@ -101,7 +101,7 @@ def test_on_start_fallback_to_client_side_request_id(clear_singleton):
     processor.on_start(span)
 
     mock_client._start_tracked_trace.assert_called_once_with(
-        experiment_id="0", timestamp_ms=5, tags={}
+        experiment_id="0", timestamp_ms=5, request_metadata={}
     )
     # When the backend returns an error, the request_id is generated at client side from trace_id
     expected_request_id = encode_trace_id(_TRACE_ID)

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -48,9 +48,8 @@ def test_trace(clear_singleton, with_active_run):
     assert trace_info.status == SpanStatusCode.OK
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 2, "y": 5}'
     assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == "64"
-    tags = trace_info.tags
     if with_active_run:
-        assert tags["mlflow.sourceRun"] == run_id
+        assert trace_info.request_metadata["mlflow.sourceRun"] == run_id
 
     assert trace.data.request == '{"x": 2, "y": 5}'
     assert trace.data.response == "64"

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -365,7 +365,7 @@ def test_start_and_end_trace(clear_singleton, with_active_run):
     assert trace_info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 1, "y": 2}'
     assert trace_info.request_metadata[TraceMetadataKey.OUTPUTS] == '{"output": 25}'
     if with_active_run:
-        assert trace_info.tags["mlflow.sourceRun"] == run_id
+        assert trace_info.request_metadata["mlflow.sourceRun"] == run_id
 
     trace_data = traces[0].data
     assert trace_data.request == '{"x": 1, "y": 2}'


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11846?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11846/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11846
```

</p>
</details>

### What changes are proposed in this pull request?

Run name `mlflow.sourceRun` is immutable so should reside in the request metadata rather than tags (mutable).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
