### PR TITLE
Tracing APIs in FileStore

### DIFF
--- a/mlflow/entities/trace_info.py
+++ b/mlflow/entities/trace_info.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Dict, Optional
 
 from mlflow.entities._mlflow_object import _MlflowObject
@@ -73,3 +73,22 @@ class TraceInfo(_MlflowObject):
             request_metadata={attr.key: attr.value for attr in proto.request_metadata},
             tags={tag.key: tag.value for tag in proto.tags},
         )
+
+    def to_dict(self):
+        """
+        Convert trace info to a dictionary for persistence.
+        Update status field to the string value for serialization.
+        """
+        trace_info_dict = asdict(self)
+        trace_info_dict["status"] = self.status.value
+        return trace_info_dict
+
+    @classmethod
+    def from_dict(cls, trace_info_dict):
+        """
+        Convert trace info dictionary to TraceInfo object.
+        """
+        if "status" not in trace_info_dict:
+            raise ValueError("status is required in trace info dictionary.")
+        trace_info_dict["status"] = TraceStatus(trace_info_dict["status"])
+        return cls(**trace_info_dict)

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -227,6 +227,7 @@ class AbstractStore:
 
         """
 
+    # TODO: rename this to create_trace_info
     def start_trace(
         self,
         experiment_id: str,
@@ -248,6 +249,8 @@ class AbstractStore:
         """
         raise NotImplementedError
 
+    # TODO: rename this to update_trace_info
+    # can we pass in execution_time_ms instead of timestamp_ms directly?
     def end_trace(
         self,
         request_id: str,

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -60,6 +60,7 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlTraceRequestMetadata,
     SqlTraceTag,
 )
+from mlflow.tracing.utils import generate_request_id
 from mlflow.utils.file_utils import local_file_uri_to_path, mkdir
 from mlflow.utils.mlflow_tags import (
     MLFLOW_DATASET_CONTEXT,
@@ -1539,7 +1540,7 @@ class SqlAlchemyStore(AbstractStore):
             self._check_experiment_is_active(experiment)
 
             trace_info = SqlTraceInfo(
-                request_id=self._generate_trace_request_id(),
+                request_id=generate_request_id(),
                 experiment_id=experiment_id,
                 timestamp_ms=timestamp_ms,
                 execution_time_ms=None,
@@ -1604,9 +1605,6 @@ class SqlAlchemyStore(AbstractStore):
         with self.ManagedSessionMaker() as session:
             sql_trace_info = self._get_sql_trace_info(session, request_id)
             return sql_trace_info.to_mlflow_entity()
-
-    def _generate_trace_request_id(self) -> str:
-        return uuid.uuid4().hex
 
     def _get_sql_trace_info(self, session, request_id) -> SqlTraceInfo:
         sql_trace_info = (

--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -73,14 +73,10 @@ class MlflowSpanExporter(SpanExporter):
 
     def _log_trace(self, trace: Trace):
         # TODO: Make this async
+        # The trace is already updated in processor.on_end method
+        # so we just log to backend store here
         try:
             self._client._upload_trace_data(trace.info, trace.data)
-            self._client._upload_ended_trace_info(
-                request_id=trace.info.request_id,
-                timestamp_ms=trace.info.timestamp_ms + trace.info.execution_time_ms,
-                status=trace.info.status,
-                request_metadata=trace.info.request_metadata,
-                tags=trace.info.tags,
-            )
+            self._client._upload_ended_trace_info(trace.info)
         except Exception as e:
             _logger.debug(f"Failed to log trace to MLflow backend: {e}", exc_info=True)

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -51,7 +51,7 @@ class InMemoryTraceManager:
         return cls._instance
 
     def __init__(self):
-        # Storing request_id -> trace mapping
+        # Storing request_id -> _Trace mapping
         self._traces: Dict[str, _Trace] = TTLCache(
             maxsize=MLFLOW_TRACE_BUFFER_MAX_SIZE.get(),
             ttl=MLFLOW_TRACE_BUFFER_TTL_SECONDS.get(),

--- a/mlflow/tracing/utils.py
+++ b/mlflow/tracing/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+import uuid
 from collections import Counter
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -179,3 +180,7 @@ def maybe_get_evaluation_request_id() -> Optional[str]:
 def exclude_immutable_tags(tags: Dict[str, str]) -> Dict[str, str]:
     """Exclude immutable tags e.g. "mlflow.user" from the given tags."""
     return {k: v for k, v in tags.items() if k not in IMMUTABLE_TAGS}
+
+
+def generate_request_id() -> str:
+    return uuid.uuid4().hex

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -866,7 +866,7 @@ class MlflowClient:
             timestamp_ms=trace_info.timestamp_ms + trace_info.execution_time_ms,
             status=trace_info.status,
             request_metadata=trace_info.request_metadata,
-            tags=self._exclude_immutable_tags(trace_info.tags or {}),
+            tags=trace_info.tags or {},
         )
 
     def set_trace_tag(self, request_id: str, key: str, value: str):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -38,7 +38,6 @@ from mlflow.entities import (
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
 from mlflow.entities.span import LiveSpan, NoOpSpan
-from mlflow.entities.trace_status import TraceStatus
 from mlflow.environment_variables import _MLFLOW_TESTING, MLFLOW_ENABLE_ASYNC_LOGGING
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import (
@@ -404,7 +403,7 @@ class MlflowClient:
         Args:
             experiment_id: ID of the associated experiment.
             max_timestamp_millis: The maximum timestamp in milliseconds since the UNIX epoch for
-                deleting traces.
+                deleting traces. Traces older than or equal to this timestamp will be deleted.
             max_traces: The maximum number of traces to delete.
             request_ids: A set of request IDs to delete.
 
@@ -559,6 +558,8 @@ class MlflowClient:
 
         try:
             # Create new trace and a root span
+            # Once OTel span is created, SpanProcessor.on_start is invoked
+            # TraceInfo is created and logged into backend store inside on_start method
             otel_span = mlflow.tracing.provider.start_detached_span(
                 name, experiment_id=experiment_id
             )
@@ -849,34 +850,23 @@ class MlflowClient:
 
     def _upload_ended_trace_info(
         self,
-        request_id: str,
-        timestamp_ms: int,
-        status: TraceStatus,
-        request_metadata: Optional[Dict[str, str]] = None,
-        tags: Optional[Dict[str, str]] = None,
+        trace_info: TraceInfo,
     ) -> TraceInfo:
         """
         Update the TraceInfo object in the backend store with the completed trace info.
 
         Args:
-            request_id: Unique string identifier of the trace.
-            timestamp_ms: int, end time of the trace, in milliseconds. The execution time field
-                in the TraceInfo will be calculated by subtracting the start time from this.
-            status: TraceStatus, status of the trace.
-            request_metadata: dict, metadata of the trace. This will be merged with the existing
-                metadata logged during the start_trace call.
-            tags: dict, tags of the trace. This will be merged with the existing tags logged
-                during the start_trace or set_trace_tag calls.
+            trace_info: Updated TraceInfo object to be stored in the backend store.
 
         Returns:
             The updated TraceInfo object.
         """
         return self._tracking_client.end_trace(
-            request_id=request_id,
-            timestamp_ms=timestamp_ms,
-            status=status,
-            request_metadata=request_metadata or {},
-            tags=tags or {},
+            request_id=trace_info.request_id,
+            timestamp_ms=trace_info.timestamp_ms + trace_info.execution_time_ms,
+            status=trace_info.status,
+            request_metadata=trace_info.request_metadata,
+            tags=self._exclude_immutable_tags(trace_info.tags or {}),
         )
 
     def set_trace_tag(self, request_id: str, key: str, value: str):

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -205,7 +205,7 @@ def mkdir(root, name=None):
     """
     target = os.path.join(root, name) if name is not None else root
     try:
-        os.makedirs(target)
+        os.makedirs(target, exist_ok=True)
     except OSError as e:
         if e.errno != errno.EEXIST or not os.path.isdir(target):
             raise e

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -47,7 +47,7 @@ def _ilike(string, pattern):
     return _convert_like_pattern_to_regex(pattern, flags=re.IGNORECASE).match(string) is not None
 
 
-def _join_in_comparison_tokens(tokens):
+def _join_in_comparison_tokens(tokens, search_traces=False):
     """
     Find a sequence of tokens that matches the pattern of an IN comparison or a NOT IN comparison,
     join the tokens into a single Comparison token. Otherwise, return the original list of tokens.
@@ -66,6 +66,23 @@ def _join_in_comparison_tokens(tokens):
         if num_tokens - index < 3:
             joined_tokens.extend(non_whitespace_tokens[index:])
             break
+
+        if search_traces:
+            # timestamp
+            if first.match(ttype=TokenType.Name.Builtin, values=["timestamp", "timestamp_ms"]):
+                (_, second) = next(iterator)
+                (_, third) = next(iterator)
+                if (
+                    second.match(
+                        ttype=TokenType.Operator.Comparison,
+                        values=SearchTraceUtils.VALID_NUMERIC_ATTRIBUTE_COMPARATORS,
+                    )
+                    and third.ttype == TokenType.Literal.Number.Integer
+                ):
+                    joined_tokens.append(Comparison(TokenList([first, second, third])))
+                    continue
+                else:
+                    joined_tokens.extend([first, second, third])
 
         # Wait until we encounter an identifier token
         if not isinstance(first, Identifier):
@@ -401,7 +418,7 @@ class SearchUtils:
             )
 
     @classmethod
-    def _validate_comparison(cls, tokens):
+    def _validate_comparison(cls, tokens, search_traces=False):
         base_error_string = "Invalid comparison clause"
         if len(tokens) != 3:
             raise MlflowException(
@@ -409,10 +426,18 @@ class SearchUtils:
                 error_code=INVALID_PARAMETER_VALUE,
             )
         if not isinstance(tokens[0], Identifier):
-            raise MlflowException(
-                f"{base_error_string}. Expected 'Identifier' found '{tokens[0]}'",
-                error_code=INVALID_PARAMETER_VALUE,
-            )
+            if not search_traces:
+                raise MlflowException(
+                    f"{base_error_string}. Expected 'Identifier' found '{tokens[0]}'",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+            if search_traces and not tokens[0].match(
+                ttype=TokenType.Name.Builtin, values=["timestamp", "timestamp_ms"]
+            ):
+                raise MlflowException(
+                    f"{base_error_string}. Expected 'TokenType.Name.Builtin' found '{tokens[0]}'",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
         if not isinstance(tokens[1], Token) and tokens[1].ttype != TokenType.Operator.Comparison:
             raise MlflowException(
                 f"{base_error_string}. Expected comparison found '{tokens[1]}'",
@@ -1456,6 +1481,7 @@ class SearchTraceUtils(SearchUtils):
         "execution_time",
         "execution_time_ms",
         "status",
+        "request_id",
         # The following keys are mapped to tags or metadata
         "name",
         "run_id",
@@ -1470,6 +1496,7 @@ class SearchTraceUtils(SearchUtils):
 
     _TAG_IDENTIFIER = "tag"
     _REQUEST_METADATA_IDENTIFIER = "request_metadata"
+    SUPPORT_IN_COMPARISON_ATTRIBUTE_KEYS = {"name", "status", "request_id", "run_id"}
 
     # Some search keys are defined differently in the DB models.
     # E.g. "name" is mapped to TraceTagKey.TRACE_NAME
@@ -1484,6 +1511,49 @@ class SearchTraceUtils(SearchUtils):
         "timestamp": "timestamp_ms",
         "execution_time": "execution_time_ms",
     }
+
+    @classmethod
+    def filter(cls, traces, filter_string):
+        """Filters a set of traces based on a search filter string."""
+        if not filter_string:
+            return traces
+        parsed = cls.parse_search_filter(filter_string)
+
+        def trace_matches(trace):
+            return all(cls._does_trace_match_clause(trace, s) for s in parsed)
+
+        return list(filter(trace_matches, traces))
+
+    @classmethod
+    def _does_trace_match_clause(cls, trace, sed):
+        key = sed.get("key")
+        value = sed.get("value")
+        comparator = sed.get("comparator").upper()
+
+        if key in cls.SEARCH_KEY_TO_TAG:
+            key = cls.SEARCH_KEY_TO_TAG[key]
+            lhs = trace.tags.get(key)
+        elif key in cls.SEARCH_KEY_TO_METADATA:
+            key = cls.SEARCH_KEY_TO_METADATA[key]
+            lhs = trace.request_metadata.get(key)
+        elif key in cls.SEARCH_KEY_TO_ATTRIBUTE:
+            key = cls.SEARCH_KEY_TO_ATTRIBUTE[key]
+            lhs = getattr(trace, key)
+        elif key in cls.VALID_SEARCH_ATTRIBUTE_KEYS:
+            lhs = getattr(trace, key)
+        else:
+            raise MlflowException(
+                f"Invalid search key '{key}', supported are {cls.VALID_SEARCH_ATTRIBUTE_KEYS}",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        if lhs is None:
+            return False
+
+        return SearchUtils.get_comparison_func(comparator)(lhs, value)
+
+    @classmethod
+    def sort(cls, traces, order_by_list):
+        return sorted(traces, key=cls._get_sort_key(order_by_list))
 
     @classmethod
     def parse_order_by_for_search_traces(cls, order_by):
@@ -1523,3 +1593,107 @@ class SearchTraceUtils(SearchUtils):
                 )
             return True
         return False
+
+    @classmethod
+    def _get_sort_key(cls, order_by_list):
+        order_by = []
+        parsed_order_by = map(cls.parse_order_by_for_search_traces, order_by_list or [])
+        for type_, key, ascending in parsed_order_by:
+            if type_ == "attribute":
+                order_by.append((key, ascending))
+            else:
+                raise MlflowException.invalid_parameter_value(
+                    f"Invalid order_by entity `{type_}` with key `{key}`"
+                )
+
+        # Add a tie-breaker
+        if not any(key == "timestamp_ms" for key, _ in order_by):
+            order_by.append(("timestamp_ms", False))
+        if not any(key == "request_id" for key, _ in order_by):
+            order_by.append(("request_id", True))
+
+        return lambda trace: tuple(_apply_reversor(trace, k, asc) for (k, asc) in order_by)
+
+    @classmethod
+    def _get_value(cls, identifier_type, key, token):
+        if identifier_type == cls._TAG_IDENTIFIER:
+            if token.ttype in cls.STRING_VALUE_TYPES or isinstance(token, Identifier):
+                return cls._strip_quotes(token.value, expect_quoted_value=True)
+            raise MlflowException(
+                "Expected a quoted string value for "
+                f"{identifier_type} (e.g. 'my-value'). Got value "
+                f"{token.value}",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        elif identifier_type == cls._ATTRIBUTE_IDENTIFIER:
+            if token.ttype in cls.STRING_VALUE_TYPES or isinstance(token, Identifier):
+                return cls._strip_quotes(token.value, expect_quoted_value=True)
+            elif isinstance(token, Parenthesis):
+                if key not in cls.SUPPORT_IN_COMPARISON_ATTRIBUTE_KEYS:
+                    raise MlflowException(
+                        f"Only attributes in {cls.SUPPORT_IN_COMPARISON_ATTRIBUTE_KEYS} "
+                        "supports comparison with a list of quoted string values.",
+                        error_code=INVALID_PARAMETER_VALUE,
+                    )
+                return cls._parse_attribute_lists(token)
+            elif token.ttype in cls.NUMERIC_VALUE_TYPES:
+                if key not in cls.NUMERIC_ATTRIBUTES:
+                    raise MlflowException(
+                        f"Only the '{cls.NUMERIC_ATTRIBUTES}' attributes support comparison with "
+                        "numeric values.",
+                        error_code=INVALID_PARAMETER_VALUE,
+                    )
+                if token.ttype == TokenType.Literal.Number.Integer:
+                    return int(token.value)
+                elif token.ttype == TokenType.Literal.Number.Float:
+                    return float(token.value)
+            else:
+                raise MlflowException(
+                    "Expected a quoted string value or a list of quoted string values for "
+                    f"attributes. Got value {token.value}",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+        else:
+            # Expected to be either "param" or "metric".
+            raise MlflowException(
+                "Invalid identifier type. Expected one of "
+                f"{[cls._ATTRIBUTE_IDENTIFIER, cls._TAG_IDENTIFIER]}.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+
+    @classmethod
+    def _parse_attribute_lists(cls, token):
+        cls._check_valid_identifier_list(token)
+        return cls._parse_list_from_sql_token(token)
+
+    @classmethod
+    def _process_statement(cls, statement):
+        # check validity
+        tokens = _join_in_comparison_tokens(statement.tokens, search_traces=True)
+        invalids = list(filter(cls._invalid_statement_token_search_traces, tokens))
+        if len(invalids) > 0:
+            invalid_clauses = ", ".join(f"'{token}'" for token in invalids)
+            raise MlflowException(
+                f"Invalid clause(s) in filter string: {invalid_clauses}",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        return [cls._get_comparison(si) for si in tokens if isinstance(si, Comparison)]
+
+    @classmethod
+    def _invalid_statement_token_search_traces(cls, token):
+        if (
+            isinstance(token, Comparison)
+            or token.is_whitespace
+            or token.match(ttype=TokenType.Keyword, values=["AND"])
+        ):
+            return False
+        return True
+
+    @classmethod
+    def _get_comparison(cls, comparison):
+        stripped_comparison = [token for token in comparison.tokens if not token.is_whitespace]
+        cls._validate_comparison(stripped_comparison, search_traces=True)
+        comp = cls._get_identifier(stripped_comparison[0].value, cls.VALID_SEARCH_ATTRIBUTE_KEYS)
+        comp["comparator"] = stripped_comparison[1].value
+        comp["value"] = cls._get_value(comp.get("type"), comp.get("key"), stripped_comparison[2])
+        return comp

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -70,8 +70,14 @@ def _join_in_comparison_tokens(tokens, search_traces=False):
         if search_traces:
             # timestamp
             if first.match(ttype=TokenType.Name.Builtin, values=["timestamp", "timestamp_ms"]):
-                (_, second) = next(iterator)
-                (_, third) = next(iterator)
+                (_, second) = next(iterator, (None, None))
+                (_, third) = next(iterator, (None, None))
+                if any(x is None for x in [second, third]):
+                    raise MlflowException(
+                        f"Invalid comparison clause with token `{first}, {second}, {third}`, "
+                        "expected 3 tokens",
+                        error_code=INVALID_PARAMETER_VALUE,
+                    )
                 if (
                     second.match(
                         ttype=TokenType.Operator.Comparison,

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import time
 import uuid
+from copy import deepcopy
 from pathlib import Path
 from typing import List
 from unittest import mock
@@ -26,6 +27,7 @@ from mlflow.entities import (
     ViewType,
     _DatasetSummary,
 )
+from mlflow.entities.trace_status import TraceStatus
 from mlflow.exceptions import MissingConfigException, MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import (
@@ -37,6 +39,7 @@ from mlflow.protos.databricks_pb2 import (
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.tracking.file_store import FileStore
+from mlflow.tracing.constant import TraceMetadataKey, TraceTagKey
 from mlflow.utils import insecure_hash
 from mlflow.utils.file_utils import TempDir, path_to_local_file_uri, read_yaml, write_yaml
 from mlflow.utils.mlflow_tags import MLFLOW_DATASET_CONTEXT, MLFLOW_LOGGED_MODELS, MLFLOW_RUN_NAME
@@ -53,6 +56,31 @@ FILESTORE_PACKAGE = "mlflow.store.tracking.file_store"
 @pytest.fixture
 def store(tmp_path):
     return FileStore(str(tmp_path.joinpath("mlruns")))
+
+
+@pytest.fixture
+def store_and_trace_info(store):
+    exp_id = store.create_experiment("test")
+    timestamp_ms = get_current_time_millis()
+    return store, store.start_trace(exp_id, timestamp_ms, {}, {})
+
+
+@pytest.fixture
+def generate_trace_infos(store):
+    exp_id = store.create_experiment("test")
+    timestamps = list(range(0, 100, 10))
+    trace_infos = []
+    request_ids = []
+    for i in range(10):
+        trace_info = store.start_trace(
+            exp_id,
+            timestamps[i],
+            {},
+            {TraceTagKey.TRACE_NAME: f"trace_{i}"},
+        )
+        trace_infos.append(trace_info)
+        request_ids.append(trace_info.request_id)
+    return trace_infos, store, exp_id, request_ids, timestamps
 
 
 def create_experiments(store, experiment_names):
@@ -2705,3 +2733,356 @@ def test_search_datasets_returns_no_more_than_max_results(store):
 
     results = store._search_datasets([exp_id])
     assert len(results) == 1000
+
+
+def test_start_trace(store):
+    exp_id = store.create_experiment("test")
+    timestamp_ms = get_current_time_millis()
+    tags = {"some_key": "test"}
+    trace_info = store.start_trace(exp_id, timestamp_ms, {}, tags)
+    assert trace_info.request_id is not None
+    assert trace_info.experiment_id == exp_id
+    assert trace_info.timestamp_ms == timestamp_ms
+    assert trace_info.execution_time_ms is None
+    assert trace_info.status == TraceStatus.IN_PROGRESS
+    assert trace_info.request_metadata == {}
+    assert trace_info.tags == tags
+
+    with pytest.raises(MlflowException, match=r"Experiment fake_exp_id does not exist."):
+        store.start_trace("fake_exp_id", timestamp_ms, {}, {})
+
+
+def test_end_trace(store_and_trace_info):
+    store, trace = store_and_trace_info
+    timestamp_ms = get_current_time_millis()
+    request_metadata = {
+        TraceMetadataKey.INPUTS: {"query": "test"},
+        TraceMetadataKey.OUTPUTS: "test",
+    }
+    tags = {TraceTagKey.TRACE_NAME: "mlflow_trace"}
+    trace_info = store.end_trace(
+        trace.request_id, timestamp_ms, TraceStatus.OK, request_metadata, tags
+    )
+    assert trace_info.request_id == trace.request_id
+    assert trace_info.timestamp_ms == trace.timestamp_ms
+    assert trace_info.execution_time_ms == timestamp_ms - trace.timestamp_ms
+    assert trace_info.status == TraceStatus.OK
+    assert trace_info.request_metadata == {**trace.request_metadata, **request_metadata}
+    assert trace_info.tags == {**trace.tags, **tags}
+
+    with pytest.raises(MlflowException, match=r"Trace with request ID 'fake_request_id' not found"):
+        store.end_trace("fake_request_id", timestamp_ms, TraceStatus.OK, request_metadata, tags)
+
+
+def test_get_trace_info(store_and_trace_info):
+    store, trace = store_and_trace_info
+    trace_info = store.get_trace_info(trace.request_id)
+    assert trace_info == trace
+
+    with pytest.raises(MlflowException, match=r"Trace with request ID 'fake_request_id' not found"):
+        store.get_trace_info("fake_request_id")
+
+    mock_trace_info = deepcopy(trace_info)
+    mock_trace_info.request_id = "invalid_request_id"
+    with mock.patch(
+        "mlflow.store.tracking.file_store.FileStore._get_trace_info_from_dir",
+        return_value=mock_trace_info,
+    ), pytest.raises(
+        MlflowException,
+        match=rf"Trace with request ID '{trace.request_id}' metadata is in invalid state.",
+    ):
+        store.get_trace_info(trace.request_id)
+
+
+def test_set_trace_tag(store_and_trace_info):
+    store, trace = store_and_trace_info
+    store.set_trace_tag(trace.request_id, "some_key", "a")
+    trace_info = store.get_trace_info(trace.request_id)
+    assert trace_info.tags["some_key"] == "a"
+
+    # test overwrite
+    store.set_trace_tag(trace.request_id, "some_key", "test")
+    trace_info = store.get_trace_info(trace.request_id)
+    assert trace_info.tags["some_key"] == "test"
+
+    # test value written as string
+    store.set_trace_tag(trace.request_id, "int_key", 1234)
+    trace_info = store.get_trace_info(trace.request_id)
+    assert trace_info.tags["int_key"] == "1234"
+
+    with pytest.raises(MlflowException, match=r"Tag name cannot be None."):
+        store.set_trace_tag(trace.request_id, None, "test")
+
+
+def test_delete_trace_tag(store_and_trace_info):
+    store, trace = store_and_trace_info
+    store.set_trace_tag(trace.request_id, "some_key", "a")
+    store.delete_trace_tag(trace.request_id, "some_key")
+    trace_info = store.get_trace_info(trace.request_id)
+    assert "some_key" not in trace_info.tags
+
+    with pytest.raises(
+        MlflowException,
+        match=rf"No tag with name: invalid_key in trace with request_id {trace.request_id}.",
+    ):
+        store.delete_trace_tag(trace.request_id, "invalid_key")
+
+
+def test_delete_traces(store):
+    exp_id = store.create_experiment("test")
+    request_ids = []
+    timestamps = list(range(0, 100, 10))
+    for i in range(10):
+        trace_info = store.start_trace(exp_id, timestamps[i], {}, {})
+        request_ids.append(trace_info.request_id)
+
+    # delete with max_timestamp_millis
+    assert store.delete_traces(exp_id, 50, 2) == 2
+    assert len(store.search_traces([exp_id])[0]) == 8
+    assert store.delete_traces(exp_id, 50) == 4
+    assert len(store.search_traces([exp_id])[0]) == 4
+
+    # delete with request_ids
+    assert store.delete_traces(exp_id, request_ids=[request_ids[6]]) == 1
+    assert len(store.search_traces([exp_id])[0]) == 3
+    assert store.delete_traces(exp_id, request_ids=["non_existing_request_id"]) == 0
+    assert len(store.search_traces([exp_id])[0]) == 3
+    assert store.delete_traces(exp_id, request_ids=request_ids) == 3
+    assert len(store.search_traces([exp_id])[0]) == 0
+
+    with pytest.raises(
+        MlflowException, match=r"Either `max_timestamp_millis` or `request_ids` must be specified."
+    ):
+        store.delete_traces(exp_id)
+    with pytest.raises(
+        MlflowException,
+        match=r"Only one of `max_timestamp_millis` and `request_ids` can be specified.",
+    ):
+        store.delete_traces(exp_id, max_timestamp_millis=100, request_ids=request_ids)
+    with pytest.raises(
+        MlflowException, match=r"`max_traces` can't be specified if `request_ids` is specified."
+    ):
+        store.delete_traces(exp_id, max_traces=2, request_ids=request_ids)
+    with pytest.raises(
+        MlflowException, match=r"`max_traces` must be a positive integer, received 0"
+    ):
+        store.delete_traces(exp_id, 100, max_traces=0)
+    with pytest.raises(MlflowException, match=r"Experiment non_existing_exp does not exist."):
+        store.delete_traces("non_existing_exp", 100, 2)
+
+
+def _validate_search_traces(store, exp_ids, filter_string, expected_traces, order_by=None):
+    traces, _ = store.search_traces(exp_ids, filter_string, order_by=order_by)
+    assert traces == expected_traces
+
+
+def test_search_traces_filter(generate_trace_infos):
+    trace_infos, store, exp_id, request_ids, timestamps = generate_trace_infos
+
+    # by default sort by timestamp_ms DESC, request_id ASC
+    _validate_search_traces(store, [exp_id], None, trace_infos[::-1])
+    _validate_search_traces(store, [exp_id], "", trace_infos[::-1])
+
+    # filter by name
+    _validate_search_traces(store, [exp_id], "name = 'trace_0'", trace_infos[:1])
+    _validate_search_traces(store, [exp_id], "name != 'trace_0'", trace_infos[1:][::-1])
+    _validate_search_traces(
+        store, [exp_id], "name IN ('trace_0', 'trace_1')", trace_infos[:2][::-1]
+    )
+    _validate_search_traces(
+        store, [exp_id], "name NOT IN ('trace_0', 'trace_1')", trace_infos[2:][::-1]
+    )
+    _validate_search_traces(store, [exp_id], "name LIKE 'trace_%'", trace_infos[::-1])
+    _validate_search_traces(store, [exp_id], "name ILIKE 'Trace_%'", trace_infos[::-1])
+    _validate_search_traces(
+        store, [exp_id], "name ILIKE 'Trace_%' AND name LIKE '%0'", trace_infos[:1]
+    )
+
+    # filter by status
+    _validate_search_traces(store, [exp_id], "status = 'IN_PROGRESS'", trace_infos[::-1])
+    _validate_search_traces(store, [exp_id], "status != 'IN_PROGRESS'", [])
+    for i in range(2):
+        trace_infos[i] = store.end_trace(request_ids[i], timestamps[i] + 10, TraceStatus.OK, {}, {})
+    for i in range(2, 5):
+        trace_infos[i] = store.end_trace(
+            request_ids[i], timestamps[i] + 20, TraceStatus.ERROR, {}, {}
+        )
+    _validate_search_traces(
+        store,
+        [exp_id],
+        "status IN ('IN_PROGRESS', 'OK')",
+        (trace_infos[:2] + trace_infos[5:])[::-1],
+    )
+    _validate_search_traces(
+        store, [exp_id], "status NOT IN ('IN_PROGRESS', 'OK')", trace_infos[2:5][::-1]
+    )
+    _validate_search_traces(store, [exp_id], "status LIKE 'O%'", trace_infos[:2][::-1])
+    _validate_search_traces(store, [exp_id], "status ILIKE 'ok'", trace_infos[:2][::-1])
+
+    # filter by timestamp
+    for timestamp_key in ["timestamp", "timestamp_ms"]:
+        _validate_search_traces(store, [exp_id], f"{timestamp_key} < 10", trace_infos[:1])
+        _validate_search_traces(store, [exp_id], f"{timestamp_key} <= 0", trace_infos[:1])
+        _validate_search_traces(store, [exp_id], f"{timestamp_key} > 0", trace_infos[1:][::-1])
+        _validate_search_traces(store, [exp_id], f"{timestamp_key} >= 10", trace_infos[1:][::-1])
+        _validate_search_traces(store, [exp_id], f"{timestamp_key} = 100", [])
+        _validate_search_traces(store, [exp_id], f"{timestamp_key} != 100", trace_infos[::-1])
+
+    # filter by request_id
+    _validate_search_traces(store, [exp_id], f"request_id = '{request_ids[0]}'", [trace_infos[0]])
+    _validate_search_traces(
+        store, [exp_id], f"request_id != '{request_ids[0]}'", trace_infos[1:][::-1]
+    )
+    _validate_search_traces(
+        store, [exp_id], f"request_id IN ('{request_ids[0]}')", [trace_infos[0]]
+    )
+    _validate_search_traces(
+        store, [exp_id], f"request_id NOT IN ('{request_ids[0]}')", trace_infos[1:][::-1]
+    )
+    _validate_search_traces(store, [exp_id], "request_id LIKE '%'", trace_infos[::-1])
+    _validate_search_traces(store, [exp_id], "request_id ILIKE '%'", trace_infos[::-1])
+
+    # filter by execution_time
+    for execution_time_key in ["execution_time", "execution_time_ms"]:
+        _validate_search_traces(
+            store, [exp_id], f"{execution_time_key} = 10", trace_infos[:2][::-1]
+        )
+        # value None is always seen as not-match
+        _validate_search_traces(
+            store, [exp_id], f"{execution_time_key} != 10", trace_infos[2:5][::-1]
+        )
+        _validate_search_traces(
+            store, [exp_id], f"{execution_time_key} > 10", trace_infos[2:5][::-1]
+        )
+        _validate_search_traces(store, [exp_id], f"{execution_time_key} < 10", [])
+        _validate_search_traces(
+            store, [exp_id], f"{execution_time_key} >= 10", trace_infos[:5][::-1]
+        )
+        _validate_search_traces(
+            store, [exp_id], f"{execution_time_key} <= 10", trace_infos[:2][::-1]
+        )
+
+    # filter by run_id
+    for i in range(5, 10):
+        trace_infos[i] = store.end_trace(
+            request_ids[i],
+            timestamps[i] + 30,
+            TraceStatus.ERROR,
+            {TraceMetadataKey.SOURCE_RUN: f"run_{i}"},
+            {},
+        )
+    _validate_search_traces(store, [exp_id], "run_id = 'run_5'", [trace_infos[5]])
+    _validate_search_traces(store, [exp_id], "run_id != 'run_5'", trace_infos[6:][::-1])
+    _validate_search_traces(store, [exp_id], "run_id IN ('run_5')", [trace_infos[5]])
+    _validate_search_traces(store, [exp_id], "run_id NOT IN ('run_5')", trace_infos[6:][::-1])
+    _validate_search_traces(store, [exp_id], "run_id LIKE 'run_%'", trace_infos[5:][::-1])
+    _validate_search_traces(store, [exp_id], "run_id ILIKE 'RUN_5'", [trace_infos[5]])
+
+    # multiple filter conditions
+    _validate_search_traces(
+        store, [exp_id], "name LIKE 'trace_%' AND timestamp <= 10", trace_infos[:2][::-1]
+    )
+    _validate_search_traces(
+        store,
+        [exp_id],
+        "name LIKE 'trace_%' AND status IN ('ERROR') AND timestamp <= 20",
+        [trace_infos[2]],
+    )
+
+
+def test_search_traces_order(generate_trace_infos):
+    trace_infos, store, exp_id, request_ids, timestamps = generate_trace_infos
+    # order by timestamp
+    for timestamp_key in ["timestamp", "timestamp_ms"]:
+        _validate_search_traces(store, [exp_id], "", trace_infos, order_by=[f"{timestamp_key} ASC"])
+        _validate_search_traces(
+            store, [exp_id], "", trace_infos[::-1], order_by=[f"{timestamp_key} DESC"]
+        )
+
+    # order by execution time
+    for i in range(5):
+        trace_infos[i] = store.end_trace(request_ids[i], timestamps[i] + 10, TraceStatus.OK, {}, {})
+    for i in range(5, 10):
+        trace_infos[i] = store.end_trace(
+            request_ids[i], timestamps[i] + 20, TraceStatus.ERROR, {}, {}
+        )
+    for execution_time_key in ["execution_time", "execution_time_ms"]:
+        _validate_search_traces(
+            store, [exp_id], "", trace_infos[::-1], order_by=[f"{execution_time_key} DESC"]
+        )
+        _validate_search_traces(
+            store,
+            [exp_id],
+            "",
+            trace_infos[:5][::-1] + trace_infos[5:][::-1],
+            order_by=[f"{execution_time_key} ASC"],
+        )
+
+    # order by status
+    _validate_search_traces(
+        store, [exp_id], "", trace_infos[:5][::-1] + trace_infos[5:][::-1], order_by=["status DESC"]
+    )
+    _validate_search_traces(store, [exp_id], "", trace_infos[::-1], order_by=["status ASC"])
+
+    # order by request_id
+    expected_trace_infos = sorted(trace_infos, key=lambda x: x.request_id)
+    _validate_search_traces(store, [exp_id], "", expected_trace_infos, order_by=["request_id ASC"])
+    expected_trace_infos = sorted(trace_infos, key=lambda x: x.request_id, reverse=True)
+    _validate_search_traces(store, [exp_id], "", expected_trace_infos, order_by=["request_id DESC"])
+
+    # order by experiment_id
+    exp_id2 = store.create_experiment("test2")
+    trace_infos.append(store.start_trace(exp_id2, timestamps[-1], {}, {}))
+    order = exp_id2 > exp_id
+    _validate_search_traces(
+        store,
+        [exp_id, exp_id2],
+        "",
+        trace_infos[::-1] if order else trace_infos[:10][::-1] + [trace_infos[-1]],
+        order_by=["experiment_id DESC"],
+    )
+    _validate_search_traces(
+        store,
+        [exp_id, exp_id2],
+        "",
+        trace_infos[:10][::-1] + [trace_infos[-1]] if order else trace_infos[::-1],
+        order_by=["experiment_id ASC"],
+    )
+
+    for i in range(10):
+        trace_infos.append(store.start_trace(exp_id2, timestamps[i], {}, {}))
+    # by default sort by timestamp DESC, request_id ASC
+    expected_trace_infos = sorted(trace_infos, key=lambda x: (-x.timestamp_ms, x.request_id))
+    _validate_search_traces(
+        store,
+        [exp_id, exp_id2],
+        "",
+        expected_trace_infos,
+    )
+
+
+def test_search_traces_raise_errors(generate_trace_infos):
+    _, store, exp_id, _, _ = generate_trace_infos
+
+    # unsupported order_by keys
+    with pytest.raises(
+        MlflowException, match=r"Invalid order_by entity `tag` with key `mlflow.traceName`"
+    ):
+        store.search_traces([exp_id], "", order_by=["name DESC"])
+    with pytest.raises(
+        MlflowException,
+        match=r"Invalid order_by entity `request_metadata` with key `mlflow.sourceRun`",
+    ):
+        store.search_traces([exp_id], "", order_by=["run_id ASC"])
+
+
+def test_search_traces_pagination(generate_trace_infos):
+    trace_infos, store, exp_id, _, _ = generate_trace_infos
+
+    # test returned token behavior
+    traces, token = store.search_traces([exp_id], None, max_results=5)
+    assert traces == trace_infos[::-1][:5]
+    assert token is not None
+    traces, token = store.search_traces([exp_id], None, max_results=5, page_token=token)
+    assert traces == trace_infos[::-1][5:]
+    assert token is None

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -3886,7 +3886,9 @@ def _create_trace(
     if not store.get_experiment(experiment_id):
         store.create_experiment(store, experiment_id)
 
-    with mock.patch.object(store, "_generate_trace_request_id", lambda: request_id):
+    with mock.patch(
+        "mlflow.store.tracking.sqlalchemy_store.generate_request_id", side_effect=lambda: request_id
+    ):
         trace_info = store.start_trace(
             experiment_id=experiment_id,
             timestamp_ms=timestamp_ms,

--- a/tests/tracing/export/test_mlflow_exporter.py
+++ b/tests/tracing/export/test_mlflow_exporter.py
@@ -53,10 +53,4 @@ def test_export():
     logged_trace_info, logged_trace_data = mock_client._upload_trace_data.call_args[0]
     assert trace_info == logged_trace_info
     assert len(logged_trace_data.spans) == 2
-    mock_client._upload_ended_trace_info.assert_called_once_with(
-        request_id=request_id,
-        timestamp_ms=1,
-        status="OK",
-        request_metadata={},
-        tags={},
-    )
+    mock_client._upload_ended_trace_info.assert_called_once_with(trace_info)

--- a/tests/tracing/processor/test_mlflow_processor.py
+++ b/tests/tracing/processor/test_mlflow_processor.py
@@ -73,6 +73,8 @@ def test_on_start_adjust_span_timestamp_to_exclude_backend_latency(clear_singlet
     original_start_time = time.time_ns()
     span = create_mock_otel_span(trace_id=_TRACE_ID, span_id=1, start_time=original_start_time)
 
+    # make sure _start_tracked_trace is invoked
+    assert processor._trace_manager.get_request_id_from_trace_id(span.context.trace_id) is None
     processor.on_start(span)
 
     assert span.start_time > original_start_time

--- a/tests/tracking/_tracking_service/test_tracking_service_client.py
+++ b/tests/tracking/_tracking_service/test_tracking_service_client.py
@@ -394,3 +394,36 @@ def test_search_traces_does_not_swallow_unexpected_exceptions(tmp_path):
 
         mock_search_traces.assert_called_once()
         mock_download_trace_data.assert_called_once()
+
+
+def test_search_traces_with_filestore(tmp_path):
+    client = TrackingServiceClient(tmp_path.as_uri())
+    exp_id = client.create_experiment("test_search_traces")
+    trace_infos = []
+    for i in range(3):
+        trace_infos.append(
+            client.start_trace(
+                exp_id,
+                i * 1000,
+                {SpanAttributeKey.REQUEST_ID: f"request_id_{i}"},
+                {},
+            )
+        )
+
+    with mock.patch.object(
+        client,
+        "_download_trace_data",
+        side_effect=[
+            TraceData(),
+            TraceData(),
+            TraceData(),
+            TraceData(),
+        ],
+    ) as mock_download_trace_data:
+        res1 = client.search_traces(experiment_ids=[exp_id], max_results=2)
+        assert [res.info for res in res1] == trace_infos[::-1][:2]
+
+        res2 = client.search_traces(experiment_ids=[exp_id], max_results=2, page_token=res1.token)
+        assert res2[0].info == trace_infos[0]
+        assert res2.token is None
+        assert mock_download_trace_data.call_count == 3


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx
Implement below APIs in FileStore:

- get_trace_info
- search_traces
- delete_traces
- set_trace_tag
- delete_trace_tag
- start_trace
- end_trace

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
