### PR TITLE
Add trace related DB models and implement start/end trace APIs for SQLAlchemy store

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -48,6 +48,9 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlParam,
     SqlRun,
     SqlTag,
+    SqlTraceInfo,
+    SqlTraceRequestMetadata,
+    SqlTraceTag,
 )
 
 _logger = logging.getLogger(__name__)
@@ -83,6 +86,9 @@ def _all_tables_exist(engine):
         SqlDataset.__tablename__,
         SqlInput.__tablename__,
         SqlInputTag.__tablename__,
+        SqlTraceInfo.__tablename__,
+        SqlTraceTag.__tablename__,
+        SqlTraceRequestMetadata.__tablename__,
     }
 
 

--- a/mlflow/store/db_migrations/versions/867495a8f9d4_add_trace_tables.py
+++ b/mlflow/store/db_migrations/versions/867495a8f9d4_add_trace_tables.py
@@ -1,0 +1,65 @@
+"""add trace tables
+
+Revision ID: 867495a8f9d4
+Revises: acf3f17fdcc7
+Create Date: 2024-04-27 12:29:25.178685
+
+"""
+from alembic import op
+from mlflow.store.tracking.dbmodels.models import SqlTraceInfo, SqlTraceRequestMetadata, SqlTraceTag
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '867495a8f9d4'
+down_revision = 'acf3f17fdcc7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        SqlTraceInfo.__tablename__,
+        sa.Column("request_id", sa.String(length=32), primary_key=True, nullable=False),
+        sa.Column(
+            "experiment_id",
+            sa.Integer(),
+            sa.ForeignKey("experiments.experiment_id"),
+            nullable=False,
+        ),
+        sa.Column("timestamp_ms", sa.BigInteger(), nullable=False),
+        sa.Column("execution_time_ms", sa.BigInteger(), nullable=True),
+        sa.Column("status", sa.String(length=24), nullable=False),
+        sa.PrimaryKeyConstraint("request_id", name="trace_info_pk"),
+        # TODO: Add indexes
+    )
+    op.create_table(
+        SqlTraceTag.__tablename__,
+        sa.Column("key", sa.String(length=250), primary_key=True, nullable=False),
+        sa.Column("value", sa.String(length=250), nullable=False),
+        sa.Column(
+            "request_id",
+            sa.String(length=32),
+            sa.ForeignKey(SqlTraceInfo.request_id),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.PrimaryKeyConstraint("key", "request_id", name="trace_tag_pk"),
+    )
+    op.create_table(
+        SqlTraceRequestMetadata.__tablename__,
+        sa.Column("key", sa.String(length=250), primary_key=True, nullable=False),
+        sa.Column("value", sa.String(length=250), nullable=False),
+        sa.Column(
+            "request_id",
+            sa.String(length=32),
+            sa.ForeignKey(SqlTraceInfo.request_id),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.PrimaryKeyConstraint("key", "request_id", name="trace_request_metadata_pk"),
+    )
+
+
+def downgrade():
+    pass

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -30,6 +30,7 @@ from mlflow.entities import (
     ViewType,
 )
 from mlflow.entities.lifecycle_stage import LifecycleStage
+from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.store.db.base_sql_model import Base
 from mlflow.utils.mlflow_tags import _get_run_name_from_tags
@@ -715,7 +716,9 @@ class SqlTraceTag(Base):
     """
     trace_info = relationship("SqlTraceInfo", backref=backref("tags", cascade="all"))
     """
-    SQLAlchemy relationship (many:one) with :py:class:`mlflow.store.dbmodels.models.SqlTraceInfo`."""
+    SQLAlchemy relationship (many:one) with
+    :py:class:`mlflow.store.dbmodels.models.SqlTraceInfo`.
+    """
 
     # Key is unique within a request_id
     __table_args__ = (PrimaryKeyConstraint("request_id", "key", name="trace_tag_pk"),)
@@ -738,7 +741,9 @@ class SqlTraceRequestMetadata(Base):
     """
     trace_info = relationship("SqlTraceInfo", backref=backref("request_metadata", cascade="all"))
     """
-    SQLAlchemy relationship (many:one) with :py:class:`mlflow.store.dbmodels.models.SqlTraceInfo`."""
+    SQLAlchemy relationship (many:one) with
+    :py:class:`mlflow.store.dbmodels.models.SqlTraceInfo`.
+    """
 
     # Key is unique within a request_id
     __table_args__ = (PrimaryKeyConstraint("request_id", "key", name="trace_request_metadata_pk"),)

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -129,6 +129,17 @@ CREATE TABLE runs (
 )
 
 
+CREATE TABLE trace_info (
+	request_id VARCHAR(32) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	timestamp_ms BIGINT NOT NULL,
+	execution_time_ms BIGINT,
+	status VARCHAR(24) NOT NULL,
+	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
+	FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+)
+
+
 CREATE TABLE latest_metrics (
 	key VARCHAR(250) NOT NULL,
 	value FLOAT NOT NULL,
@@ -180,5 +191,23 @@ CREATE TABLE tags (
 	run_uuid VARCHAR(32) NOT NULL,
 	CONSTRAINT tag_pk PRIMARY KEY (key, run_uuid),
 	FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
+)
+
+
+CREATE TABLE trace_request_metadata (
+	key VARCHAR(250) NOT NULL,
+	value VARCHAR(250) NOT NULL,
+	request_id VARCHAR(32) NOT NULL,
+	CONSTRAINT trace_request_metadata_pk PRIMARY KEY (key, request_id),
+	FOREIGN KEY(request_id) REFERENCES trace_info (request_id)
+)
+
+
+CREATE TABLE trace_tags (
+	key VARCHAR(250) NOT NULL,
+	value VARCHAR(250) NOT NULL,
+	request_id VARCHAR(32) NOT NULL,
+	CONSTRAINT trace_tag_pk PRIMARY KEY (key, request_id),
+	FOREIGN KEY(request_id) REFERENCES trace_info (request_id)
 )
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11851?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11851/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11851
```

</p>
</details>

### What changes are proposed in this pull request?

This PR defines the following DB models for OSS tracing store:
* TraceInfo
* TraceTags
* TraceRequestMetadata
The indices are still TBD so not defined in this PR. They will be added in a follow-up PR and the migration script will be replaced.

This PR also adds `start_trace()` / `end_trace()` / `get_trace_info()` APIs, the fundamental set of CR~~UD~~ traces, to ensure the new data models work correctly.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
