### PR TITLE
Add configuration for handling classification exception in MLflow evaluate due to class imbalance

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -566,3 +566,11 @@ MLFLOW_DOCKER_OPENJDK_VERSION = _EnvironmentVariable("MLFLOW_DOCKER_OPENJDK_VERS
 MLFLOW_UNITY_CATALOG_PRESIGNED_URLS_ENABLED = _BooleanEnvironmentVariable(
     "MLFLOW_UNITY_CATALOG_PRESIGNED_URLS_ENABLED", False
 )
+
+#: Private configuration option.
+#: Enables the ability to catch exceptions within MLflow evaluate for classification models 
+#: where a class imbalance due to a missing target class would raise an error in the 
+#: underlying metrology modules (scikit-learn). If set to True, specific exceptions will be 
+#: caught, alerted via the warnings module, and evaluation will resume. 
+#: (default: ``False``)
+_MLFLOW_EVALUATE_CLASSIFICATION_ERRORS_WARN_ONLY = _BooleanEnvironmentVariable("_MLFLOW_EVALUATE_CLASSIFICATION_ERRORS_WARN_ONLY", False)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -568,9 +568,11 @@ MLFLOW_UNITY_CATALOG_PRESIGNED_URLS_ENABLED = _BooleanEnvironmentVariable(
 )
 
 #: Private configuration option.
-#: Enables the ability to catch exceptions within MLflow evaluate for classification models 
-#: where a class imbalance due to a missing target class would raise an error in the 
-#: underlying metrology modules (scikit-learn). If set to True, specific exceptions will be 
-#: caught, alerted via the warnings module, and evaluation will resume. 
+#: Enables the ability to catch exceptions within MLflow evaluate for classification models
+#: where a class imbalance due to a missing target class would raise an error in the
+#: underlying metrology modules (scikit-learn). If set to True, specific exceptions will be
+#: caught, alerted via the warnings module, and evaluation will resume.
 #: (default: ``False``)
-_MLFLOW_EVALUATE_CLASSIFICATION_ERRORS_WARN_ONLY = _BooleanEnvironmentVariable("_MLFLOW_EVALUATE_CLASSIFICATION_ERRORS_WARN_ONLY", False)
+_MLFLOW_EVALUATE_CLASSIFICATION_ERRORS_WARN_ONLY = _BooleanEnvironmentVariable(
+    "_MLFLOW_EVALUATE_CLASSIFICATION_ERRORS_WARN_ONLY", False
+)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -573,6 +573,6 @@ MLFLOW_UNITY_CATALOG_PRESIGNED_URLS_ENABLED = _BooleanEnvironmentVariable(
 #: underlying metrology modules (scikit-learn). If set to True, specific exceptions will be
 #: caught, alerted via the warnings module, and evaluation will resume.
 #: (default: ``False``)
-_MLFLOW_EVALUATE_CLASSIFICATION_ERRORS_WARN_ONLY = _BooleanEnvironmentVariable(
-    "_MLFLOW_EVALUATE_CLASSIFICATION_ERRORS_WARN_ONLY", False
+_MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS = _BooleanEnvironmentVariable(
+    "_MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS", False
 )

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -1487,7 +1487,7 @@ class DefaultEvaluator(ModelEvaluator):
                     self.label_list = np.append(self.label_list, self.pos_label)
                 elif self.pos_label is None:
                     self.pos_label = self.label_list[-1]
-                with _suppress_class_imbalance_errors(IndexError):
+                with _suppress_class_imbalance_errors(IndexError, log_warning=False):
                     _logger.info(
                         "The evaluation dataset is inferred as binary dataset, positive label is "
                         f"{self.label_list[1]}, negative label is {self.label_list[0]}."

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1569,8 +1569,16 @@ def test_evaluate_with_static_dataset_error_handling_pandas_dataset():
                 predictions="model_output",
             )
 
-@pytest.mark.parametrize("baseline_model_uri", [("None"), ("binary_logistic_regressor_model_uri")], indirect=["baseline_model_uri"])
-def test_binary_classification_missing_minority_class_exception_override(binary_logistic_regressor_model_uri, breast_cancer_dataset, baseline_model_uri):
+
+@pytest.mark.parametrize(
+    "baseline_model_uri",
+    [("None"), ("binary_logistic_regressor_model_uri")],
+    indirect=["baseline_model_uri"],
+)
+def test_binary_classification_missing_minority_class_exception_override(
+    binary_logistic_regressor_model_uri, breast_cancer_dataset, baseline_model_uri, monkeypatch
+):
+    monkeypatch.setenv("_MLFLOW_EVALUATE_CLASSIFICATION_ERRORS_WARN_ONLY", True)
 
     ds_targets = breast_cancer_dataset._constructor_args["targets"]
     # Simulate a missing target label
@@ -1589,13 +1597,15 @@ def test_binary_classification_missing_minority_class_exception_override(binary_
 
     assert saved_metrics == eval_result.metrics
 
+
 @pytest.mark.parametrize(
     "baseline_model_uri",
     [("None"), ("multiclass_logistic_regressor_baseline_model_uri_4")],
     indirect=["baseline_model_uri"],
 )
-def test_multiclass_classification_missing_minority_class_exception_override(multiclass_logistic_regressor_model_uri, iris_dataset, baseline_model_uri, monkeypatch):
-
+def test_multiclass_classification_missing_minority_class_exception_override(
+    multiclass_logistic_regressor_model_uri, iris_dataset, baseline_model_uri, monkeypatch
+):
     monkeypatch.setenv("_MLFLOW_EVALUATE_CLASSIFICATION_ERRORS_WARN_ONLY", True)
 
     ds_targets = iris_dataset._constructor_args["targets"]
@@ -1615,6 +1625,7 @@ def test_multiclass_classification_missing_minority_class_exception_override(mul
 
     assert saved_metrics == eval_result.metrics
     assert "shap_beeswarm_plot.png" not in saved_artifacts
+
 
 @pytest.mark.parametrize(
     ("model", "is_endpoint_uri"),

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1578,7 +1578,7 @@ def test_evaluate_with_static_dataset_error_handling_pandas_dataset():
 def test_binary_classification_missing_minority_class_exception_override(
     binary_logistic_regressor_model_uri, breast_cancer_dataset, baseline_model_uri, monkeypatch
 ):
-    monkeypatch.setenv("_MLFLOW_EVALUATE_CLASSIFICATION_ERRORS_WARN_ONLY", True)
+    monkeypatch.setenv("_MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS", True)
 
     ds_targets = breast_cancer_dataset._constructor_args["targets"]
     # Simulate a missing target label
@@ -1606,7 +1606,7 @@ def test_binary_classification_missing_minority_class_exception_override(
 def test_multiclass_classification_missing_minority_class_exception_override(
     multiclass_logistic_regressor_model_uri, iris_dataset, baseline_model_uri, monkeypatch
 ):
-    monkeypatch.setenv("_MLFLOW_EVALUATE_CLASSIFICATION_ERRORS_WARN_ONLY", True)
+    monkeypatch.setenv("_MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS", True)
 
     ds_targets = iris_dataset._constructor_args["targets"]
     # Simulate a missing target label

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1569,6 +1569,52 @@ def test_evaluate_with_static_dataset_error_handling_pandas_dataset():
                 predictions="model_output",
             )
 
+@pytest.mark.parametrize("baseline_model_uri", [("None"), ("binary_logistic_regressor_model_uri")], indirect=["baseline_model_uri"])
+def test_binary_classification_missing_minority_class_exception_override(binary_logistic_regressor_model_uri, breast_cancer_dataset, baseline_model_uri):
+
+    ds_targets = breast_cancer_dataset._constructor_args["targets"]
+    # Simulate a missing target label
+    ds_targets = np.where(ds_targets == 0, 1, ds_targets)
+
+    with mlflow.start_run() as run:
+        eval_result = evaluate(
+            binary_logistic_regressor_model_uri,
+            breast_cancer_dataset._constructor_args["data"],
+            model_type="classifier",
+            targets=ds_targets,
+            evaluators=["default"],
+            baseline_model=baseline_model_uri,
+        )
+    _, saved_metrics, _, _ = get_run_data(run.info.run_id)
+
+    assert saved_metrics == eval_result.metrics
+
+@pytest.mark.parametrize(
+    "baseline_model_uri",
+    [("None"), ("multiclass_logistic_regressor_baseline_model_uri_4")],
+    indirect=["baseline_model_uri"],
+)
+def test_multiclass_classification_missing_minority_class_exception_override(multiclass_logistic_regressor_model_uri, iris_dataset, baseline_model_uri, monkeypatch):
+
+    monkeypatch.setenv("_MLFLOW_EVALUATE_CLASSIFICATION_ERRORS_WARN_ONLY", True)
+
+    ds_targets = iris_dataset._constructor_args["targets"]
+    # Simulate a missing target label
+    ds_targets = np.where(ds_targets == 0, 1, ds_targets)
+
+    with mlflow.start_run() as run:
+        eval_result = evaluate(
+            multiclass_logistic_regressor_model_uri,
+            iris_dataset._constructor_args["data"],
+            model_type="classifier",
+            targets=ds_targets,
+            evaluators=["default"],
+            baseline_model=baseline_model_uri,
+        )
+    _, saved_metrics, _, saved_artifacts = get_run_data(run.info.run_id)
+
+    assert saved_metrics == eval_result.metrics
+    assert "shap_beeswarm_plot.png" not in saved_artifacts
 
 @pytest.mark.parametrize(
     ("model", "is_endpoint_uri"),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/11864?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11864/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11864
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This feature is requested for automl integration purposes for triggered model evaluation failures that occur during training. In the event that the source target column exhibits an extreme class imbalance, there is a possibility that the sampling API within the Spark DataFrame API will not preserve stratified sampling of minor classes, rendering the automl run to fail due to an evaluation exception being thrown from MLflow. 

This PR enables a private environment configuration that permits the conversion of exceptions to warnings when evaluating a test dataset that is missing one (or more) target classes. This feature is disabled by default due to correctness issues when evaluating a trained classifier if all classes are not present within a validation dataset.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [X] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
