### PR TITLE
Add trace handling logic for MLflow model evaluation

### DIFF
--- a/docs/source/python_api/mlflow.tracing.rst
+++ b/docs/source/python_api/mlflow.tracing.rst
@@ -36,7 +36,7 @@ Fluent APIs are high-level APIs that allow developers to instrument their code w
     :noindex:
 
 
-.. autofunction:: mlflow.get_traces
+.. autofunction:: mlflow.get_trace
     :noindex:
 
 .. _tracing-client-apis:

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -107,7 +107,7 @@ from mlflow.models import evaluate
 from mlflow.projects import run
 from mlflow.tracing.fluent import (
     get_current_active_span,
-    get_traces,
+    get_trace,
     search_traces,
     start_span,
     trace,
@@ -221,7 +221,7 @@ __all__ = [
     "Image",
     # Tracing Fluent APIs
     "get_current_active_span",
-    "get_traces",
+    "get_trace",
     "search_traces",
     "start_span",
     "trace",

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -462,8 +462,6 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
 
     def flush_tracker(self):
         try:
-            # Make sure the trace renders in the notebook
-            mlflow.get_traces()
             self._reset()
         except Exception as e:
             _logger.debug(f"Failed to flush MLflow tracer due to error {e}.")

--- a/mlflow/pyfunc/context.py
+++ b/mlflow/pyfunc/context.py
@@ -3,9 +3,6 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Optional
 
-from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import BAD_REQUEST
-
 # A thread local variable to store the context of the current prediction request.
 # This is particularly used to associate logs/traces with a specific prediction request in the
 # caller side. The context variable is intended to be set by the called before invoking the
@@ -49,18 +46,3 @@ def get_prediction_context() -> Optional[Context]:
         The context for the current prediction request, or None if no context is set.
     """
     return _PREDICTION_REQUEST_CTX.get()
-
-
-def maybe_get_evaluation_request_id() -> Optional[str]:
-    """Get the request ID if the current prediction is as a part of MLflow model evaluation."""
-    context = get_prediction_context()
-    if not context or not context.is_evaluate:
-        return None
-
-    if not context.request_id:
-        raise MlflowException(
-            "When prediction request context has is_evaluate set to True, request ID must be set.",
-            error_code=BAD_REQUEST,
-        )
-
-    return context.request_id

--- a/mlflow/pyfunc/context.py
+++ b/mlflow/pyfunc/context.py
@@ -1,0 +1,66 @@
+import contextlib
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Optional
+
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import BAD_REQUEST
+
+# A thread local variable to store the context of the current prediction request.
+# This is particularly used to associate logs/traces with a specific prediction request in the
+# caller side. The context variable is intended to be set by the called before invoking the
+# predict method, using the set_prediction_context context manager.
+_PREDICTION_REQUEST_CTX = ContextVar("mlflow_prediction_request_context", default=None)
+
+
+@dataclass
+class Context:
+    # A unique identifier for the current prediction request.
+    request_id: str
+    # Whether the current prediction request is as a part of MLflow model evaluation.
+    is_evaluate: bool = False
+
+
+@contextlib.contextmanager
+def set_prediction_context(context: Context):
+    """
+    Set the context for the current prediction request. The context will be set as a thread-local
+    variable and will be accessible globally within the same thread.
+
+    Args:
+        context: The context for the current prediction request.
+    """
+    if not isinstance(context, Context):
+        raise TypeError(f"Expected context to be an instance of Context, but got: {context}")
+
+    token = _PREDICTION_REQUEST_CTX.set(context)
+    try:
+        yield
+    finally:
+        _PREDICTION_REQUEST_CTX.reset(token)
+
+
+def get_prediction_context() -> Optional[Context]:
+    """
+    Get the context for the current prediction request. The context is thread-local and is set
+    using the set_prediction_context context manager.
+
+    Returns:
+        The context for the current prediction request, or None if no context is set.
+    """
+    return _PREDICTION_REQUEST_CTX.get()
+
+
+def maybe_get_evaluation_request_id() -> Optional[str]:
+    """Get the request ID if the current prediction is as a part of MLflow model evaluation."""
+    context = get_prediction_context()
+    if not context or not context.is_evaluate:
+        return None
+
+    if not context.request_id:
+        raise MlflowException(
+            "When prediction request context has is_evaluate set to True, request ID must be set.",
+            error_code=BAD_REQUEST,
+        )
+
+    return context.request_id

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -27,9 +27,9 @@ def pop_trace(request_id: str) -> Optional[Dict[str, Any]]:
 
 
 # For Inference Table, we use special TTLCache to store the finished traces
-# so that they can be retrieved by the Databricks model serving. This needs
-# to be a different from the queue-based buffer used by MLflow fluent API as
-# the access is not index-based but key (request ID) based.
+# so that they can be retrieved by the Databricks model serving. The values
+# in the buffer is not Trace dataclass but a dictionary with the schema
+# used in the Databricks.
 def _initialize_trace_buffer():  # Define as a function for testing purposes
     return TTLCache(
         maxsize=MLFLOW_TRACE_BUFFER_MAX_SIZE.get(),

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -27,9 +27,9 @@ def pop_trace(request_id: str) -> Optional[Dict[str, Any]]:
 
 
 # For Inference Table, we use special TTLCache to store the finished traces
-# so that they can be retrieved by the Databricks model serving. The values
-# in the buffer is not Trace dataclass but a dictionary with the schema
-# used in the Databricks.
+# so that they can be retrieved by Databricks model serving. The values
+# in the buffer are not Trace dataclass, but rather a dictionary with the schema
+# that is used within Databricks model serving.
 def _initialize_trace_buffer():  # Define as a function for testing purposes
     return TTLCache(
         maxsize=MLFLOW_TRACE_BUFFER_MAX_SIZE.get(),

--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -5,7 +5,6 @@ from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter
 
 from mlflow.entities.trace import Trace
-from mlflow.pyfunc.context import maybe_get_evaluation_request_id
 from mlflow.tracing.display import get_display_handler
 from mlflow.tracing.display.display_handler import IPythonTraceDisplayHandler
 from mlflow.tracing.fluent import TRACE_BUFFER
@@ -46,6 +45,8 @@ class MlflowSpanExporter(SpanExporter):
             spans: A sequence of OpenTelemetry ReadableSpan objects to be exported.
                 Only root spans for each trace are passed to this method.
         """
+        from mlflow.pyfunc.context import maybe_get_evaluation_request_id
+
         for span in root_spans:
             if span._parent is not None:
                 _logger.debug("Received a non-root span. Skipping export.")

--- a/mlflow/tracing/export/mlflow.py
+++ b/mlflow/tracing/export/mlflow.py
@@ -9,6 +9,7 @@ from mlflow.tracing.display import get_display_handler
 from mlflow.tracing.display.display_handler import IPythonTraceDisplayHandler
 from mlflow.tracing.fluent import TRACE_BUFFER
 from mlflow.tracing.trace_manager import InMemoryTraceManager
+from mlflow.tracing.utils import maybe_get_evaluation_request_id
 from mlflow.tracking.client import MlflowClient
 
 _logger = logging.getLogger(__name__)
@@ -45,8 +46,6 @@ class MlflowSpanExporter(SpanExporter):
             spans: A sequence of OpenTelemetry ReadableSpan objects to be exported.
                 Only root spans for each trace are passed to this method.
         """
-        from mlflow.pyfunc.context import maybe_get_evaluation_request_id
-
         for span in root_spans:
             if span._parent is not None:
                 _logger.debug("Received a non-root span. Skipping export.")

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import time
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
@@ -12,6 +12,7 @@ import mlflow
 from mlflow.entities.trace import Trace
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
+from mlflow.pyfunc.context import maybe_get_evaluation_request_id
 from mlflow.tracing.constant import (
     MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS,
     TRUNCATION_SUFFIX,
@@ -55,7 +56,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         """
         request_id = self._trace_manager.get_request_id_from_trace_id(span.context.trace_id)
         if not request_id:
-            trace_info = self._create_trace_info(span)
+            trace_info = self._start_trace(span)
             self._trace_manager.register_trace(span.context.trace_id, trace_info)
             request_id = trace_info.request_id
         span.set_attribute(SpanAttributeKey.REQUEST_ID, json.dumps(request_id))
@@ -65,7 +66,7 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         #   and significantly skews the span duration.
         span._start_time = time.time_ns()
 
-    def _create_trace_info(self, span: OTelSpan) -> TraceInfo:
+    def _start_trace(self, span: OTelSpan) -> TraceInfo:
         experiment_id = (
             get_otel_attribute(span, SpanAttributeKey.EXPERIMENT_ID) or _get_experiment_id()
         )
@@ -75,35 +76,36 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         if run := mlflow.active_run():
             metadata[TraceMetadataKey.SOURCE_RUN] = run.info.run_id
 
-        try:
-            return self._client._start_tracked_trace(
-                experiment_id=experiment_id,
-                # TODO: This timestamp is not accurate because it is not adjusted to exclude the
-                #   latency of the backend API call. We do this adjustment for span start time
-                #   above, but can't do it for trace start time until the backend API supports
-                #   updating the trace start time.
-                timestamp_ms=span.start_time // 1_000_000,  # nanosecond to millisecond
-                request_metadata=metadata,
-            )
+        # If the trace is created in the context of MLflow model evaluation, we extract the request
+        # ID from the prediction context. Otherwise, we create a new trace info by calling the
+        # backend API.
+        if request_id := maybe_get_evaluation_request_id():
+            trace_info = self._create_trace_info(request_id, span, experiment_id, metadata)
+        else:
+            try:
+                trace_info = self._client._start_tracked_trace(
+                    experiment_id=experiment_id,
+                    # TODO: This timestamp is not accurate because it is not adjusted to exclude the
+                    #   latency of the backend API call. We do this adjustment for span start time
+                    #   above, but can't do it for trace start time until the backend API supports
+                    #   updating the trace start time.
+                    timestamp_ms=span.start_time // 1_000_000,  # nanosecond to millisecond
+                    request_metadata=metadata,
+                )
 
-        # TODO: This catches all exceptions from the tracking server so the in-memory tracing still
-        # works if the backend APIs are not ready. Once backend is ready, we should catch more
-        # specific exceptions and handle them accordingly.
-        except Exception:
-            _logger.debug(
-                "Failed to start a trace in the tracking server. This may be because the "
-                "backend APIs are not available. Fallback to client-side generation",
-                exc_info=True,
-            )
+            # TODO: This catches all exceptions from the tracking server so the in-memory tracing
+            # still works if the backend APIs are not ready. Once backend is ready, we should
+            # catch more specific exceptions and handle them accordingly.
+            except Exception:
+                _logger.debug(
+                    "Failed to start a trace in the tracking server. This may be because the "
+                    "backend APIs are not available. Fallback to client-side generation",
+                    exc_info=True,
+                )
+                request_id = encode_trace_id(span.context.trace_id)
+                trace_info = self._create_trace_info(request_id, span, experiment_id, metadata)
 
-        return TraceInfo(
-            request_id=encode_trace_id(span.context.trace_id),
-            experiment_id=experiment_id,
-            timestamp_ms=span.start_time // 1_000_000,  # nanosecond to millisecond
-            execution_time_ms=None,
-            status=TraceStatus.IN_PROGRESS,
-            request_metadata=metadata,
-        )
+        return trace_info
 
     def on_end(self, span: OTelReadableSpan) -> None:
         """
@@ -158,3 +160,19 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
             trunc_length = MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS - len(TRUNCATION_SUFFIX)
             value = value[:trunc_length] + TRUNCATION_SUFFIX
         return value
+
+    def _create_trace_info(
+        self,
+        request_id: str,
+        span: OTelSpan,
+        experiment_id: Optional[str] = None,
+        request_metadata: Optional[Dict[str, Any]] = None,
+    ) -> TraceInfo:
+        return TraceInfo(
+            request_id=request_id,
+            experiment_id=experiment_id,
+            timestamp_ms=span.start_time // 1_000_000,  # nanosecond to millisecond
+            execution_time_ms=None,
+            status=TraceStatus.IN_PROGRESS,
+            request_metadata=request_metadata or {},
+        )

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -12,7 +12,6 @@ import mlflow
 from mlflow.entities.trace import Trace
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
-from mlflow.pyfunc.context import maybe_get_evaluation_request_id
 from mlflow.tracing.constant import (
     MAX_CHARS_IN_TRACE_INFO_METADATA_AND_TAGS,
     TRUNCATION_SUFFIX,
@@ -67,6 +66,8 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         span._start_time = time.time_ns()
 
     def _start_trace(self, span: OTelSpan) -> TraceInfo:
+        from mlflow.pyfunc.context import maybe_get_evaluation_request_id
+
         experiment_id = (
             get_otel_attribute(span, SpanAttributeKey.EXPERIMENT_ID) or _get_experiment_id()
         )

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -24,6 +24,7 @@ from mlflow.tracing.utils import (
     deduplicate_span_names_in_place,
     encode_trace_id,
     get_otel_attribute,
+    maybe_get_evaluation_request_id,
 )
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.fluent import _get_experiment_id
@@ -66,8 +67,6 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         span._start_time = time.time_ns()
 
     def _start_trace(self, span: OTelSpan) -> TraceInfo:
-        from mlflow.pyfunc.context import maybe_get_evaluation_request_id
-
         experiment_id = (
             get_otel_attribute(span, SpanAttributeKey.EXPERIMENT_ID) or _get_experiment_id()
         )

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -580,6 +580,7 @@ class MlflowClient:
             return mlflow_span
         except Exception as e:
             _logger.warning(f"Failed to start span {name}: {e}")
+            raise e
             return NoOpSpan()
 
     def end_trace(

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -9,6 +9,7 @@ import mlflow
 from mlflow.entities import SpanType
 from mlflow.tracing.utils import TraceJSONEncoder
 
+from tests.tracing.conftest import clear_singleton  # noqa: F401
 from tests.tracing.helper import get_traces
 
 

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -9,7 +9,7 @@ import mlflow
 from mlflow.entities import SpanType
 from mlflow.tracing.utils import TraceJSONEncoder
 
-from tests.tracing.conftest import clear_singleton  # noqa: F401
+from tests.tracing.helper import get_traces
 
 
 def test_json_deserialization(clear_singleton):
@@ -38,7 +38,7 @@ def test_json_deserialization(clear_singleton):
     model = TestModel()
     model.predict(2, 5)
 
-    trace = mlflow.get_traces()[0]
+    trace = get_traces()[0]
     trace_json = trace.to_json()
 
     trace_json_as_dict = json.loads(trace_json)

--- a/tests/entities/test_trace_data.py
+++ b/tests/entities/test_trace_data.py
@@ -6,7 +6,7 @@ import mlflow
 from mlflow.entities import SpanType, TraceData
 from mlflow.entities.span_event import SpanEvent
 
-from tests.tracing.conftest import clear_singleton, mock_store, mock_upload_trace_data  # noqa: F401
+from tests.tracing.helper import get_traces
 
 
 def test_json_deserialization(clear_singleton):
@@ -31,7 +31,7 @@ def test_json_deserialization(clear_singleton):
     with pytest.raises(Exception, match="Error!"):
         model.predict(2, 5)
 
-    trace = mlflow.get_traces()[0]
+    trace = get_traces()[0]
     trace_data = trace.data
 
     # Compare events separately as it includes exception stacktrace which is hard to hardcode

--- a/tests/entities/test_trace_data.py
+++ b/tests/entities/test_trace_data.py
@@ -6,6 +6,7 @@ import mlflow
 from mlflow.entities import SpanType, TraceData
 from mlflow.entities.span_event import SpanEvent
 
+from tests.tracing.conftest import clear_singleton  # noqa: F401
 from tests.tracing.helper import get_traces
 
 

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -35,6 +35,7 @@ from mlflow.utils.openai_utils import (
 
 # TODO: This test helper is used outside the tracing module, we should move it to a common utils
 from tests.tracing.conftest import clear_singleton as clear_trace_singleton  # noqa: F401
+from tests.tracing.helper import get_traces
 
 MODEL_DIR = "model"
 TEST_CONTENT = "test"
@@ -186,7 +187,7 @@ def test_autolog_manage_run():
     assert MlflowClient().get_run(run.info.run_id).data.tags["mlflow.autologging"] == "langchain"
     mlflow.end_run()
 
-    traces = mlflow.get_traces(None)
+    traces = get_traces()
     assert len(traces) == 2
     for trace in traces:
         attrs = trace.data.spans[0].attributes
@@ -253,7 +254,7 @@ def test_autolog_record_exception(clear_trace_singleton):
     with pytest.raises(Exception, match="Error!"):
         model.invoke("test")
 
-    traces = mlflow.get_traces(None)
+    traces = get_traces()
     assert len(traces) == 1
     trace = traces[0]
     assert trace.info.status == "ERROR"
@@ -273,7 +274,7 @@ def test_llmchain_autolog(clear_trace_singleton):
             assert model.invoke(question) == answer
             log_model_mock.assert_called_once()
 
-    traces = mlflow.get_traces(None)
+    traces = get_traces()
     assert len(traces) == 2
     for trace in traces:
         spans = trace.data.spans
@@ -305,7 +306,7 @@ def test_llmchain_autolog_no_optional_artifacts_by_default(clear_trace_singleton
             assert model.invoke(question) == answer
             create_run_mock.assert_not_called()
 
-    traces = mlflow.get_traces(None)
+    traces = get_traces()
     assert len(traces) == 1
     spans = traces[0].data.spans
     assert len(spans) == 2
@@ -429,7 +430,7 @@ def test_agent_autolog(clear_trace_singleton):
         assert model.invoke(input, return_only_outputs=True) == {"output": TEST_CONTENT}
         log_model_mock.assert_called_once()
 
-    traces = mlflow.get_traces(None)
+    traces = get_traces()
     assert len(traces) == 4
     for trace in traces:
         spans = [(s.name, s.attributes[SpanAttributeKey.SPAN_TYPE]) for s in trace.data.spans]
@@ -522,7 +523,7 @@ def test_runnable_sequence_autolog(clear_trace_singleton):
         assert chain.invoke(input_example) == TEST_CONTENT
         log_model_mock.assert_called_once()
 
-    traces = mlflow.get_traces(None)
+    traces = get_traces()
     assert len(traces) == 2
     for trace in traces:
         spans = {(s.name, s.attributes[SpanAttributeKey.SPAN_TYPE]) for s in trace.data.spans}
@@ -620,7 +621,7 @@ def test_retriever_autolog(tmp_path, clear_trace_singleton):
         log_model_mock.assert_not_called()
         logger_mock.assert_called_once_with(UNSUPPORT_LOG_MODEL_MESSAGE)
 
-    traces = mlflow.get_traces(None)
+    traces = get_traces()
     assert len(traces) == 1
     spans = traces[0].data.spans
     assert len(spans) == 1

--- a/tests/pyfunc/test_context.py
+++ b/tests/pyfunc/test_context.py
@@ -4,11 +4,9 @@ from threading import Thread
 
 import pytest
 
-from mlflow.exceptions import MlflowException
 from mlflow.pyfunc.context import (
     Context,
     get_prediction_context,
-    maybe_get_evaluation_request_id,
     set_prediction_context,
 )
 
@@ -32,15 +30,7 @@ def test_prediction_context_thread_safe():
     assert get_prediction_context() is None
 
 
-def test_maybe_get_evaluation_request_id():
-    assert maybe_get_evaluation_request_id() is None
-
-    with set_prediction_context(Context(request_id="eval", is_evaluate=True)):
-        assert maybe_get_evaluation_request_id() == "eval"
-
-    with set_prediction_context(Context(request_id="non_eval", is_evaluate=False)):
-        assert maybe_get_evaluation_request_id() is None
-
-    with pytest.raises(MlflowException, match="When prediction request context"):
-        with set_prediction_context(Context(request_id=None, is_evaluate=True)):
-            maybe_get_evaluation_request_id()
+def test_set_prediction_context_raise_on_invalid_context():
+    with pytest.raises(TypeError, match="Expected context to be an instance of Context"):
+        with set_prediction_context("invalid"):
+            pass

--- a/tests/pyfunc/test_context.py
+++ b/tests/pyfunc/test_context.py
@@ -1,0 +1,46 @@
+import random
+import time
+from threading import Thread
+
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.pyfunc.context import (
+    Context,
+    get_prediction_context,
+    maybe_get_evaluation_request_id,
+    set_prediction_context,
+)
+
+
+def test_prediction_context_thread_safe():
+    def set_context(context):
+        with set_prediction_context(context):
+            time.sleep(0.2 * random.random())
+            assert get_prediction_context() == context
+
+    threads = []
+    for i in range(10):
+        context = Context(request_id=f"request_{i}", is_evaluate=random.choice([True, False]))
+        thread = Thread(target=set_context, args=(context,))
+        thread.start()
+        threads.append(thread)
+
+    for thread in threads:
+        thread.join()
+
+    assert get_prediction_context() is None
+
+
+def test_maybe_get_evaluation_request_id():
+    assert maybe_get_evaluation_request_id() is None
+
+    with set_prediction_context(Context(request_id="eval", is_evaluate=True)):
+        assert maybe_get_evaluation_request_id() == "eval"
+
+    with set_prediction_context(Context(request_id="non_eval", is_evaluate=False)):
+        assert maybe_get_evaluation_request_id() is None
+
+    with pytest.raises(MlflowException, match="When prediction request context"):
+        with set_prediction_context(Context(request_id=None, is_evaluate=True)):
+            maybe_get_evaluation_request_id()

--- a/tests/tracing/helper.py
+++ b/tests/tracing/helper.py
@@ -1,12 +1,13 @@
 import time
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 
 import opentelemetry.trace as trace_api
 from opentelemetry.sdk.trace import ReadableSpan
 
 from mlflow.entities import Trace, TraceData, TraceInfo
 from mlflow.entities.trace_status import TraceStatus
+from mlflow.tracing.fluent import TRACE_BUFFER
 
 
 def create_mock_otel_span(
@@ -108,3 +109,8 @@ def create_test_trace_info(
         request_metadata=request_metadata or {},
         tags=tags or {},
     )
+
+
+def get_traces() -> List[Trace]:
+    # Get all traces from the trace buffer
+    return list(TRACE_BUFFER.values())

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -50,7 +50,7 @@ from mlflow.utils.mlflow_tags import (
 
 from tests.tracing.conftest import clear_singleton  # noqa: F401
 from tests.tracing.conftest import mock_store as mock_store_for_tracing  # noqa: F401
-from tests.tracing.helper import create_test_trace_info
+from tests.tracing.helper import create_test_trace_info, get_traces
 
 
 @pytest.fixture(autouse=True)
@@ -355,7 +355,7 @@ def test_start_and_end_trace(clear_singleton, with_active_run):
     else:
         model.predict(1, 2)
 
-    traces = mlflow.get_traces()
+    traces = get_traces()
     assert len(traces) == 1
     trace_info = traces[0].info
     assert trace_info.request_id is not None
@@ -439,7 +439,7 @@ def test_start_and_end_trace_before_all_span_end(clear_singleton):
     model = TestModel()
     model.predict(1)
 
-    traces = mlflow.get_traces()
+    traces = get_traces()
     assert len(traces) == 1
 
     trace_info = traces[0].info
@@ -528,7 +528,7 @@ def test_log_trace_with_databricks_tracking_uri(
     ) as mock_upload_trace_data:
         model.predict(1, 2)
 
-    traces = mlflow.get_traces()
+    traces = get_traces()
     assert len(traces) == 1
     trace_info = traces[0].info
     assert trace_info.request_id == "tr-12345"
@@ -594,7 +594,7 @@ def test_set_and_delete_trace_tag_on_active_trace(clear_singleton):
     client.set_trace_tag(request_id, "foo", "bar")
     client.end_trace(request_id)
 
-    trace = mlflow.get_traces()[-1]
+    trace = get_traces()[0]
     assert trace.info.tags == {"mlflow.traceName": "test", "foo": "bar"}
 
 
@@ -610,7 +610,7 @@ def test_delete_trace_tag_on_active_trace(clear_singleton):
     client.delete_trace_tag(request_id, "foo")
     client.end_trace(request_id)
 
-    trace = mlflow.get_traces()[-1]
+    trace = get_traces()[0]
     assert trace.info.tags == {
         "baz": "qux",
         "mlflow.traceName": "test",  # Added by MLflow


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR implements necessary APIs and prep for integration tracing with MLflow model evaluation.

During the evaluation, MLflow will invoke pyfunc `predict()` method and use the generated trace for computing metrics. However, there is one limitation in the current trace implementation, which is the caller cannot retrieve the corresponding trace for the prediction.
```
# When prediction is invoked, a trace will be generated under the hood.
result = model.predict()
# We can retrieve the latest N traces using get_traces() APIs, but it is not guaranteed that the trace is generated from above prediction, for example, multi-threading cases.
trace = mlflow.get_traces(n=1)
```

During model evaluation, model prediction is invoked concurrently with multi-threading, so we need a way to deterministically get a trace for a prediction. This PR introduces that mechanism using thread-local context variable. The caller can set the `request_id` using context manager like below.
```
def predict_with_trace(input_data):
    request_id = uuid.uuid4().hex
    with set_prediction_context(Context(request_id=request_id, is_evaluate=True)):
          # During the prediction, MLflow fetches request_id from the context and associate the generated trace with it.
          prediction = model.predict(input_data)
    # The trace can be retrieved using get_trace() API with the request ID
    trace = mlflow.get_trace(request_id)
    return (request_id, prediction, trace)
```

This change also introduces a few changes
- The queue-based `get_traces()` API is replaced with key-based `get_trace()` API. We've discussed offline and found the functionality is fulfilled with `search_traces()` API now.
- The context also includes `is_evaluate` in addition to the request ID. This is because there is no way for MLflow to know whether the prediction is made for evaluation. While at this moment we can determine that by checking the existence of context itself, I think having the flag makes it clear what the code intends to do.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Simulated evaluation logic
```
from mlflow.pyfunc.context import Context, set_prediction_context
from concurrent.futures import ThreadPoolExecutor, as_completed
import pandas as pd
import uuid

def evaluate(input_claim):
    request_id = uuid.uuid4().hex
    with set_prediction_context(Context(request_id=request_id, is_evaluate=True)):
        # During the prediction, MLflow fetches request_id from the context and associate the generated trace with it.
        model = ExampleRAGChain(index_name="test", vs_endpoint_name="test")
        prediction = model.predict(
            claim=input_claim,
            model_name="databricks-dbrx-instruct",
            temperature=0.1,
            max_tokens=200,
        )
    trace = mlflow.get_trace(request_id)
    return (request_id, trace, prediction)

claims = [
  "0-dimensional biomaterials show inductive properties.",
  "The structure of the human genome is largely unknown.",
  "The human genome is 3.8 billion base pairs in size.",
]

results = []
with mlflow.start_run(run_name="eval-test"):
    with ThreadPoolExecutor(max_workers=3) as executor:
        futures = {executor.submit(evaluate, claim): idx for idx, claim in enumerate(claims)}
        for future in as_completed(futures):
            request_id, trace, prediction = future.result()
            results.append((request_id, trace, prediction))

pd.DataFrame(results, columns=["request_id", "trace", "prediction"])
```
![Screenshot 2024-05-01 at 23 02 09](https://github.com/mlflow/mlflow/assets/31463517/fefef641-f334-4af4-9de2-48d11b073799)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
