### PR TITLE
Inject callbacks automatically for LangChain model evaluation and handle context propagation

### DIFF
--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -122,13 +122,14 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         status=SpanStatus(SpanStatusCode.OK),
     ):
         """Close MLflow Span (or Trace if it is root component)"""
-        self._mlflow_client.end_span(
-            request_id=span.request_id,
-            span_id=span.span_id,
-            outputs=outputs,
-            attributes=attributes,
-            status=status,
-        )
+        with set_prediction_context(self._prediction_context):
+            self._mlflow_client.end_span(
+                request_id=span.request_id,
+                span_id=span.span_id,
+                outputs=outputs,
+                attributes=attributes,
+                status=status,
+            )
 
     def _reset(self):
         self._run_span_mapping = {}

--- a/mlflow/pyfunc/context.py
+++ b/mlflow/pyfunc/context.py
@@ -19,7 +19,7 @@ class Context:
 
 
 @contextlib.contextmanager
-def set_prediction_context(context: Context):
+def set_prediction_context(context: Optional[Context]):
     """
     Set the context for the current prediction request. The context will be set as a thread-local
     variable and will be accessible globally within the same thread.
@@ -27,7 +27,7 @@ def set_prediction_context(context: Context):
     Args:
         context: The context for the current prediction request.
     """
-    if not isinstance(context, Context):
+    if context and not isinstance(context, Context):
         raise TypeError(f"Expected context to be an instance of Context, but got: {context}")
 
     token = _PREDICTION_REQUEST_CTX.set(context)

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -201,12 +201,12 @@ def start_span(
         mlflow_span.end()
 
 
-def get_trace(request_id: str) -> List[Trace]:
+def get_trace(request_id: str) -> Trace:
     """
     Get a trace by the given request ID.
 
     Returns:
-        A list of :py:class:`mlflow.entities.Trace` objects.
+        A :py:class:`mlflow.entities.Trace` objects with the given request ID.
     """
     return TRACE_BUFFER.get(request_id, None)
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -570,7 +570,6 @@ class MlflowClient:
                 mlflow_span.set_inputs(inputs)
             if attributes:
                 mlflow_span.set_attributes(attributes)
-
             trace_manager = InMemoryTraceManager.get_instance()
             with trace_manager.get_trace(request_id) as trace:
                 trace.info.tags.update(self._exclude_immutable_tags(tags or {}))

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -412,7 +412,10 @@ def test_llmchain_autolog_log_inputs_outputs():
 
 
 @mock.patch("mlflow.tracing.export.mlflow.get_display_handler")
-def test_loaded_llmchain_autolog_within_model_evaluation(mock_get_display, tmp_path):
+def test_loaded_llmchain_within_model_evaluation(mock_get_display, tmp_path):
+    # Disable autolog here as it is enabled in other tests.
+    mlflow.langchain.autolog(disable=True)
+
     model = create_openai_llmchain()
     model_path = tmp_path / "model"
     mlflow.langchain.save_model(model, path=model_path)

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -411,7 +411,8 @@ def test_llmchain_autolog_log_inputs_outputs():
         assert new_session_id != session_id
 
 
-def test_loaded_llmchain_autolog_within_model_evaluation(tmp_path):
+@mock.patch("mlflow.tracing.export.mlflow.get_display_handler")
+def test_loaded_llmchain_autolog_within_model_evaluation(mock_get_display, tmp_path):
     model = create_openai_llmchain()
     model_path = tmp_path / "model"
     mlflow.langchain.save_model(model, path=model_path)
@@ -428,6 +429,10 @@ def test_loaded_llmchain_autolog_within_model_evaluation(tmp_path):
     trace = mlflow.get_trace(request_id)
     assert trace.info.request_id == request_id
     assert trace.info.request_metadata["mlflow.sourceRun"] == run_id
+
+    # Trace should not be displayed in the notebook cell if it is in evaluation
+    mock_display_handler = mock_get_display.return_value
+    mock_display_handler.display_traces.assert_not_called()
 
 
 def test_agent_autolog(clear_trace_singleton):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11881?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11881/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11881
```

</p>
</details>

### What changes are proposed in this pull request?

We have introduced a context variable for propagating prediction context e.g. `request_id`, so that we can associate the trace and prediction during model evaluation. The approach worked with custom Pyfunc model, however, there were two problems for applying them to LangChain models.

1. The tracing is not enabled unless we call `mlflow.langchain.autolog()` before evaluation. This PR changes the prediction logic to automatically inject tracing callback when it is in evaluation context.
2. The context variable approach doesn't work with LangChain callback as it is, since LangChain callback is sometimes not invoked within the same context e.g. async and supposedly they don't correctly propagate the context. We can raise an issue to LangChain, but as a quick band-aiding, we pass the context manually to the callback instance.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


![Screenshot 2024-05-02 at 14 19 07](https://github.com/mlflow/mlflow/assets/31463517/fac47808-383e-46d3-9f84-fb8997c8a94a)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
