### PR TITLE
Update search_trace() fluent API to use active experiment ID and add warning for usage of default experiment

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -15,12 +15,14 @@ from mlflow.environment_variables import (
     MLFLOW_TRACE_BUFFER_MAX_SIZE,
     MLFLOW_TRACE_BUFFER_TTL_SECONDS,
 )
+from mlflow.exceptions import MlflowException
 from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.tracing import provider
 from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.tracing.display import get_display_handler
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import capture_function_input_args, encode_span_id, get_otel_attribute
+from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils import get_results_from_paginated_fn
 
 _logger = logging.getLogger(__name__)
@@ -212,7 +214,7 @@ def get_trace(request_id: str) -> List[Trace]:
 
 
 def search_traces(
-    experiment_ids: List[str],
+    experiment_ids: Optional[List[str]] = None,
     filter_string: Optional[str] = None,
     max_results: Optional[int] = None,
     order_by: Optional[List[str]] = None,
@@ -221,7 +223,8 @@ def search_traces(
     Return traces that match the given list of search expressions within the experiments.
 
     Args:
-        experiment_ids: List of experiment ids to scope the search.
+        experiment_ids: List of experiment ids to scope the search. If not provided, the search
+            will be performed across the current active experiment.
         filter_string: A search filter string.
         max_results: Maximum number of traces desired. If None, all traces matching the search
             expressions will be returned.
@@ -231,6 +234,14 @@ def search_traces(
         A list of :py:class:`Trace <mlflow.entities.Trace>` objects that satisfy the search
         expressions.
     """
+    if not experiment_ids:
+        if experiment_id := _get_experiment_id():
+            experiment_ids = [experiment_id]
+        else:
+            raise MlflowException(
+                "No active experiment found. Set an experiment using `mlflow.set_experiment`, "
+                "or specify the list of experiment IDs in the `experiment_ids` parameter."
+            )
 
     def pagination_wrapper_func(number_to_get, next_page_token):
         return MlflowClient().search_traces(

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -74,10 +74,11 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         if experiment_id == DEFAULT_EXPERIMENT_ID:
             _logger.warning(
                 "Creating a trace within the default experiment with id "
-                f"'{DEFAULT_EXPERIMENT_ID}'. However, it is strongly recommended to set a "
-                "specific experiment when using tracing, because the default experiment can "
-                "become a monolithic huge dump with thousands of traces and negatively "
-                "impact storage performance. To avoid this, set the experiment for "
+                f"'{DEFAULT_EXPERIMENT_ID}'. It is strongly recommended to not use "
+                "the default experiment to log traces due to ambiguous search results and "
+                "probable performance issues over time due to directory table listing performance "
+                "degradation with high volumes of directories within a specific path. "
+                "To avoid performance and disambiguation issues, set the experiment for "
                 "your environment using `mlflow.set_experiment()` API."
             )
         metadata = {}

--- a/mlflow/tracing/processor/mlflow.py
+++ b/mlflow/tracing/processor/mlflow.py
@@ -27,6 +27,7 @@ from mlflow.tracing.utils import (
     maybe_get_evaluation_request_id,
 )
 from mlflow.tracking.client import MlflowClient
+from mlflow.tracking.default_experiment import DEFAULT_EXPERIMENT_ID
 from mlflow.tracking.fluent import _get_experiment_id
 
 _logger = logging.getLogger(__name__)
@@ -70,6 +71,15 @@ class MlflowSpanProcessor(SimpleSpanProcessor):
         experiment_id = (
             get_otel_attribute(span, SpanAttributeKey.EXPERIMENT_ID) or _get_experiment_id()
         )
+        if experiment_id == DEFAULT_EXPERIMENT_ID:
+            _logger.warning(
+                "Creating a trace within the default experiment with id "
+                f"'{DEFAULT_EXPERIMENT_ID}'. However, it is strongly recommended to set a "
+                "specific experiment when using tracing, because the default experiment can "
+                "become a monolithic huge dump with thousands of traces and negatively "
+                "impact storage performance. To avoid this, set the experiment for "
+                "your environment using `mlflow.set_experiment()` API."
+            )
         metadata = {}
 
         # If the span is started within an active MLflow run, we should record it as a trace tag

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -449,7 +449,7 @@ class MlflowClient:
         max_results: int = SEARCH_TRACES_DEFAULT_MAX_RESULTS,
         order_by: Optional[List[str]] = None,
         page_token: Optional[str] = None,
-    ):
+    ) -> PagedList[Trace]:
         """
         Return traces that match the given list of search expressions within the experiments.
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/11884?quickstart=1)

#### Install mlflow from this PR

```
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/11884/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 11884
```

</p>
</details>

### What changes are proposed in this pull request?

Based on offline discussion, improving experiment ID handling for tracing:
1. Update `search_trace()` fluent API to use active experiment ID as default value for convenience.
2. Emit warning when user try to create a trace under default experiment, as it can worse the storage performance and at worst case crush OS.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

1.  
![Screenshot 2024-05-02 at 21 44 56](https://github.com/mlflow/mlflow/assets/31463517/6ebadb3f-edc3-47f2-8b7f-4bb049b0d921)

2. 
![Screenshot 2024-05-02 at 21 43 32](https://github.com/mlflow/mlflow/assets/31463517/4bd43b91-6f33-4598-abb5-2a6a119aa253)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references


  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
